### PR TITLE
feat(fastmcp-server): bump appVersion to 0.10.9

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
 version: 1.3.11
-appVersion: "0.10.8"
+appVersion: "0.10.9"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: fastmcp-server 1.3.11 (appVersion 0.10.8) (#46)
+      description: bump appVersion to 0.10.9 — fix resource serialization and Windows knowledge URIs
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.10.8"
+          value: "docker.io/helmforge/fastmcp-server:0.10.9"
 
   - it: should set MCP_SERVER_NAME env
     asserts:

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.10.8"
+  tag: "0.10.9"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump `appVersion` from `0.10.8` to `0.10.9`
- Update image tag in `values.yaml` to `0.10.9`
- Update deployment test assertion to match new tag
- Update `artifacthub.io/changes` annotation

## What's in 0.10.9
- Fix resource serialization (dict → JSON string) preventing MCP clients from reading structured resources
- Fix Windows knowledge URI path separators (backslash → posix forward slash)
- See: helmforgedev/fastmcp-server#22

## Test plan
- [ ] `helm lint charts/fastmcp-server`
- [ ] `helm unittest charts/fastmcp-server`
- [ ] `helm template charts/fastmcp-server` renders with new image tag