### PR TITLE
bump: fastmcp-server 1.3.8 (appVersion 0.10.6)

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
 version: 1.3.8
-appVersion: "0.10.5"
+appVersion: "0.10.6"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: bump appVersion to 0.10.5 (#43)
+    - kind: fixed
+      description: reload importlib.metadata after pip install for entry_points discovery (#19)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.10.5"
+          value: "docker.io/helmforge/fastmcp-server:0.10.6"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.10.5"
+  tag: "0.10.6"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump appVersion to 0.10.6 (fix: reload importlib.metadata after pip install)
- Fixes entry_points discovery for pip tool packages (fastmcp-tools-*)

## Test plan
- [ ] `helm template` renders correctly with new image tag
- [ ] Chart tests pass