### PR TITLE
fix(fastmcp-server): remove legacy runtime knobs

### DIFF
--- a/charts/fastmcp-server/README.md
+++ b/charts/fastmcp-server/README.md
@@ -7,10 +7,10 @@ A Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fast
 - Multi-source loading with merge precedence: Inline > S3 > Git
 - Bearer token and JWT authentication via FastMCP
 - Multi-provider authentication with bearer and JWT
-- Auth scopes, reload scopes, and destructive-tool approval controls
+- Dedicated admin token and destructive-tool approval controls
 - Knowledge base files served as MCP resources
 - Extra pip packages installed at startup
-- S3, Git, and OCI source filters with optional background sync
+- S3, Git, and OCI sources with optional background sync
 - Gateway mode for mounting remote MCP servers
 - Tool visibility filtering by tags
 - Built-in Web UI dashboard at `/ui`
@@ -19,7 +19,6 @@ A Helm chart for deploying [FastMCP Server](https://github.com/helmforgedev/fast
 - Dedicated health endpoints (`/healthz`, `/readyz`, `/startupz`)
 - Diagnostic endpoint at `/debug/info`
 - Init container pattern for source pre-sync
-- Strict loading mode for fail-fast on errors
 
 ## Quick Start
 
@@ -150,14 +149,12 @@ auth:
   providers:
     - bearer
     - jwt
-  scopes:
-    - mcp:read
   adminExistingSecret: fastmcp-admin
   adminExistingSecretKey: admin-token
 ```
 
 See [Authentication](docs/authentication.md) for bearer, JWT, multi-provider,
-scope, and reload admin token examples.
+and reload admin token examples.
 
 ### Gateway Mode
 
@@ -173,17 +170,13 @@ gateway:
 
 See [Gateway](docs/gateway.md) for gateway mode details.
 
-### Source Filters and Sync
+### Source Sync
 
 ```yaml
 sources:
   s3:
     enabled: true
     bucket: mcp-assets
-    include:
-      - tools/**
-    exclude:
-      - "**/*.tmp"
     syncInterval: 60
 ```
 
@@ -225,7 +218,6 @@ server:
   name: production-mcp
   logLevel: WARNING
   logFormat: json
-  strictLoading: true
 
 auth:
   type: bearer
@@ -295,7 +287,7 @@ securityContext:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/helmforge/fastmcp-server` | Container image |
-| `image.tag` | `0.11.0` | Image tag |
+| `image.tag` | `0.11.1` | Image tag |
 | `server.name` | `fastmcp-server` | Server name in MCP responses |
 | `server.environment` | `dev` | Runtime environment passed as `MCP_ENV` |
 | `server.workspace` | `/app/workspace` | Workspace path for synced components |
@@ -303,7 +295,6 @@ securityContext:
 | `server.path` | `/mcp` | MCP endpoint path |
 | `server.logLevel` | `INFO` | Log level |
 | `server.logFormat` | `text` | Log format: `text` or `json` |
-| `server.strictLoading` | `false` | Fail on boot if any component has errors |
 | `ui.enabled` | `true` | Enable Web UI at `/ui` |
 | `metrics.enabled` | `false` | Enable Prometheus metrics at `/metrics` |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor CRD |

--- a/charts/fastmcp-server/ci/auth-multi-values.yaml
+++ b/charts/fastmcp-server/ci/auth-multi-values.yaml
@@ -3,11 +3,6 @@ auth:
   providers:
     - bearer
     - jwt
-  scopes:
-    - tools:read
-    - tools:execute
-  requiredScopes:
-    - tools:execute
   adminExistingSecret: fastmcp-admin
   bearer:
     existingSecret: fastmcp-auth

--- a/charts/fastmcp-server/ci/full-values.yaml
+++ b/charts/fastmcp-server/ci/full-values.yaml
@@ -18,11 +18,6 @@ server:
 
 auth:
   type: multi
-  scopes:
-    - mcp:read
-    - mcp:admin
-  requiredScopes:
-    - mcp:read
   providers:
     - bearer
     - jwt
@@ -35,8 +30,6 @@ auth:
     algorithm: HS256
 
 sources:
-  blockedFileAllowlist:
-    - knowledge/private-config.example
   inline:
     dir: /app/inline
     tools:
@@ -55,24 +48,12 @@ sources:
     region: us-east-1
     accessKey: example-access-key
     secretKey: example-secret-key
-    include:
-      - tools/**
-    exclude:
-      - "**/*.tmp"
     syncInterval: 60
   git:
     enabled: true
     repository: "https://github.com/example/tools.git"
     branch: main
     token: example-git-token
-    allowedRepositories:
-      - https://github.com/example/*
-    allowedBranches:
-      - main
-    include:
-      - tools/**
-    exclude:
-      - "**/*.tmp"
     syncInterval: 120
   oci:
     enabled: true
@@ -80,8 +61,6 @@ sources:
     tag: "1.0.0"
     username: ci
     password: ci-password
-    include:
-      - tools/**
 
 hotReload:
   enabled: true

--- a/charts/fastmcp-server/ci/oci-source-values.yaml
+++ b/charts/fastmcp-server/ci/oci-source-values.yaml
@@ -3,11 +3,6 @@ sources:
     enabled: true
     registry: ghcr.io/example/mcp-bundle
     tag: "1.0.0"
-    include:
-      - tools/**
-      - knowledge/**
-    exclude:
-      - "**/*.tmp"
   inline:
     knowledge:
       overview.md: |

--- a/charts/fastmcp-server/docs/authentication.md
+++ b/charts/fastmcp-server/docs/authentication.md
@@ -7,9 +7,6 @@ FastMCP Server separates client authentication from source credentials and tool 
 ```yaml
 auth:
   type: bearer
-  scopes:
-    - mcp:read
-    - mcp:admin
   bearer:
     existingSecret: fastmcp-auth
     existingSecretKey: token
@@ -45,8 +42,6 @@ auth:
   providers:
     - bearer
     - jwt
-  scopes:
-    - mcp:read
 ```
 
 ## Reload Admin Token

--- a/charts/fastmcp-server/docs/operations.md
+++ b/charts/fastmcp-server/docs/operations.md
@@ -8,7 +8,6 @@ The chart exposes the server runtime controls directly under `server`.
 server:
   environment: production
   logFormat: json
-  strictLoading: true
   maskErrorDetails: true
   onDuplicateTools: warn
 ```
@@ -37,13 +36,9 @@ visibility:
 server:
   maxSourceFileSizeBytes: 1048576
   maxKnowledgeBytes: 10485760
-
-sandboxing:
-  maxMemoryMb: 256
-  maxOutputSizeKb: 1024
 ```
 
-Memory enforcement is best-effort and depends on the Linux runtime. Output truncation is enforced by the FastMCP server.
+Source and knowledge limits are enforced by the FastMCP server before content is loaded.
 
 ## Validation Commands
 

--- a/charts/fastmcp-server/docs/sources.md
+++ b/charts/fastmcp-server/docs/sources.md
@@ -32,10 +32,6 @@ sources:
     bucket: mcp-assets
     prefix: production
     existingSecret: fastmcp-s3
-    include:
-      - tools/**
-    exclude:
-      - "**/*.tmp"
     syncInterval: 60
 ```
 
@@ -49,11 +45,6 @@ sources:
     branch: main
     path: mcp
     existingSecret: fastmcp-git
-    allowedRepositories:
-      - https://github.com/example/*
-    allowedBranches:
-      - main
-      - release/*
 ```
 
 ## OCI
@@ -65,16 +56,6 @@ sources:
     registry: oci://registry.example.com/mcp-content
     tag: "1.0.0"
     existingSecret: fastmcp-oci
-```
-
-## Safety Filters
-
-Use `sources.blockedFileAllowlist` only for intentional exceptions to the server source-file safety filter.
-
-```yaml
-sources:
-  blockedFileAllowlist:
-    - knowledge/private-config.example
 ```
 
 <!-- @AI-METADATA

--- a/charts/fastmcp-server/examples/jwt-values.yaml
+++ b/charts/fastmcp-server/examples/jwt-values.yaml
@@ -8,8 +8,6 @@ server:
 
 auth:
   type: jwt
-  requiredScopes:
-    - mcp:read
   jwt:
     issuer: https://auth.example.com
     audience: fastmcp-server

--- a/charts/fastmcp-server/examples/multi-auth-values.yaml
+++ b/charts/fastmcp-server/examples/multi-auth-values.yaml
@@ -11,11 +11,6 @@ auth:
   providers:
     - bearer
     - jwt
-  scopes:
-    - mcp:read
-    - mcp:admin
-  requiredScopes:
-    - mcp:read
   bearer:
     existingSecret: fastmcp-auth
     existingSecretKey: token

--- a/charts/fastmcp-server/examples/production-s3-values.yaml
+++ b/charts/fastmcp-server/examples/production-s3-values.yaml
@@ -4,15 +4,11 @@
 server:
   environment: production
   logFormat: json
-  strictLoading: true
   maskErrorDetails: true
   onDuplicateTools: warn
 
 auth:
   type: bearer
-  scopes:
-    - mcp:read
-    - mcp:admin
   bearer:
     existingSecret: fastmcp-auth
     existingSecretKey: token
@@ -24,13 +20,6 @@ sources:
     region: us-east-1
     prefix: production
     existingSecret: fastmcp-s3
-    include:
-      - tools/**
-      - resources/**
-      - prompts/**
-      - knowledge/**
-    exclude:
-      - "**/*.tmp"
     syncInterval: 60
 
 metrics:

--- a/charts/fastmcp-server/examples/production/values.yaml
+++ b/charts/fastmcp-server/examples/production/values.yaml
@@ -5,7 +5,6 @@ server:
   environment: production
   logLevel: WARNING
   logFormat: json
-  strictLoading: true
   maskErrorDetails: true
 
 metrics:
@@ -23,14 +22,6 @@ sources:
     bucket: mcp-production-tools
     region: us-east-1
     existingSecret: mcp-s3-credentials
-    include:
-      - tools/**
-      - resources/**
-      - prompts/**
-      - knowledge/**
-    exclude:
-      - "**/*.tmp"
-      - "**/private/**"
     syncInterval: 300
   inline:
     knowledge:

--- a/charts/fastmcp-server/templates/NOTES.txt
+++ b/charts/fastmcp-server/templates/NOTES.txt
@@ -15,7 +15,6 @@ Runtime:
   Gateway:     {{ .Values.gateway.enabled }}
   Visibility:  {{ .Values.visibility.mode }}
   Log format:  {{ .Values.server.logFormat }}
-  Strict load: {{ .Values.server.strictLoading }}
 
 Access:
   Port-forward the service:

--- a/charts/fastmcp-server/templates/deployment.yaml
+++ b/charts/fastmcp-server/templates/deployment.yaml
@@ -57,10 +57,6 @@ spec:
               value: {{ .Values.server.workspace | quote }}
             - name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
               value: {{ .Values.server.maxSourceFileSizeBytes | int64 | quote }}
-            {{- if .Values.sources.blockedFileAllowlist }}
-            - name: SOURCE_BLOCKED_FILE_ALLOWLIST
-              value: {{ join "," .Values.sources.blockedFileAllowlist | quote }}
-            {{- end }}
             {{- if .Values.sources.inline.dir }}
             - name: SOURCE_INLINE_DIR
               value: {{ .Values.sources.inline.dir | quote }}
@@ -79,14 +75,6 @@ spec:
             {{- with .Values.sources.s3.prefix }}
             - name: SOURCE_S3_PREFIX
               value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.sources.s3.include }}
-            - name: SOURCE_S3_INCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.s3.exclude }}
-            - name: SOURCE_S3_EXCLUDE
-              value: {{ join "," . | quote }}
             {{- end }}
             - name: SOURCE_S3_ACCESS_KEY
               valueFrom:
@@ -112,22 +100,6 @@ spec:
             {{- end }}
             - name: SOURCE_GIT_USERNAME
               value: {{ .Values.sources.git.username | quote }}
-            {{- with .Values.sources.git.allowedRepositories }}
-            - name: SOURCE_GIT_ALLOWED_REPOSITORIES
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.git.allowedBranches }}
-            - name: SOURCE_GIT_ALLOWED_BRANCHES
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.git.include }}
-            - name: SOURCE_GIT_INCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.git.exclude }}
-            - name: SOURCE_GIT_EXCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
             {{- if or .Values.sources.git.token .Values.sources.git.existingSecret }}
             - name: SOURCE_GIT_TOKEN
               valueFrom:
@@ -144,14 +116,6 @@ spec:
             {{- with .Values.sources.oci.tag }}
             - name: SOURCE_OCI_TAG
               value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.sources.oci.include }}
-            - name: SOURCE_OCI_INCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.oci.exclude }}
-            - name: SOURCE_OCI_EXCLUDE
-              value: {{ join "," . | quote }}
             {{- end }}
             {{- if or .Values.sources.oci.username .Values.sources.oci.password .Values.sources.oci.existingSecret }}
             - name: SOURCE_OCI_USERNAME
@@ -227,10 +191,6 @@ spec:
             - name: LOG_FORMAT
               value: {{ .Values.server.logFormat | quote }}
             {{- end }}
-            {{- if not (has "MCP_STRICT_LOADING" $extraEnvNames) }}
-            - name: MCP_STRICT_LOADING
-              value: {{ .Values.server.strictLoading | quote }}
-            {{- end }}
             {{- if ne (toString .Values.server.maskErrorDetails) "" }}
             - name: MCP_MASK_ERROR_DETAILS
               value: {{ .Values.server.maskErrorDetails | quote }}
@@ -247,23 +207,11 @@ spec:
               value: {{ .Values.server.maxKnowledgeBytes | int64 | quote }}
             - name: MCP_ALLOWED_KNOWLEDGE_EXTENSIONS
               value: {{ join "," .Values.server.allowedKnowledgeExtensions | quote }}
-            {{- if .Values.sources.blockedFileAllowlist }}
-            - name: SOURCE_BLOCKED_FILE_ALLOWLIST
-              value: {{ join "," .Values.sources.blockedFileAllowlist | quote }}
-            {{- end }}
             - name: MCP_REQUIRE_HUMAN_APPROVAL_FOR_DESTRUCTIVE
               value: {{ .Values.auth.requireHumanApprovalForDestructive | quote }}
             {{- if .Values.auth.allowNoAuth }}
             - name: MCP_ALLOW_NO_AUTH
               value: "true"
-            {{- end }}
-            {{- with .Values.auth.scopes }}
-            - name: MCP_AUTH_SCOPES
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.auth.requiredScopes }}
-            - name: MCP_AUTH_REQUIRED_SCOPES
-              value: {{ join "," . | quote }}
             {{- end }}
             {{- if .Values.auth.clientId }}
             - name: MCP_AUTH_CLIENT_ID
@@ -367,14 +315,6 @@ spec:
             - name: SOURCE_S3_PREFIX
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.sources.s3.include }}
-            - name: SOURCE_S3_INCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.s3.exclude }}
-            - name: SOURCE_S3_EXCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
             {{- if .Values.sources.s3.syncInterval }}
             - name: SOURCE_S3_SYNC_INTERVAL
               value: {{ .Values.sources.s3.syncInterval | int64 | quote }}
@@ -403,22 +343,6 @@ spec:
             {{- end }}
             - name: SOURCE_GIT_USERNAME
               value: {{ .Values.sources.git.username | quote }}
-            {{- with .Values.sources.git.allowedRepositories }}
-            - name: SOURCE_GIT_ALLOWED_REPOSITORIES
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.git.allowedBranches }}
-            - name: SOURCE_GIT_ALLOWED_BRANCHES
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.git.include }}
-            - name: SOURCE_GIT_INCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.git.exclude }}
-            - name: SOURCE_GIT_EXCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
             {{- if .Values.sources.git.syncInterval }}
             - name: SOURCE_GIT_SYNC_INTERVAL
               value: {{ .Values.sources.git.syncInterval | int64 | quote }}
@@ -439,14 +363,6 @@ spec:
             {{- with .Values.sources.oci.tag }}
             - name: SOURCE_OCI_TAG
               value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.sources.oci.include }}
-            - name: SOURCE_OCI_INCLUDE
-              value: {{ join "," . | quote }}
-            {{- end }}
-            {{- with .Values.sources.oci.exclude }}
-            - name: SOURCE_OCI_EXCLUDE
-              value: {{ join "," . | quote }}
             {{- end }}
             {{- if or .Values.sources.oci.username .Values.sources.oci.password .Values.sources.oci.existingSecret }}
             - name: SOURCE_OCI_USERNAME
@@ -476,14 +392,6 @@ spec:
             {{- if .Values.caching.maxSize }}
             - name: MCP_CACHE_MAX_SIZE
               value: {{ .Values.caching.maxSize | quote }}
-            {{- end }}
-            {{- if .Values.sandboxing.maxMemoryMb }}
-            - name: MCP_MAX_MEMORY_MB
-              value: {{ .Values.sandboxing.maxMemoryMb | quote }}
-            {{- end }}
-            {{- if .Values.sandboxing.maxOutputSizeKb }}
-            - name: MCP_MAX_OUTPUT_SIZE_KB
-              value: {{ .Values.sandboxing.maxOutputSizeKb | quote }}
             {{- end }}
             {{- if .Values.extraPipPackages }}
             - name: EXTRA_PIP_PACKAGES

--- a/charts/fastmcp-server/tests/deployment_test.yaml
+++ b/charts/fastmcp-server/tests/deployment_test.yaml
@@ -103,9 +103,6 @@ tests:
         allowedKnowledgeExtensions:
           - .md
           - .json
-      sources:
-        blockedFileAllowlist:
-          - knowledge/private-config.example
       auth:
         allowNoAuth: true
     asserts:
@@ -159,11 +156,6 @@ tests:
           content:
             name: MCP_ALLOWED_KNOWLEDGE_EXTENSIONS
             value: ".md,.json"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SOURCE_BLOCKED_FILE_ALLOWLIST
-            value: "knowledge/private-config.example"
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -296,16 +288,11 @@ tests:
             value: "admin-user"
         template: templates/deployment.yaml
 
-  - it: should set multi auth, scopes, and JWT env vars
+  - it: should set multi auth and JWT env vars
     set:
       auth:
         type: multi
         allowNoAuth: true
-        scopes:
-          - mcp:read
-          - mcp:admin
-        requiredScopes:
-          - mcp:read
         clientId: ci-client
         providers:
           - bearer
@@ -331,16 +318,6 @@ tests:
           content:
             name: MCP_AUTH_PROVIDERS
             value: "bearer,jwt"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_AUTH_SCOPES
-            value: "mcp:read,mcp:admin"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_AUTH_REQUIRED_SCOPES
-            value: "mcp:read"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -378,10 +355,6 @@ tests:
           endpoint: "https://minio.local"
           bucket: tools
           region: us-east-1
-          include:
-            - tools/**
-          exclude:
-            - "**/*.tmp"
           syncInterval: 60
           accessKey: admin
           secretKey: secret
@@ -404,12 +377,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SOURCE_S3_INCLUDE
-            value: "tools/**"
-        template: templates/deployment.yaml
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: SOURCE_S3_SYNC_INTERVAL
             value: "60"
         template: templates/deployment.yaml
@@ -422,14 +389,6 @@ tests:
           repository: "https://github.com/example/tools.git"
           branch: main
           username: git-user
-          allowedRepositories:
-            - https://github.com/example/*
-          allowedBranches:
-            - main
-          include:
-            - tools/**
-          exclude:
-            - "**/*.tmp"
           syncInterval: 120
           token: example-git-token
     templates:
@@ -457,12 +416,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SOURCE_GIT_ALLOWED_REPOSITORIES
-            value: "https://github.com/example/*"
-        template: templates/deployment.yaml
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: SOURCE_GIT_SYNC_INTERVAL
             value: "120"
         template: templates/deployment.yaml
@@ -476,10 +429,6 @@ tests:
           tag: "1.0.0"
           username: user
           password: pass
-          include:
-            - tools/**
-          exclude:
-            - "**/*.tmp"
     templates:
       - templates/deployment.yaml
       - templates/secret.yaml
@@ -716,44 +665,6 @@ tests:
             name: LOG_FORMAT
             value: "json"
 
-  - it: should set strict loading env to false by default
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_STRICT_LOADING
-            value: "false"
-
-  - it: should set strict loading env when enabled
-    set:
-      server:
-        strictLoading: true
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_STRICT_LOADING
-            value: "true"
-
-  - it: should allow extraEnv to override strict loading env without duplicate default
-    set:
-      server:
-        strictLoading: false
-      extraEnv:
-        - name: MCP_STRICT_LOADING
-          value: "true"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_STRICT_LOADING
-            value: "true"
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_STRICT_LOADING
-            value: "false"
-
   - it: should not have init container by default
     asserts:
       - isNull:
@@ -773,16 +684,13 @@ tests:
           path: spec.template.spec.initContainers[0].command
           value: ["python", "/app/sync_only.py"]
 
-  - it: should pass runtime source safety env to init container
+  - it: should pass runtime source env to init container
     set:
       initSync:
         enabled: true
       server:
         workspace: /custom/workspace
         maxSourceFileSizeBytes: 2097152
-      sources:
-        blockedFileAllowlist:
-          - knowledge/private-config.example
     asserts:
       - contains:
           path: spec.template.spec.initContainers[0].env
@@ -794,11 +702,6 @@ tests:
           content:
             name: MCP_MAX_SOURCE_FILE_SIZE_BYTES
             value: "2097152"
-      - contains:
-          path: spec.template.spec.initContainers[0].env
-          content:
-            name: SOURCE_BLOCKED_FILE_ALLOWLIST
-            value: "knowledge/private-config.example"
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
@@ -851,28 +754,6 @@ tests:
           content:
             name: MCP_CACHE_MAX_SIZE
             value: "500"
-
-  - it: should set sandboxing memory limit env
-    set:
-      sandboxing:
-        maxMemoryMb: 256
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_MAX_MEMORY_MB
-            value: "256"
-
-  - it: should set sandboxing output limit env
-    set:
-      sandboxing:
-        maxOutputSizeKb: 100
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: MCP_MAX_OUTPUT_SIZE_KB
-            value: "100"
 
   - it: should use replicaCount when autoscaling disabled
     set:

--- a/charts/fastmcp-server/values.schema.json
+++ b/charts/fastmcp-server/values.schema.json
@@ -47,7 +47,6 @@
         "workspace": { "type": "string", "pattern": "^/", "description": "Workspace directory used to stage synced MCP components" },
         "logLevel": { "type": "string", "enum": ["DEBUG", "INFO", "WARNING", "ERROR"], "description": "Log level" },
         "logFormat": { "type": "string", "enum": ["text", "json"], "description": "Log output format" },
-        "strictLoading": { "type": "boolean", "description": "Fail on boot if any tool/resource has errors" },
         "maskErrorDetails": {
           "type": ["boolean", "string"],
           "description": "Hide internal error details from MCP clients; empty uses the runtime default"
@@ -127,14 +126,6 @@
         "maxSize": { "type": "integer", "minimum": 1, "description": "Max cache entries per tool" }
       }
     },
-    "sandboxing": {
-      "type": "object",
-      "description": "Tool execution resource limits",
-      "properties": {
-        "maxMemoryMb": { "type": "integer", "minimum": 0, "description": "Default max memory per tool call (MB)" },
-        "maxOutputSizeKb": { "type": "integer", "minimum": 0, "description": "Default max output size per tool call (KB)" }
-      }
-    },
     "auth": {
       "type": "object",
       "description": "Authentication configuration",
@@ -145,15 +136,8 @@
           "description": "Authentication type"
         },
         "allowNoAuth": { "type": "boolean" },
-        "scopes": { "type": "array", "items": { "type": "string" } },
-        "requiredScopes": { "type": "array", "items": { "type": "string" } },
         "clientId": { "type": "string" },
         "providers": { "type": "array", "items": { "type": "string", "enum": ["bearer", "jwt"] } },
-        "reloadRequiredScopes": {
-          "type": "array",
-          "description": "Deprecated: ignored by the simplified runtime. Use auth.adminToken or auth.adminExistingSecret for /reload.",
-          "items": { "type": "string" }
-        },
         "adminToken": { "type": "string" },
         "adminExistingSecret": { "type": "string" },
         "adminExistingSecretKey": { "type": "string" },
@@ -186,11 +170,6 @@
       "type": "object",
       "description": "Content sources (merge precedence: inline > S3 > Git)",
       "properties": {
-        "blockedFileAllowlist": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Explicit allowlist for source files normally blocked by the server safety filter"
-        },
         "inline": {
           "type": "object",
           "properties": {
@@ -214,8 +193,6 @@
             "existingSecret": { "type": "string" },
             "existingSecretAccessKeyKey": { "type": "string" },
             "existingSecretSecretKeyKey": { "type": "string" },
-            "include": { "type": "array", "items": { "type": "string" } },
-            "exclude": { "type": "array", "items": { "type": "string" } },
             "syncInterval": { "type": "integer", "minimum": 0 }
           }
         },
@@ -230,10 +207,6 @@
             "existingSecret": { "type": "string" },
             "existingSecretTokenKey": { "type": "string" },
             "username": { "type": "string" },
-            "allowedRepositories": { "type": "array", "items": { "type": "string" } },
-            "allowedBranches": { "type": "array", "items": { "type": "string" } },
-            "include": { "type": "array", "items": { "type": "string" } },
-            "exclude": { "type": "array", "items": { "type": "string" } },
             "syncInterval": { "type": "integer", "minimum": 0 }
           }
         },
@@ -247,9 +220,7 @@
             "password": { "type": "string" },
             "existingSecret": { "type": "string" },
             "existingSecretUsernameKey": { "type": "string" },
-            "existingSecretPasswordKey": { "type": "string" },
-            "include": { "type": "array", "items": { "type": "string" } },
-            "exclude": { "type": "array", "items": { "type": "string" } }
+            "existingSecretPasswordKey": { "type": "string" }
           }
         }
       }

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -43,8 +43,6 @@ server:
   logLevel: INFO
   # -- Log format: text or json (structured logging)
   logFormat: text
-  # -- Strict loading: fail on boot if any tool/resource has errors
-  strictLoading: false
   # -- Hide internal error details from MCP clients. Empty uses the server runtime default.
   maskErrorDetails: ""
   # -- Duplicate tool handling mode: warn, error, replace, or ignore
@@ -116,16 +114,6 @@ caching:
   maxSize: 1000
 
 # =============================================================================
-# Sandboxing
-# =============================================================================
-
-sandboxing:
-  # -- Default max memory per tool call (MB, 0 = unlimited)
-  maxMemoryMb: 0
-  # -- Default max output size per tool call (KB, 0 = unlimited)
-  maxOutputSizeKb: 0
-
-# =============================================================================
 # Authentication
 # =============================================================================
 
@@ -134,16 +122,10 @@ auth:
   type: none
   # -- Explicitly allow no-auth in production-like environments
   allowNoAuth: false
-  # -- Scopes granted to the static bearer token
-  scopes: []
-  # -- Scopes required on every authenticated request
-  requiredScopes: []
   # -- Client ID used for bearer-token audit logs
   clientId: bearer-user
   # -- Providers enabled when auth.type is multi
   providers: []
-  # -- Deprecated: scopes are ignored by the simplified runtime. Use auth.adminToken for /reload.
-  reloadRequiredScopes: []
   # -- Dedicated admin token for privileged HTTP endpoints such as /reload
   adminToken: ""
   # -- Use an existing secret for auth.adminToken
@@ -183,9 +165,6 @@ auth:
 # Merge precedence: Inline (highest) > S3 > Git (lowest)
 
 sources:
-  # -- Explicit allowlist for source files normally blocked by the server safety filter
-  blockedFileAllowlist: []
-
   # -- Inline tools, resources, prompts, and knowledge mounted via ConfigMaps
   inline:
     # -- Inline source directory inside the container
@@ -248,10 +227,6 @@ sources:
     existingSecretAccessKeyKey: access-key
     # -- Key in existing secret for secret key
     existingSecretSecretKeyKey: secret-key
-    # -- Include glob patterns within each asset directory
-    include: []
-    # -- Exclude glob patterns within each asset directory
-    exclude: []
     # -- Background sync interval in seconds; 0 disables periodic sync
     syncInterval: 0
 
@@ -273,14 +248,6 @@ sources:
     existingSecretTokenKey: token
     # -- Username used by the temporary Git askpass helper
     username: x-access-token
-    # -- Allowed repository URL patterns
-    allowedRepositories: []
-    # -- Allowed branch name patterns
-    allowedBranches: []
-    # -- Include glob patterns within each asset directory
-    include: []
-    # -- Exclude glob patterns within each asset directory
-    exclude: []
     # -- Background sync interval in seconds; 0 disables periodic sync
     syncInterval: 0
 
@@ -302,11 +269,6 @@ sources:
     existingSecretUsernameKey: username
     # -- Key in existing secret for OCI password
     existingSecretPasswordKey: password
-    # -- Include glob patterns within each asset directory
-    include: []
-    # -- Exclude glob patterns within each asset directory
-    exclude: []
-
 # =============================================================================
 # Hot Reload
 # =============================================================================


### PR DESCRIPTION
## Summary
- removes legacy strictLoading, scopes, source include/exclude allowlists, and sandboxing values from the fastmcp-server chart
- stops rendering the old MCP/source env vars now that fastmcp-server 0.11.1 uses the simplified model
- updates schema, docs, examples, CI values, and unit tests to match the new contract

## Validation
- helm lint charts/fastmcp-server --strict
- helm unittest charts/fastmcp-server
- rendered all charts/fastmcp-server/ci values
- rendered oke-prod fastmcp-server values with chart and confirmed old env vars are absent