### PR TITLE
fix(ci): revert OCI visibility step; add .helmignore to postgresql

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -234,25 +234,6 @@ jobs:
             echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           done
 
-      - name: Make OCI package public
-        if: steps.semver.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          CHART="${{ matrix.chart }}"
-          ENCODED="helm%2F${CHART}"
-          STATUS=$(gh api "orgs/${{ github.repository_owner }}/packages/container/${ENCODED}" --jq '.visibility' 2>/dev/null || echo "unknown")
-          echo "Current visibility for ${CHART}: ${STATUS}"
-          if [ "$STATUS" != "public" ]; then
-            echo "Setting ${CHART} package visibility to public..."
-            gh api --method PATCH "orgs/${{ github.repository_owner }}/packages/container/${ENCODED}" \
-              --field visibility=public \
-              && echo "✓ Package is now public" \
-              || echo "⚠ Could not set visibility (may need write:packages scope or manual org setting)"
-          else
-            echo "✓ Package is already public"
-          fi
-
       - name: Upload provenance file
         if: steps.semver.outputs.skip != 'true'
         id: prov

--- a/charts/postgresql/.helmignore
+++ b/charts/postgresql/.helmignore
@@ -1,0 +1,28 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.gitattributes
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Helm test values
+ci/
+# OS files
+Thumbs.db

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -1,6 +1,5 @@
 # =============================================================================
 # PostgreSQL Helm Chart - Default Values
-# https://helmforge.dev/docs/charts/postgresql
 # =============================================================================
 # Supported architectures:
 # - standalone


### PR DESCRIPTION
## Summary

- Removes the "Make OCI package public" step from `publish.yml` — the root cause (issue #92) was resolved at org level by enabling the GHCR org setting that defaults new packages to public. The workflow step is no longer needed and was non-functional with `GITHUB_TOKEN` anyway.
- Reverts the docs link comment added to `values.yaml` as a test trigger in #93.
- Adds missing `.helmignore` to the `postgresql` chart (GR-037 compliance).

The `postgresql` chart change will trigger an automatic patch bump to validate that the org-level fix works end-to-end.

## Test Plan

- [x] CI detects `postgresql` as changed and bumps the version
- [x] `helm install my-pg oci://ghcr.io/helmforgedev/helm/postgresql` succeeds without authentication
- [x] No `403: permission_denied` errors