### PR TITLE
fix(ci): make GHCR OCI packages public after push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,6 +234,25 @@ jobs:
             echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           done
 
+      - name: Make OCI package public
+        if: steps.semver.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHART="${{ matrix.chart }}"
+          ENCODED="helm%2F${CHART}"
+          STATUS=$(gh api "orgs/${{ github.repository_owner }}/packages/container/${ENCODED}" --jq '.visibility' 2>/dev/null || echo "unknown")
+          echo "Current visibility for ${CHART}: ${STATUS}"
+          if [ "$STATUS" != "public" ]; then
+            echo "Setting ${CHART} package visibility to public..."
+            gh api --method PATCH "orgs/${{ github.repository_owner }}/packages/container/${ENCODED}" \
+              --field visibility=public \
+              && echo "✓ Package is now public" \
+              || echo "⚠ Could not set visibility (may need write:packages scope or manual org setting)"
+          else
+            echo "✓ Package is already public"
+          fi
+
       - name: Upload provenance file
         if: steps.semver.outputs.skip != 'true'
         id: prov

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -1,5 +1,6 @@
 # =============================================================================
 # PostgreSQL Helm Chart - Default Values
+# https://helmforge.dev/docs/charts/postgresql
 # =============================================================================
 # Supported architectures:
 # - standalone


### PR DESCRIPTION
## Problem

Fixes #92

New GHCR container packages created by `GITHUB_TOKEN` under an **org** are **private by default**. This means any chart that was published for the first time (package didn't yet exist in GHCR) gets a private package, causing `helm install` via OCI to fail with:

```
Error: GET "https://ghcr.io/v2/helmforgedev/helm/postgresql/tags/list":
response status code 403: denied: permission_denied: read_package
```

Charts like `postgresql` and `redis` were confirmed affected. The CI shows the push succeeds, but the package remains private — so authenticated pushes work, but anonymous pulls fail.

## Root Cause

GHCR docs state: *"When you first publish a package, the default visibility is private if the package is in a namespace owned by an organization."*

The `publish.yml` workflow had `packages: write` permission and successfully pushed to GHCR, but never explicitly set the package visibility to `public`.

## Fix

Adds a **"Make OCI package public"** step immediately after `helm push`. It:
1. Checks the current GHCR package visibility via the GitHub API
2. If not already `public`, sets it to `public` using `PATCH /orgs/{org}/packages/container/{encoded_name}`
3. Uses the existing `packages: write` permission — no new secrets or permissions required
4. Fails gracefully with a warning if the API call doesn't succeed (non-blocking)

## Test Plan

- [ ] Trigger `publish.yml` on a chart change and confirm the new step logs `✓ Package is now public` or `✓ Package is already public`
- [ ] Confirm `helm install my-pg oci://ghcr.io/helmforgedev/helm/postgresql` works without authentication after the workflow runs
- [ ] Verify no regression on charts already public (step is idempotent)