### PR TITLE
feat: add phase 2 charts — archivebox, countly, middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 | [liwan](charts/liwan/) | alpha | Liwan — ultra-lightweight privacy-first web analytics with embedded DuckDB |
 | [wallabag](charts/wallabag/) | alpha | Wallabag — self-hosted read-it-later with PostgreSQL, optional Redis, and Symfony configuration |
 | [strava-statistics](charts/strava-statistics/) | alpha | Statistics for Strava — self-hosted fitness dashboard with SQLite and Strava OAuth |
+| [archivebox](charts/archivebox/) | alpha | ArchiveBox — self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage |
+| [countly](charts/countly/) | alpha | Countly — product analytics platform with MongoDB, event tracking, crash reporting, and plugin system |
+| [middleware](charts/middleware/) | alpha | Middleware — open-source DORA metrics platform with PostgreSQL, Redis, and engineering performance tracking |
 
 ### Maturity levels
 

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: archivebox
+description: ArchiveBox self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage
+type: application
+version: 0.1.0
+appVersion: "0.7.3"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - archivebox
+  - archive
+  - web-archiving
+  - wayback
+  - chromium
+  - self-hosted
+home: https://archivebox.io
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/ArchiveBox/ArchiveBox
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: storage
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/archivebox
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/archivebox

--- a/charts/archivebox/README.md
+++ b/charts/archivebox/README.md
@@ -1,0 +1,100 @@
+# ArchiveBox Helm Chart
+
+Deploy [ArchiveBox](https://archivebox.io) on Kubernetes using the official [archivebox/archivebox](https://hub.docker.com/r/archivebox/archivebox) container image. Self-hosted web archiving platform that captures websites in multiple formats (HTML, PDF, PNG, WARC, media) using Chromium headless.
+
+## Features
+
+- **Multi-format archiving** — HTML, PDF, screenshot, WARC, media extraction
+- **Chromium headless** — full page rendering with `/dev/shm` memory-backed tmpfs
+- **SQLite embedded** — no external database needed
+- **Persistent storage** — archived content and SQLite database on PVC
+- **Admin credentials** — managed via Kubernetes Secret
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install archivebox helmforge/archivebox -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install archivebox oci://ghcr.io/helmforgedev/helm/archivebox -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml
+archivebox:
+  adminUsername: admin
+  adminPassword: "your-secure-password"
+```
+
+After deploying:
+
+```bash
+kubectl port-forward svc/<release>-archivebox 8000:80
+# Open http://localhost:8000
+```
+
+## Using an Existing Secret
+
+```yaml
+archivebox:
+  existingSecret: my-archivebox-secret
+  existingSecretUsernameKey: admin-username
+  existingSecretPasswordKey: admin-password
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `archivebox.port` | `8000` | Application port |
+| `archivebox.adminUsername` | `admin` | Admin username |
+| `archivebox.adminPassword` | `""` | Admin password (auto-generated if empty) |
+| `archivebox.allowedHosts` | `*` | Allowed hostnames |
+| `archivebox.publicIndex` | `True` | Public index page |
+| `archivebox.publicSnapshots` | `True` | Public snapshot access |
+| `archivebox.searchBackendEngine` | `ripgrep` | Search engine (ripgrep, sqlite, sonic) |
+| `archivebox.mediaMaxSize` | `750m` | Max media download size |
+| `archivebox.timeout` | `60` | URL archiving timeout (seconds) |
+| `persistence.enabled` | `true` | Enable persistence for /data |
+| `persistence.size` | `50Gi` | PVC size (plan for large archives) |
+| `ingress.enabled` | `false` | Enable ingress |
+| `service.port` | `80` | Service port |
+
+## Limitations
+
+- **Single instance only** — SQLite is single-writer, horizontal scaling is not supported
+- **Storage-heavy** — each archived snapshot is 2-50MB; plan PVC size accordingly (50-100GB+)
+- **Chromium resources** — requires at least 2Gi RAM for Chromium headless rendering
+- **`/dev/shm`** — automatically mounted as memory-backed tmpfs (1Gi) for Chromium
+
+## More Information
+
+- [ArchiveBox documentation](https://docs.archivebox.io)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/archivebox)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: ArchiveBox Helm Chart
+description: README for the ArchiveBox web archiving platform Helm chart
+
+keywords: archivebox, archive, web-archiving, chromium, wayback, self-hosted
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/archivebox/values.yaml
+path: charts/archivebox/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/archivebox/ci/default-values.yaml
+++ b/charts/archivebox/ci/default-values.yaml
@@ -1,0 +1,4 @@
+# CI: default values with admin credentials
+archivebox:
+  adminUsername: admin
+  adminPassword: "testpassword123"

--- a/charts/archivebox/ci/ingress-values.yaml
+++ b/charts/archivebox/ci/ingress-values.yaml
@@ -1,0 +1,19 @@
+# CI: ingress enabled with admin credentials
+archivebox:
+  adminUsername: admin
+  adminPassword: "testpassword123"
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: archive.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - archive.example.com
+      secretName: archivebox-tls

--- a/charts/archivebox/templates/_helpers.tpl
+++ b/charts/archivebox/templates/_helpers.tpl
@@ -1,0 +1,79 @@
+{{- define "archivebox.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "archivebox.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "archivebox.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "archivebox.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "archivebox.labels" -}}
+helm.sh/chart: {{ include "archivebox.chart" . }}
+{{ include "archivebox.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "archivebox.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "archivebox.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "archivebox.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "archivebox.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "archivebox.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Admin secret name */}}
+{{- define "archivebox.secretName" -}}
+{{- if .Values.archivebox.existingSecret -}}
+{{- .Values.archivebox.existingSecret -}}
+{{- else -}}
+{{- printf "%s-admin" (include "archivebox.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Admin secret keys */}}
+{{- define "archivebox.usernameKey" -}}
+{{- if .Values.archivebox.existingSecret -}}
+{{- .Values.archivebox.existingSecretUsernameKey | default "admin-username" -}}
+{{- else -}}
+{{- "admin-username" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "archivebox.passwordKey" -}}
+{{- if .Values.archivebox.existingSecret -}}
+{{- .Values.archivebox.existingSecretPasswordKey | default "admin-password" -}}
+{{- else -}}
+{{- "admin-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Data PVC claim name */}}
+{{- define "archivebox.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "archivebox.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/archivebox/templates/deployment.yaml
+++ b/charts/archivebox/templates/deployment.yaml
@@ -1,0 +1,157 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "archivebox.fullname" . }}
+  labels:
+    {{- include "archivebox.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "archivebox.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "archivebox.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "archivebox.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: archivebox
+          image: {{ include "archivebox.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["archivebox"]
+          args: ["server", "--quick-init", "0.0.0.0:{{ .Values.archivebox.port }}"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.archivebox.port }}
+              protocol: TCP
+          env:
+            - name: ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "archivebox.secretName" . }}
+                  key: {{ include "archivebox.usernameKey" . }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "archivebox.secretName" . }}
+                  key: {{ include "archivebox.passwordKey" . }}
+            - name: ALLOWED_HOSTS
+              value: {{ .Values.archivebox.allowedHosts | quote }}
+            - name: PUBLIC_INDEX
+              value: {{ .Values.archivebox.publicIndex | quote }}
+            - name: PUBLIC_SNAPSHOTS
+              value: {{ .Values.archivebox.publicSnapshots | quote }}
+            - name: PUBLIC_ADD_LINKS
+              value: {{ .Values.archivebox.publicAddLinks | quote }}
+            - name: SEARCH_BACKEND_ENGINE
+              value: {{ .Values.archivebox.searchBackendEngine | quote }}
+            - name: MEDIA_MAX_SIZE
+              value: {{ .Values.archivebox.mediaMaxSize | quote }}
+            - name: TIMEOUT
+              value: {{ .Values.archivebox.timeout | quote }}
+            - name: TZ
+              value: {{ .Values.archivebox.timezone | quote }}
+            {{- with .Values.archivebox.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: dshm
+              mountPath: /dev/shm
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "archivebox.dataClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/archivebox/templates/extra-manifests.yaml
+++ b/charts/archivebox/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/archivebox/templates/ingress.yaml
+++ b/charts/archivebox/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "archivebox.fullname" . }}
+  labels:
+    {{- include "archivebox.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "archivebox.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/archivebox/templates/pvc.yaml
+++ b/charts/archivebox/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "archivebox.dataClaimName" . }}
+  labels:
+    {{- include "archivebox.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/archivebox/templates/secret.yaml
+++ b/charts/archivebox/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.archivebox.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-admin" (include "archivebox.fullname" .) }}
+  labels:
+    {{- include "archivebox.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin-username: {{ .Values.archivebox.adminUsername | quote }}
+  admin-password: {{ .Values.archivebox.adminPassword | default (randAlphaNum 32) | quote }}
+{{- end }}

--- a/charts/archivebox/templates/service.yaml
+++ b/charts/archivebox/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "archivebox.fullname" . }}
+  labels:
+    {{- include "archivebox.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "archivebox.selectorLabels" . | nindent 4 }}

--- a/charts/archivebox/templates/serviceaccount.yaml
+++ b/charts/archivebox/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "archivebox.serviceAccountName" . }}
+  labels:
+    {{- include "archivebox.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/archivebox/tests/deployment_test.yaml
+++ b/charts/archivebox/tests/deployment_test.yaml
@@ -1,0 +1,159 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-archivebox
+
+  - it: should use Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "archivebox/archivebox:0.7.3"
+
+  - it: should set server command
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["archivebox"]
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value: ["server", "--quick-init", "0.0.0.0:8000"]
+
+  - it: should set admin credentials from secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: test-archivebox-admin
+                key: admin-username
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-archivebox-admin
+                key: admin-password
+
+  - it: should use existing secret when configured
+    set:
+      archivebox.existingSecret: my-secret
+      archivebox.existingSecretUsernameKey: user
+      archivebox.existingSecretPasswordKey: pass
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: user
+
+  - it: should set archivebox config env vars
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOWED_HOSTS
+            value: "*"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PUBLIC_INDEX
+            value: "True"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SEARCH_BACKEND_ENGINE
+            value: "ripgrep"
+
+  - it: should mount data volume
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+
+  - it: should mount /dev/shm for Chromium
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: dshm
+            mountPath: /dev/shm
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dshm
+            emptyDir:
+              medium: Memory
+              sizeLimit: 1Gi
+
+  - it: should use PVC for data when persistence enabled
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: test-archivebox-data
+
+  - it: should use emptyDir when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+
+  - it: should use HTTP probes with /health/ path
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health/
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/
+
+  - it: should set container port
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8000
+            protocol: TCP
+
+  - it: should run as non-root UID 911
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 911
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 911
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should not have init containers
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers

--- a/charts/archivebox/tests/ingress_test.yaml
+++ b/charts/archivebox/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: archive.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/archivebox/tests/pvc_test.yaml
+++ b/charts/archivebox/tests/pvc_test.yaml
@@ -1,0 +1,34 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render PVC by default
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-archivebox-data
+
+  - it: should not render when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when existingClaim is set
+    set:
+      persistence.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set storage size
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi

--- a/charts/archivebox/tests/secret_test.yaml
+++ b/charts/archivebox/tests/secret_test.yaml
@@ -1,0 +1,21 @@
+suite: Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render secret by default
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-archivebox-admin
+
+  - it: should not render when existingSecret is set
+    set:
+      archivebox.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/archivebox/tests/service_test.yaml
+++ b/charts/archivebox/tests/service_test.yaml
@@ -1,0 +1,24 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-archivebox
+
+  - it: should use port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP

--- a/charts/archivebox/values.schema.json
+++ b/charts/archivebox/values.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "ArchiveBox Helm Chart Values",
+  "description": "Values for the ArchiveBox Helm chart — self-hosted web archiving with Chromium headless and multi-format capture",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "archivebox/archivebox" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "archivebox": {
+      "type": "object",
+      "description": "ArchiveBox application configuration",
+      "properties": {
+        "port": { "type": "integer", "description": "Application port", "default": 8000 },
+        "adminUsername": { "type": "string", "description": "Admin username", "default": "admin" },
+        "adminPassword": { "type": "string", "description": "Admin password", "default": "" },
+        "existingSecret": { "type": "string", "description": "Existing secret containing admin credentials", "default": "" },
+        "existingSecretUsernameKey": { "type": "string", "default": "admin-username" },
+        "existingSecretPasswordKey": { "type": "string", "default": "admin-password" },
+        "allowedHosts": { "type": "string", "description": "Allowed hostnames", "default": "*" },
+        "publicIndex": { "type": "string", "description": "Allow public index access", "default": "True" },
+        "publicSnapshots": { "type": "string", "description": "Allow public snapshot access", "default": "True" },
+        "publicAddLinks": { "type": "string", "description": "Allow public URL submission", "default": "False" },
+        "searchBackendEngine": { "type": "string", "description": "Search backend engine", "enum": ["ripgrep", "sqlite", "sonic"], "default": "ripgrep" },
+        "mediaMaxSize": { "type": "string", "description": "Maximum media file size", "default": "750m" },
+        "timeout": { "type": "string", "description": "Archiving timeout in seconds", "default": "60" },
+        "timezone": { "type": "string", "description": "Timezone", "default": "UTC" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Persistence for /data (SQLite + archived content)",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "50Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
+  }
+}

--- a/charts/archivebox/values.yaml
+++ b/charts/archivebox/values.yaml
@@ -1,0 +1,194 @@
+# =============================================================================
+# ArchiveBox Helm Chart — Default Values
+# =============================================================================
+# Focus: self-hosted web archiving with Chromium headless and multi-format capture
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- ArchiveBox container image
+  repository: archivebox/archivebox
+  # -- Image tag (defaults to appVersion)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# ArchiveBox Configuration
+# =============================================================================
+
+archivebox:
+  # -- Application port
+  port: 8000
+  # -- Admin username (created on first run)
+  adminUsername: admin
+  # -- Admin password (required for initial setup)
+  adminPassword: ""
+  # -- Existing secret containing admin credentials
+  existingSecret: ""
+  # -- Key in existing secret for admin username
+  existingSecretUsernameKey: admin-username
+  # -- Key in existing secret for admin password
+  existingSecretPasswordKey: admin-password
+  # -- Allowed hostnames (comma-separated or *)
+  allowedHosts: "*"
+  # -- Allow public access to the index page
+  publicIndex: "True"
+  # -- Allow public access to archived snapshots
+  publicSnapshots: "True"
+  # -- Allow public access to add URLs
+  publicAddLinks: "False"
+  # -- Search backend engine (ripgrep, sqlite, sonic)
+  searchBackendEngine: ripgrep
+  # -- Maximum media file size to download (bytes notation)
+  mediaMaxSize: "750m"
+  # -- Timeout for archiving a single URL (seconds)
+  timeout: "60"
+  # -- Timezone
+  timezone: UTC
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for /data (SQLite DB + archived content)
+  enabled: true
+  # -- Storage size (plan for large archives, 50-100GB+)
+  size: 50Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for ArchiveBox
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: archive.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - archive.example.com
+    #   secretName: archivebox-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    path: /health/
+    initialDelaySeconds: 15
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    path: /health/
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /health/
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+# -- Container resource requests/limits (Chromium requires ~2Gi RAM minimum)
+resources: {}
+  # requests:
+  #   cpu: 500m
+  #   memory: 2Gi
+  # limits:
+  #   cpu: 2000m
+  #   memory: 4Gi
+
+podSecurityContext:
+  fsGroup: 911
+
+securityContext:
+  runAsUser: 911
+  runAsGroup: 911
+  runAsNonRoot: true
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []

--- a/charts/countly/Chart.lock
+++ b/charts/countly/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.6.3
+digest: sha256:3c8703926266cc579f3305cb26f0daa5f612e667e3ce8a96c2618a2a31c46ca0
+generated: "2026-04-01T18:13:56.5288514-03:00"

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: countly
+description: Countly product analytics platform with MongoDB, event tracking, crash reporting, and plugin system
+type: application
+version: 0.1.0
+appVersion: "25.03.41"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - countly
+  - analytics
+  - product-analytics
+  - event-tracking
+  - crash-reporting
+  - push-notifications
+  - self-hosted
+home: https://count.ly
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/Countly/countly-server
+dependencies:
+  - name: mongodb
+    version: 1.6.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: mongodb.enabled
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/countly
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/countly

--- a/charts/countly/README.md
+++ b/charts/countly/README.md
@@ -1,0 +1,94 @@
+# Countly Helm Chart
+
+Deploy [Countly](https://count.ly) on Kubernetes using the official [countly/countly-server](https://hub.docker.com/r/countly/countly-server) container image. Product analytics platform with event tracking, crash reporting, push notifications, A/B testing, and 41+ plugins.
+
+## Features
+
+- **MongoDB backend** — uses HelmForge MongoDB subchart or external MongoDB
+- **Dual ports** — API (3001) and Dashboard (6001) on the same container
+- **Plugin system** — configurable plugin list via values
+- **Worker scaling** — configurable API worker count
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install countly helmforge/countly -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install countly oci://ghcr.io/helmforgedev/helm/countly -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml — default values are sufficient
+# Uses bundled MongoDB subchart
+```
+
+After deploying:
+
+```bash
+kubectl port-forward svc/<release>-countly 6001:80
+# Open http://localhost:6001
+```
+
+## External MongoDB
+
+```yaml
+mongodb:
+  enabled: false
+
+externalMongodb:
+  enabled: true
+  uri: "mongodb://user:password@your-mongodb:27017/countly?authSource=admin"
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `countly.apiPort` | `3001` | API port |
+| `countly.dashboardPort` | `6001` | Dashboard port |
+| `countly.apiWorkers` | `4` | API worker processes |
+| `countly.plugins` | `""` | Plugins to enable (comma-separated) |
+| `mongodb.enabled` | `true` | Enable bundled MongoDB |
+| `externalMongodb.enabled` | `false` | Use external MongoDB |
+| `externalMongodb.uri` | `""` | External MongoDB URI |
+| `service.port` | `80` | Dashboard service port |
+| `service.apiPort` | `3001` | API service port |
+| `ingress.enabled` | `false` | Enable ingress |
+
+## Limitations
+
+- **MongoDB only** — Countly does not support PostgreSQL or other databases
+- **Single instance** — only one Countly deployment per MongoDB database
+
+## More Information
+
+- [Countly documentation](https://support.count.ly)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/countly)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Countly Helm Chart
+description: README for the Countly product analytics platform Helm chart
+
+keywords: countly, analytics, product-analytics, event-tracking, mongodb
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/countly/values.yaml
+path: charts/countly/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/countly/ci/default-values.yaml
+++ b/charts/countly/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default values with bundled MongoDB

--- a/charts/countly/ci/external-mongodb-values.yaml
+++ b/charts/countly/ci/external-mongodb-values.yaml
@@ -1,0 +1,7 @@
+# CI: external MongoDB
+mongodb:
+  enabled: false
+
+externalMongodb:
+  enabled: true
+  uri: "mongodb://user:password@external-mongodb:27017/countly?authSource=admin"

--- a/charts/countly/ci/ingress-values.yaml
+++ b/charts/countly/ci/ingress-values.yaml
@@ -1,0 +1,15 @@
+# CI: ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: countly.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - countly.example.com
+      secretName: countly-tls

--- a/charts/countly/templates/_helpers.tpl
+++ b/charts/countly/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{- define "countly.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "countly.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "countly.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "countly.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "countly.labels" -}}
+helm.sh/chart: {{ include "countly.chart" . }}
+{{ include "countly.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "countly.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "countly.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "countly.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "countly.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "countly.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* MongoDB host */}}
+{{- define "countly.mongodbHost" -}}
+{{- if .Values.externalMongodb.enabled -}}
+{{- "" -}}
+{{- else -}}
+{{- printf "%s-mongodb" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* MongoDB URI */}}
+{{- define "countly.mongodbUri" -}}
+{{- if .Values.externalMongodb.enabled -}}
+{{- .Values.externalMongodb.uri -}}
+{{- else -}}
+{{- printf "mongodb://root:$(MONGODB_ROOT_PASSWORD)@%s-mongodb:27017/countly?authSource=admin" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* MongoDB secret name */}}
+{{- define "countly.mongodbSecretName" -}}
+{{- if .Values.externalMongodb.enabled -}}
+{{- .Values.externalMongodb.existingSecret -}}
+{{- else -}}
+{{- printf "%s-mongodb" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/countly/templates/deployment.yaml
+++ b/charts/countly/templates/deployment.yaml
@@ -1,0 +1,154 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "countly.fullname" . }}
+  labels:
+    {{- include "countly.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "countly.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "countly.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "countly.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if and .Values.mongodb.enabled (not .Values.externalMongodb.enabled) }}
+      initContainers:
+        - name: wait-for-mongodb
+          image: busybox:1.37
+          command: ["sh", "-c", "until nc -z {{ include "countly.mongodbHost" . }} 27017; do echo waiting for mongodb; sleep 2; done"]
+      {{- end }}
+      containers:
+        - name: countly
+          image: {{ include "countly.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.countly.apiPort }}
+              protocol: TCP
+            - name: dashboard
+              containerPort: {{ .Values.countly.dashboardPort }}
+              protocol: TCP
+          env:
+            {{- if not .Values.externalMongodb.enabled }}
+            - name: MONGODB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "countly.mongodbSecretName" . }}
+                  key: mongodb-root-password
+            - name: COUNTLY_CONFIG__MONGODB
+              value: {{ include "countly.mongodbUri" . | quote }}
+            {{- else if .Values.externalMongodb.existingSecret }}
+            - name: COUNTLY_CONFIG__MONGODB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalMongodb.existingSecret }}
+                  key: {{ .Values.externalMongodb.existingSecretUriKey }}
+            {{- else }}
+            - name: COUNTLY_CONFIG__MONGODB
+              value: {{ .Values.externalMongodb.uri | quote }}
+            {{- end }}
+            - name: COUNTLY_CONFIG_API_API_HOST
+              value: "0.0.0.0"
+            - name: COUNTLY_CONFIG_API_API_PORT
+              value: {{ .Values.countly.apiPort | quote }}
+            - name: COUNTLY_CONFIG_FRONTEND_WEB_HOST
+              value: "0.0.0.0"
+            - name: COUNTLY_CONFIG_FRONTEND_WEB_PORT
+              value: {{ .Values.countly.dashboardPort | quote }}
+            - name: COUNTLY_CONFIG_API_API_WORKERS
+              value: {{ .Values.countly.apiWorkers | quote }}
+            - name: TZ
+              value: {{ .Values.countly.timezone | quote }}
+            {{- with .Values.countly.plugins }}
+            - name: COUNTLY_PLUGINS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.countly.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: dashboard
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: dashboard
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: dashboard
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/countly/templates/extra-manifests.yaml
+++ b/charts/countly/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/countly/templates/ingress.yaml
+++ b/charts/countly/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "countly.fullname" . }}
+  labels:
+    {{- include "countly.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "countly.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/countly/templates/service.yaml
+++ b/charts/countly/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "countly.fullname" . }}
+  labels:
+    {{- include "countly.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: dashboard
+      protocol: TCP
+    - name: api
+      port: {{ .Values.service.apiPort }}
+      targetPort: api
+      protocol: TCP
+  selector:
+    {{- include "countly.selectorLabels" . | nindent 4 }}

--- a/charts/countly/templates/serviceaccount.yaml
+++ b/charts/countly/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "countly.serviceAccountName" . }}
+  labels:
+    {{- include "countly.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/countly/tests/deployment_test.yaml
+++ b/charts/countly/tests/deployment_test.yaml
@@ -1,0 +1,117 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-countly
+
+  - it: should use RollingUpdate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "countly/countly-server:25.03.41"
+
+  - it: should expose both API and dashboard ports
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: api
+            containerPort: 3001
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: dashboard
+            containerPort: 6001
+            protocol: TCP
+
+  - it: should set MongoDB URI from subchart secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MONGODB_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-mongodb
+                key: mongodb-root-password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COUNTLY_CONFIG__MONGODB
+            value: "mongodb://root:$(MONGODB_ROOT_PASSWORD)@test-mongodb:27017/countly?authSource=admin"
+
+  - it: should use external MongoDB URI when configured
+    set:
+      mongodb.enabled: false
+      externalMongodb.enabled: true
+      externalMongodb.uri: "mongodb://exthost:27017/countly"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COUNTLY_CONFIG__MONGODB
+            value: "mongodb://exthost:27017/countly"
+
+  - it: should use external MongoDB secret when configured
+    set:
+      mongodb.enabled: false
+      externalMongodb.enabled: true
+      externalMongodb.existingSecret: my-mongo-secret
+      externalMongodb.existingSecretUriKey: uri
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COUNTLY_CONFIG__MONGODB
+            valueFrom:
+              secretKeyRef:
+                name: my-mongo-secret
+                key: uri
+
+  - it: should set API worker count
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COUNTLY_CONFIG_API_API_WORKERS
+            value: "4"
+
+  - it: should have wait-for-mongodb init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-mongodb
+
+  - it: should not have init container when using external MongoDB
+    set:
+      mongodb.enabled: false
+      externalMongodb.enabled: true
+      externalMongodb.uri: "mongodb://exthost:27017/countly"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: should use TCP probes on dashboard port
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: dashboard
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: dashboard

--- a/charts/countly/tests/ingress_test.yaml
+++ b/charts/countly/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: countly.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/countly/tests/service_test.yaml
+++ b/charts/countly/tests/service_test.yaml
@@ -1,0 +1,31 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-countly
+
+  - it: should expose dashboard and API ports
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: dashboard
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            name: api
+            port: 3001
+            targetPort: api
+            protocol: TCP

--- a/charts/countly/values.schema.json
+++ b/charts/countly/values.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Countly Helm Chart Values",
+  "description": "Values for the Countly Helm chart — product analytics platform with MongoDB, event tracking, and plugin system",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "countly/countly-server" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "countly": {
+      "type": "object",
+      "description": "Countly application configuration",
+      "properties": {
+        "apiPort": { "type": "integer", "description": "API port", "default": 3001 },
+        "dashboardPort": { "type": "integer", "description": "Dashboard port", "default": 6001 },
+        "apiWorkers": { "type": "integer", "description": "API worker processes", "default": 4 },
+        "timezone": { "type": "string", "description": "Timezone", "default": "UTC" },
+        "plugins": { "type": "string", "description": "Plugins to enable", "default": "" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "externalMongodb": {
+      "type": "object",
+      "description": "External MongoDB configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "uri": { "type": "string", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretUriKey": { "type": "string", "default": "mongodb-uri" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "apiPort": { "type": "integer", "default": 3001 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "mongodb": { "type": "object" }
+  }
+}

--- a/charts/countly/values.yaml
+++ b/charts/countly/values.yaml
@@ -1,0 +1,178 @@
+# =============================================================================
+# Countly Helm Chart — Default Values
+# =============================================================================
+# Focus: product analytics with MongoDB, event tracking, and plugin system
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Countly container image
+  repository: countly/countly-server
+  # -- Image tag (defaults to appVersion)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Countly Configuration
+# =============================================================================
+
+countly:
+  # -- API port (internal)
+  apiPort: 3001
+  # -- Dashboard/frontend port (internal)
+  dashboardPort: 6001
+  # -- Number of API worker processes
+  apiWorkers: 4
+  # -- Timezone
+  timezone: UTC
+  # -- Plugins to enable (comma-separated list or leave empty for defaults)
+  plugins: ""
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# MongoDB Connection
+# =============================================================================
+
+externalMongodb:
+  # -- Use external MongoDB instead of subchart
+  enabled: false
+  # -- MongoDB connection URI (when using external MongoDB)
+  uri: ""
+  # -- Existing secret with MongoDB URI
+  existingSecret: ""
+  # -- Key in existing secret for MongoDB URI
+  existingSecretUriKey: mongodb-uri
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Dashboard service port
+  port: 80
+  # -- API service port
+  apiPort: 3001
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Countly
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: countly.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - countly.example.com
+    #   secretName: countly-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []
+
+# =============================================================================
+# MongoDB Subchart
+# =============================================================================
+
+mongodb:
+  # -- Enable bundled MongoDB subchart
+  enabled: true
+  # -- MongoDB architecture
+  architecture: standalone
+  auth:
+    # -- Enable MongoDB authentication
+    enabled: true
+    # -- MongoDB root username
+    rootUser: root
+    # -- MongoDB root password (auto-generated if empty)
+    rootPassword: ""

--- a/charts/middleware/Chart.lock
+++ b/charts/middleware/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.3
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.5.4
+digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
+generated: "2026-04-01T18:57:51.5823596-03:00"

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -1,0 +1,46 @@
+apiVersion: v2
+name: middleware
+description: Middleware open-source DORA metrics platform with PostgreSQL and Redis for engineering team performance
+type: application
+version: 0.1.0
+appVersion: "0.3.1"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - middleware
+  - dora
+  - metrics
+  - devops
+  - engineering
+  - performance
+  - self-hosted
+home: https://www.middlewarehq.com
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/middlewarehq/middleware
+dependencies:
+  - name: postgresql
+    version: 1.8.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 1.5.4
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: redis.enabled
+annotations:
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/middleware
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/middleware

--- a/charts/middleware/README.md
+++ b/charts/middleware/README.md
@@ -1,0 +1,108 @@
+# Middleware Helm Chart
+
+Deploy [Middleware](https://www.middlewarehq.com) on Kubernetes using the official [middlewareeng/middleware](https://hub.docker.com/r/middlewareeng/middleware) container image. Open-source DORA metrics platform that measures Deployment Frequency, Lead Time, MTTR, and Change Failure Rate for engineering teams.
+
+## Features
+
+- **DORA metrics** — measures all four DORA metrics from CI/CD integrations
+- **PostgreSQL + Redis** — uses HelmForge subcharts or external services
+- **All-in-one container** — frontend, analytics, and sync server in one image
+- **Internal services disabled** — uses Kubernetes-native PostgreSQL and Redis instead of bundled services
+- **Persistent storage** — API keys and config on PVC
+- **Ingress support** — TLS with cert-manager
+
+## Installation
+
+**HTTPS repository:**
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install middleware helmforge/middleware -f values.yaml
+```
+
+**OCI registry:**
+
+```bash
+helm install middleware oci://ghcr.io/helmforgedev/helm/middleware -f values.yaml
+```
+
+## Basic Example
+
+```yaml
+# values.yaml — default values are sufficient
+# Uses bundled PostgreSQL and Redis subcharts
+```
+
+After deploying:
+
+```bash
+kubectl port-forward svc/<release>-middleware 3333:80
+# Open http://localhost:3333
+```
+
+## External Database and Redis
+
+```yaml
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false
+
+externalDatabase:
+  enabled: true
+  host: your-postgres-host
+  name: mhq-oss
+  user: middleware
+  password: "your-password"
+
+externalRedis:
+  enabled: true
+  host: your-redis-host
+```
+
+## Key Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `middleware.frontendPort` | `3333` | Frontend port |
+| `middleware.analyticsPort` | `9696` | Analytics API port |
+| `middleware.syncPort` | `9697` | Sync server port |
+| `middleware.environment` | `prod` | Environment |
+| `postgresql.enabled` | `true` | Enable bundled PostgreSQL |
+| `redis.enabled` | `true` | Enable bundled Redis |
+| `externalDatabase.enabled` | `false` | Use external database |
+| `externalRedis.enabled` | `false` | Use external Redis |
+| `persistence.enabled` | `true` | Enable persistence for /app/keys |
+| `persistence.size` | `1Gi` | PVC size |
+| `ingress.enabled` | `false` | Enable ingress |
+| `service.port` | `80` | Service port |
+
+## Limitations
+
+- **Single instance** — the all-in-one container does not support horizontal scaling
+- **Resource-heavy** — recommended 16GB RAM for production workloads
+- **Internal services disabled** — the container's bundled PostgreSQL and Redis are disabled in favor of Kubernetes-native subcharts
+
+## More Information
+
+- [Middleware documentation](https://docs.middlewarehq.com)
+- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/middleware)
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Middleware Helm Chart
+description: README for the Middleware DORA metrics platform Helm chart
+
+keywords: middleware, dora, metrics, devops, engineering, performance
+
+purpose: Chart installation, configuration, and usage documentation
+scope: Chart
+
+relations:
+  - charts/middleware/values.yaml
+path: charts/middleware/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/middleware/ci/default-values.yaml
+++ b/charts/middleware/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default values with bundled PostgreSQL and Redis

--- a/charts/middleware/ci/external-db-values.yaml
+++ b/charts/middleware/ci/external-db-values.yaml
@@ -1,0 +1,19 @@
+# CI: external database
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false
+
+externalDatabase:
+  enabled: true
+  host: external-postgres.example.com
+  port: 5432
+  name: mhq-oss
+  user: middleware
+  password: "external-password"
+
+externalRedis:
+  enabled: true
+  host: external-redis.example.com
+  port: 6379

--- a/charts/middleware/ci/ingress-values.yaml
+++ b/charts/middleware/ci/ingress-values.yaml
@@ -1,0 +1,15 @@
+# CI: ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: middleware.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - middleware.example.com
+      secretName: middleware-tls

--- a/charts/middleware/templates/_helpers.tpl
+++ b/charts/middleware/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{- define "middleware.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "middleware.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "middleware.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "middleware.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "middleware.labels" -}}
+helm.sh/chart: {{ include "middleware.chart" . }}
+{{ include "middleware.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "middleware.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "middleware.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "middleware.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "middleware.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "middleware.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* PostgreSQL host */}}
+{{- define "middleware.dbHost" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PostgreSQL port */}}
+{{- define "middleware.dbPort" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.port | toString -}}
+{{- else -}}
+{{- "5432" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PostgreSQL database name */}}
+{{- define "middleware.dbName" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.name -}}
+{{- else -}}
+{{- .Values.postgresql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PostgreSQL user */}}
+{{- define "middleware.dbUser" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.user -}}
+{{- else -}}
+{{- .Values.postgresql.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PostgreSQL secret name */}}
+{{- define "middleware.dbSecretName" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.existingSecret -}}
+{{- else -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PostgreSQL secret password key */}}
+{{- define "middleware.dbSecretPasswordKey" -}}
+{{- if .Values.externalDatabase.enabled -}}
+{{- .Values.externalDatabase.existingSecretPasswordKey | default "user-password" -}}
+{{- else -}}
+{{- "user-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Redis host */}}
+{{- define "middleware.redisHost" -}}
+{{- if .Values.externalRedis.enabled -}}
+{{- .Values.externalRedis.host -}}
+{{- else -}}
+{{- printf "%s-redis" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Redis port */}}
+{{- define "middleware.redisPort" -}}
+{{- if .Values.externalRedis.enabled -}}
+{{- .Values.externalRedis.port | toString -}}
+{{- else -}}
+{{- "6379" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Data PVC claim name */}}
+{{- define "middleware.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "middleware.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/middleware/templates/deployment.yaml
+++ b/charts/middleware/templates/deployment.yaml
@@ -1,0 +1,168 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "middleware.fullname" . }}
+  labels:
+    {{- include "middleware.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "middleware.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "middleware.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "middleware.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: busybox:1.37
+          command: ["sh", "-c", "until nc -z {{ include "middleware.dbHost" . }} 5432; do echo waiting for postgresql; sleep 2; done"]
+      {{- end }}
+      containers:
+        - name: middleware
+          image: {{ include "middleware.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.middleware.frontendPort }}
+              protocol: TCP
+            - name: analytics
+              containerPort: {{ .Values.middleware.analyticsPort }}
+              protocol: TCP
+            - name: sync
+              containerPort: {{ .Values.middleware.syncPort }}
+              protocol: TCP
+          env:
+            - name: ENVIRONMENT
+              value: {{ .Values.middleware.environment | quote }}
+            - name: POSTGRES_DB_ENABLED
+              value: {{ .Values.middleware.internalDbEnabled | quote }}
+            - name: REDIS_ENABLED
+              value: {{ .Values.middleware.internalRedisEnabled | quote }}
+            {{- if not .Values.externalDatabase.enabled }}
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "middleware.dbSecretName" . }}
+                  key: {{ include "middleware.dbSecretPasswordKey" . }}
+            {{- else if .Values.externalDatabase.existingSecret }}
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.existingSecret }}
+                  key: {{ .Values.externalDatabase.existingSecretPasswordKey | default "user-password" }}
+            {{- else }}
+            - name: DB_PASS
+              value: {{ .Values.externalDatabase.password | quote }}
+            {{- end }}
+            - name: DB_HOST
+              value: {{ include "middleware.dbHost" . | quote }}
+            - name: DB_PORT
+              value: {{ include "middleware.dbPort" . | quote }}
+            - name: DB_NAME
+              value: {{ include "middleware.dbName" . | quote }}
+            - name: DB_USER
+              value: {{ include "middleware.dbUser" . | quote }}
+            - name: REDIS_HOST
+              value: {{ include "middleware.redisHost" . | quote }}
+            - name: REDIS_PORT
+              value: {{ include "middleware.redisPort" . | quote }}
+            - name: TZ
+              value: {{ .Values.middleware.timezone | quote }}
+            {{- with .Values.middleware.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/keys
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "middleware.dataClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/middleware/templates/extra-manifests.yaml
+++ b/charts/middleware/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/middleware/templates/ingress.yaml
+++ b/charts/middleware/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "middleware.fullname" . }}
+  labels:
+    {{- include "middleware.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "middleware.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/middleware/templates/pvc.yaml
+++ b/charts/middleware/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "middleware.dataClaimName" . }}
+  labels:
+    {{- include "middleware.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/middleware/templates/service.yaml
+++ b/charts/middleware/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "middleware.fullname" . }}
+  labels:
+    {{- include "middleware.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "middleware.selectorLabels" . | nindent 4 }}

--- a/charts/middleware/templates/serviceaccount.yaml
+++ b/charts/middleware/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "middleware.serviceAccountName" . }}
+  labels:
+    {{- include "middleware.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/middleware/tests/deployment_test.yaml
+++ b/charts/middleware/tests/deployment_test.yaml
@@ -1,0 +1,141 @@
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-middleware
+
+  - it: should use Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should set the correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "middlewareeng/middleware:0.3.1"
+
+  - it: should expose three ports
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 3333
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: analytics
+            containerPort: 9696
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: sync
+            containerPort: 9697
+            protocol: TCP
+
+  - it: should disable internal DB and Redis
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DB_ENABLED
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_ENABLED
+            value: "false"
+
+  - it: should set PostgreSQL connection from subchart
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: "test-postgresql"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: test-postgresql-auth
+                key: user-password
+
+  - it: should set Redis connection from subchart
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: "test-redis"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PORT
+            value: "6379"
+
+  - it: should use external database when configured
+    set:
+      postgresql.enabled: false
+      externalDatabase.enabled: true
+      externalDatabase.host: ext-db.example.com
+      externalDatabase.name: mydb
+      externalDatabase.user: myuser
+      externalDatabase.password: mypass
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: "ext-db.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASS
+            value: "mypass"
+
+  - it: should have wait-for-postgresql init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-postgresql
+
+  - it: should not have init container with external DB
+    set:
+      postgresql.enabled: false
+      externalDatabase.enabled: true
+      externalDatabase.host: ext-db
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: should mount data volume at /app/keys
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /app/keys
+
+  - it: should use TCP probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http

--- a/charts/middleware/tests/ingress_test.yaml
+++ b/charts/middleware/tests/ingress_test.yaml
@@ -1,0 +1,23 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: middleware.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress

--- a/charts/middleware/tests/pvc_test.yaml
+++ b/charts/middleware/tests/pvc_test.yaml
@@ -1,0 +1,34 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render PVC by default
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-middleware-data
+
+  - it: should not render when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when existingClaim is set
+    set:
+      persistence.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set storage size
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi

--- a/charts/middleware/tests/service_test.yaml
+++ b/charts/middleware/tests/service_test.yaml
@@ -1,0 +1,24 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-middleware
+
+  - it: should use port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP

--- a/charts/middleware/values.schema.json
+++ b/charts/middleware/values.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Middleware Helm Chart Values",
+  "description": "Values for the Middleware Helm chart — open-source DORA metrics platform with PostgreSQL and Redis",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "middlewareeng/middleware" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "middleware": {
+      "type": "object",
+      "description": "Middleware application configuration",
+      "properties": {
+        "frontendPort": { "type": "integer", "description": "Frontend port", "default": 3333 },
+        "analyticsPort": { "type": "integer", "description": "Analytics API port", "default": 9696 },
+        "syncPort": { "type": "integer", "description": "Sync server port", "default": 9697 },
+        "environment": { "type": "string", "description": "Environment", "default": "prod" },
+        "internalDbEnabled": { "type": "string", "description": "Enable internal PostgreSQL", "default": "false" },
+        "internalRedisEnabled": { "type": "string", "description": "Enable internal Redis", "default": "false" },
+        "timezone": { "type": "string", "description": "Timezone", "default": "UTC" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "description": "External database configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "host": { "type": "string", "default": "" },
+        "port": { "type": "integer", "default": 5432 },
+        "name": { "type": "string", "default": "mhq-oss" },
+        "user": { "type": "string", "default": "middleware" },
+        "password": { "type": "string", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretPasswordKey": { "type": "string", "default": "user-password" }
+      }
+    },
+    "externalRedis": {
+      "type": "object",
+      "description": "External Redis configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "host": { "type": "string", "default": "" },
+        "port": { "type": "integer", "default": 6379 }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Persistence for /app/keys",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "1Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "postgresql": { "type": "object" },
+    "redis": { "type": "object" }
+  }
+}

--- a/charts/middleware/values.yaml
+++ b/charts/middleware/values.yaml
@@ -1,0 +1,225 @@
+# =============================================================================
+# Middleware Helm Chart — Default Values
+# =============================================================================
+# Focus: open-source DORA metrics platform for engineering team performance
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Middleware container image
+  repository: middlewareeng/middleware
+  # -- Image tag (defaults to appVersion)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Middleware Configuration
+# =============================================================================
+
+middleware:
+  # -- Frontend port (Next.js)
+  frontendPort: 3333
+  # -- Analytics API port
+  analyticsPort: 9696
+  # -- Sync server port
+  syncPort: 9697
+  # -- Environment
+  environment: prod
+  # -- Disable internal PostgreSQL (use subchart instead)
+  internalDbEnabled: "false"
+  # -- Disable internal Redis (use subchart instead)
+  internalRedisEnabled: "false"
+  # -- Timezone
+  timezone: UTC
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# External Database (when not using subchart)
+# =============================================================================
+
+externalDatabase:
+  # -- Use external database instead of subchart
+  enabled: false
+  # -- Database host
+  host: ""
+  # -- Database port
+  port: 5432
+  # -- Database name
+  name: "mhq-oss"
+  # -- Database user
+  user: "middleware"
+  # -- Database password
+  password: ""
+  # -- Existing secret with database credentials
+  existingSecret: ""
+  # -- Key in existing secret for password
+  existingSecretPasswordKey: user-password
+
+# =============================================================================
+# External Redis (when not using subchart)
+# =============================================================================
+
+externalRedis:
+  # -- Use external Redis instead of subchart
+  enabled: false
+  # -- Redis host
+  host: ""
+  # -- Redis port
+  port: 6379
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for /app/keys
+  enabled: true
+  # -- Storage size
+  size: 1Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Frontend service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Middleware
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: middleware.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - middleware.example.com
+    #   secretName: middleware-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []
+
+# =============================================================================
+# PostgreSQL Subchart
+# =============================================================================
+
+postgresql:
+  # -- Enable bundled PostgreSQL subchart
+  enabled: true
+  auth:
+    # -- PostgreSQL database name
+    database: mhq-oss
+    # -- PostgreSQL username
+    username: middleware
+    # -- PostgreSQL password (auto-generated if empty)
+    password: ""
+
+# =============================================================================
+# Redis Subchart
+# =============================================================================
+
+redis:
+  # -- Enable bundled Redis subchart
+  enabled: true
+  # -- Redis architecture
+  architecture: standalone


### PR DESCRIPTION
## Summary

- **ArchiveBox** — self-hosted web archiving with Chromium headless, multi-format capture (HTML, PDF, PNG, WARC), SQLite, /dev/shm memory-backed tmpfs, non-root UID 911
- **Countly** — product analytics with MongoDB subchart, dual ports (API 3001 + Dashboard 6001), configurable worker count and plugin system
- **Middleware** — DORA metrics platform with PostgreSQL + Redis subcharts, all-in-one container with internal services disabled, three ports (frontend/analytics/sync)

**Open Archiver** was skipped — `logiclabshq/open-archiver` has no versioned Docker tags on Docker Hub (only dev commit hashes), same blocker as Rybbit and Aptabase.

All charts follow HelmForge patterns with unit tests, CI values, `values.schema.json`, README with `@AI-METADATA`, and ArtifactHub annotations. All 3 charts are **alpha** maturity.

## Validation

- [x] `helm lint --strict` passes for all 3 charts
- [x] `helm unittest` passes for all 3 charts (60 tests total)
- [x] `helm template` with all CI values passes for all 3 charts
- [x] k3d deployment validated — all pods reach Running state
- [x] Root README.md updated with all 3 charts in the table

## Test plan

- [ ] CI lint + template + kubeconform passes
- [ ] Review each chart's values.yaml for correctness
- [ ] Verify ArtifactHub annotations render correctly after publish