### PR TITLE
fix(fastmcp-server): bump appVersion to 0.10.3

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
 version: 1.3.0
-appVersion: "0.10.1"
+appVersion: "0.10.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: v1.3.0 — Tool Ecosystem (#35)
+    - kind: fixed
+      description: UI path prefix, API auth, non-root pip
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com


### PR DESCRIPTION
## Summary

- Bump `appVersion` to `0.10.3` (image `docker.io/helmforge/fastmcp-server:0.10.3`)
- Upstream fixes: UI path prefix support, API bearer auth, non-root pip home directory

## Test plan

- [x] `helm lint --strict` passes
- [x] `helm template` renders
- [x] `helm unittest` — 84 tests pass
- [x] All 6 CI scenarios render