### PR TITLE
fix(repo): replace broken artifacthub icon urls

### DIFF
--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.0.3
 appVersion: "3.1.1"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/flowise
-icon: https://flowiseai.com/favicon.ico
+icon: https://raw.githubusercontent.com/FlowiseAI/Flowise/main/images/flowise_dark.svg
 keywords:
   - flowise
   - ai

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.0.3
 appVersion: "1.25.5"
 home: https://helmforge.dev/docs/charts/gitea
-icon: https://gitea.io/images/gitea.png
+icon: https://raw.githubusercontent.com/go-gitea/gitea/main/assets/logo.svg
 keywords:
   - gitea
   - git

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -19,7 +19,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/linuxserver/heimdall
   - https://github.com/linuxserver/Heimdall
-icon: https://raw.githubusercontent.com/linuxserver/Heimdall/master/public/favicon.png
+icon: https://raw.githubusercontent.com/linuxserver/Heimdall/master/public/img/heimdall-icon-small.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/phpmyadmin/phpmyadmin
   - https://github.com/phpmyadmin/phpmyadmin
-icon: https://www.phpmyadmin.net/static/favicon.ico
+icon: https://raw.githubusercontent.com/phpmyadmin/phpmyadmin/master/public/themes/pmahomme/img/logo_left.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database


### PR DESCRIPTION
## Summary
- Fix ArtifactHub icon errors for flowise, gitea, heimdall, phpmyadmin
- Replace `.ico` files (unsupported format) with PNG/SVG from official repos
- Fix heimdall 404 with correct path

## Test plan
- [ ] CI passes (lint, template, unittest, kubeconform)
- [ ] ArtifactHub stops reporting icon errors after next sync