### PR TITLE
feat: add superset, ckan, and druid charts (phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 | [archivebox](charts/archivebox/) | alpha | ArchiveBox — self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage |
 | [countly](charts/countly/) | alpha | Countly — product analytics platform with MongoDB, event tracking, crash reporting, and plugin system |
 | [middleware](charts/middleware/) | alpha | Middleware — open-source DORA metrics platform with PostgreSQL, Redis, and engineering performance tracking |
+| [superset](charts/superset/) | alpha | Apache Superset — data exploration and visualization with Celery workers, PostgreSQL, and Redis |
+| [ckan](charts/ckan/) | alpha | CKAN — open data portal with DataPusher, Solr, PostgreSQL, and Redis |
+| [druid](charts/druid/) | alpha | Apache Druid — distributed analytics database with coordinator, broker, historical, and router |
 
 ### Maturity levels
 

--- a/charts/ckan/Chart.lock
+++ b/charts/ckan/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.3
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.5.4
+digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
+generated: "2026-04-01T20:18:02.5974104-03:00"

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -1,0 +1,46 @@
+apiVersion: v2
+name: ckan
+description: CKAN open data portal with DataPusher, Solr, PostgreSQL, and Redis
+type: application
+version: 0.1.0
+appVersion: "2.11.4"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - ckan
+  - data
+  - portal
+  - open-data
+  - catalog
+  - api
+home: https://helmforge.dev/docs/charts/ckan
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/ckan
+  - https://github.com/ckan/ckan
+icon: https://raw.githubusercontent.com/ckan/ckan/master/ckan/public/base/images/ckan-logo.png
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/ckan
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/ckan
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+dependencies:
+  - name: postgresql
+    version: 1.8.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 1.5.4
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: redis.enabled

--- a/charts/ckan/README.md
+++ b/charts/ckan/README.md
@@ -1,0 +1,142 @@
+# CKAN
+
+CKAN is the world's leading open-source data management system for powering data hubs and data portals. It is used by national and local governments, research institutions, and other organizations to manage and publish collections of data.
+
+## Features
+
+- **CKAN application** — uWSGI-based Python application serving the data portal on port 5000
+- **DataPusher** — optional companion service for automatic resource loading (CSV, Excel to DataStore)
+- **Solr StatefulSet** — built-in search engine with CKAN-specific schema configuration
+- **PostgreSQL subchart** — bundled metadata store with option for external database
+- **Redis subchart** — bundled task queue and caching layer with option for external Redis
+- **Auto-generated secrets** — sysadmin password, session secret, JWT secret
+- **Persistent storage** — PVC for uploaded datasets at `/var/lib/ckan`
+- **Health probes** — startup, liveness, and readiness probes on `/api/action/status_show`
+- **Ingress support** — configurable with `ingressClassName` (traefik, nginx, etc.)
+- **Plugin system** — configure CKAN plugins via `ckan.plugins`
+
+## Install
+
+### Helm repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install ckan helmforge/ckan -f values.yaml
+```
+
+### OCI registry
+
+```bash
+helm install ckan oci://ghcr.io/helmforgedev/helm/ckan --version <version> -f values.yaml
+```
+
+## Architecture
+
+```
+Deployment: ckan (uWSGI, port 5000)
+Deployment: datapusher (port 8800)
+StatefulSet: solr (port 8983)
+  ├─ PostgreSQL (subchart)
+  └─ Redis (subchart)
+```
+
+## Default Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `ckan/ckan-base` | CKAN container image |
+| `image.tag` | `""` (appVersion) | Image tag |
+| `ckan.siteUrl` | `http://localhost:5000` | Public site URL |
+| `ckan.sysadminName` | `admin` | Sysadmin username |
+| `ckan.sysadminPassword` | `""` (auto) | Sysadmin password |
+| `ckan.plugins` | `envvars image_view text_view datatables_view` | Active plugins |
+| `ckan.replicaCount` | `1` | CKAN replicas |
+| `datapusher.enabled` | `true` | Enable DataPusher |
+| `solr.enabled` | `true` | Enable built-in Solr |
+| `solr.persistence.size` | `5Gi` | Solr data volume size |
+| `database.mode` | `subchart` | Database mode: subchart or external |
+| `redisConfig.mode` | `subchart` | Redis mode: subchart or external |
+| `persistence.enabled` | `true` | Enable CKAN storage persistence |
+| `persistence.size` | `10Gi` | CKAN storage volume size |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `80` | Service port |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `traefik` | Ingress class |
+| `postgresql.enabled` | `true` | Enable PostgreSQL subchart |
+| `redis.enabled` | `true` | Enable Redis subchart |
+
+## External Database
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    ckanDatabase: ckan
+    datastoreDatabase: datastore
+    username: ckan
+    password: my-password
+```
+
+## External Redis
+
+```yaml
+redis:
+  enabled: false
+
+redisConfig:
+  mode: external
+  external:
+    url: "redis://:password@redis.example.com:6379/0"
+```
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik  # or nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: ckan.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: ckan-tls
+      hosts:
+        - ckan.example.com
+```
+
+## Plugins
+
+Configure CKAN plugins via `ckan.plugins`:
+
+```yaml
+ckan:
+  plugins: "envvars image_view text_view recline_view datastore datapusher spatial_metadata spatial_query"
+```
+
+<!-- @AI-METADATA
+type: chart-readme
+title: CKAN Helm Chart
+description: CKAN open data portal with DataPusher, Solr, PostgreSQL, and Redis
+
+keywords: ckan, data, portal, open-data, catalog, api, solr
+
+purpose: Installation, configuration, and operational guide for the CKAN Helm chart
+scope: charts/ckan
+
+relations:
+  - charts/ckan/values.yaml
+  - charts/ckan/Chart.yaml
+path: charts/ckan/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/ckan/ci/default-values.yaml
+++ b/charts/ckan/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Default CI scenario — all components enabled with subcharts

--- a/charts/ckan/ci/external-db-values.yaml
+++ b/charts/ckan/ci/external-db-values.yaml
@@ -1,0 +1,27 @@
+# CI scenario — external database and Redis, no Solr
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false
+
+solr:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    ckanDatabase: ckan
+    datastoreDatabase: datastore
+    username: ckan
+    password: external-password
+
+redisConfig:
+  mode: external
+  external:
+    url: "redis://:redis-password@redis.example.com:6379/0"
+
+datapusher:
+  enabled: false

--- a/charts/ckan/ci/minimal-values.yaml
+++ b/charts/ckan/ci/minimal-values.yaml
@@ -1,0 +1,3 @@
+# CI scenario — minimal install without DataPusher
+datapusher:
+  enabled: false

--- a/charts/ckan/templates/NOTES.txt
+++ b/charts/ckan/templates/NOTES.txt
@@ -1,0 +1,12 @@
+CKAN has been installed.
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl port-forward svc/{{ include "ckan.fullname" . }} 5000:{{ .Values.service.port }}
+  Web UI: http://localhost:5000
+{{- end }}
+
+Default credentials: {{ .Values.ckan.sysadminName }} / (check secret {{ include "ckan.secretName" . }})

--- a/charts/ckan/templates/_helpers.tpl
+++ b/charts/ckan/templates/_helpers.tpl
@@ -1,0 +1,277 @@
+{{- define "ckan.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ckan.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "ckan.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ckan.labels" -}}
+helm.sh/chart: {{ include "ckan.chart" . }}
+{{ include "ckan.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "ckan.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ckan.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "ckan.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+
+{{- define "ckan.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "ckan.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Secret
+# =============================================================================
+
+{{- define "ckan.secretName" -}}
+{{- if .Values.ckan.existingSecret -}}
+{{- .Values.ckan.existingSecret -}}
+{{- else -}}
+{{- include "ckan.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Database
+# =============================================================================
+
+{{- define "ckan.databaseHost" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.databasePort" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.port | toString -}}
+{{- else -}}
+5432
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.databaseName" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.ckanDatabase -}}
+{{- else -}}
+{{- .Values.postgresql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.databaseUsername" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.username -}}
+{{- else -}}
+{{- .Values.postgresql.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.databaseSecretName" -}}
+{{- if and (eq .Values.database.mode "external") .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else if eq .Values.database.mode "external" -}}
+{{- printf "%s-database" (include "ckan.fullname" .) -}}
+{{- else -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.databaseSecretKey" -}}
+{{- if and (eq .Values.database.mode "external") .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else if eq .Values.database.mode "external" -}}
+database-password
+{{- else -}}
+user-password
+{{- end -}}
+{{- end -}}
+
+{{/*
+CKAN_SQLALCHEMY_URL template — password injected at runtime via shell export.
+*/}}
+{{- define "ckan.sqlalchemyUrlTemplate" -}}
+postgresql://{{ include "ckan.databaseUsername" . }}:__DB_PASSWORD__@{{ include "ckan.databaseHost" . }}:{{ include "ckan.databasePort" . }}/{{ include "ckan.databaseName" . }}
+{{- end -}}
+
+# =============================================================================
+# Redis
+# =============================================================================
+
+{{- define "ckan.redisUrlTemplate" -}}
+{{- if eq .Values.redisConfig.mode "external" -}}
+{{- .Values.redisConfig.external.url -}}
+{{- else -}}
+redis://:__REDIS_PASSWORD__@{{ printf "%s-redis-client" .Release.Name }}:6379/0
+{{- end -}}
+{{- end -}}
+
+{{- define "ckan.redisSecretName" -}}
+{{- if eq .Values.redisConfig.mode "external" -}}
+{{- "" -}}
+{{- else -}}
+{{- printf "%s-redis-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Solr
+# =============================================================================
+
+{{- define "ckan.solrUrl" -}}
+{{- if .Values.solr.enabled -}}
+http://{{ include "ckan.fullname" . }}-solr:{{ .Values.solr.port }}/solr/ckan
+{{- else -}}
+{{- .Values.solr.externalUrl -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# DataPusher
+# =============================================================================
+
+{{- define "ckan.datapusherUrl" -}}
+{{- if .Values.datapusher.enabled -}}
+http://{{ include "ckan.fullname" . }}-datapusher:{{ .Values.datapusher.port }}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Common env vars
+# =============================================================================
+
+{{- define "ckan.commonEnv" -}}
+- name: CKAN_SITE_URL
+  value: {{ .Values.ckan.siteUrl | quote }}
+- name: CKAN_SITE_TITLE
+  value: {{ .Values.ckan.siteTitle | quote }}
+- name: CKAN_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ckan.databaseSecretName" . }}
+      key: {{ include "ckan.databaseSecretKey" . }}
+- name: CKAN_SQLALCHEMY_URL_TEMPLATE
+  value: {{ include "ckan.sqlalchemyUrlTemplate" . | quote }}
+{{- if and (ne .Values.redisConfig.mode "external") .Values.redis.enabled }}
+- name: CKAN_REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ckan.redisSecretName" . }}
+      key: redis-password
+{{- end }}
+- name: CKAN_REDIS_URL_TEMPLATE
+  value: {{ include "ckan.redisUrlTemplate" . | quote }}
+- name: CKAN_SOLR_URL
+  value: {{ include "ckan.solrUrl" . | quote }}
+{{- if .Values.datapusher.enabled }}
+- name: CKAN_DATAPUSHER_URL
+  value: {{ include "ckan.datapusherUrl" . | quote }}
+{{- end }}
+- name: CKAN___BEAKER__SESSION__SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ckan.secretName" . }}
+      key: {{ .Values.ckan.existingSecretSessionKey | default "session-secret" }}
+- name: CKAN___API_TOKEN__JWT__ENCODE__SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ckan.secretName" . }}
+      key: {{ .Values.ckan.existingSecretJwtKey | default "jwt-secret" }}
+- name: CKAN___API_TOKEN__JWT__DECODE__SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ckan.secretName" . }}
+      key: {{ .Values.ckan.existingSecretJwtKey | default "jwt-secret" }}
+- name: CKAN__PLUGINS
+  value: {{ .Values.ckan.plugins | quote }}
+{{- with .Values.ckan.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+# =============================================================================
+# Startup command that injects passwords into URLs before exec
+# =============================================================================
+
+{{- define "ckan.startupCommand" -}}
+export CKAN_SQLALCHEMY_URL=$(echo "$CKAN_SQLALCHEMY_URL_TEMPLATE" | sed "s|__DB_PASSWORD__|$CKAN_DB_PASSWORD|g")
+export CKAN_REDIS_URL=$(echo "$CKAN_REDIS_URL_TEMPLATE" | sed "s|__REDIS_PASSWORD__|${CKAN_REDIS_PASSWORD:-}|g")
+INI=${CKAN_INI:-/srv/app/ckan.ini}
+ckan config-tool $INI "sqlalchemy.url = $CKAN_SQLALCHEMY_URL"
+ckan config-tool $INI "ckan.redis.url = $CKAN_REDIS_URL"
+ckan config-tool $INI "solr_url = $CKAN_SOLR_URL"
+ckan config-tool $INI "ckan.plugins = $CKAN__PLUGINS"
+{{- if .Values.datapusher.enabled }}
+ckan config-tool $INI "ckan.datapusher.url = $CKAN_DATAPUSHER_URL"
+{{- end }}
+exec /srv/app/start_ckan.sh
+{{- end -}}
+
+# =============================================================================
+# Init containers
+# =============================================================================
+
+{{- define "ckan.initContainers" -}}
+- name: wait-for-postgresql
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ include "ckan.databaseHost" . }}:{{ include "ckan.databasePort" . }} ..."
+      until nc -z -w2 {{ include "ckan.databaseHost" . }} {{ include "ckan.databasePort" . }}; do
+        sleep 2
+      done
+      echo "PostgreSQL is reachable."
+{{- if .Values.solr.enabled }}
+- name: wait-for-solr
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ include "ckan.fullname" . }}-solr:{{ .Values.solr.port }} ..."
+      until nc -z -w2 {{ include "ckan.fullname" . }}-solr {{ .Values.solr.port }}; do
+        sleep 2
+      done
+      echo "Solr is reachable."
+{{- end }}
+{{- if and (ne .Values.redisConfig.mode "external") .Values.redis.enabled }}
+- name: wait-for-redis
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ printf "%s-redis-client" .Release.Name }}:6379 ..."
+      until nc -z -w2 {{ printf "%s-redis-client" .Release.Name }} 6379; do
+        sleep 2
+      done
+      echo "Redis is reachable."
+{{- end }}
+{{- end -}}

--- a/charts/ckan/templates/datapusher-deployment.yaml
+++ b/charts/ckan/templates/datapusher-deployment.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.datapusher.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ckan.fullname" . }}-datapusher
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datapusher
+spec:
+  replicas: {{ .Values.datapusher.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ckan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: datapusher
+  template:
+    metadata:
+      labels:
+        {{- include "ckan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: datapusher
+        {{- with .Values.datapusher.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.datapusher.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: datapusher
+          image: "{{ .Values.datapusher.image.repository }}:{{ .Values.datapusher.image.tag }}"
+          imagePullPolicy: {{ .Values.datapusher.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.datapusher.port }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.datapusher.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ckan/templates/deployment.yaml
+++ b/charts/ckan/templates/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ckan.fullname" . }}
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ckan
+spec:
+  replicas: {{ .Values.ckan.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ckan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ckan
+  template:
+    metadata:
+      labels:
+        {{- include "ckan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ckan
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ckan.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "ckan.initContainers" . | nindent 8 }}
+      containers:
+        - name: ckan
+          image: {{ include "ckan.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {{ include "ckan.startupCommand" . | nindent 14 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "ckan.commonEnv" . | nindent 12 }}
+            - name: CKAN_SYSADMIN_NAME
+              value: {{ .Values.ckan.sysadminName | quote }}
+            - name: CKAN_SYSADMIN_EMAIL
+              value: {{ .Values.ckan.sysadminEmail | quote }}
+            - name: CKAN_SYSADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ckan.secretName" . }}
+                  key: {{ .Values.ckan.existingSecretPasswordKey | default "sysadmin-password" }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          {{- with .Values.probes.startup }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.probes.liveness }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.probes.readiness }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: ckan-storage
+              mountPath: /var/lib/ckan
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: ckan-storage
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-storage" (include "ckan.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/ckan/templates/extra-manifests.yaml
+++ b/charts/ckan/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/ckan/templates/ingress.yaml
+++ b/charts/ckan/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ckan.fullname" . }}
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ckan.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ckan/templates/pvc.yaml
+++ b/charts/ckan/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ckan.fullname" . }}-storage
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/ckan/templates/secret.yaml
+++ b/charts/ckan/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.ckan.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ckan.fullname" . }}
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  sysadmin-password: {{ .Values.ckan.sysadminPassword | default (randAlphaNum 32) | quote }}
+  session-secret: {{ .Values.ckan.sessionSecret | default (randAlphaNum 42) | quote }}
+  jwt-secret: {{ .Values.ckan.jwtSecret | default (randAlphaNum 42) | quote }}
+{{- end }}
+---
+{{- if and (eq .Values.database.mode "external") (not .Values.database.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-database" (include "ckan.fullname" .) }}
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-password: {{ .Values.database.external.password | default (randAlphaNum 32) | quote }}
+{{- end }}

--- a/charts/ckan/templates/service.yaml
+++ b/charts/ckan/templates/service.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ckan.fullname" . }}
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ckan
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "ckan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ckan
+---
+{{- if .Values.datapusher.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ckan.fullname" . }}-datapusher
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: datapusher
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.datapusher.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "ckan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: datapusher
+{{- end }}
+---
+{{- if .Values.solr.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ckan.fullname" . }}-solr
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: solr
+spec:
+  type: ClusterIP
+  ports:
+    - name: solr
+      port: {{ .Values.solr.port }}
+      targetPort: solr
+      protocol: TCP
+  selector:
+    {{- include "ckan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: solr
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ckan.fullname" . }}-solr-headless
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: solr
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: solr
+      port: {{ .Values.solr.port }}
+      targetPort: solr
+      protocol: TCP
+  selector:
+    {{- include "ckan.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: solr
+{{- end }}

--- a/charts/ckan/templates/serviceaccount.yaml
+++ b/charts/ckan/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ckan.serviceAccountName" . }}
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ckan/templates/solr-statefulset.yaml
+++ b/charts/ckan/templates/solr-statefulset.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.solr.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ckan.fullname" . }}-solr
+  labels:
+    {{- include "ckan.labels" . | nindent 4 }}
+    app.kubernetes.io/component: solr
+spec:
+  replicas: 1
+  serviceName: {{ include "ckan.fullname" . }}-solr-headless
+  selector:
+    matchLabels:
+      {{- include "ckan.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: solr
+  template:
+    metadata:
+      labels:
+        {{- include "ckan.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: solr
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: solr
+          image: "{{ .Values.solr.image.repository }}:{{ .Values.solr.image.tag }}"
+          imagePullPolicy: {{ .Values.solr.image.pullPolicy }}
+          ports:
+            - name: solr
+              containerPort: {{ .Values.solr.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /solr/ckan/admin/ping
+              port: solr
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /solr/ckan/admin/ping
+              port: solr
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          volumeMounts:
+            - name: solr-data
+              mountPath: /var/solr/data
+          {{- with .Values.solr.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  {{- if .Values.solr.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: solr-data
+      spec:
+        accessModes:
+          {{- toYaml .Values.solr.persistence.accessModes | nindent 10 }}
+        {{- with .Values.solr.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.solr.persistence.size }}
+  {{- else }}
+      volumes:
+        - name: solr-data
+          emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/charts/ckan/tests/datapusher_test.yaml
+++ b/charts/ckan/tests/datapusher_test.yaml
@@ -1,0 +1,42 @@
+suite: DataPusher Deployment
+templates:
+  - templates/datapusher-deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment when enabled
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-ckan-datapusher
+
+  - it: should have datapusher component label
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: datapusher
+
+  - it: should use correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ckan/ckan-base-datapusher:0.0.21"
+
+  - it: should not render when disabled
+    set:
+      datapusher.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should expose port 8800
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8800
+            protocol: TCP

--- a/charts/ckan/tests/deployment_test.yaml
+++ b/charts/ckan/tests/deployment_test.yaml
@@ -1,0 +1,65 @@
+suite: CKAN Deployment
+templates:
+  - templates/deployment.yaml
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-ckan
+
+  - it: should have ckan component label
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: ckan
+
+  - it: should use the correct image
+    template: templates/deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "ckan/ckan-base:2\\.11\\.4"
+
+  - it: should expose port 5000
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 5000
+            protocol: TCP
+
+  - it: should mount ckan-storage volume
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ckan-storage
+            mountPath: /var/lib/ckan
+
+  - it: should have init containers
+    template: templates/deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.initContainers
+
+  - it: should have health probes
+    template: templates/deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].startupProbe

--- a/charts/ckan/tests/ingress_test.yaml
+++ b/charts/ckan/tests/ingress_test.yaml
@@ -1,0 +1,27 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: ckan.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: ckan.example.com

--- a/charts/ckan/tests/pvc_test.yaml
+++ b/charts/ckan/tests/pvc_test.yaml
@@ -1,0 +1,34 @@
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a PVC by default
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-ckan-storage
+
+  - it: should use default size
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should not render when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when existingClaim is set
+    set:
+      persistence.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/ckan/tests/secret_test.yaml
+++ b/charts/ckan/tests/secret_test.yaml
@@ -1,0 +1,36 @@
+suite: Secrets
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render CKAN secret with auto-generated values
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - isNotNull:
+          path: stringData["sysadmin-password"]
+      - isNotNull:
+          path: stringData["session-secret"]
+      - isNotNull:
+          path: stringData["jwt-secret"]
+
+  - it: should not render when existingSecret is set
+    set:
+      ckan.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render external database secret
+    set:
+      database.mode: external
+      database.external.host: pg.example.com
+      database.external.password: ext-pass
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/ckan/tests/service_test.yaml
+++ b/charts/ckan/tests/service_test.yaml
@@ -1,0 +1,46 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render CKAN service
+    documentSelector:
+      path: metadata.name
+      value: test-ckan
+    asserts:
+      - isKind:
+          of: Service
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP
+
+  - it: should render DataPusher service
+    documentSelector:
+      path: metadata.name
+      value: test-ckan-datapusher
+    asserts:
+      - isKind:
+          of: Service
+
+  - it: should render Solr service
+    documentSelector:
+      path: metadata.name
+      value: test-ckan-solr
+    asserts:
+      - isKind:
+          of: Service
+
+  - it: should select ckan component
+    documentSelector:
+      path: metadata.name
+      value: test-ckan
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: ckan

--- a/charts/ckan/tests/solr_test.yaml
+++ b/charts/ckan/tests/solr_test.yaml
@@ -1,0 +1,38 @@
+suite: Solr StatefulSet
+templates:
+  - templates/solr-statefulset.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a StatefulSet when enabled
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: test-ckan-solr
+
+  - it: should have solr component label
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: solr
+
+  - it: should use correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ckan/ckan-solr:2.11-solr9"
+
+  - it: should not render when disabled
+    set:
+      solr.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have persistence by default
+    asserts:
+      - isNotNull:
+          path: spec.volumeClaimTemplates

--- a/charts/ckan/values.schema.json
+++ b/charts/ckan/values.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "CKAN Helm Chart Values",
+  "description": "Values for the CKAN Helm chart — open data portal with DataPusher, Solr, PostgreSQL, and Redis",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "ckan/ckan-base" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "ckan": {
+      "type": "object",
+      "description": "CKAN application configuration",
+      "properties": {
+        "siteUrl": { "type": "string", "default": "http://localhost:5000" },
+        "siteTitle": { "type": "string", "default": "CKAN" },
+        "sysadminName": { "type": "string", "default": "admin" },
+        "sysadminEmail": { "type": "string", "default": "admin@ckan.local" },
+        "sysadminPassword": { "type": "string", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "sessionSecret": { "type": "string", "default": "" },
+        "jwtSecret": { "type": "string", "default": "" },
+        "plugins": { "type": "string" },
+        "replicaCount": { "type": "integer", "default": 1 },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "datapusher": {
+      "type": "object",
+      "description": "DataPusher configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "image": { "type": "object" },
+        "replicaCount": { "type": "integer", "default": 1 },
+        "port": { "type": "integer", "default": 8800 },
+        "resources": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "podAnnotations": { "type": "object" }
+      }
+    },
+    "solr": {
+      "type": "object",
+      "description": "Solr configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "image": { "type": "object" },
+        "port": { "type": "integer", "default": 8983 },
+        "persistence": { "type": "object" },
+        "resources": { "type": "object" },
+        "externalUrl": { "type": "string", "default": "" }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "Database configuration",
+      "properties": {
+        "mode": { "type": "string", "enum": ["subchart", "external"], "default": "subchart" },
+        "external": { "type": "object" }
+      }
+    },
+    "redisConfig": {
+      "type": "object",
+      "description": "Redis configuration",
+      "properties": {
+        "mode": { "type": "string", "enum": ["subchart", "external"], "default": "subchart" },
+        "external": { "type": "object" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "description": "CKAN storage persistence",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "10Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "resources": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -1,0 +1,318 @@
+# =============================================================================
+# CKAN Configuration
+# =============================================================================
+
+# -- Override the chart name used in resource names
+nameOverride: ""
+
+# -- Override the full release name used in resource names
+fullnameOverride: ""
+
+# -- Labels added to every resource created by this chart
+commonLabels: {}
+
+image:
+  # -- CKAN container image repository
+  repository: ckan/ckan-base
+  # -- CKAN image tag. Defaults to appVersion.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# =============================================================================
+# CKAN Application
+# =============================================================================
+
+ckan:
+  # -- CKAN site URL (required for proper link generation)
+  siteUrl: "http://localhost:5000"
+  # -- CKAN site title
+  siteTitle: "CKAN"
+  # -- Sysadmin username
+  sysadminName: admin
+  # -- Sysadmin email
+  sysadminEmail: admin@ckan.local
+  # -- Sysadmin password. Auto-generated if empty.
+  sysadminPassword: ""
+  # -- Existing secret with CKAN credentials
+  existingSecret: ""
+  # -- Key in existingSecret for sysadmin password
+  existingSecretPasswordKey: sysadmin-password
+  # -- Key in existingSecret for session secret
+  existingSecretSessionKey: session-secret
+  # -- Key in existingSecret for JWT secret
+  existingSecretJwtKey: jwt-secret
+  # -- Session secret (Beaker). Auto-generated if empty.
+  sessionSecret: ""
+  # -- JWT encode/decode secret. Auto-generated if empty.
+  jwtSecret: ""
+  # -- CKAN plugins to enable
+  plugins: "envvars image_view text_view datatables_view"
+  # -- Number of CKAN replicas
+  replicaCount: 1
+  # -- Extra environment variables
+  extraEnv: []
+
+# =============================================================================
+# DataPusher
+# =============================================================================
+
+datapusher:
+  # -- Enable DataPusher
+  enabled: true
+  # -- DataPusher image repository
+  image:
+    repository: ckan/ckan-base-datapusher
+    tag: "0.0.21"
+    pullPolicy: IfNotPresent
+  # -- Number of DataPusher replicas
+  replicaCount: 1
+  # -- DataPusher port
+  port: 8800
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# Solr
+# =============================================================================
+
+solr:
+  # -- Enable built-in Solr StatefulSet
+  enabled: true
+  # -- Solr image repository
+  image:
+    repository: ckan/ckan-solr
+    tag: "2.11-solr9"
+    pullPolicy: IfNotPresent
+  # -- Solr port
+  port: 8983
+  # -- Solr persistence
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  # -- Resource requests and limits
+  resources: {}
+  # -- External Solr URL (used when solr.enabled=false)
+  externalUrl: ""
+
+# =============================================================================
+# Database
+# =============================================================================
+
+database:
+  # -- Database mode: subchart | external
+  mode: subchart
+  external:
+    # -- External database host
+    host: ""
+    # -- External database port
+    port: 5432
+    # -- External CKAN database name
+    ckanDatabase: ckan
+    # -- External DataStore database name
+    datastoreDatabase: datastore
+    # -- External database username
+    username: ckan
+    # -- External database password
+    password: ""
+    # -- DataStore read-only username
+    datastoreReadUsername: datastore_ro
+    # -- DataStore read-only password
+    datastoreReadPassword: ""
+    # -- Existing secret with external database passwords
+    existingSecret: ""
+    # -- Key in existingSecret for password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# Redis
+# =============================================================================
+
+redisConfig:
+  # -- Redis mode: subchart | external
+  mode: subchart
+  external:
+    # -- External Redis URL (e.g., redis://:password@host:6379/0)
+    url: ""
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for CKAN storage
+  enabled: true
+  # -- Storage size
+  size: 10Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 80
+  # -- Service annotations
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name (traefik, nginx, etc.)
+  ingressClassName: traefik
+  # -- Ingress annotations
+  # @default -- `{}`
+  # Example:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  annotations: {}
+  # -- Ingress hosts
+  # @default -- `[]`
+  # Example:
+  #   - host: ckan.example.com
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix
+  hosts: []
+  # -- Ingress TLS
+  # @default -- `[]`
+  # Example:
+  #   - secretName: ckan-tls
+  #     hosts:
+  #       - ckan.example.com
+  tls: []
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  liveness:
+    httpGet:
+      path: /api/action/status_show
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /api/action/status_show
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  startup:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 60
+
+# =============================================================================
+# ServiceAccount
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- ServiceAccount annotations
+  annotations: {}
+
+# =============================================================================
+# Security & Scheduling
+# =============================================================================
+
+# -- Pod-level security context
+podSecurityContext: {}
+
+# -- Container-level security context
+securityContext: {}
+
+# -- Resource requests and limits
+resources: {}
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# -- Priority class name
+priorityClassName: ""
+
+# -- Termination grace period in seconds
+terminationGracePeriodSeconds: 30
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Extra volumes
+extraVolumes: []
+
+# -- Extra volume mounts
+extraVolumeMounts: []
+
+# -- Extra Kubernetes manifests to deploy
+extraManifests: []
+
+# =============================================================================
+# PostgreSQL Subchart
+# =============================================================================
+
+postgresql:
+  # -- Enable PostgreSQL subchart
+  enabled: true
+  auth:
+    # -- PostgreSQL database name
+    database: ckan
+    # -- PostgreSQL username
+    username: ckan
+    # -- PostgreSQL password. Auto-generated if empty.
+    password: ""
+
+# =============================================================================
+# Redis Subchart
+# =============================================================================
+
+redis:
+  # -- Enable Redis subchart
+  enabled: true
+  auth:
+    # -- Redis password. Auto-generated if empty.
+    password: ""

--- a/charts/druid/Chart.lock
+++ b/charts/druid/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.3
+- name: zookeeper
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 13.8.7
+digest: sha256:43880dcf7950c427690c460ba47655fffc5e6d49831ab688145c6393d5a5bccf
+generated: "2026-04-01T21:03:16.0079409-03:00"

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -1,0 +1,46 @@
+apiVersion: v2
+name: druid
+description: Apache Druid distributed analytics database with coordinator, broker, historical, middlemanager, overlord, and router
+type: application
+version: 0.1.0
+appVersion: "36.0.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - druid
+  - analytics
+  - olap
+  - database
+  - realtime
+  - query
+home: https://helmforge.dev/docs/charts/druid
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/druid
+  - https://github.com/apache/druid
+icon: https://raw.githubusercontent.com/apache/druid/master/website/static/img/druid_nav.png
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/category: database
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/druid
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/druid
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+dependencies:
+  - name: postgresql
+    version: 1.8.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: zookeeper
+    version: 13.8.7
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: zookeeper.enabled

--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -1,0 +1,186 @@
+# Apache Druid
+
+Apache Druid is a high-performance, real-time analytics database designed for fast slice-and-dice analytics on large datasets. It is commonly used for powering user-facing analytic applications, BI dashboards, and real-time data exploration.
+
+## Features
+
+- **6-component architecture** — coordinator, overlord, broker, router, historical, and middlemanager
+- **Web console** — router component serves the Druid web console
+- **PostgreSQL subchart** — bundled metadata store with option for external database
+- **ZooKeeper subchart** — bundled Bitnami ZooKeeper with option for external cluster
+- **Deep storage** — local or S3-compatible (MinIO, AWS S3)
+- **Persistent volumes** — segment cache (historical) and task storage (middlemanager)
+- **Health probes** — liveness on `/status/health`, readiness on `/status/selfDiscovered`
+- **Ingress support** — configurable with `ingressClassName` (traefik, nginx, etc.)
+- **Per-component scaling** — independent replica counts and JVM tuning
+
+## Install
+
+### Helm repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install druid helmforge/druid -f values.yaml
+```
+
+### OCI registry
+
+```bash
+helm install druid oci://ghcr.io/helmforgedev/helm/druid --version <version> -f values.yaml
+```
+
+## Architecture
+
+```
+StatefulSet: coordinator (port 8081)
+StatefulSet: overlord (port 8090)
+Deployment:  broker (port 8082)
+Deployment:  router (port 8888) ← web console
+StatefulSet: historical (port 8083, PVC: segment-cache)
+StatefulSet: middlemanager (port 8091, PVC: task-storage)
+  ├─ PostgreSQL (subchart, metadata storage)
+  └─ ZooKeeper (subchart, coordination)
+```
+
+## Default Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `apache/druid` | Druid container image |
+| `image.tag` | `""` (appVersion) | Image tag |
+| `coordinator.enabled` | `true` | Enable coordinator |
+| `coordinator.replicaCount` | `1` | Coordinator replicas |
+| `coordinator.port` | `8081` | Coordinator port |
+| `coordinator.javaOpts` | `-Xms256m -Xmx512m` | Coordinator JVM options |
+| `overlord.enabled` | `true` | Enable overlord |
+| `overlord.port` | `8090` | Overlord port |
+| `broker.enabled` | `true` | Enable broker |
+| `broker.port` | `8082` | Broker port |
+| `broker.javaOpts` | `-Xms512m -Xmx1g` | Broker JVM options |
+| `router.enabled` | `true` | Enable router (web console) |
+| `router.port` | `8888` | Router port |
+| `historical.enabled` | `true` | Enable historical |
+| `historical.port` | `8083` | Historical port |
+| `historical.persistence.size` | `10Gi` | Segment cache volume size |
+| `middleManager.enabled` | `true` | Enable middle manager |
+| `middleManager.port` | `8091` | MiddleManager port |
+| `middleManager.workerCapacity` | `2` | Tasks per middle manager |
+| `middleManager.persistence.size` | `10Gi` | Task storage volume size |
+| `metadata.mode` | `subchart` | Metadata mode: subchart or external |
+| `zookeeperConfig.mode` | `subchart` | ZooKeeper mode: subchart or external |
+| `deepStorage.type` | `local` | Deep storage: local or s3 |
+| `service.type` | `ClusterIP` | Router service type |
+| `service.port` | `80` | Router service port |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `traefik` | Ingress class |
+| `postgresql.enabled` | `true` | Enable PostgreSQL subchart |
+| `zookeeper.enabled` | `true` | Enable ZooKeeper subchart |
+
+## External Metadata Storage
+
+```yaml
+postgresql:
+  enabled: false
+
+metadata:
+  mode: external
+  external:
+    type: postgresql
+    host: postgres.example.com
+    port: 5432
+    name: druid
+    username: druid
+    password: my-password
+```
+
+## External ZooKeeper
+
+```yaml
+zookeeper:
+  enabled: false
+
+zookeeperConfig:
+  mode: external
+  external:
+    hosts: "zk1.example.com:2181,zk2.example.com:2181,zk3.example.com:2181"
+```
+
+## S3 Deep Storage
+
+```yaml
+deepStorage:
+  type: s3
+  s3:
+    bucket: my-druid-bucket
+    baseKey: druid/segments
+    region: us-east-1
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+For MinIO or S3-compatible storage:
+
+```yaml
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid
+    baseKey: segments
+    region: us-east-1
+    endpointUrl: http://minio.minio.svc:9000
+    accessKey: minioadmin
+    secretKey: minioadmin
+```
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik  # or nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: druid.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: druid-tls
+      hosts:
+        - druid.example.com
+```
+
+## Extra Runtime Properties
+
+Each component supports `extraProperties` for additional Druid runtime configuration:
+
+```yaml
+broker:
+  extraProperties: |
+    druid.broker.http.numConnections=20
+    druid.server.http.numThreads=40
+
+historical:
+  extraProperties: |
+    druid.segmentCache.locations=[{"path":"/opt/druid/var/druid/segment-cache","maxSize":10737418240}]
+```
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Apache Druid Helm Chart
+description: Apache Druid distributed analytics database with coordinator, broker, historical, middlemanager, overlord, and router
+
+keywords: druid, analytics, olap, database, realtime, query
+
+purpose: Installation, configuration, and operational guide for the Apache Druid Helm chart
+scope: charts/druid
+
+relations:
+  - charts/druid/values.yaml
+  - charts/druid/Chart.yaml
+path: charts/druid/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/druid/ci/default-values.yaml
+++ b/charts/druid/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Default values — tests all components with subchart dependencies

--- a/charts/druid/ci/external-metadata-values.yaml
+++ b/charts/druid/ci/external-metadata-values.yaml
@@ -1,0 +1,21 @@
+# External metadata storage scenario
+postgresql:
+  enabled: false
+
+metadata:
+  mode: external
+  external:
+    type: postgresql
+    host: postgres.example.com
+    port: 5432
+    name: druid
+    username: druid
+    password: my-secret-password
+
+zookeeperConfig:
+  mode: external
+  external:
+    hosts: "zk1.example.com:2181,zk2.example.com:2181"
+
+zookeeper:
+  enabled: false

--- a/charts/druid/ci/minimal-values.yaml
+++ b/charts/druid/ci/minimal-values.yaml
@@ -1,0 +1,7 @@
+# Minimal scenario — only coordinator, broker, and router
+overlord:
+  enabled: false
+historical:
+  enabled: false
+middleManager:
+  enabled: false

--- a/charts/druid/ci/s3-storage-values.yaml
+++ b/charts/druid/ci/s3-storage-values.yaml
@@ -1,0 +1,9 @@
+# S3 deep storage scenario
+deepStorage:
+  type: s3
+  s3:
+    bucket: my-druid-bucket
+    baseKey: druid/segments
+    region: us-east-1
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/charts/druid/templates/NOTES.txt
+++ b/charts/druid/templates/NOTES.txt
@@ -1,0 +1,35 @@
+Apache Druid has been deployed!
+
+Components:
+{{- if .Values.coordinator.enabled }}
+  - Coordinator: {{ include "druid.fullname" . }}-coordinator:{{ .Values.coordinator.port }}
+{{- end }}
+{{- if .Values.overlord.enabled }}
+  - Overlord:    {{ include "druid.fullname" . }}-overlord:{{ .Values.overlord.port }}
+{{- end }}
+{{- if .Values.broker.enabled }}
+  - Broker:      {{ include "druid.fullname" . }}-broker:{{ .Values.broker.port }}
+{{- end }}
+{{- if .Values.router.enabled }}
+  - Router:      {{ include "druid.fullname" . }}-router:{{ .Values.router.port }}
+{{- end }}
+{{- if .Values.historical.enabled }}
+  - Historical:  {{ include "druid.fullname" . }}-historical:{{ .Values.historical.port }}
+{{- end }}
+{{- if .Values.middleManager.enabled }}
+  - MiddleMgr:  {{ include "druid.fullname" . }}-middlemanager:{{ .Values.middleManager.port }}
+{{- end }}
+
+{{- if .Values.router.enabled }}
+
+Web Console:
+  kubectl port-forward svc/{{ include "druid.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  Then open http://localhost:{{ .Values.service.port }}
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+
+Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- end }}

--- a/charts/druid/templates/_helpers.tpl
+++ b/charts/druid/templates/_helpers.tpl
@@ -1,0 +1,211 @@
+{{- define "druid.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "druid.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "druid.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "druid.labels" -}}
+helm.sh/chart: {{ include "druid.chart" . }}
+{{ include "druid.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "druid.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "druid.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "druid.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+
+{{- define "druid.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "druid.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Metadata Storage (PostgreSQL)
+# =============================================================================
+
+{{- define "druid.metadataHost" -}}
+{{- if eq .Values.metadata.mode "external" -}}
+{{- .Values.metadata.external.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataPort" -}}
+{{- if eq .Values.metadata.mode "external" -}}
+{{- .Values.metadata.external.port | toString -}}
+{{- else -}}
+5432
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataName" -}}
+{{- if eq .Values.metadata.mode "external" -}}
+{{- .Values.metadata.external.name -}}
+{{- else -}}
+{{- .Values.postgresql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataUsername" -}}
+{{- if eq .Values.metadata.mode "external" -}}
+{{- .Values.metadata.external.username -}}
+{{- else -}}
+{{- .Values.postgresql.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataType" -}}
+{{- if eq .Values.metadata.mode "external" -}}
+{{- .Values.metadata.external.type -}}
+{{- else -}}
+postgresql
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataSecretName" -}}
+{{- if and (eq .Values.metadata.mode "external") .Values.metadata.external.existingSecret -}}
+{{- .Values.metadata.external.existingSecret -}}
+{{- else if eq .Values.metadata.mode "external" -}}
+{{- printf "%s-metadata" (include "druid.fullname" .) -}}
+{{- else -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataSecretKey" -}}
+{{- if and (eq .Values.metadata.mode "external") .Values.metadata.external.existingSecret -}}
+{{- .Values.metadata.external.existingSecretPasswordKey -}}
+{{- else if eq .Values.metadata.mode "external" -}}
+metadata-password
+{{- else -}}
+user-password
+{{- end -}}
+{{- end -}}
+
+{{- define "druid.metadataConnectUri" -}}
+{{- $type := include "druid.metadataType" . -}}
+{{- if eq $type "mysql" -}}
+jdbc:mysql://{{ include "druid.metadataHost" . }}:{{ include "druid.metadataPort" . }}/{{ include "druid.metadataName" . }}
+{{- else -}}
+jdbc:postgresql://{{ include "druid.metadataHost" . }}:{{ include "druid.metadataPort" . }}/{{ include "druid.metadataName" . }}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# ZooKeeper
+# =============================================================================
+
+{{- define "druid.zookeeperHosts" -}}
+{{- if eq .Values.zookeeperConfig.mode "external" -}}
+{{- .Values.zookeeperConfig.external.hosts -}}
+{{- else -}}
+{{- printf "%s-zookeeper:2181" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Deep Storage
+# =============================================================================
+
+{{- define "druid.deepStorageSecretName" -}}
+{{- if .Values.deepStorage.s3.existingSecret -}}
+{{- .Values.deepStorage.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-deep-storage" (include "druid.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Common environment variables
+# =============================================================================
+
+{{- define "druid.commonEnv" -}}
+- name: DRUID_METADATA_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "druid.metadataSecretName" . }}
+      key: {{ include "druid.metadataSecretKey" . }}
+{{- if eq .Values.deepStorage.type "s3" }}
+- name: DRUID_S3_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "druid.deepStorageSecretName" . }}
+      key: {{ if .Values.deepStorage.s3.existingSecret }}{{ .Values.deepStorage.s3.existingSecretAccessKeyKey }}{{ else }}access-key{{ end }}
+- name: DRUID_S3_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "druid.deepStorageSecretName" . }}
+      key: {{ if .Values.deepStorage.s3.existingSecret }}{{ .Values.deepStorage.s3.existingSecretSecretKeyKey }}{{ else }}secret-key{{ end }}
+{{- end }}
+{{- with .Values.druid.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+# =============================================================================
+# Init containers
+# =============================================================================
+
+{{- define "druid.initContainers" -}}
+- name: prepare-dirs
+  image: busybox:1.37
+  securityContext:
+    runAsUser: 0
+  command:
+    - sh
+    - -c
+    - |
+      mkdir -p /opt/druid/var/druid/segments /opt/druid/var/druid/indexing-logs /opt/druid/var/druid/task /opt/druid/var/druid/hadoop-tmp /opt/druid/var/druid/segment-cache /opt/druid/var/tmp
+      chown -R 1000:1000 /opt/druid/var
+  volumeMounts:
+    - name: druid-var
+      mountPath: /opt/druid/var
+- name: wait-for-postgresql
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ include "druid.metadataHost" . }}:{{ include "druid.metadataPort" . }} ..."
+      until nc -z -w2 {{ include "druid.metadataHost" . }} {{ include "druid.metadataPort" . }}; do
+        sleep 2
+      done
+      echo "PostgreSQL is reachable."
+{{- if eq .Values.zookeeperConfig.mode "subchart" }}
+- name: wait-for-zookeeper
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ printf "%s-zookeeper" .Release.Name }}:2181 ..."
+      until nc -z -w2 {{ printf "%s-zookeeper" .Release.Name }} 2181; do
+        sleep 2
+      done
+      echo "ZooKeeper is reachable."
+{{- end }}
+{{- end -}}

--- a/charts/druid/templates/broker-deployment.yaml
+++ b/charts/druid/templates/broker-deployment.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.broker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druid.fullname" . }}-broker
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker
+spec:
+  replicas: {{ .Values.broker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "druid.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: broker
+  template:
+    metadata:
+      labels:
+        {{- include "druid.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: broker
+        {{- with .Values.broker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.broker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "druid.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "druid.initContainers" . | nindent 8 }}
+      containers:
+        - name: broker
+          image: {{ include "druid.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base /opt/druid/conf/druid/cluster/_common/common.runtime.properties
+              {{- if .Values.broker.extraProperties }}
+              cat >> /opt/druid/conf/druid/cluster/query/broker/runtime.properties <<'EXTRA'
+              {{ .Values.broker.extraProperties | nindent 14 }}
+              EXTRA
+              {{- end }}
+              exec /druid.sh broker
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.broker.javaOpts | quote }}
+            - name: druid_port
+              value: {{ .Values.broker.port | quote }}
+            {{- include "druid.commonEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.broker.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status/selfDiscovered
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.broker.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: common-config
+              mountPath: /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base
+              subPath: common.runtime.properties
+            - name: druid-var
+              mountPath: /opt/druid/var
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: common-config
+          configMap:
+            name: {{ include "druid.fullname" . }}-common
+        - name: druid-var
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/druid/templates/configmap.yaml
+++ b/charts/druid/templates/configmap.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "druid.fullname" . }}-common
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+data:
+  common.runtime.properties: |
+    #
+    # Extensions
+    #
+    druid.extensions.loadList=["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "{{ if eq (include "druid.metadataType" .) "mysql" }}mysql-metadata-storage{{ else }}postgresql-metadata-storage{{ end }}"{{ if eq .Values.deepStorage.type "s3" }}, "druid-s3-extensions"{{ end }}]
+
+    #
+    # ZooKeeper
+    #
+    druid.zk.service.host={{ include "druid.zookeeperHosts" . }}
+    druid.zk.paths.base=/druid
+
+    #
+    # Metadata storage
+    #
+    druid.metadata.storage.type={{ include "druid.metadataType" . }}
+    druid.metadata.storage.connector.connectURI={{ include "druid.metadataConnectUri" . }}
+    druid.metadata.storage.connector.user={{ include "druid.metadataUsername" . }}
+    druid.metadata.storage.connector.password=${env:DRUID_METADATA_PASSWORD}
+
+    #
+    # Deep storage
+    #
+    {{- if eq .Values.deepStorage.type "s3" }}
+    druid.storage.type=s3
+    druid.storage.bucket={{ .Values.deepStorage.s3.bucket }}
+    druid.storage.baseKey={{ .Values.deepStorage.s3.baseKey }}
+    druid.s3.accessKey=${env:DRUID_S3_ACCESS_KEY}
+    druid.s3.secretKey=${env:DRUID_S3_SECRET_KEY}
+    {{- if .Values.deepStorage.s3.endpointUrl }}
+    druid.s3.endpoint.url={{ .Values.deepStorage.s3.endpointUrl }}
+    druid.s3.enablePathStyleAccess=true
+    {{- end }}
+    druid.s3.endpoint.signingRegion={{ .Values.deepStorage.s3.region }}
+    {{- else }}
+    druid.storage.type=local
+    druid.storage.storageDirectory=/opt/druid/var/druid/segments
+    {{- end }}
+
+    #
+    # Indexing service logs
+    #
+    {{- if eq .Values.deepStorage.type "s3" }}
+    druid.indexer.logs.type=s3
+    druid.indexer.logs.s3Bucket={{ .Values.deepStorage.s3.bucket }}
+    druid.indexer.logs.s3Prefix=druid/indexing-logs
+    {{- else }}
+    druid.indexer.logs.type=file
+    druid.indexer.logs.directory=/opt/druid/var/druid/indexing-logs
+    {{- end }}
+
+    #
+    # Service discovery
+    #
+    druid.selectors.indexing.serviceName=druid/overlord
+    druid.selectors.coordinator.serviceName=druid/coordinator
+
+    {{ .Values.druid.extraCommonProperties | nindent 4 }}

--- a/charts/druid/templates/coordinator-statefulset.yaml
+++ b/charts/druid/templates/coordinator-statefulset.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.coordinator.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druid.fullname" . }}-coordinator
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  serviceName: {{ include "druid.fullname" . }}-coordinator-headless
+  replicas: {{ .Values.coordinator.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "druid.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: coordinator
+  template:
+    metadata:
+      labels:
+        {{- include "druid.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: coordinator
+        {{- with .Values.coordinator.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.coordinator.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "druid.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "druid.initContainers" . | nindent 8 }}
+      containers:
+        - name: coordinator
+          image: {{ include "druid.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base /opt/druid/conf/druid/cluster/_common/common.runtime.properties
+              {{- if .Values.coordinator.extraProperties }}
+              cat >> /opt/druid/conf/druid/cluster/master/coordinator-overlord/runtime.properties <<'EXTRA'
+              {{ .Values.coordinator.extraProperties | nindent 14 }}
+              EXTRA
+              {{- end }}
+              exec /druid.sh coordinator
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.coordinator.javaOpts | quote }}
+            - name: druid_port
+              value: {{ .Values.coordinator.port | quote }}
+            {{- include "druid.commonEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.coordinator.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status/selfDiscovered
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.coordinator.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: common-config
+              mountPath: /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base
+              subPath: common.runtime.properties
+            - name: druid-var
+              mountPath: /opt/druid/var
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: common-config
+          configMap:
+            name: {{ include "druid.fullname" . }}-common
+        - name: druid-var
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/druid/templates/extra-manifests.yaml
+++ b/charts/druid/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/druid/templates/historical-statefulset.yaml
+++ b/charts/druid/templates/historical-statefulset.yaml
@@ -1,0 +1,145 @@
+{{- if .Values.historical.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druid.fullname" . }}-historical
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: historical
+spec:
+  serviceName: {{ include "druid.fullname" . }}-historical-headless
+  replicas: {{ .Values.historical.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "druid.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: historical
+  template:
+    metadata:
+      labels:
+        {{- include "druid.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: historical
+        {{- with .Values.historical.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.historical.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "druid.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "druid.initContainers" . | nindent 8 }}
+      containers:
+        - name: historical
+          image: {{ include "druid.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base /opt/druid/conf/druid/cluster/_common/common.runtime.properties
+              cat >> /opt/druid/conf/druid/cluster/data/historical/runtime.properties <<'PROPS'
+              druid.segmentCache.locations=[{"path":"/data/segment-cache","maxSize":10737418240}]
+              {{- if .Values.historical.extraProperties }}
+              {{ .Values.historical.extraProperties | nindent 14 }}
+              {{- end }}
+              PROPS
+              exec /druid.sh historical
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.historical.javaOpts | quote }}
+            - name: druid_port
+              value: {{ .Values.historical.port | quote }}
+            {{- include "druid.commonEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.historical.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status/selfDiscovered
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.historical.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: common-config
+              mountPath: /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base
+              subPath: common.runtime.properties
+            - name: druid-var
+              mountPath: /opt/druid/var
+            - name: segment-cache
+              mountPath: /data/segment-cache
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: common-config
+          configMap:
+            name: {{ include "druid.fullname" . }}-common
+        - name: druid-var
+          emptyDir: {}
+        {{- if not .Values.historical.persistence.enabled }}
+        - name: segment-cache
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if .Values.historical.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: segment-cache
+      spec:
+        accessModes:
+          {{- toYaml .Values.historical.persistence.accessModes | nindent 10 }}
+        {{- with .Values.historical.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.historical.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/charts/druid/templates/ingress.yaml
+++ b/charts/druid/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "druid.fullname" . }}
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "druid.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/druid/templates/middlemanager-statefulset.yaml
+++ b/charts/druid/templates/middlemanager-statefulset.yaml
@@ -1,0 +1,146 @@
+{{- if .Values.middleManager.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druid.fullname" . }}-middlemanager
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: middlemanager
+spec:
+  serviceName: {{ include "druid.fullname" . }}-middlemanager-headless
+  replicas: {{ .Values.middleManager.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "druid.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: middlemanager
+  template:
+    metadata:
+      labels:
+        {{- include "druid.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: middlemanager
+        {{- with .Values.middleManager.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.middleManager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "druid.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "druid.initContainers" . | nindent 8 }}
+      containers:
+        - name: middlemanager
+          image: {{ include "druid.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base /opt/druid/conf/druid/cluster/_common/common.runtime.properties
+              cat >> /opt/druid/conf/druid/cluster/data/middleManager/runtime.properties <<'EXTRA'
+              druid.worker.capacity={{ .Values.middleManager.workerCapacity }}
+              druid.indexer.task.baseDir=/data/task
+              {{- if .Values.middleManager.extraProperties }}
+              {{ .Values.middleManager.extraProperties | nindent 14 }}
+              {{- end }}
+              EXTRA
+              exec /druid.sh middleManager
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.middleManager.javaOpts | quote }}
+            - name: druid_port
+              value: {{ .Values.middleManager.port | quote }}
+            {{- include "druid.commonEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.middleManager.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status/selfDiscovered
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.middleManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: common-config
+              mountPath: /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base
+              subPath: common.runtime.properties
+            - name: druid-var
+              mountPath: /opt/druid/var
+            - name: task-storage
+              mountPath: /data/task
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: common-config
+          configMap:
+            name: {{ include "druid.fullname" . }}-common
+        - name: druid-var
+          emptyDir: {}
+        {{- if not .Values.middleManager.persistence.enabled }}
+        - name: task-storage
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if .Values.middleManager.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: task-storage
+      spec:
+        accessModes:
+          {{- toYaml .Values.middleManager.persistence.accessModes | nindent 10 }}
+        {{- with .Values.middleManager.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.middleManager.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/charts/druid/templates/overlord-statefulset.yaml
+++ b/charts/druid/templates/overlord-statefulset.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.overlord.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "druid.fullname" . }}-overlord
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: overlord
+spec:
+  serviceName: {{ include "druid.fullname" . }}-overlord-headless
+  replicas: {{ .Values.overlord.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "druid.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: overlord
+  template:
+    metadata:
+      labels:
+        {{- include "druid.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: overlord
+        {{- with .Values.overlord.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.overlord.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "druid.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "druid.initContainers" . | nindent 8 }}
+      containers:
+        - name: overlord
+          image: {{ include "druid.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base /opt/druid/conf/druid/cluster/_common/common.runtime.properties
+              {{- if .Values.overlord.extraProperties }}
+              cat >> /opt/druid/conf/druid/cluster/master/coordinator-overlord/runtime.properties <<'EXTRA'
+              {{ .Values.overlord.extraProperties | nindent 14 }}
+              EXTRA
+              {{- end }}
+              exec /druid.sh overlord
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.overlord.javaOpts | quote }}
+            - name: druid_port
+              value: {{ .Values.overlord.port | quote }}
+            {{- include "druid.commonEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.overlord.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status/selfDiscovered
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.overlord.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: common-config
+              mountPath: /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base
+              subPath: common.runtime.properties
+            - name: druid-var
+              mountPath: /opt/druid/var
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: common-config
+          configMap:
+            name: {{ include "druid.fullname" . }}-common
+        - name: druid-var
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/druid/templates/router-deployment.yaml
+++ b/charts/druid/templates/router-deployment.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.router.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "druid.fullname" . }}-router
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: router
+spec:
+  replicas: {{ .Values.router.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "druid.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: router
+  template:
+    metadata:
+      labels:
+        {{- include "druid.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: router
+        {{- with .Values.router.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.router.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "druid.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "druid.initContainers" . | nindent 8 }}
+      containers:
+        - name: router
+          image: {{ include "druid.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base /opt/druid/conf/druid/cluster/_common/common.runtime.properties
+              {{- if .Values.router.extraProperties }}
+              cat >> /opt/druid/conf/druid/cluster/query/router/runtime.properties <<'EXTRA'
+              {{ .Values.router.extraProperties | nindent 14 }}
+              EXTRA
+              {{- end }}
+              exec /druid.sh router
+          env:
+            - name: JAVA_OPTS
+              value: {{ .Values.router.javaOpts | quote }}
+            - name: druid_port
+              value: {{ .Values.router.port | quote }}
+            {{- include "druid.commonEnv" . | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.router.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /status/selfDiscovered
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.router.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: common-config
+              mountPath: /opt/druid/conf/druid/cluster/_common/common.runtime.properties.base
+              subPath: common.runtime.properties
+            - name: druid-var
+              mountPath: /opt/druid/var
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: common-config
+          configMap:
+            name: {{ include "druid.fullname" . }}-common
+        - name: druid-var
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/druid/templates/secret.yaml
+++ b/charts/druid/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- if and (eq .Values.metadata.mode "external") (not .Values.metadata.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "druid.fullname" . }}-metadata
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  metadata-password: {{ .Values.metadata.external.password | quote }}
+{{- end }}
+---
+{{- if and (eq .Values.deepStorage.type "s3") (not .Values.deepStorage.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "druid.fullname" . }}-deep-storage
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  access-key: {{ .Values.deepStorage.s3.accessKey | quote }}
+  secret-key: {{ .Values.deepStorage.s3.secretKey | quote }}
+{{- end }}

--- a/charts/druid/templates/service.yaml
+++ b/charts/druid/templates/service.yaml
@@ -1,0 +1,205 @@
+{{- if .Values.router.enabled }}
+# =============================================================================
+# Router Service (main entry point / web console)
+# =============================================================================
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: router
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: router
+{{- end }}
+---
+# =============================================================================
+# Component headless services (for StatefulSet stable DNS)
+# =============================================================================
+{{- if .Values.coordinator.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-coordinator-headless
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.coordinator.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-coordinator
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.coordinator.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinator
+{{- end }}
+---
+{{- if .Values.overlord.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-overlord-headless
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: overlord
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.overlord.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: overlord
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-overlord
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: overlord
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.overlord.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: overlord
+{{- end }}
+---
+{{- if .Values.broker.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-broker
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.broker.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: broker
+{{- end }}
+---
+{{- if .Values.historical.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-historical-headless
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: historical
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.historical.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: historical
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-historical
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: historical
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.historical.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: historical
+{{- end }}
+---
+{{- if .Values.middleManager.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-middlemanager-headless
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: middlemanager
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.middleManager.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: middlemanager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "druid.fullname" . }}-middlemanager
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+    app.kubernetes.io/component: middlemanager
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.middleManager.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "druid.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: middlemanager
+{{- end }}

--- a/charts/druid/templates/serviceaccount.yaml
+++ b/charts/druid/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "druid.serviceAccountName" . }}
+  labels:
+    {{- include "druid.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/druid/tests/broker_test.yaml
+++ b/charts/druid/tests/broker_test.yaml
@@ -1,0 +1,50 @@
+suite: broker deployment
+templates:
+  - templates/broker-deployment.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should render broker deployment by default
+    template: templates/broker-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-broker
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should use correct port
+    template: templates/broker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8082
+
+  - it: should set java opts
+    template: templates/broker-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: "-Xms512m -Xmx1g"
+
+  - it: should not render when disabled
+    template: templates/broker-deployment.yaml
+    set:
+      broker.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should include health probes
+    template: templates/broker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /status/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /status/selfDiscovered

--- a/charts/druid/tests/configmap_test.yaml
+++ b/charts/druid/tests/configmap_test.yaml
@@ -1,0 +1,56 @@
+suite: configmap
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: should render common runtime properties configmap
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-common
+
+  - it: should include postgresql metadata config by default
+    asserts:
+      - matchRegex:
+          path: data["common.runtime.properties"]
+          pattern: "druid.metadata.storage.type=postgresql"
+
+  - it: should include zookeeper config
+    asserts:
+      - matchRegex:
+          path: data["common.runtime.properties"]
+          pattern: "druid.zk.service.host=RELEASE-NAME-zookeeper:2181"
+
+  - it: should use local deep storage by default
+    asserts:
+      - matchRegex:
+          path: data["common.runtime.properties"]
+          pattern: "druid.storage.type=local"
+
+  - it: should use s3 deep storage when configured
+    set:
+      deepStorage:
+        type: s3
+        s3:
+          bucket: my-bucket
+          baseKey: druid/segments
+          region: us-east-1
+    asserts:
+      - matchRegex:
+          path: data["common.runtime.properties"]
+          pattern: "druid.storage.type=s3"
+      - matchRegex:
+          path: data["common.runtime.properties"]
+          pattern: "druid.storage.bucket=my-bucket"
+
+  - it: should include external zookeeper hosts
+    set:
+      zookeeperConfig:
+        mode: external
+        external:
+          hosts: "zk1:2181,zk2:2181"
+    asserts:
+      - matchRegex:
+          path: data["common.runtime.properties"]
+          pattern: "druid.zk.service.host=zk1:2181,zk2:2181"

--- a/charts/druid/tests/coordinator_test.yaml
+++ b/charts/druid/tests/coordinator_test.yaml
@@ -1,0 +1,64 @@
+suite: coordinator statefulset
+templates:
+  - templates/coordinator-statefulset.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should render coordinator statefulset by default
+    template: templates/coordinator-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-coordinator
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: coordinator
+
+  - it: should use correct port
+    template: templates/coordinator-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8081
+
+  - it: should set java opts
+    template: templates/coordinator-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: "-Xms256m -Xmx512m"
+
+  - it: should include init containers
+    template: templates/coordinator-statefulset.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.initContainers
+
+  - it: should not render when disabled
+    template: templates/coordinator-statefulset.yaml
+    set:
+      coordinator.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have configmap checksum annotation
+    template: templates/coordinator-statefulset.yaml
+    asserts:
+      - isNotEmpty:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: should support custom replicas
+    template: templates/coordinator-statefulset.yaml
+    set:
+      coordinator.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/charts/druid/tests/historical_test.yaml
+++ b/charts/druid/tests/historical_test.yaml
@@ -1,0 +1,51 @@
+suite: historical statefulset
+templates:
+  - templates/historical-statefulset.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should render historical statefulset by default
+    template: templates/historical-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-historical
+
+  - it: should use correct port
+    template: templates/historical-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8083
+
+  - it: should have volume claim template with persistence enabled
+    template: templates/historical-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: segment-cache
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should use emptyDir when persistence is disabled
+    template: templates/historical-statefulset.yaml
+    set:
+      historical.persistence.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: segment-cache
+            emptyDir: {}
+      - isNull:
+          path: spec.volumeClaimTemplates
+
+  - it: should not render when disabled
+    template: templates/historical-statefulset.yaml
+    set:
+      historical.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/druid/tests/ingress_test.yaml
+++ b/charts/druid/tests/ingress_test.yaml
@@ -1,0 +1,45 @@
+suite: ingress
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress:
+        enabled: true
+        ingressClassName: traefik
+        hosts:
+          - host: druid.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: "traefik"
+      - equal:
+          path: spec.rules[0].host
+          value: druid.example.com
+
+  - it: should support TLS
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: druid.example.com
+            paths:
+              - path: /
+        tls:
+          - secretName: druid-tls
+            hosts:
+              - druid.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: druid-tls

--- a/charts/druid/tests/middlemanager_test.yaml
+++ b/charts/druid/tests/middlemanager_test.yaml
@@ -1,0 +1,38 @@
+suite: middlemanager statefulset
+templates:
+  - templates/middlemanager-statefulset.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should render middlemanager statefulset by default
+    template: templates/middlemanager-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-middlemanager
+
+  - it: should use correct port
+    template: templates/middlemanager-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8091
+
+  - it: should have volume claim template with persistence enabled
+    template: templates/middlemanager-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: task-storage
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should not render when disabled
+    template: templates/middlemanager-statefulset.yaml
+    set:
+      middleManager.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/druid/tests/overlord_test.yaml
+++ b/charts/druid/tests/overlord_test.yaml
@@ -1,0 +1,31 @@
+suite: overlord statefulset
+templates:
+  - templates/overlord-statefulset.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should render overlord statefulset by default
+    template: templates/overlord-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-overlord
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should use correct port
+    template: templates/overlord-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8090
+
+  - it: should not render when disabled
+    template: templates/overlord-statefulset.yaml
+    set:
+      overlord.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/druid/tests/router_test.yaml
+++ b/charts/druid/tests/router_test.yaml
@@ -1,0 +1,31 @@
+suite: router deployment
+templates:
+  - templates/router-deployment.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should render router deployment by default
+    template: templates/router-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-router
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should use correct port
+    template: templates/router-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8888
+
+  - it: should not render when disabled
+    template: templates/router-deployment.yaml
+    set:
+      router.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/druid/tests/secret_test.yaml
+++ b/charts/druid/tests/secret_test.yaml
@@ -1,0 +1,52 @@
+suite: secrets
+templates:
+  - templates/secret.yaml
+tests:
+  - it: should not render any secrets in default subchart mode with local storage
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render metadata secret in external mode
+    set:
+      metadata:
+        mode: external
+        external:
+          password: my-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+        documentIndex: 0
+
+  - it: should render deep storage secret for s3
+    set:
+      deepStorage:
+        type: s3
+        s3:
+          bucket: test
+          accessKey: AKID
+          secretKey: SKEY
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+        documentIndex: 0
+
+  - it: should render both secrets when external metadata and s3
+    set:
+      metadata:
+        mode: external
+        external:
+          password: my-password
+      deepStorage:
+        type: s3
+        s3:
+          bucket: test
+          accessKey: AKID
+          secretKey: SKEY
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/druid/tests/service_test.yaml
+++ b/charts/druid/tests/service_test.yaml
@@ -1,0 +1,42 @@
+suite: services
+templates:
+  - templates/service.yaml
+tests:
+  - it: should render router service with correct port
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should render coordinator headless service
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-coordinator-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: should render broker service
+    documentIndex: 5
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-druid-broker
+      - equal:
+          path: spec.ports[0].port
+          value: 8082

--- a/charts/druid/values.schema.json
+++ b/charts/druid/values.schema.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Apache Druid Helm Chart",
+  "description": "Apache Druid distributed analytics database with coordinator, broker, historical, middlemanager, overlord, and router",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full release name used in resource names"
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Labels added to every resource created by this chart"
+    },
+    "image": {
+      "type": "object",
+      "description": "Druid container image configuration",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Druid container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Druid image tag. Defaults to appVersion."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for private registries"
+    },
+    "druid": {
+      "type": "object",
+      "description": "Common Druid configuration",
+      "properties": {
+        "extraCommonProperties": {
+          "type": "string",
+          "description": "Extra common runtime properties applied to all components"
+        },
+        "extraEnv": {
+          "type": "array",
+          "description": "Extra environment variables for all components"
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Metadata storage configuration",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Metadata storage mode",
+          "enum": ["subchart", "external"]
+        },
+        "external": {
+          "type": "object",
+          "description": "External metadata storage configuration",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "External metadata storage type",
+              "enum": ["postgresql", "mysql"]
+            },
+            "host": {
+              "type": "string",
+              "description": "External database host"
+            },
+            "port": {
+              "type": "integer",
+              "description": "External database port"
+            },
+            "name": {
+              "type": "string",
+              "description": "External database name"
+            },
+            "username": {
+              "type": "string",
+              "description": "External database username"
+            },
+            "password": {
+              "type": "string",
+              "description": "External database password"
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing secret with external database password"
+            },
+            "existingSecretPasswordKey": {
+              "type": "string",
+              "description": "Key in existingSecret for password"
+            }
+          }
+        }
+      }
+    },
+    "zookeeperConfig": {
+      "type": "object",
+      "description": "ZooKeeper configuration",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "ZooKeeper mode",
+          "enum": ["subchart", "external"]
+        },
+        "external": {
+          "type": "object",
+          "description": "External ZooKeeper configuration",
+          "properties": {
+            "hosts": {
+              "type": "string",
+              "description": "External ZooKeeper connection string"
+            }
+          }
+        }
+      }
+    },
+    "deepStorage": {
+      "type": "object",
+      "description": "Deep storage configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Deep storage type",
+          "enum": ["local", "s3"]
+        },
+        "s3": {
+          "type": "object",
+          "description": "S3 deep storage configuration",
+          "properties": {
+            "bucket": {
+              "type": "string",
+              "description": "S3 bucket name"
+            },
+            "baseKey": {
+              "type": "string",
+              "description": "S3 base key (prefix)"
+            },
+            "region": {
+              "type": "string",
+              "description": "S3 region"
+            },
+            "endpointUrl": {
+              "type": "string",
+              "description": "S3 endpoint URL (for MinIO or compatible)"
+            },
+            "accessKey": {
+              "type": "string",
+              "description": "S3 access key"
+            },
+            "secretKey": {
+              "type": "string",
+              "description": "S3 secret key"
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing secret with S3 credentials"
+            },
+            "existingSecretAccessKeyKey": {
+              "type": "string",
+              "description": "Key in existingSecret for access key"
+            },
+            "existingSecretSecretKeyKey": {
+              "type": "string",
+              "description": "Key in existingSecret for secret key"
+            }
+          }
+        }
+      }
+    },
+    "coordinator": {
+      "type": "object",
+      "description": "Coordinator configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable coordinator" },
+        "replicaCount": { "type": "integer", "description": "Number of coordinator replicas" },
+        "port": { "type": "integer", "description": "Coordinator port" },
+        "javaOpts": { "type": "string", "description": "JVM options" },
+        "extraProperties": { "type": "string", "description": "Extra runtime properties" },
+        "resources": { "type": "object", "description": "Resource requests and limits" },
+        "podLabels": { "type": "object", "description": "Pod labels" },
+        "podAnnotations": { "type": "object", "description": "Pod annotations" }
+      }
+    },
+    "overlord": {
+      "type": "object",
+      "description": "Overlord configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable overlord" },
+        "replicaCount": { "type": "integer", "description": "Number of overlord replicas" },
+        "port": { "type": "integer", "description": "Overlord port" },
+        "javaOpts": { "type": "string", "description": "JVM options" },
+        "extraProperties": { "type": "string", "description": "Extra runtime properties" },
+        "resources": { "type": "object", "description": "Resource requests and limits" },
+        "podLabels": { "type": "object", "description": "Pod labels" },
+        "podAnnotations": { "type": "object", "description": "Pod annotations" }
+      }
+    },
+    "broker": {
+      "type": "object",
+      "description": "Broker configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable broker" },
+        "replicaCount": { "type": "integer", "description": "Number of broker replicas" },
+        "port": { "type": "integer", "description": "Broker port" },
+        "javaOpts": { "type": "string", "description": "JVM options" },
+        "extraProperties": { "type": "string", "description": "Extra runtime properties" },
+        "resources": { "type": "object", "description": "Resource requests and limits" },
+        "podLabels": { "type": "object", "description": "Pod labels" },
+        "podAnnotations": { "type": "object", "description": "Pod annotations" }
+      }
+    },
+    "router": {
+      "type": "object",
+      "description": "Router (web console) configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable router" },
+        "replicaCount": { "type": "integer", "description": "Number of router replicas" },
+        "port": { "type": "integer", "description": "Router port" },
+        "javaOpts": { "type": "string", "description": "JVM options" },
+        "extraProperties": { "type": "string", "description": "Extra runtime properties" },
+        "resources": { "type": "object", "description": "Resource requests and limits" },
+        "podLabels": { "type": "object", "description": "Pod labels" },
+        "podAnnotations": { "type": "object", "description": "Pod annotations" }
+      }
+    },
+    "historical": {
+      "type": "object",
+      "description": "Historical configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable historical" },
+        "replicaCount": { "type": "integer", "description": "Number of historical replicas" },
+        "port": { "type": "integer", "description": "Historical port" },
+        "javaOpts": { "type": "string", "description": "JVM options" },
+        "extraProperties": { "type": "string", "description": "Extra runtime properties" },
+        "persistence": {
+          "type": "object",
+          "description": "Segment cache persistence",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Enable persistence" },
+            "size": { "type": "string", "description": "PVC size" },
+            "storageClass": { "type": "string", "description": "Storage class" },
+            "accessModes": { "type": "array", "description": "Access modes", "items": { "type": "string" } }
+          }
+        },
+        "resources": { "type": "object", "description": "Resource requests and limits" },
+        "podLabels": { "type": "object", "description": "Pod labels" },
+        "podAnnotations": { "type": "object", "description": "Pod annotations" }
+      }
+    },
+    "middleManager": {
+      "type": "object",
+      "description": "MiddleManager configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable middle manager" },
+        "replicaCount": { "type": "integer", "description": "Number of middle manager replicas" },
+        "port": { "type": "integer", "description": "MiddleManager port" },
+        "javaOpts": { "type": "string", "description": "JVM options" },
+        "workerCapacity": { "type": "integer", "description": "Number of task workers per middle manager" },
+        "extraProperties": { "type": "string", "description": "Extra runtime properties" },
+        "persistence": {
+          "type": "object",
+          "description": "Task storage persistence",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Enable persistence" },
+            "size": { "type": "string", "description": "PVC size" },
+            "storageClass": { "type": "string", "description": "Storage class" },
+            "accessModes": { "type": "array", "description": "Access modes", "items": { "type": "string" } }
+          }
+        },
+        "resources": { "type": "object", "description": "Resource requests and limits" },
+        "podLabels": { "type": "object", "description": "Pod labels" },
+        "podAnnotations": { "type": "object", "description": "Pod annotations" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "description": "Service configuration for the router",
+      "properties": {
+        "type": { "type": "string", "description": "Service type" },
+        "port": { "type": "integer", "description": "Service port" },
+        "annotations": { "type": "object", "description": "Service annotations" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "description": "Ingress configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable ingress" },
+        "ingressClassName": { "type": "string", "description": "Ingress class name" },
+        "annotations": { "type": "object", "description": "Ingress annotations" },
+        "hosts": { "type": "array", "description": "Ingress hosts" },
+        "tls": { "type": "array", "description": "Ingress TLS" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "ServiceAccount configuration",
+      "properties": {
+        "create": { "type": "boolean", "description": "Create a ServiceAccount" },
+        "name": { "type": "string", "description": "ServiceAccount name" },
+        "annotations": { "type": "object", "description": "ServiceAccount annotations" }
+      }
+    },
+    "podSecurityContext": { "type": "object", "description": "Pod-level security context" },
+    "securityContext": { "type": "object", "description": "Container-level security context" },
+    "nodeSelector": { "type": "object", "description": "Node selector" },
+    "tolerations": { "type": "array", "description": "Tolerations" },
+    "affinity": { "type": "object", "description": "Affinity rules" },
+    "priorityClassName": { "type": "string", "description": "Priority class name" },
+    "terminationGracePeriodSeconds": { "type": "integer", "description": "Termination grace period in seconds" },
+    "extraVolumes": { "type": "array", "description": "Extra volumes" },
+    "extraVolumeMounts": { "type": "array", "description": "Extra volume mounts" },
+    "extraManifests": { "type": "array", "description": "Extra Kubernetes manifests to deploy" },
+    "postgresql": {
+      "type": "object",
+      "description": "PostgreSQL subchart configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable PostgreSQL subchart" },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "database": { "type": "string", "description": "PostgreSQL database name" },
+            "username": { "type": "string", "description": "PostgreSQL username" },
+            "password": { "type": "string", "description": "PostgreSQL password" }
+          }
+        }
+      }
+    },
+    "zookeeper": {
+      "type": "object",
+      "description": "ZooKeeper subchart configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable ZooKeeper subchart" },
+        "replicaCount": { "type": "integer", "description": "Number of ZooKeeper replicas" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Enable ZooKeeper persistence" },
+            "size": { "type": "string", "description": "ZooKeeper data volume size" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -1,0 +1,352 @@
+# =============================================================================
+# Apache Druid Configuration
+# =============================================================================
+
+# -- Override the chart name used in resource names
+nameOverride: ""
+
+# -- Override the full release name used in resource names
+fullnameOverride: ""
+
+# -- Labels added to every resource created by this chart
+commonLabels: {}
+
+image:
+  # -- Druid container image repository
+  repository: apache/druid
+  # -- Druid image tag. Defaults to appVersion.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# =============================================================================
+# Common Druid Configuration
+# =============================================================================
+
+druid:
+  # -- Extra common runtime properties applied to all components
+  extraCommonProperties: ""
+  # -- Extra environment variables for all components
+  extraEnv: []
+
+# =============================================================================
+# Metadata Storage (PostgreSQL)
+# =============================================================================
+
+metadata:
+  # -- Metadata storage mode: subchart | external
+  mode: subchart
+  external:
+    # -- External metadata storage type (postgresql or mysql)
+    type: postgresql
+    # -- External database host
+    host: ""
+    # -- External database port
+    port: 5432
+    # -- External database name
+    name: druid
+    # -- External database username
+    username: druid
+    # -- External database password
+    password: ""
+    # -- Existing secret with external database password
+    existingSecret: ""
+    # -- Key in existingSecret for password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# ZooKeeper
+# =============================================================================
+
+zookeeperConfig:
+  # -- ZooKeeper mode: subchart | external
+  mode: subchart
+  external:
+    # -- External ZooKeeper connection string (host1:port1,host2:port2)
+    hosts: ""
+
+# =============================================================================
+# Deep Storage
+# =============================================================================
+
+deepStorage:
+  # -- Deep storage type: local | s3
+  type: local
+  s3:
+    # -- S3 bucket name
+    bucket: ""
+    # -- S3 base key (prefix)
+    baseKey: druid/segments
+    # -- S3 region
+    region: us-east-1
+    # -- S3 endpoint URL (for MinIO or compatible)
+    endpointUrl: ""
+    # -- S3 access key
+    accessKey: ""
+    # -- S3 secret key
+    secretKey: ""
+    # -- Existing secret with S3 credentials
+    existingSecret: ""
+    # -- Key in existingSecret for access key
+    existingSecretAccessKeyKey: access-key
+    # -- Key in existingSecret for secret key
+    existingSecretSecretKeyKey: secret-key
+
+# =============================================================================
+# Coordinator
+# =============================================================================
+
+coordinator:
+  # -- Enable coordinator
+  enabled: true
+  # -- Number of coordinator replicas
+  replicaCount: 1
+  # -- Coordinator port
+  port: 8081
+  # -- JVM options
+  javaOpts: "-Xms256m -Xmx512m"
+  # -- Extra runtime properties
+  extraProperties: ""
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# Overlord
+# =============================================================================
+
+overlord:
+  # -- Enable overlord (can be combined with coordinator)
+  enabled: true
+  # -- Number of overlord replicas
+  replicaCount: 1
+  # -- Overlord port
+  port: 8090
+  # -- JVM options
+  javaOpts: "-Xms256m -Xmx512m"
+  # -- Extra runtime properties
+  extraProperties: ""
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# Broker
+# =============================================================================
+
+broker:
+  # -- Enable broker
+  enabled: true
+  # -- Number of broker replicas
+  replicaCount: 1
+  # -- Broker port
+  port: 8082
+  # -- JVM options
+  javaOpts: "-Xms512m -Xmx1g"
+  # -- Extra runtime properties
+  extraProperties: ""
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# Router (Web Console)
+# =============================================================================
+
+router:
+  # -- Enable router (web console)
+  enabled: true
+  # -- Number of router replicas
+  replicaCount: 1
+  # -- Router port
+  port: 8888
+  # -- JVM options
+  javaOpts: "-Xms128m -Xmx256m"
+  # -- Extra runtime properties
+  extraProperties: ""
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# Historical
+# =============================================================================
+
+historical:
+  # -- Enable historical
+  enabled: true
+  # -- Number of historical replicas
+  replicaCount: 1
+  # -- Historical port
+  port: 8083
+  # -- JVM options
+  javaOpts: "-Xms512m -Xmx1g"
+  # -- Extra runtime properties
+  extraProperties: ""
+  # -- Segment cache persistence
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# MiddleManager
+# =============================================================================
+
+middleManager:
+  # -- Enable middle manager
+  enabled: true
+  # -- Number of middle manager replicas
+  replicaCount: 1
+  # -- MiddleManager port
+  port: 8091
+  # -- JVM options
+  javaOpts: "-Xms128m -Xmx256m"
+  # -- Number of task workers per middle manager
+  workerCapacity: 2
+  # -- Extra runtime properties
+  extraProperties: ""
+  # -- Task storage persistence
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  # -- Resource requests and limits
+  resources: {}
+  # -- Pod labels
+  podLabels: {}
+  # -- Pod annotations
+  podAnnotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type for the router (web console)
+  type: ClusterIP
+  # -- Service port
+  port: 80
+  # -- Service annotations
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress (routes to the router/web console)
+  enabled: false
+  # -- Ingress class name (traefik, nginx, etc.)
+  ingressClassName: traefik
+  # -- Ingress annotations
+  # @default -- `{}`
+  # Example:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  annotations: {}
+  # -- Ingress hosts
+  hosts: []
+  # -- Ingress TLS
+  tls: []
+
+# =============================================================================
+# ServiceAccount
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- ServiceAccount annotations
+  annotations: {}
+
+# =============================================================================
+# Security & Scheduling
+# =============================================================================
+
+# -- Pod-level security context (fsGroup matches the druid image UID)
+podSecurityContext:
+  fsGroup: 1000
+
+# -- Container-level security context
+securityContext: {}
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# -- Priority class name
+priorityClassName: ""
+
+# -- Termination grace period in seconds
+terminationGracePeriodSeconds: 30
+
+# -- Extra volumes
+extraVolumes: []
+
+# -- Extra volume mounts
+extraVolumeMounts: []
+
+# -- Extra Kubernetes manifests to deploy
+extraManifests: []
+
+# =============================================================================
+# PostgreSQL Subchart
+# =============================================================================
+
+postgresql:
+  # -- Enable PostgreSQL subchart for metadata storage
+  enabled: true
+  auth:
+    # -- PostgreSQL database name
+    database: druid
+    # -- PostgreSQL username
+    username: druid
+    # -- PostgreSQL password. Auto-generated if empty.
+    password: ""
+
+# =============================================================================
+# ZooKeeper Subchart (Bitnami)
+# =============================================================================
+
+zookeeper:
+  # -- Enable ZooKeeper subchart
+  enabled: true
+  # -- Number of ZooKeeper replicas
+  replicaCount: 1
+  persistence:
+    # -- Enable ZooKeeper persistence
+    enabled: true
+    # -- ZooKeeper data volume size
+    size: 2Gi

--- a/charts/superset/Chart.lock
+++ b/charts/superset/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.3
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.5.4
+digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
+generated: "2026-04-01T19:51:30.2642924-03:00"

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -1,0 +1,47 @@
+apiVersion: v2
+name: superset
+description: Apache Superset BI platform with web, worker, and beat deployments backed by PostgreSQL and Redis
+type: application
+version: 0.1.0
+appVersion: "4.1.4"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - superset
+  - bi
+  - analytics
+  - visualization
+  - dashboard
+  - sql
+  - celery
+home: https://helmforge.dev/docs/charts/superset
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/superset
+  - https://github.com/apache/superset
+icon: https://raw.githubusercontent.com/apache/superset/master/superset-frontend/src/assets/images/superset-logo-horiz.svg
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/superset
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/superset
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+dependencies:
+  - name: postgresql
+    version: 1.8.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 1.5.4
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: redis.enabled

--- a/charts/superset/README.md
+++ b/charts/superset/README.md
@@ -1,0 +1,150 @@
+# Apache Superset
+
+Apache Superset is a modern, enterprise-ready business intelligence web application for data exploration and visualization. It supports 60+ database connectors, interactive dashboards, SQL Lab, and a rich set of visualizations.
+
+## Features
+
+- **Three-component architecture** — web server (Gunicorn), Celery worker, and Celery beat scheduler as separate Deployments for independent scaling
+- **Init Job** — automatic database migration, Superset initialization, and admin user creation via Helm hook
+- **PostgreSQL subchart** — bundled metadata store with option for external database
+- **Redis subchart** — bundled Celery broker and result backend with option for external Redis
+- **superset_config.py via ConfigMap** — extend Superset configuration through `superset.extraConfig`
+- **Auto-generated secrets** — admin password, Flask SECRET_KEY, database and Redis passwords
+- **Health probes** — startup, liveness, and readiness probes on `/health`
+- **Ingress support** — configurable with `ingressClassName` (traefik, nginx, etc.)
+
+## Install
+
+### Helm repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install superset helmforge/superset -f values.yaml
+```
+
+### OCI registry
+
+```bash
+helm install superset oci://ghcr.io/helmforgedev/helm/superset --version <version> -f values.yaml
+```
+
+## Architecture
+
+```
+Deployment: superset-web (Gunicorn, port 8088)
+Deployment: superset-worker (Celery workers)
+Deployment: superset-beat (Celery beat scheduler)
+Job: superset-init (DB migrate + admin creation)
+  ├─ PostgreSQL (subchart)
+  └─ Redis (subchart)
+```
+
+## Default Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `apache/superset` | Container image |
+| `image.tag` | `""` (appVersion) | Image tag |
+| `superset.adminUsername` | `admin` | Admin username |
+| `superset.adminPassword` | `""` (auto) | Admin password |
+| `superset.secretKey` | `""` (auto) | Flask SECRET_KEY |
+| `superset.loadExamples` | `false` | Load example dashboards |
+| `web.replicaCount` | `1` | Web server replicas |
+| `web.workers` | `2` | Gunicorn workers |
+| `web.timeout` | `120` | Gunicorn timeout |
+| `worker.enabled` | `true` | Enable Celery workers |
+| `worker.replicaCount` | `1` | Worker replicas |
+| `worker.concurrency` | `2` | Celery concurrency |
+| `beat.enabled` | `true` | Enable Celery beat |
+| `init.enabled` | `true` | Enable init job |
+| `database.mode` | `subchart` | Database mode: subchart or external |
+| `redisConfig.mode` | `subchart` | Redis mode: subchart or external |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `80` | Service port |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `traefik` | Ingress class |
+| `postgresql.enabled` | `true` | Enable PostgreSQL subchart |
+| `redis.enabled` | `true` | Enable Redis subchart |
+
+## External Database
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: superset
+    username: superset
+    password: my-password
+```
+
+## External Redis
+
+```yaml
+redis:
+  enabled: false
+
+redisConfig:
+  mode: external
+  external:
+    host: redis.example.com
+    port: 6379
+    password: redis-password
+    db: 0
+```
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik  # or nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: superset.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: superset-tls
+      hosts:
+        - superset.example.com
+```
+
+## Custom Configuration
+
+Extend `superset_config.py` via `superset.extraConfig`:
+
+```yaml
+superset:
+  extraConfig: |
+    FEATURE_FLAGS = {
+        "DASHBOARD_NATIVE_FILTERS": True,
+        "DASHBOARD_CROSS_FILTERS": True,
+    }
+    ROW_LIMIT = 50000
+```
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Apache Superset Helm Chart
+description: Apache Superset BI platform with web, worker, and beat deployments backed by PostgreSQL and Redis
+
+keywords: superset, bi, analytics, visualization, dashboard, celery
+
+purpose: Installation, configuration, and operational guide for the Superset Helm chart
+scope: charts/superset
+
+relations:
+  - charts/superset/values.yaml
+  - charts/superset/Chart.yaml
+path: charts/superset/README.md
+version: 1.0
+date: 2026-04-01
+-->

--- a/charts/superset/ci/default-values.yaml
+++ b/charts/superset/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# Default CI scenario — subchart PostgreSQL + Redis
+# No overrides needed, defaults are sufficient

--- a/charts/superset/ci/external-db-values.yaml
+++ b/charts/superset/ci/external-db-values.yaml
@@ -1,0 +1,23 @@
+# CI scenario — external database and Redis
+postgresql:
+  enabled: false
+
+redis:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: superset
+    username: superset
+    password: external-password
+
+redisConfig:
+  mode: external
+  external:
+    host: redis.example.com
+    port: 6379
+    password: redis-password
+    db: 0

--- a/charts/superset/ci/minimal-values.yaml
+++ b/charts/superset/ci/minimal-values.yaml
@@ -1,0 +1,9 @@
+# CI scenario — minimal install (no workers, no beat)
+worker:
+  enabled: false
+
+beat:
+  enabled: false
+
+init:
+  enabled: false

--- a/charts/superset/templates/NOTES.txt
+++ b/charts/superset/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Apache Superset has been installed.
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl port-forward svc/{{ include "superset.fullname" . }} 8088:{{ .Values.service.port }}
+  Web UI: http://localhost:8088
+{{- end }}
+
+Default credentials: {{ .Values.superset.adminUsername }} / (check secret {{ include "superset.secretName" . }})

--- a/charts/superset/templates/_helpers.tpl
+++ b/charts/superset/templates/_helpers.tpl
@@ -1,0 +1,249 @@
+{{- define "superset.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "superset.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "superset.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "superset.labels" -}}
+helm.sh/chart: {{ include "superset.chart" . }}
+{{ include "superset.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "superset.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "superset.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "superset.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+
+{{- define "superset.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "superset.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Secret
+# =============================================================================
+
+{{- define "superset.secretName" -}}
+{{- if .Values.superset.existingSecret -}}
+{{- .Values.superset.existingSecret -}}
+{{- else -}}
+{{- include "superset.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Database
+# =============================================================================
+
+{{- define "superset.databaseHost" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.databasePort" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.port | toString -}}
+{{- else -}}
+5432
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.databaseName" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.name -}}
+{{- else -}}
+{{- .Values.postgresql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.databaseUsername" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.username -}}
+{{- else -}}
+{{- .Values.postgresql.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.databaseSecretName" -}}
+{{- if and (eq .Values.database.mode "external") .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else if eq .Values.database.mode "external" -}}
+{{- printf "%s-database" (include "superset.fullname" .) -}}
+{{- else -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.databaseSecretKey" -}}
+{{- if and (eq .Values.database.mode "external") .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else if eq .Values.database.mode "external" -}}
+database-password
+{{- else -}}
+user-password
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.databasePasswordValue" -}}
+{{- if eq .Values.database.mode "external" -}}
+{{- .Values.database.external.password -}}
+{{- else -}}
+{{- .Values.postgresql.auth.password -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+SQLALCHEMY_DATABASE_URI built at runtime using $(DB_PASSWORD) interpolation.
+The actual password is injected as DB_PASSWORD env var from the secret.
+*/}}
+{{- define "superset.sqlalchemyUri" -}}
+postgresql+psycopg2://{{ include "superset.databaseUsername" . }}:$(DB_PASSWORD)@{{ include "superset.databaseHost" . }}:{{ include "superset.databasePort" . }}/{{ include "superset.databaseName" . }}
+{{- end -}}
+
+# =============================================================================
+# Redis
+# =============================================================================
+
+{{- define "superset.redisHost" -}}
+{{- if eq .Values.redisConfig.mode "external" -}}
+{{- .Values.redisConfig.external.host -}}
+{{- else -}}
+{{- printf "%s-redis-client" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.redisPort" -}}
+{{- if eq .Values.redisConfig.mode "external" -}}
+{{- .Values.redisConfig.external.port | toString -}}
+{{- else -}}
+6379
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.redisDb" -}}
+{{- if eq .Values.redisConfig.mode "external" -}}
+{{- .Values.redisConfig.external.db | toString -}}
+{{- else -}}
+0
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis URL for Celery broker: redis://:password@host:port/db
+The password is injected at runtime via $(REDIS_PASSWORD) interpolation.
+*/}}
+{{- define "superset.redisUrl" -}}
+redis://:$(REDIS_PASSWORD)@{{ include "superset.redisHost" . }}:{{ include "superset.redisPort" . }}/{{ include "superset.redisDb" . }}
+{{- end -}}
+
+{{- define "superset.redisSecretName" -}}
+{{- if and (eq .Values.redisConfig.mode "external") .Values.redisConfig.external.existingSecret -}}
+{{- .Values.redisConfig.external.existingSecret -}}
+{{- else if eq .Values.redisConfig.mode "external" -}}
+{{- printf "%s-redis-ext" (include "superset.fullname" .) -}}
+{{- else -}}
+{{- printf "%s-redis-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.redisSecretKey" -}}
+{{- if and (eq .Values.redisConfig.mode "external") .Values.redisConfig.external.existingSecret -}}
+{{- .Values.redisConfig.external.existingSecretPasswordKey -}}
+{{- else -}}
+redis-password
+{{- end -}}
+{{- end -}}
+
+{{- define "superset.redisPasswordValue" -}}
+{{- if eq .Values.redisConfig.mode "external" -}}
+{{- .Values.redisConfig.external.password -}}
+{{- else -}}
+{{- .Values.redis.auth.password -}}
+{{- end -}}
+{{- end -}}
+
+# =============================================================================
+# Common env vars shared across web, worker, beat, and init
+# =============================================================================
+
+{{- define "superset.commonEnv" -}}
+- name: SUPERSET_SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "superset.secretName" . }}
+      key: {{ .Values.superset.existingSecretSecretKeyKey | default "secret-key" }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "superset.databaseSecretName" . }}
+      key: {{ include "superset.databaseSecretKey" . }}
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "superset.redisSecretName" . }}
+      key: {{ include "superset.redisSecretKey" . }}
+- name: SQLALCHEMY_DATABASE_URI
+  value: {{ include "superset.sqlalchemyUri" . | quote }}
+- name: REDIS_URL
+  value: {{ include "superset.redisUrl" . | quote }}
+- name: SUPERSET_LOAD_EXAMPLES
+  value: {{ ternary "yes" "no" .Values.superset.loadExamples | quote }}
+{{- with .Values.superset.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+# =============================================================================
+# Init containers
+# =============================================================================
+
+{{- define "superset.initContainers" -}}
+- name: wait-for-postgresql
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ include "superset.databaseHost" . }}:{{ include "superset.databasePort" . }} ..."
+      until nc -z -w2 {{ include "superset.databaseHost" . }} {{ include "superset.databasePort" . }}; do
+        sleep 2
+      done
+      echo "PostgreSQL is reachable."
+- name: wait-for-redis
+  image: busybox:1.37
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for {{ include "superset.redisHost" . }}:{{ include "superset.redisPort" . }} ..."
+      until nc -z -w2 {{ include "superset.redisHost" . }} {{ include "superset.redisPort" . }}; do
+        sleep 2
+      done
+      echo "Redis is reachable."
+{{- end -}}

--- a/charts/superset/templates/beat-deployment.yaml
+++ b/charts/superset/templates/beat-deployment.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.beat.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "superset.fullname" . }}-beat
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: beat
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "superset.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: beat
+  template:
+    metadata:
+      labels:
+        {{- include "superset.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: beat
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.beat.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.beat.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "superset.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "superset.initContainers" . | nindent 8 }}
+      containers:
+        - name: superset-beat
+          image: {{ include "superset.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              celery --app=superset.tasks.celery_app:app beat --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule --loglevel=INFO
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "superset.commonEnv" . | nindent 12 }}
+            {{- with .Values.beat.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: superset-config
+              mountPath: /app/pythonpath/superset_config.py
+              subPath: superset_config.py
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (.Values.beat.resources | default .Values.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: superset-config
+          configMap:
+            name: {{ include "superset.fullname" . }}-config
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/superset/templates/configmap.yaml
+++ b/charts/superset/templates/configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "superset.fullname" . }}-config
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+data:
+  superset_config.py: |
+    import os
+
+    # Flask secret key — injected via SUPERSET_SECRET_KEY env var
+    SECRET_KEY = os.environ.get("SUPERSET_SECRET_KEY", "change-me")
+
+    # Database connection
+    SQLALCHEMY_DATABASE_URI = os.environ.get("SQLALCHEMY_DATABASE_URI")
+
+    # Redis / Celery
+    REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+
+    class CeleryConfig:
+        broker_url = REDIS_URL
+        result_backend = REDIS_URL
+        task_annotations = {
+            "sql_lab.get_sql_results": {
+                "rate_limit": "100/s",
+            },
+        }
+
+    CELERY_CONFIG = CeleryConfig
+
+    # Feature flags
+    FEATURE_FLAGS = {
+        "ALERT_REPORTS": True,
+    }
+
+    ENABLE_PROXY_FIX = True
+    {{- if .Values.superset.extraConfig }}
+
+    # User-defined extra configuration
+    {{ .Values.superset.extraConfig | nindent 4 }}
+    {{- end }}

--- a/charts/superset/templates/deployment.yaml
+++ b/charts/superset/templates/deployment.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "superset.fullname" . }}-web
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "superset.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "superset.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.web.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "superset.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "superset.initContainers" . | nindent 8 }}
+      containers:
+        - name: superset-web
+          image: {{ include "superset.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              superset db upgrade
+              superset init
+              gunicorn \
+                --bind 0.0.0.0:8088 \
+                --workers {{ .Values.web.workers }} \
+                --timeout {{ .Values.web.timeout }} \
+                --limit-request-line 0 \
+                --limit-request-field_size 0 \
+                "superset.app:create_app()"
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "superset.commonEnv" . | nindent 12 }}
+            {{- with .Values.web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8088
+              protocol: TCP
+          {{- with .Values.probes.startup }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.probes.liveness }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.probes.readiness }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: superset-config
+              mountPath: /app/pythonpath/superset_config.py
+              subPath: superset_config.py
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (.Values.web.resources | default .Values.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: superset-config
+          configMap:
+            name: {{ include "superset.fullname" . }}-config
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/charts/superset/templates/extra-manifests.yaml
+++ b/charts/superset/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/superset/templates/ingress.yaml
+++ b/charts/superset/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "superset.fullname" . }}
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "superset.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/superset/templates/init-job.yaml
+++ b/charts/superset/templates/init-job.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.init.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "superset.fullname" . }}-init
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "superset.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: init
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "superset.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+      initContainers:
+        {{- include "superset.initContainers" . | nindent 8 }}
+      containers:
+        - name: superset-init
+          image: {{ include "superset.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              echo "Running database migrations..."
+              superset db upgrade
+              echo "Initializing Superset..."
+              superset init
+              echo "Creating admin user..."
+              superset fab create-admin \
+                --username {{ .Values.superset.adminUsername | quote }} \
+                --firstname {{ .Values.superset.adminFirstName | quote }} \
+                --lastname {{ .Values.superset.adminLastName | quote }} \
+                --email {{ .Values.superset.adminEmail | quote }} \
+                --password "$ADMIN_PASSWORD" || true
+              {{- if .Values.superset.loadExamples }}
+              echo "Loading examples..."
+              superset load_examples
+              {{- end }}
+              echo "Init complete."
+          env:
+            {{- include "superset.commonEnv" . | nindent 12 }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "superset.secretName" . }}
+                  key: {{ .Values.superset.existingSecretPasswordKey | default "admin-password" }}
+            {{- with .Values.init.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: superset-config
+              mountPath: /app/pythonpath/superset_config.py
+              subPath: superset_config.py
+          {{- with .Values.init.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: superset-config
+          configMap:
+            name: {{ include "superset.fullname" . }}-config
+{{- end }}

--- a/charts/superset/templates/secret.yaml
+++ b/charts/superset/templates/secret.yaml
@@ -1,0 +1,36 @@
+{{- if not .Values.superset.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "superset.fullname" . }}
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin-password: {{ .Values.superset.adminPassword | default (randAlphaNum 32) | quote }}
+  secret-key: {{ .Values.superset.secretKey | default (randAlphaNum 42) | quote }}
+{{- end }}
+---
+{{- if and (eq .Values.database.mode "external") (not .Values.database.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-database" (include "superset.fullname" .) }}
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-password: {{ .Values.database.external.password | default (randAlphaNum 32) | quote }}
+{{- end }}
+---
+{{- if and (eq .Values.redisConfig.mode "external") (not .Values.redisConfig.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-redis-ext" (include "superset.fullname" .) }}
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  redis-password: {{ .Values.redisConfig.external.password | default (randAlphaNum 32) | quote }}
+{{- end }}

--- a/charts/superset/templates/service.yaml
+++ b/charts/superset/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "superset.fullname" . }}
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "superset.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/superset/templates/serviceaccount.yaml
+++ b/charts/superset/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "superset.serviceAccountName" . }}
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/superset/templates/worker-deployment.yaml
+++ b/charts/superset/templates/worker-deployment.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "superset.fullname" . }}-worker
+  labels:
+    {{- include "superset.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "superset.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "superset.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.worker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "superset.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        {{- include "superset.initContainers" . | nindent 8 }}
+      containers:
+        - name: superset-worker
+          image: {{ include "superset.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              celery --app=superset.tasks.celery_app:app worker --pool=prefork --concurrency={{ .Values.worker.concurrency }} -Ofair --loglevel=INFO
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "superset.commonEnv" . | nindent 12 }}
+            {{- with .Values.worker.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: superset-config
+              mountPath: /app/pythonpath/superset_config.py
+              subPath: superset_config.py
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with (.Values.worker.resources | default .Values.resources) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: superset-config
+          configMap:
+            name: {{ include "superset.fullname" . }}-config
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/superset/tests/beat_deployment_test.yaml
+++ b/charts/superset/tests/beat_deployment_test.yaml
@@ -1,0 +1,46 @@
+suite: Beat Deployment
+templates:
+  - templates/beat-deployment.yaml
+  - templates/secret.yaml
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment for beat
+    template: templates/beat-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-superset-beat
+
+  - it: should have beat component label
+    template: templates/beat-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: beat
+
+  - it: should run celery beat command
+    template: templates/beat-deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "celery.*beat"
+
+  - it: should always have replicas 1
+    template: templates/beat-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should not render when disabled
+    template: templates/beat-deployment.yaml
+    set:
+      beat.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/superset/tests/configmap_test.yaml
+++ b/charts/superset/tests/configmap_test.yaml
@@ -1,0 +1,25 @@
+suite: ConfigMap
+templates:
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a ConfigMap
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-superset-config
+
+  - it: should contain superset_config.py
+    asserts:
+      - isNotNull:
+          path: data["superset_config.py"]
+
+  - it: should include CeleryConfig
+    asserts:
+      - matchRegex:
+          path: data["superset_config.py"]
+          pattern: "CeleryConfig"

--- a/charts/superset/tests/deployment_test.yaml
+++ b/charts/superset/tests/deployment_test.yaml
@@ -1,0 +1,85 @@
+suite: Web Deployment
+templates:
+  - templates/deployment.yaml
+  - templates/secret.yaml
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment for web
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-superset-web
+
+  - it: should have web component label
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: web
+
+  - it: should use the correct image
+    template: templates/deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "apache/superset:4\\.1\\.4"
+
+  - it: should expose port 8088
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8088
+            protocol: TCP
+
+  - it: should mount superset config
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: superset-config
+            mountPath: /app/pythonpath/superset_config.py
+            subPath: superset_config.py
+
+  - it: should have init containers
+    template: templates/deployment.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+
+  - it: should have health probes
+    template: templates/deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should set custom replica count
+    template: templates/deployment.yaml
+    set:
+      web.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should have checksum annotations
+    template: templates/deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations["checksum/secret"]
+      - isNotNull:
+          path: spec.template.metadata.annotations["checksum/config"]

--- a/charts/superset/tests/ingress_test.yaml
+++ b/charts/superset/tests/ingress_test.yaml
@@ -1,0 +1,41 @@
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: superset.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: superset.example.com
+
+  - it: should set ingressClassName
+    set:
+      ingress:
+        enabled: true
+        ingressClassName: nginx
+        hosts:
+          - host: superset.example.com
+            paths:
+              - path: /
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx

--- a/charts/superset/tests/init_job_test.yaml
+++ b/charts/superset/tests/init_job_test.yaml
@@ -1,0 +1,48 @@
+suite: Init Job
+templates:
+  - templates/init-job.yaml
+  - templates/secret.yaml
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Job
+    template: templates/init-job.yaml
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: test-superset-init
+
+  - it: should have helm hook annotations
+    template: templates/init-job.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+
+  - it: should not render when disabled
+    template: templates/init-job.yaml
+    set:
+      init.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use correct admin username
+    template: templates/init-job.yaml
+    set:
+      superset.adminUsername: myadmin
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--username \"myadmin\""
+
+  - it: should have init containers for dependencies
+    template: templates/init-job.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2

--- a/charts/superset/tests/secret_test.yaml
+++ b/charts/superset/tests/secret_test.yaml
@@ -1,0 +1,64 @@
+suite: Secrets
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render superset secret with auto-generated values
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - isNotNull:
+          path: stringData["admin-password"]
+      - isNotNull:
+          path: stringData["secret-key"]
+
+  - it: should render fewer secrets when existingSecret is set
+    set:
+      superset.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use provided admin password
+    set:
+      superset.adminPassword: mypassword
+    asserts:
+      - equal:
+          path: stringData["admin-password"]
+          value: mypassword
+
+  - it: should render external database secret when in external mode
+    set:
+      database.mode: external
+      database.external.host: pg.example.com
+      database.external.password: ext-pass
+      postgresql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: test-superset-database
+        equal:
+          path: stringData["database-password"]
+          value: ext-pass
+
+  - it: should render external redis secret when in external mode
+    set:
+      redisConfig.mode: external
+      redisConfig.external.host: redis.example.com
+      redisConfig.external.password: redis-pass
+      redis.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentSelector:
+          path: metadata.name
+          value: test-superset-redis-ext
+        equal:
+          path: stringData["redis-password"]
+          value: redis-pass

--- a/charts/superset/tests/service_test.yaml
+++ b/charts/superset/tests/service_test.yaml
@@ -1,0 +1,38 @@
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-superset
+
+  - it: should use port 80 targeting http
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP
+
+  - it: should select web component
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: web
+
+  - it: should allow custom service type
+    set:
+      service.type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer

--- a/charts/superset/tests/worker_deployment_test.yaml
+++ b/charts/superset/tests/worker_deployment_test.yaml
@@ -1,0 +1,57 @@
+suite: Worker Deployment
+templates:
+  - templates/worker-deployment.yaml
+  - templates/secret.yaml
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a Deployment for worker
+    template: templates/worker-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-superset-worker
+
+  - it: should have worker component label
+    template: templates/worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: worker
+
+  - it: should run celery worker command
+    template: templates/worker-deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "celery.*worker"
+
+  - it: should not render when disabled
+    template: templates/worker-deployment.yaml
+    set:
+      worker.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set custom concurrency
+    template: templates/worker-deployment.yaml
+    set:
+      worker.concurrency: 4
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--concurrency=4"
+
+  - it: should set custom replica count
+    template: templates/worker-deployment.yaml
+    set:
+      worker.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3

--- a/charts/superset/values.schema.json
+++ b/charts/superset/values.schema.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Apache Superset Helm Chart Values",
+  "description": "Values for the Apache Superset Helm chart — BI platform with web, worker, and beat deployments backed by PostgreSQL and Redis",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "apache/superset" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "superset": {
+      "type": "object",
+      "description": "Superset application configuration",
+      "properties": {
+        "adminUsername": { "type": "string", "default": "admin" },
+        "adminFirstName": { "type": "string", "default": "Admin" },
+        "adminLastName": { "type": "string", "default": "User" },
+        "adminEmail": { "type": "string", "default": "admin@superset.local" },
+        "adminPassword": { "type": "string", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretPasswordKey": { "type": "string", "default": "admin-password" },
+        "secretKey": { "type": "string", "default": "" },
+        "existingSecretSecretKeyKey": { "type": "string", "default": "secret-key" },
+        "loadExamples": { "type": "boolean", "default": false },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "extraConfig": { "type": "string", "default": "" }
+      }
+    },
+    "web": {
+      "type": "object",
+      "description": "Web server configuration",
+      "properties": {
+        "replicaCount": { "type": "integer", "default": 1 },
+        "workers": { "type": "integer", "default": 2 },
+        "timeout": { "type": "integer", "default": 120 },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "resources": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "podAnnotations": { "type": "object" }
+      }
+    },
+    "worker": {
+      "type": "object",
+      "description": "Celery worker configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "replicaCount": { "type": "integer", "default": 1 },
+        "concurrency": { "type": "integer", "default": 2 },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "resources": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "podAnnotations": { "type": "object" }
+      }
+    },
+    "beat": {
+      "type": "object",
+      "description": "Celery beat scheduler configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "resources": { "type": "object" },
+        "podLabels": { "type": "object" },
+        "podAnnotations": { "type": "object" }
+      }
+    },
+    "init": {
+      "type": "object",
+      "description": "Init job configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "resources": { "type": "object" }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "Database configuration",
+      "properties": {
+        "mode": { "type": "string", "enum": ["subchart", "external"], "default": "subchart" },
+        "external": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string", "default": "" },
+            "port": { "type": "integer", "default": 5432 },
+            "name": { "type": "string", "default": "superset" },
+            "username": { "type": "string", "default": "superset" },
+            "password": { "type": "string", "default": "" },
+            "existingSecret": { "type": "string", "default": "" },
+            "existingSecretPasswordKey": { "type": "string", "default": "password" }
+          }
+        }
+      }
+    },
+    "redisConfig": {
+      "type": "object",
+      "description": "Redis configuration",
+      "properties": {
+        "mode": { "type": "string", "enum": ["subchart", "external"], "default": "subchart" },
+        "external": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string", "default": "" },
+            "port": { "type": "integer", "default": 6379 },
+            "password": { "type": "string", "default": "" },
+            "db": { "type": "integer", "default": 0 },
+            "existingSecret": { "type": "string", "default": "" },
+            "existingSecretPasswordKey": { "type": "string", "default": "password" }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "resources": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true }
+      }
+    }
+  }
+}

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -1,0 +1,321 @@
+# =============================================================================
+# Apache Superset Configuration
+# =============================================================================
+
+# -- Override the chart name used in resource names
+nameOverride: ""
+
+# -- Override the full release name used in resource names
+fullnameOverride: ""
+
+# -- Labels added to every resource created by this chart
+commonLabels: {}
+
+image:
+  # -- Superset container image repository
+  repository: apache/superset
+  # -- Superset image tag. Defaults to appVersion.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# =============================================================================
+# Superset Application
+# =============================================================================
+
+superset:
+  # -- Admin username created by the init job
+  adminUsername: admin
+  # -- Admin first name
+  adminFirstName: Admin
+  # -- Admin last name
+  adminLastName: User
+  # -- Admin email
+  adminEmail: admin@superset.local
+  # -- Admin password. Auto-generated if empty.
+  adminPassword: ""
+  # -- Existing secret with admin credentials
+  existingSecret: ""
+  # -- Key in existingSecret for admin password
+  existingSecretPasswordKey: admin-password
+  # -- Flask SECRET_KEY for session signing. Auto-generated if empty.
+  secretKey: ""
+  # -- Key in existingSecret for SECRET_KEY
+  existingSecretSecretKeyKey: secret-key
+  # -- Load example dashboards and data during init
+  loadExamples: false
+  # -- Extra environment variables for all Superset containers
+  extraEnv: []
+  # -- Extra superset_config.py content merged into the ConfigMap
+  extraConfig: ""
+
+# =============================================================================
+# Web Server
+# =============================================================================
+
+web:
+  # -- Number of web server replicas
+  replicaCount: 1
+  # -- Gunicorn workers
+  workers: 2
+  # -- Gunicorn timeout in seconds
+  timeout: 120
+  # -- Extra environment variables for the web container
+  extraEnv: []
+  # -- Resource requests and limits for the web container
+  resources: {}
+  # -- Pod labels for web pods
+  podLabels: {}
+  # -- Pod annotations for web pods
+  podAnnotations: {}
+
+# =============================================================================
+# Celery Worker
+# =============================================================================
+
+worker:
+  # -- Enable Celery workers
+  enabled: true
+  # -- Number of worker replicas
+  replicaCount: 1
+  # -- Celery worker concurrency
+  concurrency: 2
+  # -- Extra environment variables for the worker container
+  extraEnv: []
+  # -- Resource requests and limits for the worker container
+  resources: {}
+  # -- Pod labels for worker pods
+  podLabels: {}
+  # -- Pod annotations for worker pods
+  podAnnotations: {}
+
+# =============================================================================
+# Celery Beat Scheduler
+# =============================================================================
+
+beat:
+  # -- Enable Celery beat scheduler
+  enabled: true
+  # -- Extra environment variables for the beat container
+  extraEnv: []
+  # -- Resource requests and limits for the beat container
+  resources: {}
+  # -- Pod labels for beat pods
+  podLabels: {}
+  # -- Pod annotations for beat pods
+  podAnnotations: {}
+
+# =============================================================================
+# Init Job
+# =============================================================================
+
+init:
+  # -- Enable the init job that creates the admin user and upgrades the database
+  enabled: true
+  # -- Extra environment variables for the init container
+  extraEnv: []
+  # -- Resource requests and limits for the init container
+  resources: {}
+
+# =============================================================================
+# Database
+# =============================================================================
+
+database:
+  # -- Database mode: subchart | external
+  mode: subchart
+  external:
+    # -- External database host
+    host: ""
+    # -- External database port
+    port: 5432
+    # -- External database name
+    name: superset
+    # -- External database username
+    username: superset
+    # -- External database password
+    password: ""
+    # -- Existing secret with external database password
+    existingSecret: ""
+    # -- Key in existingSecret for password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# Redis
+# =============================================================================
+
+redisConfig:
+  # -- Redis mode: subchart | external
+  mode: subchart
+  external:
+    # -- External Redis host
+    host: ""
+    # -- External Redis port
+    port: 6379
+    # -- External Redis password
+    password: ""
+    # -- External Redis database number
+    db: 0
+    # -- Existing secret with external Redis password
+    existingSecret: ""
+    # -- Key in existingSecret for password
+    existingSecretPasswordKey: password
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 80
+  # -- Service annotations
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name (traefik, nginx, etc.)
+  ingressClassName: traefik
+  # -- Ingress annotations
+  # @default -- `{}`
+  # Example:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  annotations: {}
+  # -- Ingress hosts
+  # @default -- `[]`
+  # Example:
+  #   - host: superset.example.com
+  #     paths:
+  #       - path: /
+  #         pathType: Prefix
+  hosts: []
+  # -- Ingress TLS
+  # @default -- `[]`
+  # Example:
+  #   - secretName: superset-tls
+  #     hosts:
+  #       - superset.example.com
+  tls: []
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  liveness:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  startup:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 30
+
+# =============================================================================
+# ServiceAccount
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name. Uses fullname if empty.
+  name: ""
+  # -- ServiceAccount annotations
+  annotations: {}
+
+# =============================================================================
+# Security & Scheduling
+# =============================================================================
+
+# -- Pod-level security context
+podSecurityContext: {}
+
+# -- Container-level security context
+securityContext: {}
+
+# -- Resource requests and limits (global default, overridden per component)
+resources: {}
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Affinity rules
+affinity: {}
+
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# -- Priority class name
+priorityClassName: ""
+
+# -- Termination grace period in seconds
+terminationGracePeriodSeconds: 30
+
+# -- Pod labels applied to all pods
+podLabels: {}
+
+# -- Pod annotations applied to all pods
+podAnnotations: {}
+
+# -- Extra volumes
+extraVolumes: []
+
+# -- Extra volume mounts
+extraVolumeMounts: []
+
+# -- Extra Kubernetes manifests to deploy
+extraManifests: []
+
+# =============================================================================
+# PostgreSQL Subchart
+# =============================================================================
+
+postgresql:
+  # -- Enable PostgreSQL subchart
+  enabled: true
+  auth:
+    # -- PostgreSQL database name
+    database: superset
+    # -- PostgreSQL username
+    username: superset
+    # -- PostgreSQL password. Auto-generated if empty.
+    password: ""
+
+# =============================================================================
+# Redis Subchart
+# =============================================================================
+
+redis:
+  # -- Enable Redis subchart
+  enabled: true
+  auth:
+    # -- Redis password. Auto-generated if empty.
+    password: ""


### PR DESCRIPTION
## Summary

- **Apache Superset** — data exploration and visualization platform with web/worker/beat deployments, PostgreSQL and Redis subcharts, init job for db setup, configmap-mounted superset_config.py (8 test suites, 40 tests)
- **CKAN** — open data portal with DataPusher, Solr StatefulSet, PostgreSQL and Redis subcharts, ckan config-tool startup for dynamic URL injection (7 test suites, 30 tests)
- **Apache Druid** — distributed analytics database with 6 components (coordinator, overlord, broker, router, historical, middlemanager), PostgreSQL and ZooKeeper subcharts, S3 deep storage support (10 test suites, 43 tests)

All charts include: values.schema.json, CI scenarios, ingress support, external dependency mode, and README with AI-METADATA.

## Test plan

- [x] `helm lint --strict` passes for all 3 charts
- [x] `helm template` renders for all CI scenarios
- [x] `helm unittest` passes: 113 tests total
- [x] k3d validation: Superset (web+worker+beat running)
- [x] k3d validation: CKAN (ckan+datapusher+solr running)
- [x] k3d validation: Druid (coordinator+broker+router running, minimal scenario)