### PR TITLE
fix(postgresql): keep postgres as maintenance database

### DIFF
--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: use template1 for maintenance connections (#102)
+      description: keep `postgres` as the maintenance database and repair it automatically on reused PVCs when missing (#102)
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -156,6 +156,8 @@ metrics:
 - use `initdb.scripts` for deterministic first-boot SQL or shell customization
 - use `initdb.existingConfigMap` when scripts are already managed elsewhere
 - remember that `docker-entrypoint-initdb.d` runs only during first initialization of a fresh data directory
+- the chart keeps internal maintenance traffic on PostgreSQL's standard `postgres` database
+- when an older reused PVC is missing `postgres`, the primary pod repairs that database during startup before probes and internal clients depend on it
 
 ### Observability
 
@@ -181,6 +183,7 @@ metrics:
 - use the `replicas` Service only for read traffic
 - use the `replicas` Service when you need horizontal scale for read-only workloads
 - built-in backup dumps all PostgreSQL databases and global objects from the writable primary endpoint and uploads the compressed archive to S3-compatible storage
+- internal probes, metrics, backup, and administrative validation commands are expected to succeed against `postgres`
 - treat restore validation, retention policy, WAL strategy, and failover as operational workflows that still require explicit runbooks
 - review the operational guides before promoting `replication` to production
 

--- a/charts/postgresql/docs/backup-restore.md
+++ b/charts/postgresql/docs/backup-restore.md
@@ -43,7 +43,7 @@ psql \
   --host <postgres-host> \
   --port 5432 \
   --username postgres \
-  --dbname template1 \
+  --dbname postgres \
   --file /tmp/postgresql-restore.sql
 ```
 

--- a/charts/postgresql/templates/NOTES.txt
+++ b/charts/postgresql/templates/NOTES.txt
@@ -1,26 +1,153 @@
-PostgreSQL release: {{ .Release.Name }}
+======================================================================
+ PostgreSQL has been deployed
+======================================================================
 
-Architecture: {{ .Values.architecture }}
-Client service: {{ include "postgresql.clientServiceName" . }}
-Primary service: {{ include "postgresql.primaryServiceName" . }}
-Port: {{ .Values.service.port }}
+Release:            {{ .Release.Name }}
+Namespace:          {{ .Release.Namespace }}
+Architecture:       {{ .Values.architecture }}
+Client Service:     {{ include "postgresql.clientServiceName" . }}
+Primary Service:    {{ include "postgresql.primaryServiceName" . }}
+Port:               {{ .Values.service.port }}
+Maintenance DB:     postgres
+Application DB:     {{ .Values.auth.database }}
+Application User:   {{ .Values.auth.username }}
 {{- if eq .Values.architecture "replication" }}
-Replicas service: {{ include "postgresql.replicasServiceName" . }}
-
-This chart provides asynchronous replication with a fixed writable primary.
-It does not implement automatic failover or operator-style cluster management.
+Replicas Service:   {{ include "postgresql.replicasServiceName" . }}
+Replica Count:      {{ .Values.replication.readReplicas.replicaCount }}
 {{- end }}
 
-Get the generated secret:
-  kubectl get secret {{ include "postgresql.secretName" . }} -n {{ .Release.Namespace }} -o yaml
+======================================================================
+ ACCESS
+======================================================================
 
-Connect using port-forward:
-  kubectl port-forward svc/{{ include "postgresql.primaryServiceName" . }} 5432:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+Port-forward the writable endpoint:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "postgresql.primaryServiceName" . }} 5432:{{ .Values.service.port }}
 
-Get the PostgreSQL superuser password:
-  kubectl get secret {{ include "postgresql.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretPostgresPasswordKey }}}" | base64 -d
+Connect with psql to the default PostgreSQL maintenance database:
+  PGPASSWORD="$(kubectl get secret {{ include "postgresql.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretPostgresPasswordKey }}}" | base64 -d)" \
+  psql -h 127.0.0.1 -p 5432 -U postgres -d postgres
 
-Basic troubleshooting:
-  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+Connect to the application database:
+  PGPASSWORD="$(kubectl get secret {{ include "postgresql.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretUserPasswordKey }}}" | base64 -d)" \
+  psql -h 127.0.0.1 -p 5432 -U {{ .Values.auth.username }} -d {{ .Values.auth.database }}
+
+{{- if eq .Values.architecture "replication" }}
+Read-only clients should use:
+  {{ include "postgresql.replicasServiceName" . }}:{{ .Values.service.port }}
+
+Writable clients should use:
+  {{ include "postgresql.primaryServiceName" . }}:{{ .Values.service.port }}
+{{- end }}
+
+======================================================================
+ CONFIGURATION
+======================================================================
+
+- The chart keeps internal probes, metrics, and backup workflows on the standard `postgres` database.
+- If a reused data directory is missing `postgres`, the primary pod repairs it automatically during startup before normal readiness checks rely on it.
+- The application bootstrap database remains `{{ .Values.auth.database }}` and is created only on first initialization of a fresh data directory.
+- `docker-entrypoint-initdb.d` scripts do not run again on reused PVCs.
+{{- if .Values.tls.enabled }}
+- TLS is enabled for server and internal clients with sslmode `{{ .Values.tls.sslMode }}`.
+{{- else }}
+- TLS is disabled for internal chart traffic.
+{{- end }}
+{{- if .Values.metrics.enabled }}
+- Metrics exporter is enabled on port `{{ .Values.service.metricsPort }}`.
+{{- end }}
+{{- if .Values.backup.enabled }}
+- Built-in logical backup CronJob is enabled with schedule `{{ .Values.backup.schedule }}`.
+{{- end }}
+
+======================================================================
+ GETTING STARTED
+======================================================================
+
+1. Wait for PostgreSQL to become ready:
+   kubectl wait --for=condition=ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --timeout=600s
+
+2. List the chart resources:
+   kubectl get all -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+3. Confirm the `postgres` and application databases exist:
+   kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -- \
+     psql -U postgres -d postgres -tAc "SELECT datname FROM pg_database ORDER BY datname;"
+
+4. Validate basic SQL connectivity:
+   kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -- \
+     psql -U postgres -d postgres -c "SELECT current_database(), current_user, version();"
+
+{{- if eq .Values.architecture "replication" }}
+5. Validate replication state from the primary:
+   kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -- \
+     psql -U postgres -d postgres -c "SELECT application_name, state, sync_state FROM pg_stat_replication;"
+{{- end }}
+
+======================================================================
+ VALIDATION
+======================================================================
+
+Check pod readiness and restarts:
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+
+Inspect recent logs from all running containers:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200
+
+Inspect the primary PostgreSQL container logs directly:
+  kubectl logs -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -c postgresql --tail=200
+
+Check that PostgreSQL accepts connections on `postgres`:
+  kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -- \
+    pg_isready -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d postgres
+
+{{- if .Values.metrics.enabled }}
+Validate metrics output:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "postgresql.primaryMetricsServiceName" . }} {{ .Values.service.metricsPort }}:{{ .Values.service.metricsPort }}
+  curl http://127.0.0.1:{{ .Values.service.metricsPort }}/metrics
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+Check the backup CronJob and recent Jobs:
+  kubectl get cronjob,jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- end }}
+
+======================================================================
+ TROUBLESHOOTING
+======================================================================
+
+Describe a failing pod:
   kubectl describe pod -n {{ .Release.Namespace }} <pod-name>
-  kubectl logs -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0
+
+Check database list if you suspect an old PVC is missing the default database:
+  kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -- \
+    psql -U postgres -d template1 -tAc "SELECT datname FROM pg_database WHERE datname = 'postgres';"
+
+Check primary PostgreSQL events and warnings:
+  kubectl logs -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -c postgresql --since=10m
+
+{{- if eq .Values.architecture "replication" }}
+Check replica recovery state:
+  kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.replicaStatefulSetName" . }}-0 -- \
+    psql -U postgres -d postgres -tAc "SELECT pg_is_in_recovery();"
+{{- end }}
+
+======================================================================
+ RESOURCES
+======================================================================
+
+HelmForge chart docs:
+  https://helmforge.dev/docs/charts/postgresql
+
+Chart source:
+  https://github.com/helmforgedev/charts/tree/main/charts/postgresql
+
+Official PostgreSQL website:
+  https://www.postgresql.org
+
+Official PostgreSQL documentation:
+  https://www.postgresql.org/docs/current/
+
+Official PostgreSQL Docker image:
+  https://hub.docker.com/_/postgres
+
+Happy Helmforging :)

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -166,16 +166,36 @@ app.kubernetes.io/role: {{ .role }}
 {{- end -}}
 
 {{- define "postgresql.maintenanceDatabase" -}}
-template1
+postgres
+{{- end -}}
+
+{{- define "postgresql.libpqEnvExports" -}}
+{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end -}}
 {{- end -}}
 
 {{- define "postgresql.probeCommandString" -}}
-{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }}
+{{- include "postgresql.libpqEnvExports" . }}PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }}
+{{- end -}}
+
+{{- define "postgresql.primaryStartupProbeCommandString" -}}
+DATA_DIR="${PGDATA:-/var/lib/postgresql/data/pgdata}"
+if [ ! -s "${DATA_DIR}/PG_VERSION" ]; then
+  exit 1
+fi
+{{ include "postgresql.libpqEnvExports" . }}export PGPASSWORD="${POSTGRES_PASSWORD}"
+if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1" >/dev/null 2>&1; then
+  if ! psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = '{{ include "postgresql.maintenanceDatabase" . }}'" | grep -qx 1; then
+    createdb -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} {{ include "postgresql.maintenanceDatabase" . }}
+  fi
+  {{ include "postgresql.probeCommandString" . }}
+  exit $?
+fi
+exit 1
 {{- end -}}
 
 {{- define "postgresql.primaryReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") .Values.replication.primary.probes.requireWritable -}}
-{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
+{{- include "postgresql.libpqEnvExports" . }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
 {{- else -}}
 {{ include "postgresql.probeCommandString" . }}
 {{- end -}}
@@ -183,10 +203,34 @@ template1
 
 {{- define "postgresql.replicaReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") .Values.replication.readReplicas.probes.requireRecoveryMode -}}
-{{- if .Values.tls.enabled }}export PGSSLMODE={{ .Values.tls.sslMode | quote }}; export PGSSLROOTCERT=/tls/{{ .Values.tls.caFilename }}; {{- end }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1
+{{- include "postgresql.libpqEnvExports" . }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1
 {{- else -}}
 {{ include "postgresql.probeCommandString" . }}
 {{- end -}}
+{{- end -}}
+
+{{- define "postgresql.ensureMaintenanceDatabaseCommandString" -}}
+DATA_DIR="${PGDATA:-/var/lib/postgresql/data/pgdata}"
+if [ ! -s "${DATA_DIR}/PG_VERSION" ]; then
+  exit 0
+fi
+{{ include "postgresql.libpqEnvExports" . }}export PGPASSWORD="${POSTGRES_PASSWORD}"
+for attempt in $(seq 1 150); do
+  if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1" >/dev/null 2>&1; then
+    if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = '{{ include "postgresql.maintenanceDatabase" . }}'" | grep -qx 1; then
+      if {{ include "postgresql.probeCommandString" . }} >/dev/null 2>&1; then
+        exit 0
+      fi
+      sleep 2
+      continue
+    fi
+    createdb -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} {{ include "postgresql.maintenanceDatabase" . }}
+    exit 0
+  fi
+  sleep 2
+done
+echo "Unable to verify or repair the {{ include "postgresql.maintenanceDatabase" . }} database on this PostgreSQL data directory." >&2
+exit 1
 {{- end -}}
 
 {{- define "postgresql.metricsEnv" -}}

--- a/charts/postgresql/templates/backup-configmap.yaml
+++ b/charts/postgresql/templates/backup-configmap.yaml
@@ -17,7 +17,7 @@ data:
       --host="${DB_HOST}" \
       --port="${DB_PORT}" \
       --username=postgres \
-      --database=template1 | gzip -c > "${archive}"
+      --database=postgres | gzip -c > "${archive}"
     printf "%s" "${archive}" > /backup/out/backup-file
   upload-backup.sh: |
     #!/bin/sh

--- a/charts/postgresql/templates/configmap.yaml
+++ b/charts/postgresql/templates/configmap.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "postgresql.labels" . | nindent 4 }}
 data:
+  postgres_exporter.yml: |
+    {}
   postgresql.conf: |
     listen_addresses = '*'
     port = {{ .Values.service.port }}
@@ -72,7 +74,7 @@ data:
     #!/bin/bash
     set -euo pipefail
     export PGPASSWORD="${POSTGRES_PASSWORD}"
-    psql --username "${POSTGRES_USER}" --dbname template1 \
+    psql --username "${POSTGRES_USER}" --dbname postgres \
       --set=app_username="${APP_USERNAME}" \
       --set=app_password="${APP_PASSWORD}" \
       --set=app_database="${APP_DATABASE}" \

--- a/charts/postgresql/templates/statefulset-primary.yaml
+++ b/charts/postgresql/templates/statefulset-primary.yaml
@@ -75,6 +75,14 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -ec
+                  - |
+                    {{- include "postgresql.ensureMaintenanceDatabaseCommandString" . | nindent 20 }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -105,7 +113,7 @@ spec:
               command:
                 - sh
                 - -ec
-                - {{ include "postgresql.probeCommandString" . | quote }}
+                - {{ include "postgresql.primaryStartupProbeCommandString" . | quote }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
@@ -146,6 +154,8 @@ spec:
         - name: postgres-exporter
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          args:
+            - --config.file=/etc/postgres-exporter/postgres_exporter.yml
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
@@ -160,6 +170,9 @@ spec:
             {{- include "postgresql.metricsResourcesPreset" . | nindent 12 }}
             {{- end }}
           volumeMounts:
+            - name: config
+              mountPath: /etc/postgres-exporter
+              readOnly: true
             {{- if .Values.tls.enabled }}
             - name: tls
               mountPath: /tls

--- a/charts/postgresql/templates/statefulset-replicas.yaml
+++ b/charts/postgresql/templates/statefulset-replicas.yaml
@@ -40,7 +40,7 @@ spec:
               fi
               mkdir -p "${DATA_DIR}"
               chmod 0700 "${DATA_DIR}"
-              until pg_isready -h {{ include "postgresql.primaryServiceName" . }} -p {{ .Values.service.port }} -U {{ .Values.auth.replicationUsername }}; do
+              until pg_isready -h {{ include "postgresql.primaryServiceName" . }} -p {{ .Values.service.port }} -U {{ .Values.auth.replicationUsername }} -d {{ include "postgresql.maintenanceDatabase" . }}; do
                 sleep 5
               done
               rm -rf "${DATA_DIR:?}"/*
@@ -167,6 +167,8 @@ spec:
         - name: postgres-exporter
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          args:
+            - --config.file=/etc/postgres-exporter/postgres_exporter.yml
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
@@ -181,6 +183,9 @@ spec:
             {{- include "postgresql.metricsResourcesPreset" . | nindent 12 }}
             {{- end }}
           volumeMounts:
+            - name: config
+              mountPath: /etc/postgres-exporter
+              readOnly: true
             {{- if .Values.tls.enabled }}
             - name: tls
               mountPath: /tls

--- a/charts/postgresql/tests/backup_test.yaml
+++ b/charts/postgresql/tests/backup_test.yaml
@@ -32,7 +32,7 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data["postgresql-backup.sh"]
-          pattern: "--database=template1"
+          pattern: "--database=postgres"
 
   - it: should render backup cronjob
     set:

--- a/charts/postgresql/tests/configmap_test.yaml
+++ b/charts/postgresql/tests/configmap_test.yaml
@@ -5,10 +5,10 @@ release:
   name: test
   namespace: default
 tests:
-  - it: should initialize app roles through template1 maintenance database
+  - it: should initialize app roles through postgres maintenance database
     template: configmap.yaml
     documentIndex: 1
     asserts:
       - matchRegex:
           path: data["01-init-users.sh"]
-          pattern: 'psql --username "\$\{POSTGRES_USER\}" --dbname template1'
+          pattern: 'psql --username "\$\{POSTGRES_USER\}" --dbname postgres'

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -126,7 +126,7 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
-          value: PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p 5432 -d template1
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p 5432 -d postgres
 
   - it: should have readiness probe by default
     template: statefulset-primary.yaml
@@ -139,18 +139,31 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].startupProbe
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].startupProbe.exec.command[2]
-          value: PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready -U postgres -h 127.0.0.1 -p 5432 -d template1
+          pattern: 'psql -U postgres -h 127\.0\.0\.1 -p 5432 -d template1 -tAc "SELECT 1"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
+          pattern: 'createdb -U postgres -h 127\.0\.0\.1 -p 5432 postgres'
 
-  - it: should use template1 for replication primary readiness check
+  - it: should use postgres for replication primary readiness check
     template: statefulset-primary.yaml
     set:
       architecture: replication
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
-          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d template1 -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
+
+  - it: should repair the postgres maintenance database on reused data directories
+    template: statefulset-primary.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          pattern: 'psql -U postgres -h 127\.0\.0\.1 -p 5432 -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = ''postgres''"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          pattern: 'createdb -U postgres -h 127\.0\.0\.1 -p 5432 postgres'
 
   - it: should create VolumeClaimTemplate when persistence is enabled
     template: statefulset-primary.yaml
@@ -219,7 +232,16 @@ tests:
           path: spec.template.spec.containers[1].env
           content:
             name: DATA_SOURCE_URI
-            value: 127.0.0.1:5432/template1?sslmode=disable
+            value: 127.0.0.1:5432/postgres?sslmode=disable
+      - equal:
+          path: spec.template.spec.containers[1].args[0]
+          value: --config.file=/etc/postgres-exporter/postgres_exporter.yml
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/postgres-exporter
+            readOnly: true
 
   - it: should not mount TLS volume by default
     template: statefulset-primary.yaml

--- a/charts/postgresql/tests/statefulset_replicas_test.yaml
+++ b/charts/postgresql/tests/statefulset_replicas_test.yaml
@@ -6,11 +6,36 @@ release:
   name: test
   namespace: default
 tests:
-  - it: should use template1 for replica recovery readiness check
+  - it: should use postgres for replica recovery readiness check
     template: statefulset-replicas.yaml
     set:
       architecture: replication
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
-          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d template1 -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1
+          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 1
+
+  - it: should disable the default postgres_exporter config file lookup when metrics are enabled
+    template: statefulset-replicas.yaml
+    set:
+      architecture: replication
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].args[0]
+          value: --config.file=/etc/postgres-exporter/postgres_exporter.yml
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/postgres-exporter
+            readOnly: true
+
+  - it: should wait for the primary using the postgres maintenance database before cloning
+    template: statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'pg_isready -h test-postgresql-primary -p 5432 -U replicator -d postgres'


### PR DESCRIPTION
## Summary
- restore `postgres` as the chart's maintenance database for probes, metrics, backup, and validation flows
- repair reused PVCs that are missing `postgres` during startup without falling back to `template1` as the steady-state maintenance database
- remove noisy runtime warnings/errors uncovered during local k3d validation and expand `NOTES.txt` with validation commands

## Validation
- helm lint charts/postgresql --strict
- helm unittest charts/postgresql
- helm template charts/postgresql -f charts/postgresql/ci/*.yaml
- rendered NOTES dry-run check
- k3d standalone validation with metrics enabled and clean logs
- k3d reused-PVC repair validation after dropping `postgres`
- k3d replication validation with clean recent logs on primary, replica, and exporters
- k3d backup validation against local MinIO with successful upload