### PR TITLE
fix(pihole): run gravity update after managed lists

### DIFF
--- a/charts/pihole/.helmignore
+++ b/charts/pihole/.helmignore
@@ -9,6 +9,7 @@ Thumbs.db
 
 # Helm
 .helmignore
+*.tgz
 
 # Editors / IDE
 .vscode/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -131,6 +131,8 @@ metrics:
 | `pihole.upstreamDns` | `8.8.8.8;8.8.4.4` | Upstream DNS servers (semicolon-delimited) |
 | `pihole.listeningMode` | `ALL` | DNS listening mode (LOCAL, ALL, SINGLE, BIND) |
 | `pihole.dnssec` | `false` | Enable DNSSEC validation |
+| `pihole.ftl.rateLimit` | `1000` | Rate limiting query count per client; set to `0` to disable |
+| `pihole.ftl.rateLimitInterval` | `60` | Rate limiting interval in seconds |
 | `pihole.extraEnv` | `[]` | Additional environment variables |
 
 ### Admin

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -153,6 +153,15 @@ metrics:
 | `dns.blacklist` | `[]` | Blacklisted domains |
 | `dns.regex` | `[]` | Regex filters for blocking |
 
+### Gravity
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `gravity.enabled` | `true` | Reconcile Pi-hole gravity schema and Helm-managed lists before Pi-hole starts |
+| `gravity.updateOnInit` | `true` | Run `pihole -g` in a follow-up init container after Helm-managed lists are reconciled |
+| `gravity.resources` | `{}` | Resources for the gravity schema/list init container |
+| `gravity.updateResources` | `{}` | Resources for the gravity update init container |
+
 ### Persistence
 
 | Key | Default | Description |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -103,10 +103,10 @@ spec:
             - name: FTLCONF_dns_cname_inspection
               value: "false"
             {{- end }}
-            {{- if .Values.pihole.ftl.rateLimit }}
-            - name: FTLCONF_dns_ratelimit
+            - name: FTLCONF_dns_rateLimit_count
               value: {{ .Values.pihole.ftl.rateLimit | quote }}
-            {{- end }}
+            - name: FTLCONF_dns_rateLimit_interval
+              value: {{ ternary 0 .Values.pihole.ftl.rateLimitInterval (eq (int .Values.pihole.ftl.rateLimit) 0) | quote }}
             {{- if .Values.pihole.ftl.blockAAAA }}
             - name: FTLCONF_dns_blockAAAA
               value: "true"
@@ -169,10 +169,10 @@ spec:
             - name: FTLCONF_dns_cname_inspection
               value: "false"
             {{- end }}
-            {{- if .Values.pihole.ftl.rateLimit }}
-            - name: FTLCONF_dns_ratelimit
+            - name: FTLCONF_dns_rateLimit_count
               value: {{ .Values.pihole.ftl.rateLimit | quote }}
-            {{- end }}
+            - name: FTLCONF_dns_rateLimit_interval
+              value: {{ ternary 0 .Values.pihole.ftl.rateLimitInterval (eq (int .Values.pihole.ftl.rateLimit) 0) | quote }}
             {{- if .Values.pihole.ftl.blockAAAA }}
             - name: FTLCONF_dns_blockAAAA
               value: "true"

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -61,6 +61,75 @@ spec:
             - name: gravity-init-scripts
               mountPath: /scripts
               readOnly: true
+        {{- if .Values.gravity.updateOnInit }}
+        - name: gravity-update
+          image: {{ include "pihole.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Running Pi-hole gravity update after Helm-managed lists were reconciled..."
+              pihole-FTL --config >/dev/null
+              pihole -g
+          env:
+            - name: TZ
+              value: {{ .Values.pihole.timezone | quote }}
+            - name: FTLCONF_dns_upstreams
+              value: {{ include "pihole.upstreamDns" . | quote }}
+            - name: FTLCONF_dns_listeningMode
+              value: {{ .Values.pihole.listeningMode | quote }}
+            {{- if .Values.pihole.dnssec }}
+            - name: FTLCONF_dns_dnssec
+              value: "true"
+            {{- end }}
+            - name: FTLCONF_webserver_api_password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pihole.secretName" . }}
+                  key: {{ include "pihole.secretKey" . }}
+            - name: FTLCONF_misc_etc_dnsmasq_d
+              value: "true"
+            {{- if .Values.pihole.ftl.cacheSize }}
+            - name: FTLCONF_dns_cache_size
+              value: {{ .Values.pihole.ftl.cacheSize | quote }}
+            {{- end }}
+            {{- if ne (int .Values.pihole.ftl.privacyLevel) 0 }}
+            - name: FTLCONF_misc_privacylevel
+              value: {{ .Values.pihole.ftl.privacyLevel | quote }}
+            {{- end }}
+            {{- if not .Values.pihole.ftl.cnameInspection }}
+            - name: FTLCONF_dns_cname_inspection
+              value: "false"
+            {{- end }}
+            {{- if .Values.pihole.ftl.rateLimit }}
+            - name: FTLCONF_dns_ratelimit
+              value: {{ .Values.pihole.ftl.rateLimit | quote }}
+            {{- end }}
+            {{- if .Values.pihole.ftl.blockAAAA }}
+            - name: FTLCONF_dns_blockAAAA
+              value: "true"
+            {{- end }}
+            {{- if not .Values.pihole.ftl.queryLogging }}
+            - name: FTLCONF_misc_queryLogging
+              value: "false"
+            {{- end }}
+            {{- if not .Values.pihole.ftl.useDatabase }}
+            - name: FTLCONF_database_DBfile
+              value: ""
+            {{- end }}
+            {{- with .Values.pihole.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.gravity.updateResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: pihole-data
+              mountPath: /etc/pihole
+        {{- end }}
       {{- end }}
       containers:
         - name: pihole

--- a/charts/pihole/templates/gravity-init-configmap.yaml
+++ b/charts/pihole/templates/gravity-init-configmap.yaml
@@ -123,7 +123,7 @@ data:
     echo "Gravity database populated successfully."
 
     {{- if .Values.gravity.updateOnInit }}
-    echo "Gravity init complete. Pi-hole will run gravity update on startup."
+    echo "Gravity init complete. The gravity-update init container will run pihole -g next."
     {{- else }}
     echo "Skipping gravity update (gravity.updateOnInit=false)."
     echo "Run 'pihole -g' manually inside the container to update gravity."

--- a/charts/pihole/tests/deployment_test.yaml
+++ b/charts/pihole/tests/deployment_test.yaml
@@ -89,6 +89,65 @@ tests:
             name: FTLCONF_misc_etc_dnsmasq_d
             value: "true"
 
+  - it: should set Pi-hole v6 rate limit env vars
+    template: templates/deployment.yaml
+    set:
+      pihole.ftl.rateLimit: 2000
+      pihole.ftl.rateLimitInterval: 120
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FTLCONF_dns_rateLimit_count
+            value: "2000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FTLCONF_dns_rateLimit_interval
+            value: "120"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FTLCONF_dns_ratelimit
+
+  - it: should set Pi-hole v6 rate limit env vars on gravity update init container
+    template: templates/deployment.yaml
+    set:
+      pihole.ftl.rateLimit: 2000
+      pihole.ftl.rateLimitInterval: 120
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: FTLCONF_dns_rateLimit_count
+            value: "2000"
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: FTLCONF_dns_rateLimit_interval
+            value: "120"
+      - notContains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: FTLCONF_dns_ratelimit
+
+  - it: should disable Pi-hole v6 rate limiting with zero values
+    template: templates/deployment.yaml
+    set:
+      pihole.ftl.rateLimit: 0
+      pihole.ftl.rateLimitInterval: 120
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FTLCONF_dns_rateLimit_count
+            value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FTLCONF_dns_rateLimit_interval
+            value: "0"
+
   - it: should include extra env vars
     template: templates/deployment.yaml
     set:

--- a/charts/pihole/tests/deployment_test.yaml
+++ b/charts/pihole/tests/deployment_test.yaml
@@ -334,6 +334,55 @@ tests:
           path: spec.template.spec.containers[1].image
           value: "docker.io/mvance/unbound:1.22.0"
 
+  - it: should run gravity update init container by default
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: gravity-update
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: "docker.io/pihole/pihole:2026.04.0"
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].command[2]
+          pattern: "pihole -g"
+      - contains:
+          path: spec.template.spec.initContainers[1].volumeMounts
+          content:
+            name: pihole-data
+            mountPath: /etc/pihole
+
+  - it: should not run gravity update init container when disabled
+    template: templates/deployment.yaml
+    set:
+      gravity.updateOnInit: false
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: gravity-update
+
+  - it: should set resources on gravity update init container
+    template: templates/deployment.yaml
+    set:
+      gravity.updateResources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.initContainers[1].resources.limits.memory
+          value: 512Mi
+
   - it: should override upstream DNS to unbound when enabled
     template: templates/deployment.yaml
     set:

--- a/charts/pihole/tests/gravity_init_configmap_test.yaml
+++ b/charts/pihole/tests/gravity_init_configmap_test.yaml
@@ -49,6 +49,12 @@ tests:
           path: data["init-gravity.sh"]
           pattern: "INSERT OR IGNORE INTO adlist \\(address, type, enabled, comment\\) VALUES \\('https://example.com/block.txt', 0, 1, 'Added by Helm chart'\\)"
 
+  - it: should report that gravity update runs in a follow-up init container
+    asserts:
+      - matchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "gravity-update init container will run pihole -g next"
+
   - it: should not render when gravity is disabled
     set:
       gravity.enabled: false

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -99,8 +99,15 @@
             },
             "rateLimit": {
               "type": "integer",
-              "description": "Rate limiting (queries/sec per client, 0=disabled)",
+              "description": "Rate limiting query count per client; set to 0 to disable rate limiting",
+              "minimum": 0,
               "default": 1000
+            },
+            "rateLimitInterval": {
+              "type": "integer",
+              "description": "Rate limiting interval in seconds",
+              "minimum": 0,
+              "default": 60
             },
             "blockAAAA": {
               "type": "boolean",

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -359,6 +359,10 @@
         "resources": {
           "type": "object",
           "description": "Resources for the init container"
+        },
+        "updateResources": {
+          "type": "object",
+          "description": "Resources for the gravity update init container"
         }
       }
     },

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -58,8 +58,10 @@ pihole:
     privacyLevel: 0
     # -- Block CNAME-cloaked trackers (default: true)
     cnameInspection: true
-    # -- Rate limiting (queries/sec per client, 0=disabled)
+    # -- Rate limiting query count per client; set to 0 to disable rate limiting
     rateLimit: 1000
+    # -- Rate limiting interval in seconds
+    rateLimitInterval: 60
     # -- Block AAAA queries on A-only networks (default: false)
     blockAAAA: false
     # -- Query logging (default: true)
@@ -639,3 +641,4 @@ extraManifests: []
 #   ftl:
 #     cacheSize: 20000
 #     rateLimit: 2000
+#     rateLimitInterval: 60

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -219,6 +219,15 @@ gravity:
     #   cpu: 200m
     #   memory: 128Mi
 
+  # -- Resources for the gravity update init container
+  updateResources: {}
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+
 # =============================================================================
 # Backup Automation
 # =============================================================================


### PR DESCRIPTION
## Summary
- add a gravity-update init container that runs pihole -g after Helm-managed adlists/domain lists are reconciled
- keep gravity.updateOnInit as the switch for automatic gravity download on startup
- add gravity.updateResources, README/schema docs, and Helm unit tests
- replace the invalid Pi-hole v6 FTLCONF_dns_ratelimit env var with FTLCONF_dns_rateLimit_count and FTLCONF_dns_rateLimit_interval
- include packaged chart archives in the pihole .helmignore baseline

## Why
The previous gravity-init container created gravity.db and inserted managed adlist URLs before the official Pi-hole container started. The official image only runs pihole -g on boot when gravity.db is missing, so managed lists could appear in the UI without being downloaded until a manual gravity update.

Pi-hole v6 also treats rate limiting as dns.rateLimit.count and dns.rateLimit.interval. Rendering FTLCONF_dns_ratelimit causes FTL to report it as unknown, so the chart now emits the documented v6 variables and supports rateLimit: 0 by rendering both values as 0.

## Testing
- helm lint --strict charts/pihole
- helm unittest charts/pihole
- helm template rate-limit-test charts/pihole --set pihole.ftl.rateLimit=2000 --set pihole.ftl.rateLimitInterval=120
- helm template rate-limit-test charts/pihole --set pihole.ftl.rateLimit=0 --set pihole.ftl.rateLimitInterval=120
- git diff --check
- k3d smoke test on context k3d-charts-test: release pihole-ratelimit-test deployed successfully; Pi-hole logged 7 FTLCONF environment variables found (7 used, 0 invalid, 0 ignored) and listed FTLCONF_dns_rateLimit_count/interval as used