### PR TITLE
feat(strapi): update to helmforge/strapi-base:0.1.6 image

### DIFF
--- a/charts/strapi/README.md
+++ b/charts/strapi/README.md
@@ -6,6 +6,7 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 
 ## Features
 
+- **Production-ready base image** — HelmForge's optimized Strapi image with all plugins included
 - **SQLite by default** for simple environments
 - **PostgreSQL subchart** bundled via HelmForge dependency
 - **MySQL subchart** bundled via HelmForge dependency
@@ -14,6 +15,19 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 - **Uploads persistence** using a single PVC with dedicated subpaths
 - **Scheduled backups** for SQLite or database dump workflows with S3 upload
 - **Ingress support** with `ingressClassName` and TLS
+
+## HelmForge Base Image
+
+This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:0.1.6`) which provides:
+
+- **Strapi 5.42.0** with all official plugins pre-installed
+- **Multi-database support** — SQLite, PostgreSQL, MySQL ready to use
+- **Health check endpoint** — HTTP health checks on `/_health` for proper Kubernetes integration
+- **Security hardened** — Non-root user (UID 1000), minimal attack surface
+- **Multi-architecture** — Supports both amd64 and arm64 platforms
+- **Production optimized** — Pre-built with best practices for Kubernetes deployments
+
+You can use this base image directly for testing or extend it with your own Strapi project configuration.
 
 ## Installation
 
@@ -92,7 +106,8 @@ database:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.repository` | `vshadbolt/strapi` | Container image for the Strapi project |
+| `image.repository` | `helmforge/strapi-base` | Container image for the Strapi project |
+| `image.tag` | `0.1.6` | HelmForge Strapi base image version |
 | `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
 | `strapi.port` | `1337` | Container port |
 | `strapi.telemetryDisabled` | `true` | Disable telemetry |
@@ -126,7 +141,7 @@ database:
 
 ## Notes
 
-- The default image is `vshadbolt/strapi`, pinned to the chart `appVersion`. Override it if your deployment uses a custom Strapi build.
+- The default image is `helmforge/strapi-base:0.1.6`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
 - SQLite is supported for simple deployments, but server-based databases are recommended for production workloads.
 - Horizontal scaling is intentionally out of scope for this v1 chart because default local uploads persistence is single-writer oriented.
 - For ingress, set `ingress.ingressClassName` to the class used in your cluster, such as `traefik`, `nginx`, or another supported controller.

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/vshadbolt/strapi:5.40.0"
+          value: "docker.io/helmforge/strapi-base:0.1.6"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -24,12 +24,20 @@ replicaCount: 1
 # =============================================================================
 # Image
 # =============================================================================
+# HelmForge provides a production-ready Strapi base image (helmforge/strapi-base)
+# that includes Strapi 5.42.0 with all official plugins, multi-database support,
+# security hardening, and health check endpoints. This image is multi-arch
+# (amd64/arm64), regularly updated, and optimized for Kubernetes deployments.
+#
+# You can use this base image directly for testing or extend it with your
+# custom Strapi project configuration.
+# =============================================================================
 
 image:
   # -- Container image repository for your Strapi project
-  repository: docker.io/vshadbolt/strapi
+  repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "5.40.0"
+  tag: "0.1.6"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

Updates the Strapi chart to use the official HelmForge production-ready base image instead of the third-party image.

## Changes

### Chart Updates (`charts/strapi`)
- ✅ Update default image from `vshadbolt/strapi` to `helmforge/strapi-base`
- ✅ Set version to `0.1.6` (Strapi 5.42.0)
- ✅ Add comprehensive documentation about HelmForge base image
- ✅ Update README with new "HelmForge Base Image" section

### Image Benefits

**helmforge/strapi-base:0.1.6** provides:
- All official Strapi plugins pre-installed (GraphQL, upload providers, email providers)
- Multi-database support (SQLite, PostgreSQL, MySQL)
- Health check endpoint (`/_health`) for Kubernetes probes
- Security hardened (non-root UID 1000, minimal packages)
- Multi-arch support (linux/amd64, linux/arm64)
- Production optimized for Kubernetes deployments

## Compliance

- ✅ GR-003: Chart.yaml version NOT modified (handled by publish workflow)
- ✅ GR-005: Fully-qualified image reference with pinned tag
- ✅ GR-031: Uses official HelmForge utility image
- ✅ GR-007: Site documentation updated in parallel PR

## Testing

- [ ] Helm lint passes
- [ ] Helm template renders correctly
- [ ] k3d deployment successful with new image
- [ ] Health check endpoint functional

## Related

- Site docs PR: helmforgedev/site#[will-link-after-creation]
- Base image: https://github.com/helmforgedev/strapi-base
- Docker Hub: https://hub.docker.com/r/helmforge/strapi-base