### PR TITLE
fix(mosquitto): set correct ownership and permissions on generated passwordfile

### DIFF
--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -54,6 +54,8 @@ spec:
               cp /config-template/mosquitto.conf.tmpl /work/mosquitto.conf
               {{- if .Values.auth.enabled }}
               mosquitto_passwd -b -c /work/passwordfile "$AUTH_USERNAME" "$AUTH_PASSWORD"
+              chown 1883:1883 /work/passwordfile
+              chmod 0700 /work/passwordfile
               {{- end }}
               {{- if .Values.acl.enabled }}
               cp /acl-source/{{ .Values.acl.existingConfigMapKey }} /work/aclfile


### PR DESCRIPTION
## Summary

- The init container runs as root and creates the passwordfile with `600`/root ownership
- Mosquitto runs as UID 1883 and cannot open the file → `Error: Unable to open pwfile`
- Fix: `chown 1883:1883` and `chmod 0700` the passwordfile in the init container after generation

## Test plan

- [x] `helm lint --strict` passes
- [x] `helm unittest` passes (13/13)
- [x] All CI scenarios template successfully
- [x] k3d install with `auth.enabled=true` — pod starts with zero warnings
- [x] Verified mosquitto logs show clean startup without permission warnings