### PR TITLE
docs(repo): standardize chart icon URLs to helmforge.dev

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -21,7 +21,7 @@ sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/adguard-home
   - https://github.com/AdguardTeam/AdGuardHome
   - https://github.com/bakito/adguardhome-sync
-icon: https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/client/public/assets/apple-touch-icon-180x180.png
+icon: https://helmforge.dev/icons/charts/adguard-home.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -18,7 +18,7 @@ home: https://alf.io
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/alfio-event/alf.io
-icon: https://alf.io/img/alfio-logo.svg
+icon: https://helmforge.dev/icons/charts/alfio.png
 annotations:
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -19,7 +19,7 @@ home: https://helmforge.dev/docs/charts/answer
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/answer
   - https://github.com/apache/answer
-icon: https://answer.apache.org/img/logo.svg
+icon: https://helmforge.dev/icons/charts/answer.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.0.6
 appVersion: "1.8.1"
 kubeVersion: ">=1.26.0-0"
-icon: https://raw.githubusercontent.com/appwrite/appwrite/main/public/images/github-logo.png
+icon: https://helmforge.dev/icons/charts/appwrite.png
 home: https://appwrite.io
 keywords:
   - appwrite

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - wayback
   - chromium
   - self-hosted
-icon: https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/dev/archivebox/templates/static/archive.png
+icon: https://helmforge.dev/icons/charts/archivebox.png
 home: https://archivebox.io
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -20,7 +20,7 @@ home: https://helmforge.dev/docs/charts/authelia
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/authelia
   - https://github.com/authelia/authelia
-icon: https://www.authelia.com/images/branding/logo-cropped.png
+icon: https://helmforge.dev/icons/charts/authelia.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: automatisch
 description: Open-source business automation platform — self-hosted Zapier alternative with PostgreSQL and Redis
+icon: https://helmforge.dev/icons/charts/automatisch.png
 type: application
 version: 1.0.1
 appVersion: "0.15.0"

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -18,7 +18,7 @@ home: https://castopod.org
 sources:
   - https://github.com/helmforgedev/charts
   - https://code.castopod.org/adaures/castopod
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/castopod.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - website-monitoring
   - notifications
   - self-hosted
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/changedetection.png
 home: https://changedetection.io
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -19,7 +19,7 @@ home: https://chiefonboarding.com
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/chiefonboarding/ChiefOnboarding
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/chiefonboarding.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -19,7 +19,7 @@ home: https://helmforge.dev/docs/charts/ckan
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/ckan
   - https://github.com/ckan/ckan
-icon: https://raw.githubusercontent.com/ckan/ckan/master/ckan/public/base/images/ckan-logo.png
+icon: https://helmforge.dev/icons/charts/ckan.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -19,7 +19,7 @@ home: https://developers.cloudflare.com/cloudflare-one/connections/connect-netwo
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/cloudflare/cloudflared
-icon: https://helmforge.dev/icons/charts/cloudflared.svg
+icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -19,7 +19,7 @@ home: https://developers.cloudflare.com/cloudflare-one/connections/connect-netwo
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/cloudflare/cloudflared
-icon: https://www.vectorlogo.zone/logos/cloudflare/cloudflare-icon.svg
+icon: https://helmforge.dev/icons/charts/cloudflared.svg
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - crash-reporting
   - push-notifications
   - self-hosted
-icon: https://count.ly/images/logos/countly-logo-mark.svg
+icon: https://helmforge.dev/icons/charts/countly.png
 home: https://count.ly
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - cron
   - job-scheduler
   - self-hosted
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/cronicle.png
 home: https://github.com/jhuckaby/Cronicle
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ddns-updater
 description: Dynamic DNS updater supporting 50+ providers with web UI, health checks, and persistent update history
-icon: https://raw.githubusercontent.com/qdm12/ddns-updater/master/readme/ddnsgopher.svg
+icon: https://helmforge.dev/icons/charts/ddns-updater.png
 type: application
 version: 1.3.5
 appVersion: "2.9.0"

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: discount-bandit
 description: Deal aggregator and price tracker for self-hosted deal hunting
+icon: https://helmforge.dev/icons/charts/discount-bandit.png
 type: application
 version: 1.0.1
 appVersion: "4.0.3"

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.0.6
 appVersion: "0.70.3"
 kubeVersion: ">=1.26.0-0"
-icon: https://docmost.com/img/logo.svg
+icon: https://helmforge.dev/icons/charts/docmost.png
 home: https://helmforge.dev/docs/charts/docmost
 keywords:
   - docmost

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.1.6
 appVersion: "23.0.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Dolibarr ERP/CRM on Kubernetes with MySQL support
-icon: https://raw.githubusercontent.com/Dolibarr/dolibarr/develop/doc/images/dolibarr_logo.svg
+icon: https://helmforge.dev/icons/charts/dolibarr.png
 maintainers:
   - name: helmforgedev
   - name: mberlofa

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -19,7 +19,7 @@ home: https://helmforge.dev/docs/charts/druid
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/druid
   - https://github.com/apache/druid
-icon: https://raw.githubusercontent.com/apache/druid/master/website/static/img/druid_nav.png
+icon: https://helmforge.dev/icons/charts/druid.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.1.0
 appVersion: "3.1.1"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/flowise
-icon: https://raw.githubusercontent.com/FlowiseAI/Flowise/main/images/flowise_dark.svg
+icon: https://helmforge.dev/icons/charts/flowise.png
 keywords:
   - flowise
   - ai

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
   - name: mberlofa
 version: 1.8.5
 appVersion: "1.0.0"
-icon: https://helmforge.dev/icons/charts/generic.svg
+icon: https://helmforge.dev/icons/charts/generic.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   helmforge.dev/maturity: stable

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
   - name: mberlofa
 version: 1.8.5
 appVersion: "1.0.0"
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/generic.svg
 kubeVersion: ">=1.26.0-0"
 annotations:
   helmforge.dev/maturity: stable

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - headless-cms
   - newsletter
   - self-hosted
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/ghost.png
 home: https://ghost.org
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.0.6
 appVersion: "1.25.5"
 home: https://helmforge.dev/docs/charts/gitea
-icon: https://raw.githubusercontent.com/go-gitea/gitea/main/assets/logo.svg
+icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
   - gitea
   - git

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/apache/guacamole-server
   - https://github.com/apache/guacamole-client
-icon: https://raw.githubusercontent.com/apache/guacamole-website/main/images/logos/guac-classic-logo.svg
+icon: https://helmforge.dev/icons/charts/guacamole.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -19,7 +19,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/linuxserver/heimdall
   - https://github.com/linuxserver/Heimdall
-icon: https://raw.githubusercontent.com/linuxserver/Heimdall/master/public/img/heimdall-icon-small.png
+icon: https://helmforge.dev/icons/charts/heimdall.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.0.5
 appVersion: "1.57.1"
 home: https://helmforge.dev/docs/charts/homarr
-icon: https://homarr.dev/img/logo.png
+icon: https://helmforge.dev/icons/charts/homarr.png
 keywords:
   - homarr
   - dashboard

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -18,7 +18,7 @@ home: https://kafka.apache.org/
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/apache/kafka
-icon: https://kafka.apache.org/images/apache-kafka.png
+icon: https://helmforge.dev/icons/charts/kafka.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: karakeep
 description: AI-powered bookmark manager with full-text search and web archiving
+icon: https://helmforge.dev/icons/charts/karakeep.png
 type: application
 version: 1.0.1
 appVersion: "0.24.1"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: keycloak
 description: Keycloak for Kubernetes with explicit dev and production modes
-icon: https://raw.githubusercontent.com/keycloak/keycloak/main/js/apps/admin-ui/public/logo.svg
+icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 2.6.4
 appVersion: "26.5.5"

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -19,7 +19,7 @@ home: https://komga.org
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/gotson/komga
-icon: https://komga.org/img/logo.svg
+icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - liwan
   - duckdb
   - self-hosted
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/liwan.png
 home: https://liwan.dev
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -16,7 +16,7 @@ home: https://mariadb.org/
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/mariadb
-icon: https://raw.githubusercontent.com/docker-library/docs/master/mariadb/logo.png
+icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -19,7 +19,7 @@ home: https://www.metabase.com
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/metabase/metabase
-icon: https://www.metabase.com/images/logo.svg
+icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - engineering
   - performance
   - self-hosted
-icon: https://raw.githubusercontent.com/middlewarehq/middleware/main/media_files/logo192.png
+icon: https://helmforge.dev/icons/charts/middleware.png
 home: https://www.middlewarehq.com
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -21,7 +21,7 @@ home: https://www.minecraft.net
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/itzg/minecraft-server
-icon: https://www.vectorlogo.zone/logos/minecraft/minecraft-icon.svg
+icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -18,7 +18,7 @@ home: https://www.mongodb.com
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/mongo
-icon: https://www.vectorlogo.zone/logos/mongodb/mongodb-icon.svg
+icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -5,7 +5,7 @@ version: 1.0.7
 appVersion: "2.0.22"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Eclipse Mosquitto with WebSocket support and optional MQTTX Web
-icon: https://mosquitto.org/images/mosquitto-text-side-28.png
+icon: https://helmforge.dev/icons/charts/mosquitto.png
 maintainers:
   - name: helmforgedev
   - name: mberlofa

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -16,7 +16,7 @@ home: https://www.mysql.com/
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/mysql
-icon: https://raw.githubusercontent.com/docker-library/docs/master/mysql/logo.png
+icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -18,7 +18,7 @@ home: https://helmforge.dev/docs/charts/n8n
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/n8n
   - https://github.com/n8n-io/n8n
-icon: https://raw.githubusercontent.com/n8n-io/n8n/master/assets/n8n-logo.png
+icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - ntfy
   - self-hosted
   - alerting
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/ntfy.png
 home: https://ntfy.sh
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - automation
   - web-ui
   - self-hosted
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/olivetin.png
 home: https://www.olivetin.app
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.1.0
 appVersion: "0.8.12"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/open-webui
-icon: https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png
+icon: https://helmforge.dev/icons/charts/open-webui.png
 keywords:
   - open-webui
   - ai

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/phpmyadmin/phpmyadmin
   - https://github.com/phpmyadmin/phpmyadmin
-icon: https://raw.githubusercontent.com/phpmyadmin/phpmyadmin/master/public/themes/pmahomme/img/logo_left.png
+icon: https://helmforge.dev/icons/charts/phpmyadmin.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -19,7 +19,7 @@ home: https://pi-hole.net
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/pihole/pihole
-icon: https://pi-hole.net/wp-content/uploads/2016/12/Vortex-R.png
+icon: https://helmforge.dev/icons/charts/pihole.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -17,7 +17,7 @@ home: https://www.postgresql.org/
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/postgres
-icon: https://raw.githubusercontent.com/docker-library/docs/master/postgres/logo.png
+icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -18,7 +18,7 @@ home: https://www.rabbitmq.com/
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/docker-library/rabbitmq
-icon: https://raw.githubusercontent.com/rabbitmq/rabbitmq-website/main/static/img/rabbitmq-logo.svg
+icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -18,7 +18,7 @@ home: https://redis.io
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/redis
-icon: https://raw.githubusercontent.com/docker-library/docs/master/redis/logo.png
+icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -19,7 +19,7 @@ home: https://helmforge.dev/docs/charts/strapi
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/strapi
   - https://github.com/strapi/strapi
-icon: https://raw.githubusercontent.com/strapi/strapi/main/packages/core/admin/admin/src/assets/images/logo-strapi-2022.svg
+icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - cycling
   - running
   - self-hosted
-icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+icon: https://helmforge.dev/icons/charts/strava-statistics.png
 home: https://github.com/robiningelbrecht/strava-statistics
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -20,7 +20,7 @@ home: https://helmforge.dev/docs/charts/superset
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/superset
   - https://github.com/apache/superset
-icon: https://raw.githubusercontent.com/apache/superset/master/superset-frontend/src/assets/images/superset-logo-horiz.svg
+icon: https://helmforge.dev/icons/charts/superset.png
 annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -18,7 +18,7 @@ home: https://umami.is
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/umami-software/umami
-icon: https://umami.is/images/umami-logo.png
+icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -18,7 +18,7 @@ home: https://uptime.kuma.pet
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/louislam/uptime-kuma
-icon: https://uptime.kuma.pet/img/icon.svg
+icon: https://helmforge.dev/icons/charts/uptime-kuma.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -17,7 +17,7 @@ home: https://github.com/dani-garcia/vaultwarden
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/dani-garcia/vaultwarden
-icon: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon.svg
+icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -18,7 +18,7 @@ home: https://velero.io
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/vmware-tanzu/velero
-icon: https://velero.io/img/Velero.svg
+icon: https://helmforge.dev/icons/charts/velero.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -18,7 +18,7 @@ home: https://wallabag.org
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/wallabag/wallabag
-icon: https://wallabag.org/img/logo-wallabag.svg
+icon: https://helmforge.dev/icons/charts/wallabag.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -18,7 +18,7 @@ home: https://wordpress.org
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/wordpress
-icon: https://s.w.org/style/images/about/WordPress-logotype-simplified.png
+icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign


### PR DESCRIPTION
## Summary

- Standardize all 56 `Chart.yaml` `icon:` fields to use canonical URLs on `helmforge.dev`
- Replace broken external URLs (7 returning 404), missing icons (3 charts), and Kubernetes fallback placeholders (10 charts)
- Single source of truth: `https://helmforge.dev/icons/charts/{slug}.{png|svg}`

## Why

External icon URLs break over time — upstream projects restructure repos, delete assets, or rebrand. 20 out of 56 charts had broken or generic icons on ArtifactHub. Hosting icons on our own domain gives us full control and zero maintenance overhead since the icons already exist on the site.

## Impact

- All charts will display their proper branded icon on ArtifactHub after next publish
- No template or values changes — only `Chart.yaml` metadata
- Icons are already live at helmforge.dev (deployed from site repo)

## Test plan

- [x] `helm lint --strict` passes on sampled charts (redis, generic, appwrite)
- [x] All 56 Chart.yaml files have `icon: https://helmforge.dev/icons/charts/{slug}.{ext}`
- [x] No chart without an `icon:` field
- [ ] CI passes