### PR TITLE
Fix/mosquitto external ips node port

### DIFF
--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -38,6 +38,7 @@ helm install mosquitto oci://ghcr.io/helmforgedev/helm/mosquitto
 - federated mode is based on Mosquitto bridges, not on native shared-state clustering
 - federated brokers still do **not** share sessions or retained state like a true clustered MQTT platform
 - the default Service routing uses `sessionAffinity=None` for broader compatibility; enable `ClientIP` only when sticky routing is explicitly needed
+- `service.externalIPs` maps to `spec.externalIPs` on the broker Service for clusters that route traffic to those addresses
 - federated multi-replica installs automatically prefer spreading broker pods across nodes unless you provide custom `affinity` or `topologySpreadConstraints`
 - when `broker.tls.enabled=true`, set `broker.tls.certSecretName` to an existing Secret containing `tls.crt` and `tls.key` (and optionally `ca.crt` for mTLS)
 - when `broker.tls.enabled=true`, the chart disables the plain MQTT `1883` listener and Service port, serving MQTT only on `broker.tls.port` (default `8883`)
@@ -146,6 +147,7 @@ broker:
 | `auth.enabled` | `false` | Enable username/password authentication |
 | `acl.enabled` | `false` | Enable ACL file generation |
 | `service.sessionAffinity` | `None` | Service routing policy for client traffic |
+| `service.externalIPs` | `[]` | Optional `spec.externalIPs` entries for the broker Service |
 | `websocketIngress.enabled` | `false` | Expose broker WebSocket through ingress |
 | `mqttxWeb.enabled` | `false` | Deploy MQTTX Web companion UI |
 

--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -29,6 +29,7 @@ helm install mosquitto oci://ghcr.io/helmforgedev/helm/mosquitto
 - **Native MQTT TLS Listener** — optional TLS/mTLS listener using an existing Kubernetes Secret
 - **Broker Pressure Limits** — optional connection and queue/message size limits to reduce abuse impact
 - **MQTTX Web Companion** — optional browser client deployment for quick testing
+- **Service exposure** — optional `externalIPs` and static Kubernetes `nodePort` values per listener (MQTT, WebSocket, MQTTS)
 - **Values Schema** — `values.schema.json` validates user-supplied values and improves ArtifactHub rendering
 
 ## Important Notes
@@ -38,6 +39,7 @@ helm install mosquitto oci://ghcr.io/helmforgedev/helm/mosquitto
 - federated mode is based on Mosquitto bridges, not on native shared-state clustering
 - federated brokers still do **not** share sessions or retained state like a true clustered MQTT platform
 - the default Service routing uses `sessionAffinity=None` for broader compatibility; enable `ClientIP` only when sticky routing is explicitly needed
+- set `service.mqttNodePort`, `service.websocketNodePort`, and `service.mqttsNodePort` to a non-zero port (typically `30000`–`32767`) to pin static NodePorts; keep them at `0` to let the cluster assign ports automatically
 - `service.externalIPs` maps to `spec.externalIPs` on the broker Service for clusters that route traffic to those addresses
 - federated multi-replica installs automatically prefer spreading broker pods across nodes unless you provide custom `affinity` or `topologySpreadConstraints`
 - when `broker.tls.enabled=true`, set `broker.tls.certSecretName` to an existing Secret containing `tls.crt` and `tls.key` (and optionally `ca.crt` for mTLS)
@@ -106,6 +108,19 @@ mqttxWeb:
             pathType: Prefix
 ```
 
+### NodePort with static NodePorts and external IPs
+
+```yaml
+service:
+  type: NodePort
+  mqttNodePort: 31883
+  websocketNodePort: 31901
+  externalIPs:
+    - 203.0.113.10
+```
+
+When `broker.tls.enabled=true`, use `service.mqttsNodePort` instead of `mqttNodePort` for the TLS listener.
+
 ### Public Broker with MQTT TLS
 
 ```yaml
@@ -146,8 +161,16 @@ broker:
 | `broker.federation.topicPattern` | `#` | Topic pattern bridged between federated brokers |
 | `auth.enabled` | `false` | Enable username/password authentication |
 | `acl.enabled` | `false` | Enable ACL file generation |
+| `service.type` | `ClusterIP` | Service type: `ClusterIP`, `NodePort`, or `LoadBalancer` |
 | `service.sessionAffinity` | `None` | Service routing policy for client traffic |
+| `service.mqttPort` | `1883` | Service port for plain MQTT (when TLS is disabled) |
+| `service.websocketPort` | `9001` | Service port for WebSocket |
+| `service.mqttsPort` | `8883` | Service port for MQTT TLS (when TLS is enabled) |
+| `service.mqttNodePort` | `0` | Static NodePort for MQTT; `0` omits the field (auto-assigned when using NodePort/LoadBalancer) |
+| `service.websocketNodePort` | `0` | Static NodePort for WebSocket |
+| `service.mqttsNodePort` | `0` | Static NodePort for MQTTS (TLS) |
 | `service.externalIPs` | `[]` | Optional `spec.externalIPs` entries for the broker Service |
+| `service.externalTrafficPolicy` | `Cluster` | Used when `service.type` is `NodePort` or `LoadBalancer` |
 | `websocketIngress.enabled` | `false` | Expose broker WebSocket through ingress |
 | `mqttxWeb.enabled` | `false` | Deploy MQTTX Web companion UI |
 

--- a/charts/mosquitto/templates/NOTES.txt
+++ b/charts/mosquitto/templates/NOTES.txt
@@ -2,11 +2,11 @@ Mosquitto has been deployed.
 
 Broker service:
 {{- if not .Values.broker.tls.enabled }}
-  MQTT:      {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttPort }}
+  MQTT:      {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttPort }}{{ if ne (int .Values.service.mqttNodePort) 0 }} (node port {{ .Values.service.mqttNodePort }}){{ end }}
 {{- end }}
-  WebSocket: {{ include "mosquitto.fullname" . }}:{{ .Values.service.websocketPort }}
+  WebSocket: {{ include "mosquitto.fullname" . }}:{{ .Values.service.websocketPort }}{{ if ne (int .Values.service.websocketNodePort) 0 }} (node port {{ .Values.service.websocketNodePort }}){{ end }}
 {{- if .Values.broker.tls.enabled }}
-  MQTTS:     {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttsPort }}
+  MQTTS:     {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttsPort }}{{ if ne (int .Values.service.mqttsNodePort) 0 }} (node port {{ .Values.service.mqttsNodePort }}){{ end }}
 {{- if gt (len .Values.service.externalIPs) 0 }}
   External IPs:
 {{- range .Values.service.externalIPs }}

--- a/charts/mosquitto/templates/NOTES.txt
+++ b/charts/mosquitto/templates/NOTES.txt
@@ -7,6 +7,12 @@ Broker service:
   WebSocket: {{ include "mosquitto.fullname" . }}:{{ .Values.service.websocketPort }}
 {{- if .Values.broker.tls.enabled }}
   MQTTS:     {{ include "mosquitto.fullname" . }}:{{ .Values.service.mqttsPort }}
+{{- if gt (len .Values.service.externalIPs) 0 }}
+  External IPs:
+{{- range .Values.service.externalIPs }}
+    - {{ . }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.websocketIngress.enabled }}

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -14,6 +14,10 @@ spec:
   {{- if or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if gt (len .Values.service.externalIPs) 0 }}
+  externalIPs:
+    {{- .Values.service.externalIPs | toYaml | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "mosquitto.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: broker

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -27,16 +27,25 @@ spec:
       port: {{ .Values.service.mqttPort }}
       targetPort: mqtt
       protocol: TCP
+      {{- if ne (int .Values.service.mqttNodePort) 0 }}
+      nodePort: {{ .Values.service.mqttNodePort }}
+      {{- end }}
     {{- end }}
     - name: websocket
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket
       protocol: TCP
+      {{- if ne (int .Values.service.websocketNodePort) 0 }}
+      nodePort: {{ .Values.service.websocketNodePort }}
+      {{- end }}
     {{- if .Values.broker.tls.enabled }}
     - name: mqtts
       port: {{ .Values.service.mqttsPort }}
       targetPort: mqtts
       protocol: TCP
+      {{- if ne (int .Values.service.mqttsNodePort) 0 }}
+      nodePort: {{ .Values.service.mqttsNodePort }}
+      {{- end }}
     {{- end }}
 ---
 apiVersion: v1

--- a/charts/mosquitto/tests/service_test.yaml
+++ b/charts/mosquitto/tests/service_test.yaml
@@ -84,3 +84,42 @@ tests:
       - equal:
           path: spec.externalIPs[0]
           value: "203.0.113.10"
+
+  - it: should set static NodePorts on the client Service when configured
+    documentIndex: 0
+    set:
+      service.mqttNodePort: 31883
+      service.websocketNodePort: 31901
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: mqtt
+            port: 1883
+            targetPort: mqtt
+            protocol: TCP
+            nodePort: 31883
+      - contains:
+          path: spec.ports
+          content:
+            name: websocket
+            port: 9001
+            targetPort: websocket
+            protocol: TCP
+            nodePort: 31901
+
+  - it: should set mqtts NodePort when TLS and mqttsNodePort are set
+    documentIndex: 0
+    set:
+      broker.tls.enabled: true
+      broker.tls.certSecretName: mosquitto-tls
+      service.mqttsNodePort: 30883
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: mqtts
+            port: 8883
+            targetPort: mqtts
+            protocol: TCP
+            nodePort: 30883

--- a/charts/mosquitto/tests/service_test.yaml
+++ b/charts/mosquitto/tests/service_test.yaml
@@ -75,3 +75,12 @@ tests:
             port: 8883
             targetPort: mqtts
             protocol: TCP
+
+  - it: should set externalIPs on the client Service when configured
+    documentIndex: 0
+    set:
+      service.externalIPs[0]: "203.0.113.10"
+    asserts:
+      - equal:
+          path: spec.externalIPs[0]
+          value: "203.0.113.10"

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -333,6 +333,13 @@
         "mqttsPort": {
           "type": "integer",
           "description": "Override MQTT TLS service port when broker.tls.enabled=true"
+        },
+        "externalIPs": {
+          "type": "array",
+          "description": "External IPs for the broker Service (Kubernetes spec.externalIPs)",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -334,6 +334,24 @@
           "type": "integer",
           "description": "Override MQTT TLS service port when broker.tls.enabled=true"
         },
+        "mqttNodePort": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 32767,
+          "description": "Static NodePort for MQTT when service type is NodePort or LoadBalancer (0 = omit for auto assignment)"
+        },
+        "websocketNodePort": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 32767,
+          "description": "Static NodePort for WebSocket when service type is NodePort or LoadBalancer (0 = omit)"
+        },
+        "mqttsNodePort": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 32767,
+          "description": "Static NodePort for MQTTS when service type is NodePort or LoadBalancer (0 = omit)"
+        },
         "externalIPs": {
           "type": "array",
           "description": "External IPs for the broker Service (Kubernetes spec.externalIPs)",

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -148,6 +148,12 @@ service:
   websocketPort: 9001
   # -- Override MQTT TLS service port when broker.tls.enabled=true
   mqttsPort: 8883
+  # -- NodePort for MQTT when service type is NodePort or LoadBalancer (0 = omit; cluster assigns)
+  mqttNodePort: 0
+  # -- NodePort for WebSocket when service type is NodePort or LoadBalancer (0 = omit)
+  websocketNodePort: 0
+  # -- NodePort for MQTTS when service type is NodePort or LoadBalancer (0 = omit)
+  mqttsNodePort: 0
   # -- External IPs for the broker Service
   externalIPs: []
 

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -148,6 +148,8 @@ service:
   websocketPort: 9001
   # -- Override MQTT TLS service port when broker.tls.enabled=true
   mqttsPort: 8883
+  # -- External IPs for the broker Service
+  externalIPs: []
 
 headlessService:
   # -- Annotations for the headless broker Service


### PR DESCRIPTION
## Summary

- added support for externalIPs and node ports

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes
- [x] I updated the `site/` repository if this change affects public chart docs, listing, or maturity

## Version Validation

- [-] I verified the application version against official GitHub Releases
- [-] I verified the image tag against official Docker Hub tags
- [-] I only pinned a version after confirming both sources matched

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [-] If backup behavior changed, I validated the flow against local MinIO

## Notes

- 