### PR TITLE
feat(mcp-server): add mcp-server Helm chart

### DIFF
--- a/charts/mcp-server/Chart.yaml
+++ b/charts/mcp-server/Chart.yaml
@@ -1,0 +1,49 @@
+apiVersion: v2
+name: mcp-server
+description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
+type: application
+version: 0.1.0
+appVersion: "0.2.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - mcp
+  - model-context-protocol
+  - fastmcp
+  - ai
+  - llm
+  - tools
+  - knowledge-base
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/mcp-server
+  - https://github.com/helmforgedev/fastmcp-server
+icon: https://helmforge.dev/icons/charts/mcp-server.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: initial release of mcp-server chart
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: helmforgedev@users.noreply.github.com
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: incubating
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: MIT
+  artifacthub.io/category: ai-machine-learning
+  artifacthub.io/links: |
+    - name: Docker Image
+      url: https://hub.docker.com/r/helmforge/fastmcp-server
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/mcp-server
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/mcp-server
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues

--- a/charts/mcp-server/ci/auth-bearer-values.yaml
+++ b/charts/mcp-server/ci/auth-bearer-values.yaml
@@ -1,0 +1,5 @@
+# CI: bearer authentication enabled
+auth:
+  type: bearer
+  bearer:
+    token: ci-test-token-12345

--- a/charts/mcp-server/ci/custom-tools-values.yaml
+++ b/charts/mcp-server/ci/custom-tools-values.yaml
@@ -1,0 +1,30 @@
+# CI: inline tools, resources, prompts, and knowledge
+sources:
+  inline:
+    tools:
+      greet.py: |
+        def greet(name: str) -> str:
+            """Greet someone by name."""
+            return f"Hello, {name}!"
+      math_ops.py: |
+        def add(a: float, b: float) -> float:
+            """Add two numbers."""
+            return a + b
+        def multiply(a: float, b: float) -> float:
+            """Multiply two numbers."""
+            return a * b
+    resources:
+      status.py: |
+        RESOURCE_URI = "status://server"
+        def get_status() -> dict:
+            """Server status."""
+            return {"status": "healthy"}
+    prompts:
+      summarize.py: |
+        def summarize(text: str) -> str:
+            """Summarize the given text."""
+            return f"Please summarize:\n\n{text}"
+    knowledge:
+      overview.md: |
+        # Product Overview
+        This is the product overview document.

--- a/charts/mcp-server/ci/default-values.yaml
+++ b/charts/mcp-server/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# CI: default install (no sources, no auth)

--- a/charts/mcp-server/ci/full-values.yaml
+++ b/charts/mcp-server/ci/full-values.yaml
@@ -1,0 +1,80 @@
+# CI: all features enabled
+server:
+  name: full-test-server
+  logLevel: DEBUG
+
+auth:
+  type: bearer
+  bearer:
+    token: ci-test-token-full
+
+sources:
+  inline:
+    tools:
+      greet.py: |
+        def greet(name: str) -> str:
+            """Greet someone."""
+            return f"Hello, {name}!"
+    knowledge:
+      docs.md: |
+        # Documentation
+        Full test documentation.
+  s3:
+    enabled: true
+    endpoint: "https://minio.example.com"
+    bucket: mcp-assets
+    region: us-east-1
+    accessKey: minioadmin
+    secretKey: minioadmin
+  git:
+    enabled: true
+    repository: "https://github.com/example/tools.git"
+    branch: main
+    token: ghp_example
+
+extraPipPackages:
+  - requests
+  - pandas
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: mcp.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - mcp.example.com
+      secretName: mcp-tls
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::role/mcp-server
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true

--- a/charts/mcp-server/ci/git-source-values.yaml
+++ b/charts/mcp-server/ci/git-source-values.yaml
@@ -1,0 +1,8 @@
+# CI: Git source enabled
+sources:
+  git:
+    enabled: true
+    repository: "https://github.com/example/mcp-tools.git"
+    branch: main
+    path: ""
+    token: ghp_exampletoken123

--- a/charts/mcp-server/ci/s3-source-values.yaml
+++ b/charts/mcp-server/ci/s3-source-values.yaml
@@ -1,0 +1,10 @@
+# CI: S3 source enabled
+sources:
+  s3:
+    enabled: true
+    endpoint: "https://s3.example.com"
+    bucket: mcp-tools
+    region: us-east-1
+    prefix: production
+    accessKey: AKIAIOSFODNN7EXAMPLE
+    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/charts/mcp-server/templates/NOTES.txt
+++ b/charts/mcp-server/templates/NOTES.txt
@@ -1,0 +1,46 @@
+🚀 MCP Server has been deployed!
+
+Server name: {{ .Values.server.name }}
+MCP endpoint: {{ .Values.server.path }}
+
+{{- if .Values.ingress.enabled }}
+
+Ingress is enabled. Access the MCP endpoint at:
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ $.Values.server.path }}
+{{- end }}
+{{- else }}
+
+To access the MCP endpoint, run:
+
+  kubectl port-forward svc/{{ include "mcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+Then connect to: http://localhost:{{ .Values.service.port }}{{ .Values.server.path }}
+{{- end }}
+
+{{- if ne .Values.auth.type "none" }}
+
+Authentication: {{ .Values.auth.type }}
+{{- if eq .Values.auth.type "bearer" }}
+Requests must include: Authorization: Bearer <token>
+{{- end }}
+{{- else }}
+
+Authentication: disabled (no auth required)
+{{- end }}
+
+Sources:
+{{- if (include "mcp-server.hasAnyInline" .) }}
+  - Inline (ConfigMap): enabled
+{{- end }}
+{{- if .Values.sources.s3.enabled }}
+  - S3: s3://{{ .Values.sources.s3.bucket }}/{{ .Values.sources.s3.prefix }}
+{{- end }}
+{{- if .Values.sources.git.enabled }}
+  - Git: {{ .Values.sources.git.repository }} ({{ .Values.sources.git.branch }})
+{{- end }}
+{{- if not (or (include "mcp-server.hasAnyInline" .) .Values.sources.s3.enabled .Values.sources.git.enabled) }}
+  - None configured (server will start with no tools/resources)
+{{- end }}
+
+Documentation: https://helmforge.dev/docs/charts/mcp-server

--- a/charts/mcp-server/templates/_helpers.tpl
+++ b/charts/mcp-server/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{- define "mcp-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mcp-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "mcp-server.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mcp-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mcp-server.labels" -}}
+helm.sh/chart: {{ include "mcp-server.chart" . }}
+{{ include "mcp-server.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "mcp-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "mcp-server.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{/* Auth secret name */}}
+{{- define "mcp-server.authSecretName" -}}
+{{- if eq .Values.auth.type "bearer" -}}
+  {{- if .Values.auth.bearer.existingSecret -}}
+    {{- .Values.auth.bearer.existingSecret -}}
+  {{- else -}}
+    {{- printf "%s-auth" (include "mcp-server.fullname" .) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* S3 secret name */}}
+{{- define "mcp-server.s3SecretName" -}}
+{{- if .Values.sources.s3.existingSecret -}}
+  {{- .Values.sources.s3.existingSecret -}}
+{{- else -}}
+  {{- printf "%s-s3" (include "mcp-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Git secret name */}}
+{{- define "mcp-server.gitSecretName" -}}
+{{- if .Values.sources.git.existingSecret -}}
+  {{- .Values.sources.git.existingSecret -}}
+{{- else -}}
+  {{- printf "%s-git" (include "mcp-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* PVC claim name */}}
+{{- define "mcp-server.claimName" -}}
+{{- if .Values.persistence.existingClaim -}}
+  {{- .Values.persistence.existingClaim -}}
+{{- else -}}
+  {{- printf "%s-workspace" (include "mcp-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Check if any inline content exists */}}
+{{- define "mcp-server.hasInlineTools" -}}
+{{- if .Values.sources.inline.tools -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mcp-server.hasInlineResources" -}}
+{{- if .Values.sources.inline.resources -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mcp-server.hasInlinePrompts" -}}
+{{- if .Values.sources.inline.prompts -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mcp-server.hasInlineKnowledge" -}}
+{{- if .Values.sources.inline.knowledge -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mcp-server.hasAnyInline" -}}
+{{- if or (include "mcp-server.hasInlineTools" .) (include "mcp-server.hasInlineResources" .) (include "mcp-server.hasInlinePrompts" .) (include "mcp-server.hasInlineKnowledge" .) -}}true{{- end -}}
+{{- end -}}

--- a/charts/mcp-server/templates/configmap-knowledge.yaml
+++ b/charts/mcp-server/templates/configmap-knowledge.yaml
@@ -1,0 +1,13 @@
+{{- if (include "mcp-server.hasInlineKnowledge" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-knowledge
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $content := .Values.sources.inline.knowledge }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-server/templates/configmap-prompts.yaml
+++ b/charts/mcp-server/templates/configmap-prompts.yaml
@@ -1,0 +1,13 @@
+{{- if (include "mcp-server.hasInlinePrompts" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-prompts
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $content := .Values.sources.inline.prompts }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-server/templates/configmap-resources.yaml
+++ b/charts/mcp-server/templates/configmap-resources.yaml
@@ -1,0 +1,13 @@
+{{- if (include "mcp-server.hasInlineResources" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-resources
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $content := .Values.sources.inline.resources }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-server/templates/configmap-tools.yaml
+++ b/charts/mcp-server/templates/configmap-tools.yaml
@@ -1,0 +1,13 @@
+{{- if (include "mcp-server.hasInlineTools" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-tools
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $content := .Values.sources.inline.tools }}
+  {{ $filename }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-server/templates/deployment.yaml
+++ b/charts/mcp-server/templates/deployment.yaml
@@ -1,0 +1,257 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-server.fullname" . }}
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mcp-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if (include "mcp-server.hasAnyInline" .) }}
+        checksum/tools: {{ .Values.sources.inline.tools | toJson | sha256sum }}
+        checksum/resources: {{ .Values.sources.inline.resources | toJson | sha256sum }}
+        checksum/prompts: {{ .Values.sources.inline.prompts | toJson | sha256sum }}
+        checksum/knowledge: {{ .Values.sources.inline.knowledge | toJson | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "mcp-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mcp-server.fullname" .) }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: mcp-server
+          image: {{ include "mcp-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: MCP_SERVER_NAME
+              value: {{ .Values.server.name | quote }}
+            - name: MCP_PORT
+              value: {{ .Values.server.port | quote }}
+            - name: MCP_PATH
+              value: {{ .Values.server.path | quote }}
+            - name: MCP_HOST
+              value: "0.0.0.0"
+            - name: LOG_LEVEL
+              value: {{ .Values.server.logLevel | quote }}
+            {{- if ne .Values.auth.type "none" }}
+            - name: MCP_AUTH_TYPE
+              value: {{ .Values.auth.type | quote }}
+            {{- end }}
+            {{- if eq .Values.auth.type "bearer" }}
+            - name: MCP_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-server.authSecretName" . }}
+                  key: {{ .Values.auth.bearer.existingSecretKey | default "token" }}
+            {{- end }}
+            {{- if eq .Values.auth.type "jwt" }}
+            {{- with .Values.auth.jwt.issuer }}
+            - name: MCP_AUTH_JWT_ISSUER
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.auth.jwt.audience }}
+            - name: MCP_AUTH_JWT_AUDIENCE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.auth.jwt.jwksUri }}
+            - name: MCP_AUTH_JWT_JWKS_URI
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.sources.s3.enabled }}
+            - name: SOURCE_S3_ENABLED
+              value: "true"
+            {{- with .Values.sources.s3.endpoint }}
+            - name: SOURCE_S3_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOURCE_S3_BUCKET
+              value: {{ .Values.sources.s3.bucket | quote }}
+            - name: SOURCE_S3_REGION
+              value: {{ .Values.sources.s3.region | quote }}
+            {{- with .Values.sources.s3.prefix }}
+            - name: SOURCE_S3_PREFIX
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOURCE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-server.s3SecretName" . }}
+                  key: {{ .Values.sources.s3.existingSecretAccessKeyKey | default "access-key" }}
+            - name: SOURCE_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-server.s3SecretName" . }}
+                  key: {{ .Values.sources.s3.existingSecretSecretKeyKey | default "secret-key" }}
+            {{- end }}
+            {{- if .Values.sources.git.enabled }}
+            - name: SOURCE_GIT_ENABLED
+              value: "true"
+            - name: SOURCE_GIT_REPOSITORY
+              value: {{ .Values.sources.git.repository | quote }}
+            - name: SOURCE_GIT_BRANCH
+              value: {{ .Values.sources.git.branch | quote }}
+            {{- with .Values.sources.git.path }}
+            - name: SOURCE_GIT_PATH
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or .Values.sources.git.token .Values.sources.git.existingSecret }}
+            - name: SOURCE_GIT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-server.gitSecretName" . }}
+                  key: {{ .Values.sources.git.existingSecretTokenKey | default "token" }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.extraPipPackages }}
+            - name: EXTRA_PIP_PACKAGES
+              value: {{ join "," .Values.extraPipPackages | quote }}
+            {{- end }}
+            {{- if (include "mcp-server.hasAnyInline" .) }}
+            - name: SOURCE_INLINE_DIR
+              value: /app/inline
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.httpGet.path }}
+              port: {{ .Values.probes.startup.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.httpGet.path }}
+              port: {{ .Values.probes.liveness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.httpGet.path }}
+              port: {{ .Values.probes.readiness.httpGet.port }}
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: workspace
+              mountPath: /app/workspace
+            {{- if (include "mcp-server.hasInlineTools" .) }}
+            - name: inline-tools
+              mountPath: /app/inline/tools
+              readOnly: true
+            {{- end }}
+            {{- if (include "mcp-server.hasInlineResources" .) }}
+            - name: inline-resources
+              mountPath: /app/inline/resources
+              readOnly: true
+            {{- end }}
+            {{- if (include "mcp-server.hasInlinePrompts" .) }}
+            - name: inline-prompts
+              mountPath: /app/inline/prompts
+              readOnly: true
+            {{- end }}
+            {{- if (include "mcp-server.hasInlineKnowledge" .) }}
+            - name: inline-knowledge
+              mountPath: /app/inline/knowledge
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: workspace
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-server.claimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if (include "mcp-server.hasInlineTools" .) }}
+        - name: inline-tools
+          configMap:
+            name: {{ include "mcp-server.fullname" . }}-tools
+        {{- end }}
+        {{- if (include "mcp-server.hasInlineResources" .) }}
+        - name: inline-resources
+          configMap:
+            name: {{ include "mcp-server.fullname" . }}-resources
+        {{- end }}
+        {{- if (include "mcp-server.hasInlinePrompts" .) }}
+        - name: inline-prompts
+          configMap:
+            name: {{ include "mcp-server.fullname" . }}-prompts
+        {{- end }}
+        {{- if (include "mcp-server.hasInlineKnowledge" .) }}
+        - name: inline-knowledge
+          configMap:
+            name: {{ include "mcp-server.fullname" . }}-knowledge
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/mcp-server/templates/extra-manifests.yaml
+++ b/charts/mcp-server/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/mcp-server/templates/ingress.yaml
+++ b/charts/mcp-server/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mcp-server.fullname" . }}
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "mcp-server.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mcp-server/templates/networkpolicy.yaml
+++ b/charts/mcp-server/templates/networkpolicy.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-server.fullname" . }}
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mcp-server.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.server.port }}
+          protocol: TCP
+{{- end }}

--- a/charts/mcp-server/templates/pvc.yaml
+++ b/charts/mcp-server/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mcp-server.claimName" . }}
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/mcp-server/templates/secret.yaml
+++ b/charts/mcp-server/templates/secret.yaml
@@ -1,0 +1,33 @@
+{{- if and (eq .Values.auth.type "bearer") (not .Values.auth.bearer.existingSecret) .Values.auth.bearer.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-auth
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+stringData:
+  token: {{ .Values.auth.bearer.token | quote }}
+{{- end }}
+{{- if and .Values.sources.s3.enabled (not .Values.sources.s3.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-s3
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+stringData:
+  access-key: {{ .Values.sources.s3.accessKey | quote }}
+  secret-key: {{ .Values.sources.s3.secretKey | quote }}
+{{- end }}
+{{- if and .Values.sources.git.enabled .Values.sources.git.token (not .Values.sources.git.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-server.fullname" . }}-git
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+stringData:
+  token: {{ .Values.sources.git.token | quote }}
+{{- end }}

--- a/charts/mcp-server/templates/service.yaml
+++ b/charts/mcp-server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-server.fullname" . }}
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "mcp-server.selectorLabels" . | nindent 4 }}

--- a/charts/mcp-server/templates/serviceaccount.yaml
+++ b/charts/mcp-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "mcp-server.fullname" .) }}
+  labels:
+    {{- include "mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mcp-server/tests/configmap_test.yaml
+++ b/charts/mcp-server/tests/configmap_test.yaml
@@ -1,0 +1,111 @@
+suite: configmaps
+tests:
+  - it: should not render tools configmap when empty
+    templates:
+      - templates/configmap-tools.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render tools configmap with inline tools
+    templates:
+      - templates/configmap-tools.yaml
+    set:
+      sources:
+        inline:
+          tools:
+            greet.py: |
+              def greet(name: str) -> str:
+                  return f"Hello, {name}!"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-tools
+
+  - it: should not render resources configmap when empty
+    templates:
+      - templates/configmap-resources.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render resources configmap with inline resources
+    templates:
+      - templates/configmap-resources.yaml
+    set:
+      sources:
+        inline:
+          resources:
+            status.py: |
+              RESOURCE_URI = "status://server"
+              def get_status(): return {"status": "ok"}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-resources
+
+  - it: should not render prompts configmap when empty
+    templates:
+      - templates/configmap-prompts.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render prompts configmap with inline prompts
+    templates:
+      - templates/configmap-prompts.yaml
+    set:
+      sources:
+        inline:
+          prompts:
+            summarize.py: |
+              def summarize(text: str) -> str:
+                  return f"Summarize: {text}"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-prompts
+
+  - it: should not render knowledge configmap when empty
+    templates:
+      - templates/configmap-knowledge.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render knowledge configmap with inline knowledge
+    templates:
+      - templates/configmap-knowledge.yaml
+    set:
+      sources:
+        inline:
+          knowledge:
+            docs.md: |
+              # Documentation
+              Content here.
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-knowledge
+
+  - it: should have helmforge labels on all configmaps
+    templates:
+      - templates/configmap-tools.yaml
+    set:
+      sources:
+        inline:
+          tools:
+            test.py: "def test(): pass"
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/part-of: helmforge

--- a/charts/mcp-server/tests/deployment_test.yaml
+++ b/charts/mcp-server/tests/deployment_test.yaml
@@ -1,0 +1,252 @@
+suite: deployment
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should render a Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server
+
+  - it: should use correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/helmforge/fastmcp-server:0.2.0"
+
+  - it: should set MCP_SERVER_NAME env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_SERVER_NAME
+            value: "fastmcp-server"
+
+  - it: should set MCP_PORT env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_PORT
+            value: "8000"
+
+  - it: should set MCP_PATH env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_PATH
+            value: "/mcp"
+
+  - it: should expose http port 8000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            name: http
+            containerPort: 8000
+            protocol: TCP
+
+  - it: should have probes by default
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].startupProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should have helmforge labels
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/part-of: helmforge
+            app.kubernetes.io/name: mcp-server
+            app.kubernetes.io/instance: RELEASE-NAME
+
+  - it: should use workspace emptyDir by default
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: workspace
+            emptyDir: {}
+
+  - it: should use PVC when persistence enabled
+    set:
+      persistence:
+        enabled: true
+        size: 2Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: workspace
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-mcp-server-workspace
+
+  - it: should not set auth env when auth is none
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_TYPE
+          any: true
+
+  - it: should set bearer auth env
+    set:
+      auth:
+        type: bearer
+        bearer:
+          token: test-token
+    templates:
+      - templates/deployment.yaml
+      - templates/secret.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_TYPE
+            value: "bearer"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-mcp-server-auth
+                key: token
+        template: templates/deployment.yaml
+
+  - it: should set S3 env vars when enabled
+    set:
+      sources:
+        s3:
+          enabled: true
+          endpoint: "https://minio.local"
+          bucket: tools
+          region: us-east-1
+          accessKey: admin
+          secretKey: secret
+    templates:
+      - templates/deployment.yaml
+      - templates/secret.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_S3_ENABLED
+            value: "true"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_S3_BUCKET
+            value: "tools"
+        template: templates/deployment.yaml
+
+  - it: should set Git env vars when enabled
+    set:
+      sources:
+        git:
+          enabled: true
+          repository: "https://github.com/example/tools.git"
+          branch: main
+          token: ghp_test
+    templates:
+      - templates/deployment.yaml
+      - templates/secret.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_GIT_ENABLED
+            value: "true"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_GIT_REPOSITORY
+            value: "https://github.com/example/tools.git"
+        template: templates/deployment.yaml
+
+  - it: should mount inline tools when configured
+    set:
+      sources:
+        inline:
+          tools:
+            greet.py: |
+              def greet(): return "hi"
+    templates:
+      - templates/deployment.yaml
+      - templates/configmap-tools.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: inline-tools
+            mountPath: /app/inline/tools
+            readOnly: true
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: inline-tools
+            configMap:
+              name: RELEASE-NAME-mcp-server-tools
+        template: templates/deployment.yaml
+
+  - it: should not mount inline volumes when empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: inline-tools
+          any: true
+
+  - it: should set EXTRA_PIP_PACKAGES when configured
+    set:
+      extraPipPackages:
+        - requests
+        - pandas
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_PIP_PACKAGES
+            value: "requests,pandas"
+
+  - it: should set custom server name
+    set:
+      server:
+        name: my-mcp
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_SERVER_NAME
+            value: "my-mcp"
+
+  - it: should set resources when configured
+    set:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+
+  - it: should set serviceAccountName when SA is created
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-mcp-server

--- a/charts/mcp-server/tests/ingress_test.yaml
+++ b/charts/mcp-server/tests/ingress_test.yaml
@@ -1,0 +1,60 @@
+suite: ingress
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: mcp.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+
+  - it: should set ingressClassName
+    set:
+      ingress:
+        enabled: true
+        ingressClassName: nginx
+        hosts:
+          - host: mcp.example.com
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should set TLS configuration
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: mcp.example.com
+        tls:
+          - hosts:
+              - mcp.example.com
+            secretName: mcp-tls
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: mcp-tls
+
+  - it: should have helmforge labels
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: mcp.example.com
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/part-of: helmforge

--- a/charts/mcp-server/tests/networkpolicy_test.yaml
+++ b/charts/mcp-server/tests/networkpolicy_test.yaml
@@ -1,0 +1,41 @@
+suite: networkpolicy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server
+
+  - it: should allow ingress on server port
+    set:
+      networkPolicy:
+        enabled: true
+      server:
+        port: 8000
+    asserts:
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 8000
+
+  - it: should have correct pod selector
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - isSubset:
+          path: spec.podSelector.matchLabels
+          content:
+            app.kubernetes.io/name: mcp-server
+            app.kubernetes.io/instance: RELEASE-NAME

--- a/charts/mcp-server/tests/pvc_test.yaml
+++ b/charts/mcp-server/tests/pvc_test.yaml
@@ -1,0 +1,61 @@
+suite: pvc
+templates:
+  - templates/pvc.yaml
+tests:
+  - it: should not render when persistence disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render PVC when enabled
+    set:
+      persistence:
+        enabled: true
+        size: 2Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-workspace
+
+  - it: should set storage size
+    set:
+      persistence:
+        enabled: true
+        size: 5Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+
+  - it: should set storage class
+    set:
+      persistence:
+        enabled: true
+        size: 1Gi
+        storageClass: fast-ssd
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+
+  - it: should not render when using existingClaim
+    set:
+      persistence:
+        enabled: true
+        existingClaim: my-existing-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have helmforge labels
+    set:
+      persistence:
+        enabled: true
+        size: 1Gi
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/part-of: helmforge

--- a/charts/mcp-server/tests/secret_test.yaml
+++ b/charts/mcp-server/tests/secret_test.yaml
@@ -1,0 +1,79 @@
+suite: secret
+templates:
+  - templates/secret.yaml
+tests:
+  - it: should not render when auth is none and no sources
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render auth secret for bearer
+    set:
+      auth:
+        type: bearer
+        bearer:
+          token: my-secret-token
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-auth
+      - equal:
+          path: stringData.token
+          value: my-secret-token
+
+  - it: should not render auth secret when using existingSecret
+    set:
+      auth:
+        type: bearer
+        bearer:
+          token: ignored
+          existingSecret: my-external-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render S3 secret when enabled
+    set:
+      sources:
+        s3:
+          enabled: true
+          bucket: test
+          accessKey: AKID
+          secretKey: SKEY
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-s3
+        documentIndex: 0
+
+  - it: should not render S3 secret when using existingSecret
+    set:
+      sources:
+        s3:
+          enabled: true
+          bucket: test
+          existingSecret: my-s3-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render Git secret when token is set
+    set:
+      sources:
+        git:
+          enabled: true
+          repository: "https://github.com/example/tools.git"
+          token: ghp_test123
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server-git
+        documentIndex: 0

--- a/charts/mcp-server/tests/service_test.yaml
+++ b/charts/mcp-server/tests/service_test.yaml
@@ -1,0 +1,62 @@
+suite: service
+templates:
+  - templates/service.yaml
+tests:
+  - it: should render a Service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server
+
+  - it: should be ClusterIP by default
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should expose port 8000
+    asserts:
+      - equal:
+          path: spec.ports[0]
+          value:
+            name: http
+            port: 8000
+            targetPort: http
+            protocol: TCP
+
+  - it: should use correct selector labels
+    asserts:
+      - isSubset:
+          path: spec.selector
+          content:
+            app.kubernetes.io/name: mcp-server
+            app.kubernetes.io/instance: RELEASE-NAME
+
+  - it: should have helmforge labels
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            app.kubernetes.io/part-of: helmforge
+
+  - it: should support custom service type
+    set:
+      service:
+        type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: should support annotations
+    set:
+      service:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            service.beta.kubernetes.io/aws-load-balancer-type: nlb

--- a/charts/mcp-server/tests/serviceaccount_test.yaml
+++ b/charts/mcp-server/tests/serviceaccount_test.yaml
@@ -1,0 +1,41 @@
+suite: serviceaccount
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: should not render when create is false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when create is true
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mcp-server
+
+  - it: should use custom name
+    set:
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should set annotations
+    set:
+      serviceAccount:
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::role/test
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            eks.amazonaws.com/role-arn: arn:aws:iam::role/test

--- a/charts/mcp-server/values.schema.json
+++ b/charts/mcp-server/values.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "MCP Server Helm Chart Values",
+  "description": "Configuration for FastMCP server with multi-source tool, resource, prompt, and knowledge loading",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full release name used in resource names"
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Labels added to every resource created by this chart"
+    },
+    "image": {
+      "type": "object",
+      "description": "FastMCP server container image",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for private registries"
+    },
+    "server": {
+      "type": "object",
+      "description": "MCP server configuration",
+      "properties": {
+        "name": { "type": "string", "description": "Server name announced in MCP responses" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "HTTP port" },
+        "path": { "type": "string", "pattern": "^/", "description": "MCP endpoint URL path" },
+        "logLevel": { "type": "string", "enum": ["DEBUG", "INFO", "WARNING", "ERROR"], "description": "Log level" }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "description": "Authentication configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["none", "bearer", "jwt"],
+          "description": "Authentication type"
+        },
+        "bearer": {
+          "type": "object",
+          "properties": {
+            "token": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretKey": { "type": "string" }
+          }
+        },
+        "jwt": {
+          "type": "object",
+          "properties": {
+            "issuer": { "type": "string" },
+            "audience": { "type": "string" },
+            "jwksUri": { "type": "string" }
+          }
+        }
+      }
+    },
+    "sources": {
+      "type": "object",
+      "description": "Content sources (merge precedence: inline > S3 > Git)",
+      "properties": {
+        "inline": {
+          "type": "object",
+          "properties": {
+            "tools": { "type": "object", "description": "Python tool files (key=filename, value=content)" },
+            "resources": { "type": "object", "description": "Python resource files" },
+            "prompts": { "type": "object", "description": "Python prompt files" },
+            "knowledge": { "type": "object", "description": "Knowledge base files" }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "endpoint": { "type": "string" },
+            "bucket": { "type": "string" },
+            "region": { "type": "string" },
+            "prefix": { "type": "string" },
+            "accessKey": { "type": "string" },
+            "secretKey": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretAccessKeyKey": { "type": "string" },
+            "existingSecretSecretKeyKey": { "type": "string" }
+          }
+        },
+        "git": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "repository": { "type": "string" },
+            "branch": { "type": "string" },
+            "path": { "type": "string" },
+            "token": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretTokenKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "extraPipPackages": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Extra pip packages to install at startup"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "startup": { "type": "object" },
+        "liveness": { "type": "object" },
+        "readiness": { "type": "object" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraEnv": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "extraManifests": { "type": "array" }
+  }
+}

--- a/charts/mcp-server/values.yaml
+++ b/charts/mcp-server/values.yaml
@@ -1,0 +1,286 @@
+# =============================================================================
+# MCP Server Helm Chart — Default Values
+# =============================================================================
+# FastMCP server with multi-source tool, resource, prompt, and knowledge loading
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- FastMCP server container image
+  repository: docker.io/helmforge/fastmcp-server
+  # -- Image tag (pinned to appVersion)
+  tag: "0.2.0"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Server Configuration
+# =============================================================================
+
+server:
+  # -- Server name announced in MCP responses
+  name: fastmcp-server
+  # -- HTTP port for the MCP endpoint
+  port: 8000
+  # -- URL path for the MCP endpoint
+  path: /mcp
+  # -- Log level (DEBUG, INFO, WARNING, ERROR)
+  logLevel: INFO
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+auth:
+  # -- Authentication type: none, bearer, jwt
+  type: none
+  bearer:
+    # -- Static bearer token for authentication
+    token: ""
+    # -- Use an existing secret instead of inline token
+    existingSecret: ""
+    # -- Key in the existing secret containing the token
+    existingSecretKey: token
+  jwt:
+    # -- JWT issuer URL
+    issuer: ""
+    # -- JWT audience
+    audience: ""
+    # -- JWKS URI for JWT key verification
+    jwksUri: ""
+
+# =============================================================================
+# Sources — Inline, S3, Git
+# =============================================================================
+# Merge precedence: Inline (highest) > S3 > Git (lowest)
+
+sources:
+  # -- Inline tools, resources, prompts, and knowledge mounted via ConfigMaps
+  inline:
+    # -- Python tool files (key = filename, value = file content)
+    # -- @default -- `{}` (no inline tools)
+    tools: {}
+      # greet.py: |
+      #   def greet(name: str) -> str:
+      #       """Greet someone by name."""
+      #       return f"Hello, {name}!"
+      # math_ops.py: |
+      #   def add(a: float, b: float) -> float:
+      #       """Add two numbers."""
+      #       return a + b
+
+    # -- Python resource files (key = filename, value = file content)
+    # -- @default -- `{}` (no inline resources)
+    resources: {}
+      # status.py: |
+      #   RESOURCE_URI = "status://server"
+      #   def get_status() -> dict:
+      #       """Server status."""
+      #       return {"status": "healthy"}
+
+    # -- Python prompt files (key = filename, value = file content)
+    # -- @default -- `{}` (no inline prompts)
+    prompts: {}
+      # summarize.py: |
+      #   def summarize(text: str) -> str:
+      #       """Summarize the given text."""
+      #       return f"Please summarize:\n\n{text}"
+
+    # -- Knowledge base files (key = filename, value = file content)
+    # -- @default -- `{}` (no inline knowledge)
+    knowledge: {}
+      # overview.md: |
+      #   # Product Overview
+      #   This is the product overview document.
+
+  # -- S3-compatible storage source (AWS S3, MinIO, Cloudflare R2)
+  s3:
+    # -- Enable S3 source
+    enabled: false
+    # -- S3-compatible endpoint URL (leave empty for AWS S3)
+    endpoint: ""
+    # -- Bucket name
+    bucket: ""
+    # -- AWS region
+    region: us-east-1
+    # -- Key prefix inside the bucket
+    prefix: ""
+    # -- S3 access key (ignored if existingSecret is set)
+    accessKey: ""
+    # -- S3 secret key (ignored if existingSecret is set)
+    secretKey: ""
+    # -- Existing secret with S3 credentials
+    existingSecret: ""
+    # -- Key in existing secret for access key
+    existingSecretAccessKeyKey: access-key
+    # -- Key in existing secret for secret key
+    existingSecretSecretKeyKey: secret-key
+
+  # -- Git repository source
+  git:
+    # -- Enable Git source
+    enabled: false
+    # -- Git repository HTTPS URL
+    repository: ""
+    # -- Branch to clone
+    branch: main
+    # -- Subdirectory path inside the repo
+    path: ""
+    # -- Git token for private repos (ignored if existingSecret is set)
+    token: ""
+    # -- Existing secret with Git token
+    existingSecret: ""
+    # -- Key in existing secret for Git token
+    existingSecretTokenKey: token
+
+# =============================================================================
+# Extra Pip Packages
+# =============================================================================
+
+# -- Extra pip packages to install at startup (before loading tools)
+# -- @default -- `[]`
+extraPipPackages: []
+  # - requests
+  # - pandas
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  type: ClusterIP
+  port: 8000
+  annotations: {}
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable ingress for the MCP endpoint
+  enabled: false
+  # -- Ingress class name (for example: traefik, nginx)
+  ingressClassName: traefik
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt
+  # -- Ingress hosts
+  hosts: []
+    # - host: mcp.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+    # - hosts:
+    #     - mcp.example.com
+    #   secretName: mcp-server-tls
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+probes:
+  startup:
+    enabled: true
+    httpGet:
+      path: /mcp
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    enabled: true
+    httpGet:
+      path: /mcp
+      port: http
+    initialDelaySeconds: 0
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    httpGet:
+      path: /mcp
+      port: http
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# =============================================================================
+# Persistence
+# =============================================================================
+# Optional PVC for the workspace directory (useful for large knowledge bases
+# that persist across restarts instead of re-downloading from S3/Git).
+
+persistence:
+  # -- Enable persistent workspace volume
+  enabled: false
+  size: 1Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  existingClaim: ""
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: false
+  # -- ServiceAccount name
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Network Policy
+# =============================================================================
+
+networkPolicy:
+  # -- Enable NetworkPolicy
+  enabled: false
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+podLabels: {}
+podAnnotations: {}
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+
+# -- Extra manifests to deploy alongside the chart
+extraManifests: []


### PR DESCRIPTION
## Summary

- New Helm chart for deploying FastMCP server (`docker.io/helmforge/fastmcp-server:0.2.0`) on Kubernetes
- Supports all three content sources: inline (ConfigMap), S3-compatible storage, and Git repositories
- Full authentication support: bearer token and JWT
- Includes ConfigMaps for inline tools/resources/prompts/knowledge, Secrets for auth/S3/Git credentials
- Complete template set: Deployment, Service, Ingress, PVC, ServiceAccount, NetworkPolicy, extra-manifests

## Validation

- `helm lint`: clean (all 6 CI scenarios)
- `helm template`: renders correctly for all scenarios
- `helm unittest`: **61/61 tests pass** across 8 test suites
- `values.schema.json`: JSON Schema draft-07 validation
- 6 CI scenarios: default, auth-bearer, s3-source, git-source, custom-tools, full

## Test plan

- [ ] CI pipeline passes (lint, template, unittest)
- [ ] k3d validation: default install → pod running, healthcheck OK
- [ ] k3d validation: inline tools → MCP endpoint responds with tools
- [ ] k3d validation: auth bearer → rejects requests without token