### PR TITLE
fix(ingress): default paths and remove listmonk admin

### DIFF
--- a/charts/adguard-home/templates/ingress.yaml
+++ b/charts/adguard-home/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/alfio/templates/ingress.yaml
+++ b/charts/alfio/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/answer/templates/ingress.yaml
+++ b/charts/answer/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/archivebox/templates/ingress.yaml
+++ b/charts/archivebox/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/authelia/templates/ingress.yaml
+++ b/charts/authelia/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/automatisch/templates/ingress.yaml
+++ b/charts/automatisch/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/castopod/templates/ingress.yaml
+++ b/charts/castopod/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/changedetection/templates/ingress.yaml
+++ b/charts/changedetection/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/chiefonboarding/templates/ingress.yaml
+++ b/charts/chiefonboarding/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/ckan/templates/ingress.yaml
+++ b/charts/ckan/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType | default "Prefix" }}
             backend:

--- a/charts/countly/templates/ingress.yaml
+++ b/charts/countly/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/cronicle/templates/ingress.yaml
+++ b/charts/cronicle/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/ddns-updater/templates/ingress.yaml
+++ b/charts/ddns-updater/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/discount-bandit/templates/ingress.yaml
+++ b/charts/discount-bandit/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/docmost/templates/ingress.yaml
+++ b/charts/docmost/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/dolibarr/templates/ingress.yaml
+++ b/charts/dolibarr/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/druid/templates/ingress.yaml
+++ b/charts/druid/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType | default "Prefix" }}
             backend:

--- a/charts/flowise/templates/ingress.yaml
+++ b/charts/flowise/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/ghost/templates/ingress.yaml
+++ b/charts/ghost/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/gitea/templates/ingress.yaml
+++ b/charts/gitea/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/guacamole/templates/ingress.yaml
+++ b/charts/guacamole/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/heimdall/templates/ingress.yaml
+++ b/charts/heimdall/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/homarr/templates/ingress.yaml
+++ b/charts/homarr/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/karakeep/templates/ingress.yaml
+++ b/charts/karakeep/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ default "Prefix" .pathType }}
             backend:
@@ -54,7 +54,7 @@ spec:
     - host: {{ .host }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ default "Prefix" .pathType }}
             backend:

--- a/charts/komga/templates/ingress.yaml
+++ b/charts/komga/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/listmonk/README.md
+++ b/charts/listmonk/README.md
@@ -11,7 +11,7 @@ Self-hosted newsletter and mailing list manager for Kubernetes.
 - Persistent storage for media uploads
 - Configurable ingress with TLS support
 - Built-in PostgreSQL backup CronJob with S3 upload
-- Admin credentials managed via Kubernetes Secrets
+- First-access setup wizard for Super Admin account creation
 - SMTP configuration through the admin UI after installation
 
 ## Install
@@ -55,24 +55,9 @@ helm install listmonk helmforge/listmonk \
 
 SMTP and most application settings are configured through the Listmonk admin UI after installation at **Settings > SMTP**. The Helm chart handles infrastructure-level configuration (database, storage, ingress, probes).
 
-### Admin Credentials
+### Admin Setup
 
-By default, the chart creates an admin user with username `admin` and an auto-generated password stored in a Kubernetes Secret. To set custom credentials:
-
-```yaml
-listmonk:
-  adminUser: myadmin
-  adminPassword: mysecurepassword
-```
-
-Or use an existing secret:
-
-```yaml
-listmonk:
-  existingSecret: my-listmonk-secret
-  existingSecretUserKey: admin-user
-  existingSecretPasswordKey: admin-password
-```
+On first access, Listmonk displays a setup wizard where you create a Super Admin account. This is handled entirely through the web UI — the chart does not manage admin credentials.
 
 ### Database Initialization
 
@@ -86,9 +71,6 @@ The chart automatically runs `--install --idempotent --yes` and `--upgrade --yes
 | `image.repository` | string | `docker.io/listmonk/listmonk` | Image repository |
 | `image.tag` | string | `""` | Image tag (defaults to appVersion) |
 | `image.pullPolicy` | string | `IfNotPresent` | Pull policy |
-| `listmonk.adminUser` | string | `""` | Admin username (defaults to `admin`) |
-| `listmonk.adminPassword` | string | `""` | Admin password (auto-generated if empty) |
-| `listmonk.existingSecret` | string | `""` | Existing secret for admin credentials |
 | `listmonk.extraEnv` | list | `[]` | Additional environment variables |
 | `database.mode` | string | `auto` | Database mode: `auto`, `external`, `postgresql` |
 | `database.external.host` | string | `""` | External PostgreSQL hostname |

--- a/charts/listmonk/templates/NOTES.txt
+++ b/charts/listmonk/templates/NOTES.txt
@@ -13,4 +13,5 @@ To access the Listmonk admin UI, run:
 Then open http://localhost:{{ .Values.service.port }} in your browser.
 {{- end }}
 
+On first access, Listmonk will prompt you to create a Super Admin account.
 Configure SMTP and other settings through the admin UI at Settings > SMTP.

--- a/charts/listmonk/templates/_helpers.tpl
+++ b/charts/listmonk/templates/_helpers.tpl
@@ -142,14 +142,6 @@ user-password
 {{- end -}}
 {{- end -}}
 
-{{- define "listmonk.adminSecretName" -}}
-{{- if .Values.listmonk.existingSecret -}}
-{{- .Values.listmonk.existingSecret -}}
-{{- else -}}
-{{- printf "%s-admin" (include "listmonk.fullname" .) -}}
-{{- end -}}
-{{- end -}}
-
 {{/* ======== Backup helpers ======== */}}
 
 {{- define "listmonk.backupEnabled" -}}

--- a/charts/listmonk/templates/deployment.yaml
+++ b/charts/listmonk/templates/deployment.yaml
@@ -105,18 +105,6 @@ spec:
               value: {{ include "listmonk.databaseName" . | quote }}
             - name: LISTMONK_db__ssl_mode
               value: {{ include "listmonk.databaseSslMode" . | quote }}
-            {{- if or .Values.listmonk.adminUser (not .Values.listmonk.existingSecret) }}
-            - name: LISTMONK_ADMIN_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "listmonk.adminSecretName" . }}
-                  key: {{ .Values.listmonk.existingSecretUserKey | default "admin-user" }}
-            - name: LISTMONK_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "listmonk.adminSecretName" . }}
-                  key: {{ .Values.listmonk.existingSecretPasswordKey | default "admin-password" }}
-            {{- end }}
             {{- with .Values.listmonk.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/listmonk/templates/ingress.yaml
+++ b/charts/listmonk/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/listmonk/templates/secret.yaml
+++ b/charts/listmonk/templates/secret.yaml
@@ -1,16 +1,3 @@
-{{- if not .Values.listmonk.existingSecret }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "listmonk.fullname" . }}-admin
-  labels:
-    {{- include "listmonk.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  admin-user: {{ .Values.listmonk.adminUser | default "admin" | quote }}
-  admin-password: {{ .Values.listmonk.adminPassword | default (randAlphaNum 24) | quote }}
-{{- end }}
----
 {{- if and (eq (include "listmonk.databaseMode" .) "external") (not .Values.database.external.existingSecret) }}
 apiVersion: v1
 kind: Secret

--- a/charts/listmonk/tests/secret_test.yaml
+++ b/charts/listmonk/tests/secret_test.yaml
@@ -2,48 +2,46 @@ suite: secret
 templates:
   - templates/secret.yaml
 tests:
-  - it: renders admin secret with default values
-    documentIndex: 0
-    asserts:
-      - isKind:
-          of: Secret
-      - matchRegex:
-          path: metadata.name
-          pattern: -admin$
-      - equal:
-          path: stringData.admin-user
-          value: "admin"
-
-  - it: uses custom admin credentials
-    documentIndex: 0
-    set:
-      listmonk.adminUser: myadmin
-      listmonk.adminPassword: mypassword
-    asserts:
-      - equal:
-          path: stringData.admin-user
-          value: myadmin
-      - equal:
-          path: stringData.admin-password
-          value: mypassword
-
-  - it: does not render admin secret when existingSecret is set
-    set:
-      listmonk.existingSecret: my-secret
-    asserts:
-      - hasDocuments:
-          count: 0
-
   - it: renders external database secret
     set:
       postgresql.enabled: false
       database.mode: external
       database.external.host: pg.example.com
       database.external.password: secret123
-    documentIndex: 1
+    documentIndex: 0
     asserts:
       - isKind:
           of: Secret
       - equal:
           path: stringData.database-password
           value: secret123
+
+  - it: does not render database secret when using subchart
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders backup s3 secret
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: mykey
+      backup.s3.secretKey: mysecret
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.access-key
+          value: mykey
+
+  - it: does not render backup secret when existingSecret is set
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.example.com
+      backup.s3.bucket: backups
+      backup.s3.existingSecret: my-backup-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/listmonk/values.schema.json
+++ b/charts/listmonk/values.schema.json
@@ -49,26 +49,6 @@
       "type": "object",
       "description": "Listmonk application configuration",
       "properties": {
-        "adminUser": {
-          "type": "string",
-          "description": "Admin username created on first install"
-        },
-        "adminPassword": {
-          "type": "string",
-          "description": "Admin password created on first install"
-        },
-        "existingSecret": {
-          "type": "string",
-          "description": "Existing secret containing admin credentials"
-        },
-        "existingSecretUserKey": {
-          "type": "string",
-          "description": "Secret key for admin username"
-        },
-        "existingSecretPasswordKey": {
-          "type": "string",
-          "description": "Secret key for admin password"
-        },
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables"

--- a/charts/listmonk/values.yaml
+++ b/charts/listmonk/values.yaml
@@ -29,16 +29,6 @@ image:
 imagePullSecrets: []
 
 listmonk:
-  # -- Admin username created on first install
-  adminUser: ""
-  # -- Admin password created on first install. Auto-generated if empty.
-  adminPassword: ""
-  # -- Existing secret containing admin credentials
-  existingSecret: ""
-  # -- Secret key for admin username in existingSecret
-  existingSecretUserKey: admin-user
-  # -- Secret key for admin password in existingSecret
-  existingSecretPasswordKey: admin-password
   # -- Additional environment variables for the Listmonk container
   extraEnv: []
 

--- a/charts/liwan/templates/ingress.yaml
+++ b/charts/liwan/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/middleware/templates/ingress.yaml
+++ b/charts/middleware/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/mosquitto/templates/ingress.yaml
+++ b/charts/mosquitto/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:
@@ -54,7 +54,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/ntfy/templates/ingress.yaml
+++ b/charts/ntfy/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/olivetin/templates/ingress.yaml
+++ b/charts/olivetin/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/open-webui/templates/ingress.yaml
+++ b/charts/open-webui/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/phpmyadmin/templates/ingress.yaml
+++ b/charts/phpmyadmin/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ default "Prefix" .pathType }}
             backend:

--- a/charts/strapi/templates/ingress.yaml
+++ b/charts/strapi/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/strava-statistics/templates/ingress.yaml
+++ b/charts/strava-statistics/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/superset/templates/ingress.yaml
+++ b/charts/superset/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType | default "Prefix" }}
             backend:

--- a/charts/umami/templates/ingress.yaml
+++ b/charts/umami/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/uptime-kuma/templates/ingress.yaml
+++ b/charts/uptime-kuma/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/vaultwarden/templates/ingress.yaml
+++ b/charts/vaultwarden/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - host: {{ .host }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ default "Prefix" .pathType }}
             backend:

--- a/charts/wallabag/templates/ingress.yaml
+++ b/charts/wallabag/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:

--- a/charts/wordpress/templates/ingress.yaml
+++ b/charts/wordpress/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:


### PR DESCRIPTION
## Summary
- **Ingress default paths**: All 46 affected charts now default to `path: /` and `pathType: Prefix` when users define `ingress.hosts` without specifying `paths`. Previously this produced invalid empty `http.paths` rejected by Kubernetes.
- **Listmonk admin removal**: Removed non-functional `adminUser`/`adminPassword` values, secret, and helper. Listmonk v6+ handles admin account creation through its web UI setup wizard on first access.

## Affected charts (ingress fix)
adguard-home, alfio, answer, archivebox, authelia, automatisch, castopod, changedetection, chiefonboarding, ckan, countly, cronicle, ddns-updater, discount-bandit, docmost, dolibarr, druid, flowise, ghost, gitea, guacamole, heimdall, homarr, karakeep, keycloak, komga, listmonk, liwan, metabase, middleware, mosquitto, n8n, ntfy, olivetin, open-webui, phpmyadmin, pihole, rabbitmq, strapi, strava-statistics, superset, umami, uptime-kuma, vaultwarden, wallabag, wordpress

## Test plan
- [x] Listmonk unit tests pass (29/29)
- [x] `helm template` with host-only ingress (no paths) renders valid `path: / pathType: Prefix`
- [ ] Verify publish workflow succeeds for all affected charts