### PR TITLE
feat: add phase 1 charts — umami, metabase, liwan, wallabag, strava-statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 | [gitea](charts/gitea/) | stable | Gitea — self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH, and S3 backup |
 | [homarr](charts/homarr/) | stable | Homarr — modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup |
 | [mariadb](charts/mariadb/) | stable | MariaDB — standalone or GTID-based replication with TLS, metrics, configuration presets, and S3 backup |
+| [umami](charts/umami/) | alpha | Umami — privacy-focused web analytics with PostgreSQL and auto-generated app secret |
+| [metabase](charts/metabase/) | alpha | Metabase — open-source business intelligence and analytics with PostgreSQL and JVM tuning |
+| [liwan](charts/liwan/) | alpha | Liwan — ultra-lightweight privacy-first web analytics with embedded DuckDB |
+| [wallabag](charts/wallabag/) | alpha | Wallabag — self-hosted read-it-later with PostgreSQL, optional Redis, and Symfony configuration |
+| [strava-statistics](charts/strava-statistics/) | alpha | Statistics for Strava — self-hosted fitness dashboard with SQLite and Strava OAuth |
 
 ### Maturity levels
 

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: liwan
+description: Liwan ultra-lightweight privacy-first web analytics with embedded DuckDB
+type: application
+version: 0.1.0
+appVersion: "1.4.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - analytics
+  - web-analytics
+  - privacy
+  - liwan
+  - duckdb
+  - self-hosted
+home: https://liwan.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/explodingcamera/liwan
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/liwan
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/liwan

--- a/charts/liwan/README.md
+++ b/charts/liwan/README.md
@@ -1,0 +1,80 @@
+# Liwan Helm Chart
+
+Deploy [Liwan](https://liwan.dev) on Kubernetes using the official [ghcr.io/explodingcamera/liwan](https://github.com/explodingcamera/liwan/pkgs/container/liwan) container image. Ultra-lightweight privacy-first web analytics written in Rust with embedded DuckDB — runs on minimal resources with zero external dependencies.
+
+## Features
+
+- **Ultra-lightweight** — single Rust binary, minimal CPU and memory usage
+- **Zero dependencies** — DuckDB embedded, no external database needed
+- **Privacy-first** — no cookies, no personal data collection
+- **Non-root** — runs as UID 1000 by default
+- **Persistent storage** — DuckDB database and GeoIP data on PVC
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install liwan helmforge/liwan -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install liwan oci://ghcr.io/helmforgedev/helm/liwan -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml — default values are sufficient
+# DuckDB embedded, no database needed
+```
+
+After deploying:
+
+```bash
+kubectl port-forward svc/<release>-liwan 9042:80
+# Open http://localhost:9042
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `liwan.port` | `9042` | Application port |
+| `liwan.baseUrl` | `""` | Public base URL |
+| `persistence.enabled` | `true` | Enable persistence for /data |
+| `persistence.size` | `2Gi` | PVC size |
+| `ingress.enabled` | `false` | Enable ingress |
+| `service.port` | `80` | Service port |
+
+## Limitations
+
+- **Single instance only** — DuckDB is single-writer, horizontal scaling is not supported
+- **ReadWriteOnce** — PVC must be ReadWriteOnce due to DuckDB limitations
+
+## More Information
+
+- [Liwan documentation](https://liwan.dev)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/liwan)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Liwan Helm Chart
+description: README for the Liwan ultra-lightweight web analytics Helm chart
+
+keywords: liwan, analytics, privacy, duckdb, lightweight, rust
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/liwan/values.yaml
+path: charts/liwan/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/liwan/ci/default-values.yaml
+++ b/charts/liwan/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default values with embedded DuckDB

--- a/charts/liwan/ci/ingress-values.yaml
+++ b/charts/liwan/ci/ingress-values.yaml
@@ -1,0 +1,18 @@
+# CI: ingress enabled
+liwan:
+  baseUrl: "https://analytics.example.com"
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: analytics.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - analytics.example.com
+      secretName: liwan-tls

--- a/charts/liwan/templates/_helpers.tpl
+++ b/charts/liwan/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{- define "liwan.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liwan.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "liwan.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "liwan.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "liwan.labels" -}}
+helm.sh/chart: {{ include "liwan.chart" . }}
+{{ include "liwan.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "liwan.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "liwan.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "liwan.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "liwan.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "liwan.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Data PVC claim name */}}
+{{- define "liwan.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "liwan.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/liwan/templates/deployment.yaml
+++ b/charts/liwan/templates/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "liwan.fullname" . }}
+  labels:
+    {{- include "liwan.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "liwan.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "liwan.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "liwan.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: liwan
+          image: {{ include "liwan.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.liwan.port }}
+              protocol: TCP
+          env:
+            {{- with .Values.liwan.baseUrl }}
+            - name: LIWAN_BASE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.liwan.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "liwan.dataClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/liwan/templates/extra-manifests.yaml
+++ b/charts/liwan/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/liwan/templates/ingress.yaml
+++ b/charts/liwan/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "liwan.fullname" . }}
+  labels:
+    {{- include "liwan.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "liwan.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/liwan/templates/pvc.yaml
+++ b/charts/liwan/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "liwan.dataClaimName" . }}
+  labels:
+    {{- include "liwan.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/liwan/templates/service.yaml
+++ b/charts/liwan/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "liwan.fullname" . }}
+  labels:
+    {{- include "liwan.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "liwan.selectorLabels" . | nindent 4 }}

--- a/charts/liwan/templates/serviceaccount.yaml
+++ b/charts/liwan/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "liwan.serviceAccountName" . }}
+  labels:
+    {{- include "liwan.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/liwan/tests/deployment_test.yaml
+++ b/charts/liwan/tests/deployment_test.yaml
@@ -1,0 +1,84 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-liwan
+
+  - it: should use Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/explodingcamera/liwan:1.4.0"
+
+  - it: should run as non-root UID 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should mount data volume
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+
+  - it: should use PVC for data when persistence enabled
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: test-liwan-data
+
+  - it: should use emptyDir when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+
+  - it: should use TCP probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+
+  - it: should set base URL when configured
+    set:
+      liwan.baseUrl: "https://analytics.example.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LIWAN_BASE_URL
+            value: "https://analytics.example.com"
+
+  - it: should not have init containers
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers

--- a/charts/liwan/tests/ingress_test.yaml
+++ b/charts/liwan/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: analytics.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/liwan/tests/pvc_test.yaml
+++ b/charts/liwan/tests/pvc_test.yaml
@@ -1,0 +1,34 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render PVC by default
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-liwan-data
+
+  - it: should not render when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when existingClaim is set
+    set:
+      persistence.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set storage size
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 2Gi

--- a/charts/liwan/tests/service_test.yaml
+++ b/charts/liwan/tests/service_test.yaml
@@ -1,0 +1,24 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-liwan
+
+  - it: should use port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP

--- a/charts/liwan/values.schema.json
+++ b/charts/liwan/values.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Liwan Helm Chart Values",
+  "description": "Values for the Liwan Helm chart — ultra-lightweight privacy-first web analytics with embedded DuckDB",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "ghcr.io/explodingcamera/liwan" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "liwan": {
+      "type": "object",
+      "description": "Liwan application configuration",
+      "properties": {
+        "port": { "type": "integer", "description": "Application port", "default": 9042 },
+        "baseUrl": { "type": "string", "description": "Public base URL of the instance", "default": "" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Persistence for /data (DuckDB database + GeoIP)",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "2Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
+  }
+}

--- a/charts/liwan/values.yaml
+++ b/charts/liwan/values.yaml
@@ -1,0 +1,160 @@
+# =============================================================================
+# Liwan Helm Chart — Default Values
+# =============================================================================
+# Focus: ultra-lightweight privacy-first web analytics with embedded DuckDB
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Liwan container image
+  repository: ghcr.io/explodingcamera/liwan
+  # -- Image tag (defaults to appVersion)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Liwan Configuration
+# =============================================================================
+
+liwan:
+  # -- Application port
+  port: 9042
+  # -- Public base URL of the instance
+  baseUrl: ""
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for /data (DuckDB database + GeoIP)
+  enabled: true
+  # -- Storage size
+  size: 2Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Liwan
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: analytics.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - analytics.example.com
+    #   secretName: liwan-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []

--- a/charts/metabase/Chart.lock
+++ b/charts/metabase/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.2
+digest: sha256:0af1bb574d775d97a45f8237d030e20e8ab690afb34bc7383ef514de341c999f
+generated: "2026-04-01T15:56:12.2654359-03:00"

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: metabase
+description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
+type: application
+version: 0.1.0
+appVersion: "0.54.5"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - metabase
+  - bi
+  - analytics
+  - dashboard
+  - visualization
+  - self-hosted
+home: https://www.metabase.com
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/metabase/metabase
+icon: https://www.metabase.com/images/logo.svg
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/metabase
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/metabase
+dependencies:
+  - name: postgresql
+    version: 1.8.2
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -1,0 +1,105 @@
+# Metabase Helm Chart
+
+Deploy [Metabase](https://www.metabase.com) on Kubernetes using the official [metabase/metabase](https://hub.docker.com/r/metabase/metabase) Docker image. Open-source BI platform with visual data exploration, SQL editor, and shareable dashboards connecting to 60+ databases.
+
+## Features
+
+- **Visual data exploration** — point-and-click queries, no SQL required
+- **SQL editor** — native SQL with autocomplete and snippets
+- **60+ database connectors** — PostgreSQL, MySQL, BigQuery, Redshift, and more
+- **PostgreSQL metadata store** — bundled subchart or external database
+- **Auto-generated encryption key** — protects saved database credentials
+- **JVM tuning** — configurable JAVA_OPTS for memory optimization
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install metabase helmforge/metabase -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install metabase oci://ghcr.io/helmforgedev/helm/metabase -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml — default values deploy with bundled PostgreSQL
+# No configuration needed for a basic setup
+```
+
+After deploying, access Metabase:
+
+```bash
+kubectl port-forward svc/<release>-metabase 3000:80
+# Open http://localhost:3000 to complete the setup wizard
+```
+
+## External Database
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    name: metabase
+    username: metabase
+    existingSecret: metabase-db-credentials
+```
+
+## JVM Tuning
+
+```yaml
+metabase:
+  javaOpts: "-Xmx2g -Xms1g"
+
+resources:
+  requests:
+    memory: 2Gi
+  limits:
+    memory: 3Gi
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `metabase.port` | `3000` | Application port |
+| `metabase.encryptionSecretKey` | `""` | Encryption key (auto-generated) |
+| `metabase.siteUrl` | `""` | Public site URL |
+| `metabase.javaTimezone` | `UTC` | Java timezone |
+| `metabase.javaOpts` | `""` | JVM memory options |
+| `postgresql.enabled` | `true` | Deploy PostgreSQL subchart |
+| `ingress.enabled` | `false` | Enable ingress |
+| `service.port` | `80` | Service port |
+
+## More Information
+
+- [Metabase documentation](https://www.metabase.com/docs/latest/)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/metabase)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Metabase Helm Chart
+description: README for the Metabase open-source BI platform Helm chart
+
+keywords: metabase, bi, analytics, dashboard, visualization, postgresql
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/metabase/values.yaml
+path: charts/metabase/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/metabase/ci/default-values.yaml
+++ b/charts/metabase/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default PostgreSQL subchart mode

--- a/charts/metabase/ci/external-db-values.yaml
+++ b/charts/metabase/ci/external-db-values.yaml
@@ -1,0 +1,11 @@
+# CI: external PostgreSQL database
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: db.example.com
+    port: "5432"
+    name: metabase
+    username: metabase_user
+    password: "ci-password"

--- a/charts/metabase/ci/ingress-values.yaml
+++ b/charts/metabase/ci/ingress-values.yaml
@@ -1,0 +1,15 @@
+# CI: ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: metabase.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - metabase.example.com
+      secretName: metabase-tls

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -1,0 +1,120 @@
+{{- define "metabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "metabase.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "metabase.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "metabase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "metabase.labels" -}}
+helm.sh/chart: {{ include "metabase.chart" . }}
+{{ include "metabase.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "metabase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metabase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "metabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "metabase.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "metabase.image" -}}
+{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Database host */}}
+{{- define "metabase.dbHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- else -}}
+{{- .Values.database.external.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database port */}}
+{{- define "metabase.dbPort" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- "5432" -}}
+{{- else -}}
+{{- .Values.database.external.port | default "5432" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database name */}}
+{{- define "metabase.dbName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.database | default "metabase" -}}
+{{- else -}}
+{{- .Values.database.external.name | default "metabase" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database username */}}
+{{- define "metabase.dbUsername" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.username | default "metabase" -}}
+{{- else -}}
+{{- .Values.database.external.username | default "metabase" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret name for password */}}
+{{- define "metabase.dbSecretName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- printf "%s-db" (include "metabase.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret password key */}}
+{{- define "metabase.dbSecretPasswordKey" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- "user-password" -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "password" -}}
+{{- else -}}
+{{- "password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Encryption secret name */}}
+{{- define "metabase.encryptionSecretName" -}}
+{{- if .Values.metabase.existingSecret -}}
+{{- .Values.metabase.existingSecret -}}
+{{- else -}}
+{{- printf "%s-app" (include "metabase.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Encryption secret key */}}
+{{- define "metabase.encryptionSecretKey" -}}
+{{- if .Values.metabase.existingSecret -}}
+{{- .Values.metabase.existingSecretKey | default "encryption-secret-key" -}}
+{{- else -}}
+{{- "encryption-secret-key" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -1,0 +1,159 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "metabase.fullname" . }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "metabase.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "metabase.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "metabase.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for database at {{ include "metabase.dbHost" . }}:{{ include "metabase.dbPort" . }}..."
+              until nc -z -w2 {{ include "metabase.dbHost" . }} {{ include "metabase.dbPort" . }}; do
+                echo "Database not ready, retrying in 2s..."
+                sleep 2
+              done
+              echo "Database is ready."
+      containers:
+        - name: metabase
+          image: {{ include "metabase.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.metabase.port }}
+              protocol: TCP
+          env:
+            - name: MB_DB_TYPE
+              value: postgres
+            - name: MB_DB_HOST
+              value: {{ include "metabase.dbHost" . | quote }}
+            - name: MB_DB_PORT
+              value: {{ include "metabase.dbPort" . | quote }}
+            - name: MB_DB_DBNAME
+              value: {{ include "metabase.dbName" . | quote }}
+            - name: MB_DB_USER
+              value: {{ include "metabase.dbUsername" . | quote }}
+            - name: MB_DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "metabase.dbSecretName" . }}
+                  key: {{ include "metabase.dbSecretPasswordKey" . }}
+            - name: MB_JETTY_PORT
+              value: {{ .Values.metabase.port | quote }}
+            - name: MB_ENCRYPTION_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "metabase.encryptionSecretName" . }}
+                  key: {{ include "metabase.encryptionSecretKey" . }}
+            {{- with .Values.metabase.siteUrl }}
+            - name: MB_SITE_URL
+              value: {{ . | quote }}
+            {{- end }}
+            - name: JAVA_TIMEZONE
+              value: {{ .Values.metabase.javaTimezone | quote }}
+            {{- with .Values.metabase.javaOpts }}
+            - name: JAVA_OPTS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.metabase.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/metabase/templates/extra-manifests.yaml
+++ b/charts/metabase/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "metabase.fullname" . }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "metabase.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/metabase/templates/secret.yaml
+++ b/charts/metabase/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.metabase.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-app" (include "metabase.fullname" .) }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  encryption-secret-key: {{ .Values.metabase.encryptionSecretKey | default (randAlphaNum 32) | quote }}
+{{- end }}
+---
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) .Values.database.external.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-db" (include "metabase.fullname" .) }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.database.external.password | quote }}
+{{- end }}

--- a/charts/metabase/templates/service.yaml
+++ b/charts/metabase/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "metabase.fullname" . }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "metabase.selectorLabels" . | nindent 4 }}

--- a/charts/metabase/templates/serviceaccount.yaml
+++ b/charts/metabase/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metabase.serviceAccountName" . }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -1,0 +1,139 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-metabase
+
+  - it: should use RollingUpdate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "metabase/metabase:v0.54.5"
+
+  - it: should set custom image tag
+    set:
+      image.tag: "v0.53.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "metabase/metabase:v0.53.0"
+
+  - it: should set PostgreSQL env vars with subchart
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_TYPE
+            value: postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_HOST
+            value: test-postgresql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_DBNAME
+            value: metabase
+
+  - it: should reference postgresql subchart secret for DB password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: test-postgresql-auth
+                key: user-password
+
+  - it: should reference app secret for encryption key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_ENCRYPTION_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-metabase-app
+                key: encryption-secret-key
+
+  - it: should have wait-for-db init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+
+  - it: should set external database host when subchart is disabled
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.port: "5433"
+      database.external.name: my_metabase
+      database.external.username: mb_user
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_HOST
+            value: db.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_PORT
+            value: "5433"
+
+  - it: should set probes on health path
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/health
+
+  - it: should set JAVA_OPTS
+    set:
+      metabase.javaOpts: "-Xmx2g"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: "-Xmx2g"
+
+  - it: should set site URL
+    set:
+      metabase.siteUrl: "https://metabase.example.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_SITE_URL
+            value: "https://metabase.example.com"
+
+  - it: should set resources
+    set:
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 500m

--- a/charts/metabase/tests/ingress_test.yaml
+++ b/charts/metabase/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: metabase.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/metabase/tests/secret_test.yaml
+++ b/charts/metabase/tests/secret_test.yaml
@@ -1,0 +1,37 @@
+suite: Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render app secret by default
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-metabase-app
+        documentIndex: 0
+
+  - it: should not render app secret when existingSecret is set
+    set:
+      metabase.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render db secret for external db with inline password
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.password: "my-password"
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-metabase-db
+        documentIndex: 1

--- a/charts/metabase/tests/service_test.yaml
+++ b/charts/metabase/tests/service_test.yaml
@@ -1,0 +1,30 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-metabase
+
+  - it: should use ClusterIP by default
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should use port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP

--- a/charts/metabase/tests/serviceaccount_test.yaml
+++ b/charts/metabase/tests/serviceaccount_test.yaml
@@ -1,0 +1,21 @@
+suite: ServiceAccount
+templates:
+  - templates/serviceaccount.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: test-metabase

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Metabase Helm Chart Values",
+  "description": "Values for the Metabase Helm chart — open-source BI platform with PostgreSQL metadata store",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "description": "Override the chart name", "default": "" },
+    "fullnameOverride": { "type": "string", "description": "Override the full release name", "default": "" },
+    "commonLabels": { "type": "object", "description": "Labels added to every resource" },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration",
+      "properties": {
+        "repository": { "type": "string", "default": "metabase/metabase" },
+        "tag": { "type": "string", "description": "Image tag (defaults to v{appVersion})", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "metabase": {
+      "type": "object",
+      "description": "Metabase application configuration",
+      "properties": {
+        "port": { "type": "integer", "description": "Application port", "default": 3000 },
+        "encryptionSecretKey": { "type": "string", "description": "Encryption secret key (auto-generated if empty)", "default": "" },
+        "existingSecret": { "type": "string", "description": "Existing secret containing the encryption key", "default": "" },
+        "existingSecretKey": { "type": "string", "default": "encryption-secret-key" },
+        "siteUrl": { "type": "string", "description": "Public site URL", "default": "" },
+        "javaTimezone": { "type": "string", "description": "Java timezone", "default": "UTC" },
+        "javaOpts": { "type": "string", "description": "JVM options for memory tuning", "default": "" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "External database configuration",
+      "properties": {
+        "external": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string", "default": "" },
+            "port": { "type": ["string", "integer"], "default": "5432" },
+            "name": { "type": "string", "default": "metabase" },
+            "username": { "type": "string", "default": "metabase" },
+            "password": { "type": "string", "default": "" },
+            "existingSecret": { "type": "string", "default": "" },
+            "existingSecretPasswordKey": { "type": "string", "default": "password" }
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "description": "Health probe configuration",
+      "properties": {
+        "startup": { "type": "object" },
+        "liveness": { "type": "object" },
+        "readiness": { "type": "object" }
+      }
+    },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "postgresql": {
+      "type": "object",
+      "description": "PostgreSQL subchart configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "architecture": { "type": "string", "default": "standalone" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "database": { "type": "string", "default": "metabase" },
+            "username": { "type": "string", "default": "metabase" },
+            "password": { "type": "string", "default": "" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -1,0 +1,189 @@
+# =============================================================================
+# Metabase Helm Chart — Default Values
+# =============================================================================
+# Focus: open-source BI platform with PostgreSQL metadata store
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Metabase container image
+  repository: metabase/metabase
+  # -- Image tag (defaults to v{appVersion})
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Metabase Configuration
+# =============================================================================
+
+metabase:
+  # -- Application port
+  port: 3000
+  # -- Encryption secret key for saved credentials (auto-generated if empty)
+  encryptionSecretKey: ""
+  # -- Existing secret containing the encryption key
+  existingSecret: ""
+  # -- Key in the existing secret
+  existingSecretKey: encryption-secret-key
+  # -- Public site URL
+  siteUrl: ""
+  # -- Java timezone
+  javaTimezone: UTC
+  # -- JVM options for memory tuning
+  javaOpts: ""
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+    # - name: MB_SEND_NEW_USER_EMAILS
+    #   value: "false"
+
+# =============================================================================
+# Database
+# =============================================================================
+
+database:
+  # -- External PostgreSQL configuration (used when postgresql subchart is disabled)
+  external:
+    host: ""
+    port: "5432"
+    name: metabase
+    username: metabase
+    password: ""
+    # -- Existing secret containing the database password
+    existingSecret: ""
+    # -- Key in the existing secret containing the password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Metabase
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: metabase.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - metabase.example.com
+    #   secretName: metabase-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    path: /api/health
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    path: /api/health
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /api/health
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []
+
+# =============================================================================
+# Subcharts
+# =============================================================================
+
+postgresql:
+  # -- Deploy PostgreSQL as a subchart
+  enabled: true
+  architecture: standalone
+  auth:
+    database: metabase
+    username: metabase
+    # -- PostgreSQL password (auto-generated if empty)
+    password: ""
+  initdb:
+    scripts:
+      02-extensions.sql: |
+        CREATE EXTENSION IF NOT EXISTS citext;

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -1,0 +1,37 @@
+apiVersion: v2
+name: strava-statistics
+description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
+type: application
+version: 0.1.0
+appVersion: "4.7.5"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - strava
+  - fitness
+  - statistics
+  - dashboard
+  - cycling
+  - running
+  - self-hosted
+home: https://github.com/robiningelbrecht/strava-statistics
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/robiningelbrecht/strava-statistics
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/strava-statistics
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -1,0 +1,97 @@
+# Statistics for Strava Helm Chart
+
+Deploy [Statistics for Strava](https://github.com/robiningelbrecht/strava-statistics) on Kubernetes using the official [robiningelbrecht/strava-statistics](https://hub.docker.com/r/robiningelbrecht/strava-statistics) container image. Self-hosted fitness dashboard that visualizes your Strava activities with beautiful statistics, powered by SQLite.
+
+## Features
+
+- **Strava OAuth** — connects to your Strava account via OAuth credentials
+- **SQLite embedded** — no external database needed
+- **Persistent storage** — SQLite database and files on PVC
+- **Timezone support** — configurable timezone for activity display
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install strava-statistics helmforge/strava-statistics -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install strava-statistics oci://ghcr.io/helmforgedev/helm/strava-statistics -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml
+strava:
+  clientId: "YOUR_STRAVA_CLIENT_ID"
+  clientSecret: "YOUR_STRAVA_CLIENT_SECRET"
+  refreshToken: "YOUR_STRAVA_REFRESH_TOKEN"
+```
+
+After deploying:
+
+```bash
+kubectl port-forward svc/<release>-strava-statistics 8080:80
+# Open http://localhost:8080
+```
+
+## Using an Existing Secret
+
+```yaml
+strava:
+  existingSecret: my-strava-secret
+  existingSecretClientIdKey: client-id
+  existingSecretClientSecretKey: client-secret
+  existingSecretRefreshTokenKey: refresh-token
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `strava.port` | `8080` | Application port |
+| `strava.clientId` | `""` | Strava OAuth Client ID |
+| `strava.clientSecret` | `""` | Strava OAuth Client Secret |
+| `strava.refreshToken` | `""` | Strava Refresh Token |
+| `strava.existingSecret` | `""` | Use existing secret for credentials |
+| `strava.timezone` | `UTC` | Timezone |
+| `persistence.enabled` | `true` | Enable persistence for /data |
+| `persistence.size` | `2Gi` | PVC size |
+| `ingress.enabled` | `false` | Enable ingress |
+| `service.port` | `80` | Service port |
+
+## Limitations
+
+- **Single instance only** — SQLite is single-writer, horizontal scaling is not supported
+- **ReadWriteOnce** — PVC must be ReadWriteOnce due to SQLite limitations
+- **Strava API** — requires valid Strava OAuth credentials to fetch activity data
+
+## More Information
+
+- [Statistics for Strava documentation](https://github.com/robiningelbrecht/strava-statistics)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Statistics for Strava Helm Chart
+description: README for the Statistics for Strava fitness dashboard Helm chart
+
+keywords: strava, fitness, statistics, dashboard, cycling, running, sqlite
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/strava-statistics/values.yaml
+path: charts/strava-statistics/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/strava-statistics/ci/default-values.yaml
+++ b/charts/strava-statistics/ci/default-values.yaml
@@ -1,0 +1,5 @@
+# CI: default values with mock Strava credentials
+strava:
+  clientId: "12345"
+  clientSecret: "mock-client-secret"
+  refreshToken: "mock-refresh-token"

--- a/charts/strava-statistics/ci/ingress-values.yaml
+++ b/charts/strava-statistics/ci/ingress-values.yaml
@@ -1,0 +1,20 @@
+# CI: ingress enabled with Strava credentials
+strava:
+  clientId: "12345"
+  clientSecret: "mock-client-secret"
+  refreshToken: "mock-refresh-token"
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: strava.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - strava.example.com
+      secretName: strava-tls

--- a/charts/strava-statistics/templates/_helpers.tpl
+++ b/charts/strava-statistics/templates/_helpers.tpl
@@ -1,0 +1,87 @@
+{{- define "strava-statistics.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "strava-statistics.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "strava-statistics.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "strava-statistics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "strava-statistics.labels" -}}
+helm.sh/chart: {{ include "strava-statistics.chart" . }}
+{{ include "strava-statistics.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "strava-statistics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "strava-statistics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "strava-statistics.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "strava-statistics.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "strava-statistics.image" -}}
+{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Strava secret name */}}
+{{- define "strava-statistics.secretName" -}}
+{{- if .Values.strava.existingSecret -}}
+{{- .Values.strava.existingSecret -}}
+{{- else -}}
+{{- printf "%s-strava" (include "strava-statistics.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Strava secret keys */}}
+{{- define "strava-statistics.clientIdKey" -}}
+{{- if .Values.strava.existingSecret -}}
+{{- .Values.strava.existingSecretClientIdKey | default "client-id" -}}
+{{- else -}}
+{{- "client-id" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "strava-statistics.clientSecretKey" -}}
+{{- if .Values.strava.existingSecret -}}
+{{- .Values.strava.existingSecretClientSecretKey | default "client-secret" -}}
+{{- else -}}
+{{- "client-secret" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "strava-statistics.refreshTokenKey" -}}
+{{- if .Values.strava.existingSecret -}}
+{{- .Values.strava.existingSecretRefreshTokenKey | default "refresh-token" -}}
+{{- else -}}
+{{- "refresh-token" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Data PVC claim name */}}
+{{- define "strava-statistics.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "strava-statistics.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/strava-statistics/templates/deployment.yaml
+++ b/charts/strava-statistics/templates/deployment.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "strava-statistics.fullname" . }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "strava-statistics.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "strava-statistics.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "strava-statistics.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: strava-statistics
+          image: {{ include "strava-statistics.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.strava.port }}
+              protocol: TCP
+          env:
+            - name: STRAVA_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "strava-statistics.secretName" . }}
+                  key: {{ include "strava-statistics.clientIdKey" . }}
+            - name: STRAVA_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "strava-statistics.secretName" . }}
+                  key: {{ include "strava-statistics.clientSecretKey" . }}
+            - name: STRAVA_REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "strava-statistics.secretName" . }}
+                  key: {{ include "strava-statistics.refreshTokenKey" . }}
+            - name: TZ
+              value: {{ .Values.strava.timezone | quote }}
+            {{- with .Values.strava.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "strava-statistics.dataClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/strava-statistics/templates/extra-manifests.yaml
+++ b/charts/strava-statistics/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/strava-statistics/templates/ingress.yaml
+++ b/charts/strava-statistics/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "strava-statistics.fullname" . }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "strava-statistics.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/strava-statistics/templates/pvc.yaml
+++ b/charts/strava-statistics/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "strava-statistics.dataClaimName" . }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/strava-statistics/templates/secret.yaml
+++ b/charts/strava-statistics/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.strava.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-strava" (include "strava-statistics.fullname" .) }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  client-id: {{ .Values.strava.clientId | quote }}
+  client-secret: {{ .Values.strava.clientSecret | quote }}
+  refresh-token: {{ .Values.strava.refreshToken | quote }}
+{{- end }}

--- a/charts/strava-statistics/templates/service.yaml
+++ b/charts/strava-statistics/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "strava-statistics.fullname" . }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "strava-statistics.selectorLabels" . | nindent 4 }}

--- a/charts/strava-statistics/templates/serviceaccount.yaml
+++ b/charts/strava-statistics/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "strava-statistics.serviceAccountName" . }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -1,0 +1,141 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-strava-statistics
+
+  - it: should use Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "robiningelbrecht/strava-statistics:v4.7.5"
+
+  - it: should allow custom image tag
+    set:
+      image.tag: "v4.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "robiningelbrecht/strava-statistics:v4.0.0"
+
+  - it: should set Strava env vars from secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRAVA_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: test-strava-statistics-strava
+                key: client-id
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRAVA_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-strava-statistics-strava
+                key: client-secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRAVA_REFRESH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: test-strava-statistics-strava
+                key: refresh-token
+
+  - it: should use existing secret when configured
+    set:
+      strava.existingSecret: my-strava-secret
+      strava.existingSecretClientIdKey: my-id
+      strava.existingSecretClientSecretKey: my-secret
+      strava.existingSecretRefreshTokenKey: my-token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRAVA_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-strava-secret
+                key: my-id
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STRAVA_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-strava-secret
+                key: my-secret
+
+  - it: should set timezone
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TZ
+            value: "UTC"
+
+  - it: should mount data volume
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+
+  - it: should use PVC for data when persistence enabled
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: test-strava-statistics-data
+
+  - it: should use emptyDir when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+
+  - it: should use TCP probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: http
+
+  - it: should set container port
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8080
+            protocol: TCP
+
+  - it: should not have init containers
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers

--- a/charts/strava-statistics/tests/ingress_test.yaml
+++ b/charts/strava-statistics/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: strava.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/strava-statistics/tests/pvc_test.yaml
+++ b/charts/strava-statistics/tests/pvc_test.yaml
@@ -1,0 +1,34 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render PVC by default
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-strava-statistics-data
+
+  - it: should not render when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when existingClaim is set
+    set:
+      persistence.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set storage size
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 2Gi

--- a/charts/strava-statistics/tests/secret_test.yaml
+++ b/charts/strava-statistics/tests/secret_test.yaml
@@ -1,0 +1,21 @@
+suite: Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render secret by default
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-strava-statistics-strava
+
+  - it: should not render when existingSecret is set
+    set:
+      strava.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/strava-statistics/tests/service_test.yaml
+++ b/charts/strava-statistics/tests/service_test.yaml
@@ -1,0 +1,24 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-strava-statistics
+
+  - it: should use port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Statistics for Strava Helm Chart Values",
+  "description": "Values for the Statistics for Strava Helm chart — self-hosted fitness dashboard with SQLite and Strava OAuth",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "robiningelbrecht/strava-statistics" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "strava": {
+      "type": "object",
+      "description": "Strava application configuration",
+      "properties": {
+        "port": { "type": "integer", "description": "Application port", "default": 8080 },
+        "clientId": { "type": "string", "description": "Strava OAuth Client ID", "default": "" },
+        "clientSecret": { "type": "string", "description": "Strava OAuth Client Secret", "default": "" },
+        "refreshToken": { "type": "string", "description": "Strava Refresh Token", "default": "" },
+        "existingSecret": { "type": "string", "description": "Existing secret containing Strava credentials", "default": "" },
+        "existingSecretClientIdKey": { "type": "string", "default": "client-id" },
+        "existingSecretClientSecretKey": { "type": "string", "default": "client-secret" },
+        "existingSecretRefreshTokenKey": { "type": "string", "default": "refresh-token" },
+        "timezone": { "type": "string", "description": "Timezone", "default": "UTC" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Persistence for /data (SQLite database + files)",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "2Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
+  }
+}

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -1,0 +1,170 @@
+# =============================================================================
+# Statistics for Strava Helm Chart — Default Values
+# =============================================================================
+# Focus: self-hosted Strava fitness dashboard with SQLite and OAuth
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Statistics for Strava container image
+  repository: robiningelbrecht/strava-statistics
+  # -- Image tag (defaults to v{appVersion})
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Strava Configuration
+# =============================================================================
+
+strava:
+  # -- Application port
+  port: 8080
+  # -- Strava OAuth Client ID (required)
+  clientId: ""
+  # -- Strava OAuth Client Secret (required)
+  clientSecret: ""
+  # -- Strava Refresh Token (required)
+  refreshToken: ""
+  # -- Existing secret containing Strava credentials
+  existingSecret: ""
+  # -- Key in existing secret for client ID
+  existingSecretClientIdKey: client-id
+  # -- Key in existing secret for client secret
+  existingSecretClientSecretKey: client-secret
+  # -- Key in existing secret for refresh token
+  existingSecretRefreshTokenKey: refresh-token
+  # -- Timezone
+  timezone: UTC
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for /data (SQLite DB + files)
+  enabled: true
+  # -- Storage size
+  size: 2Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Statistics for Strava
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: strava.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - strava.example.com
+    #   secretName: strava-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []

--- a/charts/umami/Chart.lock
+++ b/charts/umami/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.2
+digest: sha256:0af1bb574d775d97a45f8237d030e20e8ab690afb34bc7383ef514de341c999f
+generated: "2026-04-01T15:19:38.8080029-03:00"

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -1,0 +1,41 @@
+apiVersion: v2
+name: umami
+description: Umami privacy-first web analytics with PostgreSQL backend
+type: application
+version: 0.1.0
+appVersion: "2.17.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - analytics
+  - web-analytics
+  - privacy
+  - umami
+  - self-hosted
+home: https://umami.is
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/umami-software/umami
+icon: https://umami.is/images/umami-logo.png
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/umami
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/umami
+dependencies:
+  - name: postgresql
+    version: 1.8.2
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -1,0 +1,91 @@
+# Umami Helm Chart
+
+Deploy [Umami](https://umami.is) on Kubernetes using the official [ghcr.io/umami-software/umami](https://github.com/umami-software/umami/pkgs/container/umami) container image. Privacy-first web analytics — no cookies, GDPR-compliant, lightweight alternative to Google Analytics.
+
+## Features
+
+- **Privacy-first** — no cookies, no personal data collection, GDPR/CCPA compliant
+- **Lightweight** — single Node.js container, minimal resource usage
+- **PostgreSQL backend** — bundled subchart or external database
+- **Auto-generated secrets** — APP_SECRET created automatically
+- **Custom tracker** — configurable tracker script name for ad-blocker bypass
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install umami helmforge/umami -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install umami oci://ghcr.io/helmforgedev/helm/umami -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml — default values deploy with bundled PostgreSQL
+# No configuration needed for a basic setup
+```
+
+After deploying, access Umami:
+
+```bash
+kubectl port-forward svc/<release>-umami 3000:80
+# Open http://localhost:3000
+# Default login: admin / umami
+```
+
+## External Database
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    name: umami
+    username: umami
+    existingSecret: umami-db-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `umami.port` | `3000` | Application port |
+| `umami.appSecret` | `""` | Hash secret (auto-generated) |
+| `umami.disableTelemetry` | `true` | Disable telemetry |
+| `umami.trackerScriptName` | `""` | Custom tracker script name |
+| `postgresql.enabled` | `true` | Deploy PostgreSQL subchart |
+| `ingress.enabled` | `false` | Enable ingress |
+| `service.port` | `80` | Service port |
+
+## More Information
+
+- [Umami documentation](https://umami.is/docs)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/umami)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Umami Helm Chart
+description: README for the Umami privacy-first web analytics Helm chart
+
+keywords: umami, analytics, privacy, web-analytics, postgresql
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/umami/values.yaml
+path: charts/umami/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/umami/ci/default-values.yaml
+++ b/charts/umami/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default PostgreSQL subchart mode

--- a/charts/umami/ci/external-db-values.yaml
+++ b/charts/umami/ci/external-db-values.yaml
@@ -1,0 +1,11 @@
+# CI: external PostgreSQL database
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: db.example.com
+    port: "5432"
+    name: umami
+    username: umami_user
+    password: "ci-password"

--- a/charts/umami/ci/ingress-values.yaml
+++ b/charts/umami/ci/ingress-values.yaml
@@ -1,0 +1,15 @@
+# CI: ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: analytics.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - analytics.example.com
+      secretName: umami-tls

--- a/charts/umami/templates/_helpers.tpl
+++ b/charts/umami/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{- define "umami.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "umami.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "umami.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "umami.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "umami.labels" -}}
+helm.sh/chart: {{ include "umami.chart" . }}
+{{ include "umami.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "umami.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "umami.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "umami.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "umami.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "umami.image" -}}
+{{- $tag := .Values.image.tag | default (printf "postgresql-v%s" .Chart.AppVersion) -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Database host */}}
+{{- define "umami.dbHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- else -}}
+{{- .Values.database.external.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database port */}}
+{{- define "umami.dbPort" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- "5432" -}}
+{{- else -}}
+{{- .Values.database.external.port | default "5432" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database name */}}
+{{- define "umami.dbName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.database | default "umami" -}}
+{{- else -}}
+{{- .Values.database.external.name | default "umami" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database username */}}
+{{- define "umami.dbUsername" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.username | default "umami" -}}
+{{- else -}}
+{{- .Values.database.external.username | default "umami" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret name for password */}}
+{{- define "umami.dbSecretName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- printf "%s-db" (include "umami.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret password key */}}
+{{- define "umami.dbSecretPasswordKey" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- "user-password" -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "password" -}}
+{{- else -}}
+{{- "password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* DATABASE_URL connection string */}}
+{{- define "umami.databaseUrl" -}}
+{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%s/%s" (include "umami.dbUsername" .) (include "umami.dbHost" .) (include "umami.dbPort" .) (include "umami.dbName" .) -}}
+{{- end -}}
+
+{{/* App secret name */}}
+{{- define "umami.appSecretName" -}}
+{{- if .Values.umami.existingSecret -}}
+{{- .Values.umami.existingSecret -}}
+{{- else -}}
+{{- printf "%s-app" (include "umami.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* App secret key */}}
+{{- define "umami.appSecretKey" -}}
+{{- if .Values.umami.existingSecret -}}
+{{- .Values.umami.existingSecretKey | default "app-secret" -}}
+{{- else -}}
+{{- "app-secret" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/umami/templates/deployment.yaml
+++ b/charts/umami/templates/deployment.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "umami.fullname" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "umami.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "umami.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "umami.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for database at {{ include "umami.dbHost" . }}:{{ include "umami.dbPort" . }}..."
+              until nc -z -w2 {{ include "umami.dbHost" . }} {{ include "umami.dbPort" . }}; do
+                echo "Database not ready, retrying in 2s..."
+                sleep 2
+              done
+              echo "Database is ready."
+      containers:
+        - name: umami
+          image: {{ include "umami.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.umami.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.umami.port | quote }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "umami.dbSecretName" . }}
+                  key: {{ include "umami.dbSecretPasswordKey" . }}
+            - name: DATABASE_URL
+              value: {{ include "umami.databaseUrl" . | quote }}
+            - name: APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "umami.appSecretName" . }}
+                  key: {{ include "umami.appSecretKey" . }}
+            {{- if .Values.umami.disableTelemetry }}
+            - name: DISABLE_TELEMETRY
+              value: "1"
+            {{- end }}
+            {{- with .Values.umami.trackerScriptName }}
+            - name: TRACKER_SCRIPT_NAME
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.umami.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/umami/templates/extra-manifests.yaml
+++ b/charts/umami/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/umami/templates/ingress.yaml
+++ b/charts/umami/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "umami.fullname" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "umami.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/umami/templates/secret.yaml
+++ b/charts/umami/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.umami.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-app" (include "umami.fullname" .) }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  app-secret: {{ .Values.umami.appSecret | default (randAlphaNum 32) | quote }}
+{{- end }}
+---
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) .Values.database.external.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-db" (include "umami.fullname" .) }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.database.external.password | quote }}
+{{- end }}

--- a/charts/umami/templates/service.yaml
+++ b/charts/umami/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "umami.fullname" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "umami.selectorLabels" . | nindent 4 }}

--- a/charts/umami/templates/serviceaccount.yaml
+++ b/charts/umami/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "umami.serviceAccountName" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -1,0 +1,174 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-umami
+
+  - it: should use RollingUpdate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: should use 1 replica
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should set the correct image with postgresql variant tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/umami-software/umami:postgresql-v2.17.0"
+
+  - it: should set custom image tag
+    set:
+      image.tag: "postgresql-v2.16.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/umami-software/umami:postgresql-v2.16.0"
+
+  - it: should set default env vars
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORT
+            value: "3000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_TELEMETRY
+            value: "1"
+
+  - it: should set DATABASE_URL with subchart host
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://umami:$(DATABASE_PASSWORD)@test-postgresql:5432/umami"
+
+  - it: should reference postgresql subchart secret for DATABASE_PASSWORD
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-postgresql-auth
+                key: user-password
+
+  - it: should reference app secret for APP_SECRET
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: APP_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-umami-app
+                key: app-secret
+
+  - it: should have wait-for-db init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+
+  - it: should set external database host when subchart is disabled
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.port: "5433"
+      database.external.name: my_umami
+      database.external.username: umami_user
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://umami_user:$(DATABASE_PASSWORD)@db.example.com:5433/my_umami"
+
+  - it: should use existing secret for external db password
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.existingSecret: my-db-secret
+      database.external.existingSecretPasswordKey: db-pass
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: db-pass
+
+  - it: should set probes on heartbeat path
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/heartbeat
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/heartbeat
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/heartbeat
+
+  - it: should set extra env vars
+    set:
+      umami.extraEnv:
+        - name: ALLOWED_FRAME_URLS
+          value: "https://example.com"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOWED_FRAME_URLS
+            value: "https://example.com"
+
+  - it: should set tracker script name
+    set:
+      umami.trackerScriptName: "custom.js"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TRACKER_SCRIPT_NAME
+            value: "custom.js"
+
+  - it: should not set telemetry env when disabled
+    set:
+      umami.disableTelemetry: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_TELEMETRY
+            value: "1"
+
+  - it: should set resources
+    set:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m

--- a/charts/umami/tests/ingress_test.yaml
+++ b/charts/umami/tests/ingress_test.yaml
@@ -1,0 +1,57 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: analytics.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: test-umami
+
+  - it: should set ingressClassName
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: analytics.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should set TLS
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: analytics.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - hosts:
+            - analytics.example.com
+          secretName: umami-tls
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: umami-tls

--- a/charts/umami/tests/secret_test.yaml
+++ b/charts/umami/tests/secret_test.yaml
@@ -1,0 +1,46 @@
+suite: Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render app secret by default
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-umami-app
+        documentIndex: 0
+
+  - it: should not render app secret when existingSecret is set
+    set:
+      umami.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render db secret for external db with inline password
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.password: "my-password"
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-umami-db
+        documentIndex: 1
+
+  - it: should not render db secret when existingSecret is set
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.existingSecret: my-db-secret
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/umami/tests/service_test.yaml
+++ b/charts/umami/tests/service_test.yaml
@@ -1,0 +1,47 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-umami
+
+  - it: should use ClusterIP by default
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should use port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP
+
+  - it: should set custom service type
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should set service annotations
+    set:
+      service.annotations:
+        my-annotation: my-value
+    asserts:
+      - equal:
+          path: metadata.annotations.my-annotation
+          value: my-value

--- a/charts/umami/tests/serviceaccount_test.yaml
+++ b/charts/umami/tests/serviceaccount_test.yaml
@@ -1,0 +1,40 @@
+suite: ServiceAccount
+templates:
+  - templates/serviceaccount.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: test-umami
+
+  - it: should set custom name
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: my-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-sa
+
+  - it: should set annotations
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        iam.gke.io/gcp-service-account: test@project.iam.gserviceaccount.com
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: test@project.iam.gserviceaccount.com

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -1,0 +1,385 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Umami Helm Chart Values",
+  "description": "Values for the Umami Helm chart — privacy-first web analytics with PostgreSQL backend",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full release name used in resource names",
+      "default": ""
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Labels added to every resource created by this chart"
+    },
+    "image": {
+      "type": "object",
+      "description": "Container image configuration",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Umami container image (PostgreSQL variant)",
+          "default": "ghcr.io/umami-software/umami"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag (defaults to postgresql-v{appVersion})",
+          "default": ""
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "default": "IfNotPresent"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for private registries",
+      "items": {
+        "type": "object"
+      }
+    },
+    "umami": {
+      "type": "object",
+      "description": "Umami application configuration",
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "type": "integer",
+          "description": "Application port",
+          "default": 3000
+        },
+        "appSecret": {
+          "type": "string",
+          "description": "Secret used for hashing (auto-generated if empty)",
+          "default": ""
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing secret containing the APP_SECRET key",
+          "default": ""
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "description": "Key in the existing secret",
+          "default": "app-secret"
+        },
+        "disableTelemetry": {
+          "type": "boolean",
+          "description": "Disable telemetry",
+          "default": true
+        },
+        "trackerScriptName": {
+          "type": "string",
+          "description": "Custom tracker script name (for ad-blocker bypass)",
+          "default": ""
+        },
+        "extraEnv": {
+          "type": "array",
+          "description": "Extra environment variables for the container",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "External database configuration",
+      "additionalProperties": false,
+      "properties": {
+        "external": {
+          "type": "object",
+          "description": "External PostgreSQL configuration (used when postgresql subchart is disabled)",
+          "properties": {
+            "host": {
+              "type": "string",
+              "description": "Database host",
+              "default": ""
+            },
+            "port": {
+              "type": ["string", "integer"],
+              "description": "Database port",
+              "default": "5432"
+            },
+            "name": {
+              "type": "string",
+              "description": "Database name",
+              "default": "umami"
+            },
+            "username": {
+              "type": "string",
+              "description": "Database username",
+              "default": "umami"
+            },
+            "password": {
+              "type": "string",
+              "description": "Database password",
+              "default": ""
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing secret containing the database password",
+              "default": ""
+            },
+            "existingSecretPasswordKey": {
+              "type": "string",
+              "description": "Key in the existing secret containing the password",
+              "default": "password"
+            }
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "ServiceAccount configuration",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create a ServiceAccount",
+          "default": false
+        },
+        "name": {
+          "type": "string",
+          "description": "ServiceAccount name",
+          "default": ""
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the ServiceAccount"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "description": "Service configuration",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Service type",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+          "default": "ClusterIP"
+        },
+        "port": {
+          "type": "integer",
+          "description": "HTTP service port",
+          "default": 80
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the Service"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "description": "Ingress configuration for Umami",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress for Umami",
+          "default": false
+        },
+        "ingressClassName": {
+          "type": "string",
+          "description": "Ingress class name (for example: traefik, nginx)",
+          "default": "traefik"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the ingress"
+        },
+        "hosts": {
+          "type": "array",
+          "description": "Ingress hosts",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "description": "Ingress TLS configuration",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": { "type": "array", "items": { "type": "string" } },
+              "secretName": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "description": "Health probe configuration",
+      "additionalProperties": false,
+      "properties": {
+        "startup": {
+          "type": "object",
+          "description": "Startup probe configuration",
+          "properties": {
+            "enabled": { "type": "boolean", "default": true },
+            "path": { "type": "string", "default": "/api/heartbeat" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" }
+          }
+        },
+        "liveness": {
+          "type": "object",
+          "description": "Liveness probe configuration",
+          "properties": {
+            "enabled": { "type": "boolean", "default": true },
+            "path": { "type": "string", "default": "/api/heartbeat" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" }
+          }
+        },
+        "readiness": {
+          "type": "object",
+          "description": "Readiness probe configuration",
+          "properties": {
+            "enabled": { "type": "boolean", "default": true },
+            "path": { "type": "string", "default": "/api/heartbeat" },
+            "initialDelaySeconds": { "type": "integer" },
+            "periodSeconds": { "type": "integer" },
+            "timeoutSeconds": { "type": "integer" },
+            "failureThreshold": { "type": "integer" }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "CPU and memory requests/limits for the main container"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod-level security context"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Container-level security context"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling"
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling",
+      "items": { "type": "object" }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Topology spread constraints",
+      "items": { "type": "object" }
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "Priority class name",
+      "default": ""
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "description": "Grace period for shutdown (seconds)",
+      "default": 30
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels for the pod"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Additional annotations for the pod"
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Additional volumes for the pod",
+      "items": { "type": "object" }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts for the container",
+      "items": { "type": "object" }
+    },
+    "extraManifests": {
+      "type": "array",
+      "description": "Extra Kubernetes manifests to deploy alongside the chart",
+      "items": { "type": "object" }
+    },
+    "postgresql": {
+      "type": "object",
+      "description": "PostgreSQL subchart configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy PostgreSQL as a subchart",
+          "default": true
+        },
+        "architecture": {
+          "type": "string",
+          "description": "PostgreSQL architecture",
+          "default": "standalone"
+        },
+        "auth": {
+          "type": "object",
+          "description": "PostgreSQL authentication configuration",
+          "properties": {
+            "database": { "type": "string", "default": "umami" },
+            "username": { "type": "string", "default": "umami" },
+            "password": {
+              "type": "string",
+              "description": "PostgreSQL password (auto-generated if empty)",
+              "default": ""
+            }
+          }
+        },
+        "initdb": {
+          "type": "object",
+          "description": "Init scripts for PostgreSQL first boot (creates pgcrypto extension)",
+          "properties": {
+            "scripts": {
+              "type": "object",
+              "description": "SQL or shell scripts run during first initialization"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -1,0 +1,187 @@
+# =============================================================================
+# Umami Helm Chart — Default Values
+# =============================================================================
+# Focus: privacy-first web analytics with PostgreSQL backend
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Umami container image (PostgreSQL variant)
+  repository: ghcr.io/umami-software/umami
+  # -- Image tag (defaults to postgresql-v{appVersion})
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Umami Configuration
+# =============================================================================
+
+umami:
+  # -- Application port
+  port: 3000
+  # -- Secret used for hashing (auto-generated if empty)
+  appSecret: ""
+  # -- Existing secret containing the APP_SECRET key
+  existingSecret: ""
+  # -- Key in the existing secret
+  existingSecretKey: app-secret
+  # -- Disable telemetry
+  disableTelemetry: true
+  # -- Custom tracker script name (for ad-blocker bypass)
+  trackerScriptName: ""
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+    # - name: ALLOWED_FRAME_URLS
+    #   value: "https://example.com"
+
+# =============================================================================
+# Database
+# =============================================================================
+
+database:
+  # -- External PostgreSQL configuration (used when postgresql subchart is disabled)
+  external:
+    host: ""
+    port: "5432"
+    name: umami
+    username: umami
+    password: ""
+    # -- Existing secret containing the database password
+    existingSecret: ""
+    # -- Key in the existing secret containing the password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Umami
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: analytics.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - analytics.example.com
+    #   secretName: umami-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    path: /api/heartbeat
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    path: /api/heartbeat
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /api/heartbeat
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []
+
+# =============================================================================
+# Subcharts
+# =============================================================================
+
+postgresql:
+  # -- Deploy PostgreSQL as a subchart
+  enabled: true
+  architecture: standalone
+  auth:
+    database: umami
+    username: umami
+    # -- PostgreSQL password (auto-generated if empty)
+    password: ""
+  initdb:
+    scripts:
+      02-extensions.sql: |
+        CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/charts/wallabag/Chart.lock
+++ b/charts/wallabag/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.2
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.5.3
+digest: sha256:f2ecff13c4e28f73f395cb457a45c1649fa79c31819bda1d2c35d07e6d4cf0ad
+generated: "2026-04-01T16:29:11.0797922-03:00"

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -1,0 +1,45 @@
+apiVersion: v2
+name: wallabag
+description: Wallabag self-hosted read-it-later application with PostgreSQL and optional Redis
+type: application
+version: 0.1.0
+appVersion: "2.6.14"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - wallabag
+  - read-it-later
+  - bookmarks
+  - articles
+  - self-hosted
+home: https://wallabag.org
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/wallabag/wallabag
+icon: https://wallabag.org/img/logo-wallabag.svg
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/wallabag
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/wallabag
+dependencies:
+  - name: postgresql
+    version: 1.8.2
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 1.5.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: redis.enabled

--- a/charts/wallabag/README.md
+++ b/charts/wallabag/README.md
@@ -1,0 +1,99 @@
+# Wallabag Helm Chart
+
+Deploy [Wallabag](https://wallabag.org) on Kubernetes using the official [wallabag/wallabag](https://hub.docker.com/r/wallabag/wallabag) Docker image. Self-hosted read-it-later application — save articles from the web, strip distractions, read offline with mobile apps and browser extensions.
+
+## Features
+
+- **Save anything** — articles, web pages, RSS feeds with content extraction
+- **Read offline** — mobile apps (iOS, Android) with full offline support
+- **PostgreSQL backend** — bundled subchart or external database
+- **Optional Redis** — subchart or external instance for cache and sessions
+- **Auto-generated secrets** — Symfony secret created automatically
+- **Browser extensions** — Firefox, Chrome, Opera
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install wallabag helmforge/wallabag -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install wallabag oci://ghcr.io/helmforgedev/helm/wallabag -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+wallabag:
+  domainName: "https://wallabag.example.com"
+```
+
+After deploying, access Wallabag:
+
+```bash
+kubectl port-forward svc/<release>-wallabag 8080:80
+# Open http://localhost:8080
+# Default login: wallabag / wallabag — change immediately
+```
+
+## With Redis
+
+```yaml
+redis:
+  enabled: true
+```
+
+## External Database
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    name: wallabag
+    username: wallabag
+    existingSecret: wallabag-db-credentials
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `wallabag.domainName` | `https://wallabag.example.com` | Public domain (required) |
+| `wallabag.secret` | `""` | Symfony secret (auto-generated) |
+| `wallabag.registration` | `false` | Allow user registration |
+| `postgresql.enabled` | `true` | Deploy PostgreSQL subchart |
+| `redis.enabled` | `false` | Deploy Redis subchart |
+| `persistence.enabled` | `true` | Enable persistence for /var/www/wallabag/data |
+| `ingress.enabled` | `false` | Enable ingress |
+
+## More Information
+
+- [Wallabag documentation](https://doc.wallabag.org)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/wallabag)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Wallabag Helm Chart
+description: README for the Wallabag read-it-later Helm chart
+
+keywords: wallabag, read-it-later, bookmarks, articles, postgresql, redis
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/wallabag/values.yaml
+path: charts/wallabag/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/wallabag/ci/default-values.yaml
+++ b/charts/wallabag/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default PostgreSQL subchart mode

--- a/charts/wallabag/ci/external-db-values.yaml
+++ b/charts/wallabag/ci/external-db-values.yaml
@@ -1,0 +1,11 @@
+# CI: external PostgreSQL database
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: db.example.com
+    port: "5432"
+    name: wallabag
+    username: wallabag_user
+    password: "ci-password"

--- a/charts/wallabag/ci/redis-values.yaml
+++ b/charts/wallabag/ci/redis-values.yaml
@@ -1,0 +1,5 @@
+# CI: PostgreSQL + Redis subchart
+redis:
+  enabled: true
+  auth:
+    password: "ci-redis-password"

--- a/charts/wallabag/templates/_helpers.tpl
+++ b/charts/wallabag/templates/_helpers.tpl
@@ -1,0 +1,147 @@
+{{- define "wallabag.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "wallabag.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "wallabag.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wallabag.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "wallabag.labels" -}}
+helm.sh/chart: {{ include "wallabag.chart" . }}
+{{ include "wallabag.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "wallabag.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wallabag.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "wallabag.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "wallabag.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wallabag.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Database host */}}
+{{- define "wallabag.dbHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- else -}}
+{{- .Values.database.external.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database port */}}
+{{- define "wallabag.dbPort" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- "5432" -}}
+{{- else -}}
+{{- .Values.database.external.port | default "5432" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database name */}}
+{{- define "wallabag.dbName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.database | default "wallabag" -}}
+{{- else -}}
+{{- .Values.database.external.name | default "wallabag" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database username */}}
+{{- define "wallabag.dbUsername" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.username | default "wallabag" -}}
+{{- else -}}
+{{- .Values.database.external.username | default "wallabag" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret name */}}
+{{- define "wallabag.dbSecretName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- printf "%s-db" (include "wallabag.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret password key */}}
+{{- define "wallabag.dbSecretPasswordKey" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- "user-password" -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "password" -}}
+{{- else -}}
+{{- "password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Redis host */}}
+{{- define "wallabag.redisHost" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "%s-redis" .Release.Name -}}
+{{- else -}}
+{{- .Values.externalRedis.host -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Redis port */}}
+{{- define "wallabag.redisPort" -}}
+{{- if .Values.redis.enabled -}}
+{{- "6379" -}}
+{{- else -}}
+{{- .Values.externalRedis.port | default "6379" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* App secret name */}}
+{{- define "wallabag.appSecretName" -}}
+{{- if .Values.wallabag.existingSecret -}}
+{{- .Values.wallabag.existingSecret -}}
+{{- else -}}
+{{- printf "%s-app" (include "wallabag.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* App secret key */}}
+{{- define "wallabag.appSecretKey" -}}
+{{- if .Values.wallabag.existingSecret -}}
+{{- .Values.wallabag.existingSecretKey | default "symfony-secret" -}}
+{{- else -}}
+{{- "symfony-secret" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Data PVC claim name */}}
+{{- define "wallabag.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "wallabag.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/wallabag/templates/deployment.yaml
+++ b/charts/wallabag/templates/deployment.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wallabag.fullname" . }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "wallabag.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "wallabag.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "wallabag.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-for-db
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for database at {{ include "wallabag.dbHost" . }}:{{ include "wallabag.dbPort" . }}..."
+              until nc -z -w2 {{ include "wallabag.dbHost" . }} {{ include "wallabag.dbPort" . }}; do
+                echo "Database not ready, retrying in 2s..."
+                sleep 2
+              done
+              echo "Database is ready."
+      containers:
+        - name: wallabag
+          image: {{ include "wallabag.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.wallabag.port }}
+              protocol: TCP
+          env:
+            - name: SYMFONY__ENV__DATABASE_DRIVER
+              value: pdo_pgsql
+            - name: SYMFONY__ENV__DATABASE_HOST
+              value: {{ include "wallabag.dbHost" . | quote }}
+            - name: SYMFONY__ENV__DATABASE_PORT
+              value: {{ include "wallabag.dbPort" . | quote }}
+            - name: SYMFONY__ENV__DATABASE_NAME
+              value: {{ include "wallabag.dbName" . | quote }}
+            - name: SYMFONY__ENV__DATABASE_USER
+              value: {{ include "wallabag.dbUsername" . | quote }}
+            - name: SYMFONY__ENV__DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wallabag.dbSecretName" . }}
+                  key: {{ include "wallabag.dbSecretPasswordKey" . }}
+            - name: SYMFONY__ENV__DOMAIN_NAME
+              value: {{ .Values.wallabag.domainName | quote }}
+            - name: SYMFONY__ENV__SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wallabag.appSecretName" . }}
+                  key: {{ include "wallabag.appSecretKey" . }}
+            - name: SYMFONY__ENV__FOSUSER_REGISTRATION
+              value: {{ .Values.wallabag.registration | ternary "true" "false" | quote }}
+            {{- if or .Values.redis.enabled .Values.externalRedis.host }}
+            - name: SYMFONY__ENV__REDIS_HOST
+              value: {{ printf "redis://%s:%s" (include "wallabag.redisHost" .) (include "wallabag.redisPort" .) | quote }}
+            {{- end }}
+            {{- with .Values.wallabag.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/www/wallabag/data
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "wallabag.dataClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/wallabag/templates/extra-manifests.yaml
+++ b/charts/wallabag/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/wallabag/templates/ingress.yaml
+++ b/charts/wallabag/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "wallabag.fullname" . }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "wallabag.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/wallabag/templates/pvc.yaml
+++ b/charts/wallabag/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "wallabag.dataClaimName" . }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/wallabag/templates/secret.yaml
+++ b/charts/wallabag/templates/secret.yaml
@@ -1,0 +1,23 @@
+{{- if not .Values.wallabag.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-app" (include "wallabag.fullname" .) }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  symfony-secret: {{ .Values.wallabag.secret | default (randAlphaNum 32) | quote }}
+{{- end }}
+---
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) .Values.database.external.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-db" (include "wallabag.fullname" .) }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.database.external.password | quote }}
+{{- end }}

--- a/charts/wallabag/templates/service.yaml
+++ b/charts/wallabag/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wallabag.fullname" . }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "wallabag.selectorLabels" . | nindent 4 }}

--- a/charts/wallabag/templates/serviceaccount.yaml
+++ b/charts/wallabag/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wallabag.serviceAccountName" . }}
+  labels:
+    {{- include "wallabag.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/wallabag/tests/deployment_test.yaml
+++ b/charts/wallabag/tests/deployment_test.yaml
@@ -1,0 +1,99 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-wallabag
+
+  - it: should use Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "wallabag/wallabag:2.6.14"
+
+  - it: should set PostgreSQL env vars with subchart
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYMFONY__ENV__DATABASE_DRIVER
+            value: pdo_pgsql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYMFONY__ENV__DATABASE_HOST
+            value: test-postgresql
+
+  - it: should reference postgresql subchart secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYMFONY__ENV__DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-postgresql-auth
+                key: user-password
+
+  - it: should have wait-for-db init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+
+  - it: should not set Redis env when disabled
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYMFONY__ENV__REDIS_HOST
+          any: true
+
+  - it: should set Redis env when subchart enabled
+    set:
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYMFONY__ENV__REDIS_HOST
+            value: "redis://test-redis:6379"
+
+  - it: should mount data volume
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /var/www/wallabag/data
+
+  - it: should use TCP probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+
+  - it: should set registration to false by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYMFONY__ENV__FOSUSER_REGISTRATION
+            value: "false"

--- a/charts/wallabag/tests/ingress_test.yaml
+++ b/charts/wallabag/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: wallabag.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/wallabag/tests/pvc_test.yaml
+++ b/charts/wallabag/tests/pvc_test.yaml
@@ -1,0 +1,21 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render PVC by default
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-wallabag-data
+
+  - it: should not render when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/wallabag/tests/secret_test.yaml
+++ b/charts/wallabag/tests/secret_test.yaml
@@ -1,0 +1,23 @@
+suite: Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render app secret by default
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-wallabag-app
+        documentIndex: 0
+
+  - it: should not render app secret when existingSecret is set
+    set:
+      wallabag.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/wallabag/tests/service_test.yaml
+++ b/charts/wallabag/tests/service_test.yaml
@@ -1,0 +1,14 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-wallabag

--- a/charts/wallabag/values.schema.json
+++ b/charts/wallabag/values.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Wallabag Helm Chart Values",
+  "description": "Values for the Wallabag Helm chart — self-hosted read-it-later with PostgreSQL and optional Redis",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "wallabag/wallabag" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "wallabag": {
+      "type": "object",
+      "description": "Wallabag application configuration",
+      "properties": {
+        "port": { "type": "integer", "default": 80 },
+        "domainName": { "type": "string", "description": "Public domain name (required)", "default": "https://wallabag.example.com" },
+        "secret": { "type": "string", "description": "Symfony secret (auto-generated if empty)", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretKey": { "type": "string", "default": "symfony-secret" },
+        "registration": { "type": "boolean", "description": "Allow user registration", "default": false },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "external": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string", "default": "" },
+            "port": { "type": ["string", "integer"], "default": "5432" },
+            "name": { "type": "string", "default": "wallabag" },
+            "username": { "type": "string", "default": "wallabag" },
+            "password": { "type": "string", "default": "" },
+            "existingSecret": { "type": "string", "default": "" },
+            "existingSecretPasswordKey": { "type": "string", "default": "password" }
+          }
+        }
+      }
+    },
+    "externalRedis": {
+      "type": "object",
+      "description": "External Redis configuration",
+      "properties": {
+        "host": { "type": "string", "default": "" },
+        "port": { "type": ["string", "integer"], "default": "6379" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "2Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "serviceAccount": { "type": "object" },
+    "service": { "type": "object" },
+    "ingress": { "type": "object" },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "architecture": { "type": "string", "default": "standalone" },
+        "auth": { "type": "object" }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "architecture": { "type": "string", "default": "standalone" },
+        "auth": { "type": "object" }
+      }
+    }
+  }
+}

--- a/charts/wallabag/values.yaml
+++ b/charts/wallabag/values.yaml
@@ -1,0 +1,211 @@
+# =============================================================================
+# Wallabag Helm Chart — Default Values
+# =============================================================================
+# Focus: self-hosted read-it-later with PostgreSQL and optional Redis
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Wallabag container image
+  repository: wallabag/wallabag
+  # -- Image tag (defaults to appVersion)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Wallabag Configuration
+# =============================================================================
+
+wallabag:
+  # -- Application port
+  port: 80
+  # -- Public domain name (required)
+  domainName: "https://wallabag.example.com"
+  # -- Symfony secret (auto-generated if empty)
+  secret: ""
+  # -- Existing secret containing the Symfony secret
+  existingSecret: ""
+  # -- Key in the existing secret
+  existingSecretKey: symfony-secret
+  # -- Allow user registration
+  registration: false
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# Database
+# =============================================================================
+
+database:
+  # -- External PostgreSQL configuration (used when postgresql subchart is disabled)
+  external:
+    host: ""
+    port: "5432"
+    name: wallabag
+    username: wallabag
+    password: ""
+    # -- Existing secret containing the database password
+    existingSecret: ""
+    # -- Key in the existing secret containing the password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# External Redis
+# =============================================================================
+
+externalRedis:
+  # -- External Redis host (used when redis subchart is disabled)
+  host: ""
+  port: "6379"
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for /var/www/wallabag/data
+  enabled: true
+  # -- Storage size
+  size: 2Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Wallabag
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: wallabag.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - wallabag.example.com
+    #   secretName: wallabag-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []
+
+# =============================================================================
+# Subcharts
+# =============================================================================
+
+postgresql:
+  # -- Deploy PostgreSQL as a subchart
+  enabled: true
+  architecture: standalone
+  auth:
+    database: wallabag
+    username: wallabag
+    # -- PostgreSQL password (auto-generated if empty)
+    password: ""
+
+redis:
+  # -- Deploy Redis as a subchart (optional, for cache and sessions)
+  enabled: false
+  architecture: standalone
+  auth:
+    password: ""


### PR DESCRIPTION
## Summary

- **Umami** — privacy-focused web analytics with PostgreSQL, pgcrypto extension via initdb scripts, auto-generated app secret
- **Metabase** — open-source BI/analytics with PostgreSQL, citext extension via initdb scripts, JVM tuning
- **Liwan** — ultra-lightweight privacy-first web analytics with embedded DuckDB, zero dependencies
- **Wallabag** — self-hosted read-it-later with PostgreSQL, optional Redis, Symfony config, TCP probes
- **Statistics for Strava** — fitness dashboard with SQLite, Strava OAuth credentials, persistent storage

All charts follow HelmForge patterns: `_helpers.tpl`, deployment, service, ingress, secret, PVC, serviceaccount, extra-manifests templates. All include unit tests, CI values, `values.schema.json`, README with `@AI-METADATA`, and ArtifactHub annotations.

All 5 charts are **alpha** maturity with `artifacthub.io/prerelease: "true"`.

## Validation

- [x] `helm lint --strict` passes for all 5 charts
- [x] `helm unittest` passes for all 5 charts (118 tests total)
- [x] `helm template` with all CI values passes for all 5 charts
- [x] k3d deployment validated — all pods reach Running state
- [x] Root README.md updated with all 5 charts in the table

## Test plan

- [ ] CI lint + template + kubeconform passes
- [ ] Review each chart's values.yaml for correctness
- [ ] Verify ArtifactHub annotations render correctly after publish