### PR TITLE
ci: fix index race condition in update-index job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,6 +309,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v6
         with:
+          ref: main
           path: main-src
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

- The `update-index` job checked out `main` without `ref: main`, using `github.sha` (the triggering commit) instead of the tip of main after the `publish` job pushed the release commit
- This caused newly published chart versions to be missing from the Helm repo index (e.g., mosquitto 1.0.7 was in OCI/GitHub Release but not in `helm search repo`)
- Fix: add `ref: main` to the checkout step

## Test plan

- [ ] Merge and verify next chart release appears in `helm search repo helmforge/<chart> --versions`