### PR TITLE
fix(mosquitto): use websocket probes in tls-only mode

### DIFF
--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "mosquitto.labels" . | nindent 4 }}
     app.kubernetes.io/component: broker
 spec:
-  {{- $probePort := ternary "mqtts" "mqtt" .Values.broker.tls.enabled }}
+  {{- $probePort := ternary "websocket" "mqtt" .Values.broker.tls.enabled }}
   serviceName: {{ include "mosquitto.headlessServiceName" . }}
   replicas: {{ .Values.broker.replicaCount }}
   podManagementPolicy: Parallel

--- a/charts/mosquitto/tests/statefulset_test.yaml
+++ b/charts/mosquitto/tests/statefulset_test.yaml
@@ -132,13 +132,13 @@ tests:
             protocol: TCP
       - equal:
           path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
-          value: mqtts
+          value: websocket
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
-          value: mqtts
+          value: websocket
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
-          value: mqtts
+          value: websocket
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:


### PR DESCRIPTION
## Summary
- switch startup/liveness/readiness probes to websocket when roker.tls.enabled=true
- avoid kubelet TCP checks against TLS listener (mqtts) that generated OpenSSL protocol errors in logs
- keep existing TLS-only listener behavior unchanged

## Validation
- helm lint charts/mosquitto --strict
- helm unittest charts/mosquitto
- helm template test-release charts/mosquitto -f charts/mosquitto/ci/tls-values.yaml (probes now target websocket)