### PR TITLE
fix(strapi): update helmforge/strapi-base to 0.1.7

### DIFF
--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:0.1.6"
+          value: "docker.io/helmforge/strapi-base:0.1.7"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -37,7 +37,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "0.1.6"
+  tag: "0.1.7"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

Updates Strapi chart default image from 0.1.6 to 0.1.7, which includes critical fix for TypeScript config files not being compiled to JavaScript.

## Problem

Image 0.1.6 was copying TypeScript source files (.ts) instead of compiled JavaScript files (.js), causing container startup failure:

```
Config file not loaded, extension must be one of .js,.json): database.ts
TypeError: Cannot destructure property 'client' of 'db.config.connection' as it is undefined.
```

## Changes

- ✅ Update `image.tag` from `0.1.6` to `0.1.7` in values.yaml
- ✅ Update unit test expectations

## Strapi Base Image 0.1.7

Fixed in helmforgedev/strapi-base@c7cbb98:
- Dockerfile now copies compiled JS files from build stage
- Config and src directories copied from `/opt/app/dist/` instead of source context

## Testing

- [x] Updated unit test expectations
- [ ] CI pipeline (lint, template, unittest, kubeconform) - will run on PR

## Related

- Strapi base fix: helmforgedev/strapi-base#c7cbb98
- Production deployment: Will update after merge