### PR TITLE
fix(repo): use fully qualified image names across all charts

### DIFF
--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
       {{- if (include "adguard-home.hasConfig" .) }}
       initContainers:
         - name: copy-config
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "adguard/adguardhome:v0.107.73"
+          value: "docker.io/adguard/adguardhome:v0.107.73"
 
   - it: should expose setup wizard port 3000 by default (no config)
     template: templates/deployment.yaml

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- AdGuard Home container image
-  repository: adguard/adguardhome
+  repository: docker.io/adguard/adguardhome
   # -- Image tag (defaults to "v" + appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -294,11 +294,11 @@ backup:
   resources: {}
   images:
     archiver:
-      repository: busybox
+      repository: docker.io/library/busybox
       tag: "1.37"
       pullPolicy: IfNotPresent
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/answer/templates/deployment.yaml
+++ b/charts/answer/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if ne (include "answer.databaseMode" .) "sqlite" }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/answer/tests/backup_test.yaml
+++ b/charts/answer/tests/backup_test.yaml
@@ -50,7 +50,7 @@ tests:
           value: sqlite-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: "alpine:3.22"
+          value: "docker.io/library/alpine:3.22"
 
   - it: should use postgres init container for postgresql
     template: templates/backup-cronjob.yaml
@@ -68,7 +68,7 @@ tests:
           value: postgres-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: "postgres:18.3-alpine"
+          value: "docker.io/library/postgres:18.3-alpine"
 
   - it: should use mysql init container for mysql
     template: templates/backup-cronjob.yaml
@@ -86,7 +86,7 @@ tests:
           value: mysql-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: "mysql:8.4"
+          value: "docker.io/library/mysql:8.4"
 
   - it: should use minio mc for upload container
     template: templates/backup-cronjob.yaml
@@ -102,7 +102,7 @@ tests:
           value: upload
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "minio/mc:RELEASE.2025-04-08T15-18-23Z"
+          value: "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z"
 
   - it: should render backup scripts configmap
     template: templates/backup-configmap.yaml

--- a/charts/answer/tests/deployment_test.yaml
+++ b/charts/answer/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "apache/answer:2.0.0"
+          value: "docker.io/apache/answer:2.0.0"
 
   - it: should allow custom image tag
     template: templates/deployment.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "apache/answer:1.7.1"
+          value: "docker.io/apache/answer:1.7.1"
 
   - it: should set container port to 80
     template: templates/deployment.yaml
@@ -109,7 +109,7 @@ tests:
           value: wait-for-db
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "busybox:1.37"
+          value: "docker.io/library/busybox:1.37"
 
   - it: should set postgres env vars for postgresql subchart
     template: templates/deployment.yaml

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: apache/answer
+  repository: docker.io/apache/answer
   # -- Container image tag (defaults to appVersion)
   tag: ""
   # -- Image pull policy
@@ -352,13 +352,13 @@ backup:
 
   images:
     # -- Image used for SQLite backup (must have tar)
-    sqlite: alpine:3.22
+    sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.3-alpine
     # -- Image used for MySQL backup (must have mysqldump)
-    mysql: mysql:8.4
+    mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/appwrite/tests/deployment_api_test.yaml
+++ b/charts/appwrite/tests/deployment_api_test.yaml
@@ -17,7 +17,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "appwrite/appwrite:1.8.1"
+          value: "docker.io/appwrite/appwrite:1.8.1"
 
   - it: should run http.php entrypoint
     template: templates/deployment-api.yaml

--- a/charts/appwrite/tests/deployment_console_test.yaml
+++ b/charts/appwrite/tests/deployment_console_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "appwrite/console:7.5.7"
+          value: "docker.io/appwrite/console:7.5.7"
 
   - it: should have component label
     asserts:

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -24,7 +24,7 @@ commonLabels: {}
 
 image:
   # -- Appwrite server image repository
-  repository: appwrite/appwrite
+  repository: docker.io/appwrite/appwrite
   # -- Appwrite image tag. Defaults to appVersion.
   tag: ""
   # -- Image pull policy
@@ -33,7 +33,7 @@ image:
 console:
   image:
     # -- Appwrite console image repository
-    repository: appwrite/console
+    repository: docker.io/appwrite/console
     # -- Console image tag
     tag: "7.5.7"
     # -- Console image pull policy
@@ -424,9 +424,9 @@ backup:
   archivePrefix: appwrite
   images:
     # -- MariaDB client image for mysqldump
-    mariadb: mariadb:11.7-noble
+    mariadb: docker.io/library/mariadb:11.7-noble
     # -- MinIO client image for S3 upload
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   database:

--- a/charts/archivebox/tests/deployment_test.yaml
+++ b/charts/archivebox/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "archivebox/archivebox:0.7.3"
+          value: "docker.io/archivebox/archivebox:0.7.3"
 
   - it: should set server command
     asserts:

--- a/charts/archivebox/values.schema.json
+++ b/charts/archivebox/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "archivebox/archivebox" },
+        "repository": { "type": "string", "default": "docker.io/archivebox/archivebox" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/archivebox/values.yaml
+++ b/charts/archivebox/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- ArchiveBox container image
-  repository: archivebox/archivebox
+  repository: docker.io/archivebox/archivebox
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -192,9 +192,9 @@ backup:
   archivePrefix: archivebox
   images:
     # -- Image used for data volume backup (must have tar)
-    tar: alpine:3.22
+    tar: docker.io/library/alpine:3.22
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- $dbPort := include "authelia.dbPort" . }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -62,7 +62,7 @@ spec:
       {{- $redisHost := include "authelia.redisHost" . }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -85,7 +85,7 @@ spec:
       {{- $redisHost := include "authelia.redisHost" . }}
       initContainers:
         - name: wait-for-redis
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/authelia/tests/deployment_test.yaml
+++ b/charts/authelia/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "authelia/authelia:4.39.16"
+          value: "docker.io/authelia/authelia:4.39.16"
 
   - it: should use custom image tag
     template: templates/deployment.yaml
@@ -36,7 +36,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "authelia/authelia:4.40.0"
+          value: "docker.io/authelia/authelia:4.40.0"
 
   - it: should expose port 9091
     template: templates/deployment.yaml

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Authelia container image
-  repository: authelia/authelia
+  repository: docker.io/authelia/authelia
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -411,19 +411,19 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     sqlite:
-      repository: busybox
+      repository: docker.io/library/busybox
       tag: "1.37"
       pullPolicy: IfNotPresent
     postgresql:
-      repository: postgres
+      repository: docker.io/library/postgres
       tag: "18.3-trixie"
       pullPolicy: IfNotPresent
     mysql:
-      repository: mysql
+      repository: docker.io/library/mysql
       tag: "8.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/ckan/templates/_helpers.tpl
+++ b/charts/ckan/templates/_helpers.tpl
@@ -238,7 +238,7 @@ exec /srv/app/start_ckan.sh
 
 {{- define "ckan.initContainers" -}}
 - name: wait-for-postgresql
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c
@@ -250,7 +250,7 @@ exec /srv/app/start_ckan.sh
       echo "PostgreSQL is reachable."
 {{- if .Values.solr.enabled }}
 - name: wait-for-solr
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c
@@ -263,7 +263,7 @@ exec /srv/app/start_ckan.sh
 {{- end }}
 {{- if and (ne .Values.redisConfig.mode "external") .Values.redis.enabled }}
 - name: wait-for-redis
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c

--- a/charts/ckan/tests/datapusher_test.yaml
+++ b/charts/ckan/tests/datapusher_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ckan/ckan-base-datapusher:0.0.21"
+          value: "docker.io/ckan/ckan-base-datapusher:0.0.21"
 
   - it: should not render when disabled
     set:

--- a/charts/ckan/tests/solr_test.yaml
+++ b/charts/ckan/tests/solr_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ckan/ckan-solr:2.11-solr9"
+          value: "docker.io/ckan/ckan-solr:2.11-solr9"
 
   - it: should not render when disabled
     set:

--- a/charts/ckan/values.schema.json
+++ b/charts/ckan/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "ckan/ckan-base" },
+        "repository": { "type": "string", "default": "docker.io/ckan/ckan-base" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- CKAN container image repository
-  repository: ckan/ckan-base
+  repository: docker.io/ckan/ckan-base
   # -- CKAN image tag. Defaults to appVersion.
   tag: ""
   # -- Image pull policy
@@ -65,7 +65,7 @@ datapusher:
   enabled: true
   # -- DataPusher image repository
   image:
-    repository: ckan/ckan-base-datapusher
+    repository: docker.io/ckan/ckan-base-datapusher
     tag: "0.0.21"
     pullPolicy: IfNotPresent
   # -- Number of DataPusher replicas
@@ -88,7 +88,7 @@ solr:
   enabled: true
   # -- Solr image repository
   image:
-    repository: ckan/ckan-solr
+    repository: docker.io/ckan/ckan-solr
     tag: "2.11-solr9"
     pullPolicy: IfNotPresent
   # -- Solr port
@@ -269,9 +269,9 @@ backup:
   archivePrefix: ckan
   images:
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/cloudflared/tests/deployment_test.yaml
+++ b/charts/cloudflared/tests/deployment_test.yaml
@@ -43,7 +43,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "cloudflare/cloudflared:.*"
+          pattern: "docker.io/cloudflare/cloudflared:.*"
 
   - it: should use custom image tag
     template: templates/deployment.yaml
@@ -53,7 +53,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "cloudflare/cloudflared:2025.1.0"
+          value: "docker.io/cloudflare/cloudflared:2025.1.0"
 
   - it: should set the cloudflared command with default args
     template: templates/deployment.yaml

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- cloudflared container image
-  repository: cloudflare/cloudflared
+  repository: docker.io/cloudflare/cloudflared
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent

--- a/charts/countly/templates/deployment.yaml
+++ b/charts/countly/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- if and .Values.mongodb.enabled (not .Values.externalMongodb.enabled) }}
       initContainers:
         - name: wait-for-mongodb
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command: ["sh", "-c", "until nc -z {{ include "countly.mongodbHost" . }} 27017; do echo waiting for mongodb; sleep 2; done"]
       {{- end }}
       containers:

--- a/charts/countly/tests/deployment_test.yaml
+++ b/charts/countly/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "countly/countly-server:25.03.41"
+          value: "docker.io/countly/countly-server:25.03.41"
 
   - it: should expose both API and dashboard ports
     asserts:

--- a/charts/countly/values.schema.json
+++ b/charts/countly/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "countly/countly-server" },
+        "repository": { "type": "string", "default": "docker.io/countly/countly-server" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/countly/values.yaml
+++ b/charts/countly/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Countly container image
-  repository: countly/countly-server
+  repository: docker.io/countly/countly-server
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -159,9 +159,9 @@ backup:
   archivePrefix: countly
   images:
     # -- Image used for MongoDB backup (must have mongodump)
-    mongodb: mongo:8.0
+    mongodb: docker.io/library/mongo:8.0
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/ddns-updater/tests/deployment_test.yaml
+++ b/charts/ddns-updater/tests/deployment_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "qmcgaw/ddns-updater:v2.9.0"
+          value: "docker.io/qmcgaw/ddns-updater:v2.9.0"
 
   - it: should set custom image tag
     template: templates/deployment.yaml
@@ -43,7 +43,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "qmcgaw/ddns-updater:v2.8.0"
+          value: "docker.io/qmcgaw/ddns-updater:v2.8.0"
 
   - it: should set default env vars
     template: templates/deployment.yaml

--- a/charts/ddns-updater/values.yaml
+++ b/charts/ddns-updater/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- ddns-updater container image
-  repository: qmcgaw/ddns-updater
+  repository: docker.io/qmcgaw/ddns-updater
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent

--- a/charts/docmost/ci/backup-values.yaml
+++ b/charts/docmost/ci/backup-values.yaml
@@ -3,8 +3,8 @@ backup:
   schedule: "0 3 * * *"
   archivePrefix: docmost
   images:
-    postgresql: postgres:18-alpine
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    postgresql: docker.io/library/postgres:18-alpine
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   database:
     pgDumpArgs: "--no-owner"
   s3:

--- a/charts/docmost/templates/deployment.yaml
+++ b/charts/docmost/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-postgresql
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -48,7 +48,7 @@ spec:
               done
               echo "PostgreSQL is reachable."
         - name: wait-for-redis
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -20,7 +20,7 @@ replicaCount: 1
 
 image:
   # -- Docmost container image repository
-  repository: docmost/docmost
+  repository: docker.io/docmost/docmost
   # -- Docmost image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
   tag: ""
   # -- Image pull policy
@@ -168,9 +168,9 @@ backup:
   archivePrefix: docmost
   images:
     # -- PostgreSQL client image used for pg_dump
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- MinIO client image used for S3 upload
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources applied to the backup dump and upload containers
   resources: {}
   database:

--- a/charts/dolibarr/templates/deployment.yaml
+++ b/charts/dolibarr/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/dolibarr/tests/backup_secret_test.yaml
+++ b/charts/dolibarr/tests/backup_secret_test.yaml
@@ -20,8 +20,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -65,8 +65,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"

--- a/charts/dolibarr/tests/backup_test.yaml
+++ b/charts/dolibarr/tests/backup_test.yaml
@@ -28,8 +28,8 @@ tests:
         backoffLimit: 1
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -79,8 +79,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -126,8 +126,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -169,8 +169,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -184,10 +184,10 @@ tests:
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: mysql:8.4
+          value: docker.io/library/mysql:8.4
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          value: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
 
   - it: should use existingSecret for S3 credentials
     template: templates/backup-cronjob.yaml
@@ -203,8 +203,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -241,8 +241,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -284,8 +284,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources: {}
         database:
           mysqldumpArgs: "--single-transaction --routines --triggers"
@@ -315,8 +315,8 @@ tests:
         schedule: "0 3 * * *"
         archivePrefix: dolibarr
         images:
-          mysql: mysql:8.4
-          uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          mysql: docker.io/library/mysql:8.4
+          uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
         resources:
           requests:
             cpu: 100m

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -106,7 +106,7 @@ tests:
           value: wait-for-db
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: busybox:1.37
+          value: docker.io/library/busybox:1.37
 
   - it: should mount both Dolibarr PVCs
     asserts:

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: dolibarr/dolibarr:23.0.0
+          value: docker.io/dolibarr/dolibarr:23.0.0
 
   - it: should set database env vars for the MySQL subchart
     asserts:

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -11,7 +11,7 @@ fullnameOverride: ""
 commonLabels: {}
 
 image:
-  repository: dolibarr/dolibarr
+  repository: docker.io/dolibarr/dolibarr
   tag: ""
   pullPolicy: IfNotPresent
   # Keep tag empty to default to Chart.appVersion.
@@ -173,9 +173,9 @@ backup:
   # -- Container images used by the backup CronJob.
   images:
     # -- MySQL client image for mysqldump.
-    mysql: mysql:8.4
+    mysql: docker.io/library/mysql:8.4
     # -- MinIO client image for S3 upload.
-    uploader: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+    uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
   # -- Resource requests/limits for backup containers.
   resources: {}
   # -- Database-specific backup settings.

--- a/charts/druid/templates/_helpers.tpl
+++ b/charts/druid/templates/_helpers.tpl
@@ -172,7 +172,7 @@ jdbc:postgresql://{{ include "druid.metadataHost" . }}:{{ include "druid.metadat
 
 {{- define "druid.initContainers" -}}
 - name: prepare-dirs
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   securityContext:
     runAsUser: 0
   command:
@@ -185,7 +185,7 @@ jdbc:postgresql://{{ include "druid.metadataHost" . }}:{{ include "druid.metadat
     - name: druid-var
       mountPath: /opt/druid/var
 - name: wait-for-postgresql
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c
@@ -197,7 +197,7 @@ jdbc:postgresql://{{ include "druid.metadataHost" . }}:{{ include "druid.metadat
       echo "PostgreSQL is reachable."
 {{- if eq .Values.zookeeperConfig.mode "subchart" }}
 - name: wait-for-zookeeper
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Druid container image repository
-  repository: apache/druid
+  repository: docker.io/apache/druid
   # -- Druid image tag. Defaults to appVersion.
   tag: ""
   # -- Image pull policy

--- a/charts/flowise/templates/deployment.yaml
+++ b/charts/flowise/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       initContainers:
         {{- if ne (include "flowise.databaseMode" .) "sqlite" }}
         - name: wait-for-database
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -54,7 +54,7 @@ spec:
         {{- end }}
         {{- if eq (include "flowise.architectureMode" .) "queue" }}
         - name: wait-for-redis
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/flowise/templates/worker-deployment.yaml
+++ b/charts/flowise/templates/worker-deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-database
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -48,7 +48,7 @@ spec:
               done
               echo "Database is reachable."
         - name: wait-for-redis
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/flowise/tests/backup_test.yaml
+++ b/charts/flowise/tests/backup_test.yaml
@@ -44,13 +44,13 @@ tests:
           value: postgres-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: "postgres:18-alpine"
+          value: "docker.io/library/postgres:18-alpine"
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].name
           value: upload
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          value: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
 
   - it: should render CronJob when backup enabled with external postgres
     template: templates/backup-cronjob.yaml

--- a/charts/flowise/tests/deployment_test.yaml
+++ b/charts/flowise/tests/deployment_test.yaml
@@ -12,7 +12,7 @@ tests:
           value: 1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: flowiseai/flowise:3.1.1
+          value: docker.io/flowiseai/flowise:3.1.1
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Flowise container image repository
-  repository: flowiseai/flowise
+  repository: docker.io/flowiseai/flowise
   # -- Flowise image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
   tag: ""
   # -- Image pull policy
@@ -357,9 +357,9 @@ backup:
 
   images:
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/generic/ci/daemonset-values.yaml
+++ b/charts/generic/ci/daemonset-values.yaml
@@ -7,7 +7,7 @@ workload:
       maxUnavailable: 1
 
 image:
-  repository: fluent/fluentd
+  repository: docker.io/fluent/fluentd
   tag: "v1.17"
 
 containers:

--- a/charts/generic/ci/deployment-values.yaml
+++ b/charts/generic/ci/deployment-values.yaml
@@ -3,7 +3,7 @@ workload:
   type: Deployment
 
 image:
-  repository: nginx
+  repository: docker.io/library/nginx
   tag: "1.27"
   pullPolicy: IfNotPresent
 

--- a/charts/generic/ci/multi-container-values.yaml
+++ b/charts/generic/ci/multi-container-values.yaml
@@ -15,7 +15,7 @@ containers:
         value: "3000"
   - name: sidecar
     image:
-      repository: envoyproxy/envoy
+      repository: docker.io/envoyproxy/envoy
       tag: "v1.31"
     ports:
       - containerPort: 9901

--- a/charts/generic/ci/statefulset-values.yaml
+++ b/charts/generic/ci/statefulset-values.yaml
@@ -12,7 +12,7 @@ workload:
             storage: 10Gi
 
 image:
-  repository: redis
+  repository: docker.io/library/redis
   tag: "7.4"
 
 containers:

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -78,7 +78,7 @@ containers:
 initContainers: []
   # - name: init-db
   #   image:
-  #     repository: busybox
+  #     repository: docker.io/library/busybox
   #     tag: "1.36"
   #   command: ["sh", "-c", "echo init"]
 

--- a/charts/gitea/templates/admin-job.yaml
+++ b/charts/gitea/templates/admin-job.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-gitea
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/gitea/templates/deployment.yaml
+++ b/charts/gitea/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- if ne (include "gitea.databaseMode" .) "sqlite" }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -4,7 +4,7 @@
 
 # -- Gitea image
 image:
-  repository: gitea/gitea
+  repository: docker.io/gitea/gitea
   tag: ""  # defaults to appVersion + "-rootless"
   pullPolicy: IfNotPresent
 
@@ -329,13 +329,13 @@ backup:
 
   images:
     # -- Image used for SQLite backup (must have tar)
-    sqlite: alpine:3.22
+    sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.3-alpine
     # -- Image used for MySQL backup (must have mysqldump)
-    mysql: mysql:8.4
+    mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/guacamole/templates/deployment.yaml
+++ b/charts/guacamole/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/guacamole/templates/initdb-job.yaml
+++ b/charts/guacamole/templates/initdb-job.yaml
@@ -21,7 +21,7 @@ spec:
       restartPolicy: OnFailure
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/guacamole/tests/deployment_test.yaml
+++ b/charts/guacamole/tests/deployment_test.yaml
@@ -24,10 +24,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "guacamole/guacamole:1.6.0"
+          value: "docker.io/guacamole/guacamole:1.6.0"
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "guacamole/guacd:1.6.0"
+          value: "docker.io/guacamole/guacd:1.6.0"
 
   - it: should have guacamole and guacd containers
     template: templates/deployment.yaml

--- a/charts/guacamole/values.yaml
+++ b/charts/guacamole/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Guacamole web application image
-  repository: guacamole/guacamole
+  repository: docker.io/guacamole/guacamole
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -21,7 +21,7 @@ image:
 guacd:
   image:
     # -- guacd daemon image
-    repository: guacamole/guacd
+    repository: docker.io/guacamole/guacd
     # -- guacd image tag (defaults to appVersion)
     tag: ""
     pullPolicy: IfNotPresent
@@ -275,15 +275,15 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     postgresql:
-      repository: postgres
+      repository: docker.io/library/postgres
       tag: "17.5-bookworm"
       pullPolicy: IfNotPresent
     mysql:
-      repository: mysql
+      repository: docker.io/library/mysql
       tag: "8.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/heimdall/tests/deployment_test.yaml
+++ b/charts/heimdall/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "linuxserver/heimdall:2.7.6"
+          value: "docker.io/linuxserver/heimdall:2.7.6"
 
   - it: should set PUID, PGID, and TZ env vars
     asserts:

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -15,7 +15,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: linuxserver/heimdall
+  repository: docker.io/linuxserver/heimdall
   # -- Image tag (defaults to Chart.appVersion)
   tag: ""
   # -- Image pull policy
@@ -82,9 +82,9 @@ backup:
 
   images:
     # -- Image for creating tar archives
-    archiver: alpine:3.22
+    archiver: docker.io/library/alpine:3.22
     # -- Image for uploading to S3
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resource requests and limits for backup jobs
   resources: {}

--- a/charts/homarr/templates/deployment.yaml
+++ b/charts/homarr/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- if ne (include "homarr.databaseMode" .) "sqlite" }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -325,13 +325,13 @@ backup:
 
   images:
     # -- Image used for SQLite backup (must have tar)
-    sqlite: alpine:3.22
+    sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.3-alpine
     # -- Image used for MySQL backup (must have mysqldump)
-    mysql: mysql:8.4
+    mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/kafka/tests/single_broker_test.yaml
+++ b/charts/kafka/tests/single_broker_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: 1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: apache/kafka:4.2.0
+          value: docker.io/apache/kafka:4.2.0
       - contains:
           path: spec.template.spec.containers[0].ports
           content:

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -23,7 +23,7 @@ clusterDomain: cluster.local
 
 image:
   # -- Kafka image repository
-  repository: apache/kafka
+  repository: docker.io/apache/kafka
   # -- Kafka image tag
   tag: "4.2.0"
   # -- Kafka image pull policy
@@ -176,7 +176,7 @@ metrics:
   enabled: false
   image:
     # -- JMX exporter image used only to copy the javaagent jar
-    repository: bitnami/jmx-exporter
+    repository: docker.io/bitnami/jmx-exporter
     # -- JMX exporter image tag
     tag: "1.5.0"
     # -- JMX exporter image pull policy

--- a/charts/keycloak/ci/extensions.yaml
+++ b/charts/keycloak/ci/extensions.yaml
@@ -25,7 +25,7 @@ extraEnvFrom:
 
 initContainers:
   - name: prepare-themes
-    image: busybox:1.36
+    image: docker.io/library/busybox:1.36
     command:
       - sh
       - -c
@@ -33,7 +33,7 @@ initContainers:
 
 extraContainers:
   - name: support-sidecar
-    image: busybox:1.36
+    image: docker.io/library/busybox:1.36
     command:
       - sh
       - -c

--- a/charts/keycloak/examples/extensions-and-themes.yaml
+++ b/charts/keycloak/examples/extensions-and-themes.yaml
@@ -26,7 +26,7 @@ extraEnvFrom:
 
 initContainers:
   - name: prepare-mounted-content
-    image: busybox:1.36
+    image: docker.io/library/busybox:1.36
     command:
       - sh
       - -c
@@ -34,7 +34,7 @@ initContainers:
 
 extraContainers:
   - name: support-sidecar
-    image: busybox:1.36
+    image: docker.io/library/busybox:1.36
     command:
       - sh
       - -c

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         {{- if include "keycloak.hasDatabase" . }}
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -151,15 +151,15 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     postgresql:
-      repository: postgres
+      repository: docker.io/library/postgres
       tag: "18.3-trixie"
       pullPolicy: IfNotPresent
     mysql:
-      repository: mysql
+      repository: docker.io/library/mysql
       tag: "8.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/komga/tests/deployment_test.yaml
+++ b/charts/komga/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "gotson/komga:1.24.1"
+          value: "docker.io/gotson/komga:1.24.1"
 
   - it: should set container port to 25600
     asserts:
@@ -191,4 +191,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "gotson/komga:1.20.0"
+          value: "docker.io/gotson/komga:1.20.0"

--- a/charts/komga/values.schema.json
+++ b/charts/komga/values.schema.json
@@ -27,7 +27,7 @@
         "repository": {
           "type": "string",
           "description": "Komga image repository",
-          "default": "gotson/komga"
+          "default": "docker.io/gotson/komga"
         },
         "tag": {
           "type": "string",
@@ -496,7 +496,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "minio/mc"
+                  "default": "docker.io/minio/mc"
                 },
                 "tag": {
                   "type": "string"
@@ -512,7 +512,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "alpine"
+                  "default": "docker.io/library/alpine"
                 },
                 "tag": {
                   "type": "string"

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Komga image repository
-  repository: gotson/komga
+  repository: docker.io/gotson/komga
   # -- Komga image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -201,11 +201,11 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     sqlite:
-      repository: alpine
+      repository: docker.io/library/alpine
       tag: "3.22"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "mariadb:11.4"
+          value: "docker.io/library/mariadb:11.4"
 
   - it: should always have 1 replica
     template: templates/statefulset-source.yaml

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -25,7 +25,7 @@ clusterDomain: cluster.local
 
 image:
   # -- MariaDB image repository
-  repository: mariadb
+  repository: docker.io/library/mariadb
   # -- MariaDB image tag
   tag: "11.4"
   pullPolicy: IfNotPresent
@@ -203,7 +203,7 @@ metrics:
     annotations: {}
   image:
     # -- mysqld-exporter image repository
-    repository: prom/mysqld-exporter
+    repository: docker.io/prom/mysqld-exporter
     # -- mysqld-exporter image tag
     tag: "v0.17.2"
     pullPolicy: IfNotPresent
@@ -263,11 +263,11 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     mariadb:
-      repository: mariadb
+      repository: docker.io/library/mariadb
       tag: "11.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "metabase/metabase:v0.54.5"
+          value: "docker.io/metabase/metabase:v0.54.5"
 
   - it: should set custom image tag
     set:
@@ -31,7 +31,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "metabase/metabase:v0.53.0"
+          value: "docker.io/metabase/metabase:v0.53.0"
 
   - it: should set PostgreSQL env vars with subchart
     asserts:

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "description": "Container image configuration",
       "properties": {
-        "repository": { "type": "string", "default": "metabase/metabase" },
+        "repository": { "type": "string", "default": "docker.io/metabase/metabase" },
         "tag": { "type": "string", "description": "Image tag (defaults to v{appVersion})", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Metabase container image
-  repository: metabase/metabase
+  repository: docker.io/metabase/metabase
   # -- Image tag (defaults to v{appVersion})
   tag: ""
   pullPolicy: IfNotPresent
@@ -169,9 +169,9 @@ backup:
   archivePrefix: metabase
   images:
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/middleware/templates/deployment.yaml
+++ b/charts/middleware/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- if and .Values.postgresql.enabled (not .Values.externalDatabase.enabled) }}
       initContainers:
         - name: wait-for-postgresql
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command: ["sh", "-c", "until nc -z {{ include "middleware.dbHost" . }} 5432; do echo waiting for postgresql; sleep 2; done"]
       {{- end }}
       containers:

--- a/charts/middleware/tests/deployment_test.yaml
+++ b/charts/middleware/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "middlewareeng/middleware:0.3.1"
+          value: "docker.io/middlewareeng/middleware:0.3.1"
 
   - it: should expose three ports
     asserts:

--- a/charts/middleware/values.schema.json
+++ b/charts/middleware/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "middlewareeng/middleware" },
+        "repository": { "type": "string", "default": "docker.io/middlewareeng/middleware" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/middleware/values.yaml
+++ b/charts/middleware/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Middleware container image
-  repository: middlewareeng/middleware
+  repository: docker.io/middlewareeng/middleware
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -27,7 +27,7 @@
         "repository": {
           "type": "string",
           "description": "Container image repository",
-          "default": "itzg/minecraft-server"
+          "default": "docker.io/itzg/minecraft-server"
         },
         "tag": {
           "type": "string",
@@ -523,7 +523,7 @@
             "repository": {
               "type": "string",
               "description": "mc-monitor image repository",
-              "default": "itzg/mc-monitor"
+              "default": "docker.io/itzg/mc-monitor"
             },
             "tag": {
               "type": "string",
@@ -623,12 +623,12 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "itzg/minecraft-server:java21"
+              "default": "docker.io/itzg/minecraft-server:java21"
             },
             "uploader": {
               "type": "string",
               "description": "Image used for S3 upload (MinIO client)",
-              "default": "minio/mc:RELEASE.2025-04-08T15-18-23Z"
+              "default": "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z"
             }
           }
         },

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: itzg/minecraft-server
+  repository: docker.io/itzg/minecraft-server
   # -- Container image tag (defaults to appVersion; use java21 for LTS)
   tag: ""
   # -- Image pull policy
@@ -318,7 +318,7 @@ metrics:
 
   image:
     # -- mc-monitor image repository
-    repository: itzg/mc-monitor
+    repository: docker.io/itzg/mc-monitor
     # -- mc-monitor image tag
     tag: 0.16.1
     # -- mc-monitor pull policy
@@ -376,9 +376,9 @@ backup:
   images:
     # -- Image used for RCON commands and tar archiving
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: itzg/minecraft-server:java21
+    worker: docker.io/itzg/minecraft-server:java21
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "mongo:8.2.6"
+          value: "docker.io/library/mongo:8.2.6"
 
   - it: should have 1 replica in standalone mode
     template: statefulset.yaml

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -34,7 +34,7 @@
         "repository": {
           "type": "string",
           "description": "MongoDB image repository",
-          "default": "mongo"
+          "default": "docker.io/library/mongo"
         },
         "tag": {
           "type": "string",
@@ -498,7 +498,7 @@
             "repository": {
               "type": "string",
               "description": "mongodb-exporter image repository",
-              "default": "percona/mongodb_exporter"
+              "default": "docker.io/percona/mongodb_exporter"
             },
             "tag": {
               "type": "string",
@@ -615,7 +615,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "minio/mc"
+                  "default": "docker.io/minio/mc"
                 },
                 "tag": {
                   "type": "string",
@@ -634,7 +634,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "mongo"
+                  "default": "docker.io/library/mongo"
                 },
                 "tag": {
                   "type": "string",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -19,7 +19,7 @@ commonLabels: {}
 # =============================================================================
 
 image:
-  repository: mongo
+  repository: docker.io/library/mongo
   tag: "8.2.6"
   pullPolicy: IfNotPresent
 
@@ -246,7 +246,7 @@ metrics:
   # -- Deploy a mongodb-exporter sidecar
   enabled: false
   image:
-    repository: percona/mongodb_exporter
+    repository: docker.io/percona/mongodb_exporter
     tag: "0.49.0"
     pullPolicy: IfNotPresent
   port: 9216
@@ -285,11 +285,11 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     mongodb:
-      repository: mongo
+      repository: docker.io/library/mongo
       tag: "8.2.6"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -19,7 +19,7 @@ clusterDomain: cluster.local
 
 image:
   # -- Mosquitto container image repository
-  repository: eclipse-mosquitto
+  repository: docker.io/library/eclipse-mosquitto
   # -- Mosquitto image tag validated on Docker Hub for the default non-Alpine release
   tag: "2.0.22"
   # -- Image pull policy
@@ -140,7 +140,7 @@ mqttxWeb:
   enabled: false
   image:
     # -- MQTTX Web image repository
-    repository: emqx/mqttx-web
+    repository: docker.io/emqx/mqttx-web
     # -- MQTTX Web image tag. Keep empty to use the image's default tag while upstream release/tag mismatch is under review.
     tag: ""
     # -- Image pull policy

--- a/charts/mysql/tests/statefulset_source_test.yaml
+++ b/charts/mysql/tests/statefulset_source_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "mysql:8.4"
+          value: "docker.io/library/mysql:8.4"
 
   - it: should always have 1 replica
     template: statefulset-source.yaml

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -39,7 +39,7 @@
         "repository": {
           "type": "string",
           "description": "MySQL image repository",
-          "default": "mysql"
+          "default": "docker.io/library/mysql"
         },
         "tag": {
           "type": "string",
@@ -510,7 +510,7 @@
             "repository": {
               "type": "string",
               "description": "mysqld-exporter image repository",
-              "default": "prom/mysqld-exporter"
+              "default": "docker.io/prom/mysqld-exporter"
             },
             "tag": {
               "type": "string",
@@ -669,7 +669,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "minio/mc"
+                  "default": "docker.io/minio/mc"
                 },
                 "tag": {
                   "type": "string",
@@ -688,7 +688,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "mysql"
+                  "default": "docker.io/library/mysql"
                 },
                 "tag": {
                   "type": "string",

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -25,7 +25,7 @@ clusterDomain: cluster.local
 
 image:
   # -- MySQL image repository
-  repository: mysql
+  repository: docker.io/library/mysql
   # -- MySQL image tag
   tag: "8.4"
   pullPolicy: IfNotPresent
@@ -204,7 +204,7 @@ metrics:
     annotations: {}
   image:
     # -- mysqld-exporter image repository
-    repository: prom/mysqld-exporter
+    repository: docker.io/prom/mysqld-exporter
     # -- mysqld-exporter image tag
     tag: "v0.17.2"
     pullPolicy: IfNotPresent
@@ -264,11 +264,11 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     mysql:
-      repository: mysql
+      repository: docker.io/library/mysql
       tag: "8.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       initContainers:
         {{- if ne $dbMode "sqlite" }}
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -72,7 +72,7 @@ spec:
         {{- end }}
         {{- if .Values.queue.enabled }}
         - name: wait-for-redis
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
         {{- if ne (include "n8n.databaseMode" .) "sqlite" }}
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c
@@ -57,7 +57,7 @@ spec:
               echo "Database is reachable."
         {{- end }}
         - name: wait-for-redis
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "n8nio/n8n:2.12.3"
+          value: "docker.io/n8nio/n8n:2.12.3"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: n8nio/n8n
+  repository: docker.io/n8nio/n8n
   # -- Container image tag (defaults to appVersion)
   tag: ""
   # -- Image pull policy
@@ -391,13 +391,13 @@ backup:
 
   images:
     # -- Image used for SQLite backup (must have tar)
-    sqlite: alpine:3.22
+    sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.3-alpine
     # -- Image used for MySQL backup (must have mysqldump)
-    mysql: mysql:8.4
+    mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -212,9 +212,9 @@ backup:
   archivePrefix: open-webui
   images:
     # -- Image used for PostgreSQL dump
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   database:

--- a/charts/phpmyadmin/tests/deployment_test.yaml
+++ b/charts/phpmyadmin/tests/deployment_test.yaml
@@ -166,7 +166,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "phpmyadmin/phpmyadmin:5.2.3"
+          value: "docker.io/phpmyadmin/phpmyadmin:5.2.3"
 
   - it: should allow image tag override
     set:
@@ -175,7 +175,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "phpmyadmin/phpmyadmin:5.2.2"
+          value: "docker.io/phpmyadmin/phpmyadmin:5.2.2"
 
   - it: should set replica count
     set:

--- a/charts/phpmyadmin/values.yaml
+++ b/charts/phpmyadmin/values.yaml
@@ -15,7 +15,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: phpmyadmin/phpmyadmin
+  repository: docker.io/phpmyadmin/phpmyadmin
   # -- Image tag (defaults to Chart.appVersion)
   tag: ""
   # -- Image pull policy

--- a/charts/pihole/tests/deployment_test.yaml
+++ b/charts/pihole/tests/deployment_test.yaml
@@ -288,7 +288,7 @@ tests:
           value: exporter
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "ekofr/pihole-exporter:v0.4.0"
+          value: "docker.io/ekofr/pihole-exporter:v0.4.0"
 
   - it: should not render metrics sidecar by default
     template: templates/deployment.yaml
@@ -307,7 +307,7 @@ tests:
           value: unbound
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "mvance/unbound:1.22.0"
+          value: "docker.io/mvance/unbound:1.22.0"
 
   - it: should override upstream DNS to unbound when enabled
     template: templates/deployment.yaml

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: pihole/pihole
+  repository: docker.io/pihole/pihole
   # -- Container image tag (defaults to appVersion)
   tag: ""
   # -- Image pull policy
@@ -277,7 +277,7 @@ metrics:
 
   image:
     # -- pihole-exporter image repository
-    repository: ekofr/pihole-exporter
+    repository: docker.io/ekofr/pihole-exporter
     # -- pihole-exporter image tag
     tag: v0.4.0
     # -- pihole-exporter pull policy
@@ -309,7 +309,7 @@ unbound:
 
   image:
     # -- Unbound image repository
-    repository: mvance/unbound
+    repository: docker.io/mvance/unbound
     # -- Unbound image tag
     tag: 1.22.0
     # -- Unbound pull policy

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "postgres:18.3-trixie"
+          value: "docker.io/library/postgres:18.3-trixie"
 
   - it: should have selector labels matching template labels
     template: statefulset-primary.yaml

--- a/charts/postgresql/values.schema.json
+++ b/charts/postgresql/values.schema.json
@@ -39,7 +39,7 @@
         "repository": {
           "type": "string",
           "description": "PostgreSQL image repository",
-          "default": "postgres"
+          "default": "docker.io/library/postgres"
         },
         "tag": {
           "type": "string",
@@ -651,7 +651,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "minio/mc"
+                  "default": "docker.io/minio/mc"
                 },
                 "tag": {
                   "type": "string",
@@ -670,7 +670,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "postgres"
+                  "default": "docker.io/library/postgres"
                 },
                 "tag": {
                   "type": "string",

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -25,7 +25,7 @@ clusterDomain: cluster.local
 
 image:
   # -- PostgreSQL image repository
-  repository: postgres
+  repository: docker.io/library/postgres
   # -- PostgreSQL image tag
   tag: "18.3-trixie"
   pullPolicy: IfNotPresent
@@ -258,11 +258,11 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     postgresql:
-      repository: postgres
+      repository: docker.io/library/postgres
       tag: "18.3-trixie"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/rabbitmq/tests/statefulset_test.yaml
+++ b/charts/rabbitmq/tests/statefulset_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "rabbitmq:4.2.4-management"
+          value: "docker.io/library/rabbitmq:4.2.4-management"
 
   - it: should have 1 replica in single-node mode
     template: statefulset.yaml

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -22,7 +22,7 @@ clusterDomain: cluster.local
 
 image:
   # -- RabbitMQ image repository
-  repository: rabbitmq
+  repository: docker.io/library/rabbitmq
   # -- RabbitMQ image tag
   tag: "4.2.4-management"
   pullPolicy: IfNotPresent

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -32,7 +32,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "redis:8.6.0"
+          value: "docker.io/library/redis:8.6.0"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -23,7 +23,7 @@ commonLabels: {}
 # =============================================================================
 
 image:
-  repository: redis
+  repository: docker.io/library/redis
   tag: "8.6.0"
   pullPolicy: IfNotPresent
 
@@ -190,7 +190,7 @@ startupProbe:
 metrics:
   enabled: false
   image:
-    repository: oliver006/redis_exporter
+    repository: docker.io/oliver006/redis_exporter
     tag: v1.69.0
     pullPolicy: IfNotPresent
   resources: {}

--- a/charts/strapi/templates/deployment.yaml
+++ b/charts/strapi/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       {{- if ne (include "strapi.databaseMode" .) "sqlite" }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "vshadbolt/strapi:5.40.0"
+          value: "docker.io/vshadbolt/strapi:5.40.0"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -22,7 +22,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository for your Strapi project
-  repository: vshadbolt/strapi
+  repository: docker.io/vshadbolt/strapi
   # -- Container image tag (defaults to appVersion when empty)
   tag: ""
   # -- Image pull policy
@@ -397,13 +397,13 @@ backup:
 
   images:
     # -- Image used for local file backup jobs (must have tar)
-    utility: alpine:3.22
+    utility: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.3-alpine
     # -- Image used for MySQL backup (must have mysqldump)
-    mysql: mysql:8.4
+    mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "robiningelbrecht/strava-statistics:v4.7.5"
+          value: "docker.io/robiningelbrecht/strava-statistics:v4.7.5"
 
   - it: should allow custom image tag
     set:
@@ -31,7 +31,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "robiningelbrecht/strava-statistics:v4.0.0"
+          value: "docker.io/robiningelbrecht/strava-statistics:v4.0.0"
 
   - it: should set Strava env vars from secret
     asserts:

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "robiningelbrecht/strava-statistics" },
+        "repository": { "type": "string", "default": "docker.io/robiningelbrecht/strava-statistics" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Statistics for Strava container image
-  repository: robiningelbrecht/strava-statistics
+  repository: docker.io/robiningelbrecht/strava-statistics
   # -- Image tag (defaults to v{appVersion})
   tag: ""
   pullPolicy: IfNotPresent

--- a/charts/superset/templates/_helpers.tpl
+++ b/charts/superset/templates/_helpers.tpl
@@ -225,7 +225,7 @@ redis-password
 
 {{- define "superset.initContainers" -}}
 - name: wait-for-postgresql
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c
@@ -236,7 +236,7 @@ redis-password
       done
       echo "PostgreSQL is reachable."
 - name: wait-for-redis
-  image: busybox:1.37
+  image: docker.io/library/busybox:1.37
   command:
     - sh
     - -c

--- a/charts/superset/values.schema.json
+++ b/charts/superset/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "apache/superset" },
+        "repository": { "type": "string", "default": "docker.io/apache/superset" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Superset container image repository
-  repository: apache/superset
+  repository: docker.io/apache/superset
   # -- Superset image tag. Defaults to appVersion.
   tag: ""
   # -- Image pull policy
@@ -272,9 +272,9 @@ backup:
   archivePrefix: superset
   images:
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/umami/templates/deployment.yaml
+++ b/charts/umami/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -175,9 +175,9 @@ backup:
 
   images:
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/uptime-kuma/templates/backup-cronjob.yaml
+++ b/charts/uptime-kuma/templates/backup-cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           initContainers:
             {{- if eq (include "uptime-kuma.dbType" .) "sqlite" }}
             - name: sqlite-backup
-              image: busybox:1.37
+              image: docker.io/library/busybox:1.37
               command: ["/bin/sh", "/scripts/sqlite-backup.sh"]
               {{- with .Values.backup.resources }}
               resources:

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- if eq (include "uptime-kuma.dbType" .) "mariadb" }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "louislam/uptime-kuma:2.2.1"
+          value: "docker.io/louislam/uptime-kuma:2.2.1"
 
   - it: should set custom image tag
     set:
@@ -37,7 +37,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "louislam/uptime-kuma:2.1.0"
+          value: "docker.io/louislam/uptime-kuma:2.1.0"
 
   - it: should set default env vars for SQLite mode
     asserts:

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Uptime Kuma container image
-  repository: louislam/uptime-kuma
+  repository: docker.io/louislam/uptime-kuma
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -194,11 +194,11 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     mysql:
-      repository: mysql
+      repository: docker.io/library/mysql
       tag: "8.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- if ne (include "vaultwarden.databaseMode" .) "sqlite" }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/vaultwarden/tests/deployment_test.yaml
+++ b/charts/vaultwarden/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "vaultwarden/server:1.35.4"
+          value: "docker.io/vaultwarden/server:1.35.4"
 
   - it: should have 1 replica
     template: deployment.yaml

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -14,7 +14,7 @@ clusterDomain: cluster.local
 
 image:
   # -- Vaultwarden image repository
-  repository: vaultwarden/server
+  repository: docker.io/vaultwarden/server
   # -- Vaultwarden image tag
   tag: "1.35.4"
   pullPolicy: IfNotPresent
@@ -346,19 +346,19 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: minio/mc
+      repository: docker.io/minio/mc
       tag: "RELEASE.2025-08-13T08-35-41Z"
       pullPolicy: IfNotPresent
     sqlite:
-      repository: alpine
+      repository: docker.io/library/alpine
       tag: "3.22"
       pullPolicy: IfNotPresent
     postgresql:
-      repository: postgres
+      repository: docker.io/library/postgres
       tag: "18.3-trixie"
       pullPolicy: IfNotPresent
     mysql:
-      repository: mysql
+      repository: docker.io/library/mysql
       tag: "8.4"
       pullPolicy: IfNotPresent
   s3:

--- a/charts/wallabag/templates/deployment.yaml
+++ b/charts/wallabag/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/wallabag/tests/deployment_test.yaml
+++ b/charts/wallabag/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "wallabag/wallabag:2.6.14"
+          value: "docker.io/wallabag/wallabag:2.6.14"
 
   - it: should set PostgreSQL env vars with subchart
     asserts:

--- a/charts/wallabag/values.schema.json
+++ b/charts/wallabag/values.schema.json
@@ -11,7 +11,7 @@
     "image": {
       "type": "object",
       "properties": {
-        "repository": { "type": "string", "default": "wallabag/wallabag" },
+        "repository": { "type": "string", "default": "docker.io/wallabag/wallabag" },
         "tag": { "type": "string", "default": "" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }

--- a/charts/wallabag/values.yaml
+++ b/charts/wallabag/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   # -- Wallabag container image
-  repository: wallabag/wallabag
+  repository: docker.io/wallabag/wallabag
   # -- Image tag (defaults to appVersion)
   tag: ""
   pullPolicy: IfNotPresent
@@ -188,9 +188,9 @@ backup:
   archivePrefix: wallabag
   images:
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: postgres:18-alpine
+    postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: busybox:1.37
+          image: docker.io/library/busybox:1.37
           command:
             - sh
             - -c

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -63,7 +63,7 @@ tests:
           value: dump-database
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: "mysql:8.4"
+          value: "docker.io/library/mysql:8.4"
 
   - it: should have archive-content init container
     template: templates/backup-cronjob.yaml
@@ -79,7 +79,7 @@ tests:
           value: archive-content
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: "alpine:3.22"
+          value: "docker.io/library/alpine:3.22"
 
   - it: should have upload container
     template: templates/backup-cronjob.yaml
@@ -95,7 +95,7 @@ tests:
           value: upload
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "minio/mc:RELEASE.2025-04-08T15-18-23Z"
+          value: "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z"
 
   - it: should render backup configmap when enabled
     template: templates/backup-configmap.yaml

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -146,7 +146,7 @@ tests:
           value: wait-for-db
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "busybox:1.37"
+          value: "docker.io/library/busybox:1.37"
 
   - it: should render startup probe when enabled
     template: templates/deployment.yaml
@@ -243,7 +243,7 @@ tests:
           value: metrics
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "lusotycoon/apache-exporter:v1.0.8"
+          value: "docker.io/lusotycoon/apache-exporter:v1.0.8"
 
   - it: should not render metrics sidecar by default
     template: templates/deployment.yaml

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   # -- Container image repository
-  repository: wordpress
+  repository: docker.io/library/wordpress
   # -- Container image tag (defaults to appVersion)
   tag: ""
   # -- Image pull policy
@@ -296,7 +296,7 @@ metrics:
 
   image:
     # -- apache-exporter image repository
-    repository: lusotycoon/apache-exporter
+    repository: docker.io/lusotycoon/apache-exporter
     # -- apache-exporter image tag
     tag: v1.0.8
     # -- apache-exporter pull policy
@@ -349,11 +349,11 @@ backup:
 
   images:
     # -- Image used for mysqldump (must have mysqldump binary)
-    worker: mysql:8.4
+    worker: docker.io/library/mysql:8.4
     # -- Image used for file archiving (must have tar)
-    archiver: alpine:3.22
+    archiver: docker.io/library/alpine:3.22
     # -- Image used for S3 upload (MinIO client)
-    uploader: minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
 
   # -- Resources for backup containers
   resources: {}


### PR DESCRIPTION
## Summary
- Prefix **all** Docker Hub image references with `docker.io/` across all 45 charts
- Fixes `short name mode is enforcing` errors on Kubernetes clusters using CRI-O or other runtimes with strict short name resolution policies
- **129 files changed**, 285 substitutions

## What was fixed
- `values.yaml` — main image repositories, backup images, metrics sidecars, utility images
- Templates — hardcoded `busybox:1.37` in init containers, `_helpers.tpl` with inline images
- `values.schema.json` — default values for image repository fields
- CI values files — test scenario image references
- Unit test assertions — all image value assertions updated to match

## Naming convention
- Official images: `docker.io/library/{name}` (postgres, mysql, redis, mongo, mariadb, busybox, alpine, nginx, wordpress, rabbitmq, eclipse-mosquitto)
- Org images: `docker.io/{org}/{name}` (minio/mc, appwrite/appwrite, gitea/gitea, etc.)
- Already qualified: ghcr.io, quay.io images left unchanged

## Test plan
- [x] `helm unittest` passes for all 45 charts (0 failures)
- [x] No remaining short image names in values, templates, schemas, tests, or CI files