### PR TITLE
ci: add PGP provenance signing for ArtifactHub verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,6 +148,12 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+      - name: Setup GPG keyring
+        if: steps.semver.outputs.skip != 'true'
+        run: |
+          echo "${{ secrets.GPG_KEYRING }}" | base64 -d > /tmp/secring.gpg
+          echo "GPG keyring imported"
+
       - name: Build Helm dependencies
         if: steps.semver.outputs.skip != 'true'
         run: helm dependency build charts/${{ matrix.chart }}
@@ -163,7 +169,8 @@ jobs:
         if: steps.semver.outputs.skip != 'true'
         id: push
         run: |
-          helm package charts/${{ matrix.chart }} --destination .dist
+          helm package charts/${{ matrix.chart }} --destination .dist \
+            --sign --key "${{ secrets.GPG_KEY_NAME }}" --keyring /tmp/secring.gpg
           for pkg in .dist/*.tgz; do
             echo "Publishing $pkg to OCI"
             PUSH_OUTPUT=$(helm push "$pkg" "$OCI_REGISTRY" 2>&1)
@@ -171,6 +178,14 @@ jobs:
             DIGEST=$(echo "$PUSH_OUTPUT" | grep -oE 'sha256:[a-f0-9]{64}')
             echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           done
+
+      - name: Upload provenance file
+        if: steps.semver.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: provenance-${{ matrix.chart }}
+          path: .dist/*.prov
+          retention-days: 1
 
       - name: Sign OCI artifact with Cosign
         if: steps.semver.outputs.skip != 'true' && steps.push.outputs.digest != ''
@@ -311,6 +326,13 @@ jobs:
       - name: Login to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
 
+      - name: Download provenance files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: provenance-*
+          path: provenance
+          merge-multiple: true
+
       - name: Sync chart packages from OCI
         run: |
           cd gh-pages
@@ -333,6 +355,16 @@ jobs:
 
           echo "Chart packages:"
           ls -1 *.tgz 2>/dev/null || echo "none"
+
+      - name: Copy provenance files
+        run: |
+          if ls provenance/*.prov 1>/dev/null 2>&1; then
+            cp provenance/*.prov gh-pages/
+            echo "Copied provenance files:"
+            ls -1 gh-pages/*.prov 2>/dev/null | wc -l
+          else
+            echo "No provenance files to copy"
+          fi
 
       - name: Sync artifacthub-repo.yml
         run: |
@@ -361,6 +393,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add index.yaml 2>/dev/null || true
           git add *.tgz 2>/dev/null || true
+          git add *.prov 2>/dev/null || true
           git add artifacthub-repo.yml 2>/dev/null || true
           git diff --cached --quiet && echo "No changes to index, skip" || {
             git commit -m "ci: update helm repo index [skip ci]"

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -25,6 +25,9 @@ icon: https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/client/pu
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -23,6 +23,9 @@ icon: https://answer.apache.org/img/logo.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -25,6 +25,9 @@ sources:
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -24,6 +24,9 @@ icon: https://www.authelia.com/images/branding/logo-cropped.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: security

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -23,6 +23,9 @@ icon: https://www.vectorlogo.zone/logos/cloudflare/cloudflare-icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -24,6 +24,9 @@ sources:
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -31,6 +31,9 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/docmost
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -25,6 +25,9 @@ annotations:
   artifacthub.io/category: integration-delivery
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -32,6 +32,9 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/flowise
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -11,6 +11,9 @@ kubeVersion: ">=1.26.0-0"
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -29,6 +29,9 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/gitea
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -26,6 +26,9 @@ icon: https://raw.githubusercontent.com/apache/guacamole-website/main/images/log
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -25,6 +25,9 @@ annotations:
   artifacthub.io/category: skip-prediction
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -28,6 +28,9 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/homarr
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://kafka.apache.org/images/apache-kafka.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -17,6 +17,9 @@ maintainers:
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: security

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -23,6 +23,9 @@ icon: https://komga.org/img/logo.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: storage

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -20,6 +20,9 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/mariadb/logo.
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -25,6 +25,9 @@ icon: https://www.vectorlogo.zone/logos/minecraft/minecraft-icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://www.vectorlogo.zone/logos/mongodb/mongodb-icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -24,6 +24,9 @@ annotations:
   artifacthub.io/category: streaming-messaging
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -20,6 +20,9 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/mysql/logo.pn
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://raw.githubusercontent.com/n8n-io/n8n/master/assets/n8n-logo.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -26,6 +26,9 @@ annotations:
   artifacthub.io/category: database
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -23,6 +23,9 @@ icon: https://pi-hole.net/wp-content/uploads/2016/12/Vortex-R.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: networking

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -21,6 +21,9 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/postgres/logo
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://raw.githubusercontent.com/rabbitmq/rabbitmq-website/main/static/im
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://raw.githubusercontent.com/docker-library/docs/master/redis/logo.pn
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -23,6 +23,9 @@ icon: https://raw.githubusercontent.com/strapi/strapi/main/packages/core/admin/a
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://uptime.kuma.pet/img/icon.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -21,6 +21,9 @@ icon: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/v
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: security

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://velero.io/img/Velero.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: storage

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://s.w.org/style/images/about/WordPress-logotype-simplified.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery


### PR DESCRIPTION
## Summary
- Add PGP signing to the publish workflow (`helm package --sign`) so charts include `.prov` provenance files
- Upload provenance files as artifacts and copy them to gh-pages for repository-based verification
- Add `artifacthub.io/signKey` annotation (fingerprint + public key URL) to all 33 Chart.yaml files
- Public key served at `https://repo.helmforge.dev/pgp-public-key.asc`

## Details
ArtifactHub requires PGP provenance (`.prov` files) alongside chart packages to display the "Signed" badge. Cosign signing alone is not recognized by ArtifactHub's verification.

New secrets required (already configured):
- `GPG_KEYRING` — base64-encoded GPG secret keyring
- `GPG_KEY_NAME` — GPG key identity for signing

## Test plan
- [ ] Verify publish workflow succeeds with GPG signing on next chart change
- [ ] Confirm `.prov` files appear in gh-pages alongside `.tgz` packages
- [ ] Verify ArtifactHub shows "Signed" badge after next sync