### PR TITLE
fix(charts): remove artifacthub.io/changes from all charts

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -23,9 +23,6 @@ sources:
   - https://github.com/bakito/adguardhome-sync
 icon: https://helmforge.dev/icons/charts/adguard-home.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/alfio-event/alf.io
 icon: https://helmforge.dev/icons/charts/alfio.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/apache/answer
 icon: https://helmforge.dev/icons/charts/answer.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -24,9 +24,6 @@ sources:
   - https://github.com/appwrite/appwrite
   - https://hub.docker.com/r/appwrite/appwrite
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/ArchiveBox/ArchiveBox
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/authelia/authelia
 icon: https://helmforge.dev/icons/charts/authelia.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/automatisch/automatisch
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://code.castopod.org/adaures/castopod
 icon: https://helmforge.dev/icons/charts/castopod.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/dgtlmoon/changedetection.io
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/chiefonboarding/ChiefOnboarding
 icon: https://helmforge.dev/icons/charts/chiefonboarding.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/ckan/ckan
 icon: https://helmforge.dev/icons/charts/ckan.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/cloudflare/cloudflared
 icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -27,9 +27,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/jhuckaby/Cronicle
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/qdm12/ddns-updater
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/Cybrarist/Discount-Bandit
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -23,9 +23,6 @@ sources:
   - https://github.com/docmost/docmost
   - https://docmost.com/docs
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://hub.docker.com/r/dolibarr/dolibarr
   - https://github.com/Dolibarr/dolibarr
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/apache/druid
 icon: https://helmforge.dev/icons/charts/druid.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/helmforgedev/fastmcp-server
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: added
-      description: bump appVersion to 0.10.9 (#47)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -23,9 +23,6 @@ sources:
   - https://github.com/FlowiseAI/Flowise
   - https://docs.flowiseai.com/
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -11,9 +11,6 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic.png
 kubeVersion: ">=1.26.0-0"
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/TryGhost/Ghost
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/gitea
   - https://github.com/go-gitea/gitea
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -24,9 +24,6 @@ sources:
   - https://github.com/apache/guacamole-client
 icon: https://helmforge.dev/icons/charts/guacamole.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/linuxserver/Heimdall
 icon: https://helmforge.dev/icons/charts/heimdall.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -19,9 +19,6 @@ sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/homarr
   - https://github.com/homarr-labs/homarr
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/apache/kafka
 icon: https://helmforge.dev/icons/charts/kafka.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/karakeep-app/karakeep
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -16,9 +16,6 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/gotson/komga
 icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/knadh/listmonk
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/explodingcamera/liwan
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -18,9 +18,6 @@ sources:
   - https://hub.docker.com/_/mariadb
 icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/metabase/metabase
 icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -31,9 +31,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -23,9 +23,6 @@ sources:
   - https://hub.docker.com/r/itzg/minecraft-server
 icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://hub.docker.com/_/mongo
 icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://hub.docker.com/_/eclipse-mosquitto
   - https://github.com/eclipse-mosquitto/mosquitto
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -18,9 +18,6 @@ sources:
   - https://hub.docker.com/_/mysql
 icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/n8n-io/n8n
 icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/binwiederhier/ntfy
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/OliveTin/OliveTin
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -24,9 +24,6 @@ sources:
   - https://github.com/open-webui/open-webui
   - https://docs.openwebui.com/
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/phpmyadmin/phpmyadmin
 icon: https://helmforge.dev/icons/charts/phpmyadmin.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://hub.docker.com/r/pihole/pihole
 icon: https://helmforge.dev/icons/charts/pihole.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -19,9 +19,6 @@ sources:
   - https://hub.docker.com/_/postgres
 icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/docker-library/rabbitmq
 icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://hub.docker.com/_/redis
 icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: add emptyDir volume when persistence is disabled (#49)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -21,9 +21,6 @@ sources:
   - https://github.com/strapi/strapi
 icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/robiningelbrecht/strava-statistics
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -22,9 +22,6 @@ sources:
   - https://github.com/apache/superset
 icon: https://helmforge.dev/icons/charts/superset.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/umami-software/umami
 icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/louislam/uptime-kuma
 icon: https://helmforge.dev/icons/charts/uptime-kuma.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -19,9 +19,6 @@ sources:
   - https://github.com/dani-garcia/vaultwarden
 icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/vmware-tanzu/velero
 icon: https://helmforge.dev/icons/charts/velero.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://github.com/wallabag/wallabag
 icon: https://helmforge.dev/icons/charts/wallabag.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: changed
-      description: remove artifacthub.io/images annotation from all charts (#27)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -20,9 +20,6 @@ sources:
   - https://hub.docker.com/_/wordpress
 icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
-  artifacthub.io/changes: |
-    - kind: fixed
-      description: remove tpl from extraManifests to prevent template injection (#28)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com


### PR DESCRIPTION
## Summary
- Removes `artifacthub.io/changes` annotation from all 58 Chart.yaml files
- This annotation is forbidden per SOURCE-OF-TRUTH (CI manages versioning and changelogs)

## Root cause of ArtifactHub tracking errors
The `artifacthub.io/changes` annotation had descriptions containing the text "artifacthub.io/images" (e.g. `description: remove artifacthub.io/images annotation from all charts (#27)`). ArtifactHub parsed this text as an image reference and failed with:
```
invalid image reference: could not parse reference:
```

Affecting 16 charts across versions 1.1.0 and 1.1.1. The generic chart also showed `invalid links value` for v1.9.0.

## Test plan
- [x] `helm lint` passing on sample charts (archivebox, generic, redis, rabbitmq, minecraft)
- [x] No remaining `artifacthub.io/changes` in any Chart.yaml
- [x] 58 files changed, 174 deletions
- [ ] Verify ArtifactHub tracking errors clear after next sync (~30 min)