### PR TITLE
fix(generic): validate disabled-service route targets

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -13,7 +13,7 @@ kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: BREAKING: expand generic chart platform capabilities (#118)
+      description: "BREAKING: expand generic chart platform capabilities (#118)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: helmforgedev@users.noreply.github.com

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -250,8 +250,8 @@ The chart now includes opt-in primitives for common platform needs:
 - `secrets[]`, `externalSecrets`, and `sealedSecrets` for secret integration. ExternalSecret, SealedSecret, ServiceMonitor, PodMonitor, PrometheusRule, KEDA, VPA, and Gateway API resources require their CRDs to exist before enabling them.
 - `rbac.create` and `networkPolicy.enabled` for least-privilege identity and traffic policy.
 - `securityPreset: baseline` or `restricted` for opt-in security contexts when explicit contexts are not set.
-- `services[]`, `service.headless`, `service.nameOverride`, per-port `appProtocol`, and custom Ingress backends for richer networking.
-- `podMonitor`, `prometheusRule`, advanced HPA metrics, and optional KEDA ScaledObject/ScaledJob support.
+- `services[]`, `service.headless`, `service.nameOverride`, per-port `appProtocol`, and custom Ingress backends for richer networking. When `service.enabled=false`, Ingress paths must set `backend` and HTTPRoute rules must set `backendRefs`.
+- `podMonitor`, `prometheusRule`, advanced HPA metrics, and optional KEDA ScaledObject/ScaledJob support. KEDA ScaledObjects target the chart workload and require `workload.enabled=true`; use ScaledJobs for batch-only releases.
 - `persistence.persistentVolumeClaims[]` and explicit opt-in `persistence.persistentVolumes[]` for clearer storage ownership.
 
 ### Breaking-change migration notes
@@ -358,11 +358,11 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `services` | Additional Service resources | `[]` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.ingressClassName` | Ingress class | `traefik` |
-| `ingress.hosts` | Ingress host rules | `[]` |
+| `ingress.hosts` | Ingress host rules; paths require explicit `backend` when `service.enabled=false` | `[]` |
 | `ingress.defaultBackend` | Ingress default backend | `{}` |
 | `ingress.tls` | TLS configuration | `[]` |
 | `gatewayApi.enabled` | Enable Gateway API HTTPRoutes | `false` |
-| `gatewayApi.httpRoutes` | HTTPRoute definitions | `[]` |
+| `gatewayApi.httpRoutes` | HTTPRoute definitions; rules require `backendRefs` when `service.enabled=false` | `[]` |
 | **Scheduling** | | |
 | `updateStrategy` | Deployment rollout strategy | `RollingUpdate 25%/25%` |
 | `nodeSelector` | Node selector | `{}` |
@@ -390,7 +390,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `hpa.maxReplicas` | Maximum replicas | — |
 | `hpa.metrics` | Scaling metrics | `[]` |
 | `keda.enabled` | Enable KEDA custom resources | `false` |
-| `keda.scaledObject` | KEDA ScaledObject configuration | disabled |
+| `keda.scaledObject` | KEDA ScaledObject configuration for the chart workload; requires `workload.enabled=true` | disabled |
 | `keda.scaledJobs` | KEDA ScaledJob definitions | `[]` |
 | `vpa.enabled` | Enable VPA | `false` |
 | `vpa.updateMode` | VPA update mode | `Off` |

--- a/charts/generic/docs/gateway.md
+++ b/charts/generic/docs/gateway.md
@@ -22,6 +22,8 @@ gatewayApi:
 
 If a route rule omits `backendRefs`, it points at the primary Service using `service.port`. Use custom `backendRefs` for multi-service routing.
 
+When `service.enabled=false`, every HTTPRoute rule must define `backendRefs` explicitly. The chart fails validation instead of rendering routes to a Service it is not creating.
+
 <!-- @AI-METADATA
 type: chart-docs
 title: Generic Chart - Gateway API
@@ -35,4 +37,3 @@ path: charts/generic/docs/gateway.md
 version: 1.0
 date: 2026-04-27
 -->
-

--- a/charts/generic/docs/observability.md
+++ b/charts/generic/docs/observability.md
@@ -26,6 +26,8 @@ HPA supports Resource metrics plus native autoscaling/v2 metric shapes such as P
 
 VPA and KEDA are CRD-backed and disabled by default. Use VPA for recommendations or vertical resizing, and KEDA for event-driven ScaledObjects or ScaledJobs.
 
+KEDA ScaledObjects target the chart-managed Deployment or StatefulSet and require `workload.enabled=true`. Use ScaledJobs for event-driven batch releases that do not render a long-running workload.
+
 ## Autoscaling and HA safety
 
 Deployment and StatefulSet HPA resources are supported by the Kubernetes `autoscaling/v2` API. Validate StatefulSet scaling with the application owner before enabling it in production, because ordered identity, storage semantics, and application clustering behavior remain workload-specific.

--- a/charts/generic/templates/keda.yaml
+++ b/charts/generic/templates/keda.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.keda.enabled .Values.keda.scaledObject.enabled }}
+{{- if and .Values.keda.enabled .Values.keda.scaledObject.enabled (include "chart.hasWorkload" .) }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/generic/templates/validate.yaml
+++ b/charts/generic/templates/validate.yaml
@@ -40,6 +40,27 @@
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) (not .Values.ingress.defaultBackend) }}
 {{- fail "ingress.hosts or ingress.defaultBackend is required when ingress.enabled=true" }}
 {{- end }}
+{{- if and .Values.ingress.enabled (eq .Values.service.enabled false) }}
+{{- range .Values.ingress.hosts | default list }}
+{{- range .paths | default (list "/") }}
+{{- if or (kindIs "string" .) (not .backend) }}
+{{- fail "ingress paths require an explicit backend when service.enabled=false" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.gatewayApi.enabled (eq .Values.service.enabled false) }}
+{{- range .Values.gatewayApi.httpRoutes | default list }}
+{{- range .rules | default list }}
+{{- if not .backendRefs }}
+{{- fail "gatewayApi.httpRoutes[].rules[].backendRefs is required when service.enabled=false" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.keda.enabled .Values.keda.scaledObject.enabled (not (include "chart.hasWorkload" .)) }}
+{{- fail "keda.scaledObject.enabled requires workload.enabled=true" }}
+{{- end }}
 {{- range .Values.persistence.storage | default list }}
 {{- if not .capacity }}
 {{- fail (printf "persistence.storage[%s].capacity is required" .name) }}

--- a/charts/generic/tests/validation_test.yaml
+++ b/charts/generic/tests/validation_test.yaml
@@ -36,3 +36,50 @@ tests:
       - failedTemplate:
           errorMessage: "pdb.minAvailable or pdb.maxUnavailable is required when pdb.enabled=true"
 
+  - it: should fail when ingress falls back to disabled primary service
+    set:
+      service.enabled: false
+      ingress:
+        enabled: true
+        hosts:
+          - host: app.example.com
+            paths:
+              - path: /
+                pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress paths require an explicit backend when service.enabled=false"
+
+  - it: should fail when HTTPRoute falls back to disabled primary service
+    set:
+      service.enabled: false
+      gatewayApi:
+        enabled: true
+        httpRoutes:
+          - name: app
+            parentRefs:
+              - name: gateway
+            rules:
+              - matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayApi.httpRoutes[].rules[].backendRefs is required when service.enabled=false"
+
+  - it: should fail when KEDA ScaledObject has no workload target
+    set:
+      workload.enabled: false
+      keda:
+        enabled: true
+        scaledObject:
+          enabled: true
+          triggers:
+            - type: cpu
+              metricType: Utilization
+              metadata:
+                value: "70"
+    asserts:
+      - failedTemplate:
+          errorMessage: "keda.scaledObject.enabled requires workload.enabled=true"


### PR DESCRIPTION
## Summary

Follow-up to merged PR #118 for the remaining Codex review threads.

- fail validation when Ingress would fall back to the primary Service while `service.enabled=false`
- fail validation when Gateway API HTTPRoute rules omit `backendRefs` while `service.enabled=false`
- prevent KEDA ScaledObject from rendering when the chart workload is disabled
- update chart docs/tests for the explicit routing and KEDA target contracts

Companion site docs update: helmforgedev/site#160 (commit 603c1ca).

## Validation

- `helm lint charts/generic --strict`
- `helm unittest charts/generic` (17 suites, 60 tests)
- `helm template` for all `charts/generic/ci/*.yaml`
- `helm template` for all `charts/generic/examples/*.yaml`
- positive renders for `service.enabled=false` with explicit Ingress backend and Gateway `backendRefs`
- K3D runtime on `k3d-charts-test`: install, rollout status, pod logs checked, uninstall and namespace cleanup
- `git diff --check`
- MCP `validate_chart`: 0 blockers, existing GR-003 warning only for chart version managed by CI/release-please
- MCP `check_site_sync(generic, defaults)`: PASS with `src/pages/docs/charts/generic.mdx`

## MCP note

`validate_compliance` still reports GR-023/GR-027 evidence-recognition blockers even after the site/k3d evidence above was provided. I logged that as `MISTAKE-20260427174451` in MCP so the guardrail schema can be tightened.