### PR TITLE
refactor(repo): standardize home url to helmforge.dev across all charts

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - dhcp
   - dns-over-https
   - dns-over-tls
-home: https://helmforge.dev/docs/charts/adguard-home
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/adguard-home
   - https://github.com/AdguardTeam/AdGuardHome

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - conference
   - alfio
   - self-hosted
-home: https://alf.io
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/alfio-event/alf.io

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - forum
   - knowledge-base
   - community
-home: https://helmforge.dev/docs/charts/answer
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/answer
   - https://github.com/apache/answer

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.1.1
 appVersion: "1.8.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/appwrite.png
-home: https://appwrite.io
+home: https://helmforge.dev
 keywords:
   - appwrite
   - baas

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: archivebox
+      image: docker.io/archivebox/archivebox:0.7.3

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - chromium
   - self-hosted
 icon: https://helmforge.dev/icons/charts/archivebox.png
-home: https://archivebox.io
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/ArchiveBox/ArchiveBox

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - mfa
   - oidc
   - forward-auth
-home: https://helmforge.dev/docs/charts/authelia
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/authelia
   - https://github.com/authelia/authelia

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - zapier
   - automatisch
   - self-hosted
-home: https://automatisch.io
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/automatisch/automatisch

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - castopod
   - fediverse
   - self-hosted
-home: https://castopod.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://code.castopod.org/adaures/castopod

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -49,3 +49,4 @@ annotations:
     - name: changedetection
       image: ghcr.io/dgtlmoon/changedetection.io:0.54.7
     - name: browser
+      image: docker.io/browserless/chrome:latest

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - notifications
   - self-hosted
 icon: https://helmforge.dev/icons/charts/changedetection.png
-home: https://changedetection.io
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/dgtlmoon/changedetection.io

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - automation
   - chiefonboarding
   - self-hosted
-home: https://chiefonboarding.com
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/chiefonboarding/ChiefOnboarding

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - open-data
   - catalog
   - api
-home: https://helmforge.dev/docs/charts/ckan
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/ckan
   - https://github.com/ckan/ckan

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - zero-trust
   - ingress
   - networking
-home: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/cloudflare/cloudflared

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - push-notifications
   - self-hosted
 icon: https://helmforge.dev/icons/charts/countly.png
-home: https://count.ly
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/Countly/countly-server

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - job-scheduler
   - self-hosted
 icon: https://helmforge.dev/icons/charts/cronicle.png
-home: https://github.com/jhuckaby/Cronicle
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/jhuckaby/Cronicle

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: cronicle
+      image: docker.io/soulteary/cronicle:0.9.80

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -49,3 +49,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: ddns-updater
+      image: docker.io/qmcgaw/ddns-updater:2.9.0

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - duckdns
   - namecheap
   - self-hosted
-home: https://github.com/qdm12/ddns-updater
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/qdm12/ddns-updater

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - shopping
   - discount-bandit
   - self-hosted
-home: https://github.com/Cybrarist/Discount-Bandit
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/Cybrarist/Discount-Bandit

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -47,3 +47,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: discount-bandit
+      image: docker.io/cybrarist/discount-bandit:4.0.3

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.1.1
 appVersion: "0.70.3"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/docmost.png
-home: https://helmforge.dev/docs/charts/docmost
+home: https://helmforge.dev
 keywords:
   - docmost
   - wiki

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - php
   - mysql
   - mariadb
-home: https://www.dolibarr.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/dolibarr/dolibarr

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - database
   - realtime
   - query
-home: https://helmforge.dev/docs/charts/druid
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/druid
   - https://github.com/apache/druid

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.2.1
 appVersion: "3.1.1"
 kubeVersion: ">=1.26.0-0"
-home: https://helmforge.dev/docs/charts/flowise
+home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/flowise.png
 keywords:
   - flowise

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,6 +7,7 @@ maintainers:
   - name: mberlofa
 version: 1.9.1
 appVersion: "1.0.0"
+home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic.png
 kubeVersion: ">=1.26.0-0"
 annotations:

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - newsletter
   - self-hosted
 icon: https://helmforge.dev/icons/charts/ghost.png
-home: https://ghost.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/TryGhost/Ghost

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -4,7 +4,7 @@ description: Gitea — self-hosted Git service with SQLite, PostgreSQL, or MySQL
 type: application
 version: 1.1.1
 appVersion: "1.25.5"
-home: https://helmforge.dev/docs/charts/gitea
+home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
   - gitea

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - gateway
   - oidc
   - saml
-home: https://guacamole.apache.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/apache/guacamole-server

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - homepage
   - launcher
   - self-hosted
-home: https://heimdall.site
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/linuxserver/heimdall

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: heimdall
+      image: docker.io/linuxserver/heimdall:2.7.6

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Homarr — modern application dashboard with SQLite, PostgreSQL, or
 type: application
 version: 1.1.1
 appVersion: "1.57.1"
-home: https://helmforge.dev/docs/charts/homarr
+home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
 keywords:
   - homarr

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - messaging
   - kraft
   - eventing
-home: https://kafka.apache.org/
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/apache/kafka

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -51,3 +51,4 @@ annotations:
     - name: meilisearch
       image: docker.io/getmeili/meilisearch:v1.13.3
     - name: chromium
+      image: ghcr.io/browserless/chromium:v2.18.0

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - archiving
   - karakeep
   - self-hosted
-home: https://karakeep.app
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/karakeep-app/karakeep

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: keycloak
 description: Keycloak for Kubernetes with explicit dev and production modes
+home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 2.7.1

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -52,3 +52,4 @@ annotations:
     - name: backup-uploader
       image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
     - name: backup-archiver
+      image: docker.io/library/alpine:3.22

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - media-server
   - opds
   - self-hosted
-home: https://komga.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/gotson/komga

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - duckdb
   - self-hosted
 icon: https://helmforge.dev/icons/charts/liwan.png
-home: https://liwan.dev
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/explodingcamera/liwan

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: liwan
+      image: ghcr.io/explodingcamera/liwan:1.4.0

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - mariadb
   - database
   - replication
-home: https://mariadb.org/
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/mariadb

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - dashboard
   - visualization
   - self-hosted
-home: https://www.metabase.com
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/metabase/metabase

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - performance
   - self-hosted
 icon: https://helmforge.dev/icons/charts/middleware.png
-home: https://www.middlewarehq.com
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/middlewarehq/middleware

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -58,3 +58,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: middleware
+      image: docker.io/middlewareeng/middleware:0.3.1

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - fabric
   - geyser
   - bedrock
-home: https://www.minecraft.net
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/itzg/minecraft-server

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -52,3 +52,4 @@ annotations:
     - name: minecraft
       image: docker.io/itzg/minecraft-server:java21
     - name: mc-monitor
+      image: docker.io/itzg/mc-monitor:0.16.1

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - nosql
   - replicaset
   - sharded
-home: https://www.mongodb.com
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/mongo

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - broker
   - websocket
   - mqttx
-home: https://mosquitto.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/eclipse-mosquitto

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -50,3 +50,4 @@ annotations:
     - name: mosquitto
       image: docker.io/library/eclipse-mosquitto:2.0.22
     - name: mqttx-web
+      image: docker.io/emqx/mqttx-web:latest

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - mysql
   - database
   - replication
-home: https://www.mysql.com/
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/mysql

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - automation
   - integration
   - low-code
-home: https://helmforge.dev/docs/charts/n8n
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/n8n
   - https://github.com/n8n-io/n8n

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - self-hosted
   - alerting
 icon: https://helmforge.dev/icons/charts/ntfy.png
-home: https://ntfy.sh
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/binwiederhier/ntfy

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: ntfy
+      image: docker.io/binwiederhier/ntfy:2.21.0

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: olivetin
+      image: docker.io/jamesread/olivetin:3000.11.3

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - web-ui
   - self-hosted
 icon: https://helmforge.dev/icons/charts/olivetin.png
-home: https://www.olivetin.app
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/OliveTin/OliveTin

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 1.2.1
 appVersion: "0.8.12"
 kubeVersion: ">=1.26.0-0"
-home: https://helmforge.dev/docs/charts/open-webui
+home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/open-webui.png
 keywords:
   - open-webui

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - database
   - admin
   - web-ui
-home: https://www.phpmyadmin.net
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/phpmyadmin/phpmyadmin

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - network
   - dnsmasq
   - unbound
-home: https://pi-hole.net
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/pihole/pihole

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - postgres
   - database
   - replication
-home: https://www.postgresql.org/
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/postgres

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -48,3 +48,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: rabbitmq
+      image: docker.io/library/rabbitmq:4.2.4-management

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - messaging
   - queue
   - cluster
-home: https://www.rabbitmq.com/
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/docker-library/rabbitmq

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - datastore
   - sentinel
   - cluster
-home: https://redis.io
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/redis

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - nodejs
   - postgresql
   - mysql
-home: https://helmforge.dev/docs/charts/strapi
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/strapi
   - https://github.com/strapi/strapi

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - running
   - self-hosted
 icon: https://helmforge.dev/icons/charts/strava-statistics.png
-home: https://github.com/robiningelbrecht/strava-statistics
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/robiningelbrecht/strava-statistics

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -49,3 +49,4 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: strava-statistics
+      image: docker.io/robiningelbrecht/strava-statistics:4.7.5

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - dashboard
   - sql
   - celery
-home: https://helmforge.dev/docs/charts/superset
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/superset
   - https://github.com/apache/superset

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - privacy
   - umami
   - self-hosted
-home: https://umami.is
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/umami-software/umami

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - status-page
   - health-check
   - self-hosted
-home: https://uptime.kuma.pet
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/louislam/uptime-kuma

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - bitwarden
   - password-manager
   - self-hosted
-home: https://github.com/dani-garcia/vaultwarden
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/dani-garcia/vaultwarden

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - restore
   - disaster-recovery
   - kubernetes
-home: https://velero.io
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/vmware-tanzu/velero

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - bookmarks
   - articles
   - self-hosted
-home: https://wallabag.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/wallabag/wallabag

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - blog
   - php
   - mysql
-home: https://wordpress.org
+home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/wordpress


### PR DESCRIPTION
## Summary
- Set `home: https://helmforge.dev` on all 56 charts for consistent ArtifactHub discovery
- Added missing `home:` field to `generic` and `keycloak` charts
- Official product links remain in `artifacthub.io/links` as `Official Website`

## Test plan
- [ ] CI lint passes on all charts
- [ ] Verify `home:` field renders correctly on ArtifactHub after sync