### PR TITLE
fix: remove tpl from extraManifests to prevent template injection

### DIFF
--- a/charts/answer/templates/extra-manifests.yaml
+++ b/charts/answer/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/ckan/templates/extra-manifests.yaml
+++ b/charts/ckan/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/cloudflared/templates/extra-manifests.yaml
+++ b/charts/cloudflared/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/ddns-updater/templates/extra-manifests.yaml
+++ b/charts/ddns-updater/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/dolibarr/templates/extra-manifests.yaml
+++ b/charts/dolibarr/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/druid/templates/extra-manifests.yaml
+++ b/charts/druid/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/generic/templates/extra-manifests.yaml
+++ b/charts/generic/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests | default list }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/guacamole/templates/extra-manifests.yaml
+++ b/charts/guacamole/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/heimdall/templates/extra-manifests.yaml
+++ b/charts/heimdall/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/kafka/templates/extra-manifests.yaml
+++ b/charts/kafka/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/komga/templates/extra-manifests.yaml
+++ b/charts/komga/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/listmonk/templates/extra-manifests.yaml
+++ b/charts/listmonk/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/minecraft/templates/extra-manifests.yaml
+++ b/charts/minecraft/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/mongodb/templates/extra-manifests.yaml
+++ b/charts/mongodb/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/mosquitto/templates/extra-manifests.yaml
+++ b/charts/mosquitto/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/n8n/templates/extra-manifests.yaml
+++ b/charts/n8n/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/open-webui/templates/extra-manifests.yaml
+++ b/charts/open-webui/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/phpmyadmin/templates/extra-manifests.yaml
+++ b/charts/phpmyadmin/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/pihole/templates/extra-manifests.yaml
+++ b/charts/pihole/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/rabbitmq/templates/extra-manifests.yaml
+++ b/charts/rabbitmq/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/redis/templates/extra-manifests.yaml
+++ b/charts/redis/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests | default list }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/strapi/templates/extra-manifests.yaml
+++ b/charts/strapi/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/superset/templates/extra-manifests.yaml
+++ b/charts/superset/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/uptime-kuma/templates/extra-manifests.yaml
+++ b/charts/uptime-kuma/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}

--- a/charts/wordpress/templates/extra-manifests.yaml
+++ b/charts/wordpress/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests }}
 ---
-{{ tpl (toYaml .) $ }}
+{{ toYaml . }}
 {{- end }}


### PR DESCRIPTION
## Summary
- Removes `tpl` wrapper from `extraManifests` rendering in 25 charts that had `{{ tpl (toYaml .) $ }}`
- Standardizes all charts to use `{{ toYaml . }}` (literal YAML, no Go template processing)
- Prevents `{{ }}` in user-provided content (e.g. Listmonk email templates, app configs) from being interpreted as Helm directives

## Validation
- [x] helm unittest (57 charts, 1891 tests passing)
- [x] helm lint --strict
- [x] helm template