### PR TITLE
fix(postgresql): use default-empty for REPLICATION vars in init script on standalone

### DIFF
--- a/charts/postgresql/templates/configmap.yaml
+++ b/charts/postgresql/templates/configmap.yaml
@@ -76,8 +76,8 @@ data:
       --set=app_username="${APP_USERNAME}" \
       --set=app_password="${APP_PASSWORD}" \
       --set=app_database="${APP_DATABASE}" \
-      --set=replication_username="${REPLICATION_USERNAME}" \
-      --set=replication_password="${REPLICATION_PASSWORD}" <<'SQL'
+      --set=replication_username="${REPLICATION_USERNAME:-}" \
+      --set=replication_password="${REPLICATION_PASSWORD:-}" <<'SQL'
     SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'app_username', :'app_password')
     WHERE :'app_username' <> ''
       AND :'app_password' <> ''


### PR DESCRIPTION
## Summary

- On `standalone` architecture, `REPLICATION_USERNAME` and `REPLICATION_PASSWORD` are not injected as env vars (fixed in #90)
- The init script `01-init-users.sh` uses `set -euo pipefail` — the `-u` flag causes bash to fail with `unbound variable` when those vars are referenced but not set
- Fix: use `${REPLICATION_USERNAME:-}` and `${REPLICATION_PASSWORD:-}` to default to empty string
- The SQL already handles empty values gracefully with `WHERE :'replication_username' <> ''`

## Test plan

- [ ] Deploy with `architecture: standalone` + `existingSecret` — pod starts without `unbound variable` error
- [ ] Deploy with `architecture: replication` — replication user still created correctly
- [ ] `helm unittest` passes