### PR TITLE
feat(repo): add artifacthub annotations and improve signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,25 @@ jobs:
             echo "No tests directory found, skipping"
           fi
 
+  artifacthub-lint:
+    name: ArtifactHub Lint - ${{ matrix.chart }}
+    needs: detect
+    if: needs.detect.outputs.charts != '[]' && needs.detect.outputs.charts != ''
+    runs-on: ubuntu-latest
+    container:
+      image: artifacthub/ah:v1.19.0
+      options: --user root
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: ${{ fromJson(needs.detect.outputs.charts) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run ArtifactHub lint
+        run: ah lint -p charts/${{ matrix.chart }}
+
   kubeconform:
     name: Validate - ${{ matrix.chart }}
     needs: [detect, template]
@@ -202,14 +221,15 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     if: always()
-    needs: [detect, lint, template, unittest, kubeconform]
+    needs: [detect, lint, template, unittest, kubeconform, artifacthub-lint]
     steps:
       - name: Check results
         run: |
           if [ "${{ needs.lint.result }}" = "failure" ] || \
              [ "${{ needs.template.result }}" = "failure" ] || \
              [ "${{ needs.unittest.result }}" = "failure" ] || \
-             [ "${{ needs.kubeconform.result }}" = "failure" ]; then
+             [ "${{ needs.kubeconform.result }}" = "failure" ] || \
+             [ "${{ needs.artifacthub-lint.result }}" = "failure" ]; then
             echo "CI failed"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,6 +165,55 @@ jobs:
           echo "Updated Chart.yaml:"
           grep -E '^(version|appVersion):' charts/${{ matrix.chart }}/Chart.yaml
 
+      - name: Generate ArtifactHub changes annotation
+        if: steps.semver.outputs.skip != 'true'
+        run: |
+          CHART="${{ matrix.chart }}"
+          PREV_TAG="${{ steps.semver.outputs.previous_tag }}"
+          CHART_YAML="charts/${CHART}/Chart.yaml"
+
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s" -- "charts/${CHART}/" | head -50)
+          else
+            COMMITS=$(git log "${PREV_TAG}..HEAD" --pretty=format:"%s" -- "charts/${CHART}/")
+          fi
+
+          if [ -z "$COMMITS" ]; then
+            echo "No commits found, skipping changes annotation"
+            exit 0
+          fi
+
+          CHANGES=""
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
+            # Strip scope: "feat(chart): desc" -> "desc"
+            desc=$(echo "$msg" | sed -E 's/^[a-z]+(\([^)]*\))?!?:\s*//')
+            # Determine kind from conventional commit type
+            if echo "$msg" | grep -qE '^[a-z]+(\([^)]*\))?!:'; then
+              kind="changed"
+              desc="BREAKING: $desc"
+            elif echo "$msg" | grep -qE '^feat(\([^)]*\))?:'; then
+              kind="added"
+            elif echo "$msg" | grep -qE '^fix(\([^)]*\))?:'; then
+              kind="fixed"
+            elif echo "$msg" | grep -qE '^(refactor|perf)(\([^)]*\))?:'; then
+              kind="changed"
+            elif echo "$msg" | grep -qE '^docs(\([^)]*\))?:'; then
+              kind="changed"
+            else
+              kind="changed"
+            fi
+            CHANGES="${CHANGES}    - kind: ${kind}\n      description: ${desc}\n"
+          done <<< "$COMMITS"
+
+          if [ -n "$CHANGES" ]; then
+            # Remove any existing changes annotation
+            sed -i '/artifacthub\.io\/changes:/,/^  [^ ]/{ /^  [^ ]/!d; /artifacthub\.io\/changes:/d }' "$CHART_YAML"
+            # Append changes annotation before end of file
+            printf '  artifacthub.io/changes: |\n%b' "$CHANGES" >> "$CHART_YAML"
+            echo "Added changes annotation with $(echo -e "$CHANGES" | grep -c 'kind:') entries"
+          fi
+
       - name: Package and push to OCI
         if: steps.semver.outputs.skip != 'true'
         id: push
@@ -186,6 +235,7 @@ jobs:
           name: provenance-${{ matrix.chart }}
           path: .dist/*.prov
           retention-days: 1
+          if-no-files-found: warn
 
       - name: Sign OCI artifact with Cosign
         if: steps.semver.outputs.skip != 'true' && steps.push.outputs.digest != ''
@@ -359,12 +409,16 @@ jobs:
 
       - name: Copy provenance files
         run: |
-          if ls provenance/*.prov 1>/dev/null 2>&1; then
-            cp provenance/*.prov gh-pages/
-            echo "Copied provenance files:"
-            ls -1 gh-pages/*.prov 2>/dev/null | wc -l
+          echo "Provenance directory contents:"
+          find provenance/ -type f -name '*.prov' 2>/dev/null || echo "  (no .prov files found)"
+
+          if find provenance/ -type f -name '*.prov' 2>/dev/null | grep -q .; then
+            find provenance/ -type f -name '*.prov' -exec cp {} gh-pages/ \;
+            echo "Copied provenance files to gh-pages:"
+            ls -1 gh-pages/*.prov 2>/dev/null
           else
-            echo "No provenance files to copy"
+            echo "WARNING: No provenance files found in provenance/ directory"
+            echo "This means chart signatures will not be verifiable via the HTTP repository"
           fi
 
       - name: Sync artifacthub-repo.yml

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ HelmForge is built on a simple principle: **use what upstream ships, nothing mor
 - **Official upstream images** — every chart uses the image published by the application maintainers. No custom rebuilds, no proprietary layers, no vendor-specific modifications.
 - **Pinned version tags** — charts reference explicit, immutable image tags. No `:latest`, no floating tags, no surprises after a pull.
 - **MIT licensed** — the charts, the CI, the docs — everything is MIT. No open-core, no paid tiers, no license changes down the road.
-- **Cosign signed** — every OCI artifact is signed with [Sigstore Cosign](https://www.sigstore.dev/) keyless signing via GitHub Actions OIDC. Verify before you deploy.
+- **Signed artifacts** — every release includes GPG provenance files for Helm verification and [Sigstore Cosign](https://www.sigstore.dev/) keyless signatures on OCI artifacts via GitHub Actions OIDC. Verify before you deploy.
 - **No vendor lock-in** — standard Helm, standard Kubernetes APIs, standard images. If you stop using HelmForge tomorrow, nothing breaks.
 - **Simple, explicit values** — product-oriented `values.yaml` files that map directly to the application's configuration. What you see is what you get.
 

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -36,3 +36,16 @@ annotations:
       url: https://helmforge.dev/docs/charts/adguard-home
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/adguard-home
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: adguard-home
+      image: docker.io/adguard/adguardhome:0.107.73
+    - name: adguardhome-sync
+      image: ghcr.io/bakito/adguardhome-sync:v0.9.0
+    - name: backup-archiver
+      image: docker.io/library/busybox:1.37
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/cloudflared

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -23,6 +23,11 @@ sources:
   - https://github.com/bakito/adguardhome-sync
 icon: https://helmforge.dev/icons/charts/adguard-home.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -32,6 +37,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://adguard.com/adguard-home/overview.html
     - name: Documentation
       url: https://helmforge.dev/docs/charts/adguard-home
     - name: Source

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/alfio-event/alf.io
 icon: https://helmforge.dev/icons/charts/alfio.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://alf.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/alfio
     - name: Source

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -22,6 +22,9 @@ icon: https://helmforge.dev/icons/charts/alfio.png
 annotations:
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/prerelease: "true"
@@ -30,6 +33,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/alfio
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/alfio
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: alfio
+      image: docker.io/alfio/alf.io:2.0-M5-2509-1
 dependencies:
   - name: postgresql
     version: 1.8.4

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/apache/answer
 icon: https://helmforge.dev/icons/charts/answer.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://answer.apache.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/answer
     - name: Source

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -34,6 +34,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/answer
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/answer
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: answer
+      image: docker.io/apache/answer:2.0.0
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -24,6 +24,11 @@ sources:
   - https://github.com/appwrite/appwrite
   - https://hub.docker.com/r/appwrite/appwrite
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -33,6 +38,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://appwrite.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/appwrite
     - name: Source

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -37,6 +37,13 @@ annotations:
       url: https://helmforge.dev/docs/charts/appwrite
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/appwrite
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: appwrite
+      image: docker.io/appwrite/appwrite:1.8.1
+    - name: appwrite-console
+      image: docker.io/appwrite/console:7.5.7
 dependencies:
   - name: mariadb
     version: 1.0.2

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/ArchiveBox/ArchiveBox
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: storage
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://archivebox.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/archivebox
     - name: Source

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -34,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/archivebox
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/archivebox
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: archivebox
+      image: docker.io/archivebox/archivebox:0.7.3

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -35,6 +35,19 @@ annotations:
       url: https://helmforge.dev/docs/charts/authelia
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/authelia
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: authelia
+      image: docker.io/authelia/authelia:4.39.16
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    - name: backup-archiver
+      image: docker.io/library/busybox:1.37
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/keycloak
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -22,6 +22,11 @@ sources:
   - https://github.com/authelia/authelia
 icon: https://helmforge.dev/icons/charts/authelia.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -31,6 +36,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: security
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.authelia.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/authelia
     - name: Source

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -22,6 +22,9 @@ sources:
 annotations:
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/prerelease: "true"
@@ -30,6 +33,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/automatisch
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/automatisch
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: automatisch
+      image: docker.io/automatischio/automatisch:0.15.0
 dependencies:
   - name: postgresql
     version: 1.8.4

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/automatisch/automatisch
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://automatisch.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/automatisch
     - name: Source

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -33,6 +33,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/castopod
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/castopod
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: castopod
+      image: docker.io/castopod/castopod:1.15.5
 dependencies:
   - name: mariadb
     version: 1.0.5

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://code.castopod.org/adaures/castopod
 icon: https://helmforge.dev/icons/charts/castopod.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://castopod.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/castopod
     - name: Source

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -33,3 +33,10 @@ annotations:
       url: https://helmforge.dev/docs/charts/changedetection
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/changedetection
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: changedetection
+      image: ghcr.io/dgtlmoon/changedetection.io:0.54.7
+    - name: browser
+      image: docker.io/browserless/chrome:latest

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/dgtlmoon/changedetection.io
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://changedetection.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/changedetection
     - name: Source

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -34,6 +34,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/chiefonboarding
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/chiefonboarding
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: chiefonboarding
+      image: docker.io/chiefonboarding/chiefonboarding:2.4.1
 dependencies:
   - name: postgresql
     version: 1.8.4

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/chiefonboarding/ChiefOnboarding
 icon: https://helmforge.dev/icons/charts/chiefonboarding.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://chiefonboarding.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/chiefonboarding
     - name: Source

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -21,9 +21,16 @@ sources:
   - https://github.com/ckan/ckan
 icon: https://helmforge.dev/icons/charts/ckan.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://ckan.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/ckan
     - name: Source

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -28,6 +28,15 @@ annotations:
       url: https://helmforge.dev/docs/charts/ckan
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/ckan
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: ckan
+      image: docker.io/ckan/ckan-base:2.11.4
+    - name: datapusher
+      image: docker.io/ckan/ckan-base-datapusher:0.0.21
+    - name: solr
+      image: docker.io/ckan/ckan-solr:2.11-solr9
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -21,6 +21,7 @@ sources:
   - https://github.com/cloudflare/cloudflared
 icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
+  artifacthub.io/alternativeName: "cloudflare"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -34,3 +35,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/cloudflared
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/cloudflared
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: cloudflared
+      image: docker.io/cloudflare/cloudflared:2026.3.0
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/pihole
+    - url: https://artifacthub.io/packages/helm/helmforge/adguard-home

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/cloudflare/cloudflared
 icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "cloudflare"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
@@ -31,6 +36,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
     - name: Documentation
       url: https://helmforge.dev/docs/charts/cloudflared
     - name: Source

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -40,3 +40,10 @@ annotations:
       url: https://helmforge.dev/docs/charts/countly
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/countly
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: countly
+      image: docker.io/countly/countly-server:25.03.41
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/mongodb

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -27,6 +27,11 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -36,6 +41,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://count.ly
     - name: Documentation
       url: https://helmforge.dev/docs/charts/countly
     - name: Source

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/jhuckaby/Cronicle
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/jhuckaby/Cronicle
     - name: Documentation
       url: https://helmforge.dev/docs/charts/cronicle
     - name: Source

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -34,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/cronicle
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/cronicle
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: cronicle
+      image: docker.io/soulteary/cronicle:0.9.80

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -35,3 +35,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/ddns-updater
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/ddns-updater
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: ddns-updater
+      image: docker.io/qmcgaw/ddns-updater:2.9.0

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -22,6 +22,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/qdm12/ddns-updater
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -31,6 +36,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/qdm12/ddns-updater
     - name: Documentation
       url: https://helmforge.dev/docs/charts/ddns-updater
     - name: Source

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/Cybrarist/Discount-Bandit
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/Cybrarist/Discount-Bandit
     - name: Documentation
       url: https://helmforge.dev/docs/charts/discount-bandit
     - name: Source

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -22,6 +22,9 @@ sources:
 annotations:
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/prerelease: "true"
@@ -30,3 +33,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/discount-bandit
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/discount-bandit
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: discount-bandit
+      image: docker.io/cybrarist/discount-bandit:4.0.3

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -23,9 +23,16 @@ sources:
   - https://github.com/docmost/docmost
   - https://docmost.com/docs
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://docmost.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/docmost
     - name: Source

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -30,12 +30,20 @@ annotations:
       url: https://helmforge.dev/docs/charts/docmost
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/docmost
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: docmost
+      image: docker.io/docmost/docmost:0.70.3
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -35,6 +35,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/dolibarr
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/dolibarr
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: dolibarr
+      image: docker.io/dolibarr/dolibarr:23.0.0
 dependencies:
   - name: mysql
     version: 1.7.1

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -22,6 +22,11 @@ sources:
   - https://hub.docker.com/r/dolibarr/dolibarr
   - https://github.com/Dolibarr/dolibarr
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   helmforge.dev/maturity: stable
@@ -31,6 +36,8 @@ annotations:
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.dolibarr.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/dolibarr
     - name: Source

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -28,12 +28,20 @@ annotations:
       url: https://helmforge.dev/docs/charts/druid
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/druid
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: druid
+      image: docker.io/apache/druid:36.0.0
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/kafka
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
     version: 1.8.3

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -21,9 +21,16 @@ sources:
   - https://github.com/apache/druid
 icon: https://helmforge.dev/icons/charts/druid.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://druid.apache.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/druid
     - name: Source

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -23,9 +23,16 @@ sources:
   - https://github.com/FlowiseAI/Flowise
   - https://docs.flowiseai.com/
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://flowiseai.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/flowise
     - name: Source

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -30,12 +30,20 @@ annotations:
       url: https://helmforge.dev/docs/charts/flowise
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/flowise
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: flowise
+      image: docker.io/flowiseai/flowise:3.1.1
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -10,6 +10,11 @@ appVersion: "1.0.0"
 icon: https://helmforge.dev/icons/charts/generic.png
 kubeVersion: ">=1.26.0-0"
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -25,3 +25,5 @@ annotations:
       url: https://helmforge.dev/docs/charts/generic
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/generic
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -22,6 +22,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/TryGhost/Ghost
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -31,6 +36,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://ghost.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/ghost
     - name: Source

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -35,6 +35,13 @@ annotations:
       url: https://helmforge.dev/docs/charts/ghost
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/ghost
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: ghost
+      image: docker.io/library/ghost:6.25.1
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
     version: 1.7.4

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -20,9 +20,16 @@ sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/gitea
   - https://github.com/go-gitea/gitea
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://gitea.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/gitea
     - name: Source

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -27,12 +27,19 @@ annotations:
       url: https://helmforge.dev/docs/charts/gitea
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/gitea
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: gitea
+      image: docker.io/gitea/gitea:1.25.5
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -24,6 +24,11 @@ sources:
   - https://github.com/apache/guacamole-client
 icon: https://helmforge.dev/icons/charts/guacamole.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -33,6 +38,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://guacamole.apache.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/guacamole
     - name: Source

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -37,6 +37,15 @@ annotations:
       url: https://helmforge.dev/docs/charts/guacamole
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/guacamole
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: guacamole
+      image: docker.io/guacamole/guacamole:1.6.0
+    - name: guacd
+      image: docker.io/guacamole/guacd:1.6.0
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/linuxserver/Heimdall
 icon: https://helmforge.dev/icons/charts/heimdall.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   helmforge.dev/maturity: stable
@@ -30,6 +35,8 @@ annotations:
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://heimdall.site
     - name: Documentation
       url: https://helmforge.dev/docs/charts/heimdall
     - name: Source

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -34,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/heimdall
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/heimdall
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: heimdall
+      image: docker.io/linuxserver/heimdall:2.7.6

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -19,9 +19,16 @@ sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/homarr
   - https://github.com/homarr-labs/homarr
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://homarr.dev
     - name: Documentation
       url: https://helmforge.dev/docs/charts/homarr
     - name: Source

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -26,12 +26,19 @@ annotations:
       url: https://helmforge.dev/docs/charts/homarr
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/homarr
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: homarr
+      image: ghcr.io/homarr-labs/homarr:1.57.1
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -33,3 +33,12 @@ annotations:
       url: https://helmforge.dev/docs/charts/kafka
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/kafka
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: kafka
+      image: docker.io/apache/kafka:4.2.0
+    - name: jmx-exporter
+      image: docker.io/bitnami/jmx-exporter:1.5.0
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/druid

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/apache/kafka
 icon: https://helmforge.dev/icons/charts/kafka.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://kafka.apache.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/kafka
     - name: Source

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -22,6 +22,9 @@ sources:
 annotations:
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/prerelease: "true"
@@ -30,3 +33,12 @@ annotations:
       url: https://helmforge.dev/docs/charts/karakeep
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/karakeep
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: karakeep
+      image: ghcr.io/karakeep-app/karakeep:0.24.1
+    - name: meilisearch
+      image: docker.io/getmeili/meilisearch:v1.13.3
+    - name: chromium
+      image: ghcr.io/browserless/chromium:v2.18.0

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/karakeep-app/karakeep
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: alpha
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://karakeep.app
     - name: Documentation
       url: https://helmforge.dev/docs/charts/karakeep
     - name: Source

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -15,6 +15,11 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -24,6 +29,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: security
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.keycloak.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/keycloak
     - name: Source

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -28,6 +28,16 @@ annotations:
       url: https://helmforge.dev/docs/charts/keycloak
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/keycloak
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: keycloak
+      image: quay.io/keycloak/keycloak:26.5.5
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/authelia
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/gotson/komga
 icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: storage
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://komga.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/komga
     - name: Source

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -34,3 +34,12 @@ annotations:
       url: https://helmforge.dev/docs/charts/komga
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/komga
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: komga
+      image: docker.io/gotson/komga:1.24.1
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    - name: backup-archiver
+      image: docker.io/library/alpine:3.22

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/explodingcamera/liwan
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://liwan.dev
     - name: Documentation
       url: https://helmforge.dev/docs/charts/liwan
     - name: Source

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -34,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/liwan
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/liwan
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: liwan
+      image: ghcr.io/explodingcamera/liwan:1.4.0

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -18,6 +18,11 @@ sources:
   - https://hub.docker.com/_/mariadb
 icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "maria"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
@@ -28,6 +33,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://mariadb.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/mariadb
     - name: Source

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -18,6 +18,7 @@ sources:
   - https://hub.docker.com/_/mariadb
 icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
+  artifacthub.io/alternativeName: "maria"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -31,3 +32,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/mariadb
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/mariadb
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: mariadb
+      image: docker.io/library/mariadb:11.4
+    - name: mysqld-exporter
+      image: docker.io/prom/mysqld-exporter:v0.17.2
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/phpmyadmin

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/metabase/metabase
 icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.metabase.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/metabase
     - name: Source

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -34,6 +34,13 @@ annotations:
       url: https://helmforge.dev/docs/charts/metabase
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/metabase
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: metabase
+      image: docker.io/metabase/metabase:0.54.5
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
     version: 1.8.2

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -44,3 +44,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/middleware
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/middleware
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: middleware
+      image: docker.io/middlewareeng/middleware:0.3.1

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -31,6 +31,11 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -40,6 +45,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.middlewarehq.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/middleware
     - name: Source

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -36,3 +36,10 @@ annotations:
       url: https://helmforge.dev/docs/charts/minecraft
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/minecraft
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: minecraft
+      image: docker.io/itzg/minecraft-server:java21
+    - name: mc-monitor
+      image: docker.io/itzg/mc-monitor:0.16.1

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -23,6 +23,11 @@ sources:
   - https://hub.docker.com/r/itzg/minecraft-server
 icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -32,6 +37,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.minecraft.net
     - name: Documentation
       url: https://helmforge.dev/docs/charts/minecraft
     - name: Source

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://hub.docker.com/_/mongo
 icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "mongo"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.mongodb.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/mongodb
     - name: Source

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -20,6 +20,7 @@ sources:
   - https://hub.docker.com/_/mongo
 icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
+  artifacthub.io/alternativeName: "mongo"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -33,3 +34,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/mongodb
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/mongodb
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: mongodb
+      image: docker.io/library/mongo:8.2.6
+    - name: mongodb-exporter
+      image: docker.io/percona/mongodb_exporter:0.49.0
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/countly

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -34,3 +34,10 @@ annotations:
       url: https://helmforge.dev/docs/charts/mosquitto
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/mosquitto
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: mosquitto
+      image: docker.io/library/eclipse-mosquitto:2.0.22
+    - name: mqttx-web
+      image: docker.io/emqx/mqttx-web:2.0.22

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://hub.docker.com/_/eclipse-mosquitto
   - https://github.com/eclipse-mosquitto/mosquitto
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging
   helmforge.dev/maturity: stable
@@ -30,6 +35,8 @@ annotations:
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://mosquitto.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/mosquitto
     - name: Source

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -31,3 +31,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/mysql
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/mysql
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: mysql
+      image: docker.io/library/mysql:8.4
+    - name: mysqld-exporter
+      image: docker.io/prom/mysqld-exporter:v0.17.2
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/phpmyadmin

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -18,6 +18,11 @@ sources:
   - https://hub.docker.com/_/mysql
 icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -27,6 +32,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.mysql.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/mysql
     - name: Source

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -33,6 +33,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/n8n
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/n8n
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: n8n
+      image: docker.io/n8nio/n8n:2.12.3
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/n8n-io/n8n
 icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://n8n.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/n8n
     - name: Source

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/binwiederhier/ntfy
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://ntfy.sh
     - name: Documentation
       url: https://helmforge.dev/docs/charts/ntfy
     - name: Source

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -34,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/ntfy
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/ntfy
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: ntfy
+      image: docker.io/binwiederhier/ntfy:2.21.0

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -34,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/olivetin
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/olivetin
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: olivetin
+      image: docker.io/jamesread/olivetin:3000.11.3

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/OliveTin/OliveTin
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.olivetin.app
     - name: Documentation
       url: https://helmforge.dev/docs/charts/olivetin
     - name: Source

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -24,9 +24,16 @@ sources:
   - https://github.com/open-webui/open-webui
   - https://docs.openwebui.com/
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://openwebui.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/open-webui
     - name: Source

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -31,8 +31,19 @@ annotations:
       url: https://helmforge.dev/docs/charts/open-webui
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/open-webui
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: open-webui
+      image: ghcr.io/open-webui/open-webui:0.8.12
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
     version: 1.8.3

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -35,3 +35,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/phpmyadmin
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/phpmyadmin
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: phpmyadmin
+      image: docker.io/phpmyadmin/phpmyadmin:5.2.3
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/mysql
+    - url: https://artifacthub.io/packages/helm/helmforge/mariadb

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -22,6 +22,11 @@ sources:
   - https://github.com/phpmyadmin/phpmyadmin
 icon: https://helmforge.dev/icons/charts/phpmyadmin.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   helmforge.dev/maturity: stable
@@ -31,6 +36,8 @@ annotations:
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.phpmyadmin.net
     - name: Documentation
       url: https://helmforge.dev/docs/charts/phpmyadmin
     - name: Source

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -34,3 +34,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/pihole
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/pihole
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: pihole
+      image: docker.io/pihole/pihole:2025.03.0
+    - name: pihole-exporter
+      image: docker.io/ekofr/pihole-exporter:v0.4.0
+    - name: unbound
+      image: docker.io/mvance/unbound:1.22.0
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/cloudflared

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://hub.docker.com/r/pihole/pihole
 icon: https://helmforge.dev/icons/charts/pihole.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: networking
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://pi-hole.net
     - name: Documentation
       url: https://helmforge.dev/docs/charts/pihole
     - name: Source

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -19,6 +19,7 @@ sources:
   - https://hub.docker.com/_/postgres
 icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
+  artifacthub.io/alternativeName: "postgres"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -32,3 +33,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/postgresql
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/postgresql
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: postgresql
+      image: docker.io/library/postgres:18.3-trixie
+    - name: postgres-exporter
+      image: quay.io/prometheuscommunity/postgres-exporter:v0.18.0
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/metabase

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -19,6 +19,11 @@ sources:
   - https://hub.docker.com/_/postgres
 icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "postgres"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.postgresql.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/postgresql
     - name: Source

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -20,6 +20,7 @@ sources:
   - https://github.com/docker-library/rabbitmq
 icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
+  artifacthub.io/alternativeName: "rabbit"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -33,3 +34,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/rabbitmq
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/rabbitmq
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: rabbitmq
+      image: docker.io/library/rabbitmq:4.2.4-management

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/docker-library/rabbitmq
 icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "rabbit"
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: streaming-messaging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.rabbitmq.com
     - name: Documentation
       url: https://helmforge.dev/docs/charts/rabbitmq
     - name: Source

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -33,3 +33,12 @@ annotations:
       url: https://helmforge.dev/docs/charts/redis
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/redis
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: redis
+      image: docker.io/library/redis:8.6.0
+    - name: redis-exporter
+      image: docker.io/oliver006/redis_exporter:v1.69.0
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/uptime-kuma

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://hub.docker.com/_/redis
 icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: database
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://redis.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/redis
     - name: Source

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -21,6 +21,11 @@ sources:
   - https://github.com/strapi/strapi
 icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -30,6 +35,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://strapi.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/strapi
     - name: Source

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -34,6 +34,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/strapi
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/strapi
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: strapi
+      image: docker.io/vshadbolt/strapi:5.40.0
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -35,3 +35,8 @@ annotations:
       url: https://helmforge.dev/docs/charts/strava-statistics
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: strava-statistics
+      image: docker.io/robiningelbrecht/strava-statistics:4.7.5

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -22,6 +22,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/robiningelbrecht/strava-statistics
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -31,6 +36,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/robiningelbrecht/strava-statistics
     - name: Documentation
       url: https://helmforge.dev/docs/charts/strava-statistics
     - name: Source

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -29,12 +29,20 @@ annotations:
       url: https://helmforge.dev/docs/charts/superset
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/superset
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: superset
+      image: docker.io/apache/superset:4.1.4
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
     version: 1.8.3

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -22,9 +22,16 @@ sources:
   - https://github.com/apache/superset
 icon: https://helmforge.dev/icons/charts/superset.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://superset.apache.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/superset
     - name: Source

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -33,6 +33,11 @@ annotations:
       url: https://helmforge.dev/docs/charts/umami
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/umami
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: umami
+      image: ghcr.io/umami-software/umami:2.17.0
 dependencies:
   - name: postgresql
     version: 1.8.2

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/umami-software/umami
 icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://umami.is
     - name: Documentation
       url: https://helmforge.dev/docs/charts/umami
     - name: Source

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -33,6 +33,13 @@ annotations:
       url: https://helmforge.dev/docs/charts/uptime-kuma
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: uptime-kuma
+      image: docker.io/louislam/uptime-kuma:2.2.1
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
 dependencies:
   - name: mysql
     version: 1.7.1

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/louislam/uptime-kuma
 icon: https://helmforge.dev/icons/charts/uptime-kuma.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://uptime.kuma.pet
     - name: Documentation
       url: https://helmforge.dev/docs/charts/uptime-kuma
     - name: Source

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -19,6 +19,11 @@ sources:
   - https://github.com/dani-garcia/vaultwarden
 icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -28,6 +33,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: security
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/dani-garcia/vaultwarden
     - name: Documentation
       url: https://helmforge.dev/docs/charts/vaultwarden
     - name: Source

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -32,6 +32,15 @@ annotations:
       url: https://helmforge.dev/docs/charts/vaultwarden
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/vaultwarden
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: vaultwarden
+      image: docker.io/vaultwarden/server:1.35.4
+    - name: backup-uploader
+      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    - name: backup-archiver
+      image: docker.io/library/alpine:3.22
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/vmware-tanzu/velero
 icon: https://helmforge.dev/icons/charts/velero.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: storage
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://velero.io
     - name: Documentation
       url: https://helmforge.dev/docs/charts/velero
     - name: Source

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -33,3 +33,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/velero
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/velero
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: velero
+      image: docker.io/velero/velero:v1.18.0
+    - name: velero-plugin-aws
+      image: docker.io/velero/velero-plugin-for-aws:v1.14.0
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/mongodb
+    - url: https://artifacthub.io/packages/helm/helmforge/mysql

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -33,6 +33,14 @@ annotations:
       url: https://helmforge.dev/docs/charts/wallabag
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/wallabag
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: wallabag
+      image: docker.io/wallabag/wallabag:2.6.14
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
     version: 1.8.2

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://github.com/wallabag/wallabag
 icon: https://helmforge.dev/icons/charts/wallabag.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://wallabag.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/wallabag
     - name: Source

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -33,6 +33,15 @@ annotations:
       url: https://helmforge.dev/docs/charts/wordpress
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/wordpress
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: wordpress
+      image: docker.io/library/wordpress:6.9.4
+    - name: apache-exporter
+      image: docker.io/lusotycoon/apache-exporter:v1.0.8
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
     version: 1.7.1

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -20,6 +20,11 @@ sources:
   - https://hub.docker.com/_/wordpress
 icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
   helmforge.dev/signed: cosign
   artifacthub.io/signKey: |
@@ -29,6 +34,8 @@ annotations:
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
+    - name: Official Website
+      url: https://wordpress.org
     - name: Documentation
       url: https://helmforge.dev/docs/charts/wordpress
     - name: Source


### PR DESCRIPTION
## Summary

- Add `artifacthub.io/images` to 55 charts (all except generic) listing all container images for ArtifactHub security vulnerability scanning
- Add `artifacthub.io/links` `support` entry to all 56 charts for issue reporting button on ArtifactHub
- Add `artifacthub.io/signKey` with GPG fingerprint and public key URL to 5 charts that were missing it
- Add `artifacthub.io/alternativeName` to 5 charts: postgresql→postgres, mongodb→mongo, mariadb→maria, rabbitmq→rabbit, cloudflared→cloudflare
- Add `artifacthub.io/recommendations` to 26 charts with cross-links to related HelmForge charts
- Add `artifacthub.io/changes` YAML auto-generation in publish workflow from conventional commits
- Improve provenance file handling with better diagnostics and `find`-based copying
- Update README signing description to include GPG provenance alongside Cosign

## Test plan

- [x] `helm lint --strict` passes for all 56 charts
- [ ] CI passes (lint, template, unittest, kubeconform)
- [ ] After merge, trigger `workflow_dispatch` to republish with new annotations
- [ ] Verify ArtifactHub shows images, support link, recommendations, and changelog
- [ ] Verify provenance files land in gh-pages after publish