### PR TITLE
fix(drupal): use canonical drupal icon

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -20,7 +20,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://new.drupal.org/home
   - https://hub.docker.com/_/drupal
-icon: https://helmforge.dev/icons/charts/kubernetes.png
+icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
     - kind: added


### PR DESCRIPTION
## Summary
- switch Drupal chart metadata to the canonical HelmForge icon URL
- align the chart with the site-hosted Drupal icon asset used by the catalog

## Context
- follow-up to #104 after merge
- fixes the icon policy gap called out by GR-025

## Validation
- helm dependency build charts/drupal
- helm lint --strict charts/drupal