### PR TITLE
feat(repo): promote all alpha charts to stable

### DIFF
--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -28,14 +28,13 @@ annotations:
       email: helmforgedev@users.noreply.github.com
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Official Website
       url: https://alf.io

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -28,14 +28,13 @@ annotations:
       email: helmforgedev@users.noreply.github.com
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Official Website
       url: https://automatisch.io

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -28,14 +28,13 @@ annotations:
       email: helmforgedev@users.noreply.github.com
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Official Website
       url: https://github.com/Cybrarist/Discount-Bandit

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -4,7 +4,7 @@ description: AI-powered bookmark manager with full-text search and web archiving
 icon: https://helmforge.dev/icons/charts/karakeep.png
 type: application
 version: 1.1.3
-appVersion: "0.24.1"
+appVersion: "0.31.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -28,14 +28,13 @@ annotations:
       email: helmforgedev@users.noreply.github.com
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   artifacthub.io/license: MIT
   artifacthub.io/category: skip-prediction
-  artifacthub.io/prerelease: "true"
   artifacthub.io/links: |
     - name: Official Website
       url: https://karakeep.app
@@ -47,8 +46,8 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/images: |
     - name: karakeep
-      image: ghcr.io/karakeep-app/karakeep:0.24.1
+      image: ghcr.io/karakeep-app/karakeep:0.31.0
     - name: meilisearch
-      image: docker.io/getmeili/meilisearch:v1.13.3
+      image: docker.io/getmeili/meilisearch:v1.41.0
     - name: chromium
-      image: ghcr.io/browserless/chromium:v2.18.0
+      image: ghcr.io/browserless/chromium:v2.46.0

--- a/charts/karakeep/tests/deployment_test.yaml
+++ b/charts/karakeep/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/karakeep-app/karakeep:0.24.1"
+          value: "ghcr.io/karakeep-app/karakeep:0.31.0"
 
   - it: should set DATA_DIR env
     template: templates/deployment.yaml

--- a/charts/karakeep/values.yaml
+++ b/charts/karakeep/values.yaml
@@ -42,7 +42,7 @@ meilisearch:
     # -- Meilisearch container image
     repository: docker.io/getmeili/meilisearch
     # -- Meilisearch image tag
-    tag: "v1.13.3"
+    tag: "v1.41.0"
     pullPolicy: IfNotPresent
   # -- Resources for the Meilisearch container
   resources: {}
@@ -58,7 +58,7 @@ chromium:
     # -- Chromium container image
     repository: ghcr.io/browserless/chromium
     # -- Chromium image tag
-    tag: "v2.18.0"
+    tag: "v2.46.0"
     pullPolicy: IfNotPresent
   # -- Resources for the Chromium container
   resources: {}


### PR DESCRIPTION
## Summary
- **karakeep**: update appVersion 0.24.1 → 0.31.0, meilisearch v1.13.3 → v1.41.0, chromium v2.18.0 → v2.46.0, promote to stable
- **automatisch**: promote to stable (appVersion 0.15.0 unchanged, latest)
- **discount-bandit**: promote to stable (appVersion 4.0.3 unchanged, latest stable)
- **alfio**: promote to stable (appVersion 2.0-M5-2509-1 unchanged, latest available)

All charts: removed `artifacthub.io/prerelease: "true"`, set `helmforge.dev/maturity: stable`.

## Validation
- [x] helm lint --strict (4/4)
- [x] helm template (4/4)
- [x] helm unittest (110 tests passed)
- [x] ah lint (4/4)
- [x] CI scenarios rendered (all pass)
- [x] k3d validation — default install for all 4 charts, all pods Running
- [ ] Site sync (separate PR after merge)

## Notes
- alfio has no stable 2.x release (all versions are milestones like 2.0-M5), but this is the latest available and has been published for months
- karakeep sidecars updated to latest stable: meilisearch v1.41.0, chromium v2.46.0