### PR TITLE
fix(kafka): automatically remove lost+found from PVCs to prevent startup failures

### DIFF
--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -34,11 +34,13 @@ helm install kafka oci://ghcr.io/helmforgedev/helm/kafka -f values.yaml
 - KRaft only
 - official Kafka `4.2.0` runtime image
 - persistent storage for single-broker, controllers, and brokers
+- automatic cleanup of `lost+found` directories in PVCs (ext4/xfs compatibility)
 - stable in-cluster advertised listeners for brokers
 - explicit KRaft cluster ID and controller directory ID secret handling
 - optional Prometheus metrics through the JMX exporter javaagent
 - optional `ServiceMonitor`
 - optional `PodDisruptionBudget`
+- support for `extraInitContainers` for custom initialization logic
 
 ## What this chart does not try to automate in v1
 
@@ -170,6 +172,7 @@ See `examples/`:
 - the bootstrap service is internal-only in v1
 - broker advertised listeners use stable StatefulSet pod DNS names
 - for production, do not treat this chart as a shortcut around Kafka capacity planning, topic design, and client retry behavior
+- the chart automatically removes `lost+found` directories from PVCs during pod initialization to prevent Kafka startup failures on ext4/xfs filesystems
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/kafka/templates/statefulset-cluster.yaml
+++ b/charts/kafka/templates/statefulset-cluster.yaml
@@ -61,8 +61,30 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.metrics.enabled }}
       initContainers:
+        - name: cleanup-lost-found
+          image: {{ include "kafka.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ -d "${KAFKA_DATA_DIR}/lost+found" ]; then
+                echo "Removing ${KAFKA_DATA_DIR}/lost+found directory..."
+                rm -rf "${KAFKA_DATA_DIR}/lost+found"
+                echo "✓ lost+found removed successfully"
+              fi
+          env:
+            - name: KAFKA_DATA_DIR
+              value: /var/lib/kafka/controller-data
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka/controller-data
+        {{- if .Values.metrics.enabled }}
         - name: copy-jmx-agent
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
@@ -75,7 +97,10 @@ spec:
           volumeMounts:
             - name: jmx-agent
               mountPath: /jmx
-      {{- end }}
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: kafka
           image: {{ include "kafka.image" . | quote }}
@@ -256,8 +281,30 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.metrics.enabled }}
       initContainers:
+        - name: cleanup-lost-found
+          image: {{ include "kafka.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ -d "${KAFKA_DATA_DIR}/lost+found" ]; then
+                echo "Removing ${KAFKA_DATA_DIR}/lost+found directory..."
+                rm -rf "${KAFKA_DATA_DIR}/lost+found"
+                echo "✓ lost+found removed successfully"
+              fi
+          env:
+            - name: KAFKA_DATA_DIR
+              value: /var/lib/kafka/controller-data
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka/controller-data
+        {{- if .Values.metrics.enabled }}
         - name: copy-jmx-agent
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
@@ -270,7 +317,10 @@ spec:
           volumeMounts:
             - name: jmx-agent
               mountPath: /jmx
-      {{- end }}
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: kafka
           image: {{ include "kafka.image" . | quote }}

--- a/charts/kafka/templates/statefulset-single.yaml
+++ b/charts/kafka/templates/statefulset-single.yaml
@@ -59,8 +59,30 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.metrics.enabled }}
       initContainers:
+        - name: cleanup-lost-found
+          image: {{ include "kafka.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              if [ -d "${KAFKA_DATA_DIR}/lost+found" ]; then
+                echo "Removing ${KAFKA_DATA_DIR}/lost+found directory..."
+                rm -rf "${KAFKA_DATA_DIR}/lost+found"
+                echo "✓ lost+found removed successfully"
+              fi
+          env:
+            - name: KAFKA_DATA_DIR
+              value: /var/lib/kafka/data
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka/data
+        {{- if .Values.metrics.enabled }}
         - name: copy-jmx-agent
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
@@ -73,7 +95,10 @@ spec:
           volumeMounts:
             - name: jmx-agent
               mountPath: /jmx
-      {{- end }}
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: kafka
           image: {{ include "kafka.image" . | quote }}

--- a/charts/kafka/values.schema.json
+++ b/charts/kafka/values.schema.json
@@ -433,6 +433,11 @@
       "description": "Extra environment variables for Kafka containers",
       "items": { "type": "object" }
     },
+    "extraInitContainers": {
+      "type": "array",
+      "description": "Extra init containers for Kafka pods (in addition to built-in init containers)",
+      "items": { "type": "object" }
+    },
     "extraVolumeMounts": {
       "type": "array",
       "description": "Extra volume mounts for Kafka containers",

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -226,6 +226,8 @@ terminationGracePeriodSeconds: 120
 
 # -- Extra environment variables for Kafka containers
 extraEnv: []
+# -- Extra init containers for Kafka pods (in addition to built-in init containers)
+extraInitContainers: []
 # -- Extra volume mounts for Kafka containers
 extraVolumeMounts: []
 # -- Extra volumes for Kafka pods


### PR DESCRIPTION
## Summary

Automatically remove `lost+found` directories from Kafka PVCs during pod initialization to prevent startup failures on ext4/xfs filesystems.

## Problem

Kafka fails to start when PVCs contain a `lost+found` directory (automatically created by ext4/xfs filesystems on AWS EBS and other block storage). Kafka strictly validates that all directories in `log.dirs` must follow the `topic-partition` naming pattern:

```
org.apache.kafka.common.KafkaException: Found directory /var/lib/kafka/controller-data/lost+found, 
'lost+found' is not in the form of topic-partition or topic-partition.uniqueId-delete
```

This is a **common issue** that affects many users deploying Kafka on Kubernetes with persistent volumes.

## Solution

Add a built-in `cleanup-lost-found` initContainer that:
- Runs before Kafka starts
- Checks for `${KAFKA_DATA_DIR}/lost+found`
- Removes it if present (silent if not found)
- Uses the same Kafka image and security context

The initContainer is **always enabled** and runs on every pod start, but is lightweight (single directory check + rm).

## Additional Feature

Added support for `extraInitContainers` in values.yaml, allowing users to add custom initialization logic beyond the built-in cleanup.

## Changes

- ✅ `templates/statefulset-cluster.yaml`: Add cleanup-lost-found initContainer for controllers and brokers
- ✅ `templates/statefulset-single.yaml`: Add cleanup-lost-found initContainer for single-broker
- ✅ `values.yaml`: Add `extraInitContainers` field
- ✅ `values.schema.json`: Document `extraInitContainers` schema
- ✅ `README.md`: Document automatic cleanup and extraInitContainers support

## Testing

```bash
✓ helm lint --strict charts/kafka
✓ helm template (default values)
✓ helm template (all ci/*.yaml scenarios)
✓ Verified initContainer renders correctly in both architectures
✓ Verified cleanup-lost-found runs before other initContainers
```

## Example Rendered InitContainer

```yaml
initContainers:
  - name: cleanup-lost-found
    image: "docker.io/apache/kafka:4.2.0"
    imagePullPolicy: IfNotPresent
    command:
      - /bin/sh
      - -c
      - |
        if [ -d "${KAFKA_DATA_DIR}/lost+found" ]; then
          echo "Removing ${KAFKA_DATA_DIR}/lost+found directory..."
          rm -rf "${KAFKA_DATA_DIR}/lost+found"
          echo "✓ lost+found removed successfully"
        fi
    env:
      - name: KAFKA_DATA_DIR
        value: /var/lib/kafka/controller-data
    securityContext:
      runAsUser: 1000
      runAsGroup: 1000
      runAsNonRoot: true
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: false
    volumeMounts:
      - name: data
        mountPath: /var/lib/kafka/controller-data
```

## Files Changed

```
5 files changed, 91 insertions(+), 6 deletions(-)
- charts/kafka/README.md
- charts/kafka/templates/statefulset-cluster.yaml
- charts/kafka/templates/statefulset-single.yaml
- charts/kafka/values.schema.json
- charts/kafka/values.yaml
```

## User Impact

- **Positive**: Users no longer need to manually delete `lost+found` or add custom initContainers
- **No breaking changes**: The initContainer runs automatically with no configuration required
- **Performance**: Minimal overhead (single directory check on pod start)

## Related Issues

Resolves the common Kafka startup failure on ext4/xfs PVCs with lost+found directories.