### PR TITLE
feat(fastmcp-server): v1.3.0 — Tool Ecosystem

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
-version: 1.2.0
-appVersion: "1.0.0"
+version: 1.3.0
+appVersion: "0.10.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: chart v1.3.0 — Production Grade (#34)
+      description: chart v1.3.0 — Tool Ecosystem (pip auto-discovery)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:1.0.0"
+          value: "docker.io/helmforge/fastmcp-server:0.10.1"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "1.0.0"
+  tag: "0.10.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump chart version to 1.3.0
- Update appVersion and image tag to 0.10.1 (latest with pip auto-discovery)

## Test plan
- [x] `helm lint` passes
- [x] 84 unit tests pass