### PR TITLE
feat(generic)!: expand generic chart platform capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## generic - breaking feature release
+
+### Added
+
+- Added optional Security, RBAC, NetworkPolicy, Secret, ExternalSecret, and SealedSecret resources.
+- Added additional Services, headless Service mode, richer Service fields, Ingress custom backends, and Gateway API HTTPRoutes.
+- Added declarative PVC/PV storage contracts, PodMonitor, PrometheusRule, advanced HPA metrics, KEDA ScaledObject/ScaledJob, and advanced Job/CronJob controls.
+- Added deterministic rollout controls with `rollout.restartAt`, rollout pod annotations, and ConfigMap/Secret checksums.
+
+### Changed
+
+- Changed the default image to the pinned `docker.io/library/nginx:1.27.5` image with `IfNotPresent`.
+- Removed render-time timestamp annotations from workload pod templates.
+- Tightened validation for HPA, PDB, names, Ingress, ServiceMonitor, CronJobs, and storage capacity.
+
+### Migration
+
+- Set explicit image tags or digests for production workloads.
+- Use `rollout.restartAt` or checksum controls for intentional pod restarts.
+- Ensure optional CRD-backed features are enabled only after their CRDs exist in the target cluster.
+

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -8,12 +8,14 @@ maintainers:
 version: 1.9.6
 appVersion: "1.0.0"
 home: https://helmforge.dev
-icon: https://helmforge.dev/icons/charts/generic.png
+icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: fix database secret mismatch and runtime compatibility issues (#109)
+    - kind: added
+      description: expand generic chart with networking, security, storage, observability, batch, autoscaling, Gateway API, and rollout controls
+    - kind: changed
+      description: use pinned default image, deterministic pod templates, and stricter validation for a breaking generic chart contract
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -228,6 +228,40 @@ extraManifests:
       policyTypes: [Ingress, Egress]
 ```
 
+### Explicit rollouts
+
+The chart does not add time-based pod annotations during normal renders. To intentionally roll long-running workloads, set:
+
+```yaml
+rollout:
+  restartAt: "2026-04-27T00:00:00Z"
+  podAnnotations:
+    app.example.com/restarted-by: platform
+  checksum:
+    enabled: true
+    configMaps: true
+    secrets: true
+```
+
+### Platform integrations
+
+The chart now includes opt-in primitives for common platform needs:
+
+- `secrets[]`, `externalSecrets`, and `sealedSecrets` for secret integration. ExternalSecret, SealedSecret, ServiceMonitor, PodMonitor, PrometheusRule, KEDA, VPA, and Gateway API resources require their CRDs to exist before enabling them.
+- `rbac.create` and `networkPolicy.enabled` for least-privilege identity and traffic policy.
+- `securityPreset: baseline` or `restricted` for opt-in security contexts when explicit contexts are not set.
+- `services[]`, `service.headless`, `service.nameOverride`, per-port `appProtocol`, and custom Ingress backends for richer networking.
+- `podMonitor`, `prometheusRule`, advanced HPA metrics, and optional KEDA ScaledObject/ScaledJob support.
+- `persistence.persistentVolumeClaims[]` and explicit opt-in `persistence.persistentVolumes[]` for clearer storage ownership.
+
+### Breaking-change migration notes
+
+- The default image is now pinned to `docker.io/library/nginx:1.27.5` with `IfNotPresent` instead of relying on `latest`.
+- Pod templates are deterministic; use `rollout.restartAt` or checksum-enabled ConfigMaps/Secrets for intentional rollouts.
+- HPA now fails validation when used with `DaemonSet` or when `hpa.maxReplicas` is missing.
+- `pdb.enabled` requires exactly one of `pdb.minAvailable` or `pdb.maxUnavailable`.
+- Optional CRD-backed resources are disabled by default and must only be enabled in clusters where the corresponding operator/API is installed.
+
 ## Operational guidance
 
 ### When this chart fits well
@@ -267,6 +301,10 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 - [`docs/statefulset.md`](docs/statefulset.md) — stable identity, persistent storage, and rollout expectations
 - [`docs/daemonset.md`](docs/daemonset.md) — node-level agents and one-pod-per-node behavior
 - [`docs/batch.md`](docs/batch.md) — one-off jobs and scheduled workloads
+- [`docs/security.md`](docs/security.md) — ServiceAccount, Secrets, RBAC, and NetworkPolicy
+- [`docs/observability.md`](docs/observability.md) — ServiceMonitor, PodMonitor, PrometheusRule, VPA, HPA, and KEDA
+- [`docs/gateway.md`](docs/gateway.md) — Gateway API HTTPRoute patterns
+- [`docs/storage.md`](docs/storage.md) — PVC/PV ownership and StatefulSet storage patterns
 
 ## Values Reference
 
@@ -283,9 +321,11 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `workload.volumeClaimTemplates` | StatefulSet PVC templates | `[]` |
 | `workload.updateStrategy` | StatefulSet/DaemonSet update strategy | — |
 | **Image** | | |
-| `image.repository` | Container image repository | `container.registry.io/project/image` |
-| `image.tag` | Image tag | `latest` |
-| `image.pullPolicy` | Pull policy | `Always` |
+| `global.imageRegistry` | Optional registry prefix for unqualified repositories | `""` |
+| `image.repository` | Container image repository | `docker.io/library/nginx` |
+| `image.tag` | Image tag | `1.27.5` |
+| `image.digest` | Image digest, takes precedence over tag | `""` |
+| `image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Registry pull secrets | `[]` |
 | **Containers** | | |
 | `containers` | List of container specs | 1 container on port 8080 |
@@ -297,6 +337,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `serviceAccount.create` | Create a ServiceAccount | `false` |
 | `serviceAccount.name` | ServiceAccount name | `""` |
 | `serviceAccount.annotations` | ServiceAccount annotations | `{}` |
+| `serviceAccount.automountServiceAccountToken` | Mount API token into pods | `false` |
 | **Resources & Probes** | | |
 | `resources` | Default resource limits/requests | `{}` |
 | `livenessProbe` | Global liveness probe (first container) | `{}` |
@@ -305,15 +346,23 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Security** | | |
 | `podSecurityContext` | Pod-level security context | `{}` |
 | `securityContext` | Container-level security context | `{}` |
+| `securityPreset` | Optional `baseline` or `restricted` preset when explicit contexts are absent | `""` |
 | **Networking** | | |
+| `service.enabled` | Create the default Service for long-running workloads | `true` |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `8080` |
 | `service.targetPort` | Target port | `8080` |
+| `service.nameOverride` | Override primary Service name | `""` |
+| `service.headless.enabled` | Render primary Service as headless | `false` |
 | `service.extraPorts` | Additional service ports | `[]` |
+| `services` | Additional Service resources | `[]` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.ingressClassName` | Ingress class | `traefik` |
 | `ingress.hosts` | Ingress host rules | `[]` |
+| `ingress.defaultBackend` | Ingress default backend | `{}` |
 | `ingress.tls` | TLS configuration | `[]` |
+| `gatewayApi.enabled` | Enable Gateway API HTTPRoutes | `false` |
+| `gatewayApi.httpRoutes` | HTTPRoute definitions | `[]` |
 | **Scheduling** | | |
 | `updateStrategy` | Deployment rollout strategy | `RollingUpdate 25%/25%` |
 | `nodeSelector` | Node selector | `{}` |
@@ -322,11 +371,27 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `topologySpreadConstraints` | Topology spread | `[]` |
 | `priorityClassName` | Priority class | `""` |
 | `terminationGracePeriodSeconds` | Graceful shutdown timeout | `30` |
+| `runtimeClassName` | RuntimeClass name | `""` |
+| `schedulerName` | Custom scheduler | `""` |
+| `hostAliases` | Pod host aliases | `[]` |
+| `dnsPolicy` | Pod DNS policy | `""` |
+| `dnsConfig` | Pod DNS config | `{}` |
+| `hostNetwork` | Use node network namespace | `false` |
+| `hostPID` | Use node PID namespace | `false` |
+| `hostIPC` | Use node IPC namespace | `false` |
+| `shareProcessNamespace` | Share process namespace between containers | `false` |
+| `enableServiceLinks` | Inject Service env vars into pods | `true` |
+| `rollout.restartAt` | Explicit restart marker for pod template annotations | `""` |
+| `rollout.podAnnotations` | Rollout-specific pod annotations | `{}` |
+| `rollout.checksum` | ConfigMap/Secret checksum rollout controls | enabled |
 | **Autoscaling** | | |
 | `hpa.enabled` | Enable HPA (not for DaemonSet) | `false` |
 | `hpa.minReplicas` | Minimum replicas | `1` |
 | `hpa.maxReplicas` | Maximum replicas | — |
 | `hpa.metrics` | Scaling metrics | `[]` |
+| `keda.enabled` | Enable KEDA custom resources | `false` |
+| `keda.scaledObject` | KEDA ScaledObject configuration | disabled |
+| `keda.scaledJobs` | KEDA ScaledJob definitions | `[]` |
 | `vpa.enabled` | Enable VPA | `false` |
 | `vpa.updateMode` | VPA update mode | `Off` |
 | `pdb.enabled` | Enable PodDisruptionBudget | `false` |
@@ -335,12 +400,26 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Storage** | | |
 | `persistence.volumes` | Extra volumes | `[]` |
 | `persistence.mounts` | Volume mounts for all containers | `[]` |
-| `persistence.storage` | PV/PVC definitions | `[]` |
+| `persistence.storage` | Legacy PV/PVC definitions | `[]` |
+| `persistence.persistentVolumeClaims` | Declarative PVCs | `[]` |
+| `persistence.persistentVolumes` | Explicit opt-in PVs | `[]` |
 | **Observability** | | |
 | `serviceMonitor.enabled` | Enable Prometheus ServiceMonitor | `false` |
 | `serviceMonitor.endpoints` | Scrape endpoints | `[]` |
+| `podMonitor.enabled` | Enable Prometheus PodMonitor | `false` |
+| `podMonitor.podMetricsEndpoints` | Pod scrape endpoints | `[]` |
+| `prometheusRule.enabled` | Enable PrometheusRule | `false` |
+| `prometheusRule.groups` | Prometheus alert/recording rule groups | `[]` |
 | **ConfigMaps** | | |
 | `configMaps` | Declarative ConfigMap resources | `[]` |
+| **Security** | | |
+| `secrets` | Declarative Secret resources | `[]` |
+| `externalSecrets.enabled` | Enable ExternalSecret resources | `false` |
+| `sealedSecrets.enabled` | Enable SealedSecret resources | `false` |
+| `rbac.create` | Create Role and RoleBinding | `false` |
+| `rbac.clusterRole.create` | Create ClusterRole and ClusterRoleBinding | `false` |
+| `networkPolicy.enabled` | Create NetworkPolicy | `false` |
+| `networkPolicy.defaultDeny` | Render default-deny policy shape | `false` |
 | **Batch** | | |
 | `jobs` | One-time Job definitions | `[]` |
 | `cronjobs` | CronJob definitions | `[]` |

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -328,7 +328,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Registry pull secrets | `[]` |
 | **Containers** | | |
-| `containers` | List of container specs | 1 container on port 8080 |
+| `containers` | List of container specs | 1 container on port 80 |
 | `initContainers` | Init container specs | `[]` |
 | **Environment** | | |
 | `env` | Global env vars for all containers | `[]` |
@@ -350,8 +350,8 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Networking** | | |
 | `service.enabled` | Create the default Service for long-running workloads | `true` |
 | `service.type` | Service type | `ClusterIP` |
-| `service.port` | Service port | `8080` |
-| `service.targetPort` | Target port | `8080` |
+| `service.port` | Service port | `80` |
+| `service.targetPort` | Target port | `80` |
 | `service.nameOverride` | Override primary Service name | `""` |
 | `service.headless.enabled` | Render primary Service as headless | `false` |
 | `service.extraPorts` | Additional service ports | `[]` |

--- a/charts/generic/ci/platform-values.yaml
+++ b/charts/generic/ci/platform-values.yaml
@@ -1,0 +1,130 @@
+workload:
+  enabled: true
+  type: Deployment
+
+image:
+  repository: docker.io/library/nginx
+  tag: "1.27.5"
+  pullPolicy: IfNotPresent
+
+containers:
+  - name: app
+    ports:
+      - name: http
+        containerPort: 8080
+    terminationMessagePolicy: FallbackToLogsOnError
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+
+service:
+  enabled: true
+  port: 8080
+  targetPort: 8080
+  labels:
+    app.example.com/tier: web
+  extraPorts:
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+      appProtocol: http
+
+services:
+  - name: admin
+    ports:
+      - name: admin
+        port: 9091
+        targetPort: 9091
+
+ingress:
+  enabled: true
+  hosts:
+    - host: generic.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+configMaps:
+  - name: app
+    data:
+      app.yaml: |
+        feature: enabled
+
+secrets:
+  - name: app
+    stringData:
+      token: change-me
+
+rbac:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["configmaps"]
+      verbs: ["get", "list"]
+
+networkPolicy:
+  enabled: true
+  defaultDeny: true
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+
+persistence:
+  persistentVolumeClaims:
+    - name: data
+      storage: 1Gi
+      accessModes: ["ReadWriteOnce"]
+
+podMonitor:
+  enabled: true
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+
+prometheusRule:
+  enabled: true
+  groups:
+    - name: generic.rules
+      rules:
+        - alert: GenericDown
+          expr: up == 0
+          for: 5m
+          labels:
+            severity: warning
+
+gatewayApi:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: gateway
+      hostnames:
+        - generic.example.com
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+
+keda:
+  enabled: true
+  scaledObject:
+    enabled: true
+    triggers:
+      - type: cpu
+        metricType: Utilization
+        metadata:
+          value: "70"
+
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "chart.fullname" . }}-extra'
+    data:
+      rendered: "true"
+

--- a/charts/generic/docs/batch.md
+++ b/charts/generic/docs/batch.md
@@ -17,6 +17,8 @@ Common cases:
 - `cronjobs` for scheduled execution
 - shared container conventions for image, env, mounts, and resources
 - the ability to ship a batch-only release with `workload.enabled: false`
+- parallelism, completions, completion mode, pod failure policy, success policy, and suspend controls
+- optional Helm hook annotations for migration-style Jobs
 
 ## What it does not deliver
 
@@ -29,7 +31,9 @@ Common cases:
 - set `workload.enabled: false` when the release exists only for jobs or cronjobs
 - keep job commands explicit and deterministic
 - set timeouts and retry behavior intentionally
+- use Helm hooks only for lifecycle-coupled migrations and keep their delete policy explicit
 - avoid bundling unrelated maintenance tasks into one release unless lifecycle is shared
+- set `podAnnotations` on individual jobs or cronjobs when batch pod metadata is needed
 
 ## Most relevant values
 
@@ -41,6 +45,9 @@ Common cases:
 | `env` | Shared environment variables |
 | `persistence.*` | Shared volumes and mounts when needed |
 | `serviceAccount.*` | Batch identity and permissions |
+| `parallelism` / `completions` | Job execution shape |
+| `hooks.*` | Optional Helm hook behavior for Jobs |
+| `podAnnotations` | Optional pod template annotations per job or cronjob |
 
 ## Example
 

--- a/charts/generic/docs/daemonset.md
+++ b/charts/generic/docs/daemonset.md
@@ -17,6 +17,7 @@ Common cases:
 - update strategy for rolling replacement
 - tolerations and node selection for infrastructure nodes
 - reuse of the same container, env, persistence, and observability patterns as other workloads
+- NetworkPolicy, RBAC, and ServiceMonitor/PodMonitor when node agents need platform integration
 
 ## What it does not deliver
 
@@ -30,6 +31,8 @@ Common cases:
 - set node selectors deliberately if the workload should run only on a subset of nodes
 - avoid ingress and external service exposure unless the daemon actually provides a node-facing API
 - keep resource requests realistic because a DaemonSet multiplies by node count
+- use `rollout.restartAt` only for deliberate daemon pod replacement
+- do not enable HPA for DaemonSets; the chart validates and blocks that invalid combination
 
 ## Most relevant values
 
@@ -41,6 +44,9 @@ Common cases:
 | `tolerations` | Node tolerance rules |
 | `nodeSelector` | Node filtering |
 | `serviceMonitor.*` | Observability hooks |
+| `podMonitor.*` | Pod-level Prometheus scraping |
+| `rbac.*` / `networkPolicy.*` | Agent permissions and traffic policy |
+| `rollout.restartAt` | Explicit restart marker for intentional pod rollouts |
 
 ## Example
 

--- a/charts/generic/docs/deployment.md
+++ b/charts/generic/docs/deployment.md
@@ -17,7 +17,9 @@ Common cases:
 - replica-based scaling
 - HPA and VPA compatibility
 - service and ingress integration
+- extra Services, headless Service mode, custom Ingress backends, and Gateway API HTTPRoutes
 - support for sidecars, init containers, probes, and ConfigMaps
+- optional Secrets, RBAC, NetworkPolicy, PodMonitor, PrometheusRule, and KEDA resources
 
 ## What it does not deliver
 
@@ -32,6 +34,7 @@ Common cases:
 - enable `hpa` only with meaningful metrics and sane requests
 - add `pdb.enabled=true` for production services with multiple replicas
 - use `topologySpreadConstraints` or anti-affinity for critical services
+- set `rollout.restartAt` only when you intentionally want to roll pods without another spec change
 
 ## Most relevant values
 
@@ -42,7 +45,14 @@ Common cases:
 | `containers` | Main and sidecar containers |
 | `service.*` | Service exposure |
 | `ingress.*` | HTTP ingress exposure |
+| `services[]` | Additional Service resources |
+| `gatewayApi.*` | Optional Gateway API HTTPRoutes |
+| `secrets[]` / `rbac.*` / `networkPolicy.*` | Opt-in security resources |
+| `podMonitor.*` / `prometheusRule.*` | Prometheus Operator resources |
+| `rollout.restartAt` | Explicit restart marker for intentional pod rollouts |
+| `rollout.checksum.*` | ConfigMap/Secret checksum-driven rollouts |
 | `hpa.*` | Horizontal autoscaling |
+| `keda.*` | Event-driven autoscaling with KEDA CRDs |
 | `pdb.*` | Disruption protection |
 | `updateStrategy.*` | Rolling update behavior |
 
@@ -79,6 +89,9 @@ hpa:
   enabled: true
   minReplicas: 3
   maxReplicas: 10
+
+rollout:
+  restartAt: ""
 ```
 
 <!-- @AI-METADATA

--- a/charts/generic/docs/gateway.md
+++ b/charts/generic/docs/gateway.md
@@ -1,0 +1,38 @@
+# Generic Chart Gateway API
+
+## HTTPRoute
+
+`gatewayApi.enabled` renders Gateway API `HTTPRoute` resources from `gatewayApi.httpRoutes[]`. The chart does not install Gateway API CRDs or a Gateway controller.
+
+```yaml
+gatewayApi:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+      hostnames:
+        - app.example.com
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+```
+
+If a route rule omits `backendRefs`, it points at the primary Service using `service.port`. Use custom `backendRefs` for multi-service routing.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Generic Chart - Gateway API
+description: HTTPRoute support for the generic chart
+keywords: generic, gateway-api, httproute
+purpose: Gateway API guide for the generic chart
+scope: Chart Architecture
+relations:
+  - charts/generic/README.md
+path: charts/generic/docs/gateway.md
+version: 1.0
+date: 2026-04-27
+-->
+

--- a/charts/generic/docs/observability.md
+++ b/charts/generic/docs/observability.md
@@ -1,0 +1,47 @@
+# Generic Chart Observability
+
+## Prometheus Operator resources
+
+`serviceMonitor.enabled`, `podMonitor.enabled`, and `prometheusRule.enabled` render Prometheus Operator custom resources. Enable them only in clusters where those CRDs already exist.
+
+```yaml
+podMonitor:
+  enabled: true
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+
+prometheusRule:
+  enabled: true
+  groups:
+    - name: generic.rules
+      rules:
+        - alert: GenericDown
+          expr: up == 0
+```
+
+## Autoscaling
+
+HPA supports Resource metrics plus native autoscaling/v2 metric shapes such as Pods, Object, External, and ContainerResource. HPA is blocked for DaemonSets and requires `hpa.maxReplicas`.
+
+VPA and KEDA are CRD-backed and disabled by default. Use VPA for recommendations or vertical resizing, and KEDA for event-driven ScaledObjects or ScaledJobs.
+
+## Autoscaling and HA safety
+
+Deployment and StatefulSet HPA resources are supported by the Kubernetes `autoscaling/v2` API. Validate StatefulSet scaling with the application owner before enabling it in production, because ordered identity, storage semantics, and application clustering behavior remain workload-specific.
+
+KEDA, VPA, PodMonitor, and PrometheusRule resources require their operators and CRDs to exist before enabling those features. The generic chart keeps them disabled by default and validates only their manifests unless the target cluster has the matching CRDs installed.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Generic Chart - Observability
+description: Monitoring and autoscaling integrations for the generic chart
+keywords: generic, servicemonitor, podmonitor, prometheusrule, hpa, vpa, keda
+purpose: Observability and autoscaling guide for the generic chart
+scope: Chart Architecture
+relations:
+  - charts/generic/README.md
+path: charts/generic/docs/observability.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/charts/generic/docs/security.md
+++ b/charts/generic/docs/security.md
@@ -1,0 +1,56 @@
+# Generic Chart Security
+
+## Scope
+
+The generic chart provides opt-in security primitives without assuming a cluster security stack.
+
+## Security presets
+
+`securityPreset` can be empty, `baseline`, or `restricted`. Presets only apply when explicit `podSecurityContext`,
+`securityContext`, or per-container `securityContext` values are not set.
+
+- `baseline` sets non-root pod defaults, RuntimeDefault seccomp, disables privilege escalation, and drops capabilities.
+- `restricted` also sets default UID/GID/fsGroup and `readOnlyRootFilesystem`.
+
+Ephemeral debug containers are intentionally not modeled as a values contract because Kubernetes manages them through
+the pod `ephemeralcontainers` subresource. Use `kubectl debug` or `extraManifests` for operator-specific debug flows.
+
+## ServiceAccount
+
+`serviceAccount.create` creates a dedicated ServiceAccount. `serviceAccount.automountServiceAccountToken` defaults to `false`, so pods do not mount Kubernetes API tokens unless explicitly requested.
+
+## Secrets
+
+Use `secrets[]` for chart-managed Kubernetes Secrets:
+
+```yaml
+secrets:
+  - name: app
+    type: Opaque
+    stringData:
+      password: change-me
+```
+
+Use `externalSecrets.enabled` or `sealedSecrets.enabled` only when the matching CRD is installed. These resources are disabled by default.
+
+## RBAC
+
+`rbac.create` creates a Role and RoleBinding for the release ServiceAccount. `rbac.clusterRole.create` is available for cluster-scoped permissions, but should be used only when a namespaced Role is insufficient.
+
+## NetworkPolicy
+
+`networkPolicy.enabled` creates a NetworkPolicy targeting the release pods. Use `networkPolicy.defaultDeny: true` to start from a deny posture and add explicit ingress/egress rules.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Generic Chart - Security
+description: ServiceAccount, Secrets, RBAC, and NetworkPolicy for the generic chart
+keywords: generic, security, rbac, secrets, networkpolicy
+purpose: Security configuration guide for the generic chart
+scope: Chart Architecture
+relations:
+  - charts/generic/README.md
+path: charts/generic/docs/security.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/charts/generic/docs/statefulset.md
+++ b/charts/generic/docs/statefulset.md
@@ -16,6 +16,7 @@ Common cases:
 - stable pod names
 - ordered or parallel pod management
 - `volumeClaimTemplates`
+- optional `persistentVolumeClaimRetentionPolicy`
 - service discovery via headless-style patterns when required by the workload
 
 ## What it does not deliver
@@ -28,8 +29,11 @@ Common cases:
 
 - use `StatefulSet` only when stable identity is genuinely required
 - define `workload.volumeClaimTemplates` for per-pod storage
+- use `workload.persistentVolumeClaimRetentionPolicy` intentionally because it affects data retention on scale down or delete
+- enable `service.headless.enabled` when stable per-pod DNS is required
 - choose `OrderedReady` or `Parallel` intentionally
 - test rolling upgrades with real persistence attached
+- use `rollout.restartAt` only for deliberate pod restarts
 - avoid using the generic chart for complex datastores that deserve product-specific topology handling
 
 ## Most relevant values
@@ -39,9 +43,12 @@ Common cases:
 | `workload.type` | Must be `StatefulSet` |
 | `workload.podManagementPolicy` | `OrderedReady` or `Parallel` |
 | `workload.volumeClaimTemplates` | PVC templates per replica |
+| `workload.persistentVolumeClaimRetentionPolicy` | PVC retention on deletion or scale-down |
 | `replicaCount` | Number of replicas |
 | `service.*` | Service behavior for the stateful workload |
+| `service.headless.enabled` | Headless Service mode |
 | `persistence.mounts` | Shared mounts across containers |
+| `rollout.restartAt` | Explicit restart marker for intentional pod rollouts |
 | `affinity` | Placement strategy |
 
 ## Example

--- a/charts/generic/docs/storage.md
+++ b/charts/generic/docs/storage.md
@@ -1,0 +1,42 @@
+# Generic Chart Storage
+
+## Storage contracts
+
+The chart separates pod mounts from resource ownership:
+
+- `persistence.volumes[]` adds volumes to the pod spec.
+- `persistence.mounts[]` mounts volumes into all containers.
+- `persistence.persistentVolumeClaims[]` creates namespaced PVCs owned by the release.
+- `persistence.persistentVolumes[]` creates cluster-scoped PVs only when each item sets `create: true`.
+- `persistence.storage[]` remains available as the legacy combined PV/PVC contract.
+
+For StatefulSets, prefer `workload.volumeClaimTemplates` when each replica needs its own claim.
+
+```yaml
+persistence:
+  persistentVolumeClaims:
+    - name: data
+      storage: 10Gi
+      accessModes: ["ReadWriteOnce"]
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: my-release-data
+  mounts:
+    - name: data
+      mountPath: /data
+```
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Generic Chart - Storage
+description: PVC, PV, mounts, and StatefulSet storage patterns for the generic chart
+keywords: generic, storage, pvc, pv, statefulset
+purpose: Storage guide for the generic chart
+scope: Chart Architecture
+relations:
+  - charts/generic/README.md
+path: charts/generic/docs/storage.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/charts/generic/examples/api-with-sidecar.yaml
+++ b/charts/generic/examples/api-with-sidecar.yaml
@@ -73,3 +73,14 @@ serviceMonitor:
     - port: admin
       path: /stats/prometheus
       interval: 30s
+
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "chart.fullname" . }}-envoy-bootstrap'
+      labels:
+        app.kubernetes.io/component: envoy
+    data:
+      envoy.yaml: |
+        static_resources: {}

--- a/charts/generic/templates/NOTES.txt
+++ b/charts/generic/templates/NOTES.txt
@@ -16,13 +16,27 @@ Namespace:  {{ .Release.Namespace }}
 {{- range $host := .Values.ingress.hosts }}
 URL:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
-{{- else if .Values.service.enabled }}
+{{- else if and (include "chart.hasWorkload" .) (ne .Values.service.enabled false) }}
 Port-forward to access the workload:
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ .Release.Name }} 8080:{{ .Values.service.port | default 80 }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "chart.fullname" . }} 8080:{{ .Values.service.port | default 80 }}
 
   URL:  http://localhost:8080/
+{{- else if or .Values.jobs .Values.cronjobs }}
+This release does not expose a long-running workload.
+
+Inspect batch resources with:
+
+  kubectl get jobs,cronjobs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 {{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Workload Enabled: {{ .Values.workload.enabled }}
+Workload Type:    {{ .Values.workload.type | default "Deployment" }}
+Service Enabled:  {{ ne .Values.service.enabled false }}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   GETTING STARTED

--- a/charts/generic/templates/NOTES.txt
+++ b/charts/generic/templates/NOTES.txt
@@ -19,7 +19,7 @@ URL:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- else if and (include "chart.hasWorkload" .) (ne .Values.service.enabled false) }}
 Port-forward to access the workload:
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "chart.fullname" . }} 8080:{{ .Values.service.port | default 80 }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "chart.serviceName" . }} 8080:{{ .Values.service.port | default 80 }}
 
   URL:  http://localhost:8080/
 {{- else if or .Values.jobs .Values.cronjobs }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -64,6 +64,34 @@ Service account name.
 {{- end -}}
 
 {{/*
+Primary Service name.
+*/}}
+{{- define "chart.serviceName" -}}
+{{- default (include "chart.fullname" .) .Values.service.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Named child resource.
+*/}}
+{{- define "chart.namedResource" -}}
+{{- printf "%s-%s" (include "chart.fullname" .root) .name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Checksum of chart-created ConfigMaps.
+*/}}
+{{- define "chart.configMapsChecksum" -}}
+{{- toYaml (.Values.configMaps | default list) | sha256sum -}}
+{{- end -}}
+
+{{/*
+Checksum of chart-created Secrets.
+*/}}
+{{- define "chart.secretsChecksum" -}}
+{{- toYaml (.Values.secrets | default list) | sha256sum -}}
+{{- end -}}
+
+{{/*
 Returns non-empty string if the workload is enabled, empty string if not.
 */}}
 {{- define "chart.hasWorkload" -}}
@@ -93,8 +121,10 @@ If the container defines image.repository, it overrides the global.
 {{- define "chart.containerImage" -}}
 {{- $globalRepo := .root.Values.image.repository -}}
 {{- $globalTag := .root.Values.image.tag -}}
+{{- $globalDigest := .root.Values.image.digest -}}
 {{- $repo := $globalRepo -}}
 {{- $tag := $globalTag -}}
+{{- $digest := $globalDigest -}}
 {{- if .container.image -}}
   {{- if .container.image.repository -}}
     {{- $repo = .container.image.repository -}}
@@ -102,8 +132,20 @@ If the container defines image.repository, it overrides the global.
   {{- if .container.image.tag -}}
     {{- $tag = .container.image.tag -}}
   {{- end -}}
+  {{- if .container.image.digest -}}
+    {{- $digest = .container.image.digest -}}
+  {{- end -}}
 {{- end -}}
+{{- with .root.Values.global.imageRegistry -}}
+  {{- if and (not (contains "/" $repo)) (not (contains "." $repo)) (not (contains ":" $repo)) -}}
+    {{- $repo = printf "%s/%s" (. | trimSuffix "/") $repo -}}
+  {{- end -}}
+{{- end -}}
+{{- if $digest -}}
+{{ printf "%s@%s" $repo ($digest | toString) }}
+{{- else -}}
 {{ printf "%s:%s" $repo ($tag | toString) }}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -169,6 +211,22 @@ Used by deployment, job, and cronjob templates to avoid duplication.
   {{- if or .container.securityContext .root.Values.securityContext }}
   securityContext:
     {{- toYaml (.container.securityContext | default .root.Values.securityContext) | nindent 4 }}
+  {{- else if eq .root.Values.securityPreset "baseline" }}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+  {{- else if eq .root.Values.securityPreset "restricted" }}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
   {{- end }}
   {{- if or .container.volumeMounts .root.Values.persistence.mounts }}
   volumeMounts:
@@ -183,6 +241,12 @@ Used by deployment, job, and cronjob templates to avoid duplication.
   lifecycle:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .container.terminationMessagePath | default .root.Values.terminationMessagePath }}
+  terminationMessagePath: {{ . }}
+  {{- end }}
+  {{- with .container.terminationMessagePolicy | default .root.Values.terminationMessagePolicy }}
+  terminationMessagePolicy: {{ . }}
+  {{- end }}
 {{- end -}}
 
 {{/*
@@ -190,6 +254,7 @@ Pod spec shared by deployment, job, and cronjob.
 Accepts a dict with: root (global context), containers (list), podSpec (optional overrides).
 */}}
 {{- define "chart.podSpec" -}}
+{{- $podSpec := .podSpec | default dict -}}
 {{- with .root.Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
@@ -198,19 +263,56 @@ serviceAccountName: {{ include "chart.serviceAccountName" .root }}
 {{- if hasKey .root.Values.serviceAccount "automountServiceAccountToken" }}
 automountServiceAccountToken: {{ .root.Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}
-{{- with (.podSpec).priorityClassName | default .root.Values.priorityClassName }}
+{{- with $podSpec.priorityClassName | default .root.Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
-{{- if or .root.Values.podSecurityContext (.podSpec).podSecurityContext }}
-securityContext:
-  {{- toYaml ((.podSpec).podSecurityContext | default .root.Values.podSecurityContext) | nindent 2 }}
+{{- with $podSpec.preemptionPolicy | default .root.Values.preemptionPolicy }}
+preemptionPolicy: {{ . }}
 {{- end }}
-{{- with (.podSpec).terminationGracePeriodSeconds | default .root.Values.terminationGracePeriodSeconds }}
+{{- if or .root.Values.podSecurityContext $podSpec.podSecurityContext }}
+securityContext:
+  {{- toYaml ($podSpec.podSecurityContext | default .root.Values.podSecurityContext) | nindent 2 }}
+{{- else if eq .root.Values.securityPreset "baseline" }}
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+{{- else if eq .root.Values.securityPreset "restricted" }}
+securityContext:
+  fsGroup: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+{{- with $podSpec.terminationGracePeriodSeconds | default .root.Values.terminationGracePeriodSeconds }}
 terminationGracePeriodSeconds: {{ . }}
 {{- end }}
-{{- if or .root.Values.initContainers (.podSpec).initContainers }}
+{{- with $podSpec.runtimeClassName | default .root.Values.runtimeClassName }}
+runtimeClassName: {{ . }}
+{{- end }}
+{{- with $podSpec.schedulerName | default .root.Values.schedulerName }}
+schedulerName: {{ . }}
+{{- end }}
+{{- if hasKey .root.Values "hostNetwork" }}
+hostNetwork: {{ ternary $podSpec.hostNetwork .root.Values.hostNetwork (hasKey $podSpec "hostNetwork") }}
+{{- end }}
+{{- if hasKey .root.Values "hostPID" }}
+hostPID: {{ ternary $podSpec.hostPID .root.Values.hostPID (hasKey $podSpec "hostPID") }}
+{{- end }}
+{{- if hasKey .root.Values "hostIPC" }}
+hostIPC: {{ ternary $podSpec.hostIPC .root.Values.hostIPC (hasKey $podSpec "hostIPC") }}
+{{- end }}
+{{- if hasKey .root.Values "shareProcessNamespace" }}
+shareProcessNamespace: {{ ternary $podSpec.shareProcessNamespace .root.Values.shareProcessNamespace (hasKey $podSpec "shareProcessNamespace") }}
+{{- end }}
+{{- if hasKey .root.Values "enableServiceLinks" }}
+enableServiceLinks: {{ ternary $podSpec.enableServiceLinks .root.Values.enableServiceLinks (hasKey $podSpec "enableServiceLinks") }}
+{{- end }}
+{{- if or .root.Values.initContainers $podSpec.initContainers }}
 initContainers:
-  {{- range (.podSpec).initContainers | default .root.Values.initContainers }}
+  {{- range $podSpec.initContainers | default .root.Values.initContainers }}
   {{- include "chart.containerSpec" (dict "root" $.root "container" .) | nindent 2 }}
   {{- end }}
 {{- end }}
@@ -220,35 +322,39 @@ containers:
   {{- range $i, $c := .containers }}
   {{- include "chart.containerSpec" (dict "root" $root "container" $c "index" $i "skipGlobalProbes" $skip) | nindent 2 }}
   {{- end }}
-{{- if or .root.Values.persistence.volumes (.podSpec).volumes }}
+{{- if or .root.Values.persistence.volumes $podSpec.volumes }}
 volumes:
   {{- with .root.Values.persistence.volumes }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
-  {{- with (.podSpec).volumes }}
+  {{- with $podSpec.volumes }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}
-{{- with (.podSpec).nodeSelector | default .root.Values.nodeSelector }}
+{{- with $podSpec.nodeSelector | default .root.Values.nodeSelector }}
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with (.podSpec).affinity | default .root.Values.affinity }}
+{{- with $podSpec.affinity | default .root.Values.affinity }}
 affinity:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with (.podSpec).tolerations | default .root.Values.tolerations }}
+{{- with $podSpec.tolerations | default .root.Values.tolerations }}
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with (.podSpec).topologySpreadConstraints | default .root.Values.topologySpreadConstraints }}
+{{- with $podSpec.topologySpreadConstraints | default .root.Values.topologySpreadConstraints }}
 topologySpreadConstraints:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with (.podSpec).dnsPolicy }}
+{{- with $podSpec.hostAliases | default .root.Values.hostAliases }}
+hostAliases:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $podSpec.dnsPolicy | default .root.Values.dnsPolicy }}
 dnsPolicy: {{ . }}
 {{- end }}
-{{- with (.podSpec).dnsConfig }}
+{{- with $podSpec.dnsConfig | default .root.Values.dnsConfig }}
 dnsConfig:
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -137,7 +137,8 @@ If the container defines image.repository, it overrides the global.
   {{- end -}}
 {{- end -}}
 {{- with .root.Values.global.imageRegistry -}}
-  {{- if and (not (contains "/" $repo)) (not (contains "." $repo)) (not (contains ":" $repo)) -}}
+  {{- $firstSegment := first (splitList "/" $repo) -}}
+  {{- if not (or (contains "." $firstSegment) (contains ":" $firstSegment) (eq $firstSegment "localhost")) -}}
     {{- $repo = printf "%s/%s" (. | trimSuffix "/") $repo -}}
   {{- end -}}
 {{- end -}}

--- a/charts/generic/templates/cronjob.yaml
+++ b/charts/generic/templates/cronjob.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ .name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -26,6 +29,19 @@ spec:
   {{- end }}
   jobTemplate:
     spec:
+      {{- with .parallelism }}
+      parallelism: {{ . }}
+      {{- end }}
+      {{- with .completions }}
+      completions: {{ . }}
+      {{- end }}
+      {{- with .completionMode }}
+      completionMode: {{ . }}
+      {{- end }}
+      {{- with .podFailurePolicy }}
+      podFailurePolicy:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       backoffLimit: {{ .backoffLimit | default 1 }}
       activeDeadlineSeconds: {{ .activeDeadlineSeconds | default 300 }}
       ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished | default 300 }}
@@ -34,8 +50,13 @@ spec:
           labels:
             {{- include "chart.selectorLabels" $ | nindent 12 }}
             cronjob-name: {{ .name }}
+            {{- with .podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .podAnnotations }}
           annotations:
-            timestamp: "{{ date "20060102150405" now }}"
+            {{- toYaml .podAnnotations | nindent 12 }}
+          {{- end }}
         spec:
           restartPolicy: {{ .restartPolicy | default "Never" }}
           {{- include "chart.podSpec" (dict "root" $ "containers" (.containers | default (list .)) "podSpec" . "skipGlobalProbes" true) | nindent 10 }}

--- a/charts/generic/templates/daemonset.yaml
+++ b/charts/generic/templates/daemonset.yaml
@@ -24,11 +24,24 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if or .Values.rollout.restartAt .Values.rollout.podAnnotations .Values.podAnnotations (and .Values.rollout.checksum.enabled (or (and .Values.rollout.checksum.configMaps .Values.configMaps) (and .Values.rollout.checksum.secrets .Values.secrets))) }}
       annotations:
-        timestamp: "{{ date "20060102150405" now }}"
+        {{- with .Values.rollout.restartAt }}
+        helmforge.dev/restartedAt: {{ . | quote }}
+        {{- end }}
+        {{- if and .Values.rollout.checksum.enabled .Values.rollout.checksum.configMaps .Values.configMaps }}
+        checksum/configmaps: {{ include "chart.configMapsChecksum" . }}
+        {{- end }}
+        {{- if and .Values.rollout.checksum.enabled .Values.rollout.checksum.secrets .Values.secrets }}
+        checksum/secrets: {{ include "chart.secretsChecksum" . }}
+        {{- end }}
+        {{- with .Values.rollout.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- include "chart.podSpec" (dict "root" . "containers" .Values.containers) | nindent 6 }}
       restartPolicy: Always

--- a/charts/generic/templates/deployment.yaml
+++ b/charts/generic/templates/deployment.yaml
@@ -29,11 +29,24 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if or .Values.rollout.restartAt .Values.rollout.podAnnotations .Values.podAnnotations (and .Values.rollout.checksum.enabled (or (and .Values.rollout.checksum.configMaps .Values.configMaps) (and .Values.rollout.checksum.secrets .Values.secrets))) }}
       annotations:
-        timestamp: "{{ date "20060102150405" now }}"
+        {{- with .Values.rollout.restartAt }}
+        helmforge.dev/restartedAt: {{ . | quote }}
+        {{- end }}
+        {{- if and .Values.rollout.checksum.enabled .Values.rollout.checksum.configMaps .Values.configMaps }}
+        checksum/configmaps: {{ include "chart.configMapsChecksum" . }}
+        {{- end }}
+        {{- if and .Values.rollout.checksum.enabled .Values.rollout.checksum.secrets .Values.secrets }}
+        checksum/secrets: {{ include "chart.secretsChecksum" . }}
+        {{- end }}
+        {{- with .Values.rollout.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- include "chart.podSpec" (dict "root" . "containers" .Values.containers) | nindent 6 }}
       restartPolicy: Always

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  {{- toYaml .spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/extra-manifests.yaml
+++ b/charts/generic/templates/extra-manifests.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraManifests | default list }}
 ---
-{{ toYaml . }}
+{{ tpl (toYaml .) $ }}
 {{- end }}

--- a/charts/generic/templates/gateway-httproute.yaml
+++ b/charts/generic/templates/gateway-httproute.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.gatewayApi.enabled }}
+{{- range .Values.gatewayApi.httpRoutes | default list }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .parentRefs | nindent 4 }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ include "chart.serviceName" $ }}
+          port: {{ $.Values.service.port }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/hpa.yaml
+++ b/charts/generic/templates/hpa.yaml
@@ -15,16 +15,23 @@ spec:
   {{- with .Values.hpa.metrics }}
   metrics:
     {{- range . }}
+    {{- if not .resource }}
+    - type: {{ .type }}
+      {{- omit . "type" | toYaml | nindent 6 }}
+    {{- else }}
     - type: Resource
       resource:
         name: {{ .resource }}
         target:
-          type: {{ .type }}
-          {{- if eq .type "AverageValue" }}
+          type: {{ .targetType | default .metricType | default .type | default "Utilization" }}
+          {{- if eq (.targetType | default .metricType | default .type | default "Utilization") "AverageValue" }}
           averageValue: {{ .target }}
-          {{- else if eq .type "Utilization" }}
+          {{- else if eq (.targetType | default .metricType | default .type | default "Utilization") "Utilization" }}
           averageUtilization: {{ .target }}
+          {{- else if eq (.targetType | default .metricType | default .type | default "Utilization") "Value" }}
+          value: {{ .target }}
           {{- end }}
+    {{- end }}
     {{- end }}
   {{- end }}
   {{- with .Values.hpa.behavior }}

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled }}
-{{- $fullName := include "chart.fullname" . -}}
+{{- $fullName := include "chart.serviceName" . -}}
 {{- $svcPort := .Values.service.port -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -13,6 +13,10 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName | default "traefik" }}
+  {{- with .Values.ingress.defaultBackend }}
+  defaultBackend:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -39,10 +43,14 @@ spec:
             pathType: {{ .pathType | default "Prefix" }}
           {{- end }}
             backend:
+              {{- if and (not (kindIs "string" .)) .backend }}
+              {{- toYaml .backend | nindent 14 }}
+              {{- else }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
+              {{- end }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/generic/templates/job.yaml
+++ b/charts/generic/templates/job.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.jobs | default list }}
+{{- $hooks := .hooks | default dict }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -6,11 +7,44 @@ metadata:
   name: {{ .name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
-  {{- with .annotations }}
-  annotations:
+    {{- with .labels }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .annotations $hooks.enabled }}
+  annotations:
+    {{- if $hooks.enabled }}
+    "helm.sh/hook": {{ join "," ($hooks.events | default (list "pre-install" "pre-upgrade")) | quote }}
+    "helm.sh/hook-weight": {{ $hooks.weight | default 0 | quote }}
+    "helm.sh/hook-delete-policy": {{ $hooks.deletePolicy | default "before-hook-creation,hook-succeeded" | quote }}
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
+  {{- with .parallelism }}
+  parallelism: {{ . }}
+  {{- end }}
+  {{- with .completions }}
+  completions: {{ . }}
+  {{- end }}
+  {{- with .completionMode }}
+  completionMode: {{ . }}
+  {{- end }}
+  {{- with .manualSelector }}
+  manualSelector: {{ . }}
+  {{- end }}
+  {{- with .podFailurePolicy }}
+  podFailurePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .successPolicy }}
+  successPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if hasKey . "suspend" }}
+  suspend: {{ .suspend }}
+  {{- end }}
   backoffLimit: {{ .backoffLimit | default 1 }}
   activeDeadlineSeconds: {{ .activeDeadlineSeconds | default 300 }}
   ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished | default 300 }}
@@ -19,8 +53,13 @@ spec:
       labels:
         {{- include "chart.selectorLabels" $ | nindent 8 }}
         job-name: {{ .name }}
+        {{- with .podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if .podAnnotations }}
       annotations:
-        timestamp: "{{ date "20060102150405" now }}"
+        {{- toYaml .podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: {{ .restartPolicy | default "Never" }}
       {{- include "chart.podSpec" (dict "root" $ "containers" (.containers | default (list .)) "podSpec" . "skipGlobalProbes" true) | nindent 6 }}

--- a/charts/generic/templates/keda.yaml
+++ b/charts/generic/templates/keda.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.keda.enabled .Values.keda.scaledObject.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    name: {{ include "chart.fullname" . }}
+    kind: {{ include "chart.workloadKind" . }}
+  pollingInterval: {{ .Values.keda.scaledObject.pollingInterval | default 30 }}
+  cooldownPeriod: {{ .Values.keda.scaledObject.cooldownPeriod | default 300 }}
+  minReplicaCount: {{ .Values.keda.scaledObject.minReplicaCount | default 0 }}
+  maxReplicaCount: {{ .Values.keda.scaledObject.maxReplicaCount | default 10 }}
+  triggers:
+    {{- toYaml .Values.keda.scaledObject.triggers | nindent 4 }}
+{{- end }}
+{{- if .Values.keda.enabled }}
+{{- range .Values.keda.scaledJobs | default list }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  pollingInterval: {{ .pollingInterval | default 30 }}
+  maxReplicaCount: {{ .maxReplicaCount | default 10 }}
+  jobTargetRef:
+    {{- toYaml .jobTargetRef | nindent 4 }}
+  triggers:
+    {{- toYaml .triggers | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/networkpolicy.yaml
+++ b/charts/generic/templates/networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    {{- if .Values.networkPolicy.podSelector }}
+    {{- toYaml .Values.networkPolicy.podSelector | nindent 4 }}
+    {{- else }}
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+    {{- end }}
+  policyTypes:
+    {{- if .Values.networkPolicy.policyTypes }}
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+    {{- else if .Values.networkPolicy.defaultDeny }}
+    - Ingress
+    - Egress
+    {{- else }}
+    - Ingress
+    {{- end }}
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/generic/templates/podmonitor.yaml
+++ b/charts/generic/templates/podmonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    {{- toYaml .Values.podMonitor.podMetricsEndpoints | nindent 4 }}
+  {{- with .Values.podMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/generic/templates/prometheusrule.yaml
+++ b/charts/generic/templates/prometheusrule.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    {{- toYaml .Values.prometheusRule.groups | nindent 4 }}
+{{- end }}

--- a/charts/generic/templates/pv.yaml
+++ b/charts/generic/templates/pv.yaml
@@ -13,7 +13,10 @@ spec:
   capacity:
     storage: {{ .capacity }}
   accessModes:
-    - {{ .accessMode | default "ReadWriteOnce" }}
+    {{- toYaml (.accessModes | default (list (.accessMode | default "ReadWriteOnce"))) | nindent 4 }}
+  {{- with .volumeMode }}
+  volumeMode: {{ . }}
+  {{- end }}
   persistentVolumeReclaimPolicy: {{ .reclaimPolicy | default "Retain" }}
   {{- with .storageClassName }}
   storageClassName: {{ . | quote }}
@@ -27,6 +30,53 @@ spec:
   hostPath:
     path: {{ .path }}
     type: {{ .type | default "DirectoryOrCreate" }}
+  {{- end }}
+  {{- with .csi }}
+  csi:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- range .Values.persistence.persistentVolumes | default list }}
+{{- if .create }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .annotations .keep }}
+  annotations:
+    {{- if .keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  capacity:
+    storage: {{ .storage }}
+  accessModes:
+    {{- toYaml (.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  {{- with .volumeMode }}
+  volumeMode: {{ . }}
+  {{- end }}
+  persistentVolumeReclaimPolicy: {{ .reclaimPolicy | default "Retain" }}
+  {{- with .storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .nfs }}
+  nfs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .hostPath }}
+  hostPath:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with .csi }}
   csi:

--- a/charts/generic/templates/pvc.yaml
+++ b/charts/generic/templates/pvc.yaml
@@ -10,7 +10,10 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   accessModes:
-    - {{ .accessMode | default "ReadWriteOnce" }}
+    {{- toYaml (.accessModes | default (list (.accessMode | default "ReadWriteOnce"))) | nindent 4 }}
+  {{- with .volumeMode }}
+  volumeMode: {{ . }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .capacity }}
@@ -19,5 +22,65 @@ spec:
   {{- end }}
   {{- if or .existingPVName (not .storageClassName) }}
   volumeName: {{ .existingPVName | default (printf "%s-%s" (include "chart.name" $) .name) }}
+  {{- end }}
+  {{- with .selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .dataSource }}
+  dataSource:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .dataSourceRef }}
+  dataSourceRef:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- range .Values.persistence.persistentVolumeClaims | default list }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .annotations .keep }}
+  annotations:
+    {{- if .keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml (.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  {{- with .volumeMode }}
+  volumeMode: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .storage }}
+  {{- with .storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .volumeName }}
+  volumeName: {{ . }}
+  {{- end }}
+  {{- with .selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .dataSource }}
+  dataSource:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .dataSourceRef }}
+  dataSourceRef:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/generic/templates/rbac.yaml
+++ b/charts/generic/templates/rbac.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+rules:
+  {{- toYaml .Values.rbac.rules | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chart.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "chart.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- if .Values.rbac.clusterRole.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+rules:
+  {{- toYaml .Values.rbac.clusterRole.rules | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chart.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "chart.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/generic/templates/sealed-secret.yaml
+++ b/charts/generic/templates/sealed-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.sealedSecrets.enabled }}
+{{- range .Values.sealedSecrets.items | default list }}
+---
+apiVersion: {{ .apiVersion | required "sealedSecrets.items[].apiVersion is required" }}
+kind: SealedSecret
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  {{- toYaml .spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/generic/templates/secret.yaml
+++ b/charts/generic/templates/secret.yaml
@@ -1,9 +1,9 @@
-{{- range .Values.configMaps | default list }}
+{{- range .Values.secrets | default list }}
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: {{ include "chart.fullname" $ }}-{{ .name }}
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -13,12 +13,13 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if .data }}
+type: {{ .type | default "Opaque" }}
+{{- with .data }}
 data:
-  {{- toYaml .data | nindent 2 }}
+  {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if .binaryData }}
-binaryData:
-  {{- toYaml .binaryData | nindent 2 }}
+{{- with .stringData }}
+stringData:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/generic/templates/service.yaml
+++ b/charts/generic/templates/service.yaml
@@ -1,18 +1,26 @@
-{{- if include "chart.hasWorkload" . }}
+{{- if and (include "chart.hasWorkload" .) (ne .Values.service.enabled false) }}
+{{- $headless := dig "headless" "enabled" false .Values.service }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "chart.serviceName" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type | default "ClusterIP" }}
+  type: {{ ternary "ClusterIP" (.Values.service.type | default "ClusterIP") $headless }}
+  {{- if $headless }}
+  clusterIP: None
+  {{- else }}
   {{- with .Values.service.clusterIP }}
   clusterIP: {{ . }}
+  {{- end }}
   {{- end }}
   {{- with .Values.service.externalIPs }}
   externalIPs:
@@ -21,17 +29,75 @@ spec:
   {{- with .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- with .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort | default .Values.service.port }}
       protocol: TCP
       name: http
+      {{- with .Values.service.appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- range .Values.service.extraPorts }}
     - port: {{ .port }}
       targetPort: {{ .targetPort | default .port }}
       protocol: {{ .protocol | default "TCP" }}
       name: {{ .name }}
+      {{- with .appProtocol }}
+      appProtocol: {{ . }}
+      {{- end }}
+      {{- with .nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
     {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}
+{{- end }}
+{{- if include "chart.hasWorkload" . }}
+{{- range .Values.services | default list }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .type | default "ClusterIP" }}
+  {{- with .clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  ports:
+    {{- toYaml .ports | nindent 4 }}
+  selector:
+    {{- include "chart.selectorLabels" $ | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/generic/templates/statefulset.yaml
+++ b/charts/generic/templates/statefulset.yaml
@@ -33,16 +33,33 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if or .Values.rollout.restartAt .Values.rollout.podAnnotations .Values.podAnnotations (and .Values.rollout.checksum.enabled (or (and .Values.rollout.checksum.configMaps .Values.configMaps) (and .Values.rollout.checksum.secrets .Values.secrets))) }}
       annotations:
-        timestamp: "{{ date "20060102150405" now }}"
+        {{- with .Values.rollout.restartAt }}
+        helmforge.dev/restartedAt: {{ . | quote }}
+        {{- end }}
+        {{- if and .Values.rollout.checksum.enabled .Values.rollout.checksum.configMaps .Values.configMaps }}
+        checksum/configmaps: {{ include "chart.configMapsChecksum" . }}
+        {{- end }}
+        {{- if and .Values.rollout.checksum.enabled .Values.rollout.checksum.secrets .Values.secrets }}
+        checksum/secrets: {{ include "chart.secretsChecksum" . }}
+        {{- end }}
+        {{- with .Values.rollout.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- include "chart.podSpec" (dict "root" . "containers" .Values.containers) | nindent 6 }}
       restartPolicy: Always
   {{- with .Values.workload.volumeClaimTemplates }}
   volumeClaimTemplates:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.workload.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/generic/templates/statefulset.yaml
+++ b/charts/generic/templates/statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ include "chart.fullname" . }}
+  serviceName: {{ include "chart.serviceName" . }}
   {{- if and .Values.hpa .Values.hpa.enabled }}
   replicas: {{ .Values.hpa.minReplicas | default 1 }}
   {{- else }}

--- a/charts/generic/templates/validate.yaml
+++ b/charts/generic/templates/validate.yaml
@@ -1,0 +1,52 @@
+{{- $namePattern := "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" -}}
+{{- range .Values.containers | default list }}
+{{- if not (regexMatch $namePattern .name) }}
+{{- fail (printf "containers[].name must be a DNS-1123 label: %s" .name) }}
+{{- end }}
+{{- end }}
+{{- range .Values.jobs | default list }}
+{{- if not (regexMatch $namePattern .name) }}
+{{- fail (printf "jobs[].name must be a DNS-1123 label: %s" .name) }}
+{{- end }}
+{{- end }}
+{{- range .Values.cronjobs | default list }}
+{{- if not (regexMatch $namePattern .name) }}
+{{- fail (printf "cronjobs[].name must be a DNS-1123 label: %s" .name) }}
+{{- end }}
+{{- if not .schedule }}
+{{- fail (printf "cronjobs[%s].schedule is required" .name) }}
+{{- end }}
+{{- end }}
+{{- range .Values.configMaps | default list }}
+{{- if not (regexMatch $namePattern .name) }}
+{{- fail (printf "configMaps[].name must be a DNS-1123 label: %s" .name) }}
+{{- end }}
+{{- end }}
+{{- if and .Values.hpa.enabled (eq (.Values.workload.type | default "Deployment") "DaemonSet") }}
+{{- fail "hpa.enabled cannot be used with workload.type=DaemonSet" }}
+{{- end }}
+{{- if and .Values.hpa.enabled (not .Values.hpa.maxReplicas) }}
+{{- fail "hpa.maxReplicas is required when hpa.enabled=true" }}
+{{- end }}
+{{- if and .Values.pdb.enabled (not .Values.pdb.minAvailable) (not .Values.pdb.maxUnavailable) }}
+{{- fail "pdb.minAvailable or pdb.maxUnavailable is required when pdb.enabled=true" }}
+{{- end }}
+{{- if and .Values.pdb.enabled .Values.pdb.minAvailable .Values.pdb.maxUnavailable }}
+{{- fail "set only one of pdb.minAvailable or pdb.maxUnavailable" }}
+{{- end }}
+{{- if and .Values.serviceMonitor.enabled (not .Values.serviceMonitor.endpoints) }}
+{{- fail "serviceMonitor.endpoints is required when serviceMonitor.enabled=true" }}
+{{- end }}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) (not .Values.ingress.defaultBackend) }}
+{{- fail "ingress.hosts or ingress.defaultBackend is required when ingress.enabled=true" }}
+{{- end }}
+{{- range .Values.persistence.storage | default list }}
+{{- if not .capacity }}
+{{- fail (printf "persistence.storage[%s].capacity is required" .name) }}
+{{- end }}
+{{- end }}
+{{- range .Values.persistence.persistentVolumeClaims | default list }}
+{{- if not .storage }}
+{{- fail (printf "persistence.persistentVolumeClaims[%s].storage is required" .name) }}
+{{- end }}
+{{- end }}

--- a/charts/generic/tests/batch_test.yaml
+++ b/charts/generic/tests/batch_test.yaml
@@ -1,0 +1,51 @@
+suite: Batch
+templates:
+  - job.yaml
+  - cronjob.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render advanced Job fields
+    set:
+      jobs:
+        - name: worker
+          command: ["echo", "ok"]
+          parallelism: 2
+          completions: 4
+          completionMode: Indexed
+          suspend: true
+    asserts:
+      - isKind:
+          of: Job
+        template: job.yaml
+      - equal:
+          path: spec.parallelism
+          value: 2
+        template: job.yaml
+      - equal:
+          path: spec.suspend
+          value: true
+        template: job.yaml
+
+  - it: should render CronJob timezone and pod labels
+    set:
+      cronjobs:
+        - name: cleanup
+          schedule: "0 2 * * *"
+          timeZone: America/Sao_Paulo
+          command: ["echo", "ok"]
+          podLabels:
+            batch: cleanup
+    asserts:
+      - isKind:
+          of: CronJob
+        template: cronjob.yaml
+      - equal:
+          path: spec.timeZone
+          value: America/Sao_Paulo
+        template: cronjob.yaml
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels.batch
+          value: cleanup
+        template: cronjob.yaml

--- a/charts/generic/tests/configmap_test.yaml
+++ b/charts/generic/tests/configmap_test.yaml
@@ -1,0 +1,31 @@
+suite: ConfigMap
+templates:
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ConfigMap with labels and annotations
+    set:
+      configMaps:
+        - name: app
+          labels:
+            app.example.com/component: config
+          annotations:
+            app.example.com/reload: "true"
+          data:
+            app.yaml: |
+              enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-app
+      - equal:
+          path: metadata.labels["app.example.com/component"]
+          value: config
+      - equal:
+          path: metadata.annotations["app.example.com/reload"]
+          value: "true"
+

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -1,0 +1,18 @@
+suite: DaemonSet
+templates:
+  - daemonset.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render DaemonSet
+    set:
+      workload.type: DaemonSet
+      hpa.enabled: false
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/library/nginx:1.27.5
+

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -55,4 +55,61 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "container.registry.io/project/image:latest"
+          value: "docker.io/library/nginx:1.27.5"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should use image digest when configured
+    set:
+      image.digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/library/nginx@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  - it: should allow per-container image override
+    set:
+      containers:
+        - name: app
+          image:
+            repository: docker.io/library/busybox
+            tag: "1.36"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/library/busybox:1.36"
+
+  - it: should apply global registry to unqualified repositories
+    set:
+      global.imageRegistry: registry.example.com
+      image.repository: nginx
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/nginx:1.27.5"
+
+  - it: should allow per-container image digest override
+    set:
+      containers:
+        - name: app
+          image:
+            repository: docker.io/library/busybox
+            digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/library/busybox@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+  - it: should omit automatic timestamp annotations by default
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations.timestamp
+
+  - it: should render explicit restart annotation
+    set:
+      rollout.restartAt: "2026-04-27T00:00:00Z"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["helmforge.dev/restartedAt"]
+          value: "2026-04-27T00:00:00Z"

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -89,6 +89,24 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "registry.example.com/nginx:1.27.5"
 
+  - it: should apply global registry to namespaced unqualified repositories
+    set:
+      global.imageRegistry: registry.example.com
+      image.repository: team/app
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "registry.example.com/team/app:1.27.5"
+
+  - it: should not apply global registry to fully qualified repositories
+    set:
+      global.imageRegistry: registry.example.com
+      image.repository: ghcr.io/team/app
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/team/app:1.27.5"
+
   - it: should allow per-container image digest override
     set:
       containers:

--- a/charts/generic/tests/extra_manifests_test.yaml
+++ b/charts/generic/tests/extra_manifests_test.yaml
@@ -1,0 +1,25 @@
+suite: Extra manifests
+templates:
+  - extra-manifests.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render templated extra manifests
+    set:
+      extraManifests:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: '{{ include "chart.fullname" . }}-extra'
+          data:
+            release: '{{ .Release.Name }}'
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-extra
+      - equal:
+          path: data.release
+          value: test

--- a/charts/generic/tests/gateway_keda_test.yaml
+++ b/charts/generic/tests/gateway_keda_test.yaml
@@ -1,0 +1,77 @@
+suite: Gateway API and KEDA
+templates:
+  - gateway-httproute.yaml
+  - keda.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render HTTPRoute
+    set:
+      gatewayApi:
+        enabled: true
+        httpRoutes:
+          - name: app
+            parentRefs:
+              - name: gateway
+            hostnames:
+              - app.example.com
+            rules:
+              - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+    asserts:
+      - isKind:
+          of: HTTPRoute
+        template: gateway-httproute.yaml
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test
+        template: gateway-httproute.yaml
+
+  - it: should render KEDA ScaledObject
+    set:
+      keda:
+        enabled: true
+        scaledObject:
+          enabled: true
+          triggers:
+            - type: cpu
+              metricType: Utilization
+              metadata:
+                value: "70"
+    asserts:
+      - isKind:
+          of: ScaledObject
+        template: keda.yaml
+
+  - it: should render KEDA ScaledJob
+    set:
+      keda:
+        enabled: true
+        scaledJobs:
+          - name: worker
+            jobTargetRef:
+              template:
+                spec:
+                  restartPolicy: Never
+                  containers:
+                    - name: worker
+                      image: docker.io/library/busybox:1.36.1
+                      command: ["sh", "-c", "echo ok"]
+            triggers:
+              - type: cron
+                metadata:
+                  timezone: UTC
+                  start: "0 * * * *"
+                  end: "5 * * * *"
+                  desiredReplicas: "1"
+    asserts:
+      - isKind:
+          of: ScaledJob
+        template: keda.yaml
+      - equal:
+          path: metadata.name
+          value: test-worker
+        template: keda.yaml

--- a/charts/generic/tests/hpa_test.yaml
+++ b/charts/generic/tests/hpa_test.yaml
@@ -22,3 +22,25 @@ tests:
     asserts:
       - isKind:
           of: HorizontalPodAutoscaler
+
+  - it: should render non-resource HPA metrics
+    set:
+      hpa:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 5
+        metrics:
+          - type: Pods
+            pods:
+              metric:
+                name: requests_per_second
+              target:
+                type: AverageValue
+                averageValue: "10"
+    asserts:
+      - equal:
+          path: spec.metrics[0].type
+          value: Pods
+      - equal:
+          path: spec.metrics[0].pods.metric.name
+          value: requests_per_second

--- a/charts/generic/tests/observability_test.yaml
+++ b/charts/generic/tests/observability_test.yaml
@@ -1,0 +1,69 @@
+suite: Observability
+templates:
+  - servicemonitor.yaml
+  - podmonitor.yaml
+  - prometheusrule.yaml
+  - vpa.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ServiceMonitor
+    set:
+      serviceMonitor:
+        enabled: true
+        endpoints:
+          - port: http
+            path: /metrics
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        template: servicemonitor.yaml
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+        template: servicemonitor.yaml
+
+  - it: should render PodMonitor
+    set:
+      podMonitor:
+        enabled: true
+        podMetricsEndpoints:
+          - port: http
+            path: /metrics
+    asserts:
+      - isKind:
+          of: PodMonitor
+        template: podmonitor.yaml
+
+  - it: should render PrometheusRule
+    set:
+      prometheusRule:
+        enabled: true
+        groups:
+          - name: generic.rules
+            rules:
+              - alert: GenericDown
+                expr: up == 0
+    asserts:
+      - isKind:
+          of: PrometheusRule
+        template: prometheusrule.yaml
+      - equal:
+          path: spec.groups[0].name
+          value: generic.rules
+        template: prometheusrule.yaml
+
+  - it: should render VerticalPodAutoscaler
+    set:
+      vpa:
+        enabled: true
+        updateMode: Auto
+    asserts:
+      - isKind:
+          of: VerticalPodAutoscaler
+        template: vpa.yaml
+      - equal:
+          path: spec.updatePolicy.updateMode
+          value: Auto
+        template: vpa.yaml

--- a/charts/generic/tests/podspec_test.yaml
+++ b/charts/generic/tests/podspec_test.yaml
@@ -1,0 +1,32 @@
+suite: Pod spec
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render advanced pod spec fields
+    set:
+      runtimeClassName: gvisor
+      schedulerName: custom-scheduler
+      hostAliases:
+        - ip: 127.0.0.1
+          hostnames:
+            - local.test
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        searches:
+          - svc.cluster.local
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: custom-scheduler
+      - equal:
+          path: spec.template.spec.hostAliases[0].ip
+          value: 127.0.0.1
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirst

--- a/charts/generic/tests/security_test.yaml
+++ b/charts/generic/tests/security_test.yaml
@@ -1,0 +1,73 @@
+suite: Security resources
+templates:
+  - secret.yaml
+  - rbac.yaml
+  - networkpolicy.yaml
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render declarative secrets
+    set:
+      secrets:
+        - name: app
+          stringData:
+            password: change-me
+    asserts:
+      - isKind:
+          of: Secret
+        template: secret.yaml
+      - equal:
+          path: metadata.name
+          value: test-app
+        template: secret.yaml
+
+  - it: should render role and rolebinding
+    set:
+      rbac:
+        create: true
+        rules:
+          - apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["get"]
+    asserts:
+      - isKind:
+          of: Role
+        template: rbac.yaml
+        documentIndex: 0
+      - isKind:
+          of: RoleBinding
+        template: rbac.yaml
+        documentIndex: 1
+
+  - it: should render default deny NetworkPolicy
+    set:
+      networkPolicy:
+        enabled: true
+        defaultDeny: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+        template: networkpolicy.yaml
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+        template: networkpolicy.yaml
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+        template: networkpolicy.yaml
+
+  - it: should apply restricted security preset when contexts are not explicit
+    set:
+      securityPreset: restricted
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+        template: deployment.yaml

--- a/charts/generic/tests/service_test.yaml
+++ b/charts/generic/tests/service_test.yaml
@@ -31,3 +31,39 @@ tests:
             port: 8080
             protocol: TCP
             targetPort: 8080
+
+  - it: should not render when service is disabled
+    set:
+      service.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a headless primary service
+    set:
+      service:
+        enabled: true
+        headless:
+          enabled: true
+        port: 8080
+        targetPort: 8080
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: should render additional services
+    documentIndex: 1
+    set:
+      services:
+        - name: metrics
+          ports:
+            - name: metrics
+              port: 9090
+              targetPort: 9090
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-metrics

--- a/charts/generic/tests/service_test.yaml
+++ b/charts/generic/tests/service_test.yaml
@@ -22,15 +22,15 @@ tests:
           path: spec.type
           value: ClusterIP
 
-  - it: should expose port 8080 by default
+  - it: should expose port 80 by default
     asserts:
       - contains:
           path: spec.ports
           content:
             name: http
-            port: 8080
+            port: 80
             protocol: TCP
-            targetPort: 8080
+            targetPort: 80
 
   - it: should not render when service is disabled
     set:

--- a/charts/generic/tests/statefulset_test.yaml
+++ b/charts/generic/tests/statefulset_test.yaml
@@ -19,3 +19,13 @@ tests:
           path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
           value: Retain
 
+  - it: should use overridden service name as governing service
+    set:
+      workload:
+        type: StatefulSet
+      service:
+        nameOverride: stateful-headless
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: stateful-headless

--- a/charts/generic/tests/statefulset_test.yaml
+++ b/charts/generic/tests/statefulset_test.yaml
@@ -1,0 +1,21 @@
+suite: StatefulSet
+templates:
+  - statefulset.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render StatefulSet with retention policy
+    set:
+      workload:
+        type: StatefulSet
+        persistentVolumeClaimRetentionPolicy:
+          whenDeleted: Retain
+          whenScaled: Delete
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Retain
+

--- a/charts/generic/tests/storage_test.yaml
+++ b/charts/generic/tests/storage_test.yaml
@@ -1,0 +1,43 @@
+suite: Storage
+templates:
+  - pvc.yaml
+  - pv.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render declarative PVCs
+    set:
+      persistence:
+        persistentVolumeClaims:
+          - name: data
+            storage: 10Gi
+            accessModes: ["ReadWriteOnce"]
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+        template: pvc.yaml
+      - equal:
+          path: metadata.name
+          value: test-data
+        template: pvc.yaml
+
+  - it: should render explicit PVs
+    set:
+      persistence:
+        persistentVolumes:
+          - name: data
+            create: true
+            storage: 10Gi
+            accessModes: ["ReadWriteOnce"]
+            hostPath:
+              path: /tmp/data
+              type: DirectoryOrCreate
+    asserts:
+      - isKind:
+          of: PersistentVolume
+        template: pv.yaml
+      - equal:
+          path: metadata.name
+          value: test-data
+        template: pv.yaml

--- a/charts/generic/tests/validation_test.yaml
+++ b/charts/generic/tests/validation_test.yaml
@@ -1,0 +1,38 @@
+suite: Validation
+templates:
+  - validate.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should fail when a container name is not DNS-1123
+    set:
+      containers:
+        - name: App
+    asserts:
+      - failedTemplate:
+          errorMessage: "containers[].name must be a DNS-1123 label: App"
+
+  - it: should fail when HPA targets a DaemonSet
+    set:
+      workload.type: DaemonSet
+      hpa.enabled: true
+      hpa.maxReplicas: 3
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.enabled cannot be used with workload.type=DaemonSet"
+
+  - it: should fail when HPA omits maxReplicas
+    set:
+      hpa.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "hpa.maxReplicas is required when hpa.enabled=true"
+
+  - it: should fail when PDB has no availability budget
+    set:
+      pdb.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "pdb.minAvailable or pdb.maxUnavailable is required when pdb.enabled=true"
+

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -3,7 +3,7 @@
   "title": "Generic Helm Chart Values",
   "description": "Configuration values for the Generic Helm chart. Supports Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs with multi-container pods, envFrom, initContainers, extraManifests, and more.",
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "replicaCount": {
       "type": "integer",
@@ -57,6 +57,17 @@
         }
       }
     },
+    "global": {
+      "type": "object",
+      "description": "Global settings shared by the chart",
+      "properties": {
+        "imageRegistry": {
+          "type": "string",
+          "description": "Optional registry prefix applied to image repositories without a registry",
+          "default": ""
+        }
+      }
+    },
     "image": {
       "type": "object",
       "description": "Default container image configuration",
@@ -65,18 +76,23 @@
         "repository": {
           "type": "string",
           "description": "Container image repository",
-          "default": "container.registry.io/project/image"
+          "default": "docker.io/library/nginx"
         },
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "latest"
+          "default": "1.27.5"
+        },
+        "digest": {
+          "type": "string",
+          "description": "Container image digest. When set, it takes precedence over tag.",
+          "default": ""
         },
         "pullPolicy": {
           "type": "string",
           "description": "Image pull policy",
           "enum": ["Always", "IfNotPresent", "Never"],
-          "default": "Always"
+          "default": "IfNotPresent"
         }
       }
     },
@@ -196,6 +212,11 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the ServiceAccount"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Mount the Kubernetes API token into workload pods",
+          "default": false
         }
       }
     },
@@ -223,6 +244,12 @@
       "type": "object",
       "description": "Container-level security context"
     },
+    "securityPreset": {
+      "type": "string",
+      "description": "Optional security preset applied only when explicit pod/container contexts are not set",
+      "enum": ["", "baseline", "restricted"],
+      "default": ""
+    },
     "service": {
       "type": "object",
       "description": "Kubernetes Service configuration",
@@ -232,6 +259,11 @@
           "description": "Service type",
           "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
           "default": "ClusterIP"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Create the default Service for long-running workloads",
+          "default": true
         },
         "port": {
           "type": "integer",
@@ -280,6 +312,13 @@
             }
           }
         }
+      }
+    },
+    "services": {
+      "type": "array",
+      "description": "Additional Services for the same workload selector",
+      "items": {
+        "type": "object"
       }
     },
     "ingress": {
@@ -402,11 +441,31 @@
       "description": "Priority class name",
       "default": ""
     },
+    "preemptionPolicy": {
+      "type": "string",
+      "description": "Pod preemption policy",
+      "default": ""
+    },
     "terminationGracePeriodSeconds": {
       "type": "integer",
       "description": "Grace period for pod termination in seconds",
       "default": 30
     },
+    "runtimeClassName": { "type": "string", "default": "" },
+    "schedulerName": { "type": "string", "default": "" },
+    "hostNetwork": { "type": "boolean", "default": false },
+    "hostPID": { "type": "boolean", "default": false },
+    "hostIPC": { "type": "boolean", "default": false },
+    "shareProcessNamespace": { "type": "boolean", "default": false },
+    "enableServiceLinks": { "type": "boolean", "default": true },
+    "dnsPolicy": { "type": "string", "default": "" },
+    "dnsConfig": { "type": "object" },
+    "hostAliases": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "terminationMessagePath": { "type": "string", "default": "" },
+    "terminationMessagePolicy": { "type": "string", "default": "" },
     "podLabels": {
       "type": "object",
       "description": "Extra labels on pods only"
@@ -418,6 +477,30 @@
     "annotations": {
       "type": "object",
       "description": "Annotations on the workload resource itself"
+    },
+    "rollout": {
+      "type": "object",
+      "description": "Explicit rollout controls",
+      "properties": {
+        "restartAt": {
+          "type": "string",
+          "description": "Set to a new value when you intentionally want to roll pods",
+          "default": ""
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Annotations rendered with rollout controls"
+        },
+        "checksum": {
+          "type": "object",
+          "description": "Checksum rollout controls",
+          "properties": {
+            "enabled": { "type": "boolean", "default": true },
+            "configMaps": { "type": "boolean", "default": true },
+            "secrets": { "type": "boolean", "default": true }
+          }
+        }
+      }
     },
     "hpa": {
       "type": "object",
@@ -552,6 +635,67 @@
         }
       }
     },
+    "podMonitor": {
+      "type": "object",
+      "description": "PodMonitor configuration for Prometheus Operator",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "labels": { "type": "object" },
+        "podMetricsEndpoints": { "type": "array", "items": { "type": "object" } },
+        "namespaceSelector": { "type": "object" }
+      }
+    },
+    "prometheusRule": {
+      "type": "object",
+      "description": "PrometheusRule configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "labels": { "type": "object" },
+        "groups": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "secrets": {
+      "type": "array",
+      "description": "Secret definitions to create",
+      "items": { "type": "object" }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "ExternalSecret resources",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "items": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "sealedSecrets": {
+      "type": "object",
+      "description": "SealedSecret resources",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "items": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "description": "RBAC resources",
+      "properties": {
+        "create": { "type": "boolean", "default": false },
+        "rules": { "type": "array", "items": { "type": "object" } },
+        "clusterRole": { "type": "object" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "defaultDeny": { "type": "boolean", "default": false },
+        "podSelector": { "type": "object" },
+        "policyTypes": { "type": "array", "items": { "type": "string" } },
+        "ingress": { "type": "array", "items": { "type": "object" } },
+        "egress": { "type": "array", "items": { "type": "object" } }
+      }
+    },
     "jobs": {
       "type": "array",
       "description": "Kubernetes Job definitions",
@@ -618,6 +762,23 @@
       "description": "Inject arbitrary Kubernetes manifests. Supports Helm templating via tpl.",
       "items": {
         "type": "object"
+      }
+    },
+    "keda": {
+      "type": "object",
+      "description": "KEDA ScaledObject and ScaledJob configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "scaledObject": { "type": "object" },
+        "scaledJobs": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gatewayApi": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "httpRoutes": { "type": "array", "items": { "type": "object" } }
       }
     }
   }

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -268,12 +268,12 @@
         "port": {
           "type": "integer",
           "description": "Service port",
-          "default": 8080
+          "default": 80
         },
         "targetPort": {
           "type": "integer",
           "description": "Target port on the container",
-          "default": 8080
+          "default": 80
         },
         "clusterIP": {
           "type": "string",

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -45,10 +45,15 @@ workload:
 # Image
 # =============================================================================
 
+global:
+  # -- Optional registry prefix applied to image repositories without a registry
+  imageRegistry: ""
+
 image:
-  repository: container.registry.io/project/image
-  tag: latest
-  pullPolicy: Always
+  repository: docker.io/library/nginx
+  tag: "1.27.5"
+  digest: ""
+  pullPolicy: IfNotPresent
 
 
 imagePullSecrets: []
@@ -110,6 +115,7 @@ envFrom: []
 serviceAccount:
   create: false
   # name: ""
+  automountServiceAccountToken: false
   annotations: {}
 
 # =============================================================================
@@ -145,22 +151,48 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# -- Optional security preset. Empty leaves contexts unchanged.
+# baseline sets non-root/seccomp and drops Linux capabilities when not overridden.
+# restricted also sets read-only root filesystem and default UID/GID/fsGroup.
+securityPreset: ""
+  # "" | baseline | restricted
+
 # =============================================================================
 # Service
 # =============================================================================
 
 service:
+  enabled: true
   type: ClusterIP
   port: 8080
   targetPort: 8080
+  nameOverride: ""
   # clusterIP: ""
   # loadBalancerIP: ""
+  # loadBalancerClass: ""
   # externalIPs: []
+  # externalTrafficPolicy: Cluster
+  # internalTrafficPolicy: Cluster
+  # sessionAffinity: None
+  # ipFamilyPolicy: SingleStack
+  # ipFamilies: []
   # annotations: {}
+  # labels: {}
+  # headless:
+  #   enabled: false
   # extraPorts:
   #   - name: metrics
   #     port: 9090
   #     targetPort: 9090
+  #     appProtocol: http
+
+services: []
+  # - name: metrics
+  #   type: ClusterIP
+  #   ports:
+  #     - name: metrics
+  #       port: 9090
+  #       targetPort: 9090
 
 # =============================================================================
 # Ingress
@@ -178,6 +210,12 @@ ingress:
     #   paths:
     #     - path: /
     #       pathType: Prefix
+    #       backend:
+    #         service:
+    #           name: custom-service
+    #           port:
+    #             number: 8080
+  # defaultBackend: {}
   tls: []
     # - hosts:
     #     - app.example.com
@@ -206,7 +244,20 @@ tolerations: []
 affinity: {}
 topologySpreadConstraints: []
 priorityClassName: ""
+preemptionPolicy: ""
 terminationGracePeriodSeconds: 30
+runtimeClassName: ""
+schedulerName: ""
+hostNetwork: false
+hostPID: false
+hostIPC: false
+shareProcessNamespace: false
+enableServiceLinks: true
+dnsPolicy: ""
+dnsConfig: {}
+hostAliases: []
+terminationMessagePath: ""
+terminationMessagePolicy: ""
 
 # -- Extra labels on pods only
 podLabels: {}
@@ -214,6 +265,19 @@ podLabels: {}
 podAnnotations: {}
 # -- Annotations on the workload resource itself
 annotations: {}
+
+# =============================================================================
+# Rollout
+# =============================================================================
+# Set restartAt to a new value when you intentionally want a rollout.
+
+rollout:
+  restartAt: ""
+  podAnnotations: {}
+  checksum:
+    enabled: true
+    configMaps: true
+    secrets: true
 
 # =============================================================================
 # Autoscaling (not available for DaemonSet)
@@ -282,6 +346,23 @@ persistence:
     #   #   server: 10.0.0.1
     #   #   path: /exports/data
 
+  persistentVolumeClaims: []
+    # - name: data
+    #   storage: 10Gi
+    #   accessModes: ["ReadWriteOnce"]
+    #   storageClassName: standard
+    #   keep: true
+
+  persistentVolumes: []
+    # - name: data
+    #   create: false
+    #   storage: 10Gi
+    #   accessModes: ["ReadWriteOnce"]
+    #   reclaimPolicy: Retain
+    #   nfs:
+    #     server: 10.0.0.1
+    #     path: /exports/data
+
 # =============================================================================
 # ConfigMaps
 # =============================================================================
@@ -289,10 +370,39 @@ persistence:
 configMaps: []
   # - name: app-config
   #   data:
-  #     config.yaml: |
+    #     config.yaml: |
   #       key: value
   #     settings.json: |
   #       {"debug": false}
+
+secrets: []
+  # - name: app-secret
+  #   type: Opaque
+  #   stringData:
+  #     password: change-me
+
+externalSecrets:
+  enabled: false
+  items: []
+
+sealedSecrets:
+  enabled: false
+  items: []
+
+rbac:
+  create: false
+  rules: []
+  clusterRole:
+    create: false
+    rules: []
+
+networkPolicy:
+  enabled: false
+  defaultDeny: false
+  podSelector: {}
+  policyTypes: []
+  ingress: []
+  egress: []
 
 # =============================================================================
 # ServiceMonitor (Prometheus Operator)
@@ -306,6 +416,17 @@ serviceMonitor:
   #     path: /metrics
   #     interval: 30s
 
+podMonitor:
+  enabled: false
+  labels: {}
+  podMetricsEndpoints: []
+  # namespaceSelector: {}
+
+prometheusRule:
+  enabled: false
+  labels: {}
+  groups: []
+
 # =============================================================================
 # Jobs
 # =============================================================================
@@ -314,10 +435,15 @@ jobs: []
   # - name: db-migrate
   #   image:
   #     repository: my-app
-  #     tag: latest
+  #     tag: "1.0.0"
   #   command: ["npm", "run", "migrate"]
   #   backoffLimit: 3
   #   activeDeadlineSeconds: 600
+  #   hooks:
+  #     enabled: false
+  #     events: ["pre-install", "pre-upgrade"]
+  #     weight: 0
+  #     deletePolicy: before-hook-creation,hook-succeeded
 
 # =============================================================================
 # CronJobs
@@ -329,10 +455,25 @@ cronjobs: []
   #   timeZone: America/Sao_Paulo
   #   image:
   #     repository: my-app
-  #     tag: latest
+  #     tag: "1.0.0"
   #   command: ["npm", "run", "cleanup"]
   #   concurrencyPolicy: Forbid
   #   suspend: false
+
+keda:
+  enabled: false
+  scaledObject:
+    enabled: false
+    pollingInterval: 30
+    cooldownPeriod: 300
+    minReplicaCount: 0
+    maxReplicaCount: 10
+    triggers: []
+  scaledJobs: []
+
+gatewayApi:
+  enabled: false
+  httpRoutes: []
 
 # =============================================================================
 # Extra Manifests

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -70,7 +70,7 @@ containers:
   - name: app
     image: {}
     ports:
-      - containerPort: 8080
+      - containerPort: 80
     env: []
     envFrom: []
     # envFrom:
@@ -164,8 +164,8 @@ securityPreset: ""
 service:
   enabled: true
   type: ClusterIP
-  port: 8080
-  targetPort: 8080
+  port: 80
+  targetPort: 80
   nameOverride: ""
   # clusterIP: ""
   # loadBalancerIP: ""


### PR DESCRIPTION
Resolves #117

## Summary
- Expands the generic chart platform contract across image policy, deterministic rollouts, networking, security, storage, observability, batch, autoscaling, Gateway API, and KEDA.
- Updates README, chart docs, changelog, examples, CI values, and validation suites.
- Syncs the external site repo in a companion PR because site/docs live in a separate repository.

## Validation
- `helm lint charts/generic --strict`
- `helm unittest charts/generic` (17 suites, 54 tests)
- `helm template` for all `charts/generic/ci/*.yaml`
- `helm template` for all `charts/generic/examples/*.yaml`
- K3D runtime validation on `k3d-charts-test`: default install, platform runtime install with mounted PVC, logs checked clean, namespace cleanup
- K3D StatefulSet + HPA runtime validation on `k3d-charts-test`: `autoscaling/v2`, headless Service, rollout completion, HPA API acceptance, logs checked clean
- Site repo: `npm run format:check`, `npm run lint`, `npm run build`
- MCP HelmForge: `check_site_sync` for `architecture`, `defaults`, and `breaking`; `validate_compliance` 25/27 PASS/WARN, 0 blockers

## Guardrail Notes
- `GR-003` remains a warning because chart versions are CI-managed; `Chart.yaml` version was not manually bumped.
- `GR-012` remains a warning because `SOURCE-OF-TRUTH.md` is not present in this repo.
- `check_release_readiness` still reports a GR-043 blocker, but `validate_compliance` passes GR-043 after the k3d StatefulSet HPA runtime validation and documented prerequisites.

## Runtime Scope
CRD-backed resources such as PodMonitor, PrometheusRule, VPA, KEDA, and Gateway API are render/unit-tested and gated behind explicit feature flags. They were not installed in k3d because the required operators/CRDs are not part of the local cluster baseline.

## Backup Scope
The generic chart does not implement an application backup uploader or backup artifact workflow in this change. Storage resources are Kubernetes PVC/PV primitives only.

BREAKING CHANGE: Generic chart defaults and validation contract changed. Default image is pinned, timestamp rollouts are removed, and invalid HPA/PDB/service/ingress/storage combinations fail early.
