### PR TITLE
chore(fastmcp-server): bump appVersion to 0.10.5

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
 version: 1.3.7
-appVersion: "0.10.4"
+appVersion: "0.10.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: bump appVersion to 0.10.4 (#42)
+      description: invalidate import caches after runtime pip install (#18)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.10.4"
+          value: "docker.io/helmforge/fastmcp-server:0.10.5"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.10.4"
+  tag: "0.10.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump fastmcp-server appVersion from 0.10.4 to 0.10.5
- Includes fix: `importlib.invalidate_caches()` after runtime pip install (helmforgedev/fastmcp-server#18)
- Fixes tool discovery returning 0 tools when packages installed via `EXTRA_PIP_PACKAGES`

## Test plan
- [x] Helm unit tests pass (84 tests)
- [x] Local Docker validation passed