### PR TITLE
fix(kafka): support combined mode with brokers.replicaCount=0

### DIFF
--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -27,6 +27,7 @@ helm install kafka oci://ghcr.io/helmforgedev/helm/kafka -f values.yaml
 |-------------|-------------|----------|
 | `single-broker` | development, CI, demos, and simple internal workloads without node-level broker redundancy | [docs/single-broker.md](docs/single-broker.md) |
 | `cluster` | production-oriented Kafka with dedicated KRaft controllers and brokers | [docs/cluster.md](docs/cluster.md) |
+| `cluster` (combined mode) | 3-node HA production deployments where each controller also acts as a broker (`brokers.replicaCount: 0`) | [docs/combined-mode.md](docs/combined-mode.md) |
 
 ## What this chart covers
 
@@ -64,7 +65,7 @@ singleBroker:
     size: 8Gi
 ```
 
-Cluster:
+Cluster (dedicated controllers and brokers):
 
 ```yaml
 architecture: cluster
@@ -79,6 +80,24 @@ cluster:
     replicaCount: 3
     persistence:
       size: 50Gi
+
+pdb:
+  enabled: true
+```
+
+Cluster (combined mode - controllers act as brokers):
+
+```yaml
+architecture: cluster
+
+cluster:
+  minInSyncReplicas: 2
+  controllers:
+    replicaCount: 3
+    persistence:
+      size: 50Gi
+  brokers:
+    replicaCount: 0  # Combined mode: process.roles=broker,controller
 
 pdb:
   enabled: true
@@ -116,7 +135,7 @@ metrics:
 | `config.autoCreateTopicsEnabled` | Enable automatic topic creation | `false` |
 | `singleBroker.persistence.enabled` | Enable PVC in single-broker mode | `true` |
 | `cluster.controllers.replicaCount` | Controller replicas in cluster mode | `3` |
-| `cluster.brokers.replicaCount` | Broker replicas in cluster mode | `3` |
+| `cluster.brokers.replicaCount` | Broker replicas in cluster mode. Set to `0` for combined mode (controllers act as brokers) | `3` |
 | `cluster.minInSyncReplicas` | Minimum ISR in cluster mode | `2` |
 | `metrics.enabled` | Enable JMX exporter javaagent metrics | `false` |
 | `metrics.serviceMonitor.enabled` | Create ServiceMonitor resources | `false` |
@@ -128,6 +147,7 @@ The `ci/` directory covers the main supported paths:
 
 - `single-broker.yaml`
 - `cluster.yaml`
+- `combined-mode.yaml`
 - `metrics.yaml`
 - `cluster-tuned.yaml`
 
@@ -137,11 +157,13 @@ See `examples/`:
 
 - [single-broker.yaml](examples/single-broker.yaml)
 - [cluster-production.yaml](examples/cluster-production.yaml)
+- [combined-mode/](examples/combined-mode/)
 
 ## Architecture guides
 
 - [Single Broker](docs/single-broker.md)
 - [Cluster](docs/cluster.md)
+- [Combined Mode](docs/combined-mode.md)
 
 ## Important notes
 

--- a/charts/kafka/ci/combined-mode.yaml
+++ b/charts/kafka/ci/combined-mode.yaml
@@ -1,0 +1,11 @@
+architecture: cluster
+cluster:
+  minInSyncReplicas: 2
+  controllers:
+    replicaCount: 3
+    persistence:
+      size: 50Gi
+  brokers:
+    replicaCount: 0
+pdb:
+  enabled: true

--- a/charts/kafka/docs/combined-mode.md
+++ b/charts/kafka/docs/combined-mode.md
@@ -1,0 +1,118 @@
+# Combined Mode
+
+Use `architecture=cluster` with `cluster.brokers.replicaCount=0` for production deployments that need high availability with a simplified topology where each KRaft controller also acts as a broker.
+
+## What this mode does
+
+- deploys only the controller StatefulSet (no separate broker StatefulSet)
+- each controller pod runs with `process.roles=broker,controller`
+- controller pods expose both the controller port (9093) and client port (9092)
+- the client service routes to controller pods instead of broker pods
+- internal replication factor is calculated from `controllers.replicaCount` instead of `brokers.replicaCount`
+- uses stable per-pod DNS for controller quorum bootstrap and client advertised listeners
+
+## When to use
+
+Combined mode is ideal for:
+
+- **3-node HA production** where the workload doesn't justify 6 total pods (3 controllers + 3 brokers)
+- **Cost-optimized production** with moderate throughput requirements
+- **Simplified operational model** while maintaining proper quorum and replication
+
+## Trade-offs
+
+**Advantages:**
+- Fewer pods to manage (3 instead of 6)
+- Lower resource consumption
+- Simpler topology
+
+**Disadvantages:**
+- Controllers handle both metadata coordination and client traffic
+- Cannot scale brokers independently from controllers
+- Controller nodes must be sized for both controller and broker workload
+
+## Recommended baseline
+
+- `cluster.controllers.replicaCount=3`
+- `cluster.brokers.replicaCount=0` (this triggers combined mode)
+- `cluster.minInSyncReplicas=2`
+- persistent storage on controllers (sized for broker data, not just metadata)
+- `pdb.enabled=true`
+
+## Configuration example
+
+```yaml
+architecture: cluster
+
+cluster:
+  minInSyncReplicas: 2
+  controllers:
+    replicaCount: 3
+    persistence:
+      size: 50Gi  # Size for broker data, not just controller metadata
+  brokers:
+    replicaCount: 0  # Combined mode
+
+pdb:
+  enabled: true
+```
+
+## How it works
+
+When `brokers.replicaCount=0`:
+
+1. **StatefulSet rendering**: Only `kafka-controller` StatefulSet is created (no `kafka-broker` StatefulSet)
+2. **Process roles**: Start script generates `process.roles=broker,controller` in server.properties
+3. **Listeners**: Controllers expose both `CLIENT://0.0.0.0:9092` and `CONTROLLER://0.0.0.0:9093`
+4. **Service selector**: The `kafka` client service selector points to `component: controller` pods
+5. **Replication factor**: Internal topics use `min(3, controllers.replicaCount)` instead of brokers
+
+## Validation before production
+
+1. Confirm all controller pods reach `Ready` state
+2. Verify `process.roles=broker,controller` in pod logs
+3. Create a topic with replication factor 2 or 3
+4. Produce and consume through the `kafka:9092` bootstrap service
+5. Validate pod rescheduling with persistent volumes
+6. Test controller election after pod restart
+
+## Scaling considerations
+
+- You **cannot** scale brokers independently in combined mode
+- To scale capacity, increase `controllers.replicaCount` (must maintain odd number for quorum)
+- Changing from combined mode to dedicated brokers requires migration (not seamless)
+
+## Production checklist
+
+- [ ] Set appropriate resource requests/limits for both controller and broker workload
+- [ ] Size persistence for broker data, not just controller metadata
+- [ ] Enable PodDisruptionBudget to protect quorum during maintenance
+- [ ] Configure anti-affinity to spread controllers across nodes/zones
+- [ ] Document that this topology cannot scale brokers independently
+- [ ] Monitor both controller metrics and broker metrics on the same pods
+
+## Non-goals of v1
+
+- ZooKeeper mode
+- External listeners and load balancer matrices
+- TLS and SASL/ACL automation
+- Kafka Connect, MirrorMaker, Schema Registry, or UI bundles
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Kafka - Combined Mode
+description: Production-oriented Kafka KRaft combined mode where controllers act as brokers
+
+keywords: kafka, kraft, combined mode, controllers, brokers, process.roles
+
+purpose: Explain the combined mode topology where brokers.replicaCount=0 triggers controller pods to act as both controllers and brokers
+scope: Chart Architecture
+
+relations:
+  - charts/kafka/README.md
+  - charts/kafka/docs/cluster.md
+  - charts/kafka/docs/single-broker.md
+path: charts/kafka/docs/combined-mode.md
+version: 1.0
+date: 2026-04-13
+-->

--- a/charts/kafka/examples/combined-mode/README.md
+++ b/charts/kafka/examples/combined-mode/README.md
@@ -1,0 +1,80 @@
+# Combined Mode Example
+
+This example demonstrates Kafka in **combined mode**, where each KRaft controller also acts as a broker (`process.roles=broker,controller`).
+
+## When to use
+
+Combined mode is ideal for:
+
+- **3-node HA production deployments** that need high availability without the overhead of 6 total pods (3 controllers + 3 brokers)
+- **Cost-optimized production** where workload doesn't justify separate controller and broker StatefulSets
+- **Simplified topology** while maintaining proper Kafka quorum (3 nodes for controller quorum)
+
+## What happens
+
+When `cluster.brokers.replicaCount: 0`:
+
+- Only the controller StatefulSet is created (3 replicas)
+- Each controller pod runs with `process.roles=broker,controller`
+- The client service (`kafka:9092`) routes to controller pods
+- Controller pods expose both ports: `9093` (controller) and `9092` (client)
+- Internal replication factor uses `min(3, controllers.replicaCount)`
+
+## Trade-offs
+
+**Advantages:**
+- Fewer pods (3 instead of 6)
+- Lower resource usage
+- Simpler to manage
+
+**Disadvantages:**
+- Controllers handle both metadata and client traffic
+- Cannot scale brokers independently from controllers
+- Controller workload includes broker responsibilities
+
+## Install
+
+```bash
+helm install kafka helmforge/kafka -f values.yaml
+```
+
+## Verify
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=kafka
+kubectl logs kafka-controller-0 | grep "process.roles"
+```
+
+You should see:
+```
+process.roles=broker,controller
+```
+
+## Test
+
+Create a topic and produce/consume:
+
+```bash
+kubectl exec -it kafka-controller-0 -- /opt/kafka/bin/kafka-topics.sh \
+  --create --topic test-topic \
+  --partitions 3 --replication-factor 2 \
+  --bootstrap-server kafka:9092
+
+kubectl exec -it kafka-controller-0 -- /opt/kafka/bin/kafka-console-producer.sh \
+  --topic test-topic \
+  --bootstrap-server kafka:9092
+
+kubectl exec -it kafka-controller-0 -- /opt/kafka/bin/kafka-console-consumer.sh \
+  --topic test-topic \
+  --from-beginning \
+  --bootstrap-server kafka:9092
+```
+
+## Production checklist
+
+- [ ] Set appropriate resource requests/limits based on workload
+- [ ] Enable PodDisruptionBudget (`pdb.enabled: true`)
+- [ ] Configure persistence size based on retention policy
+- [ ] Enable metrics and monitoring (`metrics.enabled: true`)
+- [ ] Plan for node affinity/anti-affinity if needed
+- [ ] Document that this topology cannot scale brokers independently

--- a/charts/kafka/examples/combined-mode/values.yaml
+++ b/charts/kafka/examples/combined-mode/values.yaml
@@ -1,0 +1,24 @@
+architecture: cluster
+
+cluster:
+  minInSyncReplicas: 2
+  controllers:
+    replicaCount: 3
+    persistence:
+      size: 50Gi
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        memory: 2Gi
+  brokers:
+    replicaCount: 0  # Combined mode: each controller acts as both controller and broker
+
+pdb:
+  enabled: true
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true

--- a/charts/kafka/templates/_helpers.tpl
+++ b/charts/kafka/templates/_helpers.tpl
@@ -100,7 +100,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "kafka.internalReplicationFactor" -}}
 {{- if eq .Values.architecture "cluster" -}}
+{{- if eq (.Values.cluster.brokers.replicaCount | int) 0 -}}
+{{- min 3 (.Values.cluster.controllers.replicaCount | int) -}}
+{{- else -}}
 {{- min 3 (.Values.cluster.brokers.replicaCount | int) -}}
+{{- end -}}
 {{- else -}}
 1
 {{- end -}}
@@ -183,10 +187,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and (eq .Values.architecture "cluster") (lt (.Values.cluster.controllers.replicaCount | int) 3) -}}
 {{- fail "cluster.controllers.replicaCount must be at least 3 for cluster mode" -}}
 {{- end -}}
-{{- if and (eq .Values.architecture "cluster") (lt (.Values.cluster.brokers.replicaCount | int) 3) -}}
-{{- fail "cluster.brokers.replicaCount must be at least 3 for cluster mode" -}}
+{{- if and (eq .Values.architecture "cluster") (gt (.Values.cluster.brokers.replicaCount | int) 0) (lt (.Values.cluster.brokers.replicaCount | int) 3) -}}
+{{- fail "cluster.brokers.replicaCount must be 0 (combined mode: controllers act as brokers) or at least 3 for dedicated-broker mode" -}}
 {{- end -}}
-{{- if and (eq .Values.architecture "cluster") (gt (.Values.cluster.minInSyncReplicas | int) (.Values.cluster.brokers.replicaCount | int)) -}}
+{{- if and (eq .Values.architecture "cluster") (gt (.Values.cluster.brokers.replicaCount | int) 0) (gt (.Values.cluster.minInSyncReplicas | int) (.Values.cluster.brokers.replicaCount | int)) -}}
 {{- fail "cluster.minInSyncReplicas cannot be greater than cluster.brokers.replicaCount" -}}
+{{- end -}}
+{{- if and (eq .Values.architecture "cluster") (eq (.Values.cluster.brokers.replicaCount | int) 0) (gt (.Values.cluster.minInSyncReplicas | int) (.Values.cluster.controllers.replicaCount | int)) -}}
+{{- fail "cluster.minInSyncReplicas cannot be greater than cluster.controllers.replicaCount in combined mode" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kafka/templates/configmap-scripts.yaml
+++ b/charts/kafka/templates/configmap-scripts.yaml
@@ -38,7 +38,7 @@ data:
 
     {{- with .Values.config.common }}
     cat >> "${config_file}" <<'EOF'
-    {{ . }}
+{{- . | nindent 4 }}
     EOF
     {{- end }}
 
@@ -55,7 +55,7 @@ data:
         "${config_file}"
       {{- with .Values.config.singleBroker }}
       cat >> "${config_file}" <<'EOF'
-      {{ . }}
+{{- . | nindent 6 }}
       EOF
       {{- end }}
       echo "inter.broker.listener.name=CLIENT" >> "${config_file}"
@@ -69,7 +69,8 @@ data:
     elif [ "${component}" = "controller" ]; then
       initial_controllers=""
       controller_count="{{ .Values.cluster.controllers.replicaCount }}"
-      advertised_controller="${HOSTNAME}.{{ include "kafka.controllerHeadlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+      broker_count="{{ .Values.cluster.brokers.replicaCount }}"
+      advertised_host="${HOSTNAME}.{{ include "kafka.controllerHeadlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
       i=0
       while [ "${i}" -lt "${controller_count}" ]; do
         if [ -n "${initial_controllers}" ]; then
@@ -79,19 +80,33 @@ data:
         initial_controllers="${initial_controllers}${i}@{{ include "kafka.controllerStatefulSetName" . }}-${i}.{{ include "kafka.controllerHeadlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.listeners.controller.port }}:${dir_id}"
         i=$((i + 1))
       done
-      sed -i \
-        -e "s|__NODE_ID__|${ordinal}|g" \
-        -e "s|__PROCESS_ROLES__|controller|g" \
-        -e "s|__LISTENERS__|CONTROLLER://:{{ .Values.listeners.controller.port }}|g" \
-        -e "s|__ADVERTISED_LISTENERS__|CONTROLLER://${advertised_controller}:{{ .Values.listeners.controller.port }}|g" \
-        -e "s|__OFFSETS_TOPIC_RF__|{{ include "kafka.internalReplicationFactor" . }}|g" \
-        -e "s|__TRANSACTION_TOPIC_RF__|{{ include "kafka.internalReplicationFactor" . }}|g" \
-        -e "s|__TRANSACTION_MIN_ISR__|{{ include "kafka.minInSyncReplicas" . }}|g" \
-        -e "s|__MIN_ISR__|{{ include "kafka.minInSyncReplicas" . }}|g" \
-        "${config_file}"
+      if [ "${broker_count}" = "0" ]; then
+        sed -i \
+          -e "s|__NODE_ID__|${ordinal}|g" \
+          -e "s|__PROCESS_ROLES__|broker,controller|g" \
+          -e "s|__LISTENERS__|CLIENT://:{{ .Values.listeners.client.port }},CONTROLLER://:{{ .Values.listeners.controller.port }}|g" \
+          -e "s|__ADVERTISED_LISTENERS__|CLIENT://${advertised_host}:{{ .Values.listeners.client.port }},CONTROLLER://${advertised_host}:{{ .Values.listeners.controller.port }}|g" \
+          -e "s|__OFFSETS_TOPIC_RF__|{{ include "kafka.internalReplicationFactor" . }}|g" \
+          -e "s|__TRANSACTION_TOPIC_RF__|{{ include "kafka.internalReplicationFactor" . }}|g" \
+          -e "s|__TRANSACTION_MIN_ISR__|{{ include "kafka.minInSyncReplicas" . }}|g" \
+          -e "s|__MIN_ISR__|{{ include "kafka.minInSyncReplicas" . }}|g" \
+          "${config_file}"
+        echo "inter.broker.listener.name=CLIENT" >> "${config_file}"
+      else
+        sed -i \
+          -e "s|__NODE_ID__|${ordinal}|g" \
+          -e "s|__PROCESS_ROLES__|controller|g" \
+          -e "s|__LISTENERS__|CONTROLLER://:{{ .Values.listeners.controller.port }}|g" \
+          -e "s|__ADVERTISED_LISTENERS__|CONTROLLER://${advertised_host}:{{ .Values.listeners.controller.port }}|g" \
+          -e "s|__OFFSETS_TOPIC_RF__|{{ include "kafka.internalReplicationFactor" . }}|g" \
+          -e "s|__TRANSACTION_TOPIC_RF__|{{ include "kafka.internalReplicationFactor" . }}|g" \
+          -e "s|__TRANSACTION_MIN_ISR__|{{ include "kafka.minInSyncReplicas" . }}|g" \
+          -e "s|__MIN_ISR__|{{ include "kafka.minInSyncReplicas" . }}|g" \
+          "${config_file}"
+      fi
       {{- with .Values.config.controller }}
       cat >> "${config_file}" <<'EOF'
-      {{ . }}
+{{- . | nindent 6 }}
       EOF
       {{- end }}
       if [ ! -f "${data_dir}/meta.properties" ]; then
@@ -117,7 +132,7 @@ data:
       echo "inter.broker.listener.name=INTERNAL" >> "${config_file}"
       {{- with .Values.config.broker }}
       cat >> "${config_file}" <<'EOF'
-      {{ . }}
+{{- . | nindent 6 }}
       EOF
       {{- end }}
       if [ ! -f "${data_dir}/meta.properties" ]; then

--- a/charts/kafka/templates/service-client.yaml
+++ b/charts/kafka/templates/service-client.yaml
@@ -15,7 +15,15 @@ spec:
   type: {{ .Values.service.type }}
   selector:
     {{- include "kafka.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ if eq .Values.architecture "cluster" }}broker{{ else }}single-broker{{ end }}
+    {{- if eq .Values.architecture "cluster" }}
+    {{- if eq (.Values.cluster.brokers.replicaCount | int) 0 }}
+    app.kubernetes.io/component: controller
+    {{- else }}
+    app.kubernetes.io/component: broker
+    {{- end }}
+    {{- else }}
+    app.kubernetes.io/component: single-broker
+    {{- end }}
   ports:
     - name: client
       port: {{ .Values.listeners.client.port }}

--- a/charts/kafka/templates/statefulset-cluster.yaml
+++ b/charts/kafka/templates/statefulset-cluster.yaml
@@ -100,6 +100,11 @@ spec:
             - name: controller
               containerPort: {{ .Values.listeners.controller.port }}
               protocol: TCP
+            {{- if eq (.Values.cluster.brokers.replicaCount | int) 0 }}
+            - name: client
+              containerPort: {{ .Values.listeners.client.port }}
+              protocol: TCP
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
@@ -188,6 +193,7 @@ spec:
         storageClassName: {{ . | quote }}
         {{- end }}
   {{- end }}
+{{- if gt (.Values.cluster.brokers.replicaCount | int) 0 }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -383,4 +389,5 @@ spec:
         storageClassName: {{ . | quote }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/kafka/values.schema.json
+++ b/charts/kafka/values.schema.json
@@ -255,7 +255,8 @@
           "properties": {
             "replicaCount": {
               "type": "integer",
-              "description": "Number of dedicated broker replicas"
+              "description": "Number of dedicated broker replicas. Set to 0 to enable combined mode where each controller also acts as a broker (process.roles=broker,controller). Useful for 3-node HA without separate controller and broker StatefulSets. When non-zero, must be at least 3.",
+              "minimum": 0
             },
             "persistence": {
               "type": "object",

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -131,7 +131,11 @@ cluster:
       size: 8Gi
     resources: {}
   brokers:
-    # -- Number of dedicated broker replicas
+    # -- Number of dedicated broker replicas.
+    # Set to 0 to enable combined mode: each controller also acts as a broker
+    # (process.roles=broker,controller). Useful for 3-node HA without separate
+    # controller and broker StatefulSets. When 0, the client service routes to
+    # controller pods directly.
     replicaCount: 3
     persistence:
       # -- Enable broker PVCs


### PR DESCRIPTION
## Summary

Enable combined mode where each KRaft controller also acts as a broker (`process.roles=broker,controller`) by setting `cluster.brokers.replicaCount: 0`.

This allows 3-node HA deployments without separate broker StatefulSets, ideal for cost-optimized production environments with moderate throughput requirements.

## Fixes

**Template Corrections:**
- ✅ `_helpers.tpl`: `internalReplicationFactor` now uses `controllers.replicaCount` when `brokers=0`
- ✅ `_helpers.tpl`: Validation allows `brokers=0` or `≥3` (not 1-2)
- ✅ `_helpers.tpl`: `minInSyncReplicas` validation for both dedicated and combined modes
- ✅ `configmap-scripts.yaml`: Heredoc YAML indentation fixed with `nindent`
- ✅ `configmap-scripts.yaml`: Controller generates `process.roles=broker,controller` when `brokers=0`
- ✅ `configmap-scripts.yaml`: Controller exposes CLIENT listener in combined mode
- ✅ `service-client.yaml`: Selector routes to controller when `brokers=0`
- ✅ `statefulset-cluster.yaml`: Controller exposes port 9092 in combined mode
- ✅ `statefulset-cluster.yaml`: Broker StatefulSet skipped when `brokers=0`

## Testing

- [x] `helm lint --strict` passed
- [x] `helm template` with default values passed
- [x] `helm template` with all `ci/*.yaml` scenarios passed
- [x] Combined mode renders only controller StatefulSet (3 replicas)
- [x] Normal cluster mode still renders both StatefulSets (controllers + brokers)
- [x] Service selector correctly routes to controller in combined mode
- [x] Controller pods expose both ports (9092 + 9093) in combined mode

## Documentation

- [x] `README.md`: Added combined mode to architecture table and quick start examples
- [x] `docs/combined-mode.md`: Comprehensive architecture guide with when to use, trade-offs, validation steps
- [x] `examples/combined-mode/`: Production-ready values.yaml with resources, PDB, and detailed README
- [x] `ci/combined-mode.yaml`: Test scenario for CI pipeline
- [x] `values.yaml`: Documented `brokers.replicaCount=0` behavior
- [x] `values.schema.json`: Schema updated with combined mode documentation and `minimum: 0`

## Configuration Example

```yaml
architecture: cluster

cluster:
  minInSyncReplicas: 2
  controllers:
    replicaCount: 3
    persistence:
      size: 50Gi  # Sized for broker data, not just metadata
  brokers:
    replicaCount: 0  # Combined mode

pdb:
  enabled: true
```

## When to Use Combined Mode

**Ideal for:**
- 3-node HA production deployments
- Cost-optimized production with moderate throughput
- Simplified operational model with proper quorum

**Trade-offs:**
- ✅ Fewer pods (3 instead of 6)
- ✅ Lower resource consumption
- ❌ Cannot scale brokers independently
- ❌ Controllers handle both metadata and client traffic

## Files Changed

```
11 files changed, 320 insertions(+), 23 deletions(-)
- charts/kafka/README.md
- charts/kafka/templates/_helpers.tpl
- charts/kafka/templates/configmap-scripts.yaml
- charts/kafka/templates/service-client.yaml
- charts/kafka/templates/statefulset-cluster.yaml
- charts/kafka/values.schema.json
- charts/kafka/values.yaml
+ charts/kafka/ci/combined-mode.yaml
+ charts/kafka/docs/combined-mode.md
+ charts/kafka/examples/combined-mode/README.md
+ charts/kafka/examples/combined-mode/values.yaml
```

## Checklist

- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Branch created from updated `main`
- [x] `helm lint --strict` passes
- [x] `helm template` tested with all CI scenarios
- [x] `values.schema.json` updated
- [x] Chart README updated
- [x] Architecture documentation created
- [x] Example configuration provided
- [x] CI test scenario added