### PR TITLE
feat(drupal): harden chart for production

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: drupal
-description: Drupal CMS with seeded sites persistence, installer guidance, and optional MySQL or SQLite install paths
+description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: "11.3.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -23,14 +23,14 @@ sources:
 icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: use canonical drupal icon (#106)
+    - kind: changed
+      description: promote drupal to stable with production backup automation, mysql/sqlite backup support, and safe autoscaling guardrails
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -1,12 +1,13 @@
 # Drupal
 
-A Helm chart for deploying [Drupal](https://new.drupal.org/home) on Kubernetes using the Docker Official Drupal image and a seeded persistent `sites/` directory.
+A production-ready Helm chart for deploying [Drupal](https://new.drupal.org/home) on Kubernetes with seeded `sites/` persistence, scheduled S3 backups, and safe horizontal scaling guardrails.
 
 Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- The chart prepares the runtime, persistence, ingress, and database path, then guides the user through the Drupal web installer.
+- HelmForge pins the Docker Official image explicitly to `11.3.8-php8.5-apache-bookworm`, which includes PHP 8.5 and the Drupal-required database extensions.
+- The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
 
@@ -41,15 +42,47 @@ Then:
 3. Follow the installer.
 4. Use the database details printed in `NOTES.txt`.
 
-## Features
+## Why This Chart Is Different
 
-- **Docker Official Drupal Image** — Pinned `drupal:11.3.8-apache-bookworm`
-- **Seeded `sites/` Persistence** — Preserves installer output and uploaded files without hiding the Drupal core files from the image
-- **MySQL Subchart Path** — Bundled MySQL for straightforward first installs
-- **SQLite Install Path** — Disable MySQL and use SQLite for simple or disposable environments
-- **External Database Path** — Bring your own MySQL-compatible database and use its installer values
-- **Ingress Support** — `ingressClassName`, hosts, and TLS
-- **Custom PHP INI** — Mount extra PHP settings through a ConfigMap
+- **Pinned production image** — uses `drupal:11.3.8-php8.5-apache-bookworm`, which matches current Drupal 11.3 support for PHP 8.5 and keeps the Debian base explicit
+- **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
+- **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
+- **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
+- **Installer-aware database paths** — bundled MySQL, external MySQL-compatible database, or SQLite
+- **Production knobs included** — default resource requests/limits, optional HPA, optional PDB, ingress, and custom PHP configuration
+
+## Production Example
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: drupal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+persistence:
+  accessMode: ReadWriteMany
+  size: 20Gi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+backup:
+  enabled: true
+  s3:
+    endpoint: https://minio.example.com
+    bucket: drupal-backups
+    existingSecret: drupal-backup-s3
+```
 
 ## Minimal Example
 
@@ -104,13 +137,17 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.3.8-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.3.8-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |
 | `mysql.auth.username` | `drupal` | Database username created by the MySQL subchart. |
 | `persistence.enabled` | `true` | Enable persistence for `/var/www/html/sites`. |
+| `persistence.accessMode` | `ReadWriteOnce` | Use `ReadWriteMany` for safe multi-replica Drupal. |
 | `persistence.size` | `8Gi` | Sites PVC size. |
+| `autoscaling.enabled` | `false` | Enable HPA when using RWX storage and a MySQL-compatible database. |
+| `pdb.enabled` | `false` | Enable a PodDisruptionBudget for higher-availability deployments. |
+| `backup.enabled` | `false` | Enable scheduled `sites/` + database backups to S3-compatible storage. |
 | `php.ini` | `""` via `php.ini` | Extra PHP configuration content. |
 | `ingress.enabled` | `false` | Enable ingress. |
 | `drupal.sqlitePath` | `sites/default/files/.ht.sqlite` | Suggested SQLite path for installer use. |
@@ -118,10 +155,13 @@ mysql:
 ## Operational Notes
 
 - The chart does not auto-run the Drupal installer.
-- The chart does not yet implement built-in backup automation.
-- Multi-replica Drupal requires shared writable storage for `sites/`; the default `ReadWriteOnce` PVC is intended for single-replica installs.
+- Backup automation requires S3-compatible storage credentials and `persistence.enabled=true`.
+- Multi-replica Drupal requires `ReadWriteMany` storage and a MySQL-compatible database; the chart blocks unsafe combinations.
+- SQLite is supported for single-replica installs, including automated backups, but it is still not the preferred production path for most Drupal sites.
 
 ## Additional Reading
 
 - [docs/database.md](docs/database.md)
+- [docs/backup.md](docs/backup.md)
 - [docs/persistence.md](docs/persistence.md)
+- [docs/scaling.md](docs/scaling.md)

--- a/charts/drupal/ci/autoscaling-values.yaml
+++ b/charts/drupal/ci/autoscaling-values.yaml
@@ -1,0 +1,14 @@
+mysql:
+  enabled: true
+
+persistence:
+  accessMode: ReadWriteMany
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+
+pdb:
+  enabled: true
+  minAvailable: 1

--- a/charts/drupal/ci/backup-mysql-values.yaml
+++ b/charts/drupal/ci/backup-mysql-values.yaml
@@ -1,0 +1,8 @@
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://minio.example.com
+    bucket: drupal-backups
+    accessKey: test-access-key
+    secretKey: test-secret-key

--- a/charts/drupal/ci/backup-sqlite-values.yaml
+++ b/charts/drupal/ci/backup-sqlite-values.yaml
@@ -1,0 +1,14 @@
+database:
+  mode: sqlite
+
+mysql:
+  enabled: false
+
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://minio.example.com
+    bucket: drupal-backups
+    accessKey: test-access-key
+    secretKey: test-secret-key

--- a/charts/drupal/docs/backup.md
+++ b/charts/drupal/docs/backup.md
@@ -1,0 +1,45 @@
+# Backup
+
+The Drupal chart includes a built-in backup CronJob for production environments.
+
+Each run creates:
+
+- a `sites/` archive so uploaded files, generated styles, and installer-managed state are preserved
+- a database backup that matches the active mode:
+  - `mysqldump` for bundled or external MySQL-compatible databases
+  - a consistent SQLite snapshot using Python's SQLite backup API
+
+## Requirements
+
+- `persistence.enabled=true`
+- `backup.enabled=true`
+- S3-compatible storage credentials
+
+## Minimal MySQL Backup Example
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://minio.example.com
+    bucket: drupal-backups
+    existingSecret: drupal-backup-s3
+```
+
+## External Database Backup Credentials
+
+When `database.mode=external`, the chart does not know the database password from the installer flow.
+
+Provide it explicitly for backup jobs:
+
+```yaml
+backup:
+  enabled: true
+  database:
+    existingSecret: drupal-backup-db
+```
+
+## SQLite Notes
+
+SQLite backups are supported, but SQLite itself remains a single-node path. Keep SQLite for evaluation, simple sites, or controlled single-replica installs.

--- a/charts/drupal/docs/database.md
+++ b/charts/drupal/docs/database.md
@@ -17,6 +17,8 @@ Use the following values from `NOTES.txt` during installation:
 - Database username: `mysql.auth.username`
 - Database password: retrieved from the MySQL auth secret
 
+This is the recommended production path when you do not need horizontal scaling beyond the bundled MySQL defaults.
+
 ## External Database
 
 Set:
@@ -34,7 +36,9 @@ mysql:
   enabled: false
 ```
 
-The chart does not create or manage the external database password. Provide your own credentials during the installer flow.
+The chart does not create or manage the external database password for the installer flow. Provide your own credentials during installation.
+
+If you also enable chart-managed backups for an external database, set `backup.database.password` or `backup.database.existingSecret`.
 
 ## SQLite
 
@@ -54,4 +58,4 @@ Recommended installer path:
 sites/default/files/.ht.sqlite
 ```
 
-Use SQLite for lightweight environments, evaluation, or disposable setups. It is not the recommended production path for most Drupal installations.
+Use SQLite for lightweight environments, evaluation, or controlled single-replica installs. It is not the recommended production path for most Drupal installations and it cannot be combined with horizontal scaling.

--- a/charts/drupal/docs/persistence.md
+++ b/charts/drupal/docs/persistence.md
@@ -20,11 +20,17 @@ This chart:
 
 This preserves installer output and uploaded files while keeping the core application files in the image layer.
 
-## Multi-Replica Warning
+## Multi-Replica Behavior
 
 The default storage mode is:
 
 - `ReadWriteOnce`
 - single replica
 
-If you scale `replicaCount` above 1, use shared writable storage or keep a single replica. Otherwise uploaded files and installer-generated state may not behave consistently across pods.
+If you scale Drupal above one replica, the chart requires:
+
+- `persistence.enabled=true`
+- `persistence.accessMode=ReadWriteMany`
+- a MySQL-compatible database
+
+This is enforced directly in the chart so unsafe multi-replica combinations fail during render time instead of breaking later in production.

--- a/charts/drupal/docs/scaling.md
+++ b/charts/drupal/docs/scaling.md
@@ -1,0 +1,29 @@
+# Scaling
+
+The Drupal chart can scale horizontally, but only when the underlying runtime is safe for shared state.
+
+## Requirements For Multi-Replica Drupal
+
+- `database.mode` must resolve to a MySQL-compatible database
+- `persistence.enabled=true`
+- `persistence.accessMode=ReadWriteMany`
+
+If any of these requirements are missing, the chart fails fast during rendering.
+
+## Autoscaling Example
+
+```yaml
+persistence:
+  accessMode: ReadWriteMany
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+
+pdb:
+  enabled: true
+  minAvailable: 1
+```
+
+This keeps the default single-replica behavior safe while still allowing production horizontal scaling when shared storage is available.

--- a/charts/drupal/examples/production/values.yaml
+++ b/charts/drupal/examples/production/values.yaml
@@ -1,0 +1,37 @@
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: drupal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 768Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+persistence:
+  accessMode: ReadWriteMany
+  size: 20Gi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://minio.example.com
+    bucket: drupal-backups
+    existingSecret: drupal-backup-s3

--- a/charts/drupal/templates/NOTES.txt
+++ b/charts/drupal/templates/NOTES.txt
@@ -45,6 +45,7 @@ HEALTH:       http://{{ include "drupal.fullname" . }}.{{ .Release.Namespace }}.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 {{- $dbMode := include "drupal.databaseMode" . }}
+{{- $replicas := include "drupal.replicaCount" . | int }}
 Detected mode: {{ $dbMode }}
 
 {{- if eq $dbMode "mysql" }}
@@ -85,7 +86,7 @@ Use this path in the installer:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Deployment:
-  Replicas:              {{ .Values.replicaCount }}
+  Replicas:              {{ $replicas }}
   Image:                 {{ .Values.image.repository }}:{{ .Values.image.tag }}
   Service Type:          {{ .Values.service.type }}
   Service Port:          {{ .Values.service.port }}
@@ -124,6 +125,21 @@ Ingress:
 
 PHP:
   Custom php.ini:        {{ if .Values.php.ini }}enabled{{ else }}disabled{{ end }}
+
+Autoscaling:
+  Enabled:               {{ .Values.autoscaling.enabled }}
+  {{- if .Values.autoscaling.enabled }}
+  Min replicas:          {{ .Values.autoscaling.minReplicas }}
+  Max replicas:          {{ .Values.autoscaling.maxReplicas }}
+  {{- end }}
+
+Backups:
+  Enabled:               {{ .Values.backup.enabled }}
+  {{- if .Values.backup.enabled }}
+  Schedule:              {{ .Values.backup.schedule }}
+  Bucket:                {{ .Values.backup.s3.bucket }}
+  Prefix:                {{ .Values.backup.s3.prefix }}
+  {{- end }}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   GETTING STARTED
@@ -218,7 +234,7 @@ View MySQL logs:
   WARNINGS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-{{- if gt (.Values.replicaCount | int) 1 }}
+{{- if gt $replicas 1 }}
 WARNING: Multi-replica Drupal deployment detected.
 
 Drupal uploads and installer-generated state live under /sites. The default
@@ -226,6 +242,7 @@ PVC settings are intended for single-replica use.
 
 Recommended actions:
   - use shared writable storage before scaling above one replica
+  - keep backups enabled for files and database recovery
   - or keep replicaCount=1
 
 {{- end }}
@@ -242,6 +259,14 @@ NOTE: SQLite mode is active.
 
 This is useful for lightweight environments and evaluation, but it is not the
 preferred production path for most Drupal sites.
+
+{{- end }}
+{{- if .Values.backup.enabled }}
+NOTE: Scheduled backups are enabled.
+
+Each backup job archives:
+  - Drupal sites files
+  - the active database (MySQL dump or SQLite snapshot)
 
 {{- end }}
 

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -71,6 +71,40 @@ Image string.
 {{- end }}
 
 {{/*
+Desired replica count before validations.
+*/}}
+{{- define "drupal.desiredReplicasRaw" -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- .Values.autoscaling.minReplicas | int -}}
+{{- else -}}
+{{- .Values.replicaCount | int -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validated desired replica count.
+*/}}
+{{- define "drupal.replicaCount" -}}
+{{- $replicas := (include "drupal.desiredReplicasRaw" . | int) -}}
+{{- $dbMode := include "drupal.databaseMode" . -}}
+{{- if and (eq $dbMode "sqlite") (not (hasPrefix "sites/" .Values.drupal.sqlitePath)) -}}
+{{- fail "database.mode=sqlite requires drupal.sqlitePath to stay under sites/ so persistence and backup cover the database file" -}}
+{{- end -}}
+{{- if gt $replicas 1 -}}
+  {{- if eq $dbMode "sqlite" -}}
+    {{- fail "Multi-replica Drupal requires a MySQL-compatible database. SQLite is supported only for single-replica deployments." -}}
+  {{- end -}}
+  {{- if not .Values.persistence.enabled -}}
+    {{- fail "Multi-replica Drupal requires persistence.enabled=true so uploaded files and installer state are shared across replicas." -}}
+  {{- end -}}
+  {{- if ne (.Values.persistence.accessMode | default "ReadWriteOnce") "ReadWriteMany" -}}
+    {{- fail "Multi-replica Drupal requires persistence.accessMode=ReadWriteMany so /var/www/html/sites can be shared safely." -}}
+  {{- end -}}
+{{- end -}}
+{{- $replicas -}}
+{{- end -}}
+
+{{/*
 Database mode detection (auto | external | mysql | sqlite).
 Auto precedence:
   1. database.external.host -> external
@@ -201,5 +235,134 @@ MySQL password secret key for installer guidance.
 {{- .Values.mysql.auth.existingSecretUserPasswordKey | default "mysql-user-password" -}}
 {{- else -}}
 {{- print "mysql-user-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether backup is enabled, with validation.
+*/}}
+{{- define "drupal.backupEnabled" -}}
+{{- if .Values.backup.enabled -}}
+  {{- if not .Values.persistence.enabled -}}
+    {{- fail "backup.enabled requires persistence.enabled=true so Drupal sites files are included in each backup." -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.endpoint -}}
+    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}
+    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+  {{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- end -}}
+  {{- $dbMode := include "drupal.databaseMode" . -}}
+  {{- if and (eq $dbMode "sqlite") (not (hasPrefix "sites/" .Values.drupal.sqlitePath)) -}}
+    {{- fail "backup.enabled with database.mode=sqlite requires drupal.sqlitePath to stay under sites/" -}}
+  {{- end -}}
+  {{- if and (ne $dbMode "sqlite") (eq (.Values.backup.database.existingSecret | default "") "") (eq (.Values.backup.database.password | default "") "") (eq $dbMode "external") -}}
+    {{- fail "backup.enabled with database.mode=external requires backup.database.existingSecret or backup.database.password so mysqldump can authenticate." -}}
+  {{- end -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether autoscaling is enabled, with validation.
+*/}}
+{{- define "drupal.autoscalingEnabled" -}}
+{{- if .Values.autoscaling.enabled -}}
+  {{- if lt (.Values.autoscaling.maxReplicas | int) (.Values.autoscaling.minReplicas | int) -}}
+    {{- fail "autoscaling.maxReplicas must be greater than or equal to autoscaling.minReplicas" -}}
+  {{- end -}}
+  {{- if not (or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage) -}}
+    {{- fail "autoscaling.enabled requires at least one target metric" -}}
+  {{- end -}}
+  {{- $_ := include "drupal.replicaCount" . -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup S3 secret name.
+*/}}
+{{- define "drupal.backupSecretName" -}}
+{{- if .Values.backup.s3.existingSecret -}}
+{{- .Values.backup.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-backup" (include "drupal.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup database password secret name.
+*/}}
+{{- define "drupal.backupDatabasePasswordSecretName" -}}
+{{- if .Values.backup.database.existingSecret -}}
+{{- .Values.backup.database.existingSecret -}}
+{{- else if .Values.backup.database.password -}}
+{{- printf "%s-backup-db" (include "drupal.fullname" .) -}}
+{{- else -}}
+{{- include "drupal.mysqlPasswordSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup database password secret key.
+*/}}
+{{- define "drupal.backupDatabasePasswordSecretKey" -}}
+{{- if .Values.backup.database.existingSecret -}}
+{{- .Values.backup.database.existingSecretPasswordKey | default "database-password" -}}
+{{- else if .Values.backup.database.password -}}
+database-password
+{{- else -}}
+{{- include "drupal.mysqlPasswordSecretKey" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup database host.
+*/}}
+{{- define "drupal.backupDatabaseHost" -}}
+{{- if .Values.backup.database.host -}}
+{{- .Values.backup.database.host -}}
+{{- else -}}
+{{- include "drupal.databaseHost" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup database port.
+*/}}
+{{- define "drupal.backupDatabasePort" -}}
+{{- if .Values.backup.database.port -}}
+{{- .Values.backup.database.port | toString -}}
+{{- else -}}
+{{- include "drupal.databasePort" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup database name.
+*/}}
+{{- define "drupal.backupDatabaseName" -}}
+{{- if .Values.backup.database.name -}}
+{{- .Values.backup.database.name -}}
+{{- else -}}
+{{- include "drupal.databaseName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Backup database username.
+*/}}
+{{- define "drupal.backupDatabaseUsername" -}}
+{{- if .Values.backup.database.username -}}
+{{- .Values.backup.database.username -}}
+{{- else -}}
+{{- include "drupal.databaseUsername" . -}}
 {{- end -}}
 {{- end -}}

--- a/charts/drupal/templates/backup-configmap.yaml
+++ b/charts/drupal/templates/backup-configmap.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.backup.enabled }}
+{{- $_ := include "drupal.backupEnabled" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "drupal.fullname" . }}-backup-scripts
+  labels:
+    {{- include "drupal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+data:
+  archive-sites.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/{{ .Values.backup.archivePrefix }}-sites-${timestamp}.tar.gz"
+    mkdir -p /backup/out
+    tar -C /var/www/html -czf "${archive}" sites
+    printf "%s" "${archive}" > /backup/out/sites-backup-file
+    echo "Sites archive created: ${archive}"
+  mysql-backup.sh: |
+    #!/bin/sh
+    set -eu
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive="/backup/out/{{ .Values.backup.archivePrefix }}-mysql-${timestamp}.sql.gz"
+    mkdir -p /backup/out
+    export MYSQL_PWD="${DB_PASSWORD}"
+    mysqldump ${MYSQL_DUMP_EXTRA_ARGS:-} \
+      --host="${DB_HOST}" \
+      --port="${DB_PORT}" \
+      --user="${DB_USERNAME}" \
+      "${DB_NAME}" | gzip -c > "${archive}"
+    printf "%s" "${archive}" > /backup/out/database-backup-file
+    echo "MySQL archive created: ${archive}"
+  sqlite-backup.py: |
+    import datetime
+    import gzip
+    import os
+    import shutil
+    import sqlite3
+
+    prefix = os.environ["BACKUP_ARCHIVE_PREFIX"]
+    source = os.environ["SQLITE_PATH"]
+    out_dir = "/backup/out"
+    os.makedirs(out_dir, exist_ok=True)
+
+    timestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+    temp_copy = os.path.join(out_dir, f"{prefix}-sqlite-{timestamp}.sqlite")
+    archive = f"{temp_copy}.gz"
+    marker = os.path.join(out_dir, "database-backup-file")
+
+    if not os.path.exists(source):
+      raise SystemExit(f"SQLite source file not found: {source}")
+
+    src = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+    dst = sqlite3.connect(temp_copy)
+    src.backup(dst)
+    dst.close()
+    src.close()
+
+    verify = sqlite3.connect(temp_copy)
+    result = verify.execute("PRAGMA quick_check;").fetchone()
+    verify.close()
+    if not result or result[0].lower() != "ok":
+      raise SystemExit(f"SQLite quick_check failed: {result}")
+
+    with open(temp_copy, "rb") as plain_file, gzip.open(archive, "wb") as gzip_file:
+      shutil.copyfileobj(plain_file, gzip_file)
+
+    os.remove(temp_copy)
+    with open(marker, "w", encoding="utf-8") as marker_file:
+      marker_file.write(archive)
+
+    print(f"SQLite archive created: {archive}")
+  upload-backup.sh: |
+    #!/bin/sh
+    set -eu
+    target="backup/${S3_BUCKET}"
+    if [ -n "${S3_PREFIX:-}" ]; then
+      target="${target}/${S3_PREFIX}"
+    fi
+
+    mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+    if [ "${S3_CREATE_BUCKET_IF_NOT_EXISTS}" = "true" ]; then
+      mc mb --ignore-existing "backup/${S3_BUCKET}"
+    fi
+
+    for marker in /backup/out/sites-backup-file /backup/out/database-backup-file; do
+      if [ -f "${marker}" ]; then
+        archive="$(cat "${marker}")"
+        mc cp "${archive}" "${target}/"
+      fi
+    done
+
+    echo "All Drupal backups uploaded successfully."
+{{- end }}

--- a/charts/drupal/templates/backup-cronjob.yaml
+++ b/charts/drupal/templates/backup-cronjob.yaml
@@ -1,0 +1,166 @@
+{{- if .Values.backup.enabled }}
+{{- $_ := include "drupal.backupEnabled" . }}
+{{- $dbMode := include "drupal.databaseMode" . -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "drupal.fullname" . }}-backup
+  labels:
+    {{- include "drupal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "drupal.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.serviceAccount.create }}
+          serviceAccountName: {{ include "drupal.serviceAccountName" . }}
+          {{- end }}
+          {{- with .Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          initContainers:
+            - name: archive-sites
+              image: {{ .Values.backup.images.archiver | quote }}
+              command: ["/bin/sh", "/scripts/archive-sites.sh"]
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-workdir
+                  mountPath: /backup/out
+                - name: sites-data
+                  mountPath: /var/www/html/sites
+                  readOnly: true
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+            {{- if eq $dbMode "sqlite" }}
+            - name: sqlite-backup
+              image: {{ .Values.backup.images.sqlite | quote }}
+              command: ["python", "/scripts/sqlite-backup.py"]
+              env:
+                - name: BACKUP_ARCHIVE_PREFIX
+                  value: {{ .Values.backup.archivePrefix | quote }}
+                - name: SQLITE_PATH
+                  value: {{ printf "/var/www/html/%s" .Values.drupal.sqlitePath | quote }}
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-workdir
+                  mountPath: /backup/out
+                - name: sites-data
+                  mountPath: /var/www/html/sites
+                  readOnly: true
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+            {{- else }}
+            - name: mysql-backup
+              image: {{ .Values.backup.images.mysql | quote }}
+              command: ["/bin/sh", "/scripts/mysql-backup.sh"]
+              env:
+                - name: DB_HOST
+                  value: {{ include "drupal.backupDatabaseHost" . | quote }}
+                - name: DB_PORT
+                  value: {{ include "drupal.backupDatabasePort" . | quote }}
+                - name: DB_NAME
+                  value: {{ include "drupal.backupDatabaseName" . | quote }}
+                - name: DB_USERNAME
+                  value: {{ include "drupal.backupDatabaseUsername" . | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "drupal.backupDatabasePasswordSecretName" . }}
+                      key: {{ include "drupal.backupDatabasePasswordSecretKey" . }}
+                - name: MYSQL_DUMP_EXTRA_ARGS
+                  value: {{ .Values.backup.database.mysqldumpArgs | quote }}
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-workdir
+                  mountPath: /backup/out
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+            {{- end }}
+          containers:
+            - name: upload
+              image: {{ .Values.backup.images.uploader | quote }}
+              command: ["/bin/sh", "/scripts/upload-backup.sh"]
+              env:
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | quote }}
+                - name: S3_CREATE_BUCKET_IF_NOT_EXISTS
+                  value: {{ ternary "true" "false" .Values.backup.s3.createBucketIfNotExists | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "drupal.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey | default "access-key" }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "drupal.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey | default "secret-key" }}
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: backup-workdir
+                  mountPath: /backup/out
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          volumes:
+            - name: backup-scripts
+              configMap:
+                name: {{ include "drupal.fullname" . }}-backup-scripts
+                defaultMode: 0755
+            - name: backup-workdir
+              emptyDir: {}
+            - name: sites-data
+              persistentVolumeClaim:
+                claimName: {{ include "drupal.sitesClaimName" . }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/drupal/templates/backup-secret.yaml
+++ b/charts/drupal/templates/backup-secret.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.backup.enabled }}
+{{- $_ := include "drupal.backupEnabled" . }}
+{{- if not .Values.backup.s3.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "drupal.backupSecretName" . }}
+  labels:
+    {{- include "drupal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+type: Opaque
+data:
+  access-key: {{ .Values.backup.s3.accessKey | b64enc | quote }}
+  secret-key: {{ .Values.backup.s3.secretKey | b64enc | quote }}
+{{- end }}
+{{- if and (.Values.backup.database.password) (not .Values.backup.database.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "drupal.backupDatabasePasswordSecretName" . }}
+  labels:
+    {{- include "drupal.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+type: Opaque
+data:
+  database-password: {{ .Values.backup.database.password | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/drupal/templates/deployment.yaml
+++ b/charts/drupal/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $replicas := include "drupal.replicaCount" . | int -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,9 +7,9 @@ metadata:
     {{- include "drupal.labels" . | nindent 4 }}
     app.kubernetes.io/component: drupal
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ $replicas }}
   strategy:
-    type: Recreate
+    type: {{ if gt $replicas 1 }}RollingUpdate{{ else }}Recreate{{ end }}
   selector:
     matchLabels:
       {{- include "drupal.selectorLabels" . | nindent 6 }}

--- a/charts/drupal/templates/hpa.yaml
+++ b/charts/drupal/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+{{- $_ := include "drupal.autoscalingEnabled" . }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "drupal.fullname" . }}
+  labels:
+    {{- include "drupal.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "drupal.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/drupal/templates/pdb.yaml
+++ b/charts/drupal/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "drupal.fullname" . }}
+  labels:
+    {{- include "drupal.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "drupal.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: drupal
+{{- end }}

--- a/charts/drupal/tests/backup_test.yaml
+++ b/charts/drupal/tests/backup_test.yaml
@@ -1,0 +1,107 @@
+suite: Backup
+templates:
+  - templates/backup-configmap.yaml
+  - templates/backup-cronjob.yaml
+  - templates/backup-secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create backup resources by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create mysql backup resources with inline S3 credentials
+    template: templates/backup-cronjob.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: drupal-backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[1].name
+          value: mysql-backup
+
+  - it: should create sqlite backup init container in sqlite mode
+    template: templates/backup-cronjob.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: drupal-backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+      database.mode: sqlite
+      mysql.enabled: false
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[1].name
+          value: sqlite-backup
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[1].env[1].value
+          value: /var/www/html/sites/default/files/.ht.sqlite
+
+  - it: should create inline external backup database password secret
+    template: templates/backup-secret.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: drupal-backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+      backup.database.password: dbsecret
+      database.mode: external
+      database.external.host: db.example.com
+      mysql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-drupal-backup-db
+        documentIndex: 1
+
+  - it: should create inline S3 secret when backup is enabled
+    template: templates/backup-secret.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: drupal-backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-drupal-backup
+
+  - it: should fail backup without endpoint
+    template: templates/backup-secret.yaml
+    set:
+      backup.enabled: true
+      backup.s3.bucket: drupal-backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail external database backup without database credentials
+    template: templates/backup-secret.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: drupal-backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+      database.mode: external
+      database.external.host: db.example.com
+      mysql.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.enabled with database.mode=external requires backup.database.existingSecret or backup.database.password so mysqldump can authenticate."

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -22,10 +22,25 @@ tests:
           path: spec.strategy.type
           value: Recreate
 
+  - it: should use RollingUpdate when scaling safely
+    template: templates/deployment.yaml
+    set:
+      replicaCount: 2
+      database.mode: mysql
+      mysql.enabled: true
+      persistence.accessMode: ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
   - it: should set the requested replica count
     template: templates/deployment.yaml
     set:
       replicaCount: 2
+      database.mode: mysql
+      mysql.enabled: true
+      persistence.accessMode: ReadWriteMany
     asserts:
       - equal:
           path: spec.replicas
@@ -36,7 +51,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.3.8-apache-bookworm
+          value: docker.io/library/drupal:11.3.8-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -46,7 +61,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.3.8-apache-bookworm
+          value: docker.io/library/drupal:11.3.8-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml
@@ -109,6 +124,29 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /
 
+  - it: should render default resource requests and limits
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "1"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
+
+  - it: should render pod fsGroup defaults
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 33
+
   - it: should mount php.ini when configured
     template: templates/deployment.yaml
     set:
@@ -157,3 +195,15 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+
+  - it: should set minReplicas on the deployment when autoscaling is enabled
+    template: templates/deployment.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 5
+      persistence.accessMode: ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2

--- a/charts/drupal/tests/hpa_test.yaml
+++ b/charts/drupal/tests/hpa_test.yaml
@@ -1,0 +1,37 @@
+suite: HorizontalPodAutoscaler
+templates:
+  - templates/hpa.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create HPA by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HPA when enabled with RWX storage
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 5
+      persistence.accessMode: ReadWriteMany
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+
+  - it: should fail autoscaling for sqlite deployments
+    set:
+      autoscaling.enabled: true
+      persistence.accessMode: ReadWriteMany
+      database.mode: sqlite
+      mysql.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "Multi-replica Drupal requires a MySQL-compatible database. SQLite is supported only for single-replica deployments."

--- a/charts/drupal/tests/pdb_test.yaml
+++ b/charts/drupal/tests/pdb_test.yaml
@@ -1,0 +1,22 @@
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PDB when enabled
+    set:
+      pdb.enabled: true
+      pdb.minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1

--- a/charts/drupal/tests/validation_test.yaml
+++ b/charts/drupal/tests/validation_test.yaml
@@ -1,0 +1,36 @@
+suite: Validations
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should fail multi-replica without RWX storage
+    set:
+      replicaCount: 2
+      database.mode: mysql
+      mysql.enabled: true
+      persistence.accessMode: ReadWriteOnce
+    asserts:
+      - failedTemplate:
+          errorMessage: "Multi-replica Drupal requires persistence.accessMode=ReadWriteMany so /var/www/html/sites can be shared safely."
+
+  - it: should fail multi-replica without persistence
+    set:
+      replicaCount: 2
+      database.mode: mysql
+      mysql.enabled: true
+      persistence.enabled: false
+      persistence.accessMode: ReadWriteMany
+    asserts:
+      - failedTemplate:
+          errorMessage: "Multi-replica Drupal requires persistence.enabled=true so uploaded files and installer state are shared across replicas."
+
+  - it: should fail sqlite path outside sites when sqlite mode is active
+    set:
+      database.mode: sqlite
+      mysql.enabled: false
+      drupal.sqlitePath: private/db.sqlite
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.mode=sqlite requires drupal.sqlitePath to stay under sites/ so persistence and backup cover the database file"

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -133,10 +133,91 @@
       }
     },
     "resources": { "type": "object" },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": {
+          "type": ["integer", "string"]
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": ["integer", "string"]
+        }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      }
+    },
+    "backup": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "suspend": { "type": "boolean" },
+        "concurrencyPolicy": {
+          "type": "string",
+          "enum": ["Allow", "Forbid", "Replace"]
+        },
+        "successfulJobsHistoryLimit": { "type": "integer", "minimum": 0 },
+        "failedJobsHistoryLimit": { "type": "integer", "minimum": 0 },
+        "backoffLimit": { "type": "integer", "minimum": 0 },
+        "archivePrefix": { "type": "string" },
+        "images": {
+          "type": "object",
+          "properties": {
+            "mysql": { "type": "string" },
+            "sqlite": { "type": "string" },
+            "archiver": { "type": "string" },
+            "uploader": { "type": "string" }
+          }
+        },
+        "resources": { "type": "object" },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "endpoint": { "type": "string" },
+            "bucket": { "type": "string" },
+            "prefix": { "type": "string" },
+            "createBucketIfNotExists": { "type": "boolean" },
+            "existingSecret": { "type": "string" },
+            "existingSecretAccessKeyKey": { "type": "string" },
+            "existingSecretSecretKeyKey": { "type": "string" },
+            "accessKey": { "type": "string" },
+            "secretKey": { "type": "string" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "string" },
+            "name": { "type": "string" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" },
+            "mysqldumpArgs": { "type": "string" }
+          }
+        }
+      }
+    },
     "startupProbe": { "type": "object" },
     "livenessProbe": { "type": "object" },
     "readinessProbe": { "type": "object" },
-    "podSecurityContext": { "type": "object" },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "fsGroup": { "type": "integer" },
+        "fsGroupChangePolicy": { "type": "string" }
+      }
+    },
     "securityContext": { "type": "object" },
     "serviceAccount": { "type": "object" },
     "nodeSelector": { "type": "object" },

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -26,7 +26,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.3.8-apache-bookworm"
+  tag: "11.3.8-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -155,7 +155,13 @@ ingress:
 # Resources and Probes
 # =============================================================================
 
-resources: {}
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
 
 startupProbe:
   # -- Enable startup probe
@@ -188,10 +194,109 @@ readinessProbe:
   failureThreshold: 3
 
 # =============================================================================
+# Autoscaling and Availability
+# =============================================================================
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler. Requires MySQL-compatible database and RWX sites storage.
+  enabled: false
+  # -- Minimum number of replicas when autoscaling is enabled
+  minReplicas: 2
+  # -- Maximum number of replicas when autoscaling is enabled
+  maxReplicas: 5
+  # -- Target average CPU utilization percentage
+  targetCPUUtilizationPercentage: 75
+  # -- Target average memory utilization percentage
+  targetMemoryUtilizationPercentage: 80
+
+pdb:
+  # -- Create a PodDisruptionBudget for the Drupal workload
+  enabled: false
+  # -- Minimum healthy pods during voluntary disruptions
+  minAvailable: 1
+  # -- Maximum unavailable pods during voluntary disruptions
+  maxUnavailable: ""
+
+# =============================================================================
+# Backup (CronJob + S3)
+# =============================================================================
+
+backup:
+  # -- Enable scheduled backups to S3-compatible storage
+  enabled: false
+  # -- Cron schedule for backups
+  schedule: "0 3 * * *"
+  # -- Suspend the CronJob without deleting it
+  suspend: false
+  # -- CronJob concurrency policy
+  concurrencyPolicy: Forbid
+  # -- Number of successful job records to keep
+  successfulJobsHistoryLimit: 3
+  # -- Number of failed job records to keep
+  failedJobsHistoryLimit: 3
+  # -- Maximum retries per backup job
+  backoffLimit: 1
+  # -- Prefix for generated backup archive names
+  archivePrefix: drupal
+
+  images:
+    # -- Image used for mysqldump operations
+    mysql: docker.io/library/mysql:8.4
+    # -- Image used for consistent SQLite backup generation
+    sqlite: docker.io/library/python:3.13-alpine
+    # -- Image used to archive Drupal sites files
+    archiver: docker.io/library/alpine:3.22
+    # -- Image used to upload archives to S3-compatible storage
+    uploader: docker.io/helmforge/mc:1.0.0
+
+  # -- Resources for backup containers
+  resources: {}
+
+  s3:
+    # -- S3-compatible endpoint URL
+    endpoint: ""
+    # -- Target bucket name
+    bucket: ""
+    # -- Key prefix within the bucket
+    prefix: drupal
+    # -- Auto-create the bucket if it does not exist
+    createBucketIfNotExists: true
+    # -- Use an existing secret for S3 credentials
+    existingSecret: ""
+    # -- Key in the existing secret for the S3 access key
+    existingSecretAccessKeyKey: access-key
+    # -- Key in the existing secret for the S3 secret key
+    existingSecretSecretKeyKey: secret-key
+    # -- Inline S3 access key when not using an existing secret
+    accessKey: ""
+    # -- Inline S3 secret key when not using an existing secret
+    secretKey: ""
+
+  database:
+    # -- Override backup database host (defaults to the active Drupal DB host)
+    host: ""
+    # -- Override backup database port
+    port: ""
+    # -- Override backup database name
+    name: ""
+    # -- Override backup database username
+    username: ""
+    # -- Inline backup database password override
+    password: ""
+    # -- Existing secret with backup database password override
+    existingSecret: ""
+    # -- Secret key in backup.database.existingSecret for the database password
+    existingSecretPasswordKey: database-password
+    # -- Extra arguments passed to mysqldump
+    mysqldumpArgs: "--single-transaction --quick --skip-lock-tables --no-tablespaces"
+
+# =============================================================================
 # Scheduling and Security
 # =============================================================================
 
-podSecurityContext: {}
+podSecurityContext:
+  fsGroup: 33
+  fsGroupChangePolicy: OnRootMismatch
 securityContext: {}
 
 serviceAccount:


### PR DESCRIPTION
Related to #104

## Summary
- promote the Drupal chart to stable maturity with a production-ready image pin
- add built-in S3 backups for Drupal sites plus MySQL or SQLite database state
- add guarded HPA and PDB support for RWX-backed multi-replica deployments
- expand tests, CI values, examples, NOTES, and chart docs for production usage

## Validation
- helm lint --strict charts/drupal
- helm unittest charts/drupal
- helm template charts/drupal with all ci/*.yaml variants
- k3d validation for MySQL backup, SQLite backup, and RWX HPA scenarios
- reviewed logs for every pod/container involved in the k3d scenarios