### PR TITLE
feat(fastmcp-server): expand runtime configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.tgz binary
+*.zip binary

--- a/charts/fastmcp-server/README.md
+++ b/charts/fastmcp-server/README.md
@@ -6,8 +6,13 @@ A Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fast
 
 - Multi-source loading with merge precedence: Inline > S3 > Git
 - Bearer token and JWT authentication via FastMCP
+- Multi-provider authentication with bearer and JWT
+- Auth scopes, reload scopes, and destructive-tool approval controls
 - Knowledge base files served as MCP resources
 - Extra pip packages installed at startup
+- S3, Git, and OCI source filters with optional background sync
+- Gateway mode for mounting remote MCP servers
+- Tool visibility filtering by tags
 - Built-in Web UI dashboard at `/ui`
 - Prometheus metrics with ServiceMonitor support
 - Structured JSON logging for log aggregation
@@ -85,8 +90,8 @@ sources:
     bucket: mcp-tools
     region: us-east-1
     prefix: production
-    accessKey: minioadmin
-    secretKey: minioadmin
+    accessKey: "<access-key>"
+    secretKey: "<secret-key>"
 ```
 
 Or with an existing secret:
@@ -112,7 +117,7 @@ sources:
     repository: "https://github.com/your-org/mcp-tools.git"
     branch: main
     path: ""
-    token: ghp_xxx  # for private repos
+    token: "<github-token>"  # for private repos
 ```
 
 ### Authentication
@@ -136,6 +141,54 @@ auth:
     audience: "mcp-server"
     jwksUri: "https://auth.example.com/.well-known/jwks.json"
 ```
+
+Multi-provider authentication:
+
+```yaml
+auth:
+  type: multi
+  providers:
+    - bearer
+    - jwt
+  scopes:
+    - mcp:read
+  reloadRequiredScopes:
+    - mcp:admin
+```
+
+See [Authentication](docs/authentication.md) for bearer, JWT, multi-provider,
+scope, and reload authorization examples.
+
+### Gateway Mode
+
+```yaml
+gateway:
+  enabled: true
+  mountServers:
+    remote:
+      transport: streamable-http
+      url: https://remote.example.com/mcp
+      namespace: remote
+```
+
+See [Gateway](docs/gateway.md) for gateway mode details.
+
+### Source Filters and Sync
+
+```yaml
+sources:
+  s3:
+    enabled: true
+    bucket: mcp-assets
+    include:
+      - tools/**
+    exclude:
+      - "**/*.tmp"
+    syncInterval: 60
+```
+
+See [Sources](docs/sources.md) for inline, S3, Git, OCI, and hot reload
+configuration.
 
 ### Observability
 
@@ -242,8 +295,10 @@ securityContext:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/helmforge/fastmcp-server` | Container image |
-| `image.tag` | `0.10.10` | Image tag |
+| `image.tag` | `0.11.0` | Image tag |
 | `server.name` | `fastmcp-server` | Server name in MCP responses |
+| `server.environment` | `dev` | Runtime environment passed as `MCP_ENV` |
+| `server.workspace` | `/app/workspace` | Workspace path for synced components |
 | `server.port` | `8000` | HTTP port |
 | `server.path` | `/mcp` | MCP endpoint path |
 | `server.logLevel` | `INFO` | Log level |
@@ -252,18 +307,25 @@ securityContext:
 | `ui.enabled` | `true` | Enable Web UI at `/ui` |
 | `metrics.enabled` | `false` | Enable Prometheus metrics at `/metrics` |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor CRD |
-| `auth.type` | `none` | Authentication: `none`, `bearer`, `jwt` |
+| `auth.type` | `none` | Authentication: `none`, `bearer`, `jwt`, `multi` |
+| `auth.reloadRequiredScopes` | `["mcp:admin"]` | Scopes required for `/reload` |
 | `sources.inline.tools` | `{}` | Inline Python tool files |
 | `sources.inline.resources` | `{}` | Inline Python resource files |
 | `sources.inline.prompts` | `{}` | Inline Python prompt files |
 | `sources.inline.knowledge` | `{}` | Inline knowledge base files |
 | `sources.s3.enabled` | `false` | Enable S3 source |
 | `sources.s3.bucket` | `""` | S3 bucket name |
+| `sources.s3.syncInterval` | `0` | Periodic S3 sync interval in seconds |
 | `sources.git.enabled` | `false` | Enable Git source |
 | `sources.git.repository` | `""` | Git repository HTTPS URL |
+| `sources.git.syncInterval` | `0` | Periodic Git sync interval in seconds |
+| `sources.oci.enabled` | `false` | Enable OCI source |
+| `gateway.enabled` | `false` | Enable gateway mode |
+| `visibility.mode` | `blocklist` | Tool visibility strategy |
 | `extraPipPackages` | `[]` | Extra pip packages at startup |
 | `initSync.enabled` | `false` | Run source sync as init container |
 | `persistence.enabled` | `false` | Enable persistent workspace |
+| `serviceAccount.create` | `true` | Create a dedicated Kubernetes ServiceAccount |
 | `ingress.enabled` | `false` | Enable ingress |
 | `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
 
@@ -321,6 +383,18 @@ Then use `http://localhost:8000/mcp` as the URL (no auth if `auth.type=none`).
 - [Basic inline tools](examples/basic/)
 - [S3 source with MinIO](examples/s3-minio/)
 - [Production setup](examples/production/)
+- [Production S3 source](examples/production-s3-values.yaml)
+- [Gateway mode](examples/gateway-values.yaml)
+- [JWT authentication](examples/jwt-values.yaml)
+- [Multi-auth](examples/multi-auth-values.yaml)
+- [Development hot reload](examples/dev-hot-reload-values.yaml)
+
+## Architecture Guides
+
+- [Authentication](docs/authentication.md)
+- [Sources](docs/sources.md)
+- [Gateway](docs/gateway.md)
+- [Operations](docs/operations.md)
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/fastmcp-server/ci/auth-multi-values.yaml
+++ b/charts/fastmcp-server/ci/auth-multi-values.yaml
@@ -1,0 +1,25 @@
+auth:
+  type: multi
+  providers:
+    - bearer
+    - jwt
+  scopes:
+    - tools:read
+    - tools:execute
+  requiredScopes:
+    - tools:execute
+  reloadRequiredScopes:
+    - mcp:reload
+  bearer:
+    existingSecret: fastmcp-auth
+  jwt:
+    issuer: "https://auth.example.com"
+    audience: "fastmcp-server"
+    jwksUri: "https://auth.example.com/.well-known/jwks.json"
+
+sources:
+  inline:
+    tools:
+      hello.py: |
+        def hello() -> str:
+            return "hello"

--- a/charts/fastmcp-server/ci/full-values.yaml
+++ b/charts/fastmcp-server/ci/full-values.yaml
@@ -1,15 +1,44 @@
 # CI: all features enabled
 server:
   name: full-test-server
+  version: "0.11.0"
+  environment: staging
+  host: 0.0.0.0
   logLevel: DEBUG
+  maskErrorDetails: true
+  onDuplicateTools: warn
+  corsAllowedOrigins:
+    - https://mcp.example.com
+  maxSourceFileSizeBytes: 2097152
+  maxKnowledgeBytes: 31457280
+  allowedKnowledgeExtensions:
+    - .md
+    - .txt
+    - .json
 
 auth:
-  type: bearer
+  type: multi
+  scopes:
+    - mcp:read
+    - mcp:admin
+  requiredScopes:
+    - mcp:read
+  providers:
+    - bearer
+    - jwt
   bearer:
     token: ci-test-token-full
+  jwt:
+    issuer: https://auth.example.com
+    audience: fastmcp
+    publicKey: ci-jwt-secret
+    algorithm: HS256
 
 sources:
+  blockedFileAllowlist:
+    - knowledge/private-config.example
   inline:
+    dir: /app/inline
     tools:
       greet.py: |
         def greet(name: str) -> str:
@@ -24,13 +53,53 @@ sources:
     endpoint: "https://minio.example.com"
     bucket: mcp-assets
     region: us-east-1
-    accessKey: minioadmin
-    secretKey: minioadmin
+    accessKey: example-access-key
+    secretKey: example-secret-key
+    include:
+      - tools/**
+    exclude:
+      - "**/*.tmp"
+    syncInterval: 60
   git:
     enabled: true
     repository: "https://github.com/example/tools.git"
     branch: main
-    token: ghp_example
+    token: example-git-token
+    allowedRepositories:
+      - https://github.com/example/*
+    allowedBranches:
+      - main
+    include:
+      - tools/**
+    exclude:
+      - "**/*.tmp"
+    syncInterval: 120
+  oci:
+    enabled: true
+    registry: "oci://registry.example.com/mcp"
+    tag: "1.0.0"
+    username: ci
+    password: ci-password
+    include:
+      - tools/**
+
+hotReload:
+  enabled: true
+
+gateway:
+  enabled: true
+  mountServers:
+    remote:
+      transport: streamable-http
+      url: https://remote.example.com/mcp
+      namespace: remote
+
+visibility:
+  mode: allowlist
+  enableTags:
+    - public
+  disableTags:
+    - admin
 
 extraPipPackages:
   - requests

--- a/charts/fastmcp-server/ci/gateway-values.yaml
+++ b/charts/fastmcp-server/ci/gateway-values.yaml
@@ -1,0 +1,11 @@
+gateway:
+  enabled: true
+  mountServers:
+    local:
+      transport: streamable-http
+      url: "http://local-mcp.default.svc.cluster.local:8000/mcp"
+
+auth:
+  type: bearer
+  bearer:
+    existingSecret: fastmcp-gateway-auth

--- a/charts/fastmcp-server/ci/git-source-values.yaml
+++ b/charts/fastmcp-server/ci/git-source-values.yaml
@@ -5,4 +5,4 @@ sources:
     repository: "https://github.com/example/mcp-tools.git"
     branch: main
     path: ""
-    token: ghp_exampletoken123
+    token: example-git-token

--- a/charts/fastmcp-server/ci/jwt-values.yaml
+++ b/charts/fastmcp-server/ci/jwt-values.yaml
@@ -1,0 +1,14 @@
+auth:
+  type: jwt
+  jwt:
+    issuer: "https://auth.example.com"
+    audience: "fastmcp-server"
+    jwksUri: "https://auth.example.com/.well-known/jwks.json"
+    algorithm: RS256
+
+sources:
+  inline:
+    tools:
+      hello.py: |
+        def hello() -> str:
+            return "hello"

--- a/charts/fastmcp-server/ci/oci-source-values.yaml
+++ b/charts/fastmcp-server/ci/oci-source-values.yaml
@@ -1,0 +1,15 @@
+sources:
+  oci:
+    enabled: true
+    registry: ghcr.io/example/mcp-bundle
+    tag: "1.0.0"
+    include:
+      - tools/**
+      - knowledge/**
+    exclude:
+      - "**/*.tmp"
+  inline:
+    knowledge:
+      overview.md: |
+        # Overview
+        OCI source render coverage.

--- a/charts/fastmcp-server/ci/visibility-values.yaml
+++ b/charts/fastmcp-server/ci/visibility-values.yaml
@@ -1,0 +1,16 @@
+visibility:
+  mode: allowlist
+  enableTags:
+    - public
+    - approved
+  disableTags:
+    - destructive
+
+sources:
+  inline:
+    tools:
+      visible.py: |
+        __tags__ = {"public"}
+
+        def visible() -> str:
+            return "visible"

--- a/charts/fastmcp-server/docs/authentication.md
+++ b/charts/fastmcp-server/docs/authentication.md
@@ -1,0 +1,71 @@
+# Authentication
+
+FastMCP Server separates client authentication from source credentials and tool credentials.
+
+## Bearer
+
+```yaml
+auth:
+  type: bearer
+  scopes:
+    - mcp:read
+    - mcp:admin
+  bearer:
+    existingSecret: fastmcp-auth
+    existingSecretKey: token
+```
+
+## JWT
+
+```yaml
+auth:
+  type: jwt
+  jwt:
+    issuer: https://auth.example.com
+    audience: fastmcp-server
+    jwksUri: https://auth.example.com/.well-known/jwks.json
+```
+
+For local HS256 testing, use an existing secret containing the shared key:
+
+```yaml
+auth:
+  type: jwt
+  jwt:
+    algorithm: HS256
+    publicKeyExistingSecret: fastmcp-jwt
+    publicKeyExistingSecretKey: public-key
+```
+
+## Multi-Provider
+
+```yaml
+auth:
+  type: multi
+  providers:
+    - bearer
+    - jwt
+  scopes:
+    - mcp:read
+  reloadRequiredScopes:
+    - mcp:admin
+```
+
+## Production Guardrail
+
+When `server.environment` is `staging`, `prod`, or `production`, authentication must be enabled unless `auth.allowNoAuth=true` is set explicitly.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: FastMCP Server Authentication
+description: Authentication guide for the FastMCP Server chart
+keywords: fastmcp, authentication, bearer, jwt, multi-auth
+purpose: Feature-specific chart documentation
+scope: Chart
+relations:
+  - charts/fastmcp-server/values.yaml
+  - charts/fastmcp-server/templates/deployment.yaml
+path: charts/fastmcp-server/docs/authentication.md
+version: 1.0
+date: 2026-04-26
+-->

--- a/charts/fastmcp-server/docs/gateway.md
+++ b/charts/fastmcp-server/docs/gateway.md
@@ -1,0 +1,40 @@
+# Gateway
+
+Gateway mode mounts remote MCP servers behind one FastMCP Server endpoint.
+
+```yaml
+gateway:
+  enabled: true
+  mountServers:
+    remote:
+      transport: streamable-http
+      url: https://remote.example.com/mcp
+      namespace: remote
+```
+
+The chart renders this configuration as `MCP_MODE=gateway` and `MCP_MOUNT_SERVERS`.
+
+For advanced cases, provide raw JSON:
+
+```yaml
+gateway:
+  enabled: true
+  rawMountServersJson: '{"remote":{"transport":"streamable-http","url":"https://remote.example.com/mcp","namespace":"remote"}}'
+```
+
+Gateway mode still uses the same client authentication settings as normal server mode. Configure `auth` to protect the gateway endpoint.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: FastMCP Server Gateway
+description: Gateway mode guide for the FastMCP Server chart
+keywords: fastmcp, gateway, mcp
+purpose: Feature-specific chart documentation
+scope: Chart
+relations:
+  - charts/fastmcp-server/values.yaml
+  - charts/fastmcp-server/templates/deployment.yaml
+path: charts/fastmcp-server/docs/gateway.md
+version: 1.0
+date: 2026-04-26
+-->

--- a/charts/fastmcp-server/docs/operations.md
+++ b/charts/fastmcp-server/docs/operations.md
@@ -1,0 +1,71 @@
+# Operations
+
+## Runtime Environment
+
+The chart exposes the server runtime controls directly under `server`.
+
+```yaml
+server:
+  environment: production
+  logFormat: json
+  strictLoading: true
+  maskErrorDetails: true
+  onDuplicateTools: warn
+```
+
+## Visibility
+
+```yaml
+visibility:
+  mode: blocklist
+  disableTags:
+    - admin
+```
+
+Use allowlist mode for tightly scoped deployments:
+
+```yaml
+visibility:
+  mode: allowlist
+  enableTags:
+    - public
+```
+
+## Limits
+
+```yaml
+server:
+  maxSourceFileSizeBytes: 1048576
+  maxKnowledgeBytes: 10485760
+
+sandboxing:
+  maxMemoryMb: 256
+  maxOutputSizeKb: 1024
+```
+
+Memory enforcement is best-effort and depends on the Linux runtime. Output truncation is enforced by the FastMCP server.
+
+## Validation Commands
+
+```bash
+helm lint charts/fastmcp-server --strict
+helm template test-release charts/fastmcp-server
+helm unittest charts/fastmcp-server
+```
+
+Runtime validation should use a k3d context and inspect logs for every chart-created pod/container.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: FastMCP Server Operations
+description: Operations guide for the FastMCP Server chart
+keywords: fastmcp, operations, limits, visibility, validation
+purpose: Feature-specific chart documentation
+scope: Chart
+relations:
+  - charts/fastmcp-server/values.yaml
+  - charts/fastmcp-server/templates/NOTES.txt
+path: charts/fastmcp-server/docs/operations.md
+version: 1.0
+date: 2026-04-26
+-->

--- a/charts/fastmcp-server/docs/sources.md
+++ b/charts/fastmcp-server/docs/sources.md
@@ -1,0 +1,93 @@
+# Sources
+
+FastMCP Server can load tools, resources, prompts, and knowledge from inline ConfigMaps, S3-compatible object storage, Git repositories, and OCI artifacts.
+
+## Inline
+
+Inline content is mounted from ConfigMaps and copied from `sources.inline.dir`.
+
+```yaml
+sources:
+  inline:
+    dir: /app/inline
+    tools:
+      greet.py: |
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+```
+
+Hot reload is available for development-style deployments:
+
+```yaml
+hotReload:
+  enabled: true
+```
+
+## S3
+
+```yaml
+sources:
+  s3:
+    enabled: true
+    bucket: mcp-assets
+    prefix: production
+    existingSecret: fastmcp-s3
+    include:
+      - tools/**
+    exclude:
+      - "**/*.tmp"
+    syncInterval: 60
+```
+
+## Git
+
+```yaml
+sources:
+  git:
+    enabled: true
+    repository: https://github.com/example/mcp-content.git
+    branch: main
+    path: mcp
+    existingSecret: fastmcp-git
+    allowedRepositories:
+      - https://github.com/example/*
+    allowedBranches:
+      - main
+      - release/*
+```
+
+## OCI
+
+```yaml
+sources:
+  oci:
+    enabled: true
+    registry: oci://registry.example.com/mcp-content
+    tag: "1.0.0"
+    existingSecret: fastmcp-oci
+```
+
+## Safety Filters
+
+Use `sources.blockedFileAllowlist` only for intentional exceptions to the server source-file safety filter.
+
+```yaml
+sources:
+  blockedFileAllowlist:
+    - knowledge/private-config.example
+```
+
+<!-- @AI-METADATA
+type: chart-docs
+title: FastMCP Server Sources
+description: Source loading guide for the FastMCP Server chart
+keywords: fastmcp, s3, git, oci, inline, hot-reload
+purpose: Feature-specific chart documentation
+scope: Chart
+relations:
+  - charts/fastmcp-server/values.yaml
+  - charts/fastmcp-server/templates/deployment.yaml
+path: charts/fastmcp-server/docs/sources.md
+version: 1.0
+date: 2026-04-26
+-->

--- a/charts/fastmcp-server/examples/dev-hot-reload-values.yaml
+++ b/charts/fastmcp-server/examples/dev-hot-reload-values.yaml
@@ -1,0 +1,21 @@
+# Development hot reload example.
+# Use case: local iteration with inline ConfigMaps and hot reload enabled.
+
+server:
+  environment: dev
+  logLevel: DEBUG
+
+hotReload:
+  enabled: true
+
+sources:
+  inline:
+    dir: /app/inline
+    tools:
+      greet.py: |
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+    knowledge:
+      overview.md: |
+        # Development Knowledge
+        Local development context for FastMCP Server.

--- a/charts/fastmcp-server/examples/gateway-values.yaml
+++ b/charts/fastmcp-server/examples/gateway-values.yaml
@@ -1,0 +1,26 @@
+# Gateway mode example.
+# Use case: expose remote MCP servers through one protected endpoint.
+
+server:
+  environment: production
+  logFormat: json
+  maskErrorDetails: true
+
+auth:
+  type: bearer
+  bearer:
+    existingSecret: fastmcp-auth
+    existingSecretKey: token
+
+gateway:
+  enabled: true
+  mountServers:
+    remote:
+      transport: streamable-http
+      url: https://remote.example.com/mcp
+      namespace: remote
+
+visibility:
+  mode: blocklist
+  disableTags:
+    - admin

--- a/charts/fastmcp-server/examples/jwt-values.yaml
+++ b/charts/fastmcp-server/examples/jwt-values.yaml
@@ -1,0 +1,23 @@
+# JWT authentication example.
+# Use case: protect FastMCP Server with an external OIDC/OAuth issuer.
+
+server:
+  environment: production
+  logFormat: json
+  maskErrorDetails: true
+
+auth:
+  type: jwt
+  requiredScopes:
+    - mcp:read
+  jwt:
+    issuer: https://auth.example.com
+    audience: fastmcp-server
+    jwksUri: https://auth.example.com/.well-known/jwks.json
+
+sources:
+  inline:
+    tools:
+      greet.py: |
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"

--- a/charts/fastmcp-server/examples/multi-auth-values.yaml
+++ b/charts/fastmcp-server/examples/multi-auth-values.yaml
@@ -1,0 +1,32 @@
+# Multi-auth example.
+# Use case: accept both a service bearer token and JWT clients.
+
+server:
+  environment: production
+  logFormat: json
+  maskErrorDetails: true
+
+auth:
+  type: multi
+  providers:
+    - bearer
+    - jwt
+  scopes:
+    - mcp:read
+    - mcp:admin
+  requiredScopes:
+    - mcp:read
+  bearer:
+    existingSecret: fastmcp-auth
+    existingSecretKey: token
+  jwt:
+    issuer: https://auth.example.com
+    audience: fastmcp-server
+    jwksUri: https://auth.example.com/.well-known/jwks.json
+
+sources:
+  inline:
+    tools:
+      greet.py: |
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"

--- a/charts/fastmcp-server/examples/production-s3-values.yaml
+++ b/charts/fastmcp-server/examples/production-s3-values.yaml
@@ -1,0 +1,45 @@
+# Production S3-backed FastMCP Server.
+# Use case: one remote S3-compatible bucket/prefix as the MCP content source.
+
+server:
+  environment: production
+  logFormat: json
+  strictLoading: true
+  maskErrorDetails: true
+  onDuplicateTools: warn
+
+auth:
+  type: bearer
+  scopes:
+    - mcp:read
+    - mcp:admin
+  bearer:
+    existingSecret: fastmcp-auth
+    existingSecretKey: token
+
+sources:
+  s3:
+    enabled: true
+    bucket: fastmcp-content
+    region: us-east-1
+    prefix: production
+    existingSecret: fastmcp-s3
+    include:
+      - tools/**
+      - resources/**
+      - prompts/**
+      - knowledge/**
+    exclude:
+      - "**/*.tmp"
+    syncInterval: 60
+
+metrics:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/charts/fastmcp-server/examples/production/values.yaml
+++ b/charts/fastmcp-server/examples/production/values.yaml
@@ -2,10 +2,19 @@
 
 server:
   name: production-mcp
+  environment: production
   logLevel: WARNING
+  logFormat: json
+  strictLoading: true
+  maskErrorDetails: true
+
+metrics:
+  enabled: true
 
 auth:
   type: bearer
+  reloadRequiredScopes:
+    - mcp:reload
   bearer:
     existingSecret: mcp-auth-token
 
@@ -15,6 +24,15 @@ sources:
     bucket: mcp-production-tools
     region: us-east-1
     existingSecret: mcp-s3-credentials
+    include:
+      - tools/**
+      - resources/**
+      - prompts/**
+      - knowledge/**
+    exclude:
+      - "**/*.tmp"
+      - "**/private/**"
+    syncInterval: 300
   inline:
     knowledge:
       runbook.md: |
@@ -45,6 +63,7 @@ persistence:
 
 serviceAccount:
   create: true
+  automountServiceAccountToken: false
 
 networkPolicy:
   enabled: true
@@ -65,3 +84,6 @@ podSecurityContext:
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL

--- a/charts/fastmcp-server/templates/NOTES.txt
+++ b/charts/fastmcp-server/templates/NOTES.txt
@@ -1,46 +1,110 @@
-FastMCP Server deployed!
+FastMCP Server has been deployed.
 
-  Server:   {{ .Values.server.name }}
-  Endpoint: http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}{{ .Values.server.path }}
-  Auth:     {{ .Values.auth.type }}
+Release:
+  Name:      {{ .Release.Name }}
+  Namespace: {{ .Release.Namespace }}
+  Chart:     {{ .Chart.Name }} {{ .Chart.Version }}
+  App:       {{ .Chart.AppVersion }}
+
+Runtime:
+  Server:      {{ .Values.server.name }}
+  Environment: {{ .Values.server.environment }}
+  Endpoint:    http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}{{ .Values.server.path }}
+  Workspace:   {{ .Values.server.workspace }}
+  Auth:        {{ .Values.auth.type }}
+  Gateway:     {{ .Values.gateway.enabled }}
+  Visibility:  {{ .Values.visibility.mode }}
+  Log format:  {{ .Values.server.logFormat }}
+  Strict load: {{ .Values.server.strictLoading }}
+
+Access:
+  Port-forward the service:
+    kubectl port-forward svc/{{ include "fastmcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+  MCP endpoint:
+    http://localhost:{{ .Values.service.port }}{{ .Values.server.path }}
 
 {{- if .Values.ui.enabled }}
-  Web UI:   http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}/ui
+  Web UI:
+    http://localhost:{{ .Values.service.port }}/ui
 {{- end }}
 
 {{- if .Values.metrics.enabled }}
-  Metrics:  http://{{ include "fastmcp-server.fullname" . }}:{{ .Values.service.port }}/metrics
+  Metrics:
+    http://localhost:{{ .Values.service.port }}/metrics
 {{- end }}
-
-To access the MCP endpoint:
-
-  kubectl port-forward svc/{{ include "fastmcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
-  curl http://localhost:{{ .Values.service.port }}{{ .Values.server.path }}
 
 {{- if .Values.ingress.enabled }}
+Ingress:
 {{- range .Values.ingress.hosts }}
-
-  Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (first .paths).path }}
-{{- end }}
-{{- end }}
-
-{{- if ne .Values.auth.type "none" }}
-
-Authentication: {{ .Values.auth.type }}
-{{- if eq .Values.auth.type "bearer" }}
-  Requests must include: Authorization: Bearer <token>
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (first .paths).path }}
 {{- end }}
 {{- end }}
 
 Sources:
 {{- if (include "fastmcp-server.hasAnyInline" .) }}
-  - Inline (ConfigMap): enabled
+  Inline ConfigMaps: enabled
+{{- else }}
+  Inline ConfigMaps: disabled
 {{- end }}
 {{- if .Values.sources.s3.enabled }}
-  - S3: s3://{{ .Values.sources.s3.bucket }}/{{ .Values.sources.s3.prefix }}
+  S3: enabled, bucket={{ .Values.sources.s3.bucket }}, prefix={{ .Values.sources.s3.prefix | default "/" }}
+{{- else }}
+  S3: disabled
 {{- end }}
 {{- if .Values.sources.git.enabled }}
-  - Git: {{ .Values.sources.git.repository }} ({{ .Values.sources.git.branch }})
+  Git: enabled, repository={{ .Values.sources.git.repository }}, branch={{ .Values.sources.git.branch }}
+{{- else }}
+  Git: disabled
+{{- end }}
+{{- if .Values.sources.oci.enabled }}
+  OCI: enabled, registry={{ .Values.sources.oci.registry }}, tag={{ .Values.sources.oci.tag | default "(runtime default)" }}
+{{- else }}
+  OCI: disabled
 {{- end }}
 
-Documentation: https://helmforge.dev/docs/charts/fastmcp-server
+Runtime limits:
+  Max source file bytes: {{ .Values.server.maxSourceFileSizeBytes }}
+  Max knowledge bytes:   {{ .Values.server.maxKnowledgeBytes }}
+  Knowledge extensions:  {{ join "," .Values.server.allowedKnowledgeExtensions }}
+  Duplicate tools:       {{ .Values.server.onDuplicateTools }}
+{{- if .Values.server.corsAllowedOrigins }}
+  CORS origins:          {{ join "," .Values.server.corsAllowedOrigins }}
+{{- else }}
+  CORS origins:          none
+{{- end }}
+
+Validation:
+  Check workload status:
+    kubectl get pods,svc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  Wait for readiness:
+    kubectl wait --for=condition=ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --timeout=120s
+
+  Check health endpoints:
+    kubectl port-forward svc/{{ include "fastmcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+    curl http://localhost:{{ .Values.service.port }}/healthz
+    curl http://localhost:{{ .Values.service.port }}/readyz
+    curl http://localhost:{{ .Values.service.port }}/startupz
+
+Troubleshooting:
+  Describe pods:
+    kubectl describe pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  Check all container logs:
+    kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200 --prefix
+
+  Inspect rendered environment:
+    kubectl describe pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if not (include "fastmcp-server.hasAnyInline" .) }}
+Warning:
+  No inline tools, resources, prompts, or knowledge are configured. If no remote
+  source loads components either, /readyz may report not_ready because the server
+  has no MCP components loaded.
+
+{{- end }}
+Documentation:
+  https://helmforge.dev/docs/charts/fastmcp-server
+
+Happy Helmforging :)

--- a/charts/fastmcp-server/templates/_helpers.tpl
+++ b/charts/fastmcp-server/templates/_helpers.tpl
@@ -40,7 +40,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and (has $env (list "prod" "production" "staging")) (eq .Values.auth.type "none") (not .Values.auth.allowNoAuth) -}}
 {{- fail "Production-like environments require auth.type other than 'none', or set auth.allowNoAuth=true for an explicit exception." -}}
 {{- end -}}
-{{- if and (eq .Values.auth.type "bearer") (not .Values.auth.bearer.token) (not .Values.auth.bearer.existingSecret) -}}
+{{- if and (or (eq .Values.auth.type "bearer") (and (eq .Values.auth.type "multi") (has "bearer" .Values.auth.providers))) (not .Values.auth.bearer.token) (not .Values.auth.bearer.existingSecret) -}}
 {{- fail "Bearer auth requires auth.bearer.token or auth.bearer.existingSecret." -}}
 {{- end -}}
 {{- if and .Values.sources.s3.enabled (not .Values.sources.s3.bucket) -}}

--- a/charts/fastmcp-server/templates/_helpers.tpl
+++ b/charts/fastmcp-server/templates/_helpers.tpl
@@ -34,14 +34,47 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{/* Validation rules that need Helm context */}}
+{{- define "fastmcp-server.validateValues" -}}
+{{- $env := lower (toString .Values.server.environment) -}}
+{{- if and (has $env (list "prod" "production" "staging")) (eq .Values.auth.type "none") (not .Values.auth.allowNoAuth) -}}
+{{- fail "Production-like environments require auth.type other than 'none', or set auth.allowNoAuth=true for an explicit exception." -}}
+{{- end -}}
+{{- if and (eq .Values.auth.type "bearer") (not .Values.auth.bearer.token) (not .Values.auth.bearer.existingSecret) -}}
+{{- fail "Bearer auth requires auth.bearer.token or auth.bearer.existingSecret." -}}
+{{- end -}}
+{{- if and .Values.sources.s3.enabled (not .Values.sources.s3.bucket) -}}
+{{- fail "S3 source requires sources.s3.bucket when sources.s3.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.sources.git.enabled (not .Values.sources.git.repository) -}}
+{{- fail "Git source requires sources.git.repository when sources.git.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.sources.oci.enabled (not .Values.sources.oci.registry) -}}
+{{- fail "OCI source requires sources.oci.registry when sources.oci.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.metrics.serviceMonitor.enabled (not .Values.metrics.enabled) -}}
+{{- fail "ServiceMonitor requires metrics.enabled=true." -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.rawMountServersJson) (empty .Values.gateway.mountServers) -}}
+{{- fail "Gateway mode requires gateway.mountServers or gateway.rawMountServersJson." -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Auth secret name */}}
 {{- define "fastmcp-server.authSecretName" -}}
-{{- if eq .Values.auth.type "bearer" -}}
   {{- if .Values.auth.bearer.existingSecret -}}
     {{- .Values.auth.bearer.existingSecret -}}
   {{- else -}}
     {{- printf "%s-auth" (include "fastmcp-server.fullname" .) -}}
   {{- end -}}
+{{- end -}}
+
+{{/* JWT public key secret name */}}
+{{- define "fastmcp-server.jwtSecretName" -}}
+{{- if .Values.auth.jwt.publicKeyExistingSecret -}}
+  {{- .Values.auth.jwt.publicKeyExistingSecret -}}
+{{- else -}}
+  {{- printf "%s-jwt" (include "fastmcp-server.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -60,6 +93,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- .Values.sources.git.existingSecret -}}
 {{- else -}}
   {{- printf "%s-git" (include "fastmcp-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* OCI secret name */}}
+{{- define "fastmcp-server.ociSecretName" -}}
+{{- if .Values.sources.oci.existingSecret -}}
+  {{- .Values.sources.oci.existingSecret -}}
+{{- else -}}
+  {{- printf "%s-oci" (include "fastmcp-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* MCP mount servers JSON */}}
+{{- define "fastmcp-server.mountServersJson" -}}
+{{- if .Values.gateway.rawMountServersJson -}}
+{{- .Values.gateway.rawMountServersJson -}}
+{{- else -}}
+{{- .Values.gateway.mountServers | toJson -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -9,9 +9,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
-  {{- with .Values.server.revisionHistoryLimit }}
-  revisionHistoryLimit: {{ . }}
-  {{- end }}
+  revisionHistoryLimit: {{ .Values.server.revisionHistoryLimit }}
   strategy:
     {{- toYaml .Values.server.strategy | nindent 4 }}
   selector:

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "fastmcp-server.validateValues" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,8 +9,11 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.server.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   strategy:
-    type: Recreate
+    {{- toYaml .Values.server.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
@@ -38,6 +42,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "fastmcp-server.fullname" .) }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -51,7 +56,17 @@ spec:
           command: ["python", "/app/sync_only.py"]
           env:
             - name: MCP_WORKSPACE
-              value: /app/workspace
+              value: {{ .Values.server.workspace | quote }}
+            - name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
+              value: {{ .Values.server.maxSourceFileSizeBytes | int64 | quote }}
+            {{- if .Values.sources.blockedFileAllowlist }}
+            - name: SOURCE_BLOCKED_FILE_ALLOWLIST
+              value: {{ join "," .Values.sources.blockedFileAllowlist | quote }}
+            {{- end }}
+            {{- if .Values.sources.inline.dir }}
+            - name: SOURCE_INLINE_DIR
+              value: {{ .Values.sources.inline.dir | quote }}
+            {{- end }}
             {{- if .Values.sources.s3.enabled }}
             - name: SOURCE_S3_ENABLED
               value: "true"
@@ -66,6 +81,14 @@ spec:
             {{- with .Values.sources.s3.prefix }}
             - name: SOURCE_S3_PREFIX
               value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.sources.s3.include }}
+            - name: SOURCE_S3_INCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.s3.exclude }}
+            - name: SOURCE_S3_EXCLUDE
+              value: {{ join "," . | quote }}
             {{- end }}
             - name: SOURCE_S3_ACCESS_KEY
               valueFrom:
@@ -89,6 +112,24 @@ spec:
             - name: SOURCE_GIT_PATH
               value: {{ . | quote }}
             {{- end }}
+            - name: SOURCE_GIT_USERNAME
+              value: {{ .Values.sources.git.username | quote }}
+            {{- with .Values.sources.git.allowedRepositories }}
+            - name: SOURCE_GIT_ALLOWED_REPOSITORIES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.git.allowedBranches }}
+            - name: SOURCE_GIT_ALLOWED_BRANCHES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.git.include }}
+            - name: SOURCE_GIT_INCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.git.exclude }}
+            - name: SOURCE_GIT_EXCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
             {{- if or .Values.sources.git.token .Values.sources.git.existingSecret }}
             - name: SOURCE_GIT_TOKEN
               valueFrom:
@@ -97,31 +138,57 @@ spec:
                   key: {{ .Values.sources.git.existingSecretTokenKey | default "token" }}
             {{- end }}
             {{- end }}
-            {{- if (include "fastmcp-server.hasAnyInline" .) }}
-            - name: SOURCE_INLINE_DIR
-              value: /app/inline
+            {{- if .Values.sources.oci.enabled }}
+            - name: SOURCE_OCI_ENABLED
+              value: "true"
+            - name: SOURCE_OCI_REGISTRY
+              value: {{ .Values.sources.oci.registry | quote }}
+            {{- with .Values.sources.oci.tag }}
+            - name: SOURCE_OCI_TAG
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.sources.oci.include }}
+            - name: SOURCE_OCI_INCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.oci.exclude }}
+            - name: SOURCE_OCI_EXCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if or .Values.sources.oci.username .Values.sources.oci.password .Values.sources.oci.existingSecret }}
+            - name: SOURCE_OCI_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.ociSecretName" . }}
+                  key: {{ .Values.sources.oci.existingSecretUsernameKey | default "username" }}
+            - name: SOURCE_OCI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.ociSecretName" . }}
+                  key: {{ .Values.sources.oci.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           volumeMounts:
             - name: workspace
-              mountPath: /app/workspace
+              mountPath: {{ .Values.server.workspace | quote }}
             {{- if (include "fastmcp-server.hasInlineTools" .) }}
             - name: inline-tools
-              mountPath: /app/inline/tools
+              mountPath: {{ printf "%s/tools" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- if (include "fastmcp-server.hasInlineResources" .) }}
             - name: inline-resources
-              mountPath: /app/inline/resources
+              mountPath: {{ printf "%s/resources" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- if (include "fastmcp-server.hasInlinePrompts" .) }}
             - name: inline-prompts
-              mountPath: /app/inline/prompts
+              mountPath: {{ printf "%s/prompts" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- if (include "fastmcp-server.hasInlineKnowledge" .) }}
             - name: inline-knowledge
-              mountPath: /app/inline/knowledge
+              mountPath: {{ printf "%s/knowledge" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
           {{- with .Values.securityContext }}
@@ -140,12 +207,18 @@ spec:
           env:
             - name: MCP_SERVER_NAME
               value: {{ .Values.server.name | quote }}
+            - name: MCP_SERVER_VERSION
+              value: {{ .Values.server.version | default .Chart.AppVersion | quote }}
+            - name: MCP_ENV
+              value: {{ .Values.server.environment | quote }}
             - name: MCP_PORT
               value: {{ .Values.server.port | quote }}
             - name: MCP_PATH
               value: {{ .Values.server.path | quote }}
             - name: MCP_HOST
-              value: "0.0.0.0"
+              value: {{ .Values.server.host | quote }}
+            - name: MCP_WORKSPACE
+              value: {{ .Values.server.workspace | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.server.logLevel | quote }}
             {{- if .Values.server.logFormat }}
@@ -156,6 +229,70 @@ spec:
             - name: MCP_STRICT_LOADING
               value: "true"
             {{- end }}
+            {{- if ne (toString .Values.server.maskErrorDetails) "" }}
+            - name: MCP_MASK_ERROR_DETAILS
+              value: {{ .Values.server.maskErrorDetails | quote }}
+            {{- end }}
+            - name: MCP_ON_DUPLICATE_TOOLS
+              value: {{ .Values.server.onDuplicateTools | quote }}
+            {{- if .Values.server.corsAllowedOrigins }}
+            - name: MCP_CORS_ALLOWED_ORIGINS
+              value: {{ join "," .Values.server.corsAllowedOrigins | quote }}
+            {{- end }}
+            - name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
+              value: {{ .Values.server.maxSourceFileSizeBytes | int64 | quote }}
+            - name: MCP_MAX_KNOWLEDGE_BYTES
+              value: {{ .Values.server.maxKnowledgeBytes | int64 | quote }}
+            - name: MCP_ALLOWED_KNOWLEDGE_EXTENSIONS
+              value: {{ join "," .Values.server.allowedKnowledgeExtensions | quote }}
+            {{- if .Values.sources.blockedFileAllowlist }}
+            - name: SOURCE_BLOCKED_FILE_ALLOWLIST
+              value: {{ join "," .Values.sources.blockedFileAllowlist | quote }}
+            {{- end }}
+            - name: MCP_REQUIRE_HUMAN_APPROVAL_FOR_DESTRUCTIVE
+              value: {{ .Values.auth.requireHumanApprovalForDestructive | quote }}
+            {{- if .Values.auth.allowNoAuth }}
+            - name: MCP_ALLOW_NO_AUTH
+              value: "true"
+            {{- end }}
+            {{- with .Values.auth.scopes }}
+            - name: MCP_AUTH_SCOPES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.auth.requiredScopes }}
+            - name: MCP_AUTH_REQUIRED_SCOPES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if .Values.auth.clientId }}
+            - name: MCP_AUTH_CLIENT_ID
+              value: {{ .Values.auth.clientId | quote }}
+            {{- end }}
+            {{- with .Values.auth.reloadRequiredScopes }}
+            - name: MCP_RELOAD_REQUIRED_SCOPES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if .Values.gateway.enabled }}
+            - name: MCP_MODE
+              value: "gateway"
+            - name: MCP_MOUNT_SERVERS
+              value: {{ include "fastmcp-server.mountServersJson" . | quote }}
+            {{- end }}
+            {{- if .Values.visibility.enableTags }}
+            - name: MCP_ENABLE_TAGS
+              value: {{ join "," .Values.visibility.enableTags | quote }}
+            {{- end }}
+            {{- if .Values.visibility.disableTags }}
+            - name: MCP_DISABLE_TAGS
+              value: {{ join "," .Values.visibility.disableTags | quote }}
+            {{- end }}
+            - name: MCP_VISIBILITY_MODE
+              value: {{ .Values.visibility.mode | quote }}
+            {{- if .Values.hotReload.enabled }}
+            - name: MCP_HOT_RELOAD
+              value: "true"
+            {{- end }}
+            - name: SOURCE_INLINE_DIR
+              value: {{ .Values.sources.inline.dir | quote }}
             {{- if .Values.ui }}
             - name: MCP_UI_ENABLED
               value: {{ .Values.ui.enabled | quote }}
@@ -170,14 +307,18 @@ spec:
             - name: MCP_AUTH_TYPE
               value: {{ .Values.auth.type | quote }}
             {{- end }}
-            {{- if eq .Values.auth.type "bearer" }}
+            {{- if and (eq .Values.auth.type "multi") .Values.auth.providers }}
+            - name: MCP_AUTH_PROVIDERS
+              value: {{ join "," .Values.auth.providers | quote }}
+            {{- end }}
+            {{- if or (eq .Values.auth.type "bearer") (and (eq .Values.auth.type "multi") (has "bearer" .Values.auth.providers)) }}
             - name: MCP_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "fastmcp-server.authSecretName" . }}
                   key: {{ .Values.auth.bearer.existingSecretKey | default "token" }}
             {{- end }}
-            {{- if eq .Values.auth.type "jwt" }}
+            {{- if or (eq .Values.auth.type "jwt") (and (eq .Values.auth.type "multi") (has "jwt" .Values.auth.providers)) }}
             {{- with .Values.auth.jwt.issuer }}
             - name: MCP_AUTH_JWT_ISSUER
               value: {{ . | quote }}
@@ -189,6 +330,17 @@ spec:
             {{- with .Values.auth.jwt.jwksUri }}
             - name: MCP_AUTH_JWT_JWKS_URI
               value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.auth.jwt.algorithm }}
+            - name: MCP_AUTH_JWT_ALGORITHM
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if or .Values.auth.jwt.publicKey .Values.auth.jwt.publicKeyExistingSecret }}
+            - name: MCP_AUTH_JWT_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.jwtSecretName" . }}
+                  key: {{ .Values.auth.jwt.publicKeyExistingSecretKey | default "public-key" }}
             {{- end }}
             {{- end }}
             {{- if .Values.sources.s3.enabled }}
@@ -205,6 +357,18 @@ spec:
             {{- with .Values.sources.s3.prefix }}
             - name: SOURCE_S3_PREFIX
               value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.sources.s3.include }}
+            - name: SOURCE_S3_INCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.s3.exclude }}
+            - name: SOURCE_S3_EXCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if .Values.sources.s3.syncInterval }}
+            - name: SOURCE_S3_SYNC_INTERVAL
+              value: {{ .Values.sources.s3.syncInterval | int64 | quote }}
             {{- end }}
             - name: SOURCE_S3_ACCESS_KEY
               valueFrom:
@@ -228,12 +392,64 @@ spec:
             - name: SOURCE_GIT_PATH
               value: {{ . | quote }}
             {{- end }}
+            - name: SOURCE_GIT_USERNAME
+              value: {{ .Values.sources.git.username | quote }}
+            {{- with .Values.sources.git.allowedRepositories }}
+            - name: SOURCE_GIT_ALLOWED_REPOSITORIES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.git.allowedBranches }}
+            - name: SOURCE_GIT_ALLOWED_BRANCHES
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.git.include }}
+            - name: SOURCE_GIT_INCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.git.exclude }}
+            - name: SOURCE_GIT_EXCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if .Values.sources.git.syncInterval }}
+            - name: SOURCE_GIT_SYNC_INTERVAL
+              value: {{ .Values.sources.git.syncInterval | int64 | quote }}
+            {{- end }}
             {{- if or .Values.sources.git.token .Values.sources.git.existingSecret }}
             - name: SOURCE_GIT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "fastmcp-server.gitSecretName" . }}
                   key: {{ .Values.sources.git.existingSecretTokenKey | default "token" }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.sources.oci.enabled }}
+            - name: SOURCE_OCI_ENABLED
+              value: "true"
+            - name: SOURCE_OCI_REGISTRY
+              value: {{ .Values.sources.oci.registry | quote }}
+            {{- with .Values.sources.oci.tag }}
+            - name: SOURCE_OCI_TAG
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.sources.oci.include }}
+            - name: SOURCE_OCI_INCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- with .Values.sources.oci.exclude }}
+            - name: SOURCE_OCI_EXCLUDE
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if or .Values.sources.oci.username .Values.sources.oci.password .Values.sources.oci.existingSecret }}
+            - name: SOURCE_OCI_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.ociSecretName" . }}
+                  key: {{ .Values.sources.oci.existingSecretUsernameKey | default "username" }}
+            - name: SOURCE_OCI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.ociSecretName" . }}
+                  key: {{ .Values.sources.oci.existingSecretPasswordKey | default "password" }}
             {{- end }}
             {{- end }}
             {{- with .Values.rateLimiting.default }}
@@ -263,10 +479,6 @@ spec:
             {{- if .Values.extraPipPackages }}
             - name: EXTRA_PIP_PACKAGES
               value: {{ join "," .Values.extraPipPackages | quote }}
-            {{- end }}
-            {{- if (include "fastmcp-server.hasAnyInline" .) }}
-            - name: SOURCE_INLINE_DIR
-              value: /app/inline
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -311,25 +523,25 @@ spec:
           {{- end }}
           volumeMounts:
             - name: workspace
-              mountPath: /app/workspace
+              mountPath: {{ .Values.server.workspace | quote }}
             {{- if (include "fastmcp-server.hasInlineTools" .) }}
             - name: inline-tools
-              mountPath: /app/inline/tools
+              mountPath: {{ printf "%s/tools" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- if (include "fastmcp-server.hasInlineResources" .) }}
             - name: inline-resources
-              mountPath: /app/inline/resources
+              mountPath: {{ printf "%s/resources" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- if (include "fastmcp-server.hasInlinePrompts" .) }}
             - name: inline-prompts
-              mountPath: /app/inline/prompts
+              mountPath: {{ printf "%s/prompts" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- if (include "fastmcp-server.hasInlineKnowledge" .) }}
             - name: inline-knowledge
-              mountPath: /app/inline/knowledge
+              mountPath: {{ printf "%s/knowledge" .Values.sources.inline.dir | quote }}
               readOnly: true
             {{- end }}
             {{- with .Values.extraVolumeMounts }}

--- a/charts/fastmcp-server/templates/networkpolicy.yaml
+++ b/charts/fastmcp-server/templates/networkpolicy.yaml
@@ -11,8 +11,19 @@ spec:
       {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    - Egress
   ingress:
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
     - ports:
         - port: {{ .Values.server.port }}
           protocol: TCP
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- else }}
+    - {}
+    {{- end }}
 {{- end }}

--- a/charts/fastmcp-server/templates/secret.yaml
+++ b/charts/fastmcp-server/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.auth.type "bearer") (not .Values.auth.bearer.existingSecret) .Values.auth.bearer.token }}
+{{- if and (or (eq .Values.auth.type "bearer") (eq .Values.auth.type "multi")) (not .Values.auth.bearer.existingSecret) .Values.auth.bearer.token }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +7,17 @@ metadata:
     {{- include "fastmcp-server.labels" . | nindent 4 }}
 stringData:
   token: {{ .Values.auth.bearer.token | quote }}
+{{- end }}
+{{- if and (or (eq .Values.auth.type "jwt") (eq .Values.auth.type "multi")) .Values.auth.jwt.publicKey (not .Values.auth.jwt.publicKeyExistingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fastmcp-server.jwtSecretName" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+stringData:
+  {{ .Values.auth.jwt.publicKeyExistingSecretKey | default "public-key" }}: {{ .Values.auth.jwt.publicKey | quote }}
 {{- end }}
 {{- if and .Values.sources.s3.enabled (not .Values.sources.s3.existingSecret) }}
 ---
@@ -30,4 +41,16 @@ metadata:
     {{- include "fastmcp-server.labels" . | nindent 4 }}
 stringData:
   token: {{ .Values.sources.git.token | quote }}
+{{- end }}
+{{- if and .Values.sources.oci.enabled (or .Values.sources.oci.username .Values.sources.oci.password) (not .Values.sources.oci.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fastmcp-server.ociSecretName" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+stringData:
+  username: {{ .Values.sources.oci.username | quote }}
+  password: {{ .Values.sources.oci.password | quote }}
 {{- end }}

--- a/charts/fastmcp-server/templates/serviceaccount.yaml
+++ b/charts/fastmcp-server/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -10,6 +10,15 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-fastmcp-server
 
+  - it: should render explicit zero revision history limit
+    set:
+      server:
+        revisionHistoryLimit: 0
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 0
+
   - it: should set MCP_SERVER_NAME env
     asserts:
       - contains:

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -34,6 +34,141 @@ tests:
             name: MCP_PATH
             value: "/mcp"
 
+  - it: should set server runtime env defaults
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_SERVER_VERSION
+            value: "0.11.0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ENV
+            value: "dev"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_HOST
+            value: "0.0.0.0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_WORKSPACE
+            value: "/app/workspace"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ON_DUPLICATE_TOOLS
+            value: "warn"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
+            value: "1048576"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MAX_KNOWLEDGE_BYTES
+            value: "10485760"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ALLOWED_KNOWLEDGE_EXTENSIONS
+            value: ".md,.txt,.json,.yaml,.yml,.html,.htm,.csv,.xml"
+
+  - it: should set optional server runtime env values when configured
+    set:
+      server:
+        version: "0.12.0"
+        environment: production
+        host: "127.0.0.1"
+        workspace: /custom/workspace
+        maskErrorDetails: true
+        onDuplicateTools: error
+        corsAllowedOrigins:
+          - https://mcp.example.com
+          - https://ui.example.com
+        maxSourceFileSizeBytes: 2097152
+        maxKnowledgeBytes: 31457280
+        allowedKnowledgeExtensions:
+          - .md
+          - .json
+      sources:
+        blockedFileAllowlist:
+          - knowledge/private-config.example
+      auth:
+        allowNoAuth: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_SERVER_VERSION
+            value: "0.12.0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ENV
+            value: "production"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_HOST
+            value: "127.0.0.1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_WORKSPACE
+            value: "/custom/workspace"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MASK_ERROR_DETAILS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ON_DUPLICATE_TOOLS
+            value: "error"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_CORS_ALLOWED_ORIGINS
+            value: "https://mcp.example.com,https://ui.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
+            value: "2097152"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MAX_KNOWLEDGE_BYTES
+            value: "31457280"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ALLOWED_KNOWLEDGE_EXTENSIONS
+            value: ".md,.json"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_BLOCKED_FILE_ALLOWLIST
+            value: "knowledge/private-config.example"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: workspace
+            mountPath: "/custom/workspace"
+
+  - it: should not set mask error details env by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MASK_ERROR_DETAILS
+          any: true
+
   - it: should expose http port 8000
     asserts:
       - equal:
@@ -128,6 +263,86 @@ tests:
                 key: token
         template: templates/deployment.yaml
 
+  - it: should set multi auth, scopes, and JWT env vars
+    set:
+      auth:
+        type: multi
+        allowNoAuth: true
+        scopes:
+          - mcp:read
+          - mcp:admin
+        requiredScopes:
+          - mcp:read
+        clientId: ci-client
+        providers:
+          - bearer
+          - jwt
+        reloadRequiredScopes:
+          - mcp:admin
+        requireHumanApprovalForDestructive: false
+        bearer:
+          token: test-token
+        jwt:
+          issuer: https://auth.example.com
+          audience: fastmcp
+          jwksUri: https://auth.example.com/jwks.json
+          publicKey: jwt-secret
+          algorithm: HS256
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_TYPE
+            value: "multi"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_PROVIDERS
+            value: "bearer,jwt"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_SCOPES
+            value: "mcp:read,mcp:admin"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_REQUIRED_SCOPES
+            value: "mcp:read"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_CLIENT_ID
+            value: "ci-client"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ALLOW_NO_AUTH
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_REQUIRE_HUMAN_APPROVAL_FOR_DESTRUCTIVE
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_RELOAD_REQUIRED_SCOPES
+            value: "mcp:admin"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_JWT_ALGORITHM
+            value: "HS256"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_AUTH_JWT_PUBLIC_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-fastmcp-server-jwt
+                key: public-key
+
   - it: should set S3 env vars when enabled
     set:
       sources:
@@ -136,6 +351,11 @@ tests:
           endpoint: "https://minio.local"
           bucket: tools
           region: us-east-1
+          include:
+            - tools/**
+          exclude:
+            - "**/*.tmp"
+          syncInterval: 60
           accessKey: admin
           secretKey: secret
     templates:
@@ -154,6 +374,18 @@ tests:
             name: SOURCE_S3_BUCKET
             value: "tools"
         template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_S3_INCLUDE
+            value: "tools/**"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_S3_SYNC_INTERVAL
+            value: "60"
+        template: templates/deployment.yaml
 
   - it: should set Git env vars when enabled
     set:
@@ -162,7 +394,17 @@ tests:
           enabled: true
           repository: "https://github.com/example/tools.git"
           branch: main
-          token: ghp_test
+          username: git-user
+          allowedRepositories:
+            - https://github.com/example/*
+          allowedBranches:
+            - main
+          include:
+            - tools/**
+          exclude:
+            - "**/*.tmp"
+          syncInterval: 120
+          token: example-git-token
     templates:
       - templates/deployment.yaml
       - templates/secret.yaml
@@ -178,6 +420,69 @@ tests:
           content:
             name: SOURCE_GIT_REPOSITORY
             value: "https://github.com/example/tools.git"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_GIT_USERNAME
+            value: "git-user"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_GIT_ALLOWED_REPOSITORIES
+            value: "https://github.com/example/*"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_GIT_SYNC_INTERVAL
+            value: "120"
+        template: templates/deployment.yaml
+
+  - it: should set OCI source env vars when enabled
+    set:
+      sources:
+        oci:
+          enabled: true
+          registry: "oci://registry.example.com/mcp"
+          tag: "1.0.0"
+          username: user
+          password: pass
+          include:
+            - tools/**
+          exclude:
+            - "**/*.tmp"
+    templates:
+      - templates/deployment.yaml
+      - templates/secret.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_OCI_ENABLED
+            value: "true"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_OCI_REGISTRY
+            value: "oci://registry.example.com/mcp"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_OCI_TAG
+            value: "1.0.0"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_OCI_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-fastmcp-server-oci
+                key: username
         template: templates/deployment.yaml
 
   - it: should mount inline tools when configured
@@ -213,6 +518,76 @@ tests:
           content:
             name: inline-tools
           any: true
+
+  - it: should support custom inline directory and hot reload
+    set:
+      hotReload:
+        enabled: true
+      sources:
+        inline:
+          dir: /custom/inline
+          tools:
+            greet.py: |
+              def greet(): return "hi"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_HOT_RELOAD
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOURCE_INLINE_DIR
+            value: "/custom/inline"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: inline-tools
+            mountPath: "/custom/inline/tools"
+            readOnly: true
+
+  - it: should set gateway and visibility env vars
+    set:
+      gateway:
+        enabled: true
+        mountServers:
+          remote:
+            transport: streamable-http
+            url: https://remote.example.com/mcp
+            namespace: remote
+      visibility:
+        mode: allowlist
+        enableTags:
+          - public
+        disableTags:
+          - admin
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MODE
+            value: "gateway"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_MOUNT_SERVERS
+            value: '{"remote":{"namespace":"remote","transport":"streamable-http","url":"https://remote.example.com/mcp"}}'
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_VISIBILITY_MODE
+            value: "allowlist"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ENABLE_TAGS
+            value: "public"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_DISABLE_TAGS
+            value: "admin"
 
   - it: should set EXTRA_PIP_PACKAGES when configured
     set:
@@ -256,6 +631,12 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: RELEASE-NAME-fastmcp-server
+
+  - it: should disable service account token automount by default
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
 
   # --- v0.4.0: New features ---
 
@@ -337,6 +718,38 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].command
           value: ["python", "/app/sync_only.py"]
+
+  - it: should pass runtime source safety env to init container
+    set:
+      initSync:
+        enabled: true
+      server:
+        workspace: /custom/workspace
+        maxSourceFileSizeBytes: 2097152
+      sources:
+        blockedFileAllowlist:
+          - knowledge/private-config.example
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: MCP_WORKSPACE
+            value: "/custom/workspace"
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
+            value: "2097152"
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: SOURCE_BLOCKED_FILE_ALLOWLIST
+            value: "knowledge/private-config.example"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: workspace
+            mountPath: "/custom/workspace"
 
   # --- v1.0.0: Production features ---
 

--- a/charts/fastmcp-server/tests/secret_test.yaml
+++ b/charts/fastmcp-server/tests/secret_test.yaml
@@ -34,6 +34,44 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should render auth secret for multi bearer provider
+    set:
+      auth:
+        type: multi
+        providers:
+          - bearer
+          - jwt
+        bearer:
+          token: my-secret-token
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-fastmcp-server-auth
+        documentIndex: 0
+
+  - it: should render JWT public key secret
+    set:
+      auth:
+        type: jwt
+        jwt:
+          publicKey: jwt-secret
+          algorithm: HS256
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-fastmcp-server-jwt
+        documentIndex: 0
+      - equal:
+          path: stringData.public-key
+          value: jwt-secret
+        documentIndex: 0
+
   - it: should render S3 secret when enabled
     set:
       sources:
@@ -68,7 +106,7 @@ tests:
         git:
           enabled: true
           repository: "https://github.com/example/tools.git"
-          token: ghp_test123
+          token: example-git-token
     asserts:
       - isKind:
           of: Secret
@@ -76,4 +114,25 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-fastmcp-server-git
+        documentIndex: 0
+
+  - it: should render OCI secret when credentials are set
+    set:
+      sources:
+        oci:
+          enabled: true
+          registry: "oci://registry.example.com/mcp"
+          username: user
+          password: pass
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-fastmcp-server-oci
+        documentIndex: 0
+      - equal:
+          path: stringData.username
+          value: user
         documentIndex: 0

--- a/charts/fastmcp-server/tests/serviceaccount_test.yaml
+++ b/charts/fastmcp-server/tests/serviceaccount_test.yaml
@@ -2,7 +2,21 @@ suite: serviceaccount
 templates:
   - templates/serviceaccount.yaml
 tests:
+  - it: should render by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-fastmcp-server
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
   - it: should not render when create is false
+    set:
+      serviceAccount:
+        create: false
     asserts:
       - hasDocuments:
           count: 0
@@ -17,6 +31,9 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-fastmcp-server
+      - equal:
+          path: automountServiceAccountToken
+          value: false
 
   - it: should use custom name
     set:

--- a/charts/fastmcp-server/tests/validation_test.yaml
+++ b/charts/fastmcp-server/tests/validation_test.yaml
@@ -1,0 +1,67 @@
+suite: validations
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should fail production without auth unless explicitly allowed
+    set:
+      server:
+        environment: production
+      auth:
+        type: none
+        allowNoAuth: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "Production-like environments require auth.type other than 'none', or set auth.allowNoAuth=true for an explicit exception."
+
+  - it: should fail bearer auth without token or existing secret
+    set:
+      auth:
+        type: bearer
+    asserts:
+      - failedTemplate:
+          errorMessage: "Bearer auth requires auth.bearer.token or auth.bearer.existingSecret."
+
+  - it: should fail S3 source without bucket
+    set:
+      sources:
+        s3:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "S3 source requires sources.s3.bucket when sources.s3.enabled=true."
+
+  - it: should fail Git source without repository
+    set:
+      sources:
+        git:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Git source requires sources.git.repository when sources.git.enabled=true."
+
+  - it: should fail OCI source without registry
+    set:
+      sources:
+        oci:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "OCI source requires sources.oci.registry when sources.oci.enabled=true."
+
+  - it: should fail ServiceMonitor without metrics
+    set:
+      metrics:
+        enabled: false
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ServiceMonitor requires metrics.enabled=true."
+
+  - it: should fail gateway without mounted servers
+    set:
+      gateway:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Gateway mode requires gateway.mountServers or gateway.rawMountServersJson."

--- a/charts/fastmcp-server/tests/validation_test.yaml
+++ b/charts/fastmcp-server/tests/validation_test.yaml
@@ -21,6 +21,17 @@ tests:
       - failedTemplate:
           errorMessage: "Bearer auth requires auth.bearer.token or auth.bearer.existingSecret."
 
+  - it: should fail multi auth with bearer provider without token or existing secret
+    set:
+      auth:
+        type: multi
+        providers:
+          - bearer
+          - jwt
+    asserts:
+      - failedTemplate:
+          errorMessage: "Bearer auth requires auth.bearer.token or auth.bearer.existingSecret."
+
   - it: should fail S3 source without bucket
     set:
       sources:

--- a/charts/fastmcp-server/values.schema.json
+++ b/charts/fastmcp-server/values.schema.json
@@ -36,11 +36,56 @@
       "description": "MCP server configuration",
       "properties": {
         "name": { "type": "string", "description": "Server name announced in MCP responses" },
+        "version": { "type": "string", "description": "Server version announced by diagnostics APIs" },
+        "environment": {
+          "type": "string",
+          "description": "Deployment environment passed as MCP_ENV"
+        },
+        "host": { "type": "string", "description": "HTTP listen address" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "HTTP port" },
         "path": { "type": "string", "pattern": "^/", "description": "MCP endpoint URL path" },
+        "workspace": { "type": "string", "pattern": "^/", "description": "Workspace directory used to stage synced MCP components" },
         "logLevel": { "type": "string", "enum": ["DEBUG", "INFO", "WARNING", "ERROR"], "description": "Log level" },
         "logFormat": { "type": "string", "enum": ["text", "json"], "description": "Log output format" },
-        "strictLoading": { "type": "boolean", "description": "Fail on boot if any tool/resource has errors" }
+        "strictLoading": { "type": "boolean", "description": "Fail on boot if any tool/resource has errors" },
+        "maskErrorDetails": {
+          "type": ["boolean", "string"],
+          "description": "Hide internal error details from MCP clients; empty uses the runtime default"
+        },
+        "onDuplicateTools": {
+          "type": "string",
+          "enum": ["warn", "error", "replace", "ignore"],
+          "description": "Duplicate tool handling mode"
+        },
+        "corsAllowedOrigins": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "CORS origins for external UI clients"
+        },
+        "maxSourceFileSizeBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum size in bytes for any loaded source file"
+        },
+        "maxKnowledgeBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum total loaded knowledge size in bytes"
+        },
+        "allowedKnowledgeExtensions": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^\\." },
+          "description": "Knowledge file extensions accepted by the server"
+        },
+        "strategy": {
+          "type": "object",
+          "description": "Deployment strategy"
+        },
+        "revisionHistoryLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of old ReplicaSets to retain"
+        }
       },
       "required": ["name", "port", "path"]
     },
@@ -96,9 +141,16 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["none", "bearer", "jwt"],
+          "enum": ["none", "bearer", "jwt", "multi"],
           "description": "Authentication type"
         },
+        "allowNoAuth": { "type": "boolean" },
+        "scopes": { "type": "array", "items": { "type": "string" } },
+        "requiredScopes": { "type": "array", "items": { "type": "string" } },
+        "clientId": { "type": "string" },
+        "providers": { "type": "array", "items": { "type": "string", "enum": ["bearer", "jwt"] } },
+        "reloadRequiredScopes": { "type": "array", "items": { "type": "string" } },
+        "requireHumanApprovalForDestructive": { "type": "boolean" },
         "bearer": {
           "type": "object",
           "properties": {
@@ -112,7 +164,11 @@
           "properties": {
             "issuer": { "type": "string" },
             "audience": { "type": "string" },
-            "jwksUri": { "type": "string" }
+            "jwksUri": { "type": "string" },
+            "publicKey": { "type": "string" },
+            "publicKeyExistingSecret": { "type": "string" },
+            "publicKeyExistingSecretKey": { "type": "string" },
+            "algorithm": { "type": "string" }
           }
         }
       },
@@ -122,9 +178,15 @@
       "type": "object",
       "description": "Content sources (merge precedence: inline > S3 > Git)",
       "properties": {
+        "blockedFileAllowlist": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicit allowlist for source files normally blocked by the server safety filter"
+        },
         "inline": {
           "type": "object",
           "properties": {
+            "dir": { "type": "string", "pattern": "^/", "description": "Inline source directory inside the container" },
             "tools": { "type": "object", "description": "Python tool files (key=filename, value=content)" },
             "resources": { "type": "object", "description": "Python resource files" },
             "prompts": { "type": "object", "description": "Python prompt files" },
@@ -143,7 +205,10 @@
             "secretKey": { "type": "string" },
             "existingSecret": { "type": "string" },
             "existingSecretAccessKeyKey": { "type": "string" },
-            "existingSecretSecretKeyKey": { "type": "string" }
+            "existingSecretSecretKeyKey": { "type": "string" },
+            "include": { "type": "array", "items": { "type": "string" } },
+            "exclude": { "type": "array", "items": { "type": "string" } },
+            "syncInterval": { "type": "integer", "minimum": 0 }
           }
         },
         "git": {
@@ -155,9 +220,64 @@
             "path": { "type": "string" },
             "token": { "type": "string" },
             "existingSecret": { "type": "string" },
-            "existingSecretTokenKey": { "type": "string" }
+            "existingSecretTokenKey": { "type": "string" },
+            "username": { "type": "string" },
+            "allowedRepositories": { "type": "array", "items": { "type": "string" } },
+            "allowedBranches": { "type": "array", "items": { "type": "string" } },
+            "include": { "type": "array", "items": { "type": "string" } },
+            "exclude": { "type": "array", "items": { "type": "string" } },
+            "syncInterval": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "oci": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "registry": { "type": "string" },
+            "tag": { "type": "string" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretUsernameKey": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" },
+            "include": { "type": "array", "items": { "type": "string" } },
+            "exclude": { "type": "array", "items": { "type": "string" } }
           }
         }
+      }
+    },
+    "hotReload": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "mountServers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "transport": { "type": "string" },
+              "url": { "type": "string" },
+              "namespace": { "type": "string" },
+              "auth": { "type": "object" }
+            },
+            "required": ["url"]
+          }
+        },
+        "rawMountServersJson": { "type": "string" }
+      }
+    },
+    "visibility": {
+      "type": "object",
+      "properties": {
+        "mode": { "type": "string", "enum": ["blocklist", "allowlist"] },
+        "enableTags": { "type": "array", "items": { "type": "string" } },
+        "disableTags": { "type": "array", "items": { "type": "string" } }
       }
     },
     "extraPipPackages": {
@@ -212,13 +332,16 @@
       "properties": {
         "create": { "type": "boolean" },
         "name": { "type": "string" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
       }
     },
     "networkPolicy": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "ingress": { "type": "array" },
+        "egress": { "type": "array" }
       }
     },
     "pdb": {

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -27,16 +27,50 @@ imagePullSecrets: []
 server:
   # -- Server name announced in MCP responses
   name: fastmcp-server
+  # -- Server version announced by diagnostics APIs (defaults to Chart appVersion when empty)
+  version: ""
+  # -- Deployment environment. Production-like values enable stricter runtime defaults in the server.
+  environment: dev
+  # -- Listen address for the HTTP server
+  host: 0.0.0.0
   # -- HTTP port for the MCP endpoint
   port: 8000
   # -- URL path for the MCP endpoint
   path: /mcp
+  # -- Workspace directory used to stage synced MCP components
+  workspace: /app/workspace
   # -- Log level (DEBUG, INFO, WARNING, ERROR)
   logLevel: INFO
   # -- Log format: text or json (structured logging)
   logFormat: text
   # -- Strict loading: fail on boot if any tool/resource has errors
   strictLoading: false
+  # -- Hide internal error details from MCP clients. Empty uses the server runtime default.
+  maskErrorDetails: ""
+  # -- Duplicate tool handling mode: warn, error, replace, or ignore
+  onDuplicateTools: warn
+  # -- Comma-separated CORS origins for external UI clients
+  corsAllowedOrigins: []
+  # -- Maximum size in bytes for any loaded source file; 0 disables
+  maxSourceFileSizeBytes: 1048576
+  # -- Maximum total loaded knowledge size in bytes; 0 disables
+  maxKnowledgeBytes: 10485760
+  # -- Knowledge file extensions accepted by the server
+  allowedKnowledgeExtensions:
+    - .md
+    - .txt
+    - .json
+    - .yaml
+    - .yml
+    - .html
+    - .htm
+    - .csv
+    - .xml
+  # -- Deployment strategy for the server Deployment
+  strategy:
+    type: Recreate
+  # -- Number of old ReplicaSets to retain
+  revisionHistoryLimit: 10
 
 # =============================================================================
 # Web UI
@@ -96,8 +130,23 @@ sandboxing:
 # =============================================================================
 
 auth:
-  # -- Authentication type: none, bearer, jwt
+  # -- Authentication type: none, bearer, jwt, multi
   type: none
+  # -- Explicitly allow no-auth in production-like environments
+  allowNoAuth: false
+  # -- Scopes granted to the static bearer token
+  scopes: []
+  # -- Scopes required on every authenticated request
+  requiredScopes: []
+  # -- Client ID used for bearer-token audit logs
+  clientId: bearer-user
+  # -- Providers enabled when auth.type is multi
+  providers: []
+  # -- Scopes required for the /reload endpoint
+  reloadRequiredScopes:
+    - mcp:admin
+  # -- Require human_approved=true for destructive tools
+  requireHumanApprovalForDestructive: true
   bearer:
     # -- Static bearer token for authentication
     token: ""
@@ -112,6 +161,14 @@ auth:
     audience: ""
     # -- JWKS URI for JWT key verification
     jwksUri: ""
+    # -- JWT public key or HS* shared secret value (ignored if publicKeyExistingSecret is set)
+    publicKey: ""
+    # -- Existing secret containing JWT public key or HS* shared secret
+    publicKeyExistingSecret: ""
+    # -- Key in existing secret containing JWT public key or HS* shared secret
+    publicKeyExistingSecretKey: public-key
+    # -- JWT algorithm, for example RS256 or HS256
+    algorithm: ""
 
 # =============================================================================
 # Sources — Inline, S3, Git
@@ -119,8 +176,13 @@ auth:
 # Merge precedence: Inline (highest) > S3 > Git (lowest)
 
 sources:
+  # -- Explicit allowlist for source files normally blocked by the server safety filter
+  blockedFileAllowlist: []
+
   # -- Inline tools, resources, prompts, and knowledge mounted via ConfigMaps
   inline:
+    # -- Inline source directory inside the container
+    dir: /app/inline
     # -- Python tool files (key = filename, value = file content)
     # -- @default -- `{}` (no inline tools)
     tools: {}
@@ -179,6 +241,12 @@ sources:
     existingSecretAccessKeyKey: access-key
     # -- Key in existing secret for secret key
     existingSecretSecretKeyKey: secret-key
+    # -- Include glob patterns within each asset directory
+    include: []
+    # -- Exclude glob patterns within each asset directory
+    exclude: []
+    # -- Background sync interval in seconds; 0 disables periodic sync
+    syncInterval: 0
 
   # -- Git repository source
   git:
@@ -196,6 +264,76 @@ sources:
     existingSecret: ""
     # -- Key in existing secret for Git token
     existingSecretTokenKey: token
+    # -- Username used by the temporary Git askpass helper
+    username: x-access-token
+    # -- Allowed repository URL patterns
+    allowedRepositories: []
+    # -- Allowed branch name patterns
+    allowedBranches: []
+    # -- Include glob patterns within each asset directory
+    include: []
+    # -- Exclude glob patterns within each asset directory
+    exclude: []
+    # -- Background sync interval in seconds; 0 disables periodic sync
+    syncInterval: 0
+
+  # -- OCI artifact source
+  oci:
+    # -- Enable OCI source
+    enabled: false
+    # -- OCI artifact reference without tag
+    registry: ""
+    # -- OCI artifact tag
+    tag: ""
+    # -- Registry username (ignored if existingSecret is set)
+    username: ""
+    # -- Registry password (ignored if existingSecret is set)
+    password: ""
+    # -- Existing secret with OCI credentials
+    existingSecret: ""
+    # -- Key in existing secret for OCI username
+    existingSecretUsernameKey: username
+    # -- Key in existing secret for OCI password
+    existingSecretPasswordKey: password
+    # -- Include glob patterns within each asset directory
+    include: []
+    # -- Exclude glob patterns within each asset directory
+    exclude: []
+
+# =============================================================================
+# Hot Reload
+# =============================================================================
+
+hotReload:
+  # -- Watch inline Python files and rebuild components automatically
+  enabled: false
+
+# =============================================================================
+# Gateway
+# =============================================================================
+
+gateway:
+  # -- Run in gateway mode and mount remote MCP servers
+  enabled: false
+  # -- Structured remote MCP server mounts rendered as MCP_MOUNT_SERVERS JSON
+  mountServers: {}
+    # remote:
+    #   transport: streamable-http
+    #   url: https://remote.example.com/mcp
+  # -- Raw MCP_MOUNT_SERVERS JSON override. When set, mountServers is ignored.
+  rawMountServersJson: ""
+
+# =============================================================================
+# Visibility
+# =============================================================================
+
+visibility:
+  # -- Visibility mode: blocklist or allowlist
+  mode: blocklist
+  # -- Tags to expose when using allowlist mode
+  enableTags: []
+  # -- Tags to hide when using blocklist mode
+  disableTags: []
 
 # =============================================================================
 # Extra Pip Packages
@@ -301,11 +439,13 @@ initSync:
 
 serviceAccount:
   # -- Create a ServiceAccount
-  create: false
+  create: true
   # -- ServiceAccount name
   name: ""
   # -- Annotations for the ServiceAccount
   annotations: {}
+  # -- Automount the Kubernetes service account token
+  automountServiceAccountToken: false
 
 # =============================================================================
 # Network Policy
@@ -314,6 +454,10 @@ serviceAccount:
 networkPolicy:
   # -- Enable NetworkPolicy
   enabled: false
+  # -- Ingress rules. Empty allows TCP traffic to server.port from all sources.
+  ingress: []
+  # -- Egress rules. Empty allows all egress when networkPolicy.enabled is true.
+  egress: []
 
 # =============================================================================
 # Resources and Security
@@ -357,9 +501,21 @@ replicaCount: 1
 
 resources: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  readOnlyRootFilesystem: false
 
 # =============================================================================
 # Scheduling


### PR DESCRIPTION
Related to #111

## Summary
- Expands the `fastmcp-server` chart runtime surface for server env parity, multi-auth, JWT, scopes, S3/Git filters and sync intervals, OCI sources, hot reload, gateway mode, visibility tags, and operational hardening.
- Adds render-time validations, schema coverage, dedicated feature docs, examples, CI values, and unit tests.
- Updates NOTES.txt into a full post-install dashboard.
- Adds `.gitattributes` to keep chart text files on LF for chart-testing/yamllint compatibility.

## Validation
- `helm lint charts/fastmcp-server --strict`: passed
- `helm lint charts/fastmcp-server -f charts/fastmcp-server/ci/full-values.yaml --strict`: passed
- `helm unittest charts/fastmcp-server`: 103 tests passed
- Render loop for all `charts/fastmcp-server/ci/*.yaml`: passed
- Render loop for all `charts/fastmcp-server/examples/**/*.yaml`: passed
- `ct lint --target-branch main --charts charts/fastmcp-server`: passed
- `kubeconform` default render: passed
- `kubeconform` full-values render: passed
- k3d runtime validation: passed on `k3d-charts-test`; pod ready `1/1`, 0 restarts, readiness/health 200, logs/env checked
- MCP HelmForge `check_site_sync`: passed for defaults and architecture
- MCP HelmForge `validate_compliance`: 26/27 passed, 0 blockers

## Notes
- `Chart.yaml` version was not changed.
- The remaining MCP warning is the existing README `SOURCE-OF-TRUTH.md` reference rule.
- Matching site documentation PR: https://github.com/helmforgedev/site/pull/159
