### PR TITLE
feat(mosquitto): add mqtt tls listener and broker pressure limits

### DIFF
--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -26,6 +26,8 @@ helm install mosquitto oci://ghcr.io/helmforgedev/helm/mosquitto
 - **Kubernetes Placement Defaults** — optional anti-affinity and topology spread defaults for multi-replica broker pods
 - **WebSocket Listener** — browser-ready MQTT access through a dedicated listener
 - **Authentication and ACL** — optional password file and ACL file generation
+- **Native MQTT TLS Listener** — optional TLS/mTLS listener using an existing Kubernetes Secret
+- **Broker Pressure Limits** — optional connection and queue/message size limits to reduce abuse impact
 - **MQTTX Web Companion** — optional browser client deployment for quick testing
 - **Values Schema** — `values.schema.json` validates user-supplied values and improves ArtifactHub rendering
 
@@ -37,6 +39,7 @@ helm install mosquitto oci://ghcr.io/helmforgedev/helm/mosquitto
 - federated brokers still do **not** share sessions or retained state like a true clustered MQTT platform
 - the default Service routing uses `sessionAffinity=None` for broader compatibility; enable `ClientIP` only when sticky routing is explicitly needed
 - federated multi-replica installs automatically prefer spreading broker pods across nodes unless you provide custom `affinity` or `topologySpreadConstraints`
+- when `broker.tls.enabled=true`, set `broker.tls.certSecretName` to an existing Secret containing `tls.crt` and `tls.key` (and optionally `ca.crt` for mTLS)
 - MQTTX Web upstream versioning currently requires verification against both Docker Hub and GitHub releases before pinning a strict default tag
 - the official Mosquitto image tag validated for this chart is `eclipse-mosquitto:2.0.22`
 
@@ -101,6 +104,31 @@ mqttxWeb:
             pathType: Prefix
 ```
 
+### Public Broker with MQTT TLS
+
+```yaml
+service:
+  type: LoadBalancer
+
+auth:
+  enabled: true
+
+acl:
+  enabled: true
+
+broker:
+  tls:
+    enabled: true
+    certSecretName: mosquitto-tls
+    port: 8883
+  limits:
+    maxConnections: 10000
+    maxInflightMessages: 100
+    maxQueuedMessages: 1000
+    maxQueuedBytes: 1048576
+    messageSizeLimit: 262144
+```
+
 ## Key Values
 
 | Key | Default | Description |
@@ -109,6 +137,9 @@ mqttxWeb:
 | `broker.replicaCount` | `1` | Number of broker replicas |
 | `broker.listeners.mqtt` | `1883` | MQTT TCP listener port |
 | `broker.listeners.websocket` | `9001` | MQTT over WebSocket listener port |
+| `broker.tls.enabled` | `false` | Enable broker MQTT TLS listener |
+| `broker.tls.certSecretName` | `""` | Secret containing `tls.crt` and `tls.key` |
+| `broker.limits.maxConnections` | `0` | Maximum simultaneously connected clients (`0` keeps broker default) |
 | `broker.federation.topicPattern` | `#` | Topic pattern bridged between federated brokers |
 | `auth.enabled` | `false` | Enable username/password authentication |
 | `acl.enabled` | `false` | Enable ACL file generation |

--- a/charts/mosquitto/ci/tls-values.yaml
+++ b/charts/mosquitto/ci/tls-values.yaml
@@ -1,0 +1,19 @@
+auth:
+  enabled: true
+  password: test-password
+
+acl:
+  enabled: true
+  rules: |
+    topic readwrite #
+
+broker:
+  tls:
+    enabled: true
+    certSecretName: mosquitto-tls
+    caFile: ca.crt
+    requireCertificate: true
+    useIdentityAsUsername: true
+
+service:
+  type: LoadBalancer

--- a/charts/mosquitto/templates/NOTES.txt
+++ b/charts/mosquitto/templates/NOTES.txt
@@ -3,6 +3,9 @@ Mosquitto has been deployed.
 Broker service:
   MQTT:      {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttPort }}
   WebSocket: {{ include "mosquitto.fullname" . }}:{{ .Values.service.websocketPort }}
+{{- if .Values.broker.tls.enabled }}
+  MQTTS:     {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttsPort }}
+{{- end }}
 
 {{- if .Values.websocketIngress.enabled }}
 WebSocket ingress hosts:

--- a/charts/mosquitto/templates/configmap.yaml
+++ b/charts/mosquitto/templates/configmap.yaml
@@ -18,11 +18,38 @@ data:
     listener {{ .Values.broker.listeners.websocket }} 0.0.0.0
     protocol websockets
 
+    {{- if .Values.broker.tls.enabled }}
+    listener {{ .Values.broker.tls.port }} 0.0.0.0
+    protocol mqtt
+    certfile /mosquitto/config/tls/{{ .Values.broker.tls.certFile }}
+    keyfile /mosquitto/config/tls/{{ .Values.broker.tls.keyFile }}
+    {{- if .Values.broker.tls.caFile }}
+    cafile /mosquitto/config/tls/{{ .Values.broker.tls.caFile }}
+    {{- end }}
+    require_certificate {{ ternary "true" "false" .Values.broker.tls.requireCertificate }}
+    use_identity_as_username {{ ternary "true" "false" .Values.broker.tls.useIdentityAsUsername }}
+    {{- end }}
+
     {{- if .Values.auth.enabled }}
     password_file /mosquitto/config/generated/passwordfile
     {{- end }}
     {{- if .Values.acl.enabled }}
     acl_file /mosquitto/config/generated/aclfile
+    {{- end }}
+    {{- if gt (int .Values.broker.limits.maxConnections) 0 }}
+    max_connections {{ .Values.broker.limits.maxConnections }}
+    {{- end }}
+    {{- if gt (int .Values.broker.limits.maxInflightMessages) 0 }}
+    max_inflight_messages {{ .Values.broker.limits.maxInflightMessages }}
+    {{- end }}
+    {{- if gt (int .Values.broker.limits.maxQueuedMessages) 0 }}
+    max_queued_messages {{ .Values.broker.limits.maxQueuedMessages }}
+    {{- end }}
+    {{- if gt (int .Values.broker.limits.maxQueuedBytes) 0 }}
+    max_queued_bytes {{ .Values.broker.limits.maxQueuedBytes }}
+    {{- end }}
+    {{- if gt (int .Values.broker.limits.messageSizeLimit) 0 }}
+    message_size_limit {{ .Values.broker.limits.messageSizeLimit }}
     {{- end }}
 
     {{- with .Values.broker.extraConfig }}

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -26,6 +26,12 @@ spec:
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket
       protocol: TCP
+    {{- if .Values.broker.tls.enabled }}
+    - name: mqtts
+      port: {{ .Values.service.mqttsPort }}
+      targetPort: mqtts
+      protocol: TCP
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -52,3 +58,9 @@ spec:
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket
       protocol: TCP
+    {{- if .Values.broker.tls.enabled }}
+    - name: mqtts
+      port: {{ .Values.service.mqttsPort }}
+      targetPort: mqtts
+      protocol: TCP
+    {{- end }}

--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -126,6 +126,11 @@ spec:
             - name: websocket
               containerPort: {{ .Values.broker.listeners.websocket }}
               protocol: TCP
+            {{- if .Values.broker.tls.enabled }}
+            - name: mqtts
+              containerPort: {{ .Values.broker.tls.port }}
+              protocol: TCP
+            {{- end }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
@@ -169,6 +174,11 @@ spec:
               mountPath: /mosquitto/config/generated
             - name: data
               mountPath: /mosquitto/data
+            {{- if .Values.broker.tls.enabled }}
+            - name: tls
+              mountPath: /mosquitto/config/tls
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -186,6 +196,11 @@ spec:
         - name: acl-source
           configMap:
             name: {{ include "mosquitto.aclConfigMapName" . }}
+        {{- end }}
+        {{- if .Values.broker.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.broker.tls.certSecretName | quote }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/mosquitto/templates/validate.yaml
+++ b/charts/mosquitto/templates/validate.yaml
@@ -4,3 +4,12 @@
 {{- if and (eq .Values.architecture.mode "federated") (lt (int .Values.broker.replicaCount) 2) -}}
 {{- fail "mosquitto: architecture.mode=federated requires broker.replicaCount>=2" -}}
 {{- end -}}
+{{- if and .Values.broker.tls.enabled (not .Values.broker.tls.certSecretName) -}}
+{{- fail "mosquitto: broker.tls.certSecretName is required when broker.tls.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.broker.tls.enabled (eq (int .Values.broker.tls.port) (int .Values.broker.listeners.mqtt)) -}}
+{{- fail "mosquitto: broker.tls.port must differ from broker.listeners.mqtt" -}}
+{{- end -}}
+{{- if and .Values.broker.tls.enabled (eq (int .Values.broker.tls.port) (int .Values.broker.listeners.websocket)) -}}
+{{- fail "mosquitto: broker.tls.port must differ from broker.listeners.websocket" -}}
+{{- end -}}

--- a/charts/mosquitto/tests/configmap_test.yaml
+++ b/charts/mosquitto/tests/configmap_test.yaml
@@ -1,0 +1,56 @@
+suite: ConfigMap
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: should include TLS listener directives when TLS is enabled
+    set:
+      broker.tls.enabled: true
+      broker.tls.port: 8883
+      broker.tls.certFile: tls.crt
+      broker.tls.keyFile: tls.key
+      broker.tls.caFile: ca.crt
+      broker.tls.requireCertificate: true
+      broker.tls.useIdentityAsUsername: true
+    asserts:
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "listener 8883 0.0.0.0"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "certfile /mosquitto/config/tls/tls.crt"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "keyfile /mosquitto/config/tls/tls.key"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "cafile /mosquitto/config/tls/ca.crt"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "require_certificate true"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "use_identity_as_username true"
+
+  - it: should include broker limit directives when configured
+    set:
+      broker.limits.maxConnections: 10000
+      broker.limits.maxInflightMessages: 100
+      broker.limits.maxQueuedMessages: 1000
+      broker.limits.maxQueuedBytes: 104857
+      broker.limits.messageSizeLimit: 262144
+    asserts:
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "max_connections 10000"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "max_inflight_messages 100"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "max_queued_messages 1000"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "max_queued_bytes 104857"
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "message_size_limit 262144"

--- a/charts/mosquitto/tests/service_test.yaml
+++ b/charts/mosquitto/tests/service_test.yaml
@@ -29,3 +29,19 @@ tests:
       - equal:
           path: spec.publishNotReadyAddresses
           value: true
+
+  - it: should expose mqtts service port when TLS is enabled
+    documentIndex: 0
+    set:
+      broker.tls.enabled: true
+      broker.tls.certSecretName: mosquitto-tls
+      broker.tls.port: 8883
+      service.mqttsPort: 8883
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: mqtts
+            port: 8883
+            targetPort: mqtts
+            protocol: TCP

--- a/charts/mosquitto/tests/statefulset_test.yaml
+++ b/charts/mosquitto/tests/statefulset_test.yaml
@@ -110,3 +110,29 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "printf '\\\\nconnection %s"
+
+  - it: should mount TLS secret and expose mqtts container port when enabled
+    template: templates/statefulset.yaml
+    set:
+      broker.tls.enabled: true
+      broker.tls.certSecretName: mosquitto-tls
+      broker.tls.port: 8883
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: mqtts
+            containerPort: 8883
+            protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /mosquitto/config/tls
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: mosquitto-tls

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -118,6 +118,75 @@
             }
           }
         },
+        "tls": {
+          "type": "object",
+          "description": "TLS listener configuration for MQTT clients",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable MQTT TLS listener"
+            },
+            "port": {
+              "type": "integer",
+              "description": "MQTT TLS listener port"
+            },
+            "certSecretName": {
+              "type": "string",
+              "description": "Existing Secret name containing broker TLS material"
+            },
+            "certFile": {
+              "type": "string",
+              "description": "Secret key name for server certificate"
+            },
+            "keyFile": {
+              "type": "string",
+              "description": "Secret key name for server private key"
+            },
+            "caFile": {
+              "type": "string",
+              "description": "Optional secret key name for CA certificate used for client certificate validation"
+            },
+            "requireCertificate": {
+              "type": "boolean",
+              "description": "Require clients to present a valid certificate (mTLS)"
+            },
+            "useIdentityAsUsername": {
+              "type": "boolean",
+              "description": "Use client certificate identity as MQTT username when mTLS is enabled"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "description": "Optional broker limits for connection and message pressure control",
+          "properties": {
+            "maxConnections": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum concurrently connected clients. Use 0 for broker default."
+            },
+            "maxInflightMessages": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum in-flight QoS 1/2 messages per client. Use 0 for broker default."
+            },
+            "maxQueuedMessages": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum queued QoS 1/2 messages per client. Use 0 for broker default."
+            },
+            "maxQueuedBytes": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum queued message bytes per client. Use 0 for broker default."
+            },
+            "messageSizeLimit": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum accepted MQTT payload size in bytes. Use 0 for broker default."
+            }
+          }
+        },
         "federation": {
           "type": "object",
           "description": "Bridge configuration used when architecture.mode=federated",
@@ -255,6 +324,10 @@
         "websocketPort": {
           "type": "integer",
           "description": "Override WebSocket service port"
+        },
+        "mqttsPort": {
+          "type": "integer",
+          "description": "Override MQTT TLS service port when broker.tls.enabled=true"
         }
       }
     },

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -53,6 +53,36 @@ broker:
     # -- MQTT over WebSocket listener port
     websocket: 9001
 
+  tls:
+    # -- Enable MQTT TLS listener
+    enabled: false
+    # -- MQTT TLS listener port
+    port: 8883
+    # -- Existing Secret name containing broker TLS material
+    certSecretName: ""
+    # -- Secret key name for server certificate
+    certFile: tls.crt
+    # -- Secret key name for server private key
+    keyFile: tls.key
+    # -- Optional secret key name for CA certificate used for client certificate validation
+    caFile: ""
+    # -- Require clients to present a valid certificate (mTLS)
+    requireCertificate: false
+    # -- Use client certificate identity as MQTT username when mTLS is enabled
+    useIdentityAsUsername: false
+
+  limits:
+    # -- Maximum concurrently connected clients. Use 0 for broker default.
+    maxConnections: 0
+    # -- Maximum in-flight QoS 1/2 messages per client. Use 0 for broker default.
+    maxInflightMessages: 0
+    # -- Maximum queued QoS 1/2 messages per client. Use 0 for broker default.
+    maxQueuedMessages: 0
+    # -- Maximum queued message bytes per client. Use 0 for broker default.
+    maxQueuedBytes: 0
+    # -- Maximum accepted MQTT payload size in bytes. Use 0 for broker default.
+    messageSizeLimit: 0
+
   federation:
     # -- Topics exported and imported through Mosquitto bridge connections when architecture.mode=federated
     topicPattern: "#"
@@ -114,6 +144,8 @@ service:
   mqttPort: 1883
   # -- Override WebSocket service port
   websocketPort: 9001
+  # -- Override MQTT TLS service port when broker.tls.enabled=true
+  mqttsPort: 8883
 
 headlessService:
   # -- Annotations for the headless broker Service


### PR DESCRIPTION
## Summary
- add native MQTT TLS listener settings under roker.tls with template validation guards
- add optional broker pressure-control limits under roker.limits
- expose optional mqtts port in services and StatefulSet when TLS is enabled
- add CI scenario ci/tls-values.yaml
- add/update unit tests for configmap, service, and statefulset TLS behavior
- update chart README for new values and secure public deployment example

## Validation
- helm lint charts/mosquitto --strict
- helm template test-release charts/mosquitto
- helm unittest charts/mosquitto
- helm template test-release charts/mosquitto -f charts/mosquitto/ci/default-values.yaml
- helm template test-release charts/mosquitto -f charts/mosquitto/ci/auth-values.yaml
- helm template test-release charts/mosquitto -f charts/mosquitto/ci/mqttx-values.yaml
- helm template test-release charts/mosquitto -f charts/mosquitto/ci/tls-values.yaml

## Notes
- HelmForge check_site_sync indicates docs update required in site repo for /docs/charts/mosquitto#values (GR-007).