### PR TITLE
fix(mosquitto): enforce tls-only mode when tls listener is enabled

### DIFF
--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -40,6 +40,7 @@ helm install mosquitto oci://ghcr.io/helmforgedev/helm/mosquitto
 - the default Service routing uses `sessionAffinity=None` for broader compatibility; enable `ClientIP` only when sticky routing is explicitly needed
 - federated multi-replica installs automatically prefer spreading broker pods across nodes unless you provide custom `affinity` or `topologySpreadConstraints`
 - when `broker.tls.enabled=true`, set `broker.tls.certSecretName` to an existing Secret containing `tls.crt` and `tls.key` (and optionally `ca.crt` for mTLS)
+- when `broker.tls.enabled=true`, the chart disables the plain MQTT `1883` listener and Service port, serving MQTT only on `broker.tls.port` (default `8883`)
 - MQTTX Web upstream versioning currently requires verification against both Docker Hub and GitHub releases before pinning a strict default tag
 - the official Mosquitto image tag validated for this chart is `eclipse-mosquitto:2.0.22`
 
@@ -137,7 +138,7 @@ broker:
 | `broker.replicaCount` | `1` | Number of broker replicas |
 | `broker.listeners.mqtt` | `1883` | MQTT TCP listener port |
 | `broker.listeners.websocket` | `9001` | MQTT over WebSocket listener port |
-| `broker.tls.enabled` | `false` | Enable broker MQTT TLS listener |
+| `broker.tls.enabled` | `false` | Enable broker MQTT TLS listener and disable plain MQTT `1883` |
 | `broker.tls.certSecretName` | `""` | Secret containing `tls.crt` and `tls.key` |
 | `broker.limits.maxConnections` | `0` | Maximum simultaneously connected clients (`0` keeps broker default) |
 | `broker.federation.topicPattern` | `#` | Topic pattern bridged between federated brokers |

--- a/charts/mosquitto/templates/NOTES.txt
+++ b/charts/mosquitto/templates/NOTES.txt
@@ -1,7 +1,9 @@
 Mosquitto has been deployed.
 
 Broker service:
+{{- if not .Values.broker.tls.enabled }}
   MQTT:      {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttPort }}
+{{- end }}
   WebSocket: {{ include "mosquitto.fullname" . }}:{{ .Values.service.websocketPort }}
 {{- if .Values.broker.tls.enabled }}
   MQTTS:     {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttsPort }}

--- a/charts/mosquitto/templates/configmap.yaml
+++ b/charts/mosquitto/templates/configmap.yaml
@@ -12,8 +12,10 @@ data:
     allow_anonymous {{ ternary "false" "true" .Values.auth.enabled }}
     per_listener_settings false
 
+    {{- if not .Values.broker.tls.enabled }}
     listener {{ .Values.broker.listeners.mqtt }} 0.0.0.0
     protocol mqtt
+    {{- end }}
 
     listener {{ .Values.broker.listeners.websocket }} 0.0.0.0
     protocol websockets

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -18,10 +18,12 @@ spec:
     {{- include "mosquitto.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: broker
   ports:
+    {{- if not .Values.broker.tls.enabled }}
     - name: mqtt
       port: {{ .Values.service.mqttPort }}
       targetPort: mqtt
       protocol: TCP
+    {{- end }}
     - name: websocket
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket
@@ -50,10 +52,12 @@ spec:
     {{- include "mosquitto.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: broker
   ports:
+    {{- if not .Values.broker.tls.enabled }}
     - name: mqtt
       port: {{ .Values.service.mqttPort }}
       targetPort: mqtt
       protocol: TCP
+    {{- end }}
     - name: websocket
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket

--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "mosquitto.labels" . | nindent 4 }}
     app.kubernetes.io/component: broker
 spec:
+  {{- $probePort := ternary "mqtts" "mqtt" .Values.broker.tls.enabled }}
   serviceName: {{ include "mosquitto.headlessServiceName" . }}
   replicas: {{ .Values.broker.replicaCount }}
   podManagementPolicy: Parallel
@@ -120,9 +121,11 @@ spec:
             - -c
             - /mosquitto/config/mosquitto.conf
           ports:
+            {{- if not .Values.broker.tls.enabled }}
             - name: mqtt
               containerPort: {{ .Values.broker.listeners.mqtt }}
               protocol: TCP
+            {{- end }}
             - name: websocket
               containerPort: {{ .Values.broker.listeners.websocket }}
               protocol: TCP
@@ -134,7 +137,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
-              port: mqtt
+              port: {{ $probePort }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
@@ -143,7 +146,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              port: mqtt
+              port: {{ $probePort }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -152,7 +155,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: mqtt
+              port: {{ $probePort }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/mosquitto/templates/validate.yaml
+++ b/charts/mosquitto/templates/validate.yaml
@@ -13,3 +13,6 @@
 {{- if and .Values.broker.tls.enabled (eq (int .Values.broker.tls.port) (int .Values.broker.listeners.websocket)) -}}
 {{- fail "mosquitto: broker.tls.port must differ from broker.listeners.websocket" -}}
 {{- end -}}
+{{- if and .Values.broker.tls.enabled (eq .Values.architecture.mode "federated") -}}
+{{- fail "mosquitto: broker.tls.enabled=true is not supported with architecture.mode=federated" -}}
+{{- end -}}

--- a/charts/mosquitto/tests/configmap_test.yaml
+++ b/charts/mosquitto/tests/configmap_test.yaml
@@ -12,6 +12,9 @@ tests:
       broker.tls.requireCertificate: true
       broker.tls.useIdentityAsUsername: true
     asserts:
+      - notMatchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "listener 1883 0.0.0.0"
       - matchRegex:
           path: data["mosquitto.conf.tmpl"]
           pattern: "listener 8883 0.0.0.0"

--- a/charts/mosquitto/tests/service_test.yaml
+++ b/charts/mosquitto/tests/service_test.yaml
@@ -38,6 +38,36 @@ tests:
       broker.tls.port: 8883
       service.mqttsPort: 8883
     asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: mqtt
+            port: 1883
+            targetPort: mqtt
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            name: mqtts
+            port: 8883
+            targetPort: mqtts
+            protocol: TCP
+
+  - it: should expose mqtts on headless service when TLS is enabled
+    documentIndex: 1
+    set:
+      broker.tls.enabled: true
+      broker.tls.certSecretName: mosquitto-tls
+      broker.tls.port: 8883
+      service.mqttsPort: 8883
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: mqtt
+            port: 1883
+            targetPort: mqtt
+            protocol: TCP
       - contains:
           path: spec.ports
           content:

--- a/charts/mosquitto/tests/statefulset_test.yaml
+++ b/charts/mosquitto/tests/statefulset_test.yaml
@@ -118,12 +118,27 @@ tests:
       broker.tls.certSecretName: mosquitto-tls
       broker.tls.port: 8883
     asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: mqtt
+            containerPort: 1883
+            protocol: TCP
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
             name: mqtts
             containerPort: 8883
             protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: mqtts
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: mqtts
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: mqtts
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -110,7 +110,7 @@
           "properties": {
             "mqtt": {
               "type": "integer",
-              "description": "MQTT TCP listener port"
+              "description": "MQTT TCP listener port (used only when broker.tls.enabled=false)"
             },
             "websocket": {
               "type": "integer",
@@ -319,7 +319,7 @@
         },
         "mqttPort": {
           "type": "integer",
-          "description": "Override MQTT service port"
+          "description": "Override MQTT service port (used only when broker.tls.enabled=false)"
         },
         "websocketPort": {
           "type": "integer",

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -48,7 +48,7 @@ broker:
   extraConfig: ""
 
   listeners:
-    # -- MQTT TCP listener port
+    # -- MQTT TCP listener port (used only when broker.tls.enabled=false)
     mqtt: 1883
     # -- MQTT over WebSocket listener port
     websocket: 9001
@@ -140,7 +140,7 @@ service:
   externalTrafficPolicy: Cluster
   # -- Annotations for the broker Service
   annotations: {}
-  # -- Override MQTT service port
+  # -- Override MQTT service port (used only when broker.tls.enabled=false)
   mqttPort: 1883
   # -- Override WebSocket service port
   websocketPort: 9001


### PR DESCRIPTION
TLS-only mode: remove plain 1883 listener/ports when TLS is enabled, switch probes to mqtts, and update tests/docs.