### PR TITLE
docs: improve README badges and contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   pull_request:
@@ -226,7 +226,7 @@ jobs:
           done
 
   ci:
-    name: CI
+    name: Tests
     runs-on: ubuntu-latest
     if: always()
     needs: [detect, lint, template, unittest, kubeconform, artifacthub-lint]
@@ -238,7 +238,7 @@ jobs:
              [ "${{ needs.unittest.result }}" = "failure" ] || \
              [ "${{ needs.kubeconform.result }}" = "failure" ] || \
              [ "${{ needs.artifacthub-lint.result }}" = "failure" ]; then
-            echo "CI failed"
+            echo "Tests failed"
             exit 1
           fi
-          echo "CI passed"
+          echo "Tests passed"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ on:
       - '!charts/**/examples/**'
       - '!charts/**/docs/**'
       - '.github/workflows/publish.yml'
+      - 'scripts/generate-charts-count-badge.mjs'
+      - 'scripts/generate-contributors-image.mjs'
   workflow_dispatch:
 
 concurrency:
@@ -452,10 +454,14 @@ jobs:
           fi
 
       - name: Generate Shields badges
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node main-src/scripts/generate-charts-count-badge.mjs main-src gh-pages/badges/charts-count.json
+          node main-src/scripts/generate-contributors-image.mjs "${{ github.repository }}" gh-pages/badges/contributors.svg
           echo "Generated badge endpoints:"
           cat gh-pages/badges/charts-count.json
+          ls -lh gh-pages/badges/contributors.svg
 
       - name: Rebuild repo index
         if: needs.publish.result == 'success'
@@ -481,6 +487,7 @@ jobs:
           git add *.prov 2>/dev/null || true
           git add artifacthub-repo.yml 2>/dev/null || true
           git add badges/*.json 2>/dev/null || true
+          git add badges/*.svg 2>/dev/null || true
           git diff --cached --quiet && echo "No changes to index, skip" || {
             git commit -m "ci: update helm repo index [skip ci]"
             git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/helmforgedev/charts/actions/workflows/ci.yml"><img src="https://github.com/helmforgedev/charts/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/helmforgedev/charts/actions/workflows/ci.yml"><img src="https://github.com/helmforgedev/charts/actions/workflows/ci.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/helmforgedev/charts/actions/workflows/publish.yml"><img src="https://github.com/helmforgedev/charts/actions/workflows/publish.yml/badge.svg" alt="Publish" /></a>
+  <a href="https://github.com/helmforgedev/charts/stargazers"><img src="https://img.shields.io/github/stars/helmforgedev/charts?style=flat&label=Stars" alt="GitHub stars" /></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
   <a href="https://artifacthub.io/packages/search?repo=helmforge"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/helmforge" alt="Artifact Hub" /></a>
   <img src="https://img.shields.io/endpoint?url=https://repo.helmforge.dev/badges/charts-count.json" alt="Charts count" />
@@ -72,11 +73,11 @@ HelmForge is built on a simple principle: **use what upstream ships, make the Ku
 
 - **Official upstream images** — charts prefer images published by the application maintainers. No proprietary rebuild layer or vendor-specific runtime wrapper.
 - **Pinned version tags** — charts reference explicit, immutable image tags. No `:latest`, no floating tags, no surprises after a pull.
-- **MIT licensed** — the charts, CI, and docs are MIT. No open-core, no paid tiers, no license changes down the road.
+- **MIT licensed** — the charts, tests, and docs are MIT. No open-core, no paid tiers, no license changes down the road.
 - **GPG + Cosign signed** — every release includes GPG provenance files for Helm verification and [Sigstore Cosign](https://www.sigstore.dev/) keyless signatures on OCI artifacts via GitHub Actions OIDC.
 - **No vendor lock-in** — standard Helm, standard Kubernetes APIs, standard images. If you stop using HelmForge tomorrow, nothing breaks.
 - **Explicit values contracts** — product-oriented `values.yaml` files map directly to application and Kubernetes configuration, with schemas and validations where they prevent bad releases.
-- **Operator-first docs** — chart READMEs, site docs, examples, and CI values are kept close to the release surface.
+- **Operator-first docs** — chart READMEs, site docs, examples, and test values are kept close to the release surface.
 
 ## Charts
 
@@ -103,7 +104,7 @@ It supports:
 - RBAC, NetworkPolicy, ServiceMonitor, PodMonitor, PrometheusRule, VPA, HPA, and KEDA.
 - Safer validation for disabled-Service routing and KEDA ScaledObject targets.
 
-## CI/CD
+## Tests and Publishing
 
 Charts are automatically tested and published via GitHub Actions.
 
@@ -114,7 +115,7 @@ Push main --> publish.yml --> Detect --> Semver --> Package --> Publish to GHCR 
 
 Both workflows dynamically detect which charts changed and run jobs only for those charts using a matrix strategy. Changes to docs (`README.md`, `examples/`, `docs/`) are ignored.
 
-The `CI` workflow runs for pull requests and pushes to `main` that affect chart templates, chart metadata, tests, or the workflow itself. The `Publish` workflow runs on pushes to `main` and publishes chart releases. Documentation-only changes are intentionally excluded from chart CI and release publishing.
+The `Tests` workflow runs for pull requests and pushes to `main` that affect chart templates, chart metadata, tests, or the workflow itself. The `Publish` workflow runs on pushes to `main` and publishes chart releases. Documentation-only changes are intentionally excluded from chart tests and release publishing.
 
 Quality gates include:
 
@@ -179,13 +180,19 @@ All charts require **Helm 4** (`apiVersion: v2`) and target **Kubernetes 1.26+**
 | 1.34.x | Supported |
 | 1.35.x | Supported |
 
-CI validates rendered manifests with [kubeconform](https://github.com/yannh/kubeconform) against the default Kubernetes JSON schemas. Local runtime validation uses [k3d](https://k3d.io/) clusters.
+The Tests workflow validates rendered manifests with [kubeconform](https://github.com/yannh/kubeconform) against the default Kubernetes JSON schemas. Local runtime validation uses [k3d](https://k3d.io/) clusters.
 
 Charts use standard stable APIs (`apps/v1`, `batch/v1`, `networking.k8s.io/v1`) and avoid alpha/beta API versions to maximize compatibility.
 
 ## Contributing
 
 Contributions are welcome. Please read the [contributing guide](CONTRIBUTING.md) for branch flow, validation requirements, commit conventions, and chart standards.
+
+## Contributors
+
+<a href="https://github.com/helmforgedev/charts/graphs/contributors">
+  <img src="https://repo.helmforge.dev/badges/contributors.svg" alt="HelmForge Charts contributors" />
+</a>
 
 ## License
 
@@ -194,11 +201,11 @@ MIT
 <!-- @AI-METADATA
 type: overview
 title: HelmForge Charts
-description: Helm chart repository overview, installation, charts list, and CI/CD
+description: Helm chart repository overview, installation, charts list, tests, and publishing
 
 keywords: helm, charts, oci, ghcr, repository, install
 
-purpose: Repository overview with charts list, installation, CI/CD, and contributing guide
+purpose: Repository overview with charts list, installation, tests, publishing, and contributing guide
 scope: Repository
 
 relations:

--- a/scripts/generate-contributors-image.mjs
+++ b/scripts/generate-contributors-image.mjs
@@ -1,0 +1,100 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const [repo = 'helmforgedev/charts', outputPath = 'badges/contributors.svg'] = process.argv.slice(2);
+const token = process.env.GITHUB_TOKEN;
+const maxContributors = Number.parseInt(process.env.CONTRIBUTORS_LIMIT ?? '24', 10);
+
+const headers = {
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'helmforge-contributors-badge',
+};
+
+if (token) {
+  headers.Authorization = `Bearer ${token}`;
+}
+
+async function fetchBuffer(url) {
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return Buffer.from(await response.arrayBuffer());
+}
+
+const contributorsResponse = await fetch(`https://api.github.com/repos/${repo}/contributors?per_page=100`, { headers });
+
+if (!contributorsResponse.ok) {
+  throw new Error(
+    `Failed to fetch contributors for ${repo}: ${contributorsResponse.status} ${contributorsResponse.statusText}`,
+  );
+}
+
+const contributors = await contributorsResponse.json();
+const humans = contributors.filter((contributor) => !contributor.login.endsWith('[bot]'));
+const selected = (humans.length > 0 ? humans : contributors).slice(0, maxContributors);
+
+const avatarSize = 64;
+const gap = 12;
+const labelHeight = 22;
+const padding = 12;
+const columns = Math.min(6, Math.max(1, selected.length));
+const rows = Math.max(1, Math.ceil(selected.length / columns));
+const width = padding * 2 + columns * avatarSize + (columns - 1) * gap;
+const height = padding * 2 + rows * (avatarSize + labelHeight + gap) - gap;
+
+const avatarImages = await Promise.all(
+  selected.map(async (contributor) => {
+    const image = await fetchBuffer(`${contributor.avatar_url}&s=${avatarSize * 2}`);
+    return {
+      ...contributor,
+      image: `data:image/png;base64,${image.toString('base64')}`,
+    };
+  }),
+);
+
+const escapedRepo = repo.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+const items = avatarImages
+  .map((contributor, index) => {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    const x = padding + column * (avatarSize + gap);
+    const y = padding + row * (avatarSize + labelHeight + gap);
+    const clipId = `avatar-${index}`;
+    const login = contributor.login
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;');
+
+    return `
+  <a href="${contributor.html_url}" target="_blank">
+    <clipPath id="${clipId}">
+      <circle cx="${x + avatarSize / 2}" cy="${y + avatarSize / 2}" r="${avatarSize / 2}" />
+    </clipPath>
+    <image href="${contributor.image}" x="${x}" y="${y}" width="${avatarSize}" height="${avatarSize}" clip-path="url(#${clipId})" />
+    <text x="${x + avatarSize / 2}" y="${y + avatarSize + 16}" text-anchor="middle">${login}</text>
+  </a>`;
+  })
+  .join('');
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" role="img" aria-labelledby="title desc">
+  <title id="title">Contributors for ${escapedRepo}</title>
+  <desc id="desc">Dynamic contributor avatars generated from GitHub contributors.</desc>
+  <style>
+    text {
+      fill: #24292f;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      font-size: 11px;
+      font-weight: 600;
+    }
+    @media (prefers-color-scheme: dark) {
+      text { fill: #f0f6fc; }
+    }
+  </style>${items}
+</svg>
+`;
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, svg);


### PR DESCRIPTION
## Summary

Related to #120.

- Rename the visible test workflow from `CI` to `Tests` while keeping the native GitHub Actions badge.
- Add a GitHub Stars badge using Shields.
- Add a dynamic contributors section backed by a generated SVG published to `gh-pages`.
- Update the Publish workflow so the contributors SVG is regenerated with the existing badge/index update step.

## Validation

- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:latest -shellcheck= .github/workflows/ci.yml .github/workflows/publish.yml`
- `git diff --check`
- `node scripts/generate-charts-count-badge.mjs . .tmp/charts-count.json`
- `node scripts/generate-contributors-image.mjs helmforgedev/charts .tmp/contributors.svg`

## HelmForge MCP

- `check_pr_validity`: allowed
- `validate_compliance`: WARN only, 0 blockers; existing GR-012 warning for README missing `SOURCE-OF-TRUTH.md`
- Runtime validation: not applicable, no chart manifests changed