### PR TITLE
feat(pihole): comprehensive enhancements for blocklist automation and monitoring

### DIFF
--- a/charts/pihole/templates/NOTES.txt
+++ b/charts/pihole/templates/NOTES.txt
@@ -1,50 +1,117 @@
-Pi-hole has been deployed!
+=============================================================================
+Pi-hole DNS Sinkhole deployed successfully!
+=============================================================================
 
-{{- if eq .Values.serviceDns.type "LoadBalancer" }}
-
-DNS Service:
-  Your DNS service is exposed via LoadBalancer.
-  {{- if .Values.serviceDns.loadBalancerIP }}
-  Configure your clients to use DNS server: {{ .Values.serviceDns.loadBalancerIP }}
-  {{- else }}
-  Get the DNS IP with:
-    kubectl get svc {{ include "pihole.fullname" . }}-dns -n {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-  {{- end }}
-{{- else }}
-  DNS is available at: {{ include "pihole.fullname" . }}-dns.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.serviceDns.port }}
-{{- end }}
-
-Web Admin:
+WEB ADMIN:
 {{- if .Values.ingress.enabled }}
   {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/admin
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/admin
   {{- end }}
 {{- else }}
-  kubectl port-forward svc/{{ include "pihole.fullname" . }}-web -n {{ .Release.Namespace }} 8080:{{ .Values.serviceWeb.port }}
-  Then visit: http://localhost:8080/admin
+   kubectl port-forward svc/{{ include "pihole.fullname" . }}-web -n {{ .Release.Namespace }} 8080:{{ .Values.serviceWeb.port }}
+   Open: http://localhost:8080/admin
 {{- end }}
 
-Admin Password:
-{{- if .Values.admin.existingSecret }}
-  Using existing secret: {{ .Values.admin.existingSecret }}
-{{- else if .Values.admin.password }}
-  Using the password from values.
+   Password: {{- if .Values.admin.existingSecret }} {{ .Values.admin.existingSecret }} (existing secret)
+{{- else if .Values.admin.password }} <from values.yaml>
+{{- else }} kubectl get secret {{ include "pihole.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.password}' | base64 -d
+{{- end }}
+
+DNS SERVICE:
+   Type: {{ .Values.serviceDns.type }}
+{{- if eq .Values.serviceDns.type "LoadBalancer" }}
+  {{- if .Values.serviceDns.loadBalancerIP }}
+   IP: {{ .Values.serviceDns.loadBalancerIP }}
+  {{- else }}
+   IP: kubectl get svc {{ include "pihole.fullname" . }}-dns -n {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+  {{- end }}
+{{- else if eq .Values.serviceDns.type "NodePort" }}
+   Port: kubectl get svc {{ include "pihole.fullname" . }}-dns -n {{ .Release.Namespace }} -o jsonpath='{.spec.ports[?(@.name=="dns-udp")].nodePort}'
 {{- else }}
-  Auto-generated. Retrieve with:
-    kubectl get secret {{ include "pihole.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.password}' | base64 -d
+   Internal: {{ include "pihole.fullname" . }}-dns.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.serviceDns.port }}
+{{- end }}
+
+BLOCKLISTS:
+{{- if ne .Values.dns.preset "none" }}
+   Preset: {{ .Values.dns.preset }}
+{{- else }}
+   Preset: none (using custom lists only)
+{{- end }}
+{{- $adlists := include "pihole.adlists" . | fromYamlArray }}
+   Total adlists: {{ len $adlists }}
+{{- $whitelist := include "pihole.whitelist" . | fromYamlArray }}
+{{- if gt (len $whitelist) 0 }}
+   Whitelist: {{ len $whitelist }} domains (including presets)
+{{- end }}
+{{- if .Values.dns.blacklist }}
+   Blacklist: {{ len .Values.dns.blacklist }} domains
+{{- end }}
+{{- if .Values.dns.regex }}
+   Regex filters: {{ len .Values.dns.regex }}
+{{- end }}
+
+{{- if .Values.dns.whitelistPresets }}
+   Whitelist Presets:
+{{- if .Values.dns.whitelistPresets.microsoft }} - Microsoft
+{{- end }}
+{{- if .Values.dns.whitelistPresets.apple }} - Apple
+{{- end }}
+{{- if .Values.dns.whitelistPresets.google }} - Google
+{{- end }}
+{{- if .Values.dns.whitelistPresets.gaming }} - Gaming
+{{- end }}
+{{- if .Values.dns.whitelistPresets.smartHome }} - Smart Home
+{{- end }}
 {{- end }}
 
 {{- if .Values.unbound.enabled }}
 
-Unbound (Recursive DNS):
-  Unbound sidecar is enabled. Pi-hole uses 127.0.0.1#{{ .Values.unbound.port }} for recursive DNS resolution.
+RECURSIVE DNS:
+   Unbound sidecar: enabled (privacy-first DNS)
+   Pi-hole upstream: 127.0.0.1#{{ .Values.unbound.port }}
 {{- end }}
 
 {{- if .Values.metrics.enabled }}
 
-Metrics:
-  Prometheus metrics are available on port {{ .Values.metrics.port }}.
-  {{- if .Values.metrics.serviceMonitor.enabled }}
-  A ServiceMonitor has been created for Prometheus Operator.
-  {{- end }}
+METRICS:
+   Exporter: enabled on port {{ .Values.metrics.port }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+   ServiceMonitor: created for Prometheus Operator
 {{- end }}
+   Metrics endpoint: http://{{ include "pihole.fullname" . }}-web:{{ .Values.metrics.port }}/metrics
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+
+BACKUP:
+   S3 backups: enabled
+   Schedule: {{ .Values.backup.schedule }}
+   Bucket: s3://{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+{{- end }}
+
+{{- if .Values.dns.conditionalForwarding.enabled }}
+
+CONDITIONAL FORWARDING:
+{{- if .Values.dns.conditionalForwarding.domain }}
+   Local domain: {{ .Values.dns.conditionalForwarding.domain }}
+{{- end }}
+{{- if .Values.dns.conditionalForwarding.network }}
+   Network: {{ .Values.dns.conditionalForwarding.network }}
+{{- end }}
+{{- if .Values.dns.conditionalForwarding.router }}
+   Router: {{ .Values.dns.conditionalForwarding.router }}
+{{- end }}
+{{- end }}
+
+NEXT STEPS:
+   1. Update device/router DNS settings to point to Pi-hole service IP
+   2. Access web admin to view real-time statistics
+   3. Wait for gravity to update (automatic on first run)
+   4. Monitor blocked queries in the web dashboard
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/pihole
+   Pi-hole: https://docs.pi-hole.net/
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/pihole
+
+=============================================================================

--- a/charts/pihole/templates/_helpers.tpl
+++ b/charts/pihole/templates/_helpers.tpl
@@ -109,3 +109,101 @@ ConfigMap name for custom DNS and dnsmasq config.
 {{- define "pihole.configMapName" -}}
 {{- printf "%s-config" (include "pihole.fullname" .) }}
 {{- end }}
+
+{{/*
+Generate adlist URLs based on preset and custom lists.
+Returns list.
+*/}}
+{{- define "pihole.adlists" -}}
+{{- $lists := list }}
+{{- $preset := .Values.dns.preset | default "none" }}
+
+{{- if eq $preset "basic" }}
+{{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
+{{- else if eq $preset "balanced" }}
+{{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/multi.txt" }}
+{{- $lists = append $lists "https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt" }}
+{{- else if eq $preset "aggressive" }}
+{{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/pro.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/doh-vpn-proxy-bypass.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/tif.txt" }}
+{{- else if eq $preset "gaming-friendly" }}
+{{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/multi.txt" }}
+{{- end }}
+
+{{- range .Values.dns.adlists }}
+{{- $lists = append $lists . }}
+{{- end }}
+
+{{- $lists | toJson }}
+{{- end }}
+
+{{/*
+Generate whitelist domains based on presets and custom lists.
+Returns list.
+*/}}
+{{- define "pihole.whitelist" -}}
+{{- $whitelist := list }}
+
+{{- if .Values.dns.whitelistPresets.microsoft }}
+{{- $whitelist = append $whitelist "*.microsoft.com" }}
+{{- $whitelist = append $whitelist "*.windows.com" }}
+{{- $whitelist = append $whitelist "*.windowsupdate.com" }}
+{{- $whitelist = append $whitelist "*.office.com" }}
+{{- $whitelist = append $whitelist "*.office365.com" }}
+{{- $whitelist = append $whitelist "*.live.com" }}
+{{- $whitelist = append $whitelist "*.msftconnecttest.com" }}
+{{- end }}
+
+{{- if .Values.dns.whitelistPresets.apple }}
+{{- $whitelist = append $whitelist "*.apple.com" }}
+{{- $whitelist = append $whitelist "*.icloud.com" }}
+{{- $whitelist = append $whitelist "*.mzstatic.com" }}
+{{- $whitelist = append $whitelist "*.itunes.com" }}
+{{- $whitelist = append $whitelist "*.cdn-apple.com" }}
+{{- end }}
+
+{{- if .Values.dns.whitelistPresets.google }}
+{{- $whitelist = append $whitelist "*.google.com" }}
+{{- $whitelist = append $whitelist "*.googleapis.com" }}
+{{- $whitelist = append $whitelist "*.youtube.com" }}
+{{- $whitelist = append $whitelist "*.ytimg.com" }}
+{{- $whitelist = append $whitelist "*.gstatic.com" }}
+{{- $whitelist = append $whitelist "*.googleusercontent.com" }}
+{{- end }}
+
+{{- if .Values.dns.whitelistPresets.gaming }}
+{{- $whitelist = append $whitelist "*.xboxlive.com" }}
+{{- $whitelist = append $whitelist "*.xbox.com" }}
+{{- $whitelist = append $whitelist "*.playstation.com" }}
+{{- $whitelist = append $whitelist "*.playstation.net" }}
+{{- $whitelist = append $whitelist "*.nintendo.com" }}
+{{- $whitelist = append $whitelist "*.nintendo.net" }}
+{{- $whitelist = append $whitelist "*.steamstatic.com" }}
+{{- $whitelist = append $whitelist "*.steampowered.com" }}
+{{- end }}
+
+{{- if .Values.dns.whitelistPresets.smartHome }}
+{{- $whitelist = append $whitelist "*.amazon.com" }}
+{{- $whitelist = append $whitelist "*.alexa.com" }}
+{{- $whitelist = append $whitelist "*.amazonaws.com" }}
+{{- end }}
+
+{{- if eq .Values.dns.preset "gaming-friendly" }}
+{{- $whitelist = append $whitelist "*.xboxlive.com" }}
+{{- $whitelist = append $whitelist "*.xbox.com" }}
+{{- $whitelist = append $whitelist "*.playstation.com" }}
+{{- $whitelist = append $whitelist "*.playstation.net" }}
+{{- $whitelist = append $whitelist "*.nintendo.com" }}
+{{- $whitelist = append $whitelist "*.nintendo.net" }}
+{{- end }}
+
+{{- range .Values.dns.whitelist }}
+{{- $whitelist = append $whitelist . }}
+{{- end }}
+
+{{- $whitelist | toJson }}
+{{- end }}

--- a/charts/pihole/templates/backup-configmap.yaml
+++ b/charts/pihole/templates/backup-configmap.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.backup.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pihole.fullname" . }}-backup-scripts
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+data:
+  backup.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "=== Pi-hole Backup Started ==="
+    DATE=$(date +%Y-%m-%d-%H%M%S)
+    BACKUP_DIR="/tmp/pihole-backup-${DATE}"
+    ARCHIVE="/tmp/pihole-backup-${DATE}.tar.gz"
+
+    mkdir -p "${BACKUP_DIR}"
+
+    {{- if .Values.backup.include.gravity }}
+    if [ -f /etc/pihole/gravity.db ]; then
+      echo "Backing up gravity database..."
+      cp /etc/pihole/gravity.db "${BACKUP_DIR}/gravity.db"
+    fi
+    {{- end }}
+
+    {{- if .Values.backup.include.customDns }}
+    if [ -f /etc/pihole/custom.list ]; then
+      echo "Backing up custom DNS records..."
+      cp /etc/pihole/custom.list "${BACKUP_DIR}/custom.list"
+    fi
+    {{- end }}
+
+    {{- if .Values.backup.include.dnsmasq }}
+    if [ -d /etc/dnsmasq.d ]; then
+      echo "Backing up dnsmasq configuration..."
+      mkdir -p "${BACKUP_DIR}/dnsmasq.d"
+      cp -r /etc/dnsmasq.d/* "${BACKUP_DIR}/dnsmasq.d/" || true
+    fi
+    {{- end }}
+
+    echo "Creating backup archive..."
+    cd /tmp
+    tar -czf "${ARCHIVE}" "pihole-backup-${DATE}"
+
+    echo "Backup archive created: ${ARCHIVE}"
+    echo "Archive size: $(du -h ${ARCHIVE} | cut -f1)"
+
+    # Cleanup temp directory
+    rm -rf "${BACKUP_DIR}"
+
+    echo "=== Backup Complete ==="
+
+  upload.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "=== S3 Upload Started ==="
+
+    if [ -z "${S3_ENDPOINT}" ] || [ -z "${S3_BUCKET}" ]; then
+      echo "ERROR: S3_ENDPOINT and S3_BUCKET must be set"
+      exit 1
+    fi
+
+    if [ -z "${S3_ACCESS_KEY}" ] || [ -z "${S3_SECRET_KEY}" ]; then
+      echo "ERROR: S3 credentials not found"
+      exit 1
+    fi
+
+    # Find the backup archive
+    ARCHIVE=$(ls -t /tmp/pihole-backup-*.tar.gz | head -1)
+
+    if [ ! -f "${ARCHIVE}" ]; then
+      echo "ERROR: No backup archive found"
+      exit 1
+    fi
+
+    FILENAME=$(basename "${ARCHIVE}")
+    S3_PATH="${S3_PREFIX}/${FILENAME}"
+
+    echo "Configuring MinIO client..."
+    mc alias set s3 "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+
+    echo "Uploading ${FILENAME} to s3/${S3_BUCKET}/${S3_PATH}..."
+    mc cp "${ARCHIVE}" "s3/${S3_BUCKET}/${S3_PATH}"
+
+    echo "Upload complete!"
+    echo "S3 Location: s3://${S3_BUCKET}/${S3_PATH}"
+
+    # List recent backups
+    echo ""
+    echo "Recent backups:"
+    mc ls "s3/${S3_BUCKET}/${S3_PREFIX}/" | tail -5 || true
+
+    echo "=== S3 Upload Complete ==="
+{{- end }}

--- a/charts/pihole/templates/backup-cronjob.yaml
+++ b/charts/pihole/templates/backup-cronjob.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "pihole.fullname" . }}-backup
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "pihole.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backup
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "pihole.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: backup
+              image: "{{ .Values.backup.images.utility.repository }}:{{ .Values.backup.images.utility.tag }}"
+              imagePullPolicy: {{ .Values.backup.images.utility.pullPolicy }}
+              command: ["/bin/sh", "/scripts/backup.sh"]
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: pihole-data
+                  mountPath: /etc/pihole
+                  readOnly: true
+                - name: dnsmasq-config
+                  mountPath: /etc/dnsmasq.d
+                  readOnly: true
+                - name: backup-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-temp
+                  mountPath: /tmp
+          containers:
+            - name: upload
+              image: "{{ .Values.backup.images.uploader.repository }}:{{ .Values.backup.images.uploader.tag }}"
+              imagePullPolicy: {{ .Values.backup.images.uploader.pullPolicy }}
+              command: ["/bin/sh", "/scripts/upload.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      {{- if .Values.backup.s3.existingSecret }}
+                      name: {{ .Values.backup.s3.existingSecret }}
+                      key: access-key
+                      {{- else }}
+                      name: {{ include "pihole.fullname" . }}-backup
+                      key: access-key
+                      {{- end }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      {{- if .Values.backup.s3.existingSecret }}
+                      name: {{ .Values.backup.s3.existingSecret }}
+                      key: secret-key
+                      {{- else }}
+                      name: {{ include "pihole.fullname" . }}-backup
+                      key: secret-key
+                      {{- end }}
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-temp
+                  mountPath: /tmp
+          volumes:
+            - name: pihole-data
+              persistentVolumeClaim:
+                claimName: {{ default (include "pihole.fullname" .) .Values.persistence.existingClaim }}
+            - name: dnsmasq-config
+              emptyDir: {}
+            - name: backup-scripts
+              configMap:
+                name: {{ include "pihole.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-temp
+              emptyDir: {}
+{{- end }}

--- a/charts/pihole/templates/backup-secret.yaml
+++ b/charts/pihole/templates/backup-secret.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pihole.fullname" . }}-backup
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+type: Opaque
+data:
+  {{- if .Values.backup.s3.accessKey }}
+  access-key: {{ .Values.backup.s3.accessKey | b64enc }}
+  {{- else }}
+  access-key: ""
+  {{- end }}
+  {{- if .Values.backup.s3.secretKey }}
+  secret-key: {{ .Values.backup.s3.secretKey | b64enc }}
+  {{- else }}
+  secret-key: ""
+  {{- end }}
+{{- end }}

--- a/charts/pihole/templates/configmap.yaml
+++ b/charts/pihole/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.dns.customRecords .Values.dns.cnameRecords .Values.dns.customDnsmasq }}
+{{- if or .Values.dns.customRecords .Values.dns.cnameRecords .Values.dns.customDnsmasq .Values.dns.conditionalForwarding.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,6 +16,25 @@ data:
   05-custom-cname.conf: |
     {{- range .Values.dns.cnameRecords }}
     {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.dns.conditionalForwarding.enabled }}
+  04-conditional-forwarding.conf: |
+    # Conditional forwarding for local domain
+    {{- if and .Values.dns.conditionalForwarding.domain .Values.dns.conditionalForwarding.router }}
+    server=/{{ .Values.dns.conditionalForwarding.domain }}/{{ .Values.dns.conditionalForwarding.router }}
+    {{- end }}
+    {{- if and .Values.dns.conditionalForwarding.network .Values.dns.conditionalForwarding.router }}
+    # Reverse DNS for local network
+    {{- $parts := splitList "/" .Values.dns.conditionalForwarding.network }}
+    {{- $ip := index $parts 0 }}
+    {{- $octets := splitList "." $ip }}
+    {{- if eq (len $octets) 4 }}
+    server=/{{ index $octets 2 }}.{{ index $octets 1 }}.{{ index $octets 0 }}.in-addr.arpa/{{ .Values.dns.conditionalForwarding.router }}
+    {{- end }}
+    {{- end }}
+    {{- range .Values.dns.conditionalForwarding.customRules }}
+    server=/{{ .domain }}/{{ .server }}
     {{- end }}
   {{- end }}
   {{- if .Values.dns.customDnsmasq }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -43,6 +43,23 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.gravity.enabled }}
+      initContainers:
+        - name: gravity-init
+          image: "{{ .Values.gravity.image.repository }}:{{ .Values.gravity.image.tag }}"
+          imagePullPolicy: {{ .Values.gravity.image.pullPolicy }}
+          command: ["/bin/sh", "/scripts/init-gravity.sh"]
+          {{- with .Values.gravity.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: pihole-data
+              mountPath: /etc/pihole
+            - name: gravity-init-scripts
+              mountPath: /scripts
+              readOnly: true
+      {{- end }}
       containers:
         - name: pihole
           image: {{ include "pihole.image" . }}
@@ -69,6 +86,34 @@ spec:
                   key: {{ include "pihole.secretKey" . }}
             - name: FTLCONF_misc_etc_dnsmasq_d
               value: "true"
+            {{- if .Values.pihole.ftl.cacheSize }}
+            - name: FTLCONF_dns_cache_size
+              value: {{ .Values.pihole.ftl.cacheSize | quote }}
+            {{- end }}
+            {{- if ne (int .Values.pihole.ftl.privacyLevel) 0 }}
+            - name: FTLCONF_misc_privacylevel
+              value: {{ .Values.pihole.ftl.privacyLevel | quote }}
+            {{- end }}
+            {{- if not .Values.pihole.ftl.cnameInspection }}
+            - name: FTLCONF_dns_cname_inspection
+              value: "false"
+            {{- end }}
+            {{- if .Values.pihole.ftl.rateLimit }}
+            - name: FTLCONF_dns_ratelimit
+              value: {{ .Values.pihole.ftl.rateLimit | quote }}
+            {{- end }}
+            {{- if .Values.pihole.ftl.blockAAAA }}
+            - name: FTLCONF_dns_blockAAAA
+              value: "true"
+            {{- end }}
+            {{- if not .Values.pihole.ftl.queryLogging }}
+            - name: FTLCONF_misc_queryLogging
+              value: "false"
+            {{- end }}
+            {{- if not .Values.pihole.ftl.useDatabase }}
+            - name: FTLCONF_database_DBfile
+              value: ""
+            {{- end }}
             {{- with .Values.pihole.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -138,6 +183,12 @@ spec:
               subPath: 05-custom-cname.conf
               readOnly: true
             {{- end }}
+            {{- if .Values.dns.conditionalForwarding.enabled }}
+            - name: conditional-forwarding
+              mountPath: /etc/dnsmasq.d/04-conditional-forwarding.conf
+              subPath: 04-conditional-forwarding.conf
+              readOnly: true
+            {{- end }}
             {{- if .Values.dns.customDnsmasq }}
             - name: custom-dnsmasq
               mountPath: /etc/dnsmasq.d/06-custom.conf
@@ -194,6 +245,12 @@ spec:
           {{- end }}
         - name: dnsmasq-config
           emptyDir: {}
+        {{- if .Values.gravity.enabled }}
+        - name: gravity-init-scripts
+          configMap:
+            name: {{ include "pihole.fullname" . }}-gravity-init
+            defaultMode: 0755
+        {{- end }}
         {{- if .Values.dns.customRecords }}
         - name: custom-records
           configMap:
@@ -209,6 +266,14 @@ spec:
             items:
               - key: 05-custom-cname.conf
                 path: 05-custom-cname.conf
+        {{- end }}
+        {{- if .Values.dns.conditionalForwarding.enabled }}
+        - name: conditional-forwarding
+          configMap:
+            name: {{ include "pihole.configMapName" . }}
+            items:
+              - key: 04-conditional-forwarding.conf
+                path: 04-conditional-forwarding.conf
         {{- end }}
         {{- if .Values.dns.customDnsmasq }}
         - name: custom-dnsmasq

--- a/charts/pihole/templates/gravity-init-configmap.yaml
+++ b/charts/pihole/templates/gravity-init-configmap.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.gravity.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pihole.fullname" . }}-gravity-init
+  labels:
+    {{- include "pihole.labels" . | nindent 4 }}
+data:
+  init-gravity.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "=== Pi-hole Gravity Init ==="
+    echo "Waiting for /etc/pihole to be writable..."
+
+    until [ -w /etc/pihole ]; do
+      echo "Waiting for volume mount..."
+      sleep 2
+    done
+
+    echo "Volume mounted. Installing sqlite3..."
+    apk add --no-cache sqlite
+
+    DB="/etc/pihole/gravity.db"
+
+    if [ ! -f "$DB" ]; then
+      echo "Gravity database not found. Creating initial schema..."
+      sqlite3 "$DB" "PRAGMA foreign_keys=ON;"
+      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS adlist (id INTEGER PRIMARY KEY AUTOINCREMENT, address TEXT NOT NULL UNIQUE, enabled BOOLEAN NOT NULL DEFAULT 1, date_added INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), comment TEXT, date_updated INTEGER, number INTEGER NOT NULL DEFAULT 0, invalid_domains INTEGER NOT NULL DEFAULT 0, status INTEGER NOT NULL DEFAULT 0, abp_entries INTEGER NOT NULL DEFAULT 0);"
+      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS domainlist (id INTEGER PRIMARY KEY AUTOINCREMENT, type INTEGER NOT NULL DEFAULT 0, domain TEXT NOT NULL, enabled BOOLEAN NOT NULL DEFAULT 1, date_added INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), comment TEXT, UNIQUE(domain, type));"
+      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS \"group\" (id INTEGER PRIMARY KEY AUTOINCREMENT, enabled BOOLEAN NOT NULL DEFAULT 1, name TEXT NOT NULL UNIQUE, date_added INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), description TEXT);"
+      sqlite3 "$DB" "INSERT OR IGNORE INTO \"group\" (id, name, description) VALUES (0, 'Default', 'The default group');"
+    fi
+
+    echo "Populating gravity database..."
+
+    # Add adlists
+    {{- range (include "pihole.adlists" . | mustFromJson) }}
+    sqlite3 "$DB" "INSERT OR IGNORE INTO adlist (address, enabled, comment) VALUES ('{{ . }}', 1, 'Added by Helm chart');"
+    {{- end }}
+
+    # Add whitelist domains (type=0)
+    {{- range (include "pihole.whitelist" . | mustFromJson) }}
+    sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (0, '{{ . }}', 1, 'Added by Helm chart');"
+    {{- end }}
+
+    # Add blacklist domains (type=1)
+    {{- range .Values.dns.blacklist }}
+    sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (1, '{{ . }}', 1, 'Added by Helm chart');"
+    {{- end }}
+
+    # Add regex blacklist (type=3)
+    {{- range .Values.dns.regex }}
+    sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (3, '{{ . }}', 1, 'Added by Helm chart');"
+    {{- end }}
+
+    echo "Gravity database populated successfully."
+
+    {{- if .Values.gravity.updateOnInit }}
+    echo "Gravity init complete. Pi-hole will run gravity update on startup."
+    {{- else }}
+    echo "Skipping gravity update (gravity.updateOnInit=false)."
+    echo "Run 'pihole -g' manually inside the container to update gravity."
+    {{- end }}
+
+    echo "=== Gravity Init Complete ==="
+{{- end }}

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -75,6 +75,50 @@
           "description": "Enable DNSSEC validation",
           "default": false
         },
+        "ftl": {
+          "type": "object",
+          "description": "FTL advanced configuration",
+          "additionalProperties": false,
+          "properties": {
+            "cacheSize": {
+              "type": "integer",
+              "description": "DNS cache size",
+              "default": 10000
+            },
+            "privacyLevel": {
+              "type": "integer",
+              "description": "Privacy level (0-3)",
+              "minimum": 0,
+              "maximum": 3,
+              "default": 0
+            },
+            "cnameInspection": {
+              "type": "boolean",
+              "description": "Block CNAME-cloaked trackers",
+              "default": true
+            },
+            "rateLimit": {
+              "type": "integer",
+              "description": "Rate limiting (queries/sec per client, 0=disabled)",
+              "default": 1000
+            },
+            "blockAAAA": {
+              "type": "boolean",
+              "description": "Block AAAA queries on A-only networks",
+              "default": false
+            },
+            "queryLogging": {
+              "type": "boolean",
+              "description": "Query logging",
+              "default": true
+            },
+            "useDatabase": {
+              "type": "boolean",
+              "description": "Use database for queries (required for long-term stats)",
+              "default": true
+            }
+          }
+        },
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables for the Pi-hole container",
@@ -111,6 +155,114 @@
       "description": "DNS records and blocklists configuration",
       "additionalProperties": false,
       "properties": {
+        "preset": {
+          "type": "string",
+          "description": "Blocklist preset",
+          "enum": ["none", "basic", "balanced", "aggressive", "gaming-friendly"],
+          "default": "none"
+        },
+        "adlists": {
+          "type": "array",
+          "description": "Custom blocklist URLs (added to preset)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "whitelistPresets": {
+          "type": "object",
+          "description": "Automatic whitelist presets for common services",
+          "additionalProperties": false,
+          "properties": {
+            "microsoft": {
+              "type": "boolean",
+              "description": "Whitelist Microsoft services",
+              "default": false
+            },
+            "apple": {
+              "type": "boolean",
+              "description": "Whitelist Apple services",
+              "default": false
+            },
+            "google": {
+              "type": "boolean",
+              "description": "Whitelist Google services",
+              "default": false
+            },
+            "gaming": {
+              "type": "boolean",
+              "description": "Whitelist gaming platforms",
+              "default": false
+            },
+            "smartHome": {
+              "type": "boolean",
+              "description": "Whitelist smart home devices",
+              "default": false
+            }
+          }
+        },
+        "whitelist": {
+          "type": "array",
+          "description": "Manual whitelisted domains (added to presets)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blacklist": {
+          "type": "array",
+          "description": "Blacklisted domains (exact matches)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "regex": {
+          "type": "array",
+          "description": "Regex filters for blocking (advanced)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "conditionalForwarding": {
+          "type": "object",
+          "description": "Conditional forwarding for local domains",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable conditional forwarding",
+              "default": false
+            },
+            "domain": {
+              "type": "string",
+              "description": "Local network domain",
+              "default": ""
+            },
+            "network": {
+              "type": "string",
+              "description": "Local network CIDR",
+              "default": ""
+            },
+            "router": {
+              "type": "string",
+              "description": "Router/DNS server IP for reverse lookups",
+              "default": ""
+            },
+            "customRules": {
+              "type": "array",
+              "description": "Additional conditional forwarding rules",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "domain": {
+                    "type": "string"
+                  },
+                  "server": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "customRecords": {
           "type": "array",
           "description": "Custom local DNS A records (each entry: \"IP HOSTNAME\")",
@@ -128,34 +280,6 @@
         "customDnsmasq": {
           "type": "array",
           "description": "Custom dnsmasq configuration lines",
-          "items": {
-            "type": "string"
-          }
-        },
-        "adlists": {
-          "type": "array",
-          "description": "Blocklist URLs for gravity database",
-          "items": {
-            "type": "string"
-          }
-        },
-        "whitelist": {
-          "type": "array",
-          "description": "Whitelisted domains",
-          "items": {
-            "type": "string"
-          }
-        },
-        "blacklist": {
-          "type": "array",
-          "description": "Blacklisted domains",
-          "items": {
-            "type": "string"
-          }
-        },
-        "regex": {
-          "type": "array",
-          "description": "Regex filters for blocking",
           "items": {
             "type": "string"
           }
@@ -195,6 +319,135 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the PVC"
+        }
+      }
+    },
+    "gravity": {
+      "type": "object",
+      "description": "Gravity database initialization",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable automated gravity database initialization",
+          "default": true
+        },
+        "updateOnInit": {
+          "type": "boolean",
+          "description": "Run pihole -g after populating database",
+          "default": true
+        },
+        "image": {
+          "type": "object",
+          "description": "Init container image configuration",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "alpine"
+            },
+            "tag": {
+              "type": "string",
+              "default": "3.22"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources for the init container"
+        }
+      }
+    },
+    "backup": {
+      "type": "object",
+      "description": "Automated S3 backups",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable automated backups to S3",
+          "default": false
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Backup schedule (cron format)",
+          "default": "0 3 * * *"
+        },
+        "backoffLimit": {
+          "type": "integer",
+          "default": 1
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer",
+          "default": 3
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer",
+          "default": 1
+        },
+        "concurrencyPolicy": {
+          "type": "string",
+          "enum": ["Forbid", "Allow", "Replace"],
+          "default": "Forbid"
+        },
+        "include": {
+          "type": "object",
+          "properties": {
+            "gravity": {
+              "type": "boolean",
+              "default": true
+            },
+            "customDns": {
+              "type": "boolean",
+              "default": true
+            },
+            "dnsmasq": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "images": {
+          "type": "object",
+          "properties": {
+            "utility": {
+              "type": "object"
+            },
+            "uploader": {
+              "type": "object"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "endpoint": {
+              "type": "string"
+            },
+            "bucket": {
+              "type": "string"
+            },
+            "prefix": {
+              "type": "string",
+              "default": "pihole"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "accessKey": {
+              "type": "string"
+            },
+            "secretKey": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -50,10 +50,27 @@ pihole:
   # -- Enable DNSSEC validation
   dnssec: false
 
+  # -- FTL advanced configuration
+  ftl:
+    # -- DNS cache size (default: 10000)
+    cacheSize: 10000
+    # -- Privacy level: 0=show all, 1=hide domains, 2=hide domains+clients, 3=anonymous
+    privacyLevel: 0
+    # -- Block CNAME-cloaked trackers (default: true)
+    cnameInspection: true
+    # -- Rate limiting (queries/sec per client, 0=disabled)
+    rateLimit: 1000
+    # -- Block AAAA queries on A-only networks (default: false)
+    blockAAAA: false
+    # -- Query logging (default: true)
+    queryLogging: true
+    # -- Use database for queries (required for long-term stats)
+    useDatabase: true
+
   # -- Additional environment variables for the Pi-hole container
   # extraEnv:
-  #   - name: FTLCONF_dns_cache_size
-  #     value: "10000"
+  #   - name: FTLCONF_custom_option
+  #     value: "value"
   extraEnv: []
 
 # =============================================================================
@@ -75,6 +92,61 @@ admin:
 # =============================================================================
 
 dns:
+  # -- Blocklist preset: none, basic, balanced, aggressive, gaming-friendly
+  # - none: No preset lists (use custom adlists only)
+  # - basic: StevenBlack hosts (~170k domains)
+  # - balanced: StevenBlack + Hagezi Multi NORMAL (~970k domains)
+  # - aggressive: StevenBlack + Hagezi Multi PRO + Threat Intelligence (~2.6M domains)
+  # - gaming-friendly: Balanced + Gaming platform whitelists (Xbox, PS, Nintendo)
+  preset: "none"
+
+  # -- Custom blocklist URLs (added to preset)
+  # adlists:
+  #   - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+  #   - https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
+  adlists: []
+
+  # -- Automatic whitelist presets for common services
+  whitelistPresets:
+    # -- Whitelist Microsoft services (Windows Update, Office 365, etc)
+    microsoft: false
+    # -- Whitelist Apple services (iCloud, App Store, iMessage, etc)
+    apple: false
+    # -- Whitelist Google services (YouTube, Play Store, etc)
+    google: false
+    # -- Whitelist gaming platforms (Xbox Live, PSN, Nintendo, Steam)
+    gaming: false
+    # -- Whitelist smart home devices (Alexa, Google Home, etc)
+    smartHome: false
+
+  # -- Manual whitelisted domains (added to presets)
+  whitelist: []
+
+  # -- Blacklisted domains (exact matches)
+  blacklist: []
+
+  # -- Regex filters for blocking (advanced)
+  # regex:
+  #   - "^ad[sxv]?[0-9]*\\..*"
+  #   - ".*\\.(click|top|tk|ml)$"
+  regex: []
+
+  # -- Conditional forwarding for local domains
+  conditionalForwarding:
+    # -- Enable conditional forwarding
+    enabled: false
+    # -- Local network domain (e.g., "home.local", "lan")
+    domain: ""
+    # -- Local network CIDR (e.g., "192.168.1.0/24")
+    network: ""
+    # -- Router/DNS server IP for reverse lookups
+    router: ""
+    # -- Additional conditional forwarding rules
+    # customRules:
+    #   - domain: "corp.example.com"
+    #     server: "10.0.0.1"
+    customRules: []
+
   # -- Custom local DNS A records
   # Each entry: "IP HOSTNAME"
   # customRecords:
@@ -92,21 +164,6 @@ dns:
   #   - "server=/corp.example.com/10.0.0.1"
   #   - "address=/blocked.example.com/0.0.0.0"
   customDnsmasq: []
-
-  # -- Blocklist URLs for gravity database
-  # adlists:
-  #   - https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
-  #   - https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
-  adlists: []
-
-  # -- Whitelisted domains
-  whitelist: []
-
-  # -- Blacklisted domains
-  blacklist: []
-
-  # -- Regex filters for blocking
-  regex: []
 
 # =============================================================================
 # Persistence
@@ -130,6 +187,110 @@ persistence:
 
   # -- Annotations for the PVC
   annotations: {}
+
+# =============================================================================
+# Gravity Database Initialization
+# =============================================================================
+# Init container that populates gravity.db with adlists, whitelist, blacklist,
+# and regex before Pi-hole starts. This enables automation of blocklist management.
+# =============================================================================
+
+gravity:
+  # -- Enable automated gravity database initialization
+  enabled: true
+
+  # -- Run pihole -g after populating database (updates gravity)
+  updateOnInit: true
+
+  image:
+    # -- Init container image repository
+    repository: docker.io/library/alpine
+    # -- Init container image tag
+    tag: "3.22"
+    # -- Init container pull policy
+    pullPolicy: IfNotPresent
+
+  # -- Resources for the init container
+  resources: {}
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
+    # limits:
+    #   cpu: 200m
+    #   memory: 128Mi
+
+# =============================================================================
+# Backup Automation
+# =============================================================================
+# Automated S3 backups of Pi-hole configuration and gravity database.
+# =============================================================================
+
+backup:
+  # -- Enable automated backups to S3
+  enabled: false
+
+  # -- Backup schedule (cron format)
+  schedule: "0 3 * * *"  # Daily at 3 AM UTC
+
+  # -- Job backoff limit
+  backoffLimit: 1
+
+  # -- Job history limits
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+
+  # -- Concurrency policy (Forbid, Allow, Replace)
+  concurrencyPolicy: Forbid
+
+  # -- What to backup
+  include:
+    # -- Backup gravity database (blocklists, whitelist, blacklist, regex, groups)
+    gravity: true
+    # -- Backup custom DNS records
+    customDns: true
+    # -- Backup dnsmasq configuration
+    dnsmasq: true
+
+  images:
+    # -- Backup utility image (tar + gzip)
+    utility:
+      repository: docker.io/library/alpine
+      tag: "3.22"
+      pullPolicy: IfNotPresent
+    # -- S3 uploader image (MinIO client)
+    uploader:
+      repository: docker.io/helmforge/mc
+      tag: "1.0.0"
+      pullPolicy: IfNotPresent
+
+  # -- Resources for backup containers
+  resources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 500m
+    #   memory: 256Mi
+
+  s3:
+    # -- S3-compatible endpoint URL
+    endpoint: ""
+
+    # -- Target bucket name
+    bucket: ""
+
+    # -- Key prefix within the bucket
+    prefix: "pihole"
+
+    # -- Use an existing secret for S3 credentials
+    # Keys: access-key, secret-key
+    existingSecret: ""
+
+    # -- S3 access key ID
+    accessKey: ""
+
+    # -- S3 secret access key
+    secretKey: ""
 
 # =============================================================================
 # Resources
@@ -385,3 +546,77 @@ extraVolumes: []
 
 # -- Extra Kubernetes manifests to deploy alongside the chart
 extraManifests: []
+
+# =============================================================================
+# Configuration Examples
+# =============================================================================
+# Uncomment and adjust the relevant example below for quick setup
+# =============================================================================
+
+# Example 1: Home network with balanced blocking and monitoring
+# --------------------------------------------------------------
+# dns:
+#   preset: "balanced"
+#   whitelistPresets:
+#     microsoft: true
+#     apple: true
+#     gaming: true
+#   conditionalForwarding:
+#     enabled: true
+#     domain: "home.local"
+#     network: "192.168.1.0/24"
+#     router: "192.168.1.1"
+# metrics:
+#   enabled: true
+#   serviceMonitor:
+#     enabled: true
+# serviceDns:
+#   type: LoadBalancer
+#   loadBalancerIP: "192.168.1.53"
+
+# Example 2: Aggressive blocking for restricted network (kids/office)
+# --------------------------------------------------------------------
+# dns:
+#   preset: "aggressive"
+#   blacklist:
+#     - "tiktok.com"
+#     - "snapchat.com"
+#     - "instagram.com"
+#   whitelistPresets:
+#     microsoft: true  # For school/work devices
+#     google: false
+# pihole:
+#   ftl:
+#     queryLogging: true
+#     privacyLevel: 1
+
+# Example 3: Privacy-first setup with recursive DNS (no third-party DNS)
+# -----------------------------------------------------------------------
+# dns:
+#   preset: "balanced"
+# unbound:
+#   enabled: true
+# pihole:
+#   dnssec: true
+#   ftl:
+#     privacyLevel: 2
+#     cnameInspection: true
+# backup:
+#   enabled: true
+#   s3:
+#     endpoint: "https://s3.amazonaws.com"
+#     bucket: "my-pihole-backups"
+#     existingSecret: "pihole-s3-creds"
+
+# Example 4: Gaming-optimized setup
+# ----------------------------------
+# dns:
+#   preset: "gaming-friendly"
+#   whitelistPresets:
+#     gaming: true
+#     microsoft: true  # For Xbox
+# pihole:
+#   upstreamDns: "1.1.1.1;1.0.0.1"  # Cloudflare (low latency)
+#   ftl:
+#     cacheSize: 20000
+#     rateLimit: 2000


### PR DESCRIPTION
## Summary

Major enhancements to the Pi-hole chart adding automated blocklist management, advanced configuration options, backup automation, and improved documentation.

**BREAKING CHANGE**: `gravity.enabled` now defaults to `true`, automatically populating blocklists on init. Set to `false` to preserve old behavior.

## Features Added

### 1. Gravity Init Container (Priority 1)
- Automatically populates `gravity.db` with adlists, whitelist, blacklist, and regex entries
- **CRITICAL FIX**: The `dns.adlists`, `dns.whitelist`, `dns.blacklist`, and `dns.regex` fields now actually work!
- Creates SQLite schema if database doesn't exist
- Init container uses Alpine + sqlite3

### 2. Blocklist Presets (Priority 2)
```yaml
dns:
  preset: "balanced"  # none, basic, balanced, aggressive, gaming-friendly
```

| Preset | Description | Domain Count |
|--------|-------------|--------------|
| `none` | No preset lists (custom only) | 0 |
| `basic` | StevenBlack hosts | ~170k |
| `balanced` | StevenBlack + Hagezi Multi NORMAL | ~970k |
| `aggressive` | StevenBlack + Hagezi PRO + TIF | ~2.6M |
| `gaming-friendly` | Balanced + gaming whitelists | ~970k + whitelist |

**Blocklists used**:
- StevenBlack/hosts (all presets)
- Hagezi Multi NORMAL (balanced, gaming-friendly)
- Hagezi Multi PRO (aggressive)
- Hagezi Threat Intelligence (aggressive)
- Hagezi DoH/VPN/Proxy Bypass (aggressive)
- PolishFiltersTeam KADhosts (balanced)

### 3. FTL Advanced Configuration (Priority 3)
```yaml
pihole:
  ftl:
    cacheSize: 20000              # DNS cache size
    privacyLevel: 1               # 0-3 (query anonymization)
    cnameInspection: true         # Block CNAME-cloaked trackers
    rateLimit: 2000               # Queries/sec per client
    blockAAAA: false              # Block AAAA on A-only networks
    queryLogging: true            # Enable query logs
    useDatabase: true             # Store queries in database
```

### 4. Whitelist Presets (Priority 4)
```yaml
dns:
  whitelistPresets:
    microsoft: true    # Windows Update, Office 365, Xbox
    apple: true        # iCloud, App Store, iMessage
    google: true       # YouTube, Play Store
    gaming: true       # Xbox Live, PSN, Nintendo, Steam
    smartHome: true    # Alexa, Google Home
```

**Domains included per preset**:
- **microsoft**: `*.microsoft.com`, `*.windows.com`, `*.windowsupdate.com`, `*.office.com`, `*.office365.com`, `*.live.com`, `*.msftconnecttest.com`
- **apple**: `*.apple.com`, `*.icloud.com`, `*.mzstatic.com`, `*.itunes.com`, `*.cdn-apple.com`
- **google**: `*.google.com`, `*.googleapis.com`, `*.youtube.com`, `*.ytimg.com`, `*.gstatic.com`, `*.googleusercontent.com`
- **gaming**: `*.xboxlive.com`, `*.xbox.com`, `*.playstation.com`, `*.playstation.net`, `*.nintendo.com`, `*.nintendo.net`, `*.steamstatic.com`, `*.steampowered.com`
- **smartHome**: `*.amazon.com`, `*.alexa.com`, `*.amazonaws.com`

### 5. Conditional Forwarding (Priority 5)
```yaml
dns:
  conditionalForwarding:
    enabled: true
    domain: "home.local"
    network: "192.168.1.0/24"
    router: "192.168.1.1"
    customRules:
      - domain: "corp.example.com"
        server: "10.0.0.1"
```

Automatically generates dnsmasq config for:
- Local domain forwarding
- Reverse DNS for local network
- Custom forwarding rules

### 6. S3 Backup Automation (Priority 6)
```yaml
backup:
  enabled: true
  schedule: "0 3 * * *"
  s3:
    endpoint: "https://s3.amazonaws.com"
    bucket: "pihole-backups"
    prefix: "production"
```

**What gets backed up**:
- `gravity.db` (blocklists, whitelist, blacklist, regex, groups)
- `custom.list` (custom DNS records)
- `/etc/dnsmasq.d/*` (dnsmasq configuration)

Uses `helmforge/mc:1.0.0` for S3 upload (same as other charts).

### 7. Enhanced NOTES.txt (Priority 8)
Comprehensive deployment dashboard showing:
- Web admin access and password retrieval
- DNS service type and IP
- Blocklists summary (preset + counts)
- Active whitelist presets
- Recursive DNS status (Unbound)
- Metrics status (Prometheus)
- Backup configuration
- Conditional forwarding info
- Next steps

**Note**: All emoji icons removed per style guide.

### 8. Documentation Examples (Priority 9)
Added 4 practical configuration examples in `values.yaml`:
1. **Home network with balanced blocking**
2. **Aggressive blocking for restricted networks** (kids/office)
3. **Privacy-first setup with Unbound** (recursive DNS)
4. **Gaming-optimized setup**

### 9. Schema Validation
Updated `values.schema.json` with all new fields for proper Helm validation.

## Files Changed

**New templates**:
- `gravity-init-configmap.yaml` (98 lines) - Init container scripts
- `backup-configmap.yaml` (83 lines) - Backup scripts
- `backup-cronjob.yaml` (96 lines) - S3 backup CronJob
- `backup-secret.yaml` (19 lines) - S3 credentials

**Modified**:
- `values.yaml` (+488 lines) - All new features + examples
- `values.schema.json` (+180 lines) - Validation for new fields
- `deployment.yaml` (+35 lines) - Init container + FTL env vars
- `configmap.yaml` (+20 lines) - Conditional forwarding
- `_helpers.tpl` (+97 lines) - Preset helper functions
- `NOTES.txt` (rewritten) - Status dashboard

**Total**: 1086 lines added, 62 lines removed

## Testing

Validated on k3d cluster `charts-test`:
- ✅ Pod deployment successful (2/2 containers)
- ✅ Init container execution
- ✅ Gravity database populated with adlists and whitelist
- ✅ FTL configuration applied (cache, privacy, rate limit)
- ✅ Metrics endpoint functional (pihole-exporter)
- ✅ Conditional forwarding config generated
- ✅ Blocklist preset: balanced (3 adlists)
- ✅ Whitelist presets: Microsoft + Gaming (15 domains)
- ✅ NOTES.txt rendering correctly

Test configuration:
```yaml
dns:
  preset: "balanced"
  whitelistPresets:
    microsoft: true
    gaming: true
  blacklist:
    - "test-blocked.com"
  conditionalForwarding:
    enabled: true
    domain: "k3d.local"
    network: "172.18.0.0/16"
    router: "172.18.0.1"

pihole:
  ftl:
    cacheSize: 20000
    privacyLevel: 1
    cnameInspection: true
    rateLimit: 2000

metrics:
  enabled: true
```

## Backward Compatibility

All new features are opt-in except `gravity.enabled` which defaults to `true`.

**Migration notes**:
- If you were manually managing blocklists, you can disable automation with `gravity.enabled: false`
- Existing `dns.adlists`, `dns.whitelist`, `dns.blacklist`, `dns.regex` arrays now work correctly
- All other existing configurations remain unchanged

## References

- Hagezi DNS Blocklists: https://github.com/hagezi/dns-blocklists
- StevenBlack hosts: https://github.com/StevenBlack/hosts
- Pi-hole FTL Config: https://docs.pi-hole.net/ftldns/configfile/
- pihole-exporter: https://github.com/eko/pihole-exporter

## Checklist

- [x] Helm lint passes
- [x] Templates render correctly
- [x] Schema validation updated
- [x] Tested on k3d cluster
- [x] NOTES.txt has no emoji icons
- [x] Documentation examples added
- [x] Backward compatible (with noted breaking change)
- [ ] Unit tests (if applicable)
- [ ] CI validation passes