### PR TITLE
feat: add s3 backup support to stable charts

### DIFF
--- a/charts/appwrite/ci/backup-values.yaml
+++ b/charts/appwrite/ci/backup-values.yaml
@@ -1,0 +1,9 @@
+# CI: Backup enabled (suspended for CI)
+backup:
+  enabled: true
+  suspend: true
+  s3:
+    endpoint: https://minio.example.com
+    bucket: appwrite-backups
+    accessKey: test-access
+    secretKey: test-secret

--- a/charts/appwrite/templates/_helpers.tpl
+++ b/charts/appwrite/templates/_helpers.tpl
@@ -405,3 +405,52 @@ startupProbe:
   failureThreshold: {{ .Values.startupProbe.failureThreshold }}
 {{- end }}
 {{- end -}}
+
+{{/* ---- Backup helpers ---- */}}
+
+{{- define "appwrite.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "appwrite.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "appwrite.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- if not .Values.backup.s3.endpoint -}}
+    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}
+    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "appwrite.backupDbHost" -}}
+{{- include "appwrite.databaseHost" . -}}
+{{- end -}}
+
+{{- define "appwrite.backupDbPort" -}}
+{{- include "appwrite.databasePort" . -}}
+{{- end -}}
+
+{{- define "appwrite.backupDbName" -}}
+{{- include "appwrite.databaseName" . -}}
+{{- end -}}
+
+{{- define "appwrite.backupDbUsername" -}}
+{{- include "appwrite.databaseRootUser" . -}}
+{{- end -}}
+
+{{- define "appwrite.backupDbPasswordSecretName" -}}
+{{- include "appwrite.databaseSecretName" . -}}
+{{- end -}}
+
+{{- define "appwrite.backupDbPasswordSecretKey" -}}
+{{- include "appwrite.databaseSecretKey" . -}}
+{{- end -}}

--- a/charts/appwrite/templates/backup-configmap.yaml
+++ b/charts/appwrite/templates/backup-configmap.yaml
@@ -1,0 +1,35 @@
+{{- if include "appwrite.backupEnabled" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "appwrite.fullname" . }}-backup-scripts
+  labels:
+    {{- include "appwrite.labels" . | nindent 4 }}
+data:
+  mariadb-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-mariadb-${timestamp}.sql.gz"
+    mkdir -p /backup/out
+    export MYSQL_PWD="${DB_PASSWORD}"
+    mysqldump ${MYSQLDUMP_EXTRA_ARGS:-} \
+      --host="${DB_HOST}" \
+      --port="${DB_PORT}" \
+      --user="${DB_USERNAME}" \
+      "${DB_NAME}" | gzip -c > "${archive}"
+    printf "%s" "${archive}" > /backup/out/backup-file
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    archive="$(cat /backup/out/backup-file)"
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+    mc cp "${archive}" "${target}/"
+{{- end }}

--- a/charts/appwrite/templates/backup-cronjob.yaml
+++ b/charts/appwrite/templates/backup-cronjob.yaml
@@ -1,0 +1,109 @@
+{{- if include "appwrite.backupEnabled" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "appwrite.fullname" . }}-backup
+  labels:
+    {{- include "appwrite.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "appwrite.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "appwrite.serviceAccountName" . }}
+          terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: mariadb-backup
+              image: {{ .Values.backup.images.mariadb | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/mariadb-backup.sh"]
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.backup.archivePrefix | quote }}
+                - name: MYSQLDUMP_EXTRA_ARGS
+                  value: {{ .Values.backup.database.mysqldumpArgs | quote }}
+                - name: DB_HOST
+                  value: {{ include "appwrite.backupDbHost" . | quote }}
+                - name: DB_PORT
+                  value: {{ include "appwrite.backupDbPort" . | quote }}
+                - name: DB_USERNAME
+                  value: {{ include "appwrite.backupDbUsername" . | quote }}
+                - name: DB_NAME
+                  value: {{ include "appwrite.backupDbName" . | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "appwrite.backupDbPasswordSecretName" . }}
+                      key: {{ include "appwrite.backupDbPasswordSecretKey" . }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "appwrite.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "appwrite.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "appwrite.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+{{- end }}

--- a/charts/appwrite/templates/secret.yaml
+++ b/charts/appwrite/templates/secret.yaml
@@ -37,3 +37,16 @@ type: Opaque
 data:
   redis-password: {{ .Values.cache.external.password | b64enc | quote }}
 {{- end }}
+{{- if and (include "appwrite.backupEnabled" .) (not .Values.backup.s3.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "appwrite.backupSecretName" . }}
+  labels:
+    {{- include "appwrite.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.backup.s3.existingSecretAccessKeyKey }}: {{ .Values.backup.s3.accessKey | quote }}
+  {{ .Values.backup.s3.existingSecretSecretKeyKey }}: {{ .Values.backup.s3.secretKey | quote }}
+{{- end }}

--- a/charts/appwrite/tests/backup_secret_test.yaml
+++ b/charts/appwrite/tests/backup_secret_test.yaml
@@ -1,0 +1,47 @@
+suite: Backup Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render backup secret by default
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render backup secret when using inline s3 credentials
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: myaccess
+      backup.s3.secretKey: mysecret
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-appwrite-backup
+        documentIndex: 1
+      - equal:
+          path: stringData.access-key
+          value: myaccess
+        documentIndex: 1
+      - equal:
+          path: stringData.secret-key
+          value: mysecret
+        documentIndex: 1
+
+  - it: should not render backup secret when existingSecret is set
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.existingSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/appwrite/tests/backup_test.yaml
+++ b/charts/appwrite/tests/backup_test.yaml
@@ -1,0 +1,215 @@
+suite: Backup
+templates:
+  - templates/backup-configmap.yaml
+  - templates/backup-cronjob.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render backup configmap by default
+    template: templates/backup-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render backup cronjob by default
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render backup configmap when enabled
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-appwrite-backup-scripts
+
+  - it: should render backup cronjob when enabled
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: test-appwrite-backup
+
+  - it: should use default schedule
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 3 * * *"
+
+  - it: should use custom schedule
+    set:
+      backup.enabled: true
+      backup.schedule: "0 1 * * *"
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 1 * * *"
+
+  - it: should use subchart database host by default
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: test-mariadb
+
+  - it: should use subchart database port by default
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_PORT
+            value: "3306"
+
+  - it: should use subchart database name by default
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_NAME
+            value: appwrite
+
+  - it: should use root user for backup
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_USERNAME
+            value: root
+
+  - it: should use external database host when configured
+    set:
+      mariadb.enabled: false
+      database.external.host: ext-db.example.com
+      database.external.rootPassword: pass
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: ext-db.example.com
+
+  - it: should fail when backup.s3.endpoint is missing
+    set:
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail when backup.s3.bucket is missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.bucket is required when backup.enabled is true"
+
+  - it: should fail when s3 credentials are missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey"
+
+  - it: should set suspend when configured
+    set:
+      backup.enabled: true
+      backup.suspend: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: true
+
+  - it: should set mysqldump args
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: MYSQLDUMP_EXTRA_ARGS
+            value: "--single-transaction --routines --triggers"

--- a/charts/appwrite/values.schema.json
+++ b/charts/appwrite/values.schema.json
@@ -153,6 +153,48 @@
     "livenessProbe": { "type": "object" },
     "readinessProbe": { "type": "object" },
     "startupProbe": { "type": "object" },
+    "backup": {
+      "type": "object",
+      "description": "Scheduled MariaDB backup to S3-compatible storage via mysqldump",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable scheduled MariaDB backup to S3-compatible storage" },
+        "schedule": { "type": "string", "description": "Cron schedule for the backup job" },
+        "suspend": { "type": "boolean", "description": "Suspend the CronJob" },
+        "concurrencyPolicy": { "type": "string", "enum": ["Allow", "Forbid", "Replace"] },
+        "successfulJobsHistoryLimit": { "type": "integer" },
+        "failedJobsHistoryLimit": { "type": "integer" },
+        "backoffLimit": { "type": "integer" },
+        "archivePrefix": { "type": "string" },
+        "images": {
+          "type": "object",
+          "properties": {
+            "mariadb": { "type": "string", "description": "MariaDB client image for mysqldump" },
+            "uploader": { "type": "string", "description": "MinIO client image for S3 upload" }
+          }
+        },
+        "resources": { "type": "object" },
+        "database": {
+          "type": "object",
+          "properties": {
+            "mysqldumpArgs": { "type": "string", "description": "Extra arguments passed to mysqldump" }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "endpoint": { "type": "string", "description": "S3-compatible endpoint URL" },
+            "bucket": { "type": "string", "description": "S3 bucket name" },
+            "prefix": { "type": "string", "description": "S3 key prefix inside the bucket" },
+            "createBucketIfNotExists": { "type": "boolean" },
+            "existingSecret": { "type": "string", "description": "Existing secret with S3 credentials" },
+            "existingSecretAccessKeyKey": { "type": "string" },
+            "existingSecretSecretKeyKey": { "type": "string" },
+            "accessKey": { "type": "string" },
+            "secretKey": { "type": "string" }
+          }
+        }
+      }
+    },
     "nodeSelector": { "type": "object" },
     "tolerations": { "type": "array" },
     "affinity": { "type": "object" },

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -402,6 +402,57 @@ startupProbe:
   failureThreshold: 30
 
 # =============================================================================
+# Backup (MariaDB via mysqldump to S3)
+# =============================================================================
+
+backup:
+  # -- Enable scheduled MariaDB backup to S3-compatible storage
+  enabled: false
+  # -- Cron schedule for the backup job
+  schedule: "0 3 * * *"
+  # -- Suspend the CronJob (useful for CI or temporary disable)
+  suspend: false
+  # -- CronJob concurrency policy
+  concurrencyPolicy: Forbid
+  # -- Number of successful job runs to keep
+  successfulJobsHistoryLimit: 3
+  # -- Number of failed job runs to keep
+  failedJobsHistoryLimit: 3
+  # -- Number of retries before marking the job as failed
+  backoffLimit: 1
+  # -- Prefix for the backup archive filename
+  archivePrefix: appwrite
+  images:
+    # -- MariaDB client image for mysqldump
+    mariadb: mariadb:11.7-noble
+    # -- MinIO client image for S3 upload
+    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+  # -- Resources for backup containers
+  resources: {}
+  database:
+    # -- Extra arguments passed to mysqldump
+    mysqldumpArgs: "--single-transaction --routines --triggers"
+  s3:
+    # -- S3-compatible endpoint URL (required when backup.enabled is true)
+    endpoint: ""
+    # -- S3 bucket name (required when backup.enabled is true)
+    bucket: ""
+    # -- S3 key prefix inside the bucket
+    prefix: appwrite
+    # -- Create the bucket if it does not exist
+    createBucketIfNotExists: true
+    # -- Existing secret with S3 credentials (overrides accessKey/secretKey)
+    existingSecret: ""
+    # -- Key in existing secret for access key
+    existingSecretAccessKeyKey: access-key
+    # -- Key in existing secret for secret key
+    existingSecretSecretKeyKey: secret-key
+    # -- S3 access key (ignored when existingSecret is set)
+    accessKey: ""
+    # -- S3 secret key (ignored when existingSecret is set)
+    secretKey: ""
+
+# =============================================================================
 # Scheduling
 # =============================================================================
 

--- a/charts/docmost/ci/backup-values.yaml
+++ b/charts/docmost/ci/backup-values.yaml
@@ -1,0 +1,16 @@
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  archivePrefix: docmost
+  images:
+    postgresql: postgres:18-alpine
+    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+  database:
+    pgDumpArgs: "--no-owner"
+  s3:
+    endpoint: https://minio.example.com
+    bucket: backups
+    prefix: docmost
+    createBucketIfNotExists: true
+    accessKey: minioadmin
+    secretKey: minioadmin

--- a/charts/docmost/templates/_helpers.tpl
+++ b/charts/docmost/templates/_helpers.tpl
@@ -206,3 +206,50 @@ redis-password
 {{- printf "%s-storage" (include "docmost.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "docmost.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "docmost.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "docmost.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- if not .Values.backup.s3.endpoint -}}
+    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}
+    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "docmost.backupDbHost" -}}
+{{- include "docmost.databaseHost" . -}}
+{{- end -}}
+
+{{- define "docmost.backupDbPort" -}}
+{{- include "docmost.databasePort" . -}}
+{{- end -}}
+
+{{- define "docmost.backupDbName" -}}
+{{- include "docmost.databaseName" . -}}
+{{- end -}}
+
+{{- define "docmost.backupDbUsername" -}}
+{{- include "docmost.databaseUsername" . -}}
+{{- end -}}
+
+{{- define "docmost.backupDbPasswordSecretName" -}}
+{{- include "docmost.databaseSecretName" . -}}
+{{- end -}}
+
+{{- define "docmost.backupDbPasswordSecretKey" -}}
+{{- include "docmost.databaseSecretKey" . -}}
+{{- end -}}

--- a/charts/docmost/templates/backup-configmap.yaml
+++ b/charts/docmost/templates/backup-configmap.yaml
@@ -1,0 +1,35 @@
+{{- if include "docmost.backupEnabled" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "docmost.fullname" . }}-backup-scripts
+  labels:
+    {{- include "docmost.labels" . | nindent 4 }}
+data:
+  postgres-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-postgresql-${timestamp}.sql.gz"
+    mkdir -p /backup/out
+    export PGPASSWORD="${DB_PASSWORD}"
+    pg_dump ${PG_DUMP_EXTRA_ARGS:-} \
+      --host="${DB_HOST}" \
+      --port="${DB_PORT}" \
+      --username="${DB_USERNAME}" \
+      --dbname="${DB_NAME}" | gzip -c > "${archive}"
+    printf "%s" "${archive}" > /backup/out/backup-file
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    archive="$(cat /backup/out/backup-file)"
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+    mc cp "${archive}" "${target}/"
+{{- end }}

--- a/charts/docmost/templates/backup-cronjob.yaml
+++ b/charts/docmost/templates/backup-cronjob.yaml
@@ -1,0 +1,111 @@
+{{- if include "docmost.backupEnabled" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "docmost.fullname" . }}-backup
+  labels:
+    {{- include "docmost.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "docmost.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "docmost.serviceAccountName" . }}
+          terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: postgres-backup
+              image: {{ .Values.backup.images.postgresql | quote }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - /scripts/postgres-backup.sh
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.backup.archivePrefix | quote }}
+                - name: DB_HOST
+                  value: {{ include "docmost.backupDbHost" . | quote }}
+                - name: DB_PORT
+                  value: {{ include "docmost.backupDbPort" . | quote }}
+                - name: DB_NAME
+                  value: {{ include "docmost.backupDbName" . | quote }}
+                - name: DB_USERNAME
+                  value: {{ include "docmost.backupDbUsername" . | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "docmost.backupDbPasswordSecretName" . }}
+                      key: {{ include "docmost.backupDbPasswordSecretKey" . }}
+                - name: PG_DUMP_EXTRA_ARGS
+                  value: {{ .Values.backup.database.pgDumpArgs | quote }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "docmost.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "docmost.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "docmost.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+{{- end }}

--- a/charts/docmost/templates/secret.yaml
+++ b/charts/docmost/templates/secret.yaml
@@ -68,3 +68,16 @@ data:
   access-key: {{ .Values.storage.s3.accessKey | b64enc | quote }}
   secret-key: {{ .Values.storage.s3.secretKey | b64enc | quote }}
 {{- end }}
+{{- if and (include "docmost.backupEnabled" .) (not .Values.backup.s3.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "docmost.backupSecretName" . }}
+  labels:
+    {{- include "docmost.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.backup.s3.existingSecretAccessKeyKey }}: {{ .Values.backup.s3.accessKey | quote }}
+  {{ .Values.backup.s3.existingSecretSecretKeyKey }}: {{ .Values.backup.s3.secretKey | quote }}
+{{- end }}

--- a/charts/docmost/tests/backup_secret_test.yaml
+++ b/charts/docmost/tests/backup_secret_test.yaml
@@ -1,0 +1,41 @@
+suite: Backup Secret
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render backup secret by default
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render backup secret when backup is enabled with inline keys
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: myaccess
+      backup.s3.secretKey: mysecret
+    documentSelector:
+      path: metadata.name
+      value: test-docmost-backup
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData["access-key"]
+          value: myaccess
+      - equal:
+          path: stringData["secret-key"]
+          value: mysecret
+
+  - it: should not render backup secret when existingSecret is set
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.existingSecret: my-backup-secret
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/docmost/tests/backup_test.yaml
+++ b/charts/docmost/tests/backup_test.yaml
@@ -1,0 +1,173 @@
+suite: Backup
+templates:
+  - templates/backup-configmap.yaml
+  - templates/backup-cronjob.yaml
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render backup configmap by default
+    template: templates/backup-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render backup cronjob by default
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render backup configmap when backup is enabled
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-docmost-backup-scripts
+
+  - it: should render backup cronjob when backup is enabled
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: test-docmost-backup
+
+  - it: should use postgresql subchart database host in backup cronjob
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: test-postgresql
+
+  - it: should use external database host in backup cronjob
+    set:
+      database.external.host: pg.example.com
+      database.external.name: docmost
+      database.external.username: docmost
+      database.external.password: secret
+      postgresql.enabled: false
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: pg.example.com
+
+  - it: should set correct schedule
+    set:
+      backup.enabled: true
+      backup.schedule: "0 6 * * *"
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 6 * * *"
+
+  - it: should pass pgDumpArgs to the initContainer
+    set:
+      backup.enabled: true
+      backup.database.pgDumpArgs: "--no-owner --clean"
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: PG_DUMP_EXTRA_ARGS
+            value: "--no-owner --clean"
+
+  - it: should use correct S3 endpoint in upload container
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.custom.com
+      backup.s3.bucket: my-bucket
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: S3_ENDPOINT
+            value: https://s3.custom.com
+
+  - it: should fail when backup.s3.endpoint is missing
+    set:
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/secret.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail when backup.s3.bucket is missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    template: templates/secret.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.bucket is required when backup.enabled is true"
+
+  - it: should fail when s3 credentials are missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+    template: templates/secret.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey"
+
+  - it: should not fail when existingSecret is set without inline keys
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.existingSecret: my-backup-secret
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - isKind:
+          of: CronJob

--- a/charts/docmost/values.schema.json
+++ b/charts/docmost/values.schema.json
@@ -165,6 +165,51 @@
         }
       }
     },
+    "backup": {
+      "type": "object",
+      "description": "Built-in backup CronJob for PostgreSQL (pg_dump to S3)",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable built-in backup CronJob for PostgreSQL (pg_dump to S3)" },
+        "schedule": { "type": "string", "description": "Backup schedule in Cron format" },
+        "suspend": { "type": "boolean", "description": "Suspend backup execution" },
+        "concurrencyPolicy": { "type": "string", "description": "CronJob concurrency policy", "enum": ["Allow", "Forbid", "Replace"] },
+        "successfulJobsHistoryLimit": { "type": "integer", "description": "Successful job history retained by the CronJob" },
+        "failedJobsHistoryLimit": { "type": "integer", "description": "Failed job history retained by the CronJob" },
+        "backoffLimit": { "type": "integer", "description": "Job backoff limit" },
+        "archivePrefix": { "type": "string", "description": "Prefix used in generated backup archive names" },
+        "images": {
+          "type": "object",
+          "description": "Container images used by the backup CronJob",
+          "properties": {
+            "postgresql": { "type": "string", "description": "PostgreSQL client image used for pg_dump" },
+            "uploader": { "type": "string", "description": "MinIO client image used for S3 upload" }
+          }
+        },
+        "resources": { "type": "object", "description": "Resources applied to the backup dump and upload containers" },
+        "database": {
+          "type": "object",
+          "description": "Database-specific backup settings",
+          "properties": {
+            "pgDumpArgs": { "type": "string", "description": "Extra arguments passed to pg_dump" }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "description": "S3-compatible storage settings for backup uploads",
+          "properties": {
+            "endpoint": { "type": "string", "description": "S3-compatible endpoint URL" },
+            "bucket": { "type": "string", "description": "Target bucket name" },
+            "prefix": { "type": "string", "description": "Optional key prefix inside the bucket" },
+            "createBucketIfNotExists": { "type": "boolean", "description": "Create the bucket automatically when it does not exist yet" },
+            "existingSecret": { "type": "string", "description": "Existing secret containing access-key and secret-key" },
+            "existingSecretAccessKeyKey": { "type": "string", "description": "Secret key name for the access key inside backup.s3.existingSecret" },
+            "existingSecretSecretKeyKey": { "type": "string", "description": "Secret key name for the secret key inside backup.s3.existingSecret" },
+            "accessKey": { "type": "string", "description": "Inline access key used when backup.s3.existingSecret is not set" },
+            "secretKey": { "type": "string", "description": "Inline secret key used when backup.s3.existingSecret is not set" }
+          }
+        }
+      }
+    },
     "service": {
       "type": "object",
       "description": "Docmost service configuration",

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -149,6 +149,53 @@ storage:
     # -- Secret key for the S3 secret key in storage.s3.existingSecret
     existingSecretSecretKeyKey: secret-key
 
+backup:
+  # -- Enable built-in backup CronJob for PostgreSQL (pg_dump to S3)
+  enabled: false
+  # -- Backup schedule in Cron format
+  schedule: "0 3 * * *"
+  # -- Suspend backup execution
+  suspend: false
+  # -- CronJob concurrency policy
+  concurrencyPolicy: Forbid
+  # -- Successful job history retained by the CronJob
+  successfulJobsHistoryLimit: 3
+  # -- Failed job history retained by the CronJob
+  failedJobsHistoryLimit: 3
+  # -- Job backoff limit
+  backoffLimit: 1
+  # -- Prefix used in generated backup archive names
+  archivePrefix: docmost
+  images:
+    # -- PostgreSQL client image used for pg_dump
+    postgresql: postgres:18-alpine
+    # -- MinIO client image used for S3 upload
+    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+  # -- Resources applied to the backup dump and upload containers
+  resources: {}
+  database:
+    # -- Extra arguments passed to pg_dump
+    pgDumpArgs: ""
+  s3:
+    # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com
+    endpoint: ""
+    # -- Target bucket name
+    bucket: ""
+    # -- Optional key prefix inside the bucket
+    prefix: docmost
+    # -- Create the bucket automatically when it does not exist yet
+    createBucketIfNotExists: true
+    # -- Existing secret containing access-key and secret-key
+    existingSecret: ""
+    # -- Secret key name for the access key inside backup.s3.existingSecret
+    existingSecretAccessKeyKey: access-key
+    # -- Secret key name for the secret key inside backup.s3.existingSecret
+    existingSecretSecretKeyKey: secret-key
+    # -- Inline access key used when backup.s3.existingSecret is not set
+    accessKey: ""
+    # -- Inline secret key used when backup.s3.existingSecret is not set
+    secretKey: ""
+
 service:
   # -- Service type for the Docmost HTTP service
   type: ClusterIP

--- a/charts/dolibarr/ci/backup-values.yaml
+++ b/charts/dolibarr/ci/backup-values.yaml
@@ -1,0 +1,17 @@
+mysql:
+  enabled: true
+  auth:
+    database: dolibarr
+    username: dolibarr
+    password: testpassword
+    rootPassword: testrootpassword
+
+backup:
+  enabled: true
+  suspend: true
+  s3:
+    endpoint: http://minio.minio.svc:9000
+    bucket: dolibarr-backups
+    prefix: dolibarr
+    accessKey: minioadmin
+    secretKey: minioadmin

--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -222,3 +222,32 @@ instance-unique-id
 {{- define "dolibarr.customPvcName" -}}
 {{- default (printf "%s-custom" (include "dolibarr.fullname" .)) .Values.persistence.custom.existingClaim -}}
 {{- end -}}
+
+{{/*
+Backup S3 secret name.
+Uses backup.s3.existingSecret when set, otherwise <fullname>-backup.
+*/}}
+{{- define "dolibarr.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "dolibarr.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup enabled validation.
+Returns "true" only when backup is enabled and required S3 fields are set.
+*/}}
+{{- define "dolibarr.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- $hasEndpoint := ne (.Values.backup.s3.endpoint | default "") "" -}}
+  {{- $hasBucket := ne (.Values.backup.s3.bucket | default "") "" -}}
+  {{- $hasCredentials := or (ne (.Values.backup.s3.existingSecret | default "") "") (and (ne (.Values.backup.s3.accessKey | default "") "") (ne (.Values.backup.s3.secretKey | default "") "")) -}}
+  {{- if and $hasEndpoint $hasBucket $hasCredentials -}}
+true
+  {{- else -}}
+    {{- fail "backup.enabled requires backup.s3.endpoint, backup.s3.bucket, and either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dolibarr/templates/backup-configmap.yaml
+++ b/charts/dolibarr/templates/backup-configmap.yaml
@@ -1,0 +1,51 @@
+{{- if eq (include "dolibarr.backupEnabled" .) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "dolibarr.fullname" . }}-backup
+  labels:
+    {{- include "dolibarr.labels" . | nindent 4 }}
+data:
+  mysql-backup.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+    DUMP_FILE="/backup/{{ .Values.backup.archivePrefix }}-${TIMESTAMP}.sql.gz"
+
+    echo "[backup] starting mysqldump of database '${MYSQL_DATABASE}' at ${TIMESTAMP}"
+
+    mysqldump -h "${MYSQL_HOST}" -P "${MYSQL_PORT}" -u "${MYSQL_USER}" \
+      {{ .Values.backup.database.mysqldumpArgs }} \
+      "${MYSQL_DATABASE}" | gzip > "${DUMP_FILE}"
+
+    DUMP_SIZE=$(stat -c%s "${DUMP_FILE}" 2>/dev/null || stat -f%z "${DUMP_FILE}")
+    echo "[backup] dump completed: ${DUMP_FILE} (${DUMP_SIZE} bytes)"
+
+  upload-backup.sh: |
+    #!/bin/bash
+    set -euo pipefail
+
+    DUMP_FILE=$(ls -t /backup/*.sql.gz | head -1)
+    if [ -z "${DUMP_FILE}" ]; then
+      echo "[upload] ERROR: no dump file found in /backup"
+      exit 1
+    fi
+
+    echo "[upload] configuring mc alias 's3'"
+    mc alias set s3 "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+
+    {{- if .Values.backup.s3.createBucketIfNotExists }}
+    if ! mc ls "s3/{{ .Values.backup.s3.bucket }}" >/dev/null 2>&1; then
+      echo "[upload] creating bucket '{{ .Values.backup.s3.bucket }}'"
+      mc mb "s3/{{ .Values.backup.s3.bucket }}"
+    fi
+    {{- end }}
+
+    BASENAME=$(basename "${DUMP_FILE}")
+    DEST="s3/{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}/${BASENAME}"
+
+    echo "[upload] uploading ${DUMP_FILE} -> ${DEST}"
+    mc cp "${DUMP_FILE}" "${DEST}"
+    echo "[upload] upload completed successfully"
+{{- end }}

--- a/charts/dolibarr/templates/backup-cronjob.yaml
+++ b/charts/dolibarr/templates/backup-cronjob.yaml
@@ -1,0 +1,87 @@
+{{- if eq (include "dolibarr.backupEnabled" .) "true" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "dolibarr.fullname" . }}-backup
+  labels:
+    {{- include "dolibarr.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "dolibarr.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          initContainers:
+            - name: mysql-backup
+              image: {{ .Values.backup.images.mysql }}
+              command: ["bash", "/scripts/mysql-backup.sh"]
+              env:
+                - name: MYSQL_HOST
+                  value: {{ include "dolibarr.databaseHost" . | quote }}
+                - name: MYSQL_PORT
+                  value: {{ include "dolibarr.databasePort" . | quote }}
+                - name: MYSQL_DATABASE
+                  value: {{ include "dolibarr.databaseName" . | quote }}
+                - name: MYSQL_USER
+                  value: {{ include "dolibarr.databaseUsername" . | quote }}
+                - name: MYSQL_PWD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "dolibarr.databaseSecretName" . }}
+                      key: {{ include "dolibarr.databaseSecretKey" . }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-data
+                  mountPath: /backup
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader }}
+              command: ["bash", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "dolibarr.backupSecretName" . }}
+                      key: {{ if .Values.backup.s3.existingSecret }}{{ .Values.backup.s3.existingSecretAccessKeyKey }}{{ else }}access-key{{ end }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "dolibarr.backupSecretName" . }}
+                      key: {{ if .Values.backup.s3.existingSecret }}{{ .Values.backup.s3.existingSecretSecretKeyKey }}{{ else }}secret-key{{ end }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-data
+                  mountPath: /backup
+                  readOnly: true
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "dolibarr.fullname" . }}-backup
+                defaultMode: 0755
+            - name: backup-data
+              emptyDir: {}
+{{- end }}

--- a/charts/dolibarr/templates/secret.yaml
+++ b/charts/dolibarr/templates/secret.yaml
@@ -59,3 +59,23 @@ data:
   instance-unique-id: {{ default (randAlphaNum 24) .Values.runtime.instanceUniqueId | b64enc }}
   {{- end }}
 {{- end }}
+---
+{{- if and (eq (include "dolibarr.backupEnabled" .) "true") (not .Values.backup.s3.existingSecret) }}
+{{- $backupSecretName := printf "%s-backup" (include "dolibarr.fullname" .) }}
+{{- $existingBackupSecret := lookup "v1" "Secret" .Release.Namespace $backupSecretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $backupSecretName }}
+  labels:
+    {{- include "dolibarr.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if and $existingBackupSecret $existingBackupSecret.data }}
+  access-key: {{ index $existingBackupSecret.data "access-key" }}
+  secret-key: {{ index $existingBackupSecret.data "secret-key" }}
+  {{- else }}
+  access-key: {{ .Values.backup.s3.accessKey | b64enc }}
+  secret-key: {{ .Values.backup.s3.secretKey | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/dolibarr/tests/backup_secret_test.yaml
+++ b/charts/dolibarr/tests/backup_secret_test.yaml
@@ -1,0 +1,83 @@
+suite: backup secret
+templates:
+  - templates/secret.yaml
+tests:
+  - it: should not render backup secret when backup is disabled
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should render backup secret when backup is enabled with inline credentials
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          existingSecret: ""
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - hasDocuments:
+          count: 4
+      - isKind:
+          of: Secret
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-dolibarr-backup
+        documentIndex: 3
+      - equal:
+          path: data["access-key"]
+          value: bWluaW9hZG1pbg==
+        documentIndex: 3
+      - equal:
+          path: data["secret-key"]
+          value: bWluaW9hZG1pbg==
+        documentIndex: 3
+
+  - it: should not render backup secret when existingSecret is set
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          existingSecret: my-s3-secret
+          existingSecretAccessKeyKey: my-access-key
+          existingSecretSecretKeyKey: my-secret-key
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/charts/dolibarr/tests/backup_test.yaml
+++ b/charts/dolibarr/tests/backup_test.yaml
@@ -1,0 +1,344 @@
+suite: backup cronjob
+templates:
+  - templates/backup-cronjob.yaml
+  - templates/backup-configmap.yaml
+tests:
+  - it: should not render when backup is disabled
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render cronjob when backup is enabled
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        suspend: false
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        backoffLimit: 1
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          existingSecret: ""
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "0 3 * * *"
+      - equal:
+          path: spec.suspend
+          value: false
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.successfulJobsHistoryLimit
+          value: 3
+      - equal:
+          path: spec.failedJobsHistoryLimit
+          value: 3
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 1
+
+  - it: should use mysql subchart database host
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env[0]
+          value:
+            name: MYSQL_HOST
+            value: RELEASE-NAME-mysql
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env[1]
+          value:
+            name: MYSQL_PORT
+            value: "3306"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env[2]
+          value:
+            name: MYSQL_DATABASE
+            value: dolibarr
+
+  - it: should use external database host when configured
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: false
+      database:
+        mode: external
+        external:
+          host: db.example.com
+          port: 3307
+          name: mydb
+          username: myuser
+          password: mypass
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env[0]
+          value:
+            name: MYSQL_HOST
+            value: db.example.com
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env[1]
+          value:
+            name: MYSQL_PORT
+            value: "3307"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env[2]
+          value:
+            name: MYSQL_DATABASE
+            value: mydb
+
+  - it: should use correct images
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].image
+          value: mysql:8.4
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+
+  - it: should use existingSecret for S3 credentials
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          existingSecret: my-s3-secret
+          existingSecretAccessKeyKey: my-access-key
+          existingSecretSecretKeyKey: my-secret-key
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: my-s3-secret
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: my-access-key
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env[2].valueFrom.secretKeyRef.key
+          value: my-secret-key
+
+  - it: should render configmap with backup scripts
+    template: templates/backup-configmap.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - isNotNull:
+          path: data["mysql-backup.sh"]
+      - isNotNull:
+          path: data["upload-backup.sh"]
+
+  - it: should not render configmap when backup is disabled
+    template: templates/backup-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set suspend to true
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        suspend: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources: {}
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: true
+
+  - it: should apply resources when set
+    template: templates/backup-cronjob.yaml
+    set:
+      mysql:
+        enabled: true
+        auth:
+          database: dolibarr
+          username: dolibarr
+          password: secret
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        archivePrefix: dolibarr
+        images:
+          mysql: mysql:8.4
+          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 256Mi
+        database:
+          mysqldumpArgs: "--single-transaction --routines --triggers"
+        s3:
+          endpoint: http://minio:9000
+          bucket: dolibarr-backups
+          prefix: dolibarr
+          createBucketIfNotExists: true
+          accessKey: minioadmin
+          secretKey: minioadmin
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].resources.limits.memory
+          value: 256Mi
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m

--- a/charts/dolibarr/values.schema.json
+++ b/charts/dolibarr/values.schema.json
@@ -554,6 +554,115 @@
       "items": {
         "type": "object"
       }
+    },
+    "backup": {
+      "type": "object",
+      "description": "S3 database backup via mysqldump CronJob",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable scheduled MySQL backups to S3-compatible storage"
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Cron schedule for the backup job"
+        },
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend the CronJob"
+        },
+        "concurrencyPolicy": {
+          "type": "string",
+          "description": "CronJob concurrency policy",
+          "enum": ["Allow", "Forbid", "Replace"]
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "description": "Number of successful jobs to keep"
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "description": "Number of failed jobs to keep"
+        },
+        "backoffLimit": {
+          "type": "integer",
+          "description": "Number of retries before marking job as failed"
+        },
+        "archivePrefix": {
+          "type": "string",
+          "description": "Prefix for the dump filename"
+        },
+        "images": {
+          "type": "object",
+          "description": "Container images used by the backup CronJob",
+          "properties": {
+            "mysql": {
+              "type": "string",
+              "description": "MySQL client image for mysqldump"
+            },
+            "uploader": {
+              "type": "string",
+              "description": "MinIO client image for S3 upload"
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests/limits for backup containers"
+        },
+        "database": {
+          "type": "object",
+          "description": "Database-specific backup settings",
+          "properties": {
+            "mysqldumpArgs": {
+              "type": "string",
+              "description": "Extra arguments passed to mysqldump"
+            }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "description": "S3-compatible storage configuration",
+          "properties": {
+            "endpoint": {
+              "type": "string",
+              "description": "S3 endpoint URL"
+            },
+            "bucket": {
+              "type": "string",
+              "description": "S3 bucket name"
+            },
+            "prefix": {
+              "type": "string",
+              "description": "Object prefix inside the bucket"
+            },
+            "createBucketIfNotExists": {
+              "type": "boolean",
+              "description": "Create the bucket if it does not exist"
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Use an existing secret for S3 credentials"
+            },
+            "existingSecretAccessKeyKey": {
+              "type": "string",
+              "description": "Key in the existing secret for the access key"
+            },
+            "existingSecretSecretKeyKey": {
+              "type": "string",
+              "description": "Key in the existing secret for the secret key"
+            },
+            "accessKey": {
+              "type": "string",
+              "description": "S3 access key (ignored when existingSecret is set)"
+            },
+            "secretKey": {
+              "type": "string",
+              "description": "S3 secret key (ignored when existingSecret is set)"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -151,3 +151,54 @@ podAnnotations: {}
 extraVolumeMounts: []
 extraVolumes: []
 extraManifests: []
+
+# -- S3 database backup via mysqldump CronJob.
+backup:
+  # -- Enable scheduled MySQL backups to S3-compatible storage.
+  enabled: false
+  # -- Cron schedule for the backup job.
+  schedule: "0 3 * * *"
+  # -- Suspend the CronJob (useful for CI or temporary disable).
+  suspend: false
+  # -- CronJob concurrency policy.
+  concurrencyPolicy: Forbid
+  # -- Number of successful jobs to keep.
+  successfulJobsHistoryLimit: 3
+  # -- Number of failed jobs to keep.
+  failedJobsHistoryLimit: 3
+  # -- Number of retries before marking job as failed.
+  backoffLimit: 1
+  # -- Prefix for the dump filename (e.g. dolibarr-20240101T030000Z.sql.gz).
+  archivePrefix: dolibarr
+  # -- Container images used by the backup CronJob.
+  images:
+    # -- MySQL client image for mysqldump.
+    mysql: mysql:8.4
+    # -- MinIO client image for S3 upload.
+    uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+  # -- Resource requests/limits for backup containers.
+  resources: {}
+  # -- Database-specific backup settings.
+  database:
+    # -- Extra arguments passed to mysqldump.
+    mysqldumpArgs: "--single-transaction --routines --triggers"
+  # -- S3-compatible storage configuration.
+  s3:
+    # -- S3 endpoint URL (e.g. https://minio.example.com).
+    endpoint: ""
+    # -- S3 bucket name.
+    bucket: ""
+    # -- Object prefix inside the bucket.
+    prefix: dolibarr
+    # -- Create the bucket if it does not exist.
+    createBucketIfNotExists: true
+    # -- Use an existing secret for S3 credentials.
+    existingSecret: ""
+    # -- Key in the existing secret for the access key.
+    existingSecretAccessKeyKey: access-key
+    # -- Key in the existing secret for the secret key.
+    existingSecretSecretKeyKey: secret-key
+    # -- S3 access key (ignored when existingSecret is set).
+    accessKey: ""
+    # -- S3 secret key (ignored when existingSecret is set).
+    secretKey: ""

--- a/charts/flowise/ci/backup-values.yaml
+++ b/charts/flowise/ci/backup-values.yaml
@@ -1,0 +1,17 @@
+# CI: Backup enabled (PostgreSQL subchart mode)
+postgresql:
+  enabled: true
+  auth:
+    database: flowise
+    username: flowise
+    password: ci-test-password
+    postgresPassword: ci-test-postgres-password
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: flowise-backups
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/charts/flowise/templates/_helpers.tpl
+++ b/charts/flowise/templates/_helpers.tpl
@@ -253,3 +253,30 @@ sleep 3; flowise start
 {{- define "flowise.workerCommand" -}}
 sleep 3; flowise worker
 {{- end -}}
+
+{{- define "flowise.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "flowise.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "flowise.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- $dbMode := include "flowise.databaseMode" . -}}
+  {{- if eq $dbMode "sqlite" -}}
+    {{- fail "backup.enabled requires PostgreSQL — backup is not supported when database mode is sqlite" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.endpoint -}}
+    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}
+    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- end -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/flowise/templates/backup-configmap.yaml
+++ b/charts/flowise/templates/backup-configmap.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "flowise.fullname" . }}-backup-scripts
+  labels:
+    {{- include "flowise.labels" . | nindent 4 }}
+data:
+  postgres-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-postgresql-${timestamp}.sql.gz"
+    mkdir -p /backup/out
+    export PGPASSWORD="${DB_PASSWORD}"
+    pg_dump ${PG_DUMP_EXTRA_ARGS:-} \
+      --host="${DB_HOST}" \
+      --port="${DB_PORT}" \
+      --username="${DB_USERNAME}" \
+      --dbname="${DB_NAME}" | gzip -c > "${archive}"
+    printf "%s" "${archive}" > /backup/out/backup-file
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    archive="$(cat /backup/out/backup-file)"
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+    mc cp "${archive}" "${target}/"
+{{- end }}

--- a/charts/flowise/templates/backup-cronjob.yaml
+++ b/charts/flowise/templates/backup-cronjob.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.backup.enabled }}
+{{- $_ := include "flowise.backupEnabled" . -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "flowise.fullname" . }}-backup
+  labels:
+    {{- include "flowise.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "flowise.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: postgres-backup
+              image: {{ .Values.backup.images.postgresql | quote }}
+              command: ["/bin/sh", "/scripts/postgres-backup.sh"]
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.backup.archivePrefix | quote }}
+                - name: PG_DUMP_EXTRA_ARGS
+                  value: {{ .Values.backup.database.pgDumpArgs | quote }}
+                - name: DB_HOST
+                  value: {{ include "flowise.databaseHost" . | quote }}
+                - name: DB_PORT
+                  value: {{ include "flowise.databasePort" . | quote }}
+                - name: DB_NAME
+                  value: {{ include "flowise.databaseName" . | quote }}
+                - name: DB_USERNAME
+                  value: {{ include "flowise.databaseUsername" . | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "flowise.databaseSecretName" . }}
+                      key: {{ include "flowise.databaseSecretKey" . }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader | quote }}
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "flowise.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "flowise.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "flowise.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+{{- end }}

--- a/charts/flowise/templates/secret.yaml
+++ b/charts/flowise/templates/secret.yaml
@@ -49,4 +49,17 @@ type: Opaque
 data:
   access-key: {{ .Values.storage.s3.accessKeyId | b64enc | quote }}
   secret-key: {{ .Values.storage.s3.secretAccessKey | b64enc | quote }}
+---
+{{- end }}
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "flowise.fullname" . }}-backup
+  labels:
+    {{- include "flowise.labels" . | nindent 4 }}
+type: Opaque
+data:
+  access-key: {{ .Values.backup.s3.accessKey | b64enc | quote }}
+  secret-key: {{ .Values.backup.s3.secretKey | b64enc | quote }}
 {{- end }}

--- a/charts/flowise/tests/backup_secret_test.yaml
+++ b/charts/flowise/tests/backup_secret_test.yaml
@@ -1,0 +1,55 @@
+suite: Backup Secret
+templates:
+  - templates/secret.yaml
+  - templates/_helpers.tpl
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render backup secret by default
+    template: templates/secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render backup secret when backup enabled with inline credentials
+    template: templates/secret.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: Secret
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-flowise-backup
+        documentIndex: 1
+      - exists:
+          path: data["access-key"]
+        documentIndex: 1
+      - exists:
+          path: data["secret-key"]
+        documentIndex: 1
+
+  - it: should not render backup secret when existingSecret is set
+    template: templates/secret.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.existingSecret: my-s3-secret
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/flowise/tests/backup_test.yaml
+++ b/charts/flowise/tests/backup_test.yaml
@@ -1,0 +1,185 @@
+suite: Backup
+templates:
+  - templates/backup-cronjob.yaml
+  - templates/backup-configmap.yaml
+  - templates/_helpers.tpl
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render CronJob by default
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render ConfigMap by default
+    template: templates/backup-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render CronJob when backup enabled with postgresql subchart
+    template: templates/backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "0 3 * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
+          value: postgres-backup
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].image
+          value: "postgres:18-alpine"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].name
+          value: upload
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+
+  - it: should render CronJob when backup enabled with external postgres
+    template: templates/backup-cronjob.yaml
+    set:
+      database.external.host: pg.example.com
+      database.external.name: flowise
+      database.external.username: flowise
+      database.external.password: secret
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - isKind:
+          of: CronJob
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: pg.example.com
+
+  - it: should use correct database secret for postgresql subchart
+    template: templates/backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].env
+          content:
+            name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-postgresql-auth
+                key: user-password
+
+  - it: should use backup secret for S3 credentials
+    template: templates/backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-flowise-backup
+                key: access-key
+
+  - it: should use existing secret for S3 credentials
+    template: templates/backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.existingSecret: my-s3-secret
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-s3-secret
+                key: access-key
+
+  - it: should render backup scripts configmap
+    template: templates/backup-configmap.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["postgres-backup.sh"]
+      - exists:
+          path: data["upload-backup.sh"]
+
+  - it: should set custom schedule
+    template: templates/backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: flowise
+      postgresql.auth.username: flowise
+      backup.enabled: true
+      backup.schedule: "0 6 * * 0"
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 6 * * 0"
+
+  - it: should fail when backup enabled with sqlite mode
+    template: templates/backup-cronjob.yaml
+    set:
+      database.mode: sqlite
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.amazonaws.com
+      backup.s3.bucket: test-bucket
+      backup.s3.accessKey: AKIA123
+      backup.s3.secretKey: secret123
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.enabled requires PostgreSQL — backup is not supported when database mode is sqlite"

--- a/charts/flowise/values.schema.json
+++ b/charts/flowise/values.schema.json
@@ -82,6 +82,79 @@
     "affinity": { "type": "object", "description": "Affinity rules for pod scheduling" },
     "extraVolumeMounts": { "type": "array", "description": "Additional volume mounts for the main Flowise container", "items": { "type": "object" } },
     "extraVolumes": { "type": "array", "description": "Additional volumes for the Flowise pods", "items": { "type": "object" } },
-    "extraManifests": { "type": "array", "description": "Extra Kubernetes manifests to deploy alongside the chart", "items": { "type": "object" } }
+    "extraManifests": { "type": "array", "description": "Extra Kubernetes manifests to deploy alongside the chart", "items": { "type": "object" } },
+    "backup": {
+      "type": "object",
+      "description": "Scheduled PostgreSQL backup to S3-compatible storage",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable scheduled PostgreSQL backups to S3-compatible storage"
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Cron schedule for backups (default: daily at 03:00 UTC)"
+        },
+        "suspend": {
+          "type": "boolean",
+          "description": "Suspend the CronJob without deleting it"
+        },
+        "concurrencyPolicy": {
+          "type": "string",
+          "description": "Concurrency policy: Forbid, Replace, Allow",
+          "enum": ["Forbid", "Replace", "Allow"]
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "description": "Number of successful job records to keep"
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "description": "Number of failed job records to keep"
+        },
+        "backoffLimit": {
+          "type": "integer",
+          "description": "Maximum retries per backup job"
+        },
+        "archivePrefix": {
+          "type": "string",
+          "description": "Prefix for backup archive filenames"
+        },
+        "images": {
+          "type": "object",
+          "description": "Container images used by backup jobs",
+          "properties": {
+            "postgresql": { "type": "string", "description": "Image used for PostgreSQL backup (must have pg_dump)" },
+            "uploader": { "type": "string", "description": "Image used for S3 upload (MinIO client)" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources for backup containers"
+        },
+        "database": {
+          "type": "object",
+          "description": "Override pg_dump arguments for backup",
+          "properties": {
+            "pgDumpArgs": { "type": "string", "description": "Extra arguments passed to pg_dump" }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "description": "S3-compatible storage configuration",
+          "properties": {
+            "endpoint": { "type": "string", "description": "S3-compatible endpoint URL" },
+            "bucket": { "type": "string", "description": "Target bucket name" },
+            "prefix": { "type": "string", "description": "Key prefix within the bucket" },
+            "createBucketIfNotExists": { "type": "boolean", "description": "Auto-create the bucket if it does not exist" },
+            "existingSecret": { "type": "string", "description": "Use an existing secret for S3 credentials" },
+            "existingSecretAccessKeyKey": { "type": "string", "description": "Key in the existing secret for the access key" },
+            "existingSecretSecretKeyKey": { "type": "string", "description": "Key in the existing secret for the secret key" },
+            "accessKey": { "type": "string", "description": "Inline S3 access key (ignored when existingSecret is set)" },
+            "secretKey": { "type": "string", "description": "Inline S3 secret key (ignored when existingSecret is set)" }
+          }
+        }
+      }
+    }
   }
 }

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -325,3 +325,73 @@ extraVolumes: []
 
 # -- Extra Kubernetes manifests to deploy alongside the chart
 extraManifests: []
+
+# =============================================================================
+# Backup Configuration (PostgreSQL only)
+# =============================================================================
+
+backup:
+  # -- Enable scheduled PostgreSQL backups to S3-compatible storage
+  enabled: false
+
+  # -- Cron schedule for backups (default: daily at 03:00 UTC)
+  schedule: "0 3 * * *"
+
+  # -- Suspend the CronJob without deleting it
+  suspend: false
+
+  # -- Concurrency policy: Forbid, Replace, Allow
+  concurrencyPolicy: Forbid
+
+  # -- Number of successful job records to keep
+  successfulJobsHistoryLimit: 3
+
+  # -- Number of failed job records to keep
+  failedJobsHistoryLimit: 3
+
+  # -- Maximum retries per backup job
+  backoffLimit: 1
+
+  # -- Prefix for backup archive filenames
+  archivePrefix: flowise
+
+  images:
+    # -- Image used for PostgreSQL backup (must have pg_dump)
+    postgresql: postgres:18-alpine
+    # -- Image used for S3 upload (MinIO client)
+    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+
+  # -- Resources for backup containers
+  resources: {}
+
+  database:
+    # -- Extra arguments passed to pg_dump
+    pgDumpArgs: ""
+
+  s3:
+    # -- S3-compatible endpoint URL
+    endpoint: ""
+
+    # -- Target bucket name
+    bucket: ""
+
+    # -- Key prefix within the bucket
+    prefix: flowise
+
+    # -- Auto-create the bucket if it does not exist
+    createBucketIfNotExists: true
+
+    # -- Use an existing secret for S3 credentials
+    existingSecret: ""
+
+    # -- Key in the existing secret for the access key
+    existingSecretAccessKeyKey: access-key
+
+    # -- Key in the existing secret for the secret key
+    existingSecretSecretKeyKey: secret-key
+
+    # -- Inline S3 access key (ignored when existingSecret is set)
+    accessKey: ""
+
+    # -- Inline S3 secret key (ignored when existingSecret is set)
+    secretKey: ""


### PR DESCRIPTION
## Summary
- Add configurable S3 backup CronJob support to 4 stable charts with critical database data
- **appwrite**: MariaDB backup via `mysqldump`
- **docmost**: PostgreSQL backup via `pg_dump`
- **dolibarr**: MySQL backup via `mysqldump`
- **flowise**: PostgreSQL backup via `pg_dump`
- Each chart includes backup-configmap, backup-cronjob, CI scenario, and unit tests
- Follows the same backup pattern established in PR #10 for alpha charts

## Test plan
- [x] `helm unittest` passes for all 4 charts
- [x] `helm lint --strict` passes for all 4 charts
- [x] All CI scenario templates render successfully
- [ ] k3d validation with MinIO endpoint