### PR TITLE
fix(strapi): update helmforge/strapi-base to 0.1.9

### DIFF
--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:0.1.7"
+          value: "docker.io/helmforge/strapi-base:0.1.9"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -37,7 +37,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "0.1.7"
+  tag: "0.1.9"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

Updates Strapi chart default image from 0.1.7 to 0.1.9, which includes critical fixes for missing core plugins.

## Problem Fixed

Image 0.1.7 was missing required Strapi plugins:
- `@strapi/plugin-users-permissions` (authentication/authorization)
- `@strapi/plugin-cloud` (Strapi cloud integration)

This caused container startup failure: "users-permissions is not installed"

## Changes

- ✅ Update `image.tag` from `0.1.7` to `0.1.9` in values.yaml
- ✅ Update unit test expectations

## Strapi Base Image 0.1.9

Fixed in helmforgedev/strapi-base:
- Added missing plugin dependencies to package.json
- Verified working with PostgreSQL in local testing
- Health endpoint confirmed functional

## Testing

- [x] Updated unit test expectations
- [x] Local docker-compose + PostgreSQL validation passed
- [ ] CI pipeline (lint, template, unittest, kubeconform) - will run on PR

## Related

- Strapi base fixes: helmforgedev/strapi-base commits 884c76a, 65edb9b, 7c551c6
- Manual Docker Hub push (GitHub Actions had npm registry timeouts)