### PR TITLE
fix(redis): add emptyDir volume when persistence is disabled

### DIFF
--- a/charts/redis/templates/cluster-statefulset.yaml
+++ b/charts/redis/templates/cluster-statefulset.yaml
@@ -104,6 +104,10 @@ spec:
         - name: config
           configMap:
             name: {{ include "redis.configMapName" . }}
+        {{- if not .Values.cluster.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
   {{- if .Values.cluster.persistence.enabled }}
   volumeClaimTemplates:
     {{- include "redis.volumeClaimTemplate" (dict "root" . "persistence" .Values.cluster.persistence) | nindent 4 }}

--- a/charts/redis/templates/replication-primary-statefulset.yaml
+++ b/charts/redis/templates/replication-primary-statefulset.yaml
@@ -93,6 +93,10 @@ spec:
         - name: config
           configMap:
             name: {{ include "redis.configMapName" . }}
+        {{- if not .Values.replication.primary.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
   {{- if .Values.replication.primary.persistence.enabled }}
   volumeClaimTemplates:
     {{- include "redis.volumeClaimTemplate" (dict "root" . "persistence" .Values.replication.primary.persistence) | nindent 4 }}

--- a/charts/redis/templates/replication-replica-statefulset.yaml
+++ b/charts/redis/templates/replication-replica-statefulset.yaml
@@ -95,6 +95,10 @@ spec:
         - name: config
           configMap:
             name: {{ include "redis.configMapName" . }}
+        {{- if not .Values.replication.replica.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
   {{- if .Values.replication.replica.persistence.enabled }}
   volumeClaimTemplates:
     {{- include "redis.volumeClaimTemplate" (dict "root" . "persistence" .Values.replication.replica.persistence) | nindent 4 }}

--- a/charts/redis/templates/standalone-statefulset.yaml
+++ b/charts/redis/templates/standalone-statefulset.yaml
@@ -104,6 +104,10 @@ spec:
         - name: config
           configMap:
             name: {{ include "redis.configMapName" . }}
+        {{- if not .Values.standalone.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: tls
           secret:


### PR DESCRIPTION
## Summary
- All statefulsets (standalone, replication-primary, replication-replica, cluster) unconditionally mount a `data` volume but only create it via `volumeClaimTemplates` when `persistence.enabled: true`
- When persistence is disabled, Kubernetes rejects the StatefulSet with: `volumeMounts[1].name: Not found: "data"`
- Adds an `emptyDir: {}` fallback volume named `data` when persistence is disabled

## Affected templates
- `standalone-statefulset.yaml`
- `replication-primary-statefulset.yaml`
- `replication-replica-statefulset.yaml`
- `cluster-statefulset.yaml`

## Test plan
- [x] `helm lint` passing
- [x] `helm unittest` — 21/21 passing
- [x] `helm template` with `persistence.enabled=false` — emptyDir present
- [x] `helm template` with `persistence.enabled=true` — no emptyDir (uses volumeClaimTemplates)
- [ ] Deploy standalone with `persistence.enabled: false` on k3d cluster