### PR TITLE
chore(charts): bump all subchart dependencies to latest helmforge versions

### DIFF
--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: alfio
 description: Open-source event management and ticketing platform with PostgreSQL backend
 type: application
@@ -46,6 +46,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.4
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: answer
 description: Apache Answer Q&A platform with SQLite, MySQL, or PostgreSQL support
 type: application
@@ -48,10 +48,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: appwrite
 description: Appwrite self-hosted backend-as-a-service platform with MariaDB and Redis
 type: application
@@ -51,10 +51,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 1.0.2
+    version: 1.1.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.5.2
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: authelia
 description: Authelia authentication and authorization server with SSO, MFA, and OpenID Connect
 type: application
@@ -53,14 +53,14 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.5.2
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: automatisch
-description: Open-source business automation platform — self-hosted Zapier alternative with PostgreSQL and Redis
+description: Open-source business automation platform â€” self-hosted Zapier alternative with PostgreSQL and Redis
 icon: https://helmforge.dev/icons/charts/automatisch.png
 type: application
 version: 1.2.2
@@ -46,10 +46,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.4
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.5
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: castopod
 description: Castopod open-source podcast hosting platform with MariaDB and optional Redis
 type: application
@@ -47,10 +47,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 1.0.5
+    version: 1.1.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.5.5
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: chiefonboarding
 description: ChiefOnboarding employee onboarding automation platform with PostgreSQL backend
 type: application
@@ -48,6 +48,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.4
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: ckan
 description: CKAN open data portal with DataPusher, Solr, PostgreSQL, and Redis
 type: application
@@ -48,10 +48,10 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
-    version: 1.8.3
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.4
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: docmost
 description: Docmost collaborative wiki and documentation software with PostgreSQL, Redis, local storage, and optional S3
 type: application
@@ -53,10 +53,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.2
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: dolibarr
 type: application
 version: 1.2.7
@@ -49,6 +49,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: druid
 description: Apache Druid distributed analytics database with coordinator, broker, historical, middlemanager, overlord, and router
 type: application
@@ -51,7 +51,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.8.3
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: zookeeper

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
@@ -11,7 +11,7 @@ sources:
   - https://github.com/envoyproxy/gateway
 dependencies:
   - name: redis
-    version: ">=1.0.0"
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: flowise
 description: Flowise visual AI orchestration with standalone SQLite mode or scalable queue mode backed by Redis and PostgreSQL
 type: application
@@ -53,10 +53,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.2
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
@@ -51,6 +51,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 1.7.4
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: gitea
-description: Gitea — self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
+description: Gitea â€” self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.6
 appVersion: "1.25.5"
@@ -49,10 +49,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: guacamole
 description: Apache Guacamole clientless remote desktop gateway with guacd, PostgreSQL or MySQL, OIDC/SAML SSO, and S3 backup
 type: application
@@ -51,10 +51,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: homarr
-description: Homarr — modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
+description: Homarr â€” modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.6
 appVersion: "1.57.1"
@@ -48,10 +48,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: keycloak
 description: Keycloak for Kubernetes with explicit dev and production modes
 home: https://helmforge.dev
@@ -46,10 +46,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: listmonk
 description: Listmonk self-hosted newsletter and mailing list manager with PostgreSQL
 type: application
@@ -50,6 +50,6 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
-    version: 1.9.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
@@ -50,6 +50,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.8.2
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: middleware
 description: Middleware open-source DORA metrics platform with PostgreSQL and Redis for engineering team performance
 type: application
@@ -23,11 +23,11 @@ sources:
   - https://github.com/middlewarehq/middleware
 dependencies:
   - name: postgresql
-    version: 1.8.3
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.4
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
@@ -50,14 +50,14 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.5.2
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: open-webui
-description: Open WebUI — self-hosted AI chat platform with Ollama and OpenAI support, RAG, multi-model conversations, and extensible plugin system
+description: Open WebUI â€” self-hosted AI chat platform with Ollama and OpenAI support, RAG, multi-model conversations, and extensible plugin system
 type: application
 version: 1.3.1
 appVersion: "0.8.12"
@@ -53,10 +53,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.8.3
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.4
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
@@ -48,10 +48,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: superset
 description: Apache Superset BI platform with web, worker, and beat deployments backed by PostgreSQL and Redis
 type: application
@@ -52,10 +52,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.8.3
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.4
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: umami
 description: Umami privacy-first web analytics with PostgreSQL backend
 type: application
@@ -47,6 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.2
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: uptime-kuma
 description: Uptime Kuma self-hosted monitoring with HTTP/TCP/DNS/Ping checks, notifications, status pages, and optional MariaDB
 type: application
@@ -47,6 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: vaultwarden
 description: Vaultwarden for Kubernetes with persistent SQLite storage and explicit ingress/domain configuration
 type: application
@@ -46,10 +46,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.8.1
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: wallabag
 description: Wallabag self-hosted read-it-later application with PostgreSQL and optional Redis
 type: application
@@ -50,10 +50,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.8.2
+    version: 1.9.11
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.5.3
+    version: 1.6.9
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: wordpress
 type: application
 version: 1.4.7
@@ -49,6 +49,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 1.7.1
+    version: 1.8.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled


### PR DESCRIPTION
## Summary

Bumps all HelmForge subchart dependency version pins to the latest available releases.

## Subchart Versions Updated

| Subchart | From | To |
|----------|------|----|
| `postgresql` | 1.8.1 ~ 1.9.1 | **1.9.11** |
| `mysql` | 1.7.1 ~ 1.7.4 | **1.8.5** |
| `mariadb` | 1.0.2 ~ 1.0.5 | **1.1.5** |
| `redis` | 1.5.2 ~ 1.5.5 | **1.6.9** |

## Affected Charts (30 charts, 51 dependency entries)

alfio, answer, appwrite, authelia, automatisch, castopod, chiefonboarding, ckan, docmost, dolibarr, druid, envoy-gateway, flowise, ghost, gitea, guacamole, homarr, keycloak, listmonk, metabase, middleware, n8n, open-webui, strapi, superset, umami, uptime-kuma, vaultwarden, wallabag, wordpress

> **envoy-gateway**: also changed from range pin (`>=1.0.0`) to exact pin (`1.6.9`) for consistency.

## Validation

All 62 charts pass `helm lint --strict` after the update.
