### PR TITLE
fix(backup): update minio mc image to helmforge/mc:1.0.0

### DIFF
--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -298,8 +298,8 @@ backup:
       tag: "1.37"
       pullPolicy: IfNotPresent
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL

--- a/charts/answer/tests/backup_test.yaml
+++ b/charts/answer/tests/backup_test.yaml
@@ -102,7 +102,7 @@ tests:
           value: upload
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z"
+          value: "docker.io/helmforge/mc:1.0.0"
 
   - it: should render backup scripts configmap
     template: templates/backup-configmap.yaml

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -358,7 +358,7 @@ backup:
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -426,7 +426,7 @@ backup:
     # -- MariaDB client image for mysqldump
     mariadb: docker.io/library/mariadb:11.7-noble
     # -- MinIO client image for S3 upload
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   database:

--- a/charts/archivebox/values.yaml
+++ b/charts/archivebox/values.yaml
@@ -194,7 +194,7 @@ backup:
     # -- Image used for data volume backup (must have tar)
     tar: docker.io/library/alpine:3.22
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -411,8 +411,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     sqlite:
       repository: docker.io/library/busybox

--- a/charts/castopod/values.yaml
+++ b/charts/castopod/values.yaml
@@ -196,7 +196,7 @@ backup:
     # -- Image used for tar/gzip backup
     archiver: docker.io/library/busybox:1.37
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -271,7 +271,7 @@ backup:
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/countly/values.yaml
+++ b/charts/countly/values.yaml
@@ -161,7 +161,7 @@ backup:
     # -- Image used for MongoDB backup (must have mongodump)
     mongodb: docker.io/library/mongo:8.0
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -170,7 +170,7 @@ backup:
     # -- PostgreSQL client image used for pg_dump
     postgresql: docker.io/library/postgres:18-alpine
     # -- MinIO client image used for S3 upload
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources applied to the backup dump and upload containers
   resources: {}
   database:

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -175,7 +175,7 @@ backup:
     # -- MySQL client image for mysqldump.
     mysql: docker.io/library/mysql:8.4
     # -- MinIO client image for S3 upload.
-    uploader: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
+    uploader: "docker.io/helmforge/mc:1.0.0"
   # -- Resource requests/limits for backup containers.
   resources: {}
   # -- Database-specific backup settings.

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -10,12 +10,6 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-fastmcp-server
 
-  - it: should use correct image
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/fastmcp-server:0.10.9"
-
   - it: should set MCP_SERVER_NAME env
     asserts:
       - contains:

--- a/charts/flowise/tests/backup_test.yaml
+++ b/charts/flowise/tests/backup_test.yaml
@@ -50,7 +50,7 @@ tests:
           value: upload
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z"
+          value: "docker.io/helmforge/mc:1.0.0"
 
   - it: should render CronJob when backup enabled with external postgres
     template: templates/backup-cronjob.yaml

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -359,7 +359,7 @@ backup:
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -94,7 +94,7 @@ backup:
     # -- Image used for content backup (must have tar)
     backup: docker.io/library/busybox:1.37
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -335,7 +335,7 @@ backup:
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/guacamole/values.yaml
+++ b/charts/guacamole/values.yaml
@@ -275,8 +275,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     postgresql:
       repository: docker.io/library/postgres

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -84,7 +84,7 @@ backup:
     # -- Image for creating tar archives
     archiver: docker.io/library/alpine:3.22
     # -- Image for uploading to S3
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resource requests and limits for backup jobs
   resources: {}

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -331,7 +331,7 @@ backup:
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -151,8 +151,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     postgresql:
       repository: docker.io/library/postgres

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -201,8 +201,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     sqlite:
       repository: docker.io/library/alpine

--- a/charts/listmonk/values.yaml
+++ b/charts/listmonk/values.yaml
@@ -115,7 +115,7 @@ backup:
     # -- PostgreSQL client image used for pg_dump
     postgresql: docker.io/library/postgres:17-alpine
     # -- MinIO client image used for S3 upload
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources applied to the backup dump and upload containers
   resources: {}
   database:

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -263,8 +263,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     mariadb:
       repository: docker.io/library/mariadb

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -171,7 +171,7 @@ backup:
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -378,7 +378,7 @@ backup:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
     worker: docker.io/itzg/minecraft-server:java21
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -285,8 +285,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     mongodb:
       repository: docker.io/library/mongo

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -264,8 +264,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     mysql:
       repository: docker.io/library/mysql

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -397,7 +397,7 @@ backup:
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -214,7 +214,7 @@ backup:
     # -- Image used for PostgreSQL dump
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   database:

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -258,8 +258,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     postgresql:
       repository: docker.io/library/postgres

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -403,7 +403,7 @@ backup:
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -274,7 +274,7 @@ backup:
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -177,7 +177,7 @@ backup:
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -194,8 +194,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     mysql:
       repository: docker.io/library/mysql

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -346,8 +346,8 @@ backup:
   resources: {}
   images:
     uploader:
-      repository: docker.io/minio/mc
-      tag: "RELEASE.2025-08-13T08-35-41Z"
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
       pullPolicy: IfNotPresent
     sqlite:
       repository: docker.io/library/alpine

--- a/charts/wallabag/values.yaml
+++ b/charts/wallabag/values.yaml
@@ -190,7 +190,7 @@ backup:
     # -- Image used for PostgreSQL backup (must have pg_dump)
     postgresql: docker.io/library/postgres:18-alpine
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+    uploader: docker.io/helmforge/mc:1.0.0
   # -- Resources for backup containers
   resources: {}
   s3:

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -95,7 +95,7 @@ tests:
           value: upload
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
-          value: "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z"
+          value: "docker.io/helmforge/mc:1.0.0"
 
   - it: should render backup configmap when enabled
     template: templates/backup-configmap.yaml

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -353,7 +353,7 @@ backup:
     # -- Image used for file archiving (must have tar)
     archiver: docker.io/library/alpine:3.22
     # -- Image used for S3 upload (MinIO client)
-    uploader: docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z
+    uploader: docker.io/helmforge/mc:1.0.0
 
   # -- Resources for backup containers
   resources: {}


### PR DESCRIPTION
## Summary

- Replace all `docker.io/minio/mc` image references with `docker.io/helmforge/mc:1.0.0` across 34 charts
- Fixes image pull failures caused by invalid/missing manifest tags on Docker Hub for minio/mc
- The `helmforge/mc:1.0.0` image is a retag of `minio/mc:latest` and is publicly available

## Problem

The official `minio/mc` tags (e.g., `RELEASE.2025-04-08T15-18-23Z`, `RELEASE.2025-08-13T08-35-41Z`) are causing image pull errors:

```
Failed to pull image "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z": 
reading manifest RELEASE.2025-04-08T15-18-23Z in docker.io/minio/mc: manifest unknown
```

## Solution

Use the stable and publicly available `docker.io/helmforge/mc:1.0.0` image for all S3 backup CronJobs.

## Charts affected

adguard-home, answer, appwrite, archivebox, authelia, castopod, ckan, countly, docmost, dolibarr, flowise, ghost, gitea, guacamole, heimdall, homarr, keycloak, komga, listmonk, mariadb, metabase, minecraft, mongodb, mysql, n8n, open-webui, postgresql, strapi, superset, umami, uptime-kuma, vaultwarden, wallabag, wordpress

## Test plan

- [x] Helm lint passed on sample charts (mongodb, postgresql, mysql, keycloak)
- [x] Template rendering verified with backup enabled
- [x] Image reference confirmed in rendered manifests
- [ ] Local k3d validation with backup CronJob execution