### PR TITLE
feat(repo): update subchart dependencies to latest versions

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -25,6 +25,7 @@ icon: https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/client/pu
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |

--- a/charts/answer/Chart.lock
+++ b/charts/answer/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:d937224208937c097eb22b325af06f9e55d28ebd510e989233a15ca5826f9ce8
-generated: "2026-03-23T15:16:16.9356235-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:01:54.403501-03:00"

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -32,10 +32,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/answer
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -23,6 +23,7 @@ icon: https://answer.apache.org/img/logo.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -144,8 +144,6 @@ postgresql:
     username: answer
     # -- Database password (auto-generated if empty)
     password: ""
-    # -- Root password (auto-generated if empty)
-    rootPassword: ""
 
   primary:
     persistence:

--- a/charts/appwrite/Chart.lock
+++ b/charts/appwrite/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.0.0
+  version: 1.0.2
 - name: redis
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.0
-digest: sha256:bab5a7aa3452691322264b1a5ee989c6b27a6ff2352ce6c32b8f113c92095b2e
-generated: "2026-03-31T22:56:21.1187294-03:00"
+  version: 1.5.2
+digest: sha256:0e4992d6fd521b3b8c6ce250cfebc90a934b7e9452924376fa81ab8dde6a221f
+generated: "2026-04-01T09:02:03.8393324-03:00"

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -34,10 +34,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/appwrite
 dependencies:
   - name: mariadb
-    version: 1.0.0
+    version: 1.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.5.0
+    version: 1.5.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -25,6 +25,7 @@ sources:
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |

--- a/charts/authelia/Chart.lock
+++ b/charts/authelia/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.4.1
 - name: redis
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.2.1
-digest: sha256:6a772707807b0cbc82979421499f6bdff5461dc615c5cd595b6885e1362e020b
-generated: "2026-03-23T18:42:09.9753795-03:00"
+  version: 1.5.2
+digest: sha256:1011ebbd5de19e5ee7f623e5000ef079189bcdfebfd814fcdb2c60edd64dbaae
+generated: "2026-04-01T09:02:39.1936762-03:00"

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -41,6 +41,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.2.1
+    version: 1.5.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -24,6 +24,7 @@ icon: https://www.authelia.com/images/branding/logo-cropped.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: security
   artifacthub.io/links: |

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -23,6 +23,7 @@ icon: https://www.vectorlogo.zone/logos/cloudflare/cloudflare-icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -24,6 +24,7 @@ sources:
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |

--- a/charts/docmost/Chart.lock
+++ b/charts/docmost/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: redis
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.2.1
-digest: sha256:680aaeabd891ff37cb7b9928a9c838aeb5468d0013e8b7b45605787d6b8fdc4b
-generated: "2026-03-31T21:52:28.7124199-03:00"
+  version: 1.5.2
+digest: sha256:7de5e97c1d37c08509210bebff2dfbd987abc5c7418a65d24725575d6d6d3aa4
+generated: "2026-04-01T09:03:13.5640851-03:00"

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -33,10 +33,10 @@ annotations:
   helmforge.dev/signed: cosign
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.2.1
+    version: 1.5.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -31,6 +31,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/docmost
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/dolibarr/Chart.lock
+++ b/charts/dolibarr/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:adf9695fec8c32ded42942a36cf9a804150903cb1259cc232003c0dfa443b4be
-generated: "2026-03-31T18:10:00-03:00"
+  version: 1.7.1
+digest: sha256:3558a90e6dd568ee8d05fe650184fe04a6188c901d5ae5093150266f0fc2dda9
+generated: "2026-04-01T09:03:35.0497513-03:00"

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -32,6 +32,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/dolibarr
 dependencies:
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -25,6 +25,7 @@ annotations:
   artifacthub.io/category: integration-delivery
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/dolibarr

--- a/charts/flowise/Chart.lock
+++ b/charts/flowise/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: redis
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.2.1
-digest: sha256:680aaeabd891ff37cb7b9928a9c838aeb5468d0013e8b7b45605787d6b8fdc4b
-generated: "2026-03-31T22:56:56.6535123-03:00"
+  version: 1.5.2
+digest: sha256:7de5e97c1d37c08509210bebff2dfbd987abc5c7418a65d24725575d6d6d3aa4
+generated: "2026-04-01T09:03:40.5848304-03:00"

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -34,10 +34,10 @@ annotations:
   helmforge.dev/signed: cosign
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.2.1
+    version: 1.5.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -32,6 +32,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/flowise
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -11,6 +11,7 @@ kubeVersion: ">=1.26.0-0"
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |

--- a/charts/gitea/Chart.lock
+++ b/charts/gitea/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:d937224208937c097eb22b325af06f9e55d28ebd510e989233a15ca5826f9ce8
-generated: "2026-03-31T21:01:11.9991682-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:04:01.4443392-03:00"

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -31,10 +31,10 @@ annotations:
   helmforge.dev/signed: cosign
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -29,6 +29,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/gitea
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/gitea/ci/postgresql.yaml
+++ b/charts/gitea/ci/postgresql.yaml
@@ -5,4 +5,3 @@ postgresql:
     database: gitea
     username: gitea
     password: testpassword
-    rootPassword: testrootpassword

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -118,8 +118,6 @@ postgresql:
     username: gitea
     # -- Database password (auto-generated if empty)
     password: ""
-    # -- Root password (auto-generated if empty)
-    rootPassword: ""
   primary:
     persistence:
       # -- Enable persistence for PostgreSQL data

--- a/charts/guacamole/Chart.lock
+++ b/charts/guacamole/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:d937224208937c097eb22b325af06f9e55d28ebd510e989233a15ca5826f9ce8
-generated: "2026-03-23T16:56:54.7359542-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:04:27.0859717-03:00"

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -26,6 +26,7 @@ icon: https://raw.githubusercontent.com/apache/guacamole-website/main/images/log
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -35,10 +35,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/guacamole
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -25,6 +25,7 @@ annotations:
   artifacthub.io/category: skip-prediction
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/heimdall

--- a/charts/homarr/Chart.lock
+++ b/charts/homarr/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:d937224208937c097eb22b325af06f9e55d28ebd510e989233a15ca5826f9ce8
-generated: "2026-03-31T21:41:04.1032003-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:04:33.6275703-03:00"

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -28,6 +28,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/homarr
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -30,10 +30,10 @@ annotations:
   helmforge.dev/signed: cosign
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/homarr/ci/postgresql.yaml
+++ b/charts/homarr/ci/postgresql.yaml
@@ -5,4 +5,3 @@ postgresql:
     database: homarr
     username: homarr
     password: testpassword
-    rootPassword: testrootpassword

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -99,8 +99,6 @@ postgresql:
     username: homarr
     # -- Database password (auto-generated if empty)
     password: ""
-    # -- Root password (auto-generated if empty)
-    rootPassword: ""
   primary:
     persistence:
       # -- Enable persistence for PostgreSQL data

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://kafka.apache.org/images/apache-kafka.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging
   artifacthub.io/links: |

--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:d937224208937c097eb22b325af06f9e55d28ebd510e989233a15ca5826f9ce8
-generated: "2026-03-20T19:33:54.2250786-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:04:46.974886-03:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -26,10 +26,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/keycloak
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -17,6 +17,7 @@ maintainers:
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: security
   artifacthub.io/links: |

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -23,6 +23,7 @@ icon: https://komga.org/img/logo.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: storage
   artifacthub.io/links: |

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -20,6 +20,7 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/mariadb/logo.
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -25,6 +25,7 @@ icon: https://www.vectorlogo.zone/logos/minecraft/minecraft-icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://www.vectorlogo.zone/logos/mongodb/mongodb-icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -24,6 +24,7 @@ annotations:
   artifacthub.io/category: streaming-messaging
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/mosquitto

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -20,6 +20,7 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/mysql/logo.pn
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |

--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
+  version: 1.7.1
 - name: redis
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.2.1
-digest: sha256:6a772707807b0cbc82979421499f6bdff5461dc615c5cd595b6885e1362e020b
-generated: "2026-03-23T15:53:15.1839345-03:00"
+  version: 1.5.2
+digest: sha256:a4dd16ac1de265b6cb7ac91008d9f6eefc6c6cb16b87d99523d9b88883d6d338
+generated: "2026-04-01T09:04:53.9123683-03:00"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -31,14 +31,14 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/n8n
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.2.1
+    version: 1.5.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://raw.githubusercontent.com/n8n-io/n8n/master/assets/n8n-logo.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -164,8 +164,6 @@ postgresql:
     username: n8n
     # -- Database password (auto-generated if empty)
     password: ""
-    # -- Root password (auto-generated if empty)
-    rootPassword: ""
 
   primary:
     persistence:

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -26,6 +26,7 @@ annotations:
   artifacthub.io/category: database
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/phpmyadmin

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -23,6 +23,7 @@ icon: https://pi-hole.net/wp-content/uploads/2016/12/Vortex-R.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -21,6 +21,7 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/postgres/logo
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://raw.githubusercontent.com/rabbitmq/rabbitmq-website/main/static/im
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging
   artifacthub.io/links: |

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/redis/logo.pn
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |

--- a/charts/strapi/Chart.lock
+++ b/charts/strapi/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:d937224208937c097eb22b325af06f9e55d28ebd510e989233a15ca5826f9ce8
-generated: "2026-03-23T15:16:16.9356235-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:05:01.3782082-03:00"

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -32,10 +32,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/strapi
 dependencies:
   - name: postgresql
-    version: 1.5.2
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -23,6 +23,7 @@ icon: https://raw.githubusercontent.com/strapi/strapi/main/packages/core/admin/a
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -175,8 +175,6 @@ postgresql:
     username: strapi
     # -- Database password (auto-generated if empty)
     password: ""
-    # -- Root password (auto-generated if empty)
-    rootPassword: ""
 
   primary:
     persistence:

--- a/charts/uptime-kuma/Chart.lock
+++ b/charts/uptime-kuma/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:adf9695fec8c32ded42942a36cf9a804150903cb1259cc232003c0dfa443b4be
-generated: "2026-03-23T18:05:49.4288753-03:00"
+  version: 1.7.1
+digest: sha256:3558a90e6dd568ee8d05fe650184fe04a6188c901d5ae5093150266f0fc2dda9
+generated: "2026-04-01T09:05:09.2198292-03:00"

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -31,6 +31,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma
 dependencies:
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://uptime.kuma.pet/img/icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |

--- a/charts/vaultwarden/Chart.lock
+++ b/charts/vaultwarden/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.1
+  version: 1.8.1
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:99dde4d248511d36ac21ebed3f4f1f0bc7d9e9c474ae8265897ce469aedbd5ac
-generated: "2026-03-20T13:25:40.6275762-03:00"
+  version: 1.7.1
+digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
+generated: "2026-04-01T09:05:24.1111496-03:00"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -30,10 +30,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/vaultwarden
 dependencies:
   - name: postgresql
-    version: 1.5.1
+    version: 1.8.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -21,6 +21,7 @@ icon: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/v
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: security
   artifacthub.io/links: |

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://velero.io/img/Velero.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: storage
   artifacthub.io/links: |

--- a/charts/wordpress/Chart.lock
+++ b/charts/wordpress/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.4.1
-digest: sha256:adf9695fec8c32ded42942a36cf9a804150903cb1259cc232003c0dfa443b4be
-generated: "2026-03-23T14:51:48.9018053-03:00"
+  version: 1.7.1
+digest: sha256:3558a90e6dd568ee8d05fe650184fe04a6188c901d5ae5093150266f0fc2dda9
+generated: "2026-04-01T09:05:37.817902-03:00"

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -22,6 +22,7 @@ icon: https://s.w.org/style/images/about/WordPress-logotype-simplified.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -31,6 +31,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/wordpress
 dependencies:
   - name: mysql
-    version: 1.4.1
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled


### PR DESCRIPTION
## Summary
- Update all subchart dependency versions to latest published releases
- postgresql: 1.5.2 → 1.8.1
- mysql: 1.4.1 → 1.7.1
- redis: 1.2.1 → 1.5.2
- mariadb: 1.0.0 → 1.0.2

Affects 15 charts: answer, appwrite, authelia, docmost, dolibarr, flowise, gitea, guacamole, homarr, keycloak, n8n, strapi, uptime-kuma, vaultwarden, wordpress.

## Test plan
- [ ] CI lint, template, and unit tests pass for all 15 charts