### PR TITLE
feat(fastmcp-server): bump appVersion to 0.3.0

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
-version: 1.0.1
-appVersion: "0.2.0"
+version: 1.1.0
+appVersion: "0.3.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: rename chart and add README, examples (#30)
+    - kind: changed
+      description: bump appVersion to 0.3.0 with tool metadata, resource templates, error masking
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/README.md
+++ b/charts/fastmcp-server/README.md
@@ -196,7 +196,7 @@ securityContext:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/helmforge/fastmcp-server` | Container image |
-| `image.tag` | `0.2.0` | Image tag |
+| `image.tag` | `0.3.0` | Image tag |
 | `server.name` | `fastmcp-server` | Server name in MCP responses |
 | `server.port` | `8000` | HTTP port |
 | `server.path` | `/mcp` | MCP endpoint path |

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.2.0"
+          value: "docker.io/helmforge/fastmcp-server:0.3.0"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.2.0"
+  tag: "0.3.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump image tag to 0.3.0 (tool metadata, resource templates, error masking, duplicate handling)
- Chart version 1.1.0
- Update README default values table
- Update test assertion for image tag

## Test plan
- [x] `helm lint` — passed
- [x] `helm unittest` — 61/61 passed
- [ ] CI green