### PR TITLE
feat: add HABS bump.yaml configs for 6 charts

### DIFF
--- a/charts/cloudflared/bump.yaml
+++ b/charts/cloudflared/bump.yaml
@@ -1,0 +1,15 @@
+chart: cloudflared
+
+upstream:
+  registry: docker.io
+  repository: cloudflare/cloudflared
+  tagFilter: "^\d{4}\.\d+\.\d+$"
+  excludeFilter: "-rc|-beta|-alpha"
+
+values:
+  imageKey: image.tag
+
+helm:
+  testArgs: >-
+    --set tunnel.token=placeholder-token-for-test
+    --set replicaCount=1

--- a/charts/envoy-gateway/bump.yaml
+++ b/charts/envoy-gateway/bump.yaml
@@ -1,0 +1,17 @@
+chart: envoy-gateway
+
+upstream:
+  registry: docker.io
+  repository: envoyproxy/gateway
+  tagFilter: "^v\d+\.\d+\.\d+$"
+  excludeFilter: "-rc|-beta|-alpha|-dev"
+
+values:
+  imageKey: controller.image.tag
+
+helm:
+  testArgs: >-
+    --set certgen.enabled=false
+    --set replicaCount=1
+    --set controller.resources.requests.cpu=100m
+    --set controller.resources.requests.memory=128Mi

--- a/charts/n8n/bump.yaml
+++ b/charts/n8n/bump.yaml
@@ -1,0 +1,16 @@
+chart: n8n
+
+upstream:
+  registry: docker.io
+  repository: n8nio/n8n
+  tagFilter: "^\d+\.\d+\.\d+$"
+  excludeFilter: "-rc|-beta|-alpha"
+
+values:
+  imageKey: image.tag
+
+helm:
+  testArgs: >-
+    --set replicaCount=1
+    --set persistence.enabled=false
+    --set externalDatabase.enabled=false

--- a/charts/open-webui/bump.yaml
+++ b/charts/open-webui/bump.yaml
@@ -1,0 +1,16 @@
+chart: open-webui
+
+upstream:
+  registry: ghcr.io
+  repository: open-webui/open-webui
+  tagFilter: "^v?\d+\.\d+\.\d+$"
+  excludeFilter: "-rc|-beta|-alpha|-dev"
+
+values:
+  imageKey: image.tag
+
+helm:
+  testArgs: >-
+    --set replicaCount=1
+    --set persistence.enabled=false
+    --set ollama.enabled=false

--- a/charts/uptime-kuma/bump.yaml
+++ b/charts/uptime-kuma/bump.yaml
@@ -1,0 +1,15 @@
+chart: uptime-kuma
+
+upstream:
+  registry: docker.io
+  repository: louislam/uptime-kuma
+  tagFilter: "^\d+\.\d+\.\d+$"
+  excludeFilter: "-rc|-beta|-alpha|-pr"
+
+values:
+  imageKey: image.tag
+
+helm:
+  testArgs: >-
+    --set replicaCount=1
+    --set persistence.enabled=false

--- a/charts/vaultwarden/bump.yaml
+++ b/charts/vaultwarden/bump.yaml
@@ -1,0 +1,15 @@
+chart: vaultwarden
+
+upstream:
+  registry: docker.io
+  repository: vaultwarden/server
+  tagFilter: "^\d+\.\d+\.\d+$"
+  excludeFilter: "-rc|-beta|-alpha|-testing"
+
+values:
+  imageKey: image.tag
+
+helm:
+  testArgs: >-
+    --set replicaCount=1
+    --set persistence.enabled=false


### PR DESCRIPTION
## Summary

Adds `bump.yaml` configuration files for HABS (HelmForge Autonomous Bump System) to 6 charts.

The image-watcher CronJob reads these files to know which upstream registries to poll and which Helm values key to update when a new stable tag is detected.

### Charts covered

| Chart | Registry | Repository | Tag pattern |
|---|---|---|---|
| envoy-gateway | docker.io | envoyproxy/gateway | `^v\d+\.\d+\.\d+$` |
| cloudflared | docker.io | cloudflare/cloudflared | `^\d{4}\.\d+\.\d+$` (calver) |
| vaultwarden | docker.io | vaultwarden/server | `^\d+\.\d+\.\d+$` |
| uptime-kuma | docker.io | louislam/uptime-kuma | `^\d+\.\d+\.\d+$` |
| n8n | docker.io | n8nio/n8n | `^\d+\.\d+\.\d+$` |
| open-webui | ghcr.io | open-webui/open-webui | `^v?\d+\.\d+\.\d+$` |

### How it works

1. Watcher CronJob polls registries every 6h
2. Detects new stable tag → creates a bumper Job
3. Bumper validates: helm lint → helm unittest → helm install test → log check → cleanup
4. Only if all pass: creates branch bump/<chart>-<tag>, updates values.yaml + appVersion, commits, pushes, opens PR
5. On failure: Telegram + SMTP notification, no branch created

Related: helmforgedev/habs repository