### PR TITLE
fix(repo): add missing icon field to 10 chart.yaml files

### DIFF
--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -5,6 +5,7 @@ type: application
 version: 1.0.4
 appVersion: "1.8.1"
 kubeVersion: ">=1.26.0-0"
+icon: https://raw.githubusercontent.com/appwrite/appwrite/main/public/images/github-logo.png
 home: https://appwrite.io
 keywords:
   - appwrite

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -15,6 +15,7 @@ keywords:
   - wayback
   - chromium
   - self-hosted
+icon: https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/dev/archivebox/templates/static/archive.png
 home: https://archivebox.io
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -16,6 +16,7 @@ keywords:
   - crash-reporting
   - push-notifications
   - self-hosted
+icon: https://count.ly/images/logos/countly-logo-mark.svg
 home: https://count.ly
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -5,6 +5,7 @@ type: application
 version: 1.0.4
 appVersion: "0.70.3"
 kubeVersion: ">=1.26.0-0"
+icon: https://docmost.com/img/logo.svg
 home: https://helmforge.dev/docs/charts/docmost
 keywords:
   - docmost

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -5,6 +5,7 @@ version: 1.1.4
 appVersion: "23.0.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Dolibarr ERP/CRM on Kubernetes with MySQL support
+icon: https://raw.githubusercontent.com/Dolibarr/dolibarr/develop/doc/images/dolibarr_logo.svg
 maintainers:
   - name: helmforgedev
   - name: mberlofa

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,6 +7,7 @@ maintainers:
   - name: mberlofa
 version: 1.8.3
 appVersion: "1.0.0"
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
 kubeVersion: ">=1.26.0-0"
 annotations:
   helmforge.dev/maturity: stable

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -15,6 +15,7 @@ keywords:
   - liwan
   - duckdb
   - self-hosted
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
 home: https://liwan.dev
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -16,6 +16,7 @@ keywords:
   - engineering
   - performance
   - self-hosted
+icon: https://raw.githubusercontent.com/middlewarehq/middleware/main/media_files/logo192.png
 home: https://www.middlewarehq.com
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -5,6 +5,7 @@ version: 1.0.4
 appVersion: "2.0.22"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Eclipse Mosquitto with WebSocket support and optional MQTTX Web
+icon: https://mosquitto.org/images/mosquitto-text-side-28.png
 maintainers:
   - name: helmforgedev
   - name: mberlofa

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -16,6 +16,7 @@ keywords:
   - cycling
   - running
   - self-hosted
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
 home: https://github.com/robiningelbrecht/strava-statistics
 sources:
   - https://github.com/helmforgedev/charts


### PR DESCRIPTION
## Summary
- Add official project logos to 7 charts: appwrite, archivebox, countly, docmost, dolibarr, middleware, mosquitto
- Add generic Kubernetes logo to 3 charts without official logos: generic, liwan, strava-statistics
- All 44 charts now have an `icon:` field in Chart.yaml for ArtifactHub and Helm UI rendering

## Test plan
- [x] `helm lint --strict` passes on modified charts
- [x] Verified no charts remain without `icon:` field