### PR TITLE
fix(fastmcp-server): update default image tag to 0.10.3

### DIFF
--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.10.1"
+          value: "docker.io/helmforge/fastmcp-server:0.10.3"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.10.1"
+  tag: "0.10.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- Update default `image.tag` from `0.10.1` to `0.10.3` in values.yaml
- Update unit test to match new default tag

## Test plan

- [x] `helm lint --strict` passes
- [x] `helm template` renders
- [x] `helm unittest` — 84 tests pass