### PR TITLE
bump: fastmcp-server 1.3.11 (appVersion 0.10.8)

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
 version: 1.3.10
-appVersion: "0.10.7"
+appVersion: "0.10.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: fastmcp-server 1.3.10 (appVersion 0.10.7) (#45)
+    - kind: fixed
+      description: use subprocess for entry_points discovery after pip install (#21)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.10.7"
+          value: "docker.io/helmforge/fastmcp-server:0.10.8"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.10.7"
+  tag: "0.10.8"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump appVersion to 0.10.8
- Fixes entry_points discovery by using subprocess (Python 3.13 metadata caching)

## Test plan
- [x] Validated locally with Docker: 5 packages, 12 tools discovered