### PR TITLE
fix(postgresql): use template1 for maintenance connections

### DIFF
--- a/charts/postgresql/.helmignore
+++ b/charts/postgresql/.helmignore
@@ -23,6 +23,8 @@
 *.tmproj
 .vscode/
 # Helm test values
+.helmignore
+*.tgz
 ci/
 # OS files
 Thumbs.db

--- a/charts/postgresql/docs/backup-restore.md
+++ b/charts/postgresql/docs/backup-restore.md
@@ -43,7 +43,7 @@ psql \
   --host <postgres-host> \
   --port 5432 \
   --username postgres \
-  --dbname postgres \
+  --dbname template1 \
   --file /tmp/postgresql-restore.sql
 ```
 

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -165,13 +165,17 @@ app.kubernetes.io/role: {{ .role }}
 {{- end -}}
 {{- end -}}
 
+{{- define "postgresql.maintenanceDatabase" -}}
+template1
+{{- end -}}
+
 {{- define "postgresql.probeCommandString" -}}
-{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p {{ .Values.service.port }}
+{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }}
 {{- end -}}
 
 {{- define "postgresql.primaryReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") .Values.replication.primary.probes.requireWritable -}}
-{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
+{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
 {{- else -}}
 {{ include "postgresql.probeCommandString" . }}
 {{- end -}}
@@ -179,7 +183,7 @@ app.kubernetes.io/role: {{ .role }}
 
 {{- define "postgresql.replicaReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") .Values.replication.readReplicas.probes.requireRecoveryMode -}}
-{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1
+{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1
 {{- else -}}
 {{ include "postgresql.probeCommandString" . }}
 {{- end -}}
@@ -187,7 +191,7 @@ app.kubernetes.io/role: {{ .role }}
 
 {{- define "postgresql.metricsEnv" -}}
 - name: DATA_SOURCE_URI
-  value: 127.0.0.1:{{ .Values.service.port }}/postgres?sslmode={{ if .Values.tls.enabled }}{{ .Values.tls.sslMode }}{{ else }}disable{{ end }}{{ if and .Values.tls.enabled (or (eq .Values.tls.sslMode "verify-ca") (eq .Values.tls.sslMode "verify-full")) }}&sslrootcert=/tls/{{ .Values.tls.caFilename }}{{ end }}
+  value: 127.0.0.1:{{ .Values.service.port }}/{{ include "postgresql.maintenanceDatabase" . }}?sslmode={{ if .Values.tls.enabled }}{{ .Values.tls.sslMode }}{{ else }}disable{{ end }}{{ if and .Values.tls.enabled (or (eq .Values.tls.sslMode "verify-ca") (eq .Values.tls.sslMode "verify-full")) }}&sslrootcert=/tls/{{ .Values.tls.caFilename }}{{ end }}
 - name: DATA_SOURCE_USER
   value: postgres
 - name: DATA_SOURCE_PASS

--- a/charts/postgresql/templates/backup-configmap.yaml
+++ b/charts/postgresql/templates/backup-configmap.yaml
@@ -16,7 +16,8 @@ data:
     pg_dumpall ${PG_DUMPALL_EXTRA_ARGS:-} \
       --host="${DB_HOST}" \
       --port="${DB_PORT}" \
-      --username=postgres | gzip -c > "${archive}"
+      --username=postgres \
+      --database=template1 | gzip -c > "${archive}"
     printf "%s" "${archive}" > /backup/out/backup-file
   upload-backup.sh: |
     #!/bin/sh

--- a/charts/postgresql/templates/configmap.yaml
+++ b/charts/postgresql/templates/configmap.yaml
@@ -72,7 +72,7 @@ data:
     #!/bin/bash
     set -euo pipefail
     export PGPASSWORD="${POSTGRES_PASSWORD}"
-    psql --username "${POSTGRES_USER}" --dbname postgres \
+    psql --username "${POSTGRES_USER}" --dbname template1 \
       --set=app_username="${APP_USERNAME}" \
       --set=app_password="${APP_PASSWORD}" \
       --set=app_database="${APP_DATABASE}" \

--- a/charts/postgresql/tests/backup_test.yaml
+++ b/charts/postgresql/tests/backup_test.yaml
@@ -30,6 +30,9 @@ tests:
     asserts:
       - isKind:
           of: ConfigMap
+      - matchRegex:
+          path: data["postgresql-backup.sh"]
+          pattern: "--database=template1"
 
   - it: should render backup cronjob
     set:

--- a/charts/postgresql/tests/configmap_test.yaml
+++ b/charts/postgresql/tests/configmap_test.yaml
@@ -1,0 +1,14 @@
+suite: ConfigMap
+templates:
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should initialize app roles through template1 maintenance database
+    template: configmap.yaml
+    documentIndex: 1
+    asserts:
+      - matchRegex:
+          path: data["01-init-users.sh"]
+          pattern: 'psql --username "\$\{POSTGRES_USER\}" --dbname template1'

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -124,6 +124,9 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].livenessProbe
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p 5432 -d template1
 
   - it: should have readiness probe by default
     template: statefulset-primary.yaml
@@ -136,6 +139,18 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p 5432 -d template1
+
+  - it: should use template1 for replication primary readiness check
+    template: statefulset-primary.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d template1 -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
 
   - it: should create VolumeClaimTemplate when persistence is enabled
     template: statefulset-primary.yaml
@@ -200,6 +215,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].name
           value: postgres-exporter
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DATA_SOURCE_URI
+            value: 127.0.0.1:5432/template1?sslmode=disable
 
   - it: should not mount TLS volume by default
     template: statefulset-primary.yaml

--- a/charts/postgresql/tests/statefulset_replicas_test.yaml
+++ b/charts/postgresql/tests/statefulset_replicas_test.yaml
@@ -1,0 +1,16 @@
+suite: StatefulSet Replicas
+templates:
+  - statefulset-replicas.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should use template1 for replica recovery readiness check
+    template: statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d template1 -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1


### PR DESCRIPTION
## Summary
- Use `template1` for PostgreSQL internal maintenance connections instead of assuming a user-created `postgres` database exists.
- Update liveness/startup/readiness probes, metrics exporter URI, init script, backup script, and restore docs.
- Add unittest coverage for probes, exporter, initdb, backup, and replica readiness.
- Keep the PostgreSQL chart `.helmignore` aligned with Helm package ignore patterns.

## Why
A reused PVC can contain a valid PostgreSQL data directory without a `postgres` database. In that case the official image skips initialization and the current chart keeps logging `FATAL: database "postgres" does not exist` from internal checks.

## Testing
- `helm lint charts/postgresql --strict`
- `helm unittest charts/postgresql`
- Rendered all `charts/postgresql/ci/*.yaml` scenarios
- MCP HelmForge release readiness: PASS

## Docs
Companion site PR: https://github.com/helmforgedev/site/pull/150