### PR TITLE
feat(strapi): update to base image v0.0.3 with working health check

### DIFF
--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -3,7 +3,7 @@ name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
 version: 2.2.0
-appVersion: "5.40.0"
+appVersion: "5.42.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,8 +22,10 @@ sources:
 icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: update base image to 0.1.11
+    - kind: changed
+      description: update base image to v0.0.3 with working health check endpoint
+    - kind: fixed
+      description: health check now returns HTTP 200 with JSON body (was 204 no content)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:0.1.11"
+          value: "docker.io/helmforge/strapi-base:v0.0.3"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -37,7 +37,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "0.1.11"
+  tag: "v0.0.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
Updates Strapi chart to use new base image `v0.0.3` which fixes the health check endpoint.

## Changes
- **Image**: `helmforge/strapi-base:0.1.11` → `helmforge/strapi-base:v0.0.3`
- **App Version**: `5.40.0` → `5.42.0`

## Health Check Fix
The v0.0.3 base image fixes the health check endpoint:
- **Before**: HTTP 204 (No Content)
- **After**: HTTP 200 with JSON body

```json
{
  "status": "ok",
  "timestamp": "2026-04-10T04:12:21.382Z",
  "uptime": 26.279551624,
  "database": "connected",
  "version": "5.42.0"
}
```

## Base Image Changes (v0.0.3)
- ✅ Working health check endpoint (Koa middleware implementation)
- ✅ Strapi 5.42.0 with all plugins
- ✅ Node.js 22 Alpine
- ✅ Multi-arch (amd64, arm64)
- ✅ Cosign signed + SBOM
- ✅ Trivy scanned

## Testing
- [x] Tested locally with docker-compose
- [x] Health check returns HTTP 200 with valid JSON
- [x] Admin panel functional
- [x] MCP HelmForge validation passed

## Release Notes
The CI will automatically increment the chart version via release-please.

---
**Related**: helmforgedev/strapi-base#v0.0.3