### PR TITLE
feat(listmonk): add dedicated listmonk helm chart

### DIFF
--- a/charts/listmonk/Chart.lock
+++ b/charts/listmonk/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.9.1
+digest: sha256:a7bb45c41c1b64493c1e09a08e99dd8f741d7f7e3e78da1b73bedc7e45d45ae3
+generated: "2026-04-03T21:03:36.835227-03:00"

--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -1,0 +1,56 @@
+apiVersion: v2
+name: listmonk
+description: Listmonk self-hosted newsletter and mailing list manager with PostgreSQL
+type: application
+version: 0.1.0
+appVersion: "6.1.0"
+kubeVersion: ">=1.26.0-0"
+icon: https://helmforge.dev/icons/charts/listmonk.png
+home: https://helmforge.dev
+keywords:
+  - listmonk
+  - newsletter
+  - mailing-list
+  - email
+  - smtp
+  - campaigns
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/knadh/listmonk
+annotations:
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  artifacthub.io/license: MIT
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://listmonk.app
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/listmonk
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/listmonk
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/images: |
+    - name: listmonk
+      image: docker.io/listmonk/listmonk:v6.1.0
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+  artifacthub.io/prerelease: "true"
+  helmforge.dev/maturity: alpha
+  helmforge.dev/signed: gpg+cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
+dependencies:
+  - name: postgresql
+    version: 1.9.1
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled

--- a/charts/listmonk/README.md
+++ b/charts/listmonk/README.md
@@ -1,0 +1,159 @@
+# Listmonk Helm Chart
+
+Self-hosted newsletter and mailing list manager for Kubernetes.
+
+[Listmonk](https://listmonk.app) is a high-performance, self-hosted newsletter and mailing list manager. It comes as a single binary with a built-in web UI for managing subscribers, campaigns, templates, and transactional emails.
+
+## Features
+
+- Bundled PostgreSQL via HelmForge subchart or external database support
+- Automatic database initialization and migration on startup
+- Persistent storage for media uploads
+- Configurable ingress with TLS support
+- Built-in PostgreSQL backup CronJob with S3 upload
+- Admin credentials managed via Kubernetes Secrets
+- SMTP configuration through the admin UI after installation
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install listmonk helmforge/listmonk
+```
+
+## Quick Start
+
+### Default install (bundled PostgreSQL)
+
+```bash
+helm install listmonk helmforge/listmonk
+```
+
+### External PostgreSQL
+
+```bash
+helm install listmonk helmforge/listmonk \
+  --set postgresql.enabled=false \
+  --set database.mode=external \
+  --set database.external.host=pg.example.com \
+  --set database.external.password=changeme
+```
+
+### With ingress
+
+```bash
+helm install listmonk helmforge/listmonk \
+  --set ingress.enabled=true \
+  --set ingress.ingressClassName=traefik \
+  --set "ingress.hosts[0].host=listmonk.example.com" \
+  --set "ingress.hosts[0].paths[0].path=/" \
+  --set "ingress.hosts[0].paths[0].pathType=Prefix"
+```
+
+## Configuration
+
+SMTP and most application settings are configured through the Listmonk admin UI after installation at **Settings > SMTP**. The Helm chart handles infrastructure-level configuration (database, storage, ingress, probes).
+
+### Admin Credentials
+
+By default, the chart creates an admin user with username `admin` and an auto-generated password stored in a Kubernetes Secret. To set custom credentials:
+
+```yaml
+listmonk:
+  adminUser: myadmin
+  adminPassword: mysecurepassword
+```
+
+Or use an existing secret:
+
+```yaml
+listmonk:
+  existingSecret: my-listmonk-secret
+  existingSecretUserKey: admin-user
+  existingSecretPasswordKey: admin-password
+```
+
+### Database Initialization
+
+The chart automatically runs `--install --idempotent --yes` and `--upgrade --yes` as init containers before the main application starts. This handles both fresh installs and upgrades.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `replicaCount` | int | `1` | Number of replicas |
+| `image.repository` | string | `docker.io/listmonk/listmonk` | Image repository |
+| `image.tag` | string | `""` | Image tag (defaults to appVersion) |
+| `image.pullPolicy` | string | `IfNotPresent` | Pull policy |
+| `listmonk.adminUser` | string | `""` | Admin username (defaults to `admin`) |
+| `listmonk.adminPassword` | string | `""` | Admin password (auto-generated if empty) |
+| `listmonk.existingSecret` | string | `""` | Existing secret for admin credentials |
+| `listmonk.extraEnv` | list | `[]` | Additional environment variables |
+| `database.mode` | string | `auto` | Database mode: `auto`, `external`, `postgresql` |
+| `database.external.host` | string | `""` | External PostgreSQL hostname |
+| `database.external.port` | int | `5432` | External PostgreSQL port |
+| `database.external.name` | string | `listmonk` | External database name |
+| `database.external.username` | string | `listmonk` | External database username |
+| `database.external.password` | string | `""` | External database password |
+| `database.external.sslMode` | string | `disable` | PostgreSQL SSL mode |
+| `database.external.existingSecret` | string | `""` | Existing secret for database password |
+| `postgresql.enabled` | bool | `true` | Deploy PostgreSQL subchart |
+| `postgresql.auth.database` | string | `listmonk` | PostgreSQL database name |
+| `postgresql.auth.username` | string | `listmonk` | PostgreSQL username |
+| `storage.enabled` | bool | `true` | Enable persistent uploads storage |
+| `storage.size` | string | `5Gi` | Uploads PVC size |
+| `storage.existingClaim` | string | `""` | Use existing PVC |
+| `backup.enabled` | bool | `false` | Enable backup CronJob |
+| `backup.schedule` | string | `0 3 * * *` | Backup cron schedule |
+| `service.type` | string | `ClusterIP` | Service type |
+| `service.port` | int | `80` | Service port |
+| `ingress.enabled` | bool | `false` | Enable ingress |
+| `ingress.ingressClassName` | string | `""` | Ingress class (`traefik`, `nginx`, etc.) |
+| `ingress.hosts` | list | `[]` | Ingress hosts |
+| `ingress.tls` | list | `[]` | Ingress TLS configuration |
+
+## Backup
+
+Enable PostgreSQL backups to S3-compatible storage:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    prefix: listmonk
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+Or use an existing secret:
+
+```yaml
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    existingSecret: my-s3-credentials
+```
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Listmonk Helm Chart
+description: Helm chart for deploying Listmonk newsletter and mailing list manager on Kubernetes
+
+keywords: listmonk, newsletter, mailing-list, email, helm, kubernetes
+
+purpose: Installation and configuration guide for the Listmonk Helm chart
+scope: Chart Documentation
+
+relations:
+  - charts/listmonk/values.yaml
+  - charts/listmonk/Chart.yaml
+path: charts/listmonk/README.md
+version: 1.0
+date: 2026-04-03
+-->

--- a/charts/listmonk/ci/default-values.yaml
+++ b/charts/listmonk/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default values (standalone with bundled PostgreSQL)

--- a/charts/listmonk/ci/external-db-values.yaml
+++ b/charts/listmonk/ci/external-db-values.yaml
@@ -1,0 +1,13 @@
+# CI: external PostgreSQL database
+postgresql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: listmonk
+    username: listmonk
+    password: changeme
+    sslMode: require

--- a/charts/listmonk/ci/ingress-values.yaml
+++ b/charts/listmonk/ci/ingress-values.yaml
@@ -1,0 +1,13 @@
+# CI: ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: listmonk.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: listmonk-tls
+      hosts:
+        - listmonk.example.com

--- a/charts/listmonk/templates/NOTES.txt
+++ b/charts/listmonk/templates/NOTES.txt
@@ -1,0 +1,16 @@
+Listmonk has been deployed.
+
+{{- if .Values.ingress.enabled }}
+Access Listmonk at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+To access the Listmonk admin UI, run:
+
+  kubectl port-forward svc/{{ include "listmonk.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+Then open http://localhost:{{ .Values.service.port }} in your browser.
+{{- end }}
+
+Configure SMTP and other settings through the admin UI at Settings > SMTP.

--- a/charts/listmonk/templates/_helpers.tpl
+++ b/charts/listmonk/templates/_helpers.tpl
@@ -1,0 +1,176 @@
+{{- define "listmonk.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "listmonk.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "listmonk.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "listmonk.labels" -}}
+helm.sh/chart: {{ include "listmonk.chart" . }}
+{{ include "listmonk.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "listmonk.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "listmonk.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "listmonk.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "listmonk.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.image" -}}
+{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/* ======== Database helpers ======== */}}
+
+{{- define "listmonk.databaseMode" -}}
+{{- $mode := .Values.database.mode | default "auto" -}}
+{{- if not (has $mode (list "auto" "external" "postgresql")) -}}
+{{- fail (printf "database.mode must be one of: auto, external, postgresql (got %s)" $mode) -}}
+{{- end -}}
+{{- $hasExternal := or (ne (.Values.database.external.host | default "") "") (ne (.Values.database.external.existingSecret | default "") "") -}}
+{{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
+{{- if eq $mode "auto" -}}
+  {{- if and $hasExternal $hasPostgresql -}}
+    {{- fail "listmonk database selection is ambiguous: configure only one of database.external.* or postgresql.enabled" -}}
+  {{- end -}}
+  {{- if $hasExternal -}}external
+  {{- else if $hasPostgresql -}}postgresql
+  {{- else -}}{{- fail "listmonk requires PostgreSQL: enable postgresql.enabled or configure database.external.host" -}}
+  {{- end -}}
+{{- else -}}
+  {{- if and (eq $mode "external") (not $hasExternal) -}}
+    {{- fail "database.mode=external requires database.external.host or database.external.existingSecret" -}}
+  {{- end -}}
+  {{- if and (eq $mode "external") $hasPostgresql -}}
+    {{- fail "database.mode=external cannot be combined with postgresql.enabled" -}}
+  {{- end -}}
+  {{- if and (eq $mode "postgresql") (not $hasPostgresql) -}}
+    {{- fail "database.mode=postgresql requires postgresql.enabled=true" -}}
+  {{- end -}}
+  {{- if and (eq $mode "postgresql") $hasExternal -}}
+    {{- fail "database.mode=postgresql cannot be combined with database.external.*" -}}
+  {{- end -}}
+  {{- $mode -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databaseHost" -}}
+{{- if eq (include "listmonk.databaseMode" .) "external" -}}
+{{- .Values.database.external.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databasePort" -}}
+{{- if eq (include "listmonk.databaseMode" .) "external" -}}
+{{- .Values.database.external.port | default 5432 | toString -}}
+{{- else -}}
+5432
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databaseName" -}}
+{{- if eq (include "listmonk.databaseMode" .) "external" -}}
+{{- .Values.database.external.name -}}
+{{- else -}}
+{{- .Values.postgresql.auth.database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databaseUsername" -}}
+{{- if eq (include "listmonk.databaseMode" .) "external" -}}
+{{- .Values.database.external.username -}}
+{{- else -}}
+{{- .Values.postgresql.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databaseSslMode" -}}
+{{- if eq (include "listmonk.databaseMode" .) "external" -}}
+{{- .Values.database.external.sslMode | default "disable" -}}
+{{- else -}}
+disable
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databaseSecretName" -}}
+{{- if and (eq (include "listmonk.databaseMode" .) "external") .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else if eq (include "listmonk.databaseMode" .) "external" -}}
+{{- printf "%s-database" (include "listmonk.fullname" .) -}}
+{{- else -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.databaseSecretKey" -}}
+{{- if and (eq (include "listmonk.databaseMode" .) "external") .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "database-password" -}}
+{{- else if eq (include "listmonk.databaseMode" .) "external" -}}
+database-password
+{{- else -}}
+user-password
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.adminSecretName" -}}
+{{- if .Values.listmonk.existingSecret -}}
+{{- .Values.listmonk.existingSecret -}}
+{{- else -}}
+{{- printf "%s-admin" (include "listmonk.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* ======== Backup helpers ======== */}}
+
+{{- define "listmonk.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- if not .Values.backup.s3.endpoint -}}
+    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}
+    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- end -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "listmonk.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "listmonk.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/listmonk/templates/backup-configmap.yaml
+++ b/charts/listmonk/templates/backup-configmap.yaml
@@ -1,0 +1,35 @@
+{{- if include "listmonk.backupEnabled" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "listmonk.fullname" . }}-backup-scripts
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+data:
+  postgres-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/${BACKUP_ARCHIVE_PREFIX}-postgresql-${timestamp}.sql.gz"
+    mkdir -p /backup/out
+    export PGPASSWORD="${DB_PASSWORD}"
+    pg_dump ${PG_DUMP_EXTRA_ARGS:-} \
+      --host="${DB_HOST}" \
+      --port="${DB_PORT}" \
+      --username="${DB_USERNAME}" \
+      --dbname="${DB_NAME}" | gzip -c > "${archive}"
+    printf "%s" "${archive}" > /backup/out/backup-file
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    archive="$(cat /backup/out/backup-file)"
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+    mc cp "${archive}" "${target}/"
+{{- end }}

--- a/charts/listmonk/templates/backup-cronjob.yaml
+++ b/charts/listmonk/templates/backup-cronjob.yaml
@@ -1,0 +1,111 @@
+{{- if include "listmonk.backupEnabled" . }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "listmonk.fullname" . }}-backup
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "listmonk.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "listmonk.serviceAccountName" . }}
+          terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: postgres-backup
+              image: {{ .Values.backup.images.postgresql | quote }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - /scripts/postgres-backup.sh
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.backup.archivePrefix | quote }}
+                - name: DB_HOST
+                  value: {{ include "listmonk.databaseHost" . | quote }}
+                - name: DB_PORT
+                  value: {{ include "listmonk.databasePort" . | quote }}
+                - name: DB_NAME
+                  value: {{ include "listmonk.databaseName" . | quote }}
+                - name: DB_USERNAME
+                  value: {{ include "listmonk.databaseUsername" . | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "listmonk.databaseSecretName" . }}
+                      key: {{ include "listmonk.databaseSecretKey" . }}
+                - name: PG_DUMP_EXTRA_ARGS
+                  value: {{ .Values.backup.database.pgDumpArgs | quote }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader | quote }}
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "listmonk.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "listmonk.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              resources:
+                {{- toYaml .Values.backup.resources | nindent 16 }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: backup-workdir
+                  mountPath: /backup/out
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ include "listmonk.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+{{- end }}

--- a/charts/listmonk/templates/deployment.yaml
+++ b/charts/listmonk/templates/deployment.yaml
@@ -1,0 +1,188 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "listmonk.fullname" . }}
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "listmonk.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "listmonk.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "listmonk.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: docker.io/library/busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for {{ include "listmonk.databaseHost" . }}:{{ include "listmonk.databasePort" . }} ..."
+              until nc -z -w2 {{ include "listmonk.databaseHost" . }} {{ include "listmonk.databasePort" . }}; do
+                sleep 2
+              done
+              echo "PostgreSQL is reachable."
+        - name: db-init
+          image: {{ include "listmonk.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              ./listmonk --install --idempotent --yes --config="" && \
+              ./listmonk --upgrade --yes --config=""
+          env:
+            - name: LISTMONK_db__host
+              value: {{ include "listmonk.databaseHost" . | quote }}
+            - name: LISTMONK_db__port
+              value: {{ include "listmonk.databasePort" . | quote }}
+            - name: LISTMONK_db__user
+              value: {{ include "listmonk.databaseUsername" . | quote }}
+            - name: LISTMONK_db__password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "listmonk.databaseSecretName" . }}
+                  key: {{ include "listmonk.databaseSecretKey" . }}
+            - name: LISTMONK_db__database
+              value: {{ include "listmonk.databaseName" . | quote }}
+            - name: LISTMONK_db__ssl_mode
+              value: {{ include "listmonk.databaseSslMode" . | quote }}
+      containers:
+        - name: listmonk
+          image: {{ include "listmonk.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - ./listmonk
+            - --config=""
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: LISTMONK_app__address
+              value: "0.0.0.0:9000"
+            - name: LISTMONK_db__host
+              value: {{ include "listmonk.databaseHost" . | quote }}
+            - name: LISTMONK_db__port
+              value: {{ include "listmonk.databasePort" . | quote }}
+            - name: LISTMONK_db__user
+              value: {{ include "listmonk.databaseUsername" . | quote }}
+            - name: LISTMONK_db__password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "listmonk.databaseSecretName" . }}
+                  key: {{ include "listmonk.databaseSecretKey" . }}
+            - name: LISTMONK_db__database
+              value: {{ include "listmonk.databaseName" . | quote }}
+            - name: LISTMONK_db__ssl_mode
+              value: {{ include "listmonk.databaseSslMode" . | quote }}
+            {{- if or .Values.listmonk.adminUser (not .Values.listmonk.existingSecret) }}
+            - name: LISTMONK_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "listmonk.adminSecretName" . }}
+                  key: {{ .Values.listmonk.existingSecretUserKey | default "admin-user" }}
+            - name: LISTMONK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "listmonk.adminSecretName" . }}
+                  key: {{ .Values.listmonk.existingSecretPasswordKey | default "admin-password" }}
+            {{- end }}
+            {{- with .Values.listmonk.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: uploads
+              mountPath: /listmonk/uploads
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: uploads
+          {{- if .Values.storage.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.existingClaim }}
+          {{- else if .Values.storage.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "listmonk.fullname" . }}-uploads
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/listmonk/templates/extra-manifests.yaml
+++ b/charts/listmonk/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/listmonk/templates/ingress.yaml
+++ b/charts/listmonk/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "listmonk.fullname" . }}
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "listmonk.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/listmonk/templates/pvc.yaml
+++ b/charts/listmonk/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.storage.enabled (not .Values.storage.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "listmonk.fullname" . }}-uploads
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+  {{- with .Values.storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.storage.accessMode }}
+  {{- if .Values.storage.storageClass }}
+  storageClassName: {{ .Values.storage.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}
+{{- end }}

--- a/charts/listmonk/templates/secret.yaml
+++ b/charts/listmonk/templates/secret.yaml
@@ -1,0 +1,37 @@
+{{- if not .Values.listmonk.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "listmonk.fullname" . }}-admin
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin-user: {{ .Values.listmonk.adminUser | default "admin" | quote }}
+  admin-password: {{ .Values.listmonk.adminPassword | default (randAlphaNum 24) | quote }}
+{{- end }}
+---
+{{- if and (eq (include "listmonk.databaseMode" .) "external") (not .Values.database.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "listmonk.fullname" . }}-database
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-password: {{ .Values.database.external.password | quote }}
+{{- end }}
+---
+{{- if and (include "listmonk.backupEnabled" .) (not .Values.backup.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "listmonk.fullname" . }}-backup
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  access-key: {{ .Values.backup.s3.accessKey | quote }}
+  secret-key: {{ .Values.backup.s3.secretKey | quote }}
+{{- end }}

--- a/charts/listmonk/templates/service.yaml
+++ b/charts/listmonk/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "listmonk.fullname" . }}
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "listmonk.selectorLabels" . | nindent 4 }}

--- a/charts/listmonk/templates/serviceaccount.yaml
+++ b/charts/listmonk/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "listmonk.serviceAccountName" . }}
+  labels:
+    {{- include "listmonk.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/listmonk/tests/deployment_test.yaml
+++ b/charts/listmonk/tests/deployment_test.yaml
@@ -1,0 +1,117 @@
+suite: deployment
+templates:
+  - templates/deployment.yaml
+  - templates/secret.yaml
+tests:
+  - it: renders deployment with default values
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: uses correct image
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/listmonk/listmonk:v6.1.0"
+
+  - it: exposes port 9000
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 9000
+            protocol: TCP
+
+  - it: includes wait-for-postgresql init container
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-postgresql
+
+  - it: includes db-init init container
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: db-init
+
+  - it: sets database env vars
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LISTMONK_app__address
+            value: "0.0.0.0:9000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LISTMONK_db__database
+            value: "listmonk"
+
+  - it: mounts uploads volume
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: uploads
+            mountPath: /listmonk/uploads
+
+  - it: uses custom image tag
+    template: templates/deployment.yaml
+    set:
+      image.tag: "v5.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/listmonk/listmonk:v5.0.0"
+
+  - it: adds extra env vars
+    template: templates/deployment.yaml
+    set:
+      listmonk.extraEnv:
+        - name: TZ
+          value: America/Sao_Paulo
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TZ
+            value: America/Sao_Paulo
+
+  - it: renders startup probe by default
+    template: templates/deployment.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: disables startup probe when configured
+    template: templates/deployment.yaml
+    set:
+      startupProbe.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: renders with external database
+    template: templates/deployment.yaml
+    set:
+      postgresql.enabled: false
+      database.mode: external
+      database.external.host: pg.example.com
+      database.external.password: secret123
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LISTMONK_db__host
+            value: "pg.example.com"

--- a/charts/listmonk/tests/ingress_test.yaml
+++ b/charts/listmonk/tests/ingress_test.yaml
@@ -1,0 +1,44 @@
+suite: ingress
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: does not render ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders ingress when enabled
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: traefik
+      ingress.hosts:
+        - host: listmonk.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: traefik
+      - equal:
+          path: spec.rules[0].host
+          value: listmonk.example.com
+
+  - it: renders TLS configuration
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: listmonk.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - secretName: listmonk-tls
+          hosts:
+            - listmonk.example.com
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: listmonk-tls

--- a/charts/listmonk/tests/pvc_test.yaml
+++ b/charts/listmonk/tests/pvc_test.yaml
@@ -1,0 +1,33 @@
+suite: pvc
+templates:
+  - templates/pvc.yaml
+tests:
+  - it: renders PVC with default values
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+
+  - it: does not render PVC when storage is disabled
+    set:
+      storage.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render PVC when existingClaim is set
+    set:
+      storage.existingClaim: my-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses custom storage size
+    set:
+      storage.size: 20Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 20Gi

--- a/charts/listmonk/tests/secret_test.yaml
+++ b/charts/listmonk/tests/secret_test.yaml
@@ -1,0 +1,49 @@
+suite: secret
+templates:
+  - templates/secret.yaml
+tests:
+  - it: renders admin secret with default values
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: -admin$
+      - equal:
+          path: stringData.admin-user
+          value: "admin"
+
+  - it: uses custom admin credentials
+    documentIndex: 0
+    set:
+      listmonk.adminUser: myadmin
+      listmonk.adminPassword: mypassword
+    asserts:
+      - equal:
+          path: stringData.admin-user
+          value: myadmin
+      - equal:
+          path: stringData.admin-password
+          value: mypassword
+
+  - it: does not render admin secret when existingSecret is set
+    set:
+      listmonk.existingSecret: my-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders external database secret
+    set:
+      postgresql.enabled: false
+      database.mode: external
+      database.external.host: pg.example.com
+      database.external.password: secret123
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.database-password
+          value: secret123

--- a/charts/listmonk/tests/service_test.yaml
+++ b/charts/listmonk/tests/service_test.yaml
@@ -1,0 +1,35 @@
+suite: service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders service with default values
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            port: 80
+            targetPort: http
+            protocol: TCP
+            name: http
+
+  - it: uses custom service type
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: adds service annotations
+    set:
+      service.annotations:
+        my-annotation: my-value
+    asserts:
+      - equal:
+          path: metadata.annotations.my-annotation
+          value: my-value

--- a/charts/listmonk/tests/serviceaccount_test.yaml
+++ b/charts/listmonk/tests/serviceaccount_test.yaml
@@ -1,0 +1,25 @@
+suite: serviceaccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: does not render serviceaccount by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders serviceaccount when enabled
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+
+  - it: adds annotations to serviceaccount
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::role/test
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::role/test"

--- a/charts/listmonk/values.schema.json
+++ b/charts/listmonk/values.schema.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Listmonk Helm Chart Values",
+  "description": "Configuration values for the Listmonk Helm chart",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full release name used in resource names"
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Labels added to every resource created by this chart"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of Listmonk application replicas",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "description": "Listmonk container image configuration",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Listmonk container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Listmonk image tag"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for private registries"
+    },
+    "listmonk": {
+      "type": "object",
+      "description": "Listmonk application configuration",
+      "properties": {
+        "adminUser": {
+          "type": "string",
+          "description": "Admin username created on first install"
+        },
+        "adminPassword": {
+          "type": "string",
+          "description": "Admin password created on first install"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing secret containing admin credentials"
+        },
+        "existingSecretUserKey": {
+          "type": "string",
+          "description": "Secret key for admin username"
+        },
+        "existingSecretPasswordKey": {
+          "type": "string",
+          "description": "Secret key for admin password"
+        },
+        "extraEnv": {
+          "type": "array",
+          "description": "Additional environment variables"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "Database configuration",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Database mode",
+          "enum": ["auto", "external", "postgresql"]
+        },
+        "external": {
+          "type": "object",
+          "description": "External PostgreSQL configuration"
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "description": "PostgreSQL subchart configuration"
+    },
+    "storage": {
+      "type": "object",
+      "description": "Persistent storage for uploaded media"
+    },
+    "backup": {
+      "type": "object",
+      "description": "Built-in backup CronJob configuration"
+    },
+    "service": {
+      "type": "object",
+      "description": "Kubernetes Service configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Service type",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "description": "Service port"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Service annotations"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "description": "Ingress configuration"
+    },
+    "startupProbe": {
+      "type": "object",
+      "description": "Startup probe configuration"
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Liveness probe configuration"
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe configuration"
+    },
+    "resources": {
+      "type": "object",
+      "description": "CPU and memory requests/limits"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod-level security context"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Container-level security context"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "ServiceAccount configuration"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling"
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling"
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "Priority class name"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "description": "Grace period for shutdown in seconds"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels for the pod"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Additional annotations for the pod"
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts"
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Additional volumes"
+    },
+    "extraManifests": {
+      "type": "array",
+      "description": "Extra Kubernetes manifests"
+    }
+  }
+}

--- a/charts/listmonk/values.yaml
+++ b/charts/listmonk/values.yaml
@@ -1,0 +1,258 @@
+# =============================================================================
+# Listmonk Helm Chart
+# =============================================================================
+# Self-hosted newsletter and mailing list manager.
+# Requires PostgreSQL. SMTP is configured through the admin UI after install.
+# =============================================================================
+
+# -- Override the chart name used in resource names
+nameOverride: ""
+
+# -- Override the full release name used in resource names
+fullnameOverride: ""
+
+# -- Labels added to every resource created by this chart
+commonLabels: {}
+
+# -- Number of Listmonk application replicas
+replicaCount: 1
+
+image:
+  # -- Listmonk container image repository
+  repository: docker.io/listmonk/listmonk
+  # -- Listmonk image tag. Defaults to appVersion when empty.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+listmonk:
+  # -- Admin username created on first install
+  adminUser: ""
+  # -- Admin password created on first install. Auto-generated if empty.
+  adminPassword: ""
+  # -- Existing secret containing admin credentials
+  existingSecret: ""
+  # -- Secret key for admin username in existingSecret
+  existingSecretUserKey: admin-user
+  # -- Secret key for admin password in existingSecret
+  existingSecretPasswordKey: admin-password
+  # -- Additional environment variables for the Listmonk container
+  extraEnv: []
+
+database:
+  # -- Database mode: auto | external | postgresql
+  mode: auto
+  external:
+    # -- External PostgreSQL hostname
+    host: ""
+    # -- External PostgreSQL port
+    port: 5432
+    # -- External PostgreSQL database name
+    name: listmonk
+    # -- External PostgreSQL username
+    username: listmonk
+    # -- External PostgreSQL password. Ignored when existingSecret is set.
+    password: ""
+    # -- PostgreSQL SSL mode
+    sslMode: disable
+    # -- Existing secret containing the external PostgreSQL password
+    existingSecret: ""
+    # -- Secret key for the external PostgreSQL password
+    existingSecretPasswordKey: database-password
+
+# -- Deploy PostgreSQL as a subchart
+postgresql:
+  enabled: true
+  architecture: standalone
+  auth:
+    # -- PostgreSQL database name created on first run
+    database: listmonk
+    # -- PostgreSQL username created on first run
+    username: listmonk
+    # -- PostgreSQL application user password. Auto-generated if empty.
+    password: ""
+    # -- PostgreSQL superuser password. Auto-generated if empty.
+    postgresPassword: ""
+  initdb:
+    scripts:
+      # -- Bootstrap Listmonk database privileges and extensions on first PostgreSQL initialization.
+      10-listmonk-bootstrap.sql: |
+        GRANT CREATE ON DATABASE listmonk TO listmonk;
+        \connect listmonk
+        CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  standalone:
+    persistence:
+      # -- Enable persistence for PostgreSQL data
+      enabled: true
+      # -- PVC size for PostgreSQL
+      size: 8Gi
+
+storage:
+  # -- Enable persistent local storage for uploaded media
+  enabled: true
+  # -- Storage class for the uploads PVC
+  storageClass: ""
+  # -- Access mode for the uploads PVC
+  accessMode: ReadWriteOnce
+  # -- Size of the uploads PVC
+  size: 5Gi
+  # -- Existing PVC claim for uploads storage
+  existingClaim: ""
+  # -- Annotations for the uploads PVC
+  annotations: {}
+
+backup:
+  # -- Enable built-in backup CronJob for PostgreSQL (pg_dump to S3)
+  enabled: false
+  # -- Backup schedule in Cron format
+  schedule: "0 3 * * *"
+  # -- Suspend backup execution
+  suspend: false
+  # -- CronJob concurrency policy
+  concurrencyPolicy: Forbid
+  # -- Successful job history retained by the CronJob
+  successfulJobsHistoryLimit: 3
+  # -- Failed job history retained by the CronJob
+  failedJobsHistoryLimit: 3
+  # -- Job backoff limit
+  backoffLimit: 1
+  # -- Prefix used in generated backup archive names
+  archivePrefix: listmonk
+  images:
+    # -- PostgreSQL client image used for pg_dump
+    postgresql: docker.io/library/postgres:17-alpine
+    # -- MinIO client image used for S3 upload
+    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+  # -- Resources applied to the backup dump and upload containers
+  resources: {}
+  database:
+    # -- Extra arguments passed to pg_dump
+    pgDumpArgs: ""
+  s3:
+    # -- S3-compatible endpoint URL
+    endpoint: ""
+    # -- Target bucket name
+    bucket: ""
+    # -- Optional key prefix inside the bucket
+    prefix: listmonk
+    # -- Create the bucket automatically when it does not exist yet
+    createBucketIfNotExists: true
+    # -- Existing secret containing access-key and secret-key
+    existingSecret: ""
+    # -- Secret key name for the access key inside backup.s3.existingSecret
+    existingSecretAccessKeyKey: access-key
+    # -- Secret key name for the secret key inside backup.s3.existingSecret
+    existingSecretSecretKeyKey: secret-key
+    # -- Inline access key used when backup.s3.existingSecret is not set
+    accessKey: ""
+    # -- Inline secret key used when backup.s3.existingSecret is not set
+    secretKey: ""
+
+service:
+  # -- Service type for the Listmonk HTTP service
+  type: ClusterIP
+  # -- Service port exposed by the Listmonk service
+  port: 80
+  # -- Annotations for the Listmonk service
+  annotations: {}
+
+ingress:
+  # -- Enable ingress for Listmonk
+  enabled: false
+  # -- Ingress class name
+  ingressClassName: ""
+  # -- Ingress annotations
+  # annotations:
+  #   cert-manager.io/cluster-issuer: letsencrypt-prod
+  annotations: {}
+  # -- Ingress hosts
+  hosts: []
+    # - host: listmonk.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - secretName: listmonk-tls
+    #   hosts:
+    #     - listmonk.example.com
+
+startupProbe:
+  # -- Enable startup probe
+  enabled: true
+  # -- HTTP path used by the startup probe
+  path: /
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
+livenessProbe:
+  # -- Enable liveness probe
+  enabled: true
+  # -- HTTP path used by the liveness probe
+  path: /
+  initialDelaySeconds: 0
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  # -- Enable readiness probe
+  enabled: true
+  # -- HTTP path used by the readiness probe
+  path: /
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# -- CPU and memory requests/limits for the Listmonk container
+resources: {}
+
+# -- Pod-level security context
+podSecurityContext: {}
+
+# -- Container-level security context
+securityContext: {}
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount
+  create: false
+  # -- ServiceAccount name override
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Priority class name
+priorityClassName: ""
+
+# -- Grace period for shutdown, in seconds
+terminationGracePeriodSeconds: 30
+
+# -- Additional labels for the Listmonk pod
+podLabels: {}
+
+# -- Additional annotations for the Listmonk pod
+podAnnotations: {}
+
+# -- Additional volume mounts for the Listmonk container
+extraVolumeMounts: []
+
+# -- Additional volumes for the Listmonk pod
+extraVolumes: []
+
+# -- Extra Kubernetes manifests to deploy alongside the chart
+extraManifests: []


### PR DESCRIPTION
## Summary
- New Helm chart for [Listmonk](https://listmonk.app) v6.1.0 — self-hosted newsletter and mailing list manager
- Bundled PostgreSQL via HelmForge subchart with automatic pgcrypto extension setup
- Automatic database init (`--install --idempotent`) and migration (`--upgrade`) via init containers
- Persistent uploads storage, configurable ingress, built-in backup CronJob
- Admin credentials managed via Kubernetes Secrets

## Test plan
- [x] `helm lint --strict` — 0 failures
- [x] `helm template` — all CI scenarios render
- [x] `helm unittest` — 29/29 tests pass
- [x] `ah lint` — 0 errors
- [x] k3d default install — pods Running, HTTP 200 on port 9000
- [x] k3d ingress upgrade — ingress created, TLS configured
- [x] CI pipeline passes