### PR TITLE
fix(generic): whitelist placeholder image for ArtifactHub scanning

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -12,6 +12,8 @@ annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/imagesWhitelist: |
+    - container.registry.io/project/image:latest
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |


### PR DESCRIPTION
## Summary
- Add `artifacthub.io/imagesWhitelist` annotation to the generic chart to suppress scanning errors
- The generic chart uses `container.registry.io/project/image` as a placeholder — ArtifactHub's Trivy scanner fails because this registry doesn't exist
- Whitelisting tells ArtifactHub to skip vulnerability scanning for this placeholder image

## Test plan
- [ ] Verify ArtifactHub scanning errors stop after next sync