### PR TITLE
fix(postgresql): skip REPLICATION_PASSWORD env and secret key on standalone

### DIFF
--- a/charts/postgresql/templates/secret.yaml
+++ b/charts/postgresql/templates/secret.yaml
@@ -9,7 +9,9 @@ type: Opaque
 data:
   {{ .Values.auth.existingSecretPostgresPasswordKey }}: {{ include "postgresql.postgresPassword" . | b64enc | quote }}
   {{ .Values.auth.existingSecretUserPasswordKey }}: {{ include "postgresql.userPassword" . | b64enc | quote }}
+  {{- if eq .Values.architecture "replication" }}
   {{ .Values.auth.existingSecretReplicationPasswordKey }}: {{ include "postgresql.replicationPassword" . | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- if and (include "postgresql.backupEnabled" .) (not .Values.backup.s3.existingSecret) }}
 ---

--- a/charts/postgresql/templates/statefulset-primary.yaml
+++ b/charts/postgresql/templates/statefulset-primary.yaml
@@ -57,13 +57,15 @@ spec:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
                   key: {{ .Values.auth.existingSecretUserPasswordKey }}
+            {{- if eq .Values.architecture "replication" }}
             - name: REPLICATION_USERNAME
-              value: {{ ternary .Values.auth.replicationUsername "" (eq .Values.architecture "replication") | quote }}
+              value: {{ .Values.auth.replicationUsername | quote }}
             - name: REPLICATION_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
                   key: {{ .Values.auth.existingSecretReplicationPasswordKey }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: PGSSLMODE
               value: {{ .Values.tls.sslMode | quote }}

--- a/charts/postgresql/tests/secret_test.yaml
+++ b/charts/postgresql/tests/secret_test.yaml
@@ -22,7 +22,18 @@ tests:
           path: type
           value: Opaque
 
-  - it: should contain required password keys
+  - it: should contain required password keys on standalone
+    asserts:
+      - isNotNull:
+          path: data["postgres-password"]
+      - isNotNull:
+          path: data["user-password"]
+      - notExists:
+          path: data["replication-password"]
+
+  - it: should contain replication-password key on replication architecture
+    set:
+      architecture: replication
     asserts:
       - isNotNull:
           path: data["postgres-password"]


### PR DESCRIPTION
## Summary

- `REPLICATION_PASSWORD` env was always mounted in the pod regardless of architecture, causing pod failures when using `existingSecret` on `standalone` without the `replication-password` key
- `replication-password` key was always included in the generated secret, even on `standalone`
- Both are now guarded by `{{- if eq .Values.architecture "replication" }}`

## Changes

- `templates/statefulset-primary.yaml`: wrap `REPLICATION_USERNAME` and `REPLICATION_PASSWORD` env vars in architecture check
- `templates/secret.yaml`: wrap `replication-password` key in architecture check

## Test plan

- [ ] Helm template with `architecture: standalone` + `existingSecret` — no `REPLICATION_PASSWORD` env in pod spec
- [ ] Helm template with `architecture: standalone` + `existingSecret` — no `replication-password` key in generated secret
- [ ] Helm template with `architecture: replication` — `REPLICATION_PASSWORD` and `replication-password` still present
- [ ] CI `existing-secret.yaml` passes