### PR TITLE
fix(fastmcp-server): render strict loading false

### DIFF
--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -203,6 +203,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            {{- $extraEnvNames := list }}
+            {{- range .Values.extraEnv }}
+            {{- $extraEnvNames = append $extraEnvNames .name }}
+            {{- end }}
             - name: MCP_SERVER_NAME
               value: {{ .Values.server.name | quote }}
             - name: MCP_SERVER_VERSION
@@ -223,9 +227,9 @@ spec:
             - name: LOG_FORMAT
               value: {{ .Values.server.logFormat | quote }}
             {{- end }}
-            {{- if .Values.server.strictLoading }}
+            {{- if not (has "MCP_STRICT_LOADING" $extraEnvNames) }}
             - name: MCP_STRICT_LOADING
-              value: "true"
+              value: {{ .Values.server.strictLoading | quote }}
             {{- end }}
             {{- if ne (toString .Values.server.maskErrorDetails) "" }}
             - name: MCP_MASK_ERROR_DETAILS

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -698,6 +698,14 @@ tests:
             name: LOG_FORMAT
             value: "json"
 
+  - it: should set strict loading env to false by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_STRICT_LOADING
+            value: "false"
+
   - it: should set strict loading env when enabled
     set:
       server:
@@ -708,6 +716,25 @@ tests:
           content:
             name: MCP_STRICT_LOADING
             value: "true"
+
+  - it: should allow extraEnv to override strict loading env without duplicate default
+    set:
+      server:
+        strictLoading: false
+      extraEnv:
+        - name: MCP_STRICT_LOADING
+          value: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_STRICT_LOADING
+            value: "true"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_STRICT_LOADING
+            value: "false"
 
   - it: should not have init container by default
     asserts:


### PR DESCRIPTION
## Summary
- render MCP_STRICT_LOADING for both true and false chart values
- allow extraEnv to override the generated strict loading env without duplicating it
- add unit coverage for default false, enabled true, and extraEnv override behavior

## Validation
- helm lint charts/fastmcp-server --strict
- helm unittest charts/fastmcp-server
- helm template with GitOps values piped to kubeconform

Note: HelmForge MCP validation was attempted but the remote MCP endpoint returned HTTP 503.