### PR TITLE
fix(charts): fix database secret mismatch and runtime compatibility issues

### DIFF
--- a/charts/adguard-home/.helmignore
+++ b/charts/adguard-home/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/adguard-home/templates/NOTES.txt
+++ b/charts/adguard-home/templates/NOTES.txt
@@ -1,0 +1,223 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  AdGuard Home has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if (include "adguard-home.hasConfig" .) }}
+Mode: Pre-configured (setup wizard bypassed)
+{{- else }}
+Mode: Setup wizard (first-access via port 3000)
+{{- end }}
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+ADMIN PANEL: https://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access the Admin Panel locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "adguard-home.fullname" . }}-web 3000:{{ .Values.service.web.port }}
+
+{{- if (include "adguard-home.hasConfig" .) }}
+  ADMIN PANEL: http://localhost:3000/
+{{- else }}
+  SETUP WIZARD: http://localhost:3000/  (first-run wizard runs on port 3000)
+{{- end }}
+{{- end }}
+
+DNS Service:
+  Type: {{ .Values.service.dns.type }}
+{{- if eq .Values.service.dns.type "LoadBalancer" }}
+  Get assigned IP:
+    export DNS_IP=$(kubectl get svc {{ include "adguard-home.fullname" . }}-dns \
+      -n {{ .Release.Namespace }} \
+      -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "DNS server: $DNS_IP:53"
+{{- else if eq .Values.service.dns.type "NodePort" }}
+  Get NodePort:
+    export NODE_PORT=$(kubectl get svc {{ include "adguard-home.fullname" . }}-dns \
+      -n {{ .Release.Namespace }} \
+      -o jsonpath='{.spec.ports[0].nodePort}')
+    echo "DNS NodePort: $NODE_PORT"
+{{- else }}
+  Internal DNS endpoint (ClusterIP):
+    {{ include "adguard-home.fullname" . }}-dns.{{ .Release.Namespace }}.svc.cluster.local:53
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Deployment:
+  Image:              {{ include "adguard-home.image" . }}
+  Strategy:           Recreate (single-instance, no rolling update)
+  Persistence (conf): {{ .Values.persistence.conf.enabled }} ({{ .Values.persistence.conf.size }})
+  Persistence (work): {{ .Values.persistence.work.enabled }} ({{ .Values.persistence.work.size }})
+
+Configuration:
+{{- if (include "adguard-home.hasConfig" .) }}
+  Mode:               Pre-seeded (AdGuardHome.yaml mounted from secret)
+{{- else }}
+  Mode:               Interactive wizard on first access
+{{- end }}
+
+Optional Features:
+  Sync:               {{ .Values.sync.enabled }}
+{{- if .Values.sync.enabled }}
+  Sync Image:         {{ .Values.sync.image.repository }}:{{ .Values.sync.image.tag }}
+  Sync Cron:          {{ .Values.sync.cron }}
+  Sync RunOnStart:    {{ .Values.sync.runOnStart }}
+{{- end }}
+  Backup:             {{ .Values.backup.enabled }}
+{{- if .Values.backup.enabled }}
+  Backup Schedule:    {{ .Values.backup.schedule }}
+  Backup Destination: {{ .Values.backup.s3.bucket | default "<not configured>" }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for AdGuard Home to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=adguard-home \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=adguard-home -n {{ .Release.Namespace }}
+
+3. View startup logs:
+   kubectl logs -l app.kubernetes.io/name=adguard-home \
+     -n {{ .Release.Namespace }} --all-containers --tail=50
+
+{{- if not (include "adguard-home.hasConfig" .) }}
+4. Complete initial setup via the web wizard:
+   kubectl port-forward -n {{ .Release.Namespace }} \
+     svc/{{ include "adguard-home.fullname" . }}-web 3000:{{ .Values.service.web.port }}
+   Open: http://localhost:3000/
+
+5. After wizard completion, configure your network to use this server as DNS.
+{{- else }}
+4. Verify DNS is responding:
+   kubectl exec -n {{ .Release.Namespace }} \
+     deploy/{{ include "adguard-home.fullname" . }} -- \
+     nslookup google.com 127.0.0.1
+
+5. Access the admin panel (see ACCESS INFORMATION above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check pod status:
+  kubectl get pods -l app.kubernetes.io/name=adguard-home -n {{ .Release.Namespace }}
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/name=adguard-home -n {{ .Release.Namespace }}
+
+View application logs:
+  kubectl logs -l app.kubernetes.io/name=adguard-home \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+{{- if (include "adguard-home.hasConfig" .) }}
+View init container (config seeder) logs:
+  kubectl logs -l app.kubernetes.io/name=adguard-home \
+    -n {{ .Release.Namespace }} -c copy-config
+{{- end }}
+
+Check PVC status:
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Check service endpoints:
+  kubectl get endpoints -n {{ .Release.Namespace }} | grep {{ include "adguard-home.fullname" . }}
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Execute shell in pod (for debugging):
+  kubectl exec -n {{ .Release.Namespace }} \
+    -it deploy/{{ include "adguard-home.fullname" . }} -- /bin/sh
+
+{{- if .Values.sync.enabled }}
+View sync logs:
+  kubectl logs -l app.kubernetes.io/name=adguard-home \
+    -n {{ .Release.Namespace }} -c adguardhome-sync --tail=50
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+Check backup CronJob status:
+  kubectl get cronjob {{ include "adguard-home.fullname" . }}-backup -n {{ .Release.Namespace }}
+
+View last backup job logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/component=backup --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if and .Values.backup.enabled (not .Values.backup.s3.bucket) }}
+
+WARNING: Backup is enabled but no S3 bucket is configured!
+Backup jobs will fail. Configure the bucket:
+  helm upgrade {{ .Release.Name }} adguard-home \
+    --set backup.s3.endpoint=https://s3.example.com \
+    --set backup.s3.bucket=my-backup-bucket \
+    --reuse-values
+{{- end }}
+
+{{- if and .Values.sync.enabled (not .Values.sync.origin.url) }}
+
+WARNING: Sync is enabled but origin URL is not configured!
+Configure the origin AdGuard Home instance:
+  helm upgrade {{ .Release.Name }} adguard-home \
+    --set sync.origin.url=http://adguard-primary.example.com \
+    --set sync.origin.username=admin \
+    --reuse-values
+{{- end }}
+
+{{- if not .Values.persistence.conf.enabled }}
+
+WARNING: Configuration persistence (conf) is disabled!
+AdGuard Home configuration will be lost on pod restart.
+Enable for production:
+  helm upgrade {{ .Release.Name }} adguard-home \
+    --set persistence.conf.enabled=true --reuse-values
+{{- end }}
+
+{{- if not .Values.persistence.work.enabled }}
+
+WARNING: Data persistence (work) is disabled!
+Query logs, statistics and filter lists will be lost on pod restart.
+Enable for production:
+  helm upgrade {{ .Release.Name }} adguard-home \
+    --set persistence.work.enabled=true --reuse-values
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:        https://helmforge.dev/docs/charts/adguard-home
+Chart Repository:     https://github.com/helmforgedev/charts/tree/main/charts/adguard-home
+Report Issues:        https://github.com/helmforgedev/charts/issues
+
+AdGuard Home:         https://adguard.com/adguard-home/overview.html
+AdGuard Home Docs:    https://github.com/AdguardTeam/AdGuardHome/wiki
+AdGuardHome Sync:     https://github.com/bakito/adguardhome-sync
+
+For questions or feedback about this chart, please visit:
+  https://github.com/helmforgedev/charts/discussions
+
+Happy Helmforging :)

--- a/charts/alfio/.helmignore
+++ b/charts/alfio/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/alfio/templates/NOTES.txt
+++ b/charts/alfio/templates/NOTES.txt
@@ -1,0 +1,176 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  alf.io has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   https://{{ $host.host }}/
+ADMIN:    https://{{ $host.host }}/admin/
+API:      https://{{ $host.host }}/api/
+{{- end }}
+{{- else }}
+Port-forward to access alf.io locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "alfio.fullname" . }} 8080:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8080/
+  ADMIN:    http://localhost:8080/admin/
+  API:      http://localhost:8080/api/
+
+{{- end }}
+
+Internal cluster endpoint:
+  http://{{ include "alfio.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CREDENTIALS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Default admin credentials (first launch):
+  Username: admin
+  Password: (set during first-time setup wizard)
+
+IMPORTANT: Complete the setup wizard on first access to configure admin credentials.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Deployment:
+  Image:           {{ include "alfio.image" . }}
+  Spring Profiles: {{ .Values.alfio.profiles }}
+{{- if .Values.alfio.baseUrl }}
+  Base URL:        {{ .Values.alfio.baseUrl }}
+{{- else }}
+  Base URL:        (not set — configure for production use)
+{{- end }}
+
+Database:
+{{- if .Values.postgresql.enabled }}
+  Type:            PostgreSQL (subchart)
+  Host:            {{ include "alfio.dbHost" . }}:{{ include "alfio.dbPort" . }}
+  Database:        {{ include "alfio.dbName" . }}
+  Username:        {{ include "alfio.dbUsername" . }}
+{{- else }}
+  Type:            PostgreSQL (external)
+  Host:            {{ .Values.database.external.host }}:{{ .Values.database.external.port }}
+  Database:        {{ .Values.database.external.name }}
+  Username:        {{ .Values.database.external.username }}
+{{- end }}
+  JDBC URL:        {{ include "alfio.jdbcUrl" . }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for alf.io to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=alfio \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=alfio -n {{ .Release.Namespace }}
+
+3. View startup logs:
+   kubectl logs -l app.kubernetes.io/name=alfio \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Access alf.io (see ACCESS INFORMATION above):
+   - Complete the setup wizard on first access
+   - Create your organization and first event
+
+5. Configure base URL for production:
+   helm upgrade {{ .Release.Name }} alfio \
+     --set alfio.baseUrl=https://tickets.example.com \
+     --set alfio.profiles=spring-boot \
+     --reuse-values
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check pod status:
+  kubectl get pods -l app.kubernetes.io/name=alfio -n {{ .Release.Namespace }}
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/name=alfio -n {{ .Release.Namespace }}
+
+View application logs:
+  kubectl logs -l app.kubernetes.io/name=alfio \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+Check service endpoints:
+  kubectl get endpoints -n {{ .Release.Namespace }} | grep {{ include "alfio.fullname" . }}
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Execute shell in pod:
+  kubectl exec -n {{ .Release.Namespace }} \
+    -it deploy/{{ include "alfio.fullname" . }} -- /bin/sh
+
+{{- if .Values.postgresql.enabled }}
+Check PostgreSQL subchart pod:
+  kubectl get pods -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }}
+
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+Health check endpoint:
+  kubectl exec -n {{ .Release.Namespace }} \
+    deploy/{{ include "alfio.fullname" . }} -- \
+    wget -qO- http://localhost:8080/healthz
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if and (eq (.Values.alfio.profiles) "dev") (not .Values.alfio.baseUrl) }}
+
+WARNING: Spring profile is set to 'dev' and baseUrl is not configured.
+For production, use:
+  helm upgrade {{ .Release.Name }} alfio \
+    --set alfio.profiles=spring-boot \
+    --set alfio.baseUrl=https://tickets.example.com \
+    --reuse-values
+{{- end }}
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. To expose alf.io externally:
+  helm upgrade {{ .Release.Name }} alfio \
+    --set ingress.enabled=true \
+    --set ingress.hosts[0].host=tickets.example.com \
+    --set ingress.hosts[0].paths[0].path=/ \
+    --set ingress.hosts[0].paths[0].pathType=Prefix \
+    --reuse-values
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/alfio
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/alfio
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+alf.io Website:    https://alf.io
+alf.io GitHub:     https://github.com/alfio-event/alf.io
+alf.io Docs:       https://alfio-event.github.io/alf.io/
+
+For questions or feedback about this chart, please visit:
+  https://github.com/helmforgedev/charts/discussions
+
+Happy Helmforging :)

--- a/charts/answer/.helmignore
+++ b/charts/answer/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/appwrite/.helmignore
+++ b/charts/appwrite/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/appwrite/templates/NOTES.txt
+++ b/charts/appwrite/templates/NOTES.txt
@@ -1,0 +1,190 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Appwrite has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Domain: {{ include "appwrite.domain" . }}
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+CONSOLE:  https://{{ $host.host }}/
+API:      https://{{ $host.host }}/v1/
+{{- end }}
+{{- else }}
+Port-forward to access Appwrite Console:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "appwrite.fullname" . }} 8080:80
+
+  CONSOLE:  http://localhost:8080/
+  API:      http://localhost:8080/v1/
+
+{{- end }}
+
+Internal cluster API endpoint:
+  http://{{ include "appwrite.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/v1
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Deployment:
+  API Image:         {{ include "appwrite.image" . }}
+  Console Image:     {{ include "appwrite.consoleImage" . }}
+  Persistence:       {{ .Values.persistence.enabled }}
+
+Database (MariaDB):
+  Mode:              {{ include "appwrite.databaseMode" . }}
+{{- if eq (include "appwrite.databaseMode" .) "subchart" }}
+  Host:              {{ include "appwrite.databaseHost" . }}:{{ include "appwrite.databasePort" . }}
+  Database:          {{ include "appwrite.databaseName" . }}
+{{- else }}
+  Host:              {{ .Values.database.external.host }}:{{ .Values.database.external.port | default 3306 }}
+  Database:          {{ .Values.database.external.name | default "appwrite" }}
+{{- end }}
+
+Cache (Redis):
+  Mode:              {{ include "appwrite.cacheMode" . }}
+{{- if eq (include "appwrite.cacheMode" .) "subchart" }}
+  Host:              {{ include "appwrite.redisHost" . }}:{{ include "appwrite.redisPort" . }}
+{{- else }}
+  Host:              {{ .Values.cache.external.host }}:{{ .Values.cache.external.port | default 6379 }}
+{{- end }}
+
+Optional:
+  Backup:            {{ .Values.backup.enabled }}
+{{- if .Values.backup.enabled }}
+  Backup Schedule:   {{ .Values.backup.schedule }}
+  Backup Bucket:     {{ .Values.backup.s3.bucket | default "<not configured>" }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for all Appwrite pods to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/instance={{ .Release.Name }} \
+     -n {{ .Release.Namespace }} --timeout=600s
+
+2. Check all pod statuses:
+   kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+3. View API startup logs:
+   kubectl logs -l app.kubernetes.io/component=api \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Create your first account:
+   Open the Console URL, click "Sign Up" and create your admin account
+
+5. Create a new project in the Console and use the API key to integrate
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check all pods:
+  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+View API logs:
+  kubectl logs -l app.kubernetes.io/component=api \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+View worker logs:
+  kubectl logs -l app.kubernetes.io/component=worker \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+View realtime logs:
+  kubectl logs -l app.kubernetes.io/component=realtime \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+
+View scheduler logs:
+  kubectl logs -l app.kubernetes.io/component=scheduler \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/component=api -n {{ .Release.Namespace }}
+
+Check PVC status:
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if eq (include "appwrite.databaseMode" .) "subchart" }}
+View MariaDB logs:
+  kubectl logs -l app.kubernetes.io/name=mariadb \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+{{- if eq (include "appwrite.cacheMode" .) "subchart" }}
+View Redis logs:
+  kubectl logs -l app.kubernetes.io/name=redis \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+Check backup CronJob:
+  kubectl get cronjob {{ include "appwrite.fullname" . }}-backup -n {{ .Release.Namespace }}
+
+View last backup job logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/component=backup --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.persistence.enabled }}
+
+WARNING: Persistence is disabled!
+Appwrite uploads, functions, and certs will be lost on pod restart.
+Enable for production:
+  helm upgrade {{ .Release.Name }} appwrite \
+    --set persistence.enabled=true --reuse-values
+{{- end }}
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+For production, configure ingress with TLS:
+  helm upgrade {{ .Release.Name }} appwrite \
+    --set ingress.enabled=true \
+    --set "ingress.hosts[0].host=appwrite.example.com" \
+    --reuse-values
+{{- end }}
+
+{{- if not .Values.appwrite.domain }}
+
+WARNING: appwrite.domain is not set!
+Appwrite needs a proper domain for OAuth and function URLs.
+Set it:
+  helm upgrade {{ .Release.Name }} appwrite \
+    --set appwrite.domain=appwrite.example.com --reuse-values
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/appwrite
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/appwrite
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+Appwrite Website:  https://appwrite.io
+Appwrite Docs:     https://appwrite.io/docs
+Appwrite GitHub:   https://github.com/appwrite/appwrite
+
+For questions or feedback about this chart, please visit:
+  https://github.com/helmforgedev/charts/discussions
+
+Happy Helmforging :)

--- a/charts/archivebox/.helmignore
+++ b/charts/archivebox/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/archivebox/templates/NOTES.txt
+++ b/charts/archivebox/templates/NOTES.txt
@@ -1,0 +1,182 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ArchiveBox has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+ADMIN:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/admin/
+API:      http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/api/v1/
+{{- end }}
+{{- else }}
+Port-forward to access ArchiveBox locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "archivebox.fullname" . }} 8000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8000/
+  ADMIN:    http://localhost:8000/admin/
+  API:      http://localhost:8000/api/v1/
+
+{{- end }}
+
+Internal cluster endpoint:
+  http://{{ include "archivebox.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CREDENTIALS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.archivebox.existingSecret }}
+Credentials loaded from existing secret: {{ .Values.archivebox.existingSecret }}
+{{- else }}
+Admin Username: {{ .Values.archivebox.adminUsername | default "admin" }}
+Admin Password: (retrieve from secret)
+
+  kubectl get secret {{ include "archivebox.fullname" . }}-admin \
+    -n {{ .Release.Namespace }} \
+    -o jsonpath='{.data.admin-password}' | base64 -d
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Deployment:
+  Image:              {{ include "archivebox.image" . }}
+  Timezone:           {{ .Values.archivebox.timezone | default "UTC" }}
+  Search Backend:     {{ .Values.archivebox.searchBackendEngine | default "ripgrep" }}
+  Max Media Size:     {{ .Values.archivebox.mediaMaxSize | default "750m" }}
+  Timeout (per URL):  {{ .Values.archivebox.timeout | default "60" }}s
+  Persistence:        {{ .Values.persistence.enabled }} ({{ .Values.persistence.size }})
+
+Visibility:
+  Public Index:       {{ .Values.archivebox.publicIndex | default "True" }}
+  Public Snapshots:   {{ .Values.archivebox.publicSnapshots | default "True" }}
+  Public Add Links:   {{ .Values.archivebox.publicAddLinks | default "False" }}
+
+Optional Features:
+  Backup:             {{ .Values.backup.enabled }}
+{{- if .Values.backup.enabled }}
+  Backup Schedule:    {{ .Values.backup.schedule }}
+  Backup Bucket:      {{ .Values.backup.s3.bucket | default "<not configured>" }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for ArchiveBox to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=archivebox \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=archivebox -n {{ .Release.Namespace }}
+
+3. View startup logs:
+   kubectl logs -l app.kubernetes.io/name=archivebox \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Access the web interface (see ACCESS INFORMATION above)
+
+5. Add your first URL to archive via the Web UI or API:
+   curl -X POST http://localhost:8000/api/v1/add \
+     -H "Authorization: Bearer <your-api-token>" \
+     -d '{"urls": ["https://example.com"]}'
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check pod status:
+  kubectl get pods -l app.kubernetes.io/name=archivebox -n {{ .Release.Namespace }}
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/name=archivebox -n {{ .Release.Namespace }}
+
+View application logs:
+  kubectl logs -l app.kubernetes.io/name=archivebox \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+Check PVC status:
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Check service endpoints:
+  kubectl get endpoints -n {{ .Release.Namespace }} | grep {{ include "archivebox.fullname" . }}
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Execute shell in pod:
+  kubectl exec -n {{ .Release.Namespace }} \
+    -it deploy/{{ include "archivebox.fullname" . }} -- /bin/bash
+
+Run ArchiveBox CLI (list snapshots):
+  kubectl exec -n {{ .Release.Namespace }} \
+    deploy/{{ include "archivebox.fullname" . }} -- archivebox list
+
+{{- if .Values.backup.enabled }}
+Check backup CronJob:
+  kubectl get cronjob {{ include "archivebox.fullname" . }}-backup -n {{ .Release.Namespace }}
+
+View last backup job logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/component=backup --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.persistence.enabled }}
+
+WARNING: Persistence is disabled!
+All archived content and the SQLite database will be lost on pod restart.
+Enable for production:
+  helm upgrade {{ .Release.Name }} archivebox \
+    --set persistence.enabled=true --reuse-values
+{{- end }}
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+{{- if not .Values.archivebox.adminPassword }}
+
+WARNING: No admin password set.
+ArchiveBox will require you to set a password on first access.
+Set it:
+  helm upgrade {{ .Release.Name }} archivebox \
+    --set archivebox.adminPassword=<strong-password> --reuse-values
+{{- end }}
+
+NOTE: ArchiveBox uses Chromium headless for archiving.
+Minimum recommended resources: 2 CPU cores, 2Gi RAM.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/archivebox
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/archivebox
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+ArchiveBox:        https://archivebox.io
+ArchiveBox Docs:   https://docs.archivebox.io
+ArchiveBox GitHub: https://github.com/ArchiveBox/ArchiveBox
+
+For questions or feedback about this chart, please visit:
+  https://github.com/helmforgedev/charts/discussions
+
+Happy Helmforging :)

--- a/charts/authelia/.helmignore
+++ b/charts/authelia/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/authelia/templates/NOTES.txt
+++ b/charts/authelia/templates/NOTES.txt
@@ -1,0 +1,106 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Authelia has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+AUTH PORTAL:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Authelia locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "authelia.fullname" . }} 9091:80
+
+  AUTH PORTAL:  http://localhost:9091/
+  HEALTH:       http://localhost:9091/api/health
+
+{{- end }}
+
+Internal cluster endpoint:
+  http://{{ include "authelia.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/api/authz/forward-auth
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for Authelia to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=authelia \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=authelia -n {{ .Release.Namespace }}
+
+3. View startup logs:
+   kubectl logs -l app.kubernetes.io/name=authelia \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Configure your reverse proxy to forward auth to:
+   http://{{ include "authelia.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local/api/authz/forward-auth
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check pod status:
+  kubectl get pods -l app.kubernetes.io/name=authelia -n {{ .Release.Namespace }}
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/name=authelia -n {{ .Release.Namespace }}
+
+View application logs:
+  kubectl logs -l app.kubernetes.io/name=authelia \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+Check service endpoints:
+  kubectl get endpoints -n {{ .Release.Namespace }} | grep {{ include "authelia.fullname" . }}
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Execute shell in pod:
+  kubectl exec -n {{ .Release.Namespace }} \
+    -it deploy/{{ include "authelia.fullname" . }} -- /bin/sh
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Configure your reverse proxy to route
+to the Authelia service using the forward-auth endpoint.
+{{- end }}
+
+IMPORTANT: Authelia requires proper configuration of:
+  - SMTP server for email notifications
+  - Session domain and cookie configuration
+  - At least one authentication backend (LDAP, file, or database)
+  - Trusted proxies for forward-auth to work correctly
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/authelia
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/authelia
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+Authelia Website:  https://www.authelia.com
+Authelia Docs:     https://www.authelia.com/docs/
+Authelia GitHub:   https://github.com/authelia/authelia
+
+For questions or feedback about this chart, please visit:
+  https://github.com/helmforgedev/charts/discussions
+
+Happy Helmforging :)

--- a/charts/automatisch/.helmignore
+++ b/charts/automatisch/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/automatisch/templates/NOTES.txt
+++ b/charts/automatisch/templates/NOTES.txt
@@ -1,0 +1,99 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Automatisch has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Automatisch locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "automatisch.fullname" . }} 3000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:3000/
+
+{{- end }}
+
+Internal cluster endpoint:
+  http://{{ include "automatisch.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for Automatisch to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=automatisch \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=automatisch -n {{ .Release.Namespace }}
+
+3. View startup logs:
+   kubectl logs -l app.kubernetes.io/name=automatisch \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Open the Web UI and create your admin account on first launch
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check pod status:
+  kubectl get pods -l app.kubernetes.io/name=automatisch -n {{ .Release.Namespace }}
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/name=automatisch -n {{ .Release.Namespace }}
+
+View application logs:
+  kubectl logs -l app.kubernetes.io/name=automatisch \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+{{- if .Values.redis.enabled }}
+View Redis logs:
+  kubectl logs -l app.kubernetes.io/name=redis \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/automatisch
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/automatisch
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+Automatisch:       https://automatisch.io
+Automatisch Docs:  https://automatisch.io/docs
+Automatisch GH:    https://github.com/automatisch/automatisch
+
+Happy Helmforging :)

--- a/charts/castopod/.helmignore
+++ b/charts/castopod/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/castopod/templates/NOTES.txt
+++ b/charts/castopod/templates/NOTES.txt
@@ -1,0 +1,93 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Castopod has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+ADMIN:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/cp-admin/
+{{- end }}
+{{- else }}
+Port-forward to access Castopod locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "castopod.fullname" . }} 8000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8000/
+  ADMIN:    http://localhost:8000/cp-admin/
+
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for Castopod to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=castopod \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=castopod -n {{ .Release.Namespace }}
+
+3. View startup logs:
+   kubectl logs -l app.kubernetes.io/name=castopod \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Access /cp-admin/ and run the setup wizard to create your first podcast
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check pod status:
+  kubectl get pods -l app.kubernetes.io/name=castopod -n {{ .Release.Namespace }}
+
+Describe pod (events and errors):
+  kubectl describe pod -l app.kubernetes.io/name=castopod -n {{ .Release.Namespace }}
+
+View application logs:
+  kubectl logs -l app.kubernetes.io/name=castopod \
+    -n {{ .Release.Namespace }} --all-containers --tail=100
+
+View all chart resources:
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.mariadb.enabled }}
+View MariaDB logs:
+  kubectl logs -l app.kubernetes.io/name=mariadb \
+    -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+Castopod requires a public domain for podcast federation (ActivityPub).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/castopod
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/castopod
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+Castopod:          https://castopod.org
+Castopod Docs:     https://docs.castopod.org
+Castopod GitHub:   https://code.castopod.org/adaures/castopod
+
+Happy Helmforging :)

--- a/charts/changedetection/.helmignore
+++ b/charts/changedetection/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/changedetection/templates/NOTES.txt
+++ b/charts/changedetection/templates/NOTES.txt
@@ -1,0 +1,59 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  changedetection.io has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access changedetection.io locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "changedetection.fullname" . }} 5000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:5000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for the pod to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=changedetection \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=changedetection -n {{ .Release.Namespace }}
+
+3. View logs:
+   kubectl logs -l app.kubernetes.io/name=changedetection \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=changedetection -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=changedetection -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/changedetection
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/changedetection
+changedetection.io: https://changedetection.io | https://github.com/dgtlmoon/changedetection.io
+
+Happy Helmforging :)

--- a/charts/chiefonboarding/.helmignore
+++ b/charts/chiefonboarding/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/chiefonboarding/templates/NOTES.txt
+++ b/charts/chiefonboarding/templates/NOTES.txt
@@ -1,0 +1,77 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ChiefOnboarding has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+ADMIN:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/admin/
+{{- end }}
+{{- else }}
+Port-forward to access ChiefOnboarding locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "chiefonboarding.fullname" . }} 8000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8000/
+  ADMIN:    http://localhost:8000/admin/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Wait for the pod to be ready:
+   kubectl wait --for=condition=ready pod \
+     -l app.kubernetes.io/name=chiefonboarding \
+     -n {{ .Release.Namespace }} --timeout=300s
+
+2. Check pod status:
+   kubectl get pods -l app.kubernetes.io/name=chiefonboarding -n {{ .Release.Namespace }}
+
+3. View logs:
+   kubectl logs -l app.kubernetes.io/name=chiefonboarding \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Log in with your admin credentials to set up onboarding workflows
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=chiefonboarding -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=chiefonboarding -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/chiefonboarding
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/chiefonboarding
+ChiefOnboarding:   https://chiefonboarding.com | https://github.com/chiefonboarding/ChiefOnboarding
+
+Happy Helmforging :)

--- a/charts/ckan/.helmignore
+++ b/charts/ckan/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/cloudflared/.helmignore
+++ b/charts/cloudflared/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -1,0 +1,52 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  cloudflared has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TUNNEL STATUS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+cloudflared creates secure outbound-only tunnels to Cloudflare.
+No inbound ports are required.
+
+Tunnel metrics endpoint (internal):
+  http://{{ include "cloudflared.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port | default 2000 }}/metrics
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Check tunnel pod status:
+   kubectl get pods -l app.kubernetes.io/name=cloudflared -n {{ .Release.Namespace }}
+
+2. View tunnel connection logs:
+   kubectl logs -l app.kubernetes.io/name=cloudflared \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+3. Verify tunnel is connected (look for "Connection established"):
+   kubectl logs -l app.kubernetes.io/name=cloudflared \
+     -n {{ .Release.Namespace }} --all-containers | grep -i "connection\|tunnel\|registered"
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=cloudflared -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=cloudflared -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/cloudflared
+Cloudflare Tunnel: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+cloudflared GH:    https://github.com/cloudflare/cloudflared
+
+Happy Helmforging :)

--- a/charts/countly/.helmignore
+++ b/charts/countly/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/countly/templates/NOTES.txt
+++ b/charts/countly/templates/NOTES.txt
@@ -1,0 +1,59 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Countly has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Countly locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "countly.fullname" . }} 6001:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:6001/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.mongodb.enabled }}
+View MongoDB logs:
+  kubectl logs -l app.kubernetes.io/name=mongodb -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:   https://helmforge.dev/docs/charts/countly
+Countly:         https://count.ly | https://github.com/Countly/countly-server
+
+Happy Helmforging :)

--- a/charts/cronicle/.helmignore
+++ b/charts/cronicle/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/cronicle/templates/NOTES.txt
+++ b/charts/cronicle/templates/NOTES.txt
@@ -1,0 +1,69 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Cronicle has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Cronicle locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "cronicle.fullname" . }} 3012:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:3012/
+  ADMIN:    http://localhost:3012/#Admin
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CREDENTIALS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Default admin credentials (change after first login!):
+  Username: admin
+  Password: admin
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/cronicle
+Cronicle:       https://github.com/jhuckaby/Cronicle
+
+Happy Helmforging :)

--- a/charts/ddns-updater/.helmignore
+++ b/charts/ddns-updater/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/ddns-updater/templates/NOTES.txt
+++ b/charts/ddns-updater/templates/NOTES.txt
@@ -1,0 +1,53 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  DDNS Updater has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DDNS Updater runs as a background service — no inbound web UI by default.
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access the status UI:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ddns-updater.fullname" . }} 8000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl get pods -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
+2. kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+3. Check that your DNS provider credentials are configured correctly
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:   https://helmforge.dev/docs/charts/ddns-updater
+ddns-updater GH: https://github.com/qdm12/ddns-updater
+
+Happy Helmforging :)

--- a/charts/discount-bandit/.helmignore
+++ b/charts/discount-bandit/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/discount-bandit/templates/NOTES.txt
+++ b/charts/discount-bandit/templates/NOTES.txt
@@ -1,0 +1,60 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Discount Bandit has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Discount Bandit locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "discount-bandit.fullname" . }} 3000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:3000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:      https://helmforge.dev/docs/charts/discount-bandit
+Discount Bandit GH: https://github.com/PastaBolo/discount-bandit
+
+Happy Helmforging :)

--- a/charts/docmost/.helmignore
+++ b/charts/docmost/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/dolibarr/.helmignore
+++ b/charts/dolibarr/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -149,6 +149,8 @@ Database mode detection (auto | external | mysql).
 {{- define "dolibarr.databaseSecretName" -}}
 {{- if and (eq (include "dolibarr.databaseMode" .) "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
+{{- else if eq (include "dolibarr.databaseMode" .) "mysql" -}}
+{{- printf "%s-mysql-auth" .Release.Name -}}
 {{- else -}}
 {{- printf "%s-database" (include "dolibarr.fullname" .) -}}
 {{- end -}}
@@ -157,6 +159,8 @@ Database mode detection (auto | external | mysql).
 {{- define "dolibarr.databaseSecretKey" -}}
 {{- if and (eq (include "dolibarr.databaseMode" .) "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else if eq (include "dolibarr.databaseMode" .) "mysql" -}}
+mysql-user-password
 {{- else -}}
 database-password
 {{- end -}}

--- a/charts/druid/.helmignore
+++ b/charts/druid/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/elasticsearch/.helmignore
+++ b/charts/elasticsearch/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/fastmcp-server/.helmignore
+++ b/charts/fastmcp-server/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/flowise/.helmignore
+++ b/charts/flowise/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/generic/.helmignore
+++ b/charts/generic/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/generic/templates/NOTES.txt
+++ b/charts/generic/templates/NOTES.txt
@@ -1,0 +1,54 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {{ .Chart.Name | title }} has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+URL:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else if .Values.service.enabled }}
+Port-forward to access the workload:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Release.Name }} 8080:{{ .Values.service.port | default 80 }}
+
+  URL:  http://localhost:8080/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Check resource status:
+   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+2. View logs:
+   kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} \
+     -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl describe pod -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --all-containers --tail=100
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:     https://helmforge.dev/docs/charts/generic
+Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/generic
+Report Issues:     https://github.com/helmforgedev/charts/issues
+
+Happy Helmforging :)

--- a/charts/ghost/.helmignore
+++ b/charts/ghost/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/ghost/templates/NOTES.txt
+++ b/charts/ghost/templates/NOTES.txt
@@ -1,0 +1,69 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Ghost has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+BLOG:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+ADMIN:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/ghost/
+{{- end }}
+{{- else }}
+Port-forward to access Ghost locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ghost.fullname" . }} 2368:{{ .Values.service.port }}
+
+  BLOG:   http://localhost:2368/
+  ADMIN:  http://localhost:2368/ghost/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Open /ghost/ and complete setup wizard to create your admin account
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.mysql.enabled }}
+View MySQL logs:
+  kubectl logs -l app.kubernetes.io/name=mysql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+Ghost requires a public URL to send emails and for SEO.
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/ghost
+Ghost:          https://ghost.org | https://github.com/TryGhost/Ghost
+
+Happy Helmforging :)

--- a/charts/gitea/.helmignore
+++ b/charts/gitea/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/gitea/templates/NOTES.txt
+++ b/charts/gitea/templates/NOTES.txt
@@ -1,0 +1,75 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Gitea has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Gitea locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "gitea.fullname" . }} 3000:{{ .Values.service.http.port | default 3000 }}
+
+  WEB UI:   http://localhost:3000/
+{{- end }}
+
+SSH (if enabled):
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "gitea.fullname" . }}-ssh 2222:{{ .Values.service.ssh.port | default 2222 }}
+
+  SSH:  ssh://git@localhost:2222/<org>/<repo>.git
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Open the Web UI and complete the Gitea setup wizard (first access)
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+{{- if .Values.mysql.enabled }}
+View MySQL logs:
+  kubectl logs -l app.kubernetes.io/name=mysql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/gitea
+Gitea:          https://gitea.com | https://github.com/go-gitea/gitea
+
+Happy Helmforging :)

--- a/charts/guacamole/.helmignore
+++ b/charts/guacamole/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/guacamole/templates/_helpers.tpl
+++ b/charts/guacamole/templates/_helpers.tpl
@@ -107,6 +107,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "guacamole.dbSecretName" -}}
 {{- if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
+{{- else if and (eq (include "guacamole.dbType" .) "postgresql") .Values.postgresql.enabled -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- else if and (eq (include "guacamole.dbType" .) "mysql") .Values.mysql.enabled -}}
+{{- printf "%s-mysql-auth" .Release.Name -}}
 {{- else -}}
 {{- printf "%s-database" (include "guacamole.fullname" .) -}}
 {{- end -}}
@@ -116,6 +120,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "guacamole.dbSecretPasswordKey" -}}
 {{- if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else if and (eq (include "guacamole.dbType" .) "postgresql") .Values.postgresql.enabled -}}
+{{- "user-password" -}}
+{{- else if and (eq (include "guacamole.dbType" .) "mysql") .Values.mysql.enabled -}}
+{{- "mysql-user-password" -}}
 {{- else -}}
 {{- "password" -}}
 {{- end -}}

--- a/charts/heimdall/.helmignore
+++ b/charts/heimdall/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/heimdall/templates/NOTES.txt
+++ b/charts/heimdall/templates/NOTES.txt
@@ -1,0 +1,65 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Heimdall has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+DASHBOARD:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Heimdall locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "heimdall.fullname" . }} 8080:{{ .Values.service.port | default 80 }}
+
+  DASHBOARD:  http://localhost:8080/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Open the dashboard and add your application links
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.persistence.enabled }}
+
+WARNING: Persistence is disabled! Your Heimdall configuration will be lost on pod restart.
+{{- end }}
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/heimdall
+Heimdall:       https://heimdall.site | https://github.com/linuxserver/Heimdall
+
+Happy Helmforging :)

--- a/charts/homarr/.helmignore
+++ b/charts/homarr/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/homarr/templates/NOTES.txt
+++ b/charts/homarr/templates/NOTES.txt
@@ -1,0 +1,65 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Homarr has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+DASHBOARD:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Homarr locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "homarr.fullname" . }} 7575:{{ .Values.service.port | default 7575 }}
+
+  DASHBOARD:  http://localhost:7575/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Open the dashboard, create your admin account and configure your widgets
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/homarr
+Homarr:         https://homarr.dev | https://github.com/ajnart/homarr
+
+Happy Helmforging :)

--- a/charts/kafka/.helmignore
+++ b/charts/kafka/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/karakeep/.helmignore
+++ b/charts/karakeep/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/karakeep/templates/NOTES.txt
+++ b/charts/karakeep/templates/NOTES.txt
@@ -1,0 +1,50 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Karakeep has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Karakeep locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "karakeep.fullname" . }} 3000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:3000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/karakeep
+Karakeep:       https://karakeep.app | https://github.com/karakeep-app/karakeep
+
+Happy Helmforging :)

--- a/charts/keycloak/.helmignore
+++ b/charts/keycloak/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/komga/.helmignore
+++ b/charts/komga/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/listmonk/.helmignore
+++ b/charts/listmonk/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/liwan/.helmignore
+++ b/charts/liwan/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/liwan/templates/NOTES.txt
+++ b/charts/liwan/templates/NOTES.txt
@@ -1,0 +1,52 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Liwan has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+TRACKER:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}:9042/
+{{- end }}
+{{- else }}
+Port-forward to access Liwan locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "liwan.fullname" . }} 9042:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:9042/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/liwan
+Liwan:          https://liwan.dev | https://github.com/explodingcamera/liwan
+
+Happy Helmforging :)

--- a/charts/mariadb/.helmignore
+++ b/charts/mariadb/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/metabase/.helmignore
+++ b/charts/metabase/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -1,0 +1,70 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Metabase has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Metabase locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "metabase.fullname" . }} 3000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:3000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }} --timeout=600s
+2. kubectl get pods -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Open the UI and complete the initial setup wizard
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+{{- if .Values.backup.enabled }}
+Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+NOTE: Metabase can take 2-3 minutes to fully initialize on first start.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/metabase
+Metabase:       https://www.metabase.com | https://github.com/metabase/metabase
+
+Happy Helmforging :)

--- a/charts/middleware/.helmignore
+++ b/charts/middleware/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/middleware/templates/NOTES.txt
+++ b/charts/middleware/templates/NOTES.txt
@@ -1,0 +1,59 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Middleware has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Middleware locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "middleware.fullname" . }} 3000:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:3000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=middleware -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=middleware -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=middleware -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=middleware -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=middleware -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+{{- if .Values.redis.enabled }}
+View Redis logs:
+  kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/middleware
+Middleware:     https://middleware.io | https://github.com/middlewarehq/middleware
+
+Happy Helmforging :)

--- a/charts/minecraft/.helmignore
+++ b/charts/minecraft/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -17,7 +17,7 @@ keywords:
   - fabric
   - geyser
   - bedrock
-home: https://helmforge.dev
+home: https://helmforge.dev/docs/charts/minecraft
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/r/itzg/minecraft-server

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "java21"
+  tag: "java25"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -376,7 +376,7 @@ backup:
   images:
     # -- Image used for RCON commands and tar archiving
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:java21
+    worker: docker.io/itzg/minecraft-server:java25
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 

--- a/charts/mongodb/.helmignore
+++ b/charts/mongodb/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/mosquitto/.helmignore
+++ b/charts/mosquitto/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/mysql/.helmignore
+++ b/charts/mysql/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/n8n/.helmignore
+++ b/charts/n8n/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/ntfy/.helmignore
+++ b/charts/ntfy/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/ntfy/templates/NOTES.txt
+++ b/charts/ntfy/templates/NOTES.txt
@@ -1,0 +1,66 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ntfy has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+API:     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/<topic>
+{{- end }}
+{{- else }}
+Port-forward to access ntfy locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ntfy.fullname" . }} 2586:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:2586/
+  API:      http://localhost:2586/<topic>
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+Send your first notification:
+  curl -d "Hello World" http://localhost:2586/my-topic
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+For push notifications to mobile apps, ntfy needs a public HTTPS endpoint.
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/ntfy
+ntfy:           https://ntfy.sh | https://github.com/binwiederhier/ntfy
+
+Happy Helmforging :)

--- a/charts/olivetin/.helmignore
+++ b/charts/olivetin/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/olivetin/templates/NOTES.txt
+++ b/charts/olivetin/templates/NOTES.txt
@@ -1,0 +1,51 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  OliveTin has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access OliveTin locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "olivetin.fullname" . }} 1337:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:1337/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl exec -n {{ .Release.Namespace }} -it deploy/{{ include "olivetin.fullname" . }} -- /bin/sh
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/olivetin
+OliveTin:       https://www.olivetin.app | https://github.com/OliveTin/OliveTin
+
+Happy Helmforging :)

--- a/charts/open-webui/.helmignore
+++ b/charts/open-webui/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/open-webui/templates/NOTES.txt
+++ b/charts/open-webui/templates/NOTES.txt
@@ -1,0 +1,77 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Open WebUI has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Open WebUI locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "open-webui.fullname" . }} 8080:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8080/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Deployment:
+  Image:   {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=open-webui -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=open-webui -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=open-webui -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Create your admin account on first access
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=open-webui -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=open-webui -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+{{- if .Values.redis.enabled }}
+View Redis logs:
+  kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/open-webui
+Open WebUI:     https://openwebui.com | https://github.com/open-webui/open-webui
+
+Happy Helmforging :)

--- a/charts/phpmyadmin/.helmignore
+++ b/charts/phpmyadmin/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/phpmyadmin/templates/NOTES.txt
+++ b/charts/phpmyadmin/templates/NOTES.txt
@@ -1,0 +1,69 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  phpMyAdmin has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access phpMyAdmin locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "phpmyadmin.fullname" . }} 8080:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8080/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Database Host:  {{ .Values.phpmyadmin.dbHost | default "Configure via phpmyadmin.dbHost" }}
+Database Port:  {{ .Values.phpmyadmin.dbPort | default 3306 }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SECURITY WARNING: Do NOT expose phpMyAdmin to the public internet without
+authentication (IP restriction, VPN, or reverse proxy auth).
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/phpmyadmin
+phpMyAdmin:     https://www.phpmyadmin.net | https://github.com/phpmyadmin/phpmyadmin
+
+Happy Helmforging :)

--- a/charts/rabbitmq/.helmignore
+++ b/charts/rabbitmq/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/redis/.helmignore
+++ b/charts/redis/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -1,0 +1,53 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Redis has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONNECTION INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Redis endpoint (internal):
+  {{ include "redis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:6379
+
+Redis client endpoint (if replication mode):
+  {{ include "redis.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:6379
+
+Redis password (retrieve from secret):
+  kubectl get secret {{ include "redis.fullname" . }}-auth \
+    -n {{ .Release.Namespace }} \
+    -o jsonpath='{.data.redis-password}' | base64 -d
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl get pods -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }}
+2. kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+Test connectivity:
+  kubectl exec -n {{ .Release.Namespace }} \
+    -it sts/{{ include "redis.fullname" . }} -- redis-cli ping
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/redis
+Redis:          https://redis.io | https://github.com/redis/redis
+
+Happy Helmforging :)

--- a/charts/strapi/.helmignore
+++ b/charts/strapi/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - nodejs
   - postgresql
   - mysql
-home: https://helmforge.dev
+home: https://helmforge.dev/docs/charts/strapi
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/strapi
   - https://github.com/strapi/strapi

--- a/charts/strapi/templates/_helpers.tpl
+++ b/charts/strapi/templates/_helpers.tpl
@@ -220,6 +220,10 @@ sqlite
 {{- $mode := include "strapi.databaseMode" . -}}
 {{- if and (eq $mode "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
+{{- else if eq $mode "postgresql" -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- else if eq $mode "mysql" -}}
+{{- printf "%s-mysql-auth" .Release.Name -}}
 {{- else -}}
 {{- printf "%s-database" (include "strapi.fullname" .) -}}
 {{- end -}}
@@ -229,6 +233,10 @@ sqlite
 {{- $mode := include "strapi.databaseMode" . -}}
 {{- if and (eq $mode "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else if eq $mode "postgresql" -}}
+user-password
+{{- else if eq $mode "mysql" -}}
+mysql-user-password
 {{- else -}}
 database-password
 {{- end -}}

--- a/charts/strava-statistics/.helmignore
+++ b/charts/strava-statistics/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/strava-statistics/templates/NOTES.txt
+++ b/charts/strava-statistics/templates/NOTES.txt
@@ -1,0 +1,63 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Strava Statistics has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Strava Statistics locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "strava-statistics.fullname" . }} 8080:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8080/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Authorize with your Strava account on first access
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+Strava OAuth requires a public callback URL. Configure your Strava API
+app with your public URL for proper OAuth authorization flow.
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:      https://helmforge.dev/docs/charts/strava-statistics
+strava-statistics:  https://github.com/robiningelbrecht/strava-statistics
+
+Happy Helmforging :)

--- a/charts/superset/.helmignore
+++ b/charts/superset/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/umami/.helmignore
+++ b/charts/umami/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/umami/templates/NOTES.txt
+++ b/charts/umami/templates/NOTES.txt
@@ -1,0 +1,75 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Umami has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+DASHBOARD:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+TRACKER:     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/script.js
+{{- end }}
+{{- else }}
+Port-forward to access Umami locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "umami.fullname" . }} 3000:{{ .Values.service.port | default 3000 }}
+
+  DASHBOARD:  http://localhost:3000/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CREDENTIALS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Default admin credentials (change after first login!):
+  Username: admin
+  Password: umami
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Log in and add your first website to track
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+The tracking script requires a public URL to collect analytics data.
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/umami
+Umami:          https://umami.is | https://github.com/umami-software/umami
+
+Happy Helmforging :)

--- a/charts/uptime-kuma/.helmignore
+++ b/charts/uptime-kuma/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/uptime-kuma/templates/NOTES.txt
+++ b/charts/uptime-kuma/templates/NOTES.txt
@@ -1,0 +1,67 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Uptime Kuma has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+DASHBOARD:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+STATUS PAGE:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/status/
+{{- end }}
+{{- else }}
+Port-forward to access Uptime Kuma locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "uptime-kuma.fullname" . }} 3001:{{ .Values.service.port | default 3001 }}
+
+  DASHBOARD:    http://localhost:3001/
+  STATUS PAGE:  http://localhost:3001/status/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Create your admin account on first access and add monitors
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.persistence.enabled }}
+
+WARNING: Persistence is disabled! All monitors and data will be lost on restart.
+{{- end }}
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/uptime-kuma
+Uptime Kuma:    https://uptime.kuma.pet | https://github.com/louislam/uptime-kuma
+
+Happy Helmforging :)

--- a/charts/vaultwarden/.helmignore
+++ b/charts/vaultwarden/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - bitwarden
   - password-manager
   - self-hosted
-home: https://helmforge.dev
+home: https://helmforge.dev/docs/charts/vaultwarden
 sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/dani-garcia/vaultwarden

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -69,8 +69,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- with (include "vaultwarden.domain" .) }}
             - name: DOMAIN
-              value: {{ include "vaultwarden.domain" . | quote }}
+              value: {{ . | quote }}
+            {{- end }}
             - name: SIGNUPS_ALLOWED
               value: {{ ternary "true" "false" .Values.vaultwarden.signupsAllowed | quote }}
             - name: SIGNUPS_VERIFY

--- a/charts/velero/.helmignore
+++ b/charts/velero/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/wallabag/.helmignore
+++ b/charts/wallabag/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/wallabag/templates/NOTES.txt
+++ b/charts/wallabag/templates/NOTES.txt
@@ -1,0 +1,78 @@
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Wallabag has been successfully deployed!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Chart:      {{ .Chart.Name }}
+Version:    {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ACCESS INFORMATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- end }}
+{{- else }}
+Port-forward to access Wallabag locally:
+
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "wallabag.fullname" . }} 8080:{{ .Values.service.port }}
+
+  WEB UI:   http://localhost:8080/
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CREDENTIALS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Admin credentials:
+  kubectl get secret {{ include "wallabag.fullname" . }} \
+    -n {{ .Release.Namespace }} \
+    -o jsonpath='{.data.wallabag-password}' | base64 -d
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  GETTING STARTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=wallabag -n {{ .Release.Namespace }} --timeout=300s
+2. kubectl get pods -l app.kubernetes.io/name=wallabag -n {{ .Release.Namespace }}
+3. kubectl logs -l app.kubernetes.io/name=wallabag -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+4. Log in and start saving articles for offline reading
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  TROUBLESHOOTING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  kubectl describe pod -l app.kubernetes.io/name=wallabag -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=wallabag -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.postgresql.enabled }}
+View PostgreSQL logs:
+  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+{{- if .Values.redis.enabled }}
+View Redis logs:
+  kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  WARNINGS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+{{- if not .Values.ingress.enabled }}
+
+NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ADDITIONAL RESOURCES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation:  https://helmforge.dev/docs/charts/wallabag
+Wallabag:       https://wallabag.org | https://github.com/wallabag/wallabag
+
+Happy Helmforging :)

--- a/charts/wordpress/.helmignore
+++ b/charts/wordpress/.helmignore
@@ -1,0 +1,29 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+*.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -14,7 +14,7 @@ keywords:
   - blog
   - php
   - mysql
-home: https://helmforge.dev
+home: https://helmforge.dev/docs/charts/wordpress
 sources:
   - https://github.com/helmforgedev/charts
   - https://hub.docker.com/_/wordpress

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -165,6 +165,8 @@ Database password secret name.
 {{- $mode := include "wordpress.databaseMode" . -}}
 {{- if and (eq $mode "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
+{{- else if eq $mode "mysql" -}}
+{{- printf "%s-mysql-auth" .Release.Name -}}
 {{- else -}}
 {{- printf "%s-database" (include "wordpress.fullname" .) -}}
 {{- end -}}
@@ -177,6 +179,8 @@ Database password secret key.
 {{- $mode := include "wordpress.databaseMode" . -}}
 {{- if and (eq $mode "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else if eq $mode "mysql" -}}
+{{- print "mysql-user-password" -}}
 {{- else -}}
 {{- print "database-password" -}}
 {{- end -}}

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -72,8 +72,8 @@ tests:
             name: WORDPRESS_DB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: test-wordpress-database
-                key: database-password
+                name: test-mysql-auth
+                key: mysql-user-password
 
   - it: should set table prefix
     template: templates/deployment.yaml


### PR DESCRIPTION
## Summary

Fixes database credential mismatches that caused `CrashLoopBackOff` on first install for dolibarr, guacamole, strapi, and wordpress. Also fixes minecraft Java version incompatibility and vaultwarden empty DOMAIN crash.

All bugs were discovered and validated via K3d deploy+log cycle.

## Changes

### Database Secret Mismatch (4 charts)

Charts were generating a separate `{release}-{chart}-database` secret with a random password that **did not match** the password in the subchart-generated secret (`{release}-postgresql-auth` / `{release}-mysql-auth`), causing `Access denied` / `password authentication failed` on startup.

- **fix(dolibarr)**: `databaseSecretName` now points to `{release}-postgresql-auth` (key: `user-password`)
- **fix(guacamole)**: same postgresql-auth fix
- **fix(strapi)**: same postgresql-auth fix + mysql-auth support (key: `mysql-user-password`)
- **fix(wordpress)**: `databaseSecretName` now points to `{release}-mysql-auth` (key: `mysql-user-password`)

### Runtime Compatibility

- **fix(minecraft)**: bump default `image.tag` from `java21` to `java25` — Minecraft 1.21.5+ (LATEST tag) requires Java 25 (class file version 69.0), causing `UnsupportedClassVersionError` with java21
- **fix(vaultwarden)**: wrap `DOMAIN` env in `{{- with }}` so it is only emitted when configured — Vaultwarden 1.33+ rejects startup with `DOMAIN=""` (relative URL without a base)

## Testing

All 6 charts validated via K3d deploy+log cycle:

| Chart | Status | Evidence |
|-------|--------|----------|
| dolibarr | 1/1 Running | DB connected |
| guacamole | 1/1 Running | DB connected |
| strapi | 1/1 Running | `Strapi started successfully` |
| minecraft | 1/1 Running | Server started with java25 |
| vaultwarden | 1/1 Running | `Rocket has launched from http://0.0.0.0:80` |
| wordpress | 1/1 Running | Probe 200 OK on `/wp-admin/install.php` |
