### PR TITLE
remove artifacthub.io/images annotation from all charts

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -48,14 +48,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/adguard-home
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: adguard-home
-      image: docker.io/adguard/adguardhome:0.107.73
-    - name: adguardhome-sync
-      image: ghcr.io/bakito/adguardhome-sync:v0.9.0
-    - name: backup-archiver
-      image: docker.io/library/busybox:1.37
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/cloudflared

--- a/charts/adguard-home/templates/_helpers.tpl
+++ b/charts/adguard-home/templates/_helpers.tpl
@@ -32,8 +32,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Image helper — tag prefixed with "v" */}}
 {{- define "adguard-home.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Returns true when a pre-seed config is provided */}}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- AdGuard Home container image
   repository: docker.io/adguard/adguardhome
-  # -- Image tag (defaults to "v" + appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "v0.107.73"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -44,9 +44,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/alfio
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: alfio
-      image: docker.io/alfio/alf.io:2.0-M5-2509-1
 dependencies:
   - name: postgresql
     version: 1.8.4

--- a/charts/alfio/templates/_helpers.tpl
+++ b/charts/alfio/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "alfio.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database host */}}

--- a/charts/alfio/values.yaml
+++ b/charts/alfio/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- alf.io container image
   repository: docker.io/alfio/alf.io
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "2.0-M5-2509-1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -46,9 +46,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/answer
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: answer
-      image: docker.io/apache/answer:2.0.0
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/answer/templates/_helpers.tpl
+++ b/charts/answer/templates/_helpers.tpl
@@ -39,7 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "answer.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 # =============================================================================

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -22,8 +22,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/apache/answer
-  # -- Container image tag (defaults to appVersion)
-  tag: ""
+  # -- Container image tag
+  tag: "2.0.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -49,11 +49,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/appwrite
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: appwrite
-      image: docker.io/appwrite/appwrite:1.8.1
-    - name: appwrite-console
-      image: docker.io/appwrite/console:7.5.7
 dependencies:
   - name: mariadb
     version: 1.0.2

--- a/charts/appwrite/templates/_helpers.tpl
+++ b/charts/appwrite/templates/_helpers.tpl
@@ -53,7 +53,7 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
 {{- define "appwrite.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "appwrite.consoleImage" -}}

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -26,7 +26,7 @@ image:
   # -- Appwrite server image repository
   repository: docker.io/appwrite/appwrite
   # -- Appwrite image tag. Defaults to appVersion.
-  tag: ""
+  tag: "1.8.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/archivebox
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: archivebox
-      image: docker.io/archivebox/archivebox:0.7.3

--- a/charts/archivebox/templates/_helpers.tpl
+++ b/charts/archivebox/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "archivebox.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Admin secret name */}}

--- a/charts/archivebox/values.yaml
+++ b/charts/archivebox/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- ArchiveBox container image
   repository: docker.io/archivebox/archivebox
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "0.7.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -47,13 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/authelia
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: authelia
-      image: docker.io/authelia/authelia:4.39.16
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
-    - name: backup-archiver
-      image: docker.io/library/busybox:1.37
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/keycloak
     - url: https://artifacthub.io/packages/helm/helmforge/redis

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -32,8 +32,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Image helper */}}
 {{- define "authelia.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* ============================================================ */}}

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Authelia container image
   repository: docker.io/authelia/authelia
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "4.39.16"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -44,9 +44,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/automatisch
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: automatisch
-      image: docker.io/automatischio/automatisch:0.15.0
 dependencies:
   - name: postgresql
     version: 1.8.4

--- a/charts/automatisch/templates/_helpers.tpl
+++ b/charts/automatisch/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "automatisch.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* ======================================================================= */}}

--- a/charts/automatisch/values.yaml
+++ b/charts/automatisch/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Automatisch container image
   repository: docker.io/automatischio/automatisch
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "0.15.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -45,9 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/castopod
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: castopod
-      image: docker.io/castopod/castopod:1.15.5
 dependencies:
   - name: mariadb
     version: 1.0.5

--- a/charts/castopod/templates/_helpers.tpl
+++ b/charts/castopod/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "castopod.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database host */}}

--- a/charts/castopod/values.yaml
+++ b/charts/castopod/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Castopod container image
   repository: docker.io/castopod/castopod
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "1.15.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -45,8 +45,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/changedetection
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: changedetection
-      image: ghcr.io/dgtlmoon/changedetection.io:0.54.7
-    - name: browser
-      image: docker.io/browserless/chrome:latest

--- a/charts/changedetection/templates/_helpers.tpl
+++ b/charts/changedetection/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "changedetection.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -48,9 +48,9 @@ browser:
   enabled: false
   image:
     # -- Playwright browser image
-    repository: docker.io/browserless/chrome
+    repository: ghcr.io/browserless/chromium
     # -- Image tag
-    tag: "latest"
+    tag: "v2.46.0"
     pullPolicy: IfNotPresent
   # -- Resources for the browser container
   resources: {}

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- changedetection.io container image
   repository: ghcr.io/dgtlmoon/changedetection.io
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "0.54.7"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -46,9 +46,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/chiefonboarding
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: chiefonboarding
-      image: docker.io/chiefonboarding/chiefonboarding:2.4.1
 dependencies:
   - name: postgresql
     version: 1.8.4

--- a/charts/chiefonboarding/templates/_helpers.tpl
+++ b/charts/chiefonboarding/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "chiefonboarding.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database host */}}

--- a/charts/chiefonboarding/values.yaml
+++ b/charts/chiefonboarding/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- ChiefOnboarding container image
   repository: docker.io/chiefonboarding/chiefonboarding
-  # -- Image tag (defaults to v{appVersion})
-  tag: ""
+  # -- Image tag
+  tag: "v2.4.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -40,13 +40,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/ckan
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: ckan
-      image: docker.io/ckan/ckan-base:2.11.4
-    - name: datapusher
-      image: docker.io/ckan/ckan-base-datapusher:0.0.21
-    - name: solr
-      image: docker.io/ckan/ckan-solr:2.11-solr9
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/ckan/templates/_helpers.tpl
+++ b/charts/ckan/templates/_helpers.tpl
@@ -31,7 +31,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "ckan.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "ckan.serviceAccountName" -}}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- CKAN container image repository
   repository: docker.io/ckan/ckan-base
   # -- CKAN image tag. Defaults to appVersion.
-  tag: ""
+  tag: "2.11.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -47,9 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/cloudflared
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: cloudflared
-      image: docker.io/cloudflare/cloudflared:2026.3.0
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/pihole
     - url: https://artifacthub.io/packages/helm/helmforge/adguard-home

--- a/charts/cloudflared/templates/_helpers.tpl
+++ b/charts/cloudflared/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "cloudflared.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Tunnel token secret name */}}

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "2026.3.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -52,8 +52,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/countly
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: countly
-      image: docker.io/countly/countly-server:25.03.41
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/mongodb

--- a/charts/countly/templates/_helpers.tpl
+++ b/charts/countly/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "countly.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* MongoDB host */}}

--- a/charts/countly/values.yaml
+++ b/charts/countly/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Countly container image
   repository: docker.io/countly/countly-server
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "25.03.41"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/cronicle
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: cronicle
-      image: docker.io/soulteary/cronicle:0.9.80

--- a/charts/cronicle/templates/_helpers.tpl
+++ b/charts/cronicle/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "cronicle.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/cronicle/values.yaml
+++ b/charts/cronicle/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Cronicle container image
   repository: docker.io/soulteary/cronicle
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "0.9.80"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -47,6 +47,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/ddns-updater
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: ddns-updater
-      image: docker.io/qmcgaw/ddns-updater:2.9.0

--- a/charts/ddns-updater/templates/_helpers.tpl
+++ b/charts/ddns-updater/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "ddns-updater.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Config secret name */}}

--- a/charts/ddns-updater/values.yaml
+++ b/charts/ddns-updater/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- ddns-updater container image
   repository: docker.io/qmcgaw/ddns-updater
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "v2.9.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -44,6 +44,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/discount-bandit
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: discount-bandit
-      image: docker.io/cybrarist/discount-bandit:4.0.3

--- a/charts/discount-bandit/templates/_helpers.tpl
+++ b/charts/discount-bandit/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "discount-bandit.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/discount-bandit/values.yaml
+++ b/charts/discount-bandit/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Discount Bandit container image
   repository: docker.io/cybrarist/discount-bandit
-  # -- Image tag (defaults to appVersion with v prefix)
-  tag: ""
+  # -- Image tag
+  tag: "v4.0.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -42,9 +42,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/docmost
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: docmost
-      image: docker.io/docmost/docmost:0.70.3
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/docmost/templates/_helpers.tpl
+++ b/charts/docmost/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "docmost.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "docmost.databaseMode" -}}

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -22,7 +22,7 @@ image:
   # -- Docmost container image repository
   repository: docker.io/docmost/docmost
   # -- Docmost image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
-  tag: ""
+  tag: "0.70.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -47,9 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/dolibarr
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: dolibarr
-      image: docker.io/dolibarr/dolibarr:23.0.0
 dependencies:
   - name: mysql
     version: 1.7.1

--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -67,8 +67,7 @@ ServiceAccount name.
 Image string with tag fallback to appVersion.
 */}}
 {{- define "dolibarr.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -12,7 +12,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/dolibarr/dolibarr
-  tag: ""
+  tag: "23.0.0"
   pullPolicy: IfNotPresent
   # Keep tag empty to default to Chart.appVersion.
 

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -40,9 +40,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/druid
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: druid
-      image: docker.io/apache/druid:36.0.0
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/druid/templates/_helpers.tpl
+++ b/charts/druid/templates/_helpers.tpl
@@ -31,7 +31,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "druid.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "druid.serviceAccountName" -}}

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Druid container image repository
   repository: docker.io/apache/druid
   # -- Druid image tag. Defaults to appVersion.
-  tag: ""
+  tag: "36.0.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -42,9 +42,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/flowise
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: flowise
-      image: docker.io/flowiseai/flowise:3.1.1
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/flowise/templates/_helpers.tpl
+++ b/charts/flowise/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "flowise.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "flowise.architectureMode" -}}

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Flowise container image repository
   repository: docker.io/flowiseai/flowise
   # -- Flowise image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
-  tag: ""
+  tag: "3.1.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -25,8 +25,6 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/imagesWhitelist: |
-    - container.registry.io/project/image:latest
   artifacthub.io/license: MIT
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
@@ -35,3 +33,4 @@ annotations:
     - name: Source
       url: https://github.com/helmforgedev/charts/tree/main/charts/generic
     - name: support
+      url: https://github.com/helmforgedev/charts/issues

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -47,9 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/ghost
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: ghost
-      image: docker.io/library/ghost:6.25.1
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:

--- a/charts/ghost/templates/_helpers.tpl
+++ b/charts/ghost/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "ghost.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Content PVC claim name */}}

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Ghost container image
   repository: docker.io/library/ghost
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "6.25.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -39,9 +39,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/gitea
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: gitea
-      image: docker.io/gitea/gitea:1.25.5
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/gitea/templates/_helpers.tpl
+++ b/charts/gitea/templates/_helpers.tpl
@@ -63,8 +63,7 @@ ServiceAccount name
 Image reference with tag defaulting to appVersion-rootless
 */}}
 {{- define "gitea.image" -}}
-{{- $tag := .Values.image.tag | default (printf "%s-rootless" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end }}
 
 {{/* ======================================================================== */}}

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -5,7 +5,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: ""  # defaults to appVersion + "-rootless"
+  tag: "1.25.5-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -49,13 +49,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/guacamole
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: guacamole
-      image: docker.io/guacamole/guacamole:1.6.0
-    - name: guacd
-      image: docker.io/guacamole/guacd:1.6.0
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/guacamole/templates/_helpers.tpl
+++ b/charts/guacamole/templates/_helpers.tpl
@@ -39,13 +39,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "guacamole.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "guacamole.guacdImage" -}}
-{{- $tag := .Values.guacd.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.guacd.image.repository $tag -}}
+{{- printf "%s:%s" .Values.guacd.image.repository .Values.guacd.image.tag -}}
 {{- end -}}
 
 {{/* ========== Database helpers ========== */}}

--- a/charts/guacamole/values.yaml
+++ b/charts/guacamole/values.yaml
@@ -14,16 +14,16 @@ commonLabels: {}
 image:
   # -- Guacamole web application image
   repository: docker.io/guacamole/guacamole
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "1.6.0"
   pullPolicy: IfNotPresent
 
 guacd:
   image:
     # -- guacd daemon image
     repository: docker.io/guacamole/guacd
-    # -- guacd image tag (defaults to appVersion)
-    tag: ""
+    # -- guacd image tag
+    tag: "1.6.0"
     pullPolicy: IfNotPresent
   # -- guacd daemon port
   port: 4822

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/heimdall
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: heimdall
-      image: docker.io/linuxserver/heimdall:2.7.6

--- a/charts/heimdall/templates/_helpers.tpl
+++ b/charts/heimdall/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "heimdall.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* S3 credentials secret name */}}

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -16,8 +16,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/linuxserver/heimdall
-  # -- Image tag (defaults to Chart.appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "2.7.6"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -38,9 +38,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/homarr
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: homarr
-      image: ghcr.io/homarr-labs/homarr:1.57.1
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/homarr/templates/_helpers.tpl
+++ b/charts/homarr/templates/_helpers.tpl
@@ -42,8 +42,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{- define "homarr.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end }}
 
 {{/* ======================================================================== */}}

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -5,7 +5,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: ""  # defaults to "v" + appVersion
+  tag: "v1.57.1"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -45,10 +45,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/kafka
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: kafka
-      image: docker.io/apache/kafka:4.2.0
-    - name: jmx-exporter
-      image: docker.io/bitnami/jmx-exporter:1.5.0
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/druid

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -44,10 +44,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/karakeep
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: karakeep
-      image: ghcr.io/karakeep-app/karakeep:0.31.0
-    - name: meilisearch
-      image: docker.io/getmeili/meilisearch:v1.41.0
-    - name: chromium
-      image: ghcr.io/browserless/chromium:v2.46.0

--- a/charts/karakeep/templates/_helpers.tpl
+++ b/charts/karakeep/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "karakeep.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/karakeep/values.yaml
+++ b/charts/karakeep/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Karakeep container image
   repository: ghcr.io/karakeep-app/karakeep
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "0.31.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -41,11 +41,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/keycloak
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: keycloak
-      image: quay.io/keycloak/keycloak:26.5.5
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/authelia
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -46,10 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/komga
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: komga
-      image: docker.io/gotson/komga:1.24.1
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
-    - name: backup-archiver
-      image: docker.io/library/alpine:3.22

--- a/charts/komga/templates/_helpers.tpl
+++ b/charts/komga/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "komga.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Config PVC claim name */}}

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Komga image repository
   repository: docker.io/gotson/komga
-  # -- Komga image tag (defaults to appVersion)
-  tag: ""
+  # -- Komga image tag
+  tag: "1.24.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -40,9 +40,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/listmonk
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: listmonk
-      image: docker.io/listmonk/listmonk:v6.1.0
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc

--- a/charts/listmonk/templates/_helpers.tpl
+++ b/charts/listmonk/templates/_helpers.tpl
@@ -44,8 +44,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "listmonk.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* ======== Database helpers ======== */}}

--- a/charts/listmonk/values.yaml
+++ b/charts/listmonk/values.yaml
@@ -21,7 +21,7 @@ image:
   # -- Listmonk container image repository
   repository: docker.io/listmonk/listmonk
   # -- Listmonk image tag. Defaults to appVersion when empty.
-  tag: ""
+  tag: "v6.1.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/liwan
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: liwan
-      image: ghcr.io/explodingcamera/liwan:1.4.0

--- a/charts/liwan/templates/_helpers.tpl
+++ b/charts/liwan/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "liwan.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/liwan/values.yaml
+++ b/charts/liwan/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Liwan container image
   repository: ghcr.io/explodingcamera/liwan
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "1.4.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -44,12 +44,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/mariadb
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: mariadb
-      image: docker.io/library/mariadb:11.4
-    - name: mysqld-exporter
-      image: docker.io/prom/mysqld-exporter:v0.17.2
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/phpmyadmin

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -46,9 +46,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/metabase
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: metabase
-      image: docker.io/metabase/metabase:0.54.5
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "metabase.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database host */}}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
-  # -- Image tag (defaults to v{appVersion})
-  tag: ""
+  # -- Image tag
+  tag: "v0.54.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -56,6 +56,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/middleware
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: middleware
-      image: docker.io/middlewareeng/middleware:0.3.1

--- a/charts/middleware/templates/_helpers.tpl
+++ b/charts/middleware/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "middleware.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* PostgreSQL host */}}

--- a/charts/middleware/values.yaml
+++ b/charts/middleware/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Middleware container image
   repository: docker.io/middlewareeng/middleware
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "0.3.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -48,8 +48,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/minecraft
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: minecraft
-      image: docker.io/itzg/minecraft-server:java21
-    - name: mc-monitor
-      image: docker.io/itzg/mc-monitor:0.16.1

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -134,6 +134,5 @@ true
 Image string with tag fallback to appVersion.
 */}}
 {{- define "minecraft.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -22,8 +22,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
-  # -- Container image tag (defaults to appVersion; use java21 for LTS)
-  tag: ""
+  # -- Container image tag
+  tag: "java21"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -46,12 +46,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/mongodb
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: mongodb
-      image: docker.io/library/mongo:8.2.6
-    - name: mongodb-exporter
-      image: docker.io/percona/mongodb_exporter:0.49.0
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/countly

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -46,8 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/mosquitto
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: mosquitto
-      image: docker.io/library/eclipse-mosquitto:2.0.22
-    - name: mqttx-web
-      image: docker.io/emqx/mqttx-web:latest

--- a/charts/mosquitto/templates/_helpers.tpl
+++ b/charts/mosquitto/templates/_helpers.tpl
@@ -37,8 +37,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "mosquitto.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "mosquitto.mqttxImage" -}}

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -43,12 +43,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/mysql
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: mysql
-      image: docker.io/library/mysql:8.4
-    - name: mysqld-exporter
-      image: docker.io/prom/mysqld-exporter:v0.17.2
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/phpmyadmin

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -45,9 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/n8n
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: n8n
-      image: docker.io/n8nio/n8n:2.12.3
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
     - url: https://artifacthub.io/packages/helm/helmforge/redis

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/component: worker
 {{- end -}}
 
 {{- define "n8n.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 # =============================================================================

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -22,8 +22,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
-  # -- Container image tag (defaults to appVersion)
-  tag: ""
+  # -- Container image tag
+  tag: "2.12.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/ntfy
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: ntfy
-      image: docker.io/binwiederhier/ntfy:2.21.0

--- a/charts/ntfy/templates/_helpers.tpl
+++ b/charts/ntfy/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "ntfy.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "v2.21.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/olivetin
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: olivetin
-      image: docker.io/jamesread/olivetin:3000.11.3

--- a/charts/olivetin/templates/_helpers.tpl
+++ b/charts/olivetin/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "olivetin.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "3000.11.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -43,9 +43,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/open-webui
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: open-webui
-      image: ghcr.io/open-webui/open-webui:0.8.12
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "open-webui.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Data PVC claim name */}}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Open WebUI container image
   repository: ghcr.io/open-webui/open-webui
-  # -- Image tag (defaults to appVersion with v prefix)
-  tag: ""
+  # -- Image tag
+  tag: "v0.8.12"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -47,9 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/phpmyadmin
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: phpmyadmin
-      image: docker.io/phpmyadmin/phpmyadmin:5.2.3
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
     - url: https://artifacthub.io/packages/helm/helmforge/mariadb

--- a/charts/phpmyadmin/templates/_helpers.tpl
+++ b/charts/phpmyadmin/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "phpmyadmin.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Auth secret name */}}

--- a/charts/phpmyadmin/values.yaml
+++ b/charts/phpmyadmin/values.yaml
@@ -16,8 +16,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/phpmyadmin/phpmyadmin
-  # -- Image tag (defaults to Chart.appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "5.2.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -46,12 +46,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/pihole
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: pihole
-      image: docker.io/pihole/pihole:2025.03.0
-    - name: pihole-exporter
-      image: docker.io/ekofr/pihole-exporter:v0.4.0
-    - name: unbound
-      image: docker.io/mvance/unbound:1.22.0
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/cloudflared

--- a/charts/pihole/templates/_helpers.tpl
+++ b/charts/pihole/templates/_helpers.tpl
@@ -89,8 +89,7 @@ Secret key for admin password.
 Image string with tag fallback to appVersion.
 */}}
 {{- define "pihole.image" -}}
-{{- $tag := default .Chart.AppVersion .Values.image.tag }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -22,8 +22,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/pihole/pihole
-  # -- Container image tag (defaults to appVersion)
-  tag: ""
+  # -- Container image tag
+  tag: "2025.03.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -45,12 +45,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/postgresql
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: postgresql
-      image: docker.io/library/postgres:18.3-trixie
-    - name: postgres-exporter
-      image: quay.io/prometheuscommunity/postgres-exporter:v0.18.0
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/metabase

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -46,6 +46,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/rabbitmq
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: rabbitmq
-      image: docker.io/library/rabbitmq:4.2.4-management

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -45,10 +45,5 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/redis
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: redis
-      image: docker.io/library/redis:8.6.0
-    - name: redis-exporter
-      image: docker.io/oliver006/redis_exporter:v1.69.0
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/uptime-kuma

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -46,9 +46,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/strapi
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: strapi
-      image: docker.io/vshadbolt/strapi:5.40.0
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/strapi/templates/_helpers.tpl
+++ b/charts/strapi/templates/_helpers.tpl
@@ -39,7 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "strapi.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "strapi.databaseMode" -}}

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -23,8 +23,8 @@ commonLabels: {}
 image:
   # -- Container image repository for your Strapi project
   repository: docker.io/vshadbolt/strapi
-  # -- Container image tag (defaults to appVersion when empty)
-  tag: ""
+  # -- Container image tag
+  tag: "5.40.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -47,6 +47,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: strava-statistics
-      image: docker.io/robiningelbrecht/strava-statistics:4.7.5

--- a/charts/strava-statistics/templates/_helpers.tpl
+++ b/charts/strava-statistics/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "strava-statistics.image" -}}
-{{- $tag := .Values.image.tag | default (printf "v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Strava secret name */}}

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Statistics for Strava container image
   repository: docker.io/robiningelbrecht/strava-statistics
-  # -- Image tag (defaults to v{appVersion})
-  tag: ""
+  # -- Image tag
+  tag: "v4.7.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -41,9 +41,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/superset
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: superset
-      image: docker.io/apache/superset:4.1.4
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |

--- a/charts/superset/templates/_helpers.tpl
+++ b/charts/superset/templates/_helpers.tpl
@@ -31,7 +31,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "superset.image" -}}
-{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "superset.serviceAccountName" -}}

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Superset container image repository
   repository: docker.io/apache/superset
   # -- Superset image tag. Defaults to appVersion.
-  tag: ""
+  tag: "4.1.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -45,9 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/umami
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: umami
-      image: ghcr.io/umami-software/umami:2.17.0
 dependencies:
   - name: postgresql
     version: 1.8.2

--- a/charts/umami/templates/_helpers.tpl
+++ b/charts/umami/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "umami.image" -}}
-{{- $tag := .Values.image.tag | default (printf "postgresql-v%s" .Chart.AppVersion) -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database host */}}

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Umami container image (PostgreSQL variant)
   repository: ghcr.io/umami-software/umami
-  # -- Image tag (defaults to postgresql-v{appVersion})
-  tag: ""
+  # -- Image tag
+  tag: "postgresql-v2.17.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -45,11 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: uptime-kuma
-      image: docker.io/louislam/uptime-kuma:2.2.1
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
 dependencies:
   - name: mysql
     version: 1.7.1

--- a/charts/uptime-kuma/templates/_helpers.tpl
+++ b/charts/uptime-kuma/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "uptime-kuma.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database type */}}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Uptime Kuma container image
   repository: docker.io/louislam/uptime-kuma
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "2.2.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -44,13 +44,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/vaultwarden
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: vaultwarden
-      image: docker.io/vaultwarden/server:1.35.4
-    - name: backup-uploader
-      image: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
-    - name: backup-archiver
-      image: docker.io/library/alpine:3.22
 dependencies:
   - name: postgresql
     version: 1.8.1

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -45,11 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/velero
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: velero
-      image: docker.io/velero/velero:v1.18.0
-    - name: velero-plugin-aws
-      image: docker.io/velero/velero-plugin-for-aws:v1.14.0
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
     - url: https://artifacthub.io/packages/helm/helmforge/mongodb

--- a/charts/velero/templates/_helpers.tpl
+++ b/charts/velero/templates/_helpers.tpl
@@ -37,8 +37,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "velero.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{- define "velero.serviceAccountName" -}}

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -20,8 +20,8 @@ commonLabels: {}
 image:
   # -- Velero server image repository
   repository: docker.io/velero/velero
-  # -- Velero server image tag (defaults to appVersion when empty)
-  tag: ""
+  # -- Velero server image tag
+  tag: "v1.18.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -45,9 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/wallabag
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: wallabag
-      image: docker.io/wallabag/wallabag:2.6.14
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
     - url: https://artifacthub.io/packages/helm/helmforge/redis

--- a/charts/wallabag/templates/_helpers.tpl
+++ b/charts/wallabag/templates/_helpers.tpl
@@ -39,8 +39,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "wallabag.image" -}}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
-{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
 {{/* Database host */}}

--- a/charts/wallabag/values.yaml
+++ b/charts/wallabag/values.yaml
@@ -14,8 +14,8 @@ commonLabels: {}
 image:
   # -- Wallabag container image
   repository: docker.io/wallabag/wallabag
-  # -- Image tag (defaults to appVersion)
-  tag: ""
+  # -- Image tag
+  tag: "2.6.14"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -45,11 +45,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/wordpress
     - name: support
       url: https://github.com/helmforgedev/charts/issues
-  artifacthub.io/images: |
-    - name: wordpress
-      image: docker.io/library/wordpress:6.9.4
-    - name: apache-exporter
-      image: docker.io/lusotycoon/apache-exporter:v1.0.8
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -67,8 +67,7 @@ ServiceAccount name.
 Image string with tag fallback to appVersion.
 */}}
 {{- define "wordpress.image" -}}
-{{- $tag := default (printf "%s-apache" .Chart.AppVersion) .Values.image.tag }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}
 
 {{/*

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -22,8 +22,8 @@ commonLabels: {}
 image:
   # -- Container image repository
   repository: docker.io/library/wordpress
-  # -- Container image tag (defaults to appVersion)
-  tag: ""
+  # -- Container image tag
+  tag: "6.9.4-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Removes `artifacthub.io/images` annotation from all 57 charts — high maintenance cost with no significant benefit, and broken entries in old immutable OCI versions can't be fixed retroactively
- Fixes generic chart: removes placeholder `artifacthub.io/imagesWhitelist` and adds missing `url:` to support link

## ArtifactHub errors resolved
- **Scanning errors** (8 charts): caused by images ArtifactHub couldn't resolve from the annotation — removing the annotation eliminates the issue
- **Generic invalid links** (1.9.x): support entry was missing `url:` field
- **Tracking errors on old versions** (1.1.0/1.1.1): immutable OCI artifacts, can't be fixed, but no new versions will have this problem

## Test plan
- [ ] Verify ArtifactHub stops reporting scanning errors on next index
- [ ] Verify generic chart link validation passes