### PR TITLE
feat(fastmcp-server): chart v1.2.0 with UI, metrics, health endpoints

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
-version: 1.1.0
-appVersion: "0.3.0"
+version: 1.2.0
+appVersion: "0.4.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: bump appVersion to 0.3.0 with tool metadata, resource templates, error masking
+    - kind: added
+      description: built-in Web UI, Prometheus metrics, structured logging, health endpoints, diagnostics, init container, strict loading
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/README.md
+++ b/charts/fastmcp-server/README.md
@@ -8,6 +8,13 @@ A Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fast
 - Bearer token and JWT authentication via FastMCP
 - Knowledge base files served as MCP resources
 - Extra pip packages installed at startup
+- Built-in Web UI dashboard at `/ui`
+- Prometheus metrics with ServiceMonitor support
+- Structured JSON logging for log aggregation
+- Dedicated health endpoints (`/healthz`, `/readyz`, `/startupz`)
+- Diagnostic endpoint at `/debug/info`
+- Init container pattern for source pre-sync
+- Strict loading mode for fail-fast on errors
 
 ## Quick Start
 
@@ -129,12 +136,42 @@ auth:
     jwksUri: "https://auth.example.com/.well-known/jwks.json"
 ```
 
+### Observability
+
+Enable Prometheus metrics and ServiceMonitor:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+```
+
+Structured JSON logging:
+
+```yaml
+server:
+  logFormat: json
+```
+
+### Init Container Pattern
+
+Pre-sync sources before the server starts:
+
+```yaml
+initSync:
+  enabled: true
+```
+
 ### Production Example
 
 ```yaml
 server:
   name: production-mcp
   logLevel: WARNING
+  logFormat: json
+  strictLoading: true
 
 auth:
   type: bearer
@@ -155,6 +192,14 @@ sources:
 extraPipPackages:
   - requests
   - pandas
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+initSync:
+  enabled: true
 
 ingress:
   enabled: true
@@ -196,11 +241,16 @@ securityContext:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/helmforge/fastmcp-server` | Container image |
-| `image.tag` | `0.3.0` | Image tag |
+| `image.tag` | `0.4.0` | Image tag |
 | `server.name` | `fastmcp-server` | Server name in MCP responses |
 | `server.port` | `8000` | HTTP port |
 | `server.path` | `/mcp` | MCP endpoint path |
 | `server.logLevel` | `INFO` | Log level |
+| `server.logFormat` | `text` | Log format: `text` or `json` |
+| `server.strictLoading` | `false` | Fail on boot if any component has errors |
+| `ui.enabled` | `true` | Enable Web UI at `/ui` |
+| `metrics.enabled` | `false` | Enable Prometheus metrics at `/metrics` |
+| `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor CRD |
 | `auth.type` | `none` | Authentication: `none`, `bearer`, `jwt` |
 | `sources.inline.tools` | `{}` | Inline Python tool files |
 | `sources.inline.resources` | `{}` | Inline Python resource files |
@@ -211,6 +261,7 @@ securityContext:
 | `sources.git.enabled` | `false` | Enable Git source |
 | `sources.git.repository` | `""` | Git repository HTTPS URL |
 | `extraPipPackages` | `[]` | Extra pip packages at startup |
+| `initSync.enabled` | `false` | Run source sync as init container |
 | `persistence.enabled` | `false` | Enable persistent workspace |
 | `ingress.enabled` | `false` | Enable ingress |
 | `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
@@ -234,6 +285,6 @@ relations:
   - charts/fastmcp-server/values.yaml
   - charts/fastmcp-server/Chart.yaml
 path: charts/fastmcp-server/README.md
-version: 1.0
+version: 1.2
 date: 2026-04-05
 -->

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -41,6 +41,92 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.initSync.enabled }}
+      initContainers:
+        - name: source-sync
+          image: {{ include "fastmcp-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "/app/sync_only.py"]
+          env:
+            - name: MCP_WORKSPACE
+              value: /app/workspace
+            {{- if .Values.sources.s3.enabled }}
+            - name: SOURCE_S3_ENABLED
+              value: "true"
+            {{- with .Values.sources.s3.endpoint }}
+            - name: SOURCE_S3_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOURCE_S3_BUCKET
+              value: {{ .Values.sources.s3.bucket | quote }}
+            - name: SOURCE_S3_REGION
+              value: {{ .Values.sources.s3.region | quote }}
+            {{- with .Values.sources.s3.prefix }}
+            - name: SOURCE_S3_PREFIX
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOURCE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.s3SecretName" . }}
+                  key: {{ .Values.sources.s3.existingSecretAccessKeyKey | default "access-key" }}
+            - name: SOURCE_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.s3SecretName" . }}
+                  key: {{ .Values.sources.s3.existingSecretSecretKeyKey | default "secret-key" }}
+            {{- end }}
+            {{- if .Values.sources.git.enabled }}
+            - name: SOURCE_GIT_ENABLED
+              value: "true"
+            - name: SOURCE_GIT_REPOSITORY
+              value: {{ .Values.sources.git.repository | quote }}
+            - name: SOURCE_GIT_BRANCH
+              value: {{ .Values.sources.git.branch | quote }}
+            {{- with .Values.sources.git.path }}
+            - name: SOURCE_GIT_PATH
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or .Values.sources.git.token .Values.sources.git.existingSecret }}
+            - name: SOURCE_GIT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.gitSecretName" . }}
+                  key: {{ .Values.sources.git.existingSecretTokenKey | default "token" }}
+            {{- end }}
+            {{- end }}
+            {{- if (include "fastmcp-server.hasAnyInline" .) }}
+            - name: SOURCE_INLINE_DIR
+              value: /app/inline
+            {{- end }}
+          volumeMounts:
+            - name: workspace
+              mountPath: /app/workspace
+            {{- if (include "fastmcp-server.hasInlineTools" .) }}
+            - name: inline-tools
+              mountPath: /app/inline/tools
+              readOnly: true
+            {{- end }}
+            {{- if (include "fastmcp-server.hasInlineResources" .) }}
+            - name: inline-resources
+              mountPath: /app/inline/resources
+              readOnly: true
+            {{- end }}
+            {{- if (include "fastmcp-server.hasInlinePrompts" .) }}
+            - name: inline-prompts
+              mountPath: /app/inline/prompts
+              readOnly: true
+            {{- end }}
+            {{- if (include "fastmcp-server.hasInlineKnowledge" .) }}
+            - name: inline-knowledge
+              mountPath: /app/inline/knowledge
+              readOnly: true
+            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: mcp-server
           image: {{ include "fastmcp-server.image" . }}
@@ -60,6 +146,24 @@ spec:
               value: "0.0.0.0"
             - name: LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
+            {{- if .Values.server.logFormat }}
+            - name: LOG_FORMAT
+              value: {{ .Values.server.logFormat | quote }}
+            {{- end }}
+            {{- if .Values.server.strictLoading }}
+            - name: MCP_STRICT_LOADING
+              value: "true"
+            {{- end }}
+            {{- if .Values.ui }}
+            - name: MCP_UI_ENABLED
+              value: {{ .Values.ui.enabled | quote }}
+            {{- end }}
+            {{- if .Values.metrics }}
+            {{- if .Values.metrics.enabled }}
+            - name: MCP_METRICS_ENABLED
+              value: "true"
+            {{- end }}
+            {{- end }}
             {{- if ne .Values.auth.type "none" }}
             - name: MCP_AUTH_TYPE
               value: {{ .Values.auth.type | quote }}

--- a/charts/fastmcp-server/templates/servicemonitor.yaml
+++ b/charts/fastmcp-server/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.metrics .Values.metrics.enabled .Values.metrics.serviceMonitor .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fastmcp-server.fullname" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+{{- end }}

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.3.0"
+          value: "docker.io/helmforge/fastmcp-server:0.4.0"
 
   - it: should set MCP_SERVER_NAME env
     asserts:
@@ -57,6 +57,18 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe
       - isNotNull:
           path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should use new health endpoints for probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /startupz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
 
   - it: should have helmforge labels
     asserts:
@@ -250,3 +262,84 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: RELEASE-NAME-fastmcp-server
+
+  # --- v0.4.0: New features ---
+
+  - it: should enable UI by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_UI_ENABLED
+            value: "true"
+
+  - it: should disable UI when configured
+    set:
+      ui:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_UI_ENABLED
+            value: "false"
+
+  - it: should set metrics env when enabled
+    set:
+      metrics:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_METRICS_ENABLED
+            value: "true"
+
+  - it: should not set metrics env by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_METRICS_ENABLED
+          any: true
+
+  - it: should set LOG_FORMAT env
+    set:
+      server:
+        logFormat: json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: "json"
+
+  - it: should set strict loading env when enabled
+    set:
+      server:
+        strictLoading: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_STRICT_LOADING
+            value: "true"
+
+  - it: should not have init container by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+
+  - it: should add init container when initSync enabled
+    set:
+      initSync:
+        enabled: true
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: source-sync
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value: ["python", "/app/sync_only.py"]

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.3.0"
+  tag: "0.4.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -33,6 +33,31 @@ server:
   path: /mcp
   # -- Log level (DEBUG, INFO, WARNING, ERROR)
   logLevel: INFO
+  # -- Log format: text or json (structured logging)
+  logFormat: text
+  # -- Strict loading: fail on boot if any tool/resource has errors
+  strictLoading: false
+
+# =============================================================================
+# Web UI
+# =============================================================================
+
+ui:
+  # -- Enable built-in Web UI at /ui
+  enabled: true
+
+# =============================================================================
+# Metrics
+# =============================================================================
+
+metrics:
+  # -- Enable Prometheus metrics at /metrics
+  enabled: false
+  # -- Create ServiceMonitor for Prometheus Operator
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}
 
 # =============================================================================
 # Authentication
@@ -190,7 +215,7 @@ probes:
   startup:
     enabled: true
     httpGet:
-      path: /mcp
+      path: /startupz
       port: http
     initialDelaySeconds: 5
     periodSeconds: 5
@@ -199,7 +224,7 @@ probes:
   liveness:
     enabled: true
     httpGet:
-      path: /mcp
+      path: /healthz
       port: http
     initialDelaySeconds: 0
     periodSeconds: 15
@@ -208,7 +233,7 @@ probes:
   readiness:
     enabled: true
     httpGet:
-      path: /mcp
+      path: /readyz
       port: http
     initialDelaySeconds: 0
     periodSeconds: 10
@@ -229,6 +254,14 @@ persistence:
   accessModes:
     - ReadWriteOnce
   existingClaim: ""
+
+# =============================================================================
+# Init Sync
+# =============================================================================
+
+initSync:
+  # -- Run source sync as an init container before the server starts
+  enabled: false
 
 # =============================================================================
 # Service Account


### PR DESCRIPTION
## Summary
- Bump chart version to 1.2.0, appVersion to 0.4.0
- Add `ui.enabled`, `metrics.enabled`, `metrics.serviceMonitor` values
- Add `server.logFormat`, `server.strictLoading` values
- Add `initSync.enabled` with init container support
- Update probes to `/healthz`, `/readyz`, `/startupz`
- New `ServiceMonitor` template for Prometheus Operator
- Updated README with observability section and production example

## Test Plan
- [x] 70 helm unittest tests passing
- [ ] `helm template` renders correctly
- [ ] Deploy to k3d and verify all endpoints