### PR TITLE
feat(open-webui): add open webui helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 | [superset](charts/superset/) | stable | Apache Superset — data exploration and visualization with Celery workers, PostgreSQL, and Redis |
 | [ckan](charts/ckan/) | stable | CKAN — open data portal with DataPusher, Solr, PostgreSQL, and Redis |
 | [druid](charts/druid/) | stable | Apache Druid — distributed analytics database with coordinator, broker, historical, and router |
+| [open-webui](charts/open-webui/) | alpha | Open WebUI — self-hosted AI chat platform with Ollama/OpenAI, RAG, PostgreSQL, Redis, and S3 backup |
 
 ### Maturity levels
 

--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.3
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.5.4
+digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
+generated: "2026-04-02T18:57:43.0566722-03:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,0 +1,45 @@
+apiVersion: v2
+name: open-webui
+description: Open WebUI — self-hosted AI chat platform with Ollama and OpenAI support, RAG, multi-model conversations, and extensible plugin system
+type: application
+version: 1.0.0
+appVersion: "0.8.12"
+kubeVersion: ">=1.26.0-0"
+home: https://helmforge.dev/docs/charts/open-webui
+icon: https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png
+keywords:
+  - open-webui
+  - ai
+  - llm
+  - chat
+  - ollama
+  - openai
+  - rag
+  - postgresql
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/open-webui/open-webui
+  - https://docs.openwebui.com/
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/category: ai-machine-learning
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/open-webui
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/open-webui
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: cosign
+  artifacthub.io/prerelease: "true"
+dependencies:
+  - name: postgresql
+    version: 1.8.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 1.5.4
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: redis.enabled

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,0 +1,158 @@
+# Open WebUI Helm Chart
+
+Self-hosted AI chat platform with Ollama and OpenAI support, RAG pipelines, multi-model conversations, and an extensible plugin system. This chart deploys Open WebUI on Kubernetes with optional PostgreSQL and Redis subcharts.
+
+## Features
+
+- Single-container deployment with health probes
+- SQLite (default) or PostgreSQL for production persistence
+- Optional Redis for multi-instance WebSocket coordination
+- Ollama backend integration
+- OpenAI-compatible API support (any provider)
+- Configurable ingress with TLS
+- S3-compatible backup CronJob for PostgreSQL data
+- Auto-generated session secret key
+- Telemetry disabled by default
+
+## Quick Start
+
+```bash
+helm install open-webui oci://ghcr.io/helmforgedev/helm/open-webui
+```
+
+With Ollama backend:
+
+```bash
+helm install open-webui oci://ghcr.io/helmforgedev/helm/open-webui \
+  --set openWebui.ollamaBaseUrl=http://ollama.default.svc:11434
+```
+
+With PostgreSQL (production):
+
+```bash
+helm install open-webui oci://ghcr.io/helmforgedev/helm/open-webui \
+  --set postgresql.enabled=true
+```
+
+With ingress:
+
+```bash
+helm install open-webui oci://ghcr.io/helmforgedev/helm/open-webui \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=chat.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+## Database Modes
+
+Open WebUI supports three database modes controlled by `database.mode`:
+
+| Mode | Description |
+|------|-------------|
+| `auto` (default) | Uses PostgreSQL subchart if `postgresql.enabled=true`, otherwise SQLite |
+| `sqlite` | Always uses embedded SQLite (single instance only) |
+| `external` | Uses `database.url` or `database.existingSecret` for an external PostgreSQL |
+
+### External PostgreSQL
+
+```yaml
+postgresql:
+  enabled: false
+database:
+  mode: external
+  url: "postgresql://user:password@host:5432/openwebui"
+```
+
+Or with an existing secret:
+
+```yaml
+postgresql:
+  enabled: false
+database:
+  mode: external
+  existingSecret: my-db-secret
+  existingSecretKey: database-url
+```
+
+## Redis for Multi-Instance
+
+When running multiple replicas, Redis coordinates WebSocket sessions:
+
+```yaml
+redis:
+  enabled: true
+```
+
+Or with an external Redis:
+
+```yaml
+redisConfig:
+  mode: external
+  url: "redis://:password@redis.example.com:6379/0"
+```
+
+## OpenAI-Compatible Providers
+
+Connect to any OpenAI-compatible API (OpenAI, Azure, Anthropic proxy, LiteLLM):
+
+```yaml
+openWebui:
+  openaiBaseUrl: https://api.openai.com/v1
+  openaiApiKey: sk-...
+```
+
+Or with an existing secret:
+
+```yaml
+openWebui:
+  openaiBaseUrl: https://api.openai.com/v1
+  openaiExistingSecret: my-openai-secret
+  openaiExistingSecretKey: openai-api-key
+```
+
+## S3 Backup
+
+When using PostgreSQL, enable scheduled backups to S3-compatible storage:
+
+```yaml
+postgresql:
+  enabled: true
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: http://minio.minio.svc:9000
+    bucket: open-webui-backups
+    accessKey: minioadmin
+    secretKey: minioadmin
+```
+
+## Default Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `ghcr.io/open-webui/open-webui` | Container image |
+| `image.tag` | `""` (uses appVersion) | Image tag |
+| `openWebui.port` | `8080` | Application port |
+| `openWebui.ollamaBaseUrl` | `""` | Ollama backend URL |
+| `openWebui.doNotTrack` | `true` | Disable telemetry |
+| `database.mode` | `auto` | Database mode: auto, sqlite, external |
+| `persistence.enabled` | `true` | Enable PVC for /app/backend/data |
+| `persistence.size` | `10Gi` | PVC size |
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.ingressClassName` | `traefik` | Ingress class (also supports `nginx`) |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart |
+| `redis.enabled` | `false` | Deploy Redis subchart |
+| `backup.enabled` | `false` | Enable S3 backup CronJob |
+
+See [`values.yaml`](values.yaml) for the full configuration reference.
+
+<!-- @AI-METADATA
+type: chart-readme
+path: charts/open-webui/README.md
+date: 2026-04-02
+relations:
+  - charts/open-webui/values.yaml
+  - charts/open-webui/Chart.yaml
+-->

--- a/charts/open-webui/ci/backup-values.yaml
+++ b/charts/open-webui/ci/backup-values.yaml
@@ -1,0 +1,20 @@
+# CI scenario: PostgreSQL with S3 backup
+postgresql:
+  enabled: true
+  auth:
+    password: "ci-test-password"
+  primary:
+    persistence:
+      size: 1Gi
+
+backup:
+  enabled: true
+  suspend: true
+  schedule: "0 3 * * *"
+  archivePrefix: open-webui
+  s3:
+    endpoint: http://minio.minio.svc:9000
+    bucket: open-webui-backups
+    prefix: daily
+    accessKey: minioadmin
+    secretKey: minioadmin

--- a/charts/open-webui/ci/default.yaml
+++ b/charts/open-webui/ci/default.yaml
@@ -1,0 +1,1 @@
+# Default CI scenario: standalone SQLite mode

--- a/charts/open-webui/ci/ingress-values.yaml
+++ b/charts/open-webui/ci/ingress-values.yaml
@@ -1,0 +1,13 @@
+# CI scenario: with ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: chat.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - chat.example.com
+      secretName: open-webui-tls

--- a/charts/open-webui/ci/postgresql-values.yaml
+++ b/charts/open-webui/ci/postgresql-values.yaml
@@ -1,0 +1,8 @@
+# CI scenario: PostgreSQL subchart mode
+postgresql:
+  enabled: true
+  auth:
+    password: "ci-test-password"
+  primary:
+    persistence:
+      size: 1Gi

--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -1,0 +1,222 @@
+{{- define "open-webui.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "open-webui.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "open-webui.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "open-webui.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "open-webui.labels" -}}
+helm.sh/chart: {{ include "open-webui.chart" . }}
+{{ include "open-webui.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "open-webui.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "open-webui.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "open-webui.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "open-webui.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "open-webui.image" -}}
+{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* Data PVC claim name */}}
+{{- define "open-webui.dataClaimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "open-webui.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* ===== Secret helpers ===== */}}
+
+{{/* Application secret name */}}
+{{- define "open-webui.secretName" -}}
+{{- if .Values.openWebui.existingSecret -}}
+{{- .Values.openWebui.existingSecret -}}
+{{- else -}}
+{{- printf "%s-app" (include "open-webui.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* OpenAI secret name */}}
+{{- define "open-webui.openaiSecretName" -}}
+{{- if .Values.openWebui.openaiExistingSecret -}}
+{{- .Values.openWebui.openaiExistingSecret -}}
+{{- else -}}
+{{- include "open-webui.secretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/* ===== Database helpers ===== */}}
+
+{{/* Database mode detection */}}
+{{- define "open-webui.databaseMode" -}}
+{{- if eq .Values.database.mode "sqlite" -}}
+sqlite
+{{- else if eq .Values.database.mode "external" -}}
+external
+{{- else -}}
+{{- /* auto: use subchart if enabled, otherwise sqlite */}}
+{{- if .Values.postgresql.enabled -}}
+auto
+{{- else -}}
+sqlite
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database type (sqlite or postgres) */}}
+{{- define "open-webui.databaseType" -}}
+{{- $mode := include "open-webui.databaseMode" . -}}
+{{- if eq $mode "sqlite" -}}
+sqlite
+{{- else -}}
+postgres
+{{- end -}}
+{{- end -}}
+
+{{/* Database URL for PostgreSQL */}}
+{{- define "open-webui.databaseUrl" -}}
+{{- $mode := include "open-webui.databaseMode" . -}}
+{{- if eq $mode "external" -}}
+{{- .Values.database.url -}}
+{{- else if eq $mode "auto" -}}
+{{- printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%s/%s" .Values.postgresql.auth.username (include "open-webui.databaseHost" .) "5432" .Values.postgresql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database host */}}
+{{- define "open-webui.databaseHost" -}}
+{{- $mode := include "open-webui.databaseMode" . -}}
+{{- if eq $mode "auto" -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Database secret name (subchart password) */}}
+{{- define "open-webui.databaseSecretName" -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+
+{{/* Database secret key */}}
+{{- define "open-webui.databaseSecretKey" -}}
+user-password
+{{- end -}}
+
+{{/* ===== Redis helpers ===== */}}
+
+{{/* Redis mode detection */}}
+{{- define "open-webui.redisMode" -}}
+{{- if eq .Values.redisConfig.mode "disabled" -}}
+disabled
+{{- else if eq .Values.redisConfig.mode "external" -}}
+external
+{{- else -}}
+{{- if .Values.redis.enabled -}}
+auto
+{{- else -}}
+disabled
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Redis URL */}}
+{{- define "open-webui.redisUrl" -}}
+{{- $mode := include "open-webui.redisMode" . -}}
+{{- if eq $mode "external" -}}
+{{- .Values.redisConfig.url -}}
+{{- else if eq $mode "auto" -}}
+{{- printf "redis://:%s@%s-redis:6379/0" "$(REDIS_PASSWORD)" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Redis secret name */}}
+{{- define "open-webui.redisSecretName" -}}
+{{- printf "%s-redis" .Release.Name -}}
+{{- end -}}
+
+{{/* ===== Backup helpers ===== */}}
+
+{{/* Backup S3 secret name */}}
+{{- define "open-webui.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "open-webui.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate backup configuration */}}
+{{- define "open-webui.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- $dbType := include "open-webui.databaseType" . -}}
+  {{- if eq $dbType "sqlite" -}}
+    {{- fail "backup requires PostgreSQL — set postgresql.enabled=true or database.mode=external" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.endpoint -}}
+    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}
+    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) -}}
+    {{- fail "backup.s3.accessKey or backup.s3.existingSecret is required when backup.enabled is true" -}}
+  {{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Backup database host */}}
+{{- define "open-webui.backupDbHost" -}}
+{{- include "open-webui.databaseHost" . -}}
+{{- end -}}
+
+{{/* Backup database port */}}
+{{- define "open-webui.backupDbPort" -}}
+5432
+{{- end -}}
+
+{{/* Backup database name */}}
+{{- define "open-webui.backupDbName" -}}
+{{- .Values.postgresql.auth.database -}}
+{{- end -}}
+
+{{/* Backup database username */}}
+{{- define "open-webui.backupDbUsername" -}}
+{{- .Values.postgresql.auth.username -}}
+{{- end -}}
+
+{{/* Backup database password secret name */}}
+{{- define "open-webui.backupDbPasswordSecretName" -}}
+{{- include "open-webui.databaseSecretName" . -}}
+{{- end -}}
+
+{{/* Backup database password secret key */}}
+{{- define "open-webui.backupDbPasswordSecretKey" -}}
+{{- include "open-webui.databaseSecretKey" . -}}
+{{- end -}}

--- a/charts/open-webui/templates/backup-configmap.yaml
+++ b/charts/open-webui/templates/backup-configmap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "open-webui.fullname" . }}-backup-scripts
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+data:
+  postgres-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-postgresql-${timestamp}.sql.gz"
+    mkdir -p /backup/out
+    export PGPASSWORD="${DB_PASSWORD}"
+    pg_dump ${PG_DUMP_EXTRA_ARGS:-} \
+      --host="${DB_HOST}" --port="${DB_PORT}" \
+      --username="${DB_USERNAME}" --dbname="${DB_NAME}" | gzip -c > "${archive}"
+    printf "%s" "${archive}" > /backup/out/backup-file
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    archive="$(cat /backup/out/backup-file)"
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+    mc cp "${archive}" "${target}/"
+{{- end }}

--- a/charts/open-webui/templates/backup-cronjob.yaml
+++ b/charts/open-webui/templates/backup-cronjob.yaml
@@ -1,0 +1,105 @@
+{{- if include "open-webui.backupEnabled" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "open-webui.fullname" . }}-backup
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "open-webui.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: postgres-backup
+              image: {{ .Values.backup.images.postgresql | quote }}
+              command: ["/bin/sh", "/scripts/postgres-backup.sh"]
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.backup.archivePrefix | quote }}
+                - name: PG_DUMP_EXTRA_ARGS
+                  value: {{ .Values.backup.database.pgDumpArgs | quote }}
+                - name: DB_HOST
+                  value: {{ include "open-webui.backupDbHost" . | quote }}
+                - name: DB_PORT
+                  value: {{ include "open-webui.backupDbPort" . | quote }}
+                - name: DB_NAME
+                  value: {{ include "open-webui.backupDbName" . | quote }}
+                - name: DB_USERNAME
+                  value: {{ include "open-webui.backupDbUsername" . | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "open-webui.backupDbPasswordSecretName" . }}
+                      key: {{ include "open-webui.backupDbPasswordSecretKey" . }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader | quote }}
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "open-webui.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "open-webui.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "open-webui.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+{{- end }}

--- a/charts/open-webui/templates/deployment.yaml
+++ b/charts/open-webui/templates/deployment.yaml
@@ -1,0 +1,216 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "open-webui.fullname" . }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "open-webui.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "open-webui.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "open-webui.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: open-webui
+          image: {{ include "open-webui.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- $dbMode := include "open-webui.databaseMode" . }}
+          {{- if eq $dbMode "auto" }}
+          command: ["bash", "-c"]
+          args:
+            - |
+              export DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+              exec bash start.sh
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.openWebui.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.openWebui.port | quote }}
+            - name: SCARF_NO_ANALYTICS
+              value: "true"
+            - name: DO_NOT_TRACK
+              value: {{ ternary "true" "false" .Values.openWebui.doNotTrack | quote }}
+            - name: ANONYMIZED_TELEMETRY
+              value: "false"
+            {{- /* Database configuration */}}
+            {{- $dbType := include "open-webui.databaseType" . }}
+            {{- $dbMode := include "open-webui.databaseMode" . }}
+            {{- if eq $dbType "postgres" }}
+            {{- if eq $dbMode "auto" }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "open-webui.databaseSecretName" . }}
+                  key: {{ include "open-webui.databaseSecretKey" . }}
+            - name: DB_HOST
+              value: {{ include "open-webui.databaseHost" . | quote }}
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: DB_NAME
+              value: {{ .Values.postgresql.auth.database | quote }}
+            {{- else if eq $dbMode "external" }}
+            - name: DATABASE_URL
+              {{- if .Values.database.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+              {{- else }}
+              value: {{ .Values.database.url | quote }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- /* Redis configuration */}}
+            {{- $redisMode := include "open-webui.redisMode" . }}
+            {{- if ne $redisMode "disabled" }}
+            {{- if eq $redisMode "auto" }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "open-webui.redisSecretName" . }}
+                  key: password
+            {{- end }}
+            - name: REDIS_URL
+              {{- if eq $redisMode "external" }}
+              {{- if .Values.redisConfig.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redisConfig.existingSecret }}
+                  key: {{ .Values.redisConfig.existingSecretKey }}
+              {{- else }}
+              value: {{ .Values.redisConfig.url | quote }}
+              {{- end }}
+              {{- else }}
+              value: {{ include "open-webui.redisUrl" . | quote }}
+              {{- end }}
+            - name: WEBSOCKET_MANAGER
+              value: redis
+            - name: ENABLE_WEBSOCKET_SUPPORT
+              value: "true"
+            {{- end }}
+            {{- /* Secret key */}}
+            - name: WEBUI_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "open-webui.secretName" . }}
+                  key: {{ .Values.openWebui.existingSecretKey | default "secret-key" }}
+            {{- /* Ollama */}}
+            {{- if .Values.openWebui.ollamaBaseUrl }}
+            - name: OLLAMA_BASE_URL
+              value: {{ .Values.openWebui.ollamaBaseUrl | quote }}
+            {{- end }}
+            {{- /* OpenAI */}}
+            {{- if or .Values.openWebui.openaiBaseUrl .Values.openWebui.openaiApiKey .Values.openWebui.openaiExistingSecret }}
+            {{- if .Values.openWebui.openaiBaseUrl }}
+            - name: OPENAI_API_BASE_URL
+              value: {{ .Values.openWebui.openaiBaseUrl | quote }}
+            {{- end }}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "open-webui.openaiSecretName" . }}
+                  key: {{ .Values.openWebui.openaiExistingSecretKey | default "openai-api-key" }}
+            {{- end }}
+            {{- with .Values.openWebui.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /app/backend/data
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "open-webui.dataClaimName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/open-webui/templates/extra-manifests.yaml
+++ b/charts/open-webui/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/open-webui/templates/ingress.yaml
+++ b/charts/open-webui/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "open-webui.fullname" . }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "open-webui.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/open-webui/templates/pvc.yaml
+++ b/charts/open-webui/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "open-webui.dataClaimName" . }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/open-webui/templates/secret.yaml
+++ b/charts/open-webui/templates/secret.yaml
@@ -1,0 +1,29 @@
+{{- if not .Values.openWebui.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-app" (include "open-webui.fullname" .) }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+stringData:
+  secret-key: {{ .Values.openWebui.secretKey | default (randAlphaNum 64) | quote }}
+  {{- if .Values.openWebui.openaiApiKey }}
+  openai-api-key: {{ .Values.openWebui.openaiApiKey | quote }}
+  {{- end }}
+{{- end }}
+---
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-backup" (include "open-webui.fullname" .) }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  access-key: {{ .Values.backup.s3.accessKey | quote }}
+  secret-key: {{ .Values.backup.s3.secretKey | quote }}
+{{- end }}

--- a/charts/open-webui/templates/service.yaml
+++ b/charts/open-webui/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "open-webui.fullname" . }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "open-webui.selectorLabels" . | nindent 4 }}

--- a/charts/open-webui/templates/serviceaccount.yaml
+++ b/charts/open-webui/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "open-webui.serviceAccountName" . }}
+  labels:
+    {{- include "open-webui.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/open-webui/tests/backup_test.yaml
+++ b/charts/open-webui/tests/backup_test.yaml
@@ -1,0 +1,90 @@
+suite: Backup
+templates:
+  - backup-cronjob.yaml
+  - backup-configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create backup configmap when disabled
+    template: backup-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create backup cronjob when disabled
+    template: backup-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create backup CronJob when enabled with postgresql
+    set:
+      postgresql.enabled: true
+      backup.enabled: true
+      backup.s3.endpoint: http://minio:9000
+      backup.s3.bucket: backups
+      backup.s3.accessKey: admin
+      backup.s3.secretKey: admin123
+    template: backup-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "0 3 * * *"
+
+  - it: should create backup ConfigMap with postgres-backup script
+    set:
+      postgresql.enabled: true
+      backup.enabled: true
+      backup.s3.endpoint: http://minio:9000
+      backup.s3.bucket: backups
+      backup.s3.accessKey: admin
+      backup.s3.secretKey: admin123
+    template: backup-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - isNotEmpty:
+          path: data["postgres-backup.sh"]
+
+  - it: should fail when backup enabled with sqlite
+    template: backup-cronjob.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: http://minio:9000
+      backup.s3.bucket: backups
+      backup.s3.accessKey: admin
+      backup.s3.secretKey: admin123
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup requires PostgreSQL — set postgresql.enabled=true or database.mode=external"
+
+  - it: should fail without s3 endpoint
+    template: backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.accessKey: admin
+      backup.s3.secretKey: admin123
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail without s3 bucket
+    template: backup-cronjob.yaml
+    set:
+      postgresql.enabled: true
+      backup.enabled: true
+      backup.s3.endpoint: http://minio:9000
+      backup.s3.accessKey: admin
+      backup.s3.secretKey: admin123
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.bucket is required when backup.enabled is true"

--- a/charts/open-webui/tests/deployment_test.yaml
+++ b/charts/open-webui/tests/deployment_test.yaml
@@ -1,0 +1,93 @@
+suite: Deployment
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should create a deployment with defaults
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-open-webui
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: should set health probe paths
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+
+  - it: should mount data volume when persistence enabled
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /app/backend/data
+
+  - it: should set WEBUI_SECRET_KEY from secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEBUI_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-open-webui-app
+                key: secret-key
+
+  - it: should disable telemetry by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DO_NOT_TRACK
+            value: "true"
+
+  - it: should set DB_HOST when postgresql enabled
+    set:
+      postgresql.enabled: true
+      postgresql.auth.username: openwebui
+      postgresql.auth.database: openwebui
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: test-postgresql
+
+  - it: should set REDIS_URL when redis enabled
+    set:
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEBSOCKET_MANAGER
+            value: redis
+
+  - it: should set OLLAMA_BASE_URL when configured
+    set:
+      openWebui.ollamaBaseUrl: http://ollama:11434
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OLLAMA_BASE_URL
+            value: http://ollama:11434
+
+  - it: should use custom image tag
+    set:
+      image.tag: v0.7.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/open-webui/open-webui:v0.7.0"

--- a/charts/open-webui/tests/ingress_test.yaml
+++ b/charts/open-webui/tests/ingress_test.yaml
@@ -1,0 +1,26 @@
+suite: Ingress
+templates:
+  - ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create ingress when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create ingress when enabled
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: chat.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: chat.example.com

--- a/charts/open-webui/tests/pvc_test.yaml
+++ b/charts/open-webui/tests/pvc_test.yaml
@@ -1,0 +1,28 @@
+suite: PVC
+templates:
+  - pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should create PVC when persistence enabled
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should not create PVC when using existing claim
+    set:
+      persistence.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create PVC when persistence disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/open-webui/tests/secret_test.yaml
+++ b/charts/open-webui/tests/secret_test.yaml
@@ -1,0 +1,27 @@
+suite: Secret
+templates:
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should create app secret with auto-generated key
+    documentSelector:
+      path: metadata.name
+      value: test-open-webui-app
+    asserts:
+      - isKind:
+          of: Secret
+      - isNotEmpty:
+          path: stringData.secret-key
+
+  - it: should include openai key when provided
+    set:
+      openWebui.openaiApiKey: sk-test123
+    documentSelector:
+      path: metadata.name
+      value: test-open-webui-app
+    asserts:
+      - equal:
+          path: stringData.openai-api-key
+          value: sk-test123

--- a/charts/open-webui/tests/service_test.yaml
+++ b/charts/open-webui/tests/service_test.yaml
@@ -1,0 +1,17 @@
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should create a ClusterIP service by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 80

--- a/charts/open-webui/values.schema.json
+++ b/charts/open-webui/values.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Open WebUI Helm Chart Values",
+  "description": "Values for the Open WebUI Helm chart — self-hosted AI chat platform with Ollama and OpenAI support",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "ghcr.io/open-webui/open-webui" },
+        "tag": { "type": "string", "default": "" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "openWebui": {
+      "type": "object",
+      "description": "Open WebUI application configuration",
+      "properties": {
+        "port": { "type": "integer", "description": "Application port", "default": 8080 },
+        "secretKey": { "type": "string", "description": "Secret key for signing sessions", "default": "" },
+        "existingSecret": { "type": "string", "description": "Existing secret containing the secret key", "default": "" },
+        "ollamaBaseUrl": { "type": "string", "description": "Ollama backend URL", "default": "" },
+        "openaiBaseUrl": { "type": "string", "description": "OpenAI-compatible API base URL", "default": "" },
+        "openaiApiKey": { "type": "string", "description": "OpenAI API key", "default": "" },
+        "doNotTrack": { "type": "boolean", "description": "Disable telemetry", "default": true },
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "Database configuration",
+      "properties": {
+        "mode": { "type": "string", "enum": ["auto", "sqlite", "external"], "default": "auto" },
+        "url": { "type": "string", "description": "External PostgreSQL connection URL", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretKey": { "type": "string", "default": "database-url" }
+      }
+    },
+    "redisConfig": {
+      "type": "object",
+      "description": "Redis configuration for multi-instance WebSocket coordination",
+      "properties": {
+        "mode": { "type": "string", "enum": ["auto", "external", "disabled"], "default": "auto" },
+        "url": { "type": "string", "default": "" },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretKey": { "type": "string", "default": "redis-url" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Persistence for /app/backend/data",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "10Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string", "default": "" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "default": 80 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "backup": {
+      "type": "object",
+      "description": "Scheduled PostgreSQL backups to S3-compatible storage",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable scheduled backups", "default": false },
+        "schedule": { "type": "string", "description": "Cron schedule for backups", "default": "0 3 * * *" },
+        "suspend": { "type": "boolean", "description": "Suspend the CronJob", "default": false },
+        "archivePrefix": { "type": "string", "description": "Prefix for backup archive filenames", "default": "open-webui" },
+        "images": { "type": "object", "description": "Container images used for backup jobs" },
+        "resources": { "type": "object", "description": "CPU and memory for backup containers" },
+        "s3": { "type": "object", "description": "S3-compatible storage configuration" }
+      }
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "postgresql": { "type": "object", "description": "PostgreSQL subchart configuration" },
+    "redis": { "type": "object", "description": "Redis subchart configuration" }
+  }
+}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -1,0 +1,300 @@
+# =============================================================================
+# Open WebUI Helm Chart — Default Values
+# =============================================================================
+# Focus: self-hosted AI chat platform with Ollama/OpenAI, RAG, and multi-model
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Open WebUI container image
+  repository: ghcr.io/open-webui/open-webui
+  # -- Image tag (defaults to appVersion with v prefix)
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Open WebUI Configuration
+# =============================================================================
+
+openWebui:
+  # -- Application port
+  port: 8080
+  # -- Secret key for signing sessions (auto-generated if empty)
+  secretKey: ""
+  # -- Existing secret containing the secret key
+  existingSecret: ""
+  # -- Key in existing secret for the secret key
+  existingSecretKey: secret-key
+  # -- Ollama backend URL
+  ollamaBaseUrl: ""
+  # -- OpenAI-compatible API base URL
+  openaiBaseUrl: ""
+  # -- OpenAI API key
+  openaiApiKey: ""
+  # -- Existing secret for OpenAI API key
+  openaiExistingSecret: ""
+  # -- Key in existing secret for OpenAI API key
+  openaiExistingSecretKey: openai-api-key
+  # -- Disable telemetry
+  doNotTrack: true
+  # -- Extra environment variables for the container
+  # -- @default -- `[]`
+  extraEnv: []
+
+# =============================================================================
+# Database
+# =============================================================================
+# Open WebUI uses SQLite by default. For multi-instance or production setups,
+# use PostgreSQL by enabling the subchart or providing an external database URL.
+
+database:
+  # -- Database mode: auto, sqlite, external
+  # -- auto: uses PostgreSQL subchart if enabled, otherwise SQLite
+  # -- sqlite: always uses embedded SQLite (single instance only)
+  # -- external: uses database.url for an external PostgreSQL
+  mode: auto
+  # -- External PostgreSQL connection URL
+  # -- Example: postgresql://user:password@host:5432/openwebui
+  url: ""
+  # -- Existing secret containing the database URL
+  existingSecret: ""
+  # -- Key in existing secret for the database URL
+  existingSecretKey: database-url
+
+# =============================================================================
+# Redis (for multi-instance WebSocket coordination)
+# =============================================================================
+# Redis is required for multi-instance deployments to coordinate WebSocket
+# sessions and real-time features.
+
+redisConfig:
+  # -- Redis mode: auto, external, disabled
+  # -- auto: uses Redis subchart if enabled
+  # -- external: uses redisConfig.url
+  # -- disabled: no Redis (single instance only)
+  mode: auto
+  # -- External Redis URL
+  url: ""
+  # -- Existing secret containing the Redis URL
+  existingSecret: ""
+  # -- Key in existing secret for the Redis URL
+  existingSecretKey: redis-url
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Enable persistence for /app/backend/data
+  enabled: true
+  # -- Storage size
+  size: 10Gi
+  # -- Storage class
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing PVC
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- HTTP service port
+  port: 80
+  # -- Annotations for the Service
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for Open WebUI
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: chat.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - chat.example.com
+    #   secretName: open-webui-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    path: /health
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    path: /health
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /health
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# S3 Backup
+# =============================================================================
+
+backup:
+  # -- Enable scheduled data backups to S3-compatible storage
+  enabled: false
+  # -- Cron schedule for backups (default: daily at 03:00 UTC)
+  schedule: "0 3 * * *"
+  # -- Suspend the CronJob without deleting it
+  suspend: false
+  # -- Concurrency policy: Forbid, Replace, Allow
+  concurrencyPolicy: Forbid
+  # -- Number of successful job records to keep
+  successfulJobsHistoryLimit: 3
+  # -- Number of failed job records to keep
+  failedJobsHistoryLimit: 3
+  # -- Maximum retries per backup job
+  backoffLimit: 1
+  # -- Prefix for backup archive filenames
+  archivePrefix: open-webui
+  images:
+    # -- Image used for PostgreSQL dump
+    postgresql: postgres:18-alpine
+    # -- Image used for S3 upload (MinIO client)
+    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+  # -- Resources for backup containers
+  resources: {}
+  database:
+    # -- Extra pg_dump arguments
+    pgDumpArgs: ""
+  s3:
+    # -- S3-compatible endpoint URL
+    endpoint: ""
+    # -- Target bucket name
+    bucket: ""
+    # -- Key prefix within the bucket
+    prefix: open-webui
+    # -- Auto-create the bucket if it does not exist
+    createBucketIfNotExists: true
+    # -- Use an existing secret for S3 credentials
+    existingSecret: ""
+    # -- Key in the existing secret for the access key
+    existingSecretAccessKeyKey: access-key
+    # -- Key in the existing secret for the secret key
+    existingSecretSecretKeyKey: secret-key
+    # -- Inline S3 access key (ignored when existingSecret is set)
+    accessKey: ""
+    # -- Inline S3 secret key (ignored when existingSecret is set)
+    secretKey: ""
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []
+
+# =============================================================================
+# PostgreSQL Subchart
+# =============================================================================
+
+postgresql:
+  # -- Enable PostgreSQL subchart (recommended for production)
+  enabled: false
+  architecture: standalone
+  auth:
+    # -- Database name
+    database: openwebui
+    # -- Database username
+    username: openwebui
+    # -- Database password (auto-generated if empty)
+    password: ""
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+# =============================================================================
+# Redis Subchart
+# =============================================================================
+
+redis:
+  # -- Enable Redis subchart (required for multi-instance)
+  enabled: false
+  architecture: standalone
+  auth:
+    enabled: true
+    password: ""
+  master:
+    persistence:
+      enabled: false


### PR DESCRIPTION
## Summary
- New chart: **Open WebUI** — self-hosted AI chat platform with Ollama/OpenAI support, RAG, and multi-model conversations
- SQLite default mode, PostgreSQL subchart for production, Redis for multi-instance WebSocket coordination
- S3-compatible backup CronJob for PostgreSQL data
- 24 unit tests across 6 test suites, 4 CI scenarios
- k3d validated: default (SQLite) and PostgreSQL modes both functional

## Features
- Ollama and OpenAI-compatible API backend integration
- Database modes: auto/sqlite/external with PostgreSQL subchart dependency
- Redis for WebSocket session coordination in multi-instance setups
- Ingress with TLS, health probes, persistence (10Gi default)
- Auto-generated session secret key, telemetry disabled by default
- S3 backup with pg_dump for PostgreSQL deployments

## Test plan
- [x] `helm unittest charts/open-webui` — 24 tests passing
- [x] `helm lint charts/open-webui --strict` — clean
- [x] All 4 CI scenario templates render successfully
- [x] k3d validation: default install (SQLite mode) — pods Running
- [x] k3d validation: PostgreSQL mode — pods Running, DB connected