### PR TITLE
feat(fastmcp-server): chart v1.3.0 — Production Grade

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
-version: 1.1.0
-appVersion: "0.3.0"
+version: 1.2.0
+appVersion: "0.4.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,9 +24,7 @@ icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: bump appVersion to 0.3.0 (#32)
-    - kind: fixed
-      description: remove Docker standalone docs from README (#31)
+      description: built-in Web UI, Prometheus metrics, structured logging, health endpoints, diagnostics, init container, strict loading
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
-version: 1.2.0
-appVersion: "0.4.0"
+version: 1.3.0
+appVersion: "1.0.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: built-in Web UI, Prometheus metrics, structured logging, health endpoints, diagnostics, init container, strict loading
+      description: "v1.0.0: rate limiting, caching, tool sandboxing, PDB, HPA, values.schema.json, NOTES.txt"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/README.md
+++ b/charts/fastmcp-server/README.md
@@ -8,6 +8,13 @@ A Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fast
 - Bearer token and JWT authentication via FastMCP
 - Knowledge base files served as MCP resources
 - Extra pip packages installed at startup
+- Built-in Web UI dashboard at `/ui`
+- Prometheus metrics with ServiceMonitor support
+- Structured JSON logging for log aggregation
+- Dedicated health endpoints (`/healthz`, `/readyz`, `/startupz`)
+- Diagnostic endpoint at `/debug/info`
+- Init container pattern for source pre-sync
+- Strict loading mode for fail-fast on errors
 
 ## Quick Start
 
@@ -129,12 +136,42 @@ auth:
     jwksUri: "https://auth.example.com/.well-known/jwks.json"
 ```
 
+### Observability
+
+Enable Prometheus metrics and ServiceMonitor:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+```
+
+Structured JSON logging:
+
+```yaml
+server:
+  logFormat: json
+```
+
+### Init Container Pattern
+
+Pre-sync sources before the server starts:
+
+```yaml
+initSync:
+  enabled: true
+```
+
 ### Production Example
 
 ```yaml
 server:
   name: production-mcp
   logLevel: WARNING
+  logFormat: json
+  strictLoading: true
 
 auth:
   type: bearer
@@ -155,6 +192,14 @@ sources:
 extraPipPackages:
   - requests
   - pandas
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+initSync:
+  enabled: true
 
 ingress:
   enabled: true
@@ -196,11 +241,16 @@ securityContext:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/helmforge/fastmcp-server` | Container image |
-| `image.tag` | `0.3.0` | Image tag |
+| `image.tag` | `0.4.0` | Image tag |
 | `server.name` | `fastmcp-server` | Server name in MCP responses |
 | `server.port` | `8000` | HTTP port |
 | `server.path` | `/mcp` | MCP endpoint path |
 | `server.logLevel` | `INFO` | Log level |
+| `server.logFormat` | `text` | Log format: `text` or `json` |
+| `server.strictLoading` | `false` | Fail on boot if any component has errors |
+| `ui.enabled` | `true` | Enable Web UI at `/ui` |
+| `metrics.enabled` | `false` | Enable Prometheus metrics at `/metrics` |
+| `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor CRD |
 | `auth.type` | `none` | Authentication: `none`, `bearer`, `jwt` |
 | `sources.inline.tools` | `{}` | Inline Python tool files |
 | `sources.inline.resources` | `{}` | Inline Python resource files |
@@ -211,6 +261,7 @@ securityContext:
 | `sources.git.enabled` | `false` | Enable Git source |
 | `sources.git.repository` | `""` | Git repository HTTPS URL |
 | `extraPipPackages` | `[]` | Extra pip packages at startup |
+| `initSync.enabled` | `false` | Run source sync as init container |
 | `persistence.enabled` | `false` | Enable persistent workspace |
 | `ingress.enabled` | `false` | Enable ingress |
 | `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
@@ -234,6 +285,6 @@ relations:
   - charts/fastmcp-server/values.yaml
   - charts/fastmcp-server/Chart.yaml
 path: charts/fastmcp-server/README.md
-version: 1.0
+version: 1.2
 date: 2026-04-05
 -->

--- a/charts/fastmcp-server/templates/NOTES.txt
+++ b/charts/fastmcp-server/templates/NOTES.txt
@@ -1,32 +1,35 @@
-🚀 MCP Server has been deployed!
+FastMCP Server deployed!
 
-Server name: {{ .Values.server.name }}
-MCP endpoint: {{ .Values.server.path }}
+  Server:   {{ .Values.server.name }}
+  Endpoint: http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}{{ .Values.server.path }}
+  Auth:     {{ .Values.auth.type }}
 
-{{- if .Values.ingress.enabled }}
-
-Ingress is enabled. Access the MCP endpoint at:
-{{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ $.Values.server.path }}
+{{- if .Values.ui.enabled }}
+  Web UI:   http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}/ui
 {{- end }}
-{{- else }}
 
-To access the MCP endpoint, run:
+{{- if .Values.metrics.enabled }}
+  Metrics:  http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}/metrics
+{{- end }}
+
+To access the MCP endpoint:
 
   kubectl port-forward svc/{{ include "fastmcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  curl http://localhost:{{ .Values.service.port }}{{ .Values.server.path }}
 
-Then connect to: http://localhost:{{ .Values.service.port }}{{ .Values.server.path }}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+
+  Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (first .paths).path }}
+{{- end }}
 {{- end }}
 
 {{- if ne .Values.auth.type "none" }}
 
 Authentication: {{ .Values.auth.type }}
 {{- if eq .Values.auth.type "bearer" }}
-Requests must include: Authorization: Bearer <token>
+  Requests must include: Authorization: Bearer <token>
 {{- end }}
-{{- else }}
-
-Authentication: disabled (no auth required)
 {{- end }}
 
 Sources:
@@ -39,8 +42,5 @@ Sources:
 {{- if .Values.sources.git.enabled }}
   - Git: {{ .Values.sources.git.repository }} ({{ .Values.sources.git.branch }})
 {{- end }}
-{{- if not (or (include "fastmcp-server.hasAnyInline" .) .Values.sources.s3.enabled .Values.sources.git.enabled) }}
-  - None configured (server will start with no tools/resources)
-{{- end }}
 
-Documentation: https://helmforge.dev/docs/charts/mcp-server
+Documentation: https://helmforge.dev/docs/charts/fastmcp-server

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "fastmcp-server.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:
@@ -233,6 +235,30 @@ spec:
                   name: {{ include "fastmcp-server.gitSecretName" . }}
                   key: {{ .Values.sources.git.existingSecretTokenKey | default "token" }}
             {{- end }}
+            {{- end }}
+            {{- with .Values.rateLimiting.default }}
+            - name: MCP_RATE_LIMIT_DEFAULT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- range $tool, $rate := .Values.rateLimiting.perTool }}
+            - name: MCP_RATE_LIMIT_{{ $tool }}
+              value: {{ $rate | quote }}
+            {{- end }}
+            {{- if not .Values.caching.enabled }}
+            - name: MCP_CACHE_ENABLED
+              value: "false"
+            {{- end }}
+            {{- if .Values.caching.maxSize }}
+            - name: MCP_CACHE_MAX_SIZE
+              value: {{ .Values.caching.maxSize | quote }}
+            {{- end }}
+            {{- if .Values.sandboxing.maxMemoryMb }}
+            - name: MCP_MAX_MEMORY_MB
+              value: {{ .Values.sandboxing.maxMemoryMb | quote }}
+            {{- end }}
+            {{- if .Values.sandboxing.maxOutputSizeKb }}
+            - name: MCP_MAX_OUTPUT_SIZE_KB
+              value: {{ .Values.sandboxing.maxOutputSizeKb | quote }}
             {{- end }}
             {{- if .Values.extraPipPackages }}
             - name: EXTRA_PIP_PACKAGES

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -41,6 +41,92 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.initSync.enabled }}
+      initContainers:
+        - name: source-sync
+          image: {{ include "fastmcp-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "/app/sync_only.py"]
+          env:
+            - name: MCP_WORKSPACE
+              value: /app/workspace
+            {{- if .Values.sources.s3.enabled }}
+            - name: SOURCE_S3_ENABLED
+              value: "true"
+            {{- with .Values.sources.s3.endpoint }}
+            - name: SOURCE_S3_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOURCE_S3_BUCKET
+              value: {{ .Values.sources.s3.bucket | quote }}
+            - name: SOURCE_S3_REGION
+              value: {{ .Values.sources.s3.region | quote }}
+            {{- with .Values.sources.s3.prefix }}
+            - name: SOURCE_S3_PREFIX
+              value: {{ . | quote }}
+            {{- end }}
+            - name: SOURCE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.s3SecretName" . }}
+                  key: {{ .Values.sources.s3.existingSecretAccessKeyKey | default "access-key" }}
+            - name: SOURCE_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.s3SecretName" . }}
+                  key: {{ .Values.sources.s3.existingSecretSecretKeyKey | default "secret-key" }}
+            {{- end }}
+            {{- if .Values.sources.git.enabled }}
+            - name: SOURCE_GIT_ENABLED
+              value: "true"
+            - name: SOURCE_GIT_REPOSITORY
+              value: {{ .Values.sources.git.repository | quote }}
+            - name: SOURCE_GIT_BRANCH
+              value: {{ .Values.sources.git.branch | quote }}
+            {{- with .Values.sources.git.path }}
+            - name: SOURCE_GIT_PATH
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or .Values.sources.git.token .Values.sources.git.existingSecret }}
+            - name: SOURCE_GIT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.gitSecretName" . }}
+                  key: {{ .Values.sources.git.existingSecretTokenKey | default "token" }}
+            {{- end }}
+            {{- end }}
+            {{- if (include "fastmcp-server.hasAnyInline" .) }}
+            - name: SOURCE_INLINE_DIR
+              value: /app/inline
+            {{- end }}
+          volumeMounts:
+            - name: workspace
+              mountPath: /app/workspace
+            {{- if (include "fastmcp-server.hasInlineTools" .) }}
+            - name: inline-tools
+              mountPath: /app/inline/tools
+              readOnly: true
+            {{- end }}
+            {{- if (include "fastmcp-server.hasInlineResources" .) }}
+            - name: inline-resources
+              mountPath: /app/inline/resources
+              readOnly: true
+            {{- end }}
+            {{- if (include "fastmcp-server.hasInlinePrompts" .) }}
+            - name: inline-prompts
+              mountPath: /app/inline/prompts
+              readOnly: true
+            {{- end }}
+            {{- if (include "fastmcp-server.hasInlineKnowledge" .) }}
+            - name: inline-knowledge
+              mountPath: /app/inline/knowledge
+              readOnly: true
+            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: mcp-server
           image: {{ include "fastmcp-server.image" . }}
@@ -60,6 +146,24 @@ spec:
               value: "0.0.0.0"
             - name: LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
+            {{- if .Values.server.logFormat }}
+            - name: LOG_FORMAT
+              value: {{ .Values.server.logFormat | quote }}
+            {{- end }}
+            {{- if .Values.server.strictLoading }}
+            - name: MCP_STRICT_LOADING
+              value: "true"
+            {{- end }}
+            {{- if .Values.ui }}
+            - name: MCP_UI_ENABLED
+              value: {{ .Values.ui.enabled | quote }}
+            {{- end }}
+            {{- if .Values.metrics }}
+            {{- if .Values.metrics.enabled }}
+            - name: MCP_METRICS_ENABLED
+              value: "true"
+            {{- end }}
+            {{- end }}
             {{- if ne .Values.auth.type "none" }}
             - name: MCP_AUTH_TYPE
               value: {{ .Values.auth.type | quote }}

--- a/charts/fastmcp-server/templates/hpa.yaml
+++ b/charts/fastmcp-server/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fastmcp-server.fullname" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fastmcp-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/fastmcp-server/templates/pdb.yaml
+++ b/charts/fastmcp-server/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "fastmcp-server.fullname" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/fastmcp-server/templates/servicemonitor.yaml
+++ b/charts/fastmcp-server/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.metrics .Values.metrics.enabled .Values.metrics.serviceMonitor .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fastmcp-server.fullname" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+{{- end }}

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.4.0"
+          value: "docker.io/helmforge/fastmcp-server:1.0.0"
 
   - it: should set MCP_SERVER_NAME env
     asserts:
@@ -343,3 +343,88 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].command
           value: ["python", "/app/sync_only.py"]
+
+  # --- v1.0.0: Production features ---
+
+  - it: should set rate limit default env
+    set:
+      rateLimiting:
+        default: "100/min"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_RATE_LIMIT_DEFAULT
+            value: "100/min"
+
+  - it: should set per-tool rate limit env
+    set:
+      rateLimiting:
+        perTool:
+          DEPLOY: "5/min"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_RATE_LIMIT_DEPLOY
+            value: "5/min"
+
+  - it: should disable caching via env
+    set:
+      caching:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_CACHE_ENABLED
+            value: "false"
+
+  - it: should set cache max size env
+    set:
+      caching:
+        maxSize: 500
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_CACHE_MAX_SIZE
+            value: "500"
+
+  - it: should set sandboxing memory limit env
+    set:
+      sandboxing:
+        maxMemoryMb: 256
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MAX_MEMORY_MB
+            value: "256"
+
+  - it: should set sandboxing output limit env
+    set:
+      sandboxing:
+        maxOutputSizeKb: 100
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MAX_OUTPUT_SIZE_KB
+            value: "100"
+
+  - it: should use replicaCount when autoscaling disabled
+    set:
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should not set replicas when autoscaling enabled
+    set:
+      autoscaling:
+        enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.3.0"
+          value: "docker.io/helmforge/fastmcp-server:0.4.0"
 
   - it: should set MCP_SERVER_NAME env
     asserts:
@@ -57,6 +57,18 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe
       - isNotNull:
           path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should use new health endpoints for probes
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /startupz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
 
   - it: should have helmforge labels
     asserts:
@@ -250,3 +262,84 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: RELEASE-NAME-fastmcp-server
+
+  # --- v0.4.0: New features ---
+
+  - it: should enable UI by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_UI_ENABLED
+            value: "true"
+
+  - it: should disable UI when configured
+    set:
+      ui:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_UI_ENABLED
+            value: "false"
+
+  - it: should set metrics env when enabled
+    set:
+      metrics:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_METRICS_ENABLED
+            value: "true"
+
+  - it: should not set metrics env by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_METRICS_ENABLED
+          any: true
+
+  - it: should set LOG_FORMAT env
+    set:
+      server:
+        logFormat: json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LOG_FORMAT
+            value: "json"
+
+  - it: should set strict loading env when enabled
+    set:
+      server:
+        strictLoading: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_STRICT_LOADING
+            value: "true"
+
+  - it: should not have init container by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+
+  - it: should add init container when initSync enabled
+    set:
+      initSync:
+        enabled: true
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: source-sync
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value: ["python", "/app/sync_only.py"]

--- a/charts/fastmcp-server/tests/hpa_test.yaml
+++ b/charts/fastmcp-server/tests/hpa_test.yaml
@@ -1,0 +1,40 @@
+suite: hpa
+templates:
+  - templates/hpa.yaml
+tests:
+  - it: should not create HPA by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HPA when enabled
+    set:
+      autoscaling:
+        enabled: true
+        minReplicas: 2
+        maxReplicas: 10
+        targetCPUUtilizationPercentage: 70
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: should set CPU target metric
+    set:
+      autoscaling:
+        enabled: true
+        targetCPUUtilizationPercentage: 80
+    asserts:
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80

--- a/charts/fastmcp-server/tests/pdb_test.yaml
+++ b/charts/fastmcp-server/tests/pdb_test.yaml
@@ -1,0 +1,32 @@
+suite: pdb
+templates:
+  - templates/pdb.yaml
+tests:
+  - it: should not create PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PDB when enabled
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should set custom minAvailable
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/charts/fastmcp-server/values.schema.json
+++ b/charts/fastmcp-server/values.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "title": "MCP Server Helm Chart Values",
+  "title": "FastMCP Server Helm Chart Values",
   "description": "Configuration for FastMCP server with multi-source tool, resource, prompt, and knowledge loading",
   "type": "object",
   "additionalProperties": true,
@@ -24,7 +24,8 @@
         "repository": { "type": "string" },
         "tag": { "type": "string" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
-      }
+      },
+      "required": ["repository", "tag"]
     },
     "imagePullSecrets": {
       "type": "array",
@@ -37,7 +38,56 @@
         "name": { "type": "string", "description": "Server name announced in MCP responses" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "HTTP port" },
         "path": { "type": "string", "pattern": "^/", "description": "MCP endpoint URL path" },
-        "logLevel": { "type": "string", "enum": ["DEBUG", "INFO", "WARNING", "ERROR"], "description": "Log level" }
+        "logLevel": { "type": "string", "enum": ["DEBUG", "INFO", "WARNING", "ERROR"], "description": "Log level" },
+        "logFormat": { "type": "string", "enum": ["text", "json"], "description": "Log output format" },
+        "strictLoading": { "type": "boolean", "description": "Fail on boot if any tool/resource has errors" }
+      },
+      "required": ["name", "port", "path"]
+    },
+    "ui": {
+      "type": "object",
+      "description": "Web UI configuration",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Prometheus metrics configuration",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "interval": { "type": "string" },
+            "labels": { "type": "object" }
+          }
+        }
+      }
+    },
+    "rateLimiting": {
+      "type": "object",
+      "description": "Rate limiting for tool calls",
+      "properties": {
+        "default": { "type": "string", "description": "Default rate limit for all tools (e.g., 100/min)" },
+        "perTool": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Per-tool rate limits (key = TOOL_NAME_UPPER)" }
+      }
+    },
+    "caching": {
+      "type": "object",
+      "description": "Result caching for idempotent tools",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "maxSize": { "type": "integer", "minimum": 1, "description": "Max cache entries per tool" }
+      }
+    },
+    "sandboxing": {
+      "type": "object",
+      "description": "Tool execution resource limits",
+      "properties": {
+        "maxMemoryMb": { "type": "integer", "minimum": 0, "description": "Default max memory per tool call (MB)" },
+        "maxOutputSizeKb": { "type": "integer", "minimum": 0, "description": "Default max output size per tool call (KB)" }
       }
     },
     "auth": {
@@ -65,7 +115,8 @@
             "jwksUri": { "type": "string" }
           }
         }
-      }
+      },
+      "required": ["type"]
     },
     "sources": {
       "type": "object",
@@ -150,6 +201,12 @@
         "existingClaim": { "type": "string" }
       }
     },
+    "initSync": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "serviceAccount": {
       "type": "object",
       "properties": {
@@ -164,6 +221,26 @@
         "enabled": { "type": "boolean" }
       }
     },
+    "pdb": {
+      "type": "object",
+      "description": "Pod Disruption Budget",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "description": "Horizontal Pod Autoscaler",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+      }
+    },
+    "replicaCount": { "type": "integer", "minimum": 1, "description": "Number of replicas (ignored when autoscaling is enabled)" },
     "resources": { "type": "object" },
     "podSecurityContext": { "type": "object" },
     "securityContext": { "type": "object" },

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.4.0"
+  tag: "1.0.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -58,6 +58,38 @@ metrics:
     enabled: false
     interval: 30s
     labels: {}
+
+# =============================================================================
+# Rate Limiting
+# =============================================================================
+
+rateLimiting:
+  # -- Default rate limit for all tools (e.g., "100/min")
+  default: ""
+  # -- Per-tool rate limits (key = TOOL_NAME_UPPER, value = rate string)
+  perTool: {}
+    # DEPLOY: "5/min"
+    # DELETE_DATA: "2/min"
+
+# =============================================================================
+# Caching
+# =============================================================================
+
+caching:
+  # -- Enable result caching for tools with __cache_ttl__
+  enabled: true
+  # -- Maximum cache entries per tool
+  maxSize: 1000
+
+# =============================================================================
+# Sandboxing
+# =============================================================================
+
+sandboxing:
+  # -- Default max memory per tool call (MB, 0 = unlimited)
+  maxMemoryMb: 0
+  # -- Default max output size per tool call (KB, 0 = unlimited)
+  maxOutputSizeKb: 0
 
 # =============================================================================
 # Authentication
@@ -282,6 +314,42 @@ serviceAccount:
 networkPolicy:
   # -- Enable NetworkPolicy
   enabled: false
+
+# =============================================================================
+# Resources and Security
+# =============================================================================
+
+# =============================================================================
+# Pod Disruption Budget
+# =============================================================================
+
+pdb:
+  # -- Enable PodDisruptionBudget (requires replicas > 1)
+  enabled: false
+  # -- Minimum available pods during disruption
+  minAvailable: 1
+
+# =============================================================================
+# Horizontal Pod Autoscaler
+# =============================================================================
+
+autoscaling:
+  # -- Enable HPA
+  enabled: false
+  # -- Minimum number of replicas
+  minReplicas: 1
+  # -- Maximum number of replicas
+  maxReplicas: 5
+  # -- Target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage (optional)
+  targetMemoryUtilizationPercentage: ""
+
+# =============================================================================
+# Replicas (when autoscaling is disabled)
+# =============================================================================
+
+replicaCount: 1
 
 # =============================================================================
 # Resources and Security

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.3.0"
+  tag: "0.4.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -33,6 +33,31 @@ server:
   path: /mcp
   # -- Log level (DEBUG, INFO, WARNING, ERROR)
   logLevel: INFO
+  # -- Log format: text or json (structured logging)
+  logFormat: text
+  # -- Strict loading: fail on boot if any tool/resource has errors
+  strictLoading: false
+
+# =============================================================================
+# Web UI
+# =============================================================================
+
+ui:
+  # -- Enable built-in Web UI at /ui
+  enabled: true
+
+# =============================================================================
+# Metrics
+# =============================================================================
+
+metrics:
+  # -- Enable Prometheus metrics at /metrics
+  enabled: false
+  # -- Create ServiceMonitor for Prometheus Operator
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}
 
 # =============================================================================
 # Authentication
@@ -190,7 +215,7 @@ probes:
   startup:
     enabled: true
     httpGet:
-      path: /mcp
+      path: /startupz
       port: http
     initialDelaySeconds: 5
     periodSeconds: 5
@@ -199,7 +224,7 @@ probes:
   liveness:
     enabled: true
     httpGet:
-      path: /mcp
+      path: /healthz
       port: http
     initialDelaySeconds: 0
     periodSeconds: 15
@@ -208,7 +233,7 @@ probes:
   readiness:
     enabled: true
     httpGet:
-      path: /mcp
+      path: /readyz
       port: http
     initialDelaySeconds: 0
     periodSeconds: 10
@@ -229,6 +254,14 @@ persistence:
   accessModes:
     - ReadWriteOnce
   existingClaim: ""
+
+# =============================================================================
+# Init Sync
+# =============================================================================
+
+initSync:
+  # -- Run source sync as an init container before the server starts
+  enabled: false
 
 # =============================================================================
 # Service Account


### PR DESCRIPTION
## Summary
- Chart version 1.3.0, appVersion 1.0.0
- PodDisruptionBudget template (`pdb.enabled`)
- HorizontalPodAutoscaler template (`autoscaling.enabled`)
- Rate limiting, caching, sandboxing env vars in deployment
- Updated `values.schema.json` with all new fields
- Updated `NOTES.txt` with UI/metrics info
- `replicaCount` support with autoscaling-aware replicas

## Test plan
- [x] `helm lint` passes
- [x] `helm unittest`: 84/84 tests passing
- [x] PDB and HPA templates render correctly
- [x] New env vars render for rate limiting, caching, sandboxing