### PR TITLE
feat(listmonk): promote chart maturity to stable

### DIFF
--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -48,8 +48,7 @@ annotations:
     url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
-  artifacthub.io/prerelease: "true"
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:


### PR DESCRIPTION
## Summary
- Promote listmonk from alpha to stable after first successful release (v1.0.0)
- Remove `artifacthub.io/prerelease` annotation
- Set `helmforge.dev/maturity: stable`

## Validation
- Release v1.0.0 published with GPG+Cosign signing
- `.prov` file confirmed in gh-pages
- 29 unit tests, 3 CI scenarios
- k3d validated (default + ingress)