### PR TITLE
fix(mosquitto): prefer max_packet_size over legacy message_size_limit

### DIFF
--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -141,6 +141,7 @@ broker:
 | `broker.tls.enabled` | `false` | Enable broker MQTT TLS listener and disable plain MQTT `1883` |
 | `broker.tls.certSecretName` | `""` | Secret containing `tls.crt` and `tls.key` |
 | `broker.limits.maxConnections` | `0` | Maximum simultaneously connected clients (`0` keeps broker default) |
+| `broker.limits.maxPacketSize` | `0` | Maximum accepted MQTT packet size in bytes (`0` keeps broker default) |
 | `broker.federation.topicPattern` | `#` | Topic pattern bridged between federated brokers |
 | `auth.enabled` | `false` | Enable username/password authentication |
 | `acl.enabled` | `false` | Enable ACL file generation |

--- a/charts/mosquitto/templates/configmap.yaml
+++ b/charts/mosquitto/templates/configmap.yaml
@@ -50,8 +50,12 @@ data:
     {{- if gt (int .Values.broker.limits.maxQueuedBytes) 0 }}
     max_queued_bytes {{ .Values.broker.limits.maxQueuedBytes }}
     {{- end }}
-    {{- if gt (int .Values.broker.limits.messageSizeLimit) 0 }}
-    message_size_limit {{ .Values.broker.limits.messageSizeLimit }}
+    {{- $maxPacketSize := int .Values.broker.limits.maxPacketSize }}
+    {{- $legacyMessageSizeLimit := int .Values.broker.limits.messageSizeLimit }}
+    {{- if gt $maxPacketSize 0 }}
+    max_packet_size {{ $maxPacketSize }}
+    {{- else if gt $legacyMessageSizeLimit 0 }}
+    max_packet_size {{ $legacyMessageSizeLimit }}
     {{- end }}
 
     {{- with .Values.broker.extraConfig }}

--- a/charts/mosquitto/tests/configmap_test.yaml
+++ b/charts/mosquitto/tests/configmap_test.yaml
@@ -40,6 +40,7 @@ tests:
       broker.limits.maxInflightMessages: 100
       broker.limits.maxQueuedMessages: 1000
       broker.limits.maxQueuedBytes: 104857
+      broker.limits.maxPacketSize: 131072
       broker.limits.messageSizeLimit: 262144
     asserts:
       - matchRegex:
@@ -56,4 +57,12 @@ tests:
           pattern: "max_queued_bytes 104857"
       - matchRegex:
           path: data["mosquitto.conf.tmpl"]
-          pattern: "message_size_limit 262144"
+          pattern: "max_packet_size 131072"
+
+  - it: should map legacy messageSizeLimit to max_packet_size
+    set:
+      broker.limits.messageSizeLimit: 262144
+    asserts:
+      - matchRegex:
+          path: data["mosquitto.conf.tmpl"]
+          pattern: "max_packet_size 262144"

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -183,7 +183,12 @@
             "messageSizeLimit": {
               "type": "integer",
               "minimum": 0,
-              "description": "Maximum accepted MQTT payload size in bytes. Use 0 for broker default."
+              "description": "Deprecated: use maxPacketSize instead."
+            },
+            "maxPacketSize": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum accepted MQTT packet size in bytes. Use 0 for broker default."
             }
           }
         },

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -80,7 +80,9 @@ broker:
     maxQueuedMessages: 0
     # -- Maximum queued message bytes per client. Use 0 for broker default.
     maxQueuedBytes: 0
-    # -- Maximum accepted MQTT payload size in bytes. Use 0 for broker default.
+    # -- Maximum accepted MQTT packet size in bytes. Use 0 for broker default.
+    maxPacketSize: 0
+    # -- Deprecated: use broker.limits.maxPacketSize instead.
     messageSizeLimit: 0
 
   federation:


### PR DESCRIPTION
Switch Mosquitto config output to max_packet_size, add broker.limits.maxPacketSize, and keep legacy messageSizeLimit as fallback. Validated with helm lint --strict and helm unittest.