### PR TITLE
feat(repo): promote 11 alpha charts to stable maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,17 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 | [gitea](charts/gitea/) | stable | Gitea — self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH, and S3 backup |
 | [homarr](charts/homarr/) | stable | Homarr — modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup |
 | [mariadb](charts/mariadb/) | stable | MariaDB — standalone or GTID-based replication with TLS, metrics, configuration presets, and S3 backup |
-| [umami](charts/umami/) | alpha | Umami — privacy-focused web analytics with PostgreSQL and auto-generated app secret |
-| [metabase](charts/metabase/) | alpha | Metabase — open-source business intelligence and analytics with PostgreSQL and JVM tuning |
-| [liwan](charts/liwan/) | alpha | Liwan — ultra-lightweight privacy-first web analytics with embedded DuckDB |
-| [wallabag](charts/wallabag/) | alpha | Wallabag — self-hosted read-it-later with PostgreSQL, optional Redis, and Symfony configuration |
-| [strava-statistics](charts/strava-statistics/) | alpha | Statistics for Strava — self-hosted fitness dashboard with SQLite and Strava OAuth |
-| [archivebox](charts/archivebox/) | alpha | ArchiveBox — self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage |
-| [countly](charts/countly/) | alpha | Countly — product analytics platform with MongoDB, event tracking, crash reporting, and plugin system |
-| [middleware](charts/middleware/) | alpha | Middleware — open-source DORA metrics platform with PostgreSQL, Redis, and engineering performance tracking |
-| [superset](charts/superset/) | alpha | Apache Superset — data exploration and visualization with Celery workers, PostgreSQL, and Redis |
-| [ckan](charts/ckan/) | alpha | CKAN — open data portal with DataPusher, Solr, PostgreSQL, and Redis |
-| [druid](charts/druid/) | alpha | Apache Druid — distributed analytics database with coordinator, broker, historical, and router |
+| [umami](charts/umami/) | stable | Umami — privacy-focused web analytics with PostgreSQL and auto-generated app secret |
+| [metabase](charts/metabase/) | stable | Metabase — open-source business intelligence and analytics with PostgreSQL and JVM tuning |
+| [liwan](charts/liwan/) | stable | Liwan — ultra-lightweight privacy-first web analytics with embedded DuckDB |
+| [wallabag](charts/wallabag/) | stable | Wallabag — self-hosted read-it-later with PostgreSQL, optional Redis, and Symfony configuration |
+| [strava-statistics](charts/strava-statistics/) | stable | Statistics for Strava — self-hosted fitness dashboard with SQLite and Strava OAuth |
+| [archivebox](charts/archivebox/) | stable | ArchiveBox — self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage |
+| [countly](charts/countly/) | stable | Countly — product analytics platform with MongoDB, event tracking, crash reporting, and plugin system |
+| [middleware](charts/middleware/) | stable | Middleware — open-source DORA metrics platform with PostgreSQL, Redis, and engineering performance tracking |
+| [superset](charts/superset/) | stable | Apache Superset — data exploration and visualization with Celery workers, PostgreSQL, and Redis |
+| [ckan](charts/ckan/) | stable | CKAN — open data portal with DataPusher, Solr, PostgreSQL, and Redis |
+| [druid](charts/druid/) | stable | Apache Druid — distributed analytics database with coordinator, broker, historical, and router |
 
 ### Maturity levels
 

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -20,9 +20,8 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/ArchiveBox/ArchiveBox
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -23,13 +23,12 @@ icon: https://raw.githubusercontent.com/ckan/ckan/master/ckan/public/base/images
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/ckan
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/ckan
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -26,9 +26,8 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -23,13 +23,12 @@ icon: https://raw.githubusercontent.com/apache/druid/master/website/static/img/d
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/druid
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/druid
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -20,9 +20,8 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/explodingcamera/liwan
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -21,9 +21,8 @@ sources:
   - https://github.com/metabase/metabase
 icon: https://www.metabase.com/images/logo.svg
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -30,9 +30,8 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -21,9 +21,8 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/robiningelbrecht/strava-statistics
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -24,13 +24,12 @@ icon: https://raw.githubusercontent.com/apache/superset/master/superset-frontend
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/superset
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/superset
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -20,9 +20,8 @@ sources:
   - https://github.com/umami-software/umami
 icon: https://umami.is/images/umami-logo.png
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -20,9 +20,8 @@ sources:
   - https://github.com/wallabag/wallabag
 icon: https://wallabag.org/img/logo-wallabag.svg
 annotations:
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc


### PR DESCRIPTION
## Summary

- Promote all 11 alpha charts to **stable** maturity
- All charts have: published releases, CI scenarios, unit tests, k3d validation
- Charts promoted: archivebox, ckan, countly, druid, liwan, metabase, middleware, strava-statistics, superset, umami, wallabag
- Updated `helmforge.dev/maturity` annotation in each Chart.yaml
- Removed `artifacthub.io/prerelease` annotations
- Updated README.md charts table

## k3d validation results

| Chart | Status |
|-------|--------|
| archivebox | Running |
| ckan | Running |
| countly | Running |
| druid | ZooKeeper image stale (separate fix) |
| liwan | Running |
| metabase | Running |
| middleware | Running |
| strava-statistics | Running |
| superset | Running |
| umami | Running + backup e2e validated |
| wallabag | Running |

## Test plan

- [x] All 11 Chart.yaml updated to `helmforge.dev/maturity: stable`
- [x] All `artifacthub.io/prerelease` annotations removed
- [x] README.md table updated
- [x] k3d validation for 10/11 charts (druid has stale ZK image — separate fix)