### PR TITLE
fix(charts): harden fastmcp reload and postgresql auth

### DIFF
--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -3,7 +3,7 @@ name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
 version: 1.6.1
-appVersion: "0.11.0"
+appVersion: "0.11.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/fastmcp-server/README.md
+++ b/charts/fastmcp-server/README.md
@@ -152,12 +152,12 @@ auth:
     - jwt
   scopes:
     - mcp:read
-  reloadRequiredScopes:
-    - mcp:admin
+  adminExistingSecret: fastmcp-admin
+  adminExistingSecretKey: admin-token
 ```
 
 See [Authentication](docs/authentication.md) for bearer, JWT, multi-provider,
-scope, and reload authorization examples.
+scope, and reload admin token examples.
 
 ### Gateway Mode
 
@@ -308,7 +308,8 @@ securityContext:
 | `metrics.enabled` | `false` | Enable Prometheus metrics at `/metrics` |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor CRD |
 | `auth.type` | `none` | Authentication: `none`, `bearer`, `jwt`, `multi` |
-| `auth.reloadRequiredScopes` | `["mcp:admin"]` | Scopes required for `/reload` |
+| `auth.adminToken` | `""` | Dedicated admin token for privileged endpoints such as `/reload` |
+| `auth.adminExistingSecret` | `""` | Existing Secret containing the admin token |
 | `sources.inline.tools` | `{}` | Inline Python tool files |
 | `sources.inline.resources` | `{}` | Inline Python resource files |
 | `sources.inline.prompts` | `{}` | Inline Python prompt files |

--- a/charts/fastmcp-server/ci/auth-multi-values.yaml
+++ b/charts/fastmcp-server/ci/auth-multi-values.yaml
@@ -8,8 +8,7 @@ auth:
     - tools:execute
   requiredScopes:
     - tools:execute
-  reloadRequiredScopes:
-    - mcp:reload
+  adminExistingSecret: fastmcp-admin
   bearer:
     existingSecret: fastmcp-auth
   jwt:

--- a/charts/fastmcp-server/ci/full-values.yaml
+++ b/charts/fastmcp-server/ci/full-values.yaml
@@ -1,7 +1,7 @@
 # CI: all features enabled
 server:
   name: full-test-server
-  version: "0.11.0"
+  version: "0.11.1"
   environment: staging
   host: 0.0.0.0
   logLevel: DEBUG

--- a/charts/fastmcp-server/docs/authentication.md
+++ b/charts/fastmcp-server/docs/authentication.md
@@ -47,9 +47,19 @@ auth:
     - jwt
   scopes:
     - mcp:read
-  reloadRequiredScopes:
-    - mcp:admin
 ```
+
+## Reload Admin Token
+
+`/reload` performs source sync and component rebuild, so it should use a privileged token separate from normal MCP client auth.
+
+```yaml
+auth:
+  adminExistingSecret: fastmcp-admin
+  adminExistingSecretKey: admin-token
+```
+
+If `auth.adminToken` or `auth.adminExistingSecret` is not set, the server falls back to regular HTTP auth for compatibility. Production deployments should configure a dedicated admin token.
 
 ## Production Guardrail
 

--- a/charts/fastmcp-server/examples/production/values.yaml
+++ b/charts/fastmcp-server/examples/production/values.yaml
@@ -13,8 +13,7 @@ metrics:
 
 auth:
   type: bearer
-  reloadRequiredScopes:
-    - mcp:reload
+  adminExistingSecret: mcp-admin-token
   bearer:
     existingSecret: mcp-auth-token
 

--- a/charts/fastmcp-server/templates/_helpers.tpl
+++ b/charts/fastmcp-server/templates/_helpers.tpl
@@ -69,6 +69,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- end -}}
 {{- end -}}
 
+{{/* Admin auth secret name */}}
+{{- define "fastmcp-server.adminSecretName" -}}
+  {{- if .Values.auth.adminExistingSecret -}}
+    {{- .Values.auth.adminExistingSecret -}}
+  {{- else -}}
+    {{- printf "%s-admin" (include "fastmcp-server.fullname" .) -}}
+  {{- end -}}
+{{- end -}}
+
 {{/* JWT public key secret name */}}
 {{- define "fastmcp-server.jwtSecretName" -}}
 {{- if .Values.auth.jwt.publicKeyExistingSecret -}}

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -269,9 +269,16 @@ spec:
             - name: MCP_AUTH_CLIENT_ID
               value: {{ .Values.auth.clientId | quote }}
             {{- end }}
-            {{- with .Values.auth.reloadRequiredScopes }}
-            - name: MCP_RELOAD_REQUIRED_SCOPES
-              value: {{ join "," . | quote }}
+            {{- if or .Values.auth.adminToken .Values.auth.adminExistingSecret }}
+            - name: MCP_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fastmcp-server.adminSecretName" . }}
+                  key: {{ .Values.auth.adminExistingSecretKey | default "admin-token" }}
+            {{- end }}
+            {{- if .Values.auth.adminClientId }}
+            - name: MCP_ADMIN_CLIENT_ID
+              value: {{ .Values.auth.adminClientId | quote }}
             {{- end }}
             {{- if .Values.gateway.enabled }}
             - name: MCP_MODE

--- a/charts/fastmcp-server/templates/secret.yaml
+++ b/charts/fastmcp-server/templates/secret.yaml
@@ -8,6 +8,17 @@ metadata:
 stringData:
   token: {{ .Values.auth.bearer.token | quote }}
 {{- end }}
+{{- if and .Values.auth.adminToken (not .Values.auth.adminExistingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fastmcp-server.adminSecretName" . }}
+  labels:
+    {{- include "fastmcp-server.labels" . | nindent 4 }}
+stringData:
+  {{ .Values.auth.adminExistingSecretKey | default "admin-token" }}: {{ .Values.auth.adminToken | quote }}
+{{- end }}
 {{- if and (or (eq .Values.auth.type "jwt") (eq .Values.auth.type "multi")) .Values.auth.jwt.publicKey (not .Values.auth.jwt.publicKeyExistingSecret) }}
 ---
 apiVersion: v1

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -49,7 +49,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: MCP_SERVER_VERSION
-            value: "0.11.0"
+            value: "0.11.1"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -272,6 +272,30 @@ tests:
                 key: token
         template: templates/deployment.yaml
 
+  - it: should set admin token env for privileged reload endpoint
+    set:
+      auth:
+        adminToken: admin-token
+    templates:
+      - templates/deployment.yaml
+      - templates/secret.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ADMIN_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-fastmcp-server-admin
+                key: admin-token
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_ADMIN_CLIENT_ID
+            value: "admin-user"
+        template: templates/deployment.yaml
+
   - it: should set multi auth, scopes, and JWT env vars
     set:
       auth:
@@ -286,8 +310,7 @@ tests:
         providers:
           - bearer
           - jwt
-        reloadRequiredScopes:
-          - mcp:admin
+        adminToken: admin-token
         requireHumanApprovalForDestructive: false
         bearer:
           token: test-token
@@ -333,11 +356,6 @@ tests:
           content:
             name: MCP_REQUIRE_HUMAN_APPROVAL_FOR_DESTRUCTIVE
             value: "false"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_RELOAD_REQUIRED_SCOPES
-            value: "mcp:admin"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/fastmcp-server/tests/secret_test.yaml
+++ b/charts/fastmcp-server/tests/secret_test.yaml
@@ -34,6 +34,23 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should render admin secret when adminToken is set
+    set:
+      auth:
+        adminToken: admin-secret-token
+    asserts:
+      - isKind:
+          of: Secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-fastmcp-server-admin
+        documentIndex: 0
+      - equal:
+          path: stringData.admin-token
+          value: admin-secret-token
+        documentIndex: 0
+
   - it: should render auth secret for multi bearer provider
     set:
       auth:

--- a/charts/fastmcp-server/values.schema.json
+++ b/charts/fastmcp-server/values.schema.json
@@ -149,7 +149,15 @@
         "requiredScopes": { "type": "array", "items": { "type": "string" } },
         "clientId": { "type": "string" },
         "providers": { "type": "array", "items": { "type": "string", "enum": ["bearer", "jwt"] } },
-        "reloadRequiredScopes": { "type": "array", "items": { "type": "string" } },
+        "reloadRequiredScopes": {
+          "type": "array",
+          "description": "Deprecated: ignored by the simplified runtime. Use auth.adminToken or auth.adminExistingSecret for /reload.",
+          "items": { "type": "string" }
+        },
+        "adminToken": { "type": "string" },
+        "adminExistingSecret": { "type": "string" },
+        "adminExistingSecretKey": { "type": "string" },
+        "adminClientId": { "type": "string" },
         "requireHumanApprovalForDestructive": { "type": "boolean" },
         "bearer": {
           "type": "object",

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- FastMCP server container image
   repository: docker.io/helmforge/fastmcp-server
   # -- Image tag (pinned to appVersion)
-  tag: "0.11.0"
+  tag: "0.11.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -142,9 +142,16 @@ auth:
   clientId: bearer-user
   # -- Providers enabled when auth.type is multi
   providers: []
-  # -- Scopes required for the /reload endpoint
-  reloadRequiredScopes:
-    - mcp:admin
+  # -- Deprecated: scopes are ignored by the simplified runtime. Use auth.adminToken for /reload.
+  reloadRequiredScopes: []
+  # -- Dedicated admin token for privileged HTTP endpoints such as /reload
+  adminToken: ""
+  # -- Use an existing secret for auth.adminToken
+  adminExistingSecret: ""
+  # -- Key in auth.adminExistingSecret containing the admin token
+  adminExistingSecretKey: admin-token
+  # -- Client ID used for admin-token audit logs
+  adminClientId: admin-user
   # -- Require human_approved=true for destructive tools
   requireHumanApprovalForDestructive: true
   bearer:

--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -138,6 +138,7 @@ metrics:
 ### Security
 
 - prefer `auth.existingSecret` in production
+- keep the password Secret aligned with the password stored in any existing PVC; PostgreSQL does not rewrite `pg_authid` just because a Kubernetes Secret changed
 - keep client access internal unless there is a strong reason to expose PostgreSQL outside the cluster network
 - use `networkPolicy.enabled=true` or external platform controls when possible
 - rotate passwords through secret management workflows instead of editing values inline
@@ -170,6 +171,7 @@ metrics:
 
 - use `config.preset` for a small set of opinionated PostgreSQL defaults
 - use `config.pgHbaEntries` when you need structured host-based access rules
+- keep `config.localAuthMethod=scram-sha-256` for production so local socket clients do not bypass password auth
 - use `*.resourcesPreset` for small and predictable environment sizing before reaching for fully custom resources
 - keep `config.postgresql` and `config.pgHba` for raw overrides when structured values are not enough
 - keep `auth.database`, `auth.username`, and `auth.replicationUsername` as plain values; `existingSecret` is intentionally limited to sensitive runtime data

--- a/charts/postgresql/docs/secret-rotation.md
+++ b/charts/postgresql/docs/secret-rotation.md
@@ -7,9 +7,12 @@ This chart supports password and TLS material through existing Kubernetes secret
 ## Password rotation
 
 - update the secret referenced by `auth.existingSecret`
+- ensure the secret value matches the password stored in the existing data directory before restarting pods
 - restart PostgreSQL workloads in a controlled maintenance window
 - verify application connectivity after the rollout
 - if replication is enabled, rotate replication credentials with care and confirm replicas can reconnect
+
+If a PVC already contains a PostgreSQL data directory and the Secret is missing or was regenerated with a different value, PostgreSQL keeps the old password in `pg_authid` while pods receive the new `POSTGRES_PASSWORD`. The chart refuses unsafe password auto-generation when it detects the primary PVC; recover by restoring the correct Secret, rotating the database password intentionally, or reinitializing the data directory.
 
 ## TLS rotation
 
@@ -24,6 +27,7 @@ This chart supports password and TLS material through existing Kubernetes secret
 - validate one environment at a time
 - document rollback steps before rotation
 - for production, use an external secret manager or an automated secret delivery workflow
+- keep `config.localAuthMethod` at `scram-sha-256` unless a tightly controlled bootstrap/debug workflow explicitly requires `trust`
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -117,6 +117,37 @@ app.kubernetes.io/role: {{ .role }}
 {{- printf "%s-replicas" (include "postgresql.fullname" .) -}}
 {{- end -}}
 
+{{- define "postgresql.primaryPvcName" -}}
+{{- printf "data-%s-0" (include "postgresql.primaryStatefulSetName" .) -}}
+{{- end -}}
+
+{{- define "postgresql.primaryPersistenceEnabled" -}}
+{{- if ternary .Values.replication.primary.persistence.enabled .Values.standalone.persistence.enabled (eq .Values.architecture "replication") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.detectedPrimaryPvc" -}}
+{{- if include "postgresql.primaryPersistenceEnabled" . -}}
+{{- $pvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace (include "postgresql.primaryPvcName" .) -}}
+{{- if $pvc -}}true{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.validatePasswordGeneration" -}}
+{{- if and (not .Values.auth.existingSecret) (include "postgresql.detectedPrimaryPvc" .) (not .Values.auth.allowPasswordGenerationWithExistingData) -}}
+{{- $secretName := include "postgresql.secretName" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $hasPostgres := and $existing $existing.data (hasKey $existing.data .Values.auth.existingSecretPostgresPasswordKey) -}}
+{{- $hasUser := and $existing $existing.data (hasKey $existing.data .Values.auth.existingSecretUserPasswordKey) -}}
+{{- $hasReplication := and $existing $existing.data (hasKey $existing.data .Values.auth.existingSecretReplicationPasswordKey) -}}
+{{- $needsPostgres := and (not .Values.auth.postgresPassword) (not $hasPostgres) -}}
+{{- $needsUser := and (not .Values.auth.password) (not $hasUser) -}}
+{{- $needsReplication := and (eq .Values.architecture "replication") (not .Values.auth.replicationPassword) (not $hasReplication) -}}
+{{- if or $needsPostgres $needsUser $needsReplication -}}
+{{- fail (printf "Refusing to auto-generate PostgreSQL passwords because existing PVC %q was detected but the managed Secret is missing one or more required password keys. Restore/reuse the existing Secret, set explicit auth passwords that match the database, or set auth.allowPasswordGenerationWithExistingData=true only for an empty/reinitialized data directory." (include "postgresql.primaryPvcName" .)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "postgresql.postgresPassword" -}}
 {{- $secretName := include "postgresql.secretName" . -}}
 {{- if .Values.auth.existingSecret -}}
@@ -128,6 +159,7 @@ app.kubernetes.io/role: {{ .role }}
 {{- if and $existing $existing.data (hasKey $existing.data .Values.auth.existingSecretPostgresPasswordKey) -}}
 {{- index $existing.data .Values.auth.existingSecretPostgresPasswordKey | b64dec -}}
 {{- else -}}
+{{- include "postgresql.validatePasswordGeneration" . -}}
 {{- randAlphaNum 32 -}}
 {{- end -}}
 {{- end -}}

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -210,23 +210,12 @@ postgres
 {{- end -}}
 
 {{- define "postgresql.primaryStartupProbeCommandString" -}}
-DATA_DIR="${PGDATA:-/var/lib/postgresql/data/pgdata}"
-if [ ! -s "${DATA_DIR}/PG_VERSION" ]; then
-  exit 1
-fi
-{{ include "postgresql.libpqEnvExports" . }}export PGPASSWORD="${POSTGRES_PASSWORD}"
-if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1" >/dev/null 2>&1; then
-  if ! psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = '{{ include "postgresql.maintenanceDatabase" . }}'" | grep -qx 1; then
-    createdb -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} {{ include "postgresql.maintenanceDatabase" . }}
-  fi
-  {{ include "postgresql.probeCommandString" . }}
-  exit $?
-fi
-exit 1
+{{ include "postgresql.ensureMaintenanceDatabaseCommandString" . }}
 {{- end -}}
 
 {{- define "postgresql.primaryReadinessCommandString" -}}
-{{- if and (eq .Values.architecture "replication") .Values.replication.primary.probes.requireWritable -}}
+{{ include "postgresql.ensureMaintenanceDatabaseCommandString" . }}
+{{ if and (eq .Values.architecture "replication") .Values.replication.primary.probes.requireWritable -}}
 {{- include "postgresql.libpqEnvExports" . }}PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d {{ include "postgresql.maintenanceDatabase" . }} -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
 {{- else -}}
 {{ include "postgresql.probeCommandString" . }}
@@ -244,25 +233,17 @@ exit 1
 {{- define "postgresql.ensureMaintenanceDatabaseCommandString" -}}
 DATA_DIR="${PGDATA:-/var/lib/postgresql/data/pgdata}"
 if [ ! -s "${DATA_DIR}/PG_VERSION" ]; then
-  exit 0
+  exit 1
 fi
 {{ include "postgresql.libpqEnvExports" . }}export PGPASSWORD="${POSTGRES_PASSWORD}"
-for attempt in $(seq 1 150); do
-  if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1" >/dev/null 2>&1; then
-    if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = '{{ include "postgresql.maintenanceDatabase" . }}'" | grep -qx 1; then
-      if {{ include "postgresql.probeCommandString" . }} >/dev/null 2>&1; then
-        exit 0
-      fi
-      sleep 2
-      continue
-    fi
+if psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1" >/dev/null 2>&1; then
+  if ! psql -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = '{{ include "postgresql.maintenanceDatabase" . }}'" | grep -qx 1; then
     createdb -U postgres -h 127.0.0.1 -p {{ .Values.service.port }} {{ include "postgresql.maintenanceDatabase" . }}
-    exit 0
   fi
-  sleep 2
-done
-echo "Unable to verify or repair the {{ include "postgresql.maintenanceDatabase" . }} database on this PostgreSQL data directory." >&2
-exit 1
+else
+  echo "Unable to verify or repair the {{ include "postgresql.maintenanceDatabase" . }} database on this PostgreSQL data directory." >&2
+  exit 1
+fi
 {{- end -}}
 
 {{- define "postgresql.metricsEnv" -}}

--- a/charts/postgresql/templates/configmap.yaml
+++ b/charts/postgresql/templates/configmap.yaml
@@ -35,7 +35,7 @@ data:
     {{ . | nindent 4 }}
     {{- end }}
   pg_hba.conf: |
-    local   all             all                                     trust
+    local   all             all                                     {{ .Values.config.localAuthMethod }}
     {{- if .Values.tls.enabled }}
     hostssl all             all             127.0.0.1/32            scram-sha-256
     hostssl all             all             ::1/128                 scram-sha-256

--- a/charts/postgresql/templates/secret.yaml
+++ b/charts/postgresql/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- include "postgresql.validatePasswordGeneration" . -}}
 {{- if not .Values.auth.existingSecret }}
 apiVersion: v1
 kind: Secret

--- a/charts/postgresql/templates/statefulset-primary.yaml
+++ b/charts/postgresql/templates/statefulset-primary.yaml
@@ -75,14 +75,6 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          lifecycle:
-            postStart:
-              exec:
-                command:
-                  - sh
-                  - -ec
-                  - |
-                    {{- include "postgresql.ensureMaintenanceDatabaseCommandString" . | nindent 20 }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:

--- a/charts/postgresql/tests/configmap_test.yaml
+++ b/charts/postgresql/tests/configmap_test.yaml
@@ -12,3 +12,21 @@ tests:
       - matchRegex:
           path: data["01-init-users.sh"]
           pattern: 'psql --username "\$\{POSTGRES_USER\}" --dbname postgres'
+
+  - it: should require SCRAM for local socket connections by default
+    template: configmap.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["pg_hba.conf"]
+          pattern: 'local\s+all\s+all\s+scram-sha-256'
+
+  - it: should allow overriding local socket authentication method
+    template: configmap.yaml
+    documentIndex: 0
+    set:
+      config.localAuthMethod: trust
+    asserts:
+      - matchRegex:
+          path: data["pg_hba.conf"]
+          pattern: 'local\s+all\s+all\s+trust'

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -155,14 +155,13 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
           value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
 
-  - it: should repair the postgres maintenance database on reused data directories
+  - it: should not use postStart for maintenance database repair
     template: statefulset-primary.yaml
     asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].lifecycle
       - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
-          pattern: 'psql -U postgres -h 127\.0\.0\.1 -p 5432 -d template1 -tAc "SELECT 1 FROM pg_database WHERE datname = ''postgres''"'
-      - matchRegex:
-          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
           pattern: 'createdb -U postgres -h 127\.0\.0\.1 -p 5432 postgres'
 
   - it: should create VolumeClaimTemplate when persistence is enabled

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -151,9 +151,12 @@ tests:
     set:
       architecture: replication
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
-          value: PGPASSWORD="${POSTGRES_PASSWORD}" psql -U postgres -h 127.0.0.1 -p 5432 -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery() THEN 1 ELSE 0 END" | grep -qx 0
+          pattern: 'createdb -U postgres -h 127\.0\.0\.1 -p 5432 postgres'
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: 'psql -U postgres -h 127\.0\.0\.1 -p 5432 -d postgres -tAc "SELECT CASE WHEN pg_is_in_recovery\(\) THEN 1 ELSE 0 END" \| grep -qx 0'
 
   - it: should not use postStart for maintenance database repair
     template: statefulset-primary.yaml
@@ -161,7 +164,18 @@ tests:
       - isNull:
           path: spec.template.spec.containers[0].lifecycle
       - matchRegex:
-          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: 'createdb -U postgres -h 127\.0\.0\.1 -p 5432 postgres'
+
+  - it: should keep maintenance database repair when startup probe is disabled
+    template: statefulset-primary.yaml
+    set:
+      startupProbe.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
           pattern: 'createdb -U postgres -h 127\.0\.0\.1 -p 5432 postgres'
 
   - it: should create VolumeClaimTemplate when persistence is enabled

--- a/charts/postgresql/values.schema.json
+++ b/charts/postgresql/values.schema.json
@@ -69,7 +69,7 @@
       "properties": {
         "postgresPassword": {
           "type": "string",
-          "description": "PostgreSQL superuser password. Auto-generated if empty and no existingSecret is set.",
+          "description": "PostgreSQL superuser password. Auto-generated only for a first install without persisted data when empty and no existingSecret is set.",
           "default": ""
         },
         "database": {
@@ -84,7 +84,7 @@
         },
         "password": {
           "type": "string",
-          "description": "Application user password. Auto-generated if empty and no existingSecret is set.",
+          "description": "Application user password. Auto-generated only for a first install without persisted data when empty and no existingSecret is set.",
           "default": ""
         },
         "replicationUsername": {
@@ -94,8 +94,13 @@
         },
         "replicationPassword": {
           "type": "string",
-          "description": "Replication user password. Auto-generated if empty and no existingSecret is set.",
+          "description": "Replication user password. Auto-generated only for a first install without persisted data when empty and no existingSecret is set.",
           "default": ""
+        },
+        "allowPasswordGenerationWithExistingData": {
+          "type": "boolean",
+          "description": "Allow password generation even when an existing primary PVC is detected. Dangerous unless the data directory is empty.",
+          "default": false
         },
         "existingSecret": {
           "type": "string",
@@ -124,6 +129,11 @@
       "description": "PostgreSQL configuration",
       "additionalProperties": false,
       "properties": {
+        "localAuthMethod": {
+          "type": "string",
+          "description": "Authentication method for local Unix-socket connections in pg_hba.conf.",
+          "default": "scram-sha-256"
+        },
         "preset": {
           "type": "string",
           "description": "Optional configuration preset: none | small | medium | large",

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -37,18 +37,20 @@ imagePullSecrets: []
 # =============================================================================
 
 auth:
-  # -- PostgreSQL superuser password. Auto-generated if empty and no existingSecret is set.
+  # -- PostgreSQL superuser password. Auto-generated only for a first install without persisted data when empty and no existingSecret is set.
   postgresPassword: ""
   # -- Application database created on first bootstrap
   database: app
   # -- Application user created on first bootstrap
   username: app
-  # -- Application user password. Auto-generated if empty and no existingSecret is set.
+  # -- Application user password. Auto-generated only for a first install without persisted data when empty and no existingSecret is set.
   password: ""
   # -- Replication user used by read replicas
   replicationUsername: replicator
-  # -- Replication user password. Auto-generated if empty and no existingSecret is set.
+  # -- Replication user password. Auto-generated only for a first install without persisted data when empty and no existingSecret is set.
   replicationPassword: ""
+  # -- Allow password generation even when the chart detects an existing primary PVC. Dangerous unless the data directory is empty.
+  allowPasswordGenerationWithExistingData: false
   # -- Existing secret with PostgreSQL passwords
   existingSecret: ""
   # -- Usernames and database names remain regular values on purpose. This chart only reads secrets for sensitive runtime data.
@@ -64,6 +66,9 @@ auth:
 # =============================================================================
 
 config:
+  # -- Authentication method for local Unix-socket connections in pg_hba.conf.
+  # Use scram-sha-256 for production. Set to trust only for tightly controlled bootstrap/debug workflows.
+  localAuthMethod: scram-sha-256
   # -- Optional configuration preset: none | small | medium | large
   preset: none
   # -- Extra postgresql.conf content appended to the generated configuration


### PR DESCRIPTION
## Summary
- update fastmcp-server chart for dedicated MCP_ADMIN_TOKEN based /reload authorization
- remove deprecated reload scope env wiring and document admin-token usage
- harden postgresql password generation when a primary PVC already exists
- remove fragile postStart maintenance repair and require SCRAM for local socket auth by default

## Validation
- helm lint charts/fastmcp-server --strict
- helm lint charts/postgresql --strict
- helm unittest charts/fastmcp-server
- helm unittest charts/postgresql
- rendered all fastmcp-server ci values with helm template
- rendered all postgresql ci values with helm template