### PR TITLE
feat(open-webui): promote chart maturity from alpha to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 | [superset](charts/superset/) | stable | Apache Superset — data exploration and visualization with Celery workers, PostgreSQL, and Redis |
 | [ckan](charts/ckan/) | stable | CKAN — open data portal with DataPusher, Solr, PostgreSQL, and Redis |
 | [druid](charts/druid/) | stable | Apache Druid — distributed analytics database with coordinator, broker, historical, and router |
-| [open-webui](charts/open-webui/) | alpha | Open WebUI — self-hosted AI chat platform with Ollama/OpenAI, RAG, PostgreSQL, Redis, and S3 backup |
+| [open-webui](charts/open-webui/) | stable | Open WebUI — self-hosted AI chat platform with Ollama/OpenAI, RAG, PostgreSQL, Redis, and S3 backup |
 
 ### Maturity levels
 

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -31,9 +31,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/open-webui
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/open-webui
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
-  artifacthub.io/prerelease: "true"
 dependencies:
   - name: postgresql
     version: 1.8.3


### PR DESCRIPTION
## Summary

- Promotes open-webui chart from **alpha** to **stable** maturity
- Removes `artifacthub.io/prerelease: "true"` annotation
- Updates maturity column in root README.md

## Validation performed

- [x] `helm lint --strict` passes
- [x] `helm unittest` — 24/24 tests passing across 6 suites
- [x] All 4 CI scenarios template successfully (default, ingress, postgresql, backup)
- [x] k3d install: default SQLite mode — pod running, health OK
- [x] k3d install: PostgreSQL subchart — both pods running, health OK

## Stable criteria met

- 2+ published releases (1.0.1, 1.0.2)
- CI scenarios covering default, ingress, PostgreSQL, backup
- k3d validated on both primary deployment modes
- No breaking changes