### PR TITLE
docs(cncf): prepare sandbox governance and Apache licensing

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,58 @@
+# Adopters
+
+This file lists organizations, teams, and individuals using HelmForge in development, testing, homelab, platform, or production environments.
+
+Public adopter information helps the community understand where HelmForge is useful, which charts are being exercised, and what operational scenarios matter most.
+
+## Current Adopters
+
+HelmForge has public production adopters and welcomes additional entries from organizations, teams, and individuals.
+
+If you use HelmForge and are willing to be listed, open a pull request adding your entry to the table below.
+
+| Name | Website | Usage | Environment | Contact |
+|------|---------|-------|-------------|---------|
+| Deskbee | https://deskbee.co/ | PostgreSQL, Redis, and Generic charts for provisioning applications and APIs | production | N/A |
+| Bancorbras | https://grupobancorbras.com.br/ | PostgreSQL, Redis, Generic, Velero, MySQL, and Keycloak charts | production | N/A |
+| _Your organization or project here_ | _Optional_ | _Charts or use case_ | _dev / homelab / staging / production_ | _GitHub handle or email_ |
+
+## How To Add Your Organization
+
+Add a row to the table with:
+
+- name of the organization, team, project, or individual
+- optional website or public profile
+- charts or use case
+- environment type
+- optional contact for follow-up questions
+
+Example:
+
+```markdown
+| Example Platform Team | https://example.com | PostgreSQL, Redis, Vaultwarden | production | @example-maintainer |
+```
+
+## Privacy
+
+Only add adopter information you are authorized to publish.
+
+Maintainers may remove entries that are inaccurate, promotional without clear usage, or submitted without permission.
+
+<!-- @AI-METADATA
+type: guide
+title: Adopters
+description: Public adopter list and instructions for adding HelmForge usage
+
+keywords: adopters, users, adoption, cncf, community
+
+purpose: Track public HelmForge adopters and provide a contribution path for adopter entries
+scope: Repository
+
+relations:
+  - README.md
+  - CONTRIBUTING.md
+  - GOVERNANCE.md
+path: ADOPTERS.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Code of Conduct
+
+HelmForge is committed to providing a friendly, safe, respectful, and inclusive environment for everyone who participates in the project.
+
+## Our Standard
+
+Project participants are expected to:
+
+- use welcoming and inclusive language
+- respect differing viewpoints and experiences
+- accept constructive feedback gracefully
+- focus on what is best for the project and its users
+- show empathy toward other community members
+
+Unacceptable behavior includes:
+
+- harassment, intimidation, or discrimination in any form
+- sexualized language or imagery
+- personal attacks, insults, or sustained disruption
+- publishing private information without explicit permission
+- behavior that would reasonably make another participant feel unsafe or unwelcome
+
+## Scope
+
+This Code of Conduct applies to all HelmForge project spaces, including:
+
+- GitHub repositories, issues, pull requests, discussions, and reviews
+- project documentation and website contributions
+- chat, calls, events, and other community spaces operated by the project
+- public communication where someone is clearly representing HelmForge
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to the project maintainers:
+
+- email: berlofa@helmforge.dev
+- alternate email: maicon.berloffa@gmail.com
+- private vulnerability or sensitive project report: https://github.com/helmforgedev/charts/security/advisories/new
+
+Reports should include as much context as you are comfortable sharing, such as links, screenshots, timestamps, involved accounts, and a description of the impact.
+
+Maintainers will handle reports privately, avoid unnecessary disclosure, and take action proportionate to the situation.
+
+## Enforcement
+
+Maintainers may take any action they deem appropriate to protect the community, including:
+
+- privately warning a participant
+- asking for changes in language or behavior
+- moderating, hiding, or deleting comments
+- closing or locking issues, pull requests, or discussions
+- temporarily or permanently limiting participation in project spaces
+- escalating to hosting platforms or relevant community programs when needed
+
+Maintainers who are personally involved in a report should recuse themselves from enforcement decisions when possible.
+
+## Alignment With CNCF
+
+HelmForge uses the CNCF Code of Conduct as a reference for community expectations and intends to align with CNCF community standards as part of its Sandbox application process.
+
+Reference: https://www.cncf.io/conduct/
+
+<!-- @AI-METADATA
+type: guide
+title: Code of Conduct
+description: Community conduct expectations and reporting process for HelmForge
+
+keywords: code-of-conduct, community, reporting, enforcement, cncf
+
+purpose: Define expected community behavior and report handling for HelmForge project spaces
+scope: Repository
+
+relations:
+  - GOVERNANCE.md
+  - MAINTAINERS.md
+  - SECURITY.md
+path: CODE_OF_CONDUCT.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,10 @@ Conventional Commits drive semantic versioning and release notes.
 
 - [README.md](README.md)
 - [SECURITY.md](SECURITY.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [GOVERNANCE.md](GOVERNANCE.md)
+- [MAINTAINERS.md](MAINTAINERS.md)
+- [ADOPTERS.md](ADOPTERS.md)
 
 <!-- @AI-METADATA
 type: guide
@@ -158,7 +162,11 @@ relations:
   - README.md
   - .claude/AGENTS.md
   - SECURITY.md
+  - CODE_OF_CONDUCT.md
+  - GOVERNANCE.md
+  - MAINTAINERS.md
+  - ADOPTERS.md
 path: CONTRIBUTING.md
-version: 1.1
-date: 2026-04-01
+version: 1.2
+date: 2026-04-27
 -->

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,144 @@
+# Governance
+
+HelmForge is an open-source project for production-oriented Helm charts and related packaging workflows for Kubernetes.
+
+This document describes how the project is governed, how decisions are made, and how contributors can grow into project leadership.
+
+## Values
+
+HelmForge is guided by these values:
+
+- **Open source first**: charts, docs, tests, and release automation should remain open and usable without a paid tier.
+- **Vendor neutrality**: the project should avoid unnecessary lock-in to a commercial runtime, registry, image ecosystem, or hosting provider.
+- **Upstream alignment**: charts should prefer official upstream images and documented upstream behavior.
+- **Operational honesty**: charts should be explicit about what they do and do not manage. A Helm chart should not pretend to be an operator.
+- **Verifiable releases**: published artifacts should be reproducible, signed, and easy to verify.
+- **Practical defaults**: defaults should be useful for real Kubernetes operations while avoiding unsafe claims about production readiness.
+- **Respectful community**: participation should follow the project Code of Conduct.
+
+## Scope
+
+In scope:
+
+- Helm charts under `charts/`
+- chart values contracts, JSON schemas, tests, examples, and documentation
+- release automation for packaged charts
+- Helm repository and OCI distribution workflows
+- project website and documentation content related to HelmForge
+- supporting images or tools that are directly required by HelmForge charts
+- governance, contribution, security, and community processes
+
+Out of scope:
+
+- becoming a hosted platform or commercial control plane
+- replacing Helm, Kubernetes, GitOps controllers, or domain-specific operators
+- providing support guarantees or SLAs
+- maintaining forks of upstream applications except when a narrowly-scoped support image is explicitly documented
+- hiding commercial or proprietary functionality behind the open-source project
+
+## Roles
+
+### Users
+
+Users deploy HelmForge charts and may report issues, request charts, suggest improvements, or provide adoption feedback.
+
+### Contributors
+
+Contributors submit issues, documentation, examples, tests, chart changes, or review feedback.
+
+### Maintainers
+
+Maintainers have write access to project repositories and are responsible for review, merge decisions, releases, quality gates, and project direction.
+
+Current maintainers are listed in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Decision Making
+
+HelmForge uses lazy consensus for most decisions.
+
+A proposal is considered accepted when:
+
+- it is made in a public issue, pull request, or discussion
+- maintainers and contributors have had reasonable time to respond
+- no maintainer has raised a blocking objection
+- required checks and review expectations are satisfied
+
+Maintainers should seek explicit agreement for changes that affect:
+
+- project scope
+- governance
+- licensing
+- security policy
+- release signing
+- chart standards
+- public compatibility promises
+- CNCF application or foundation-related commitments
+
+If consensus cannot be reached, maintainers should document the disagreement and make a decision based on project values, user impact, maintainability, and security.
+
+## Pull Request Review
+
+Chart changes should follow [CONTRIBUTING.md](CONTRIBUTING.md) and pass the required validation workflow.
+
+Maintainers may merge changes when:
+
+- CI passes or failures are understood and documented
+- the change follows chart standards
+- user-visible behavior is documented
+- tests and schemas are updated when behavior or values change
+- release and site sync implications are understood
+
+Substantial changes should receive maintainer review before merge. Urgent security fixes, release automation repairs, and mechanical documentation updates may be merged faster when needed.
+
+## Releases
+
+Chart releases are automated through GitHub Actions.
+
+Maintainers do not manually create chart release tags or edit chart versions for normal releases. Conventional Commits drive chart semantic versioning and release notes.
+
+Published charts are distributed through:
+
+- HTTPS Helm repository: https://repo.helmforge.dev
+- OCI registry: `ghcr.io/helmforgedev/helm`
+- Artifact Hub: https://artifacthub.io/packages/search?repo=helmforge
+
+Release integrity is part of project governance. Signing, provenance, and publishing workflows should be treated as protected project infrastructure.
+
+## Security
+
+Security reporting and response expectations are defined in [SECURITY.md](SECURITY.md).
+
+Security-sensitive issues should not be discussed publicly until maintainers have assessed the report and coordinated an appropriate disclosure path.
+
+## Code of Conduct
+
+All project participants are expected to follow [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+Maintainers may take moderation or enforcement action when needed to protect contributors, users, and project spaces.
+
+## Changes To Governance
+
+Governance changes should be proposed through a pull request and should receive explicit maintainer approval before merge.
+
+When HelmForge is accepted into a foundation or changes its legal or governance obligations, this document should be updated to reflect the new requirements.
+
+<!-- @AI-METADATA
+type: guide
+title: Governance
+description: Governance model, project scope, values, roles, and decision process
+
+keywords: governance, maintainers, decision-making, scope, cncf
+
+purpose: Document how HelmForge is governed and how project decisions are made
+scope: Repository
+
+relations:
+  - MAINTAINERS.md
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+  - SECURITY.md
+  - ADOPTERS.md
+path: GOVERNANCE.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,55 @@
-MIT License
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/
 
-Copyright (c) 2026 mberlofa
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on or derived from the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link or bind by name to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution alone or by combination of their Contribution with the Work to which such Contribution was submitted. If You institute patent litigation against any entity, including a cross-claim or counterclaim in a lawsuit, alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort, including negligence, contract, or otherwise, unless required by applicable law, such as deliberate and grossly negligent acts, or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work, including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,81 @@
+# Maintainers
+
+Maintainers are responsible for the long-term health, direction, quality, and release integrity of HelmForge.
+
+## Current Maintainers
+
+| Name | GitHub | Role | Areas |
+|------|--------|------|-------|
+| Maicon Berlofa | [@mberlofa](https://github.com/mberlofa) | Founder and maintainer | Charts, release automation, documentation, governance |
+| HelmForge Maintainers | [@helmforgedev](https://github.com/helmforgedev) | Project maintainer group | Repository administration, releases, project coordination |
+
+## Responsibilities
+
+Maintainers are expected to:
+
+- review and merge pull requests
+- keep chart quality gates healthy
+- maintain release automation and signing workflows
+- triage issues and security reports
+- protect project scope and technical direction
+- document user-visible behavior and operational boundaries
+- promote healthy community participation
+- follow the project Code of Conduct
+
+## Maintainer Expectations
+
+Maintainers should:
+
+- act in the interest of the project, users, and community
+- make decisions transparently in public issues and pull requests whenever possible
+- disclose conflicts of interest when they affect a decision
+- avoid merging their own substantial changes without review unless the change is urgent or mechanical
+- keep security-sensitive discussions private until disclosure is appropriate
+- preserve the vendor-neutral and open-source character of the project
+
+## Becoming a Maintainer
+
+Regular contributors may be invited to become maintainers when they have demonstrated:
+
+- sustained, high-quality contributions
+- sound technical judgment
+- respectful collaboration
+- familiarity with HelmForge chart standards and release workflows
+- reliability in reviews, issue triage, or documentation work
+
+A maintainer nomination should be opened as a public issue or discussion unless privacy is required. Existing maintainers decide by lazy consensus as described in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Emeritus Maintainers
+
+Maintainers may step down at any time. A maintainer may also be moved to emeritus status after a long period of inactivity, lack of response to maintainer pings, or by their own request.
+
+Emeritus maintainers are welcome to return through the normal maintainer process when they become active again.
+
+## Contact
+
+General project contact:
+
+- berlofa@helmforge.dev
+- maicon.berloffa@gmail.com
+
+Security-sensitive reports should follow [SECURITY.md](SECURITY.md).
+
+<!-- @AI-METADATA
+type: guide
+title: Maintainers
+description: Maintainer list, responsibilities, expectations, and nomination process
+
+keywords: maintainers, governance, roles, responsibilities, community
+
+purpose: Identify HelmForge maintainers and define maintainer responsibilities and expectations
+scope: Repository
+
+relations:
+  - GOVERNANCE.md
+  - CODE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+  - SECURITY.md
+path: MAINTAINERS.md
+version: 1.0
+date: 2026-04-27
+-->

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/helmforgedev/charts/actions/workflows/ci.yml"><img src="https://github.com/helmforgedev/charts/actions/workflows/ci.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/helmforgedev/charts/actions/workflows/publish.yml"><img src="https://github.com/helmforgedev/charts/actions/workflows/publish.yml/badge.svg" alt="Publish" /></a>
   <a href="https://github.com/helmforgedev/charts/stargazers"><img src="https://img.shields.io/github/stars/helmforgedev/charts?style=flat&label=Stars&logo=github" alt="GitHub stars" /></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
+  <a href="https://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" alt="License: Apache-2.0" /></a>
   <a href="https://artifacthub.io/packages/search?repo=helmforge"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/helmforge" alt="Artifact Hub" /></a>
   <img src="https://img.shields.io/endpoint?url=https://repo.helmforge.dev/badges/charts-count.json" alt="Charts count" />
   <img src="https://img.shields.io/badge/Signed-GPG%20%2B%20Cosign-brightgreen" alt="GPG + Cosign Signed" />
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <a href="https://helmforge.dev">Website</a> · <a href="https://helmforge.dev/docs">Documentation</a> · <a href="https://repo.helmforge.dev">Helm Repository</a> · <a href="CONTRIBUTING.md">Contributing</a>
+  <a href="https://helmforge.dev">Website</a> · <a href="https://helmforge.dev/docs">Documentation</a> · <a href="https://repo.helmforge.dev">Helm Repository</a> · <a href="CONTRIBUTING.md">Contributing</a> · <a href="GOVERNANCE.md">Governance</a>
 </p>
 
 ## Quick Start
@@ -73,7 +73,7 @@ HelmForge is built on a simple principle: **use what upstream ships, make the Ku
 
 - **Official upstream images** — charts prefer images published by the application maintainers. No proprietary rebuild layer or vendor-specific runtime wrapper.
 - **Pinned version tags** — charts reference explicit, immutable image tags. No `:latest`, no floating tags, no surprises after a pull.
-- **MIT licensed** — the charts, tests, and docs are MIT. No open-core, no paid tiers, no license changes down the road.
+- **Apache-2.0 licensed** — the charts, tests, and docs use a CNCF-aligned permissive license. No open-core, no paid tiers, no license traps.
 - **GPG + Cosign signed** — every release includes GPG provenance files for Helm verification and [Sigstore Cosign](https://www.sigstore.dev/) keyless signatures on OCI artifacts via GitHub Actions OIDC.
 - **No vendor lock-in** — standard Helm, standard Kubernetes APIs, standard images. If you stop using HelmForge tomorrow, nothing breaks.
 - **Explicit values contracts** — product-oriented `values.yaml` files map directly to application and Kubernetes configuration, with schemas and validations where they prevent bad releases.
@@ -188,6 +188,14 @@ Charts use standard stable APIs (`apps/v1`, `batch/v1`, `networking.k8s.io/v1`) 
 
 Contributions are welcome. Please read the [contributing guide](CONTRIBUTING.md) for branch flow, validation requirements, commit conventions, and chart standards.
 
+Community and project governance documents:
+
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Governance](GOVERNANCE.md)
+- [Maintainers](MAINTAINERS.md)
+- [Adopters](ADOPTERS.md)
+- [Security Policy](SECURITY.md)
+
 ## Contributors
 
 <a href="https://github.com/helmforgedev/charts/graphs/contributors">
@@ -196,7 +204,7 @@ Contributions are welcome. Please read the [contributing guide](CONTRIBUTING.md)
 
 ## License
 
-MIT
+Apache License 2.0
 
 <!-- @AI-METADATA
 type: overview
@@ -211,8 +219,14 @@ scope: Repository
 relations:
   - .claude/AGENTS.md
   - docs/testing-strategy.md
+  - CONTRIBUTING.md
+  - CODE_OF_CONDUCT.md
+  - GOVERNANCE.md
+  - MAINTAINERS.md
+  - ADOPTERS.md
+  - SECURITY.md
 path: README.md
-version: 1.0
+version: 1.1
 date: 2026-04-01
 updated: 2026-04-27
 -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ If you discover a security vulnerability in any HelmForge chart, please report i
 Instead, use one of the following methods:
 
 1. **GitHub Security Advisories** (preferred): [Report a vulnerability](https://github.com/helmforgedev/charts/security/advisories/new)
-2. **Email**: <helmforgedev@users.noreply.github.com>
+2. **Email**: <berlofa@helmforge.dev> or <maicon.berloffa@gmail.com>
 
 ### What to include
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -4,4 +4,4 @@
 repositoryID: "ae1b564e-9d42-4d68-a206-d4422b2be115"
 owners:
   - name: helmforgedev
-    email: helmforgedev@users.noreply.github.com
+    email: berlofa@helmforge.dev

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -28,7 +28,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -37,7 +37,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: networking
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: alfio
 description: Open-source event management and ticketing platform with PostgreSQL backend
 type: application
@@ -25,7 +25,7 @@ annotations:
       description: remove artifacthub.io/changes from all charts (#50)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -33,7 +33,7 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: answer
 description: Apache Answer Q&A platform with SQLite, MySQL, or PostgreSQL support
 type: application
@@ -26,7 +26,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: appwrite
 description: Appwrite self-hosted backend-as-a-service platform with MariaDB and Redis
 type: application
@@ -29,7 +29,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -38,7 +38,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: storage
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: authelia
 description: Authelia authentication and authorization server with SSO, MFA, and OpenID Connect
 type: application
@@ -27,7 +27,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: security
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: automatisch
 description: Open-source business automation platform â€” self-hosted Zapier alternative with PostgreSQL and Redis
 icon: https://helmforge.dev/icons/charts/automatisch.png
@@ -25,7 +25,7 @@ annotations:
       description: remove artifacthub.io/changes from all charts (#50)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -33,7 +33,7 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: castopod
 description: Castopod open-source podcast hosting platform with MariaDB and optional Redis
 type: application
@@ -25,7 +25,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: chiefonboarding
 description: ChiefOnboarding employee onboarding automation platform with PostgreSQL backend
 type: application
@@ -26,7 +26,7 @@ annotations:
       description: remove artifacthub.io/changes from all charts (#50)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: ckan
 description: CKAN open data portal with DataPusher, Solr, PostgreSQL, and Redis
 type: application
@@ -26,10 +26,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "cloudflare"
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: networking
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -32,7 +32,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -41,7 +41,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/cronicle/Chart.yaml
+++ b/charts/cronicle/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/ddns-updater/Chart.yaml
+++ b/charts/ddns-updater/Chart.yaml
@@ -27,7 +27,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: networking
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -33,7 +33,7 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: docmost
 description: Docmost collaborative wiki and documentation software with PostgreSQL, Redis, local storage, and optional S3
 type: application
@@ -28,10 +28,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: dolibarr
 type: application
 version: 1.2.7
@@ -27,10 +27,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: druid
 description: Apache Druid distributed analytics database with coordinator, broker, historical, middlemanager, overlord, and router
 type: application
@@ -26,10 +26,10 @@ annotations:
       description: remove artifacthub.io/changes from all charts (#50)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -27,7 +27,7 @@ annotations:
       description: harden chart for production (#107)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: alpha
@@ -38,7 +38,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
@@ -32,11 +32,11 @@ annotations:
       description: bump all subchart dependencies to latest helmforge versions (#110)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   artifacthub.io/category: networking
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "true"
   helmforge.dev/maturity: beta
   helmforge.dev/signed: gpg+cosign

--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -27,7 +27,7 @@ annotations:
       description: restore chart v1.4.3 (#116)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: incubating
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/links: |
     - name: Docker Image

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: flowise
 description: Flowise visual AI orchestration with standalone SQLite mode or scalable queue mode backed by Redis and PostgreSQL
 type: application
@@ -28,10 +28,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -16,7 +16,7 @@ annotations:
       description: validate disabled-service route targets (#119)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -25,7 +25,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Documentation

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
@@ -27,7 +27,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: gitea
 description: Gitea â€” self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
@@ -25,10 +25,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: guacamole
 description: Apache Guacamole clientless remote desktop gateway with guacd, PostgreSQL or MySQL, OIDC/SAML SSO, and S3 backup
 type: application
@@ -29,7 +29,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -38,7 +38,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: networking
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -26,10 +26,10 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: homarr
 description: Homarr â€” modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
@@ -24,10 +24,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: streaming-messaging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -33,7 +33,7 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: keycloak
 description: Keycloak for Kubernetes with explicit dev and production modes
 home: https://helmforge.dev
@@ -21,7 +21,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -30,7 +30,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: security
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: storage
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: listmonk
 description: Listmonk self-hosted newsletter and mailing list manager with PostgreSQL
 type: application
@@ -26,10 +26,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -23,7 +23,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "maria"
@@ -33,7 +33,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
@@ -26,7 +26,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: middleware
 description: Middleware open-source DORA metrics platform with PostgreSQL and Redis for engineering team performance
 type: application
@@ -36,7 +36,7 @@ annotations:
       description: remove artifacthub.io/changes from all charts (#50)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -45,7 +45,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -28,7 +28,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -37,7 +37,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "mongo"
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -263,7 +263,7 @@ Key differences from the Bitnami MongoDB chart:
 |--------|-----------|---------|
 | Image | Official `mongo` | `bitnami/mongodb` |
 | Data path | `/data/db` | `/bitnami/mongodb` |
-| License | MIT | Custom (restricted) |
+| License | Apache-2.0 | Custom (restricted image terms) |
 | values.yaml | ~200 lines | ~2000+ lines |
 | Templates | ~15 files | ~30+ files |
 | Dependencies | None | `bitnami/common` library |

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -26,10 +26,10 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: streaming-messaging
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -23,7 +23,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -32,7 +32,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
@@ -25,7 +25,7 @@ annotations:
       description: align metadata and remove bump yaml files (#83)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: open-webui
 description: Open WebUI â€” self-hosted AI chat platform with Ollama and OpenAI support, RAG, multi-model conversations, and extensible plugin system
 type: application
@@ -29,10 +29,10 @@ annotations:
       description: align metadata and remove bump yaml files (#83)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: ai-machine-learning
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/openhab/Chart.yaml
+++ b/charts/openhab/Chart.yaml
@@ -27,10 +27,10 @@ annotations:
       description: initial implementation (#73)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berlofaa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/prerelease: "true"
   helmforge.dev/maturity: beta

--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -27,10 +27,10 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
       description: run gravity update after managed lists (#101)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: networking
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -24,7 +24,7 @@ annotations:
       description: harden fastmcp reload and postgresql auth (#114)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "postgres"
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   artifacthub.io/alternativeName: "rabbit"
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: streaming-messaging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: database
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
@@ -26,7 +26,7 @@ annotations:
       description: update to base image v0.0.3 with working health check (#71)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -35,7 +35,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -27,7 +27,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -36,7 +36,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: superset
 description: Apache Superset BI platform with web, worker, and beat deployments backed by PostgreSQL and Redis
 type: application
@@ -27,10 +27,10 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: umami
 description: Umami privacy-first web analytics with PostgreSQL backend
 type: application
@@ -25,7 +25,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: uptime-kuma
 description: Uptime Kuma self-hosted monitoring with HTTP/TCP/DNS/Ping checks, notifications, status pages, and optional MariaDB
 type: application
@@ -25,7 +25,7 @@ annotations:
       description: align metadata and remove bump yaml files (#83)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: monitoring-logging
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: vaultwarden
 description: Vaultwarden for Kubernetes with persistent SQLite storage and explicit ingress/domain configuration
 type: application
@@ -24,7 +24,7 @@ annotations:
       description: align metadata and remove bump yaml files (#83)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -33,7 +33,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: security
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
       description: fix database secret mismatch and runtime compatibility issues (#109)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: storage
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: wallabag
 description: Wallabag self-hosted read-it-later application with PostgreSQL and optional Redis
 type: application
@@ -25,7 +25,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: skip-prediction
   artifacthub.io/links: |
     - name: Official Website

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -1,4 +1,4 @@
-﻿apiVersion: v2
+apiVersion: v2
 name: wordpress
 type: application
 version: 1.4.7
@@ -25,7 +25,7 @@ annotations:
       description: update minio mc image to helmforge/mc:1.0.0 (#57)
   artifacthub.io/maintainers: |
     - name: HelmForge
-      email: helmforgedev@users.noreply.github.com
+      email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
@@ -34,7 +34,7 @@ annotations:
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
     url: https://repo.helmforge.dev/pgp-public-key.asc
   helmforge.dev/repository: https://repo.helmforge.dev
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
   artifacthub.io/links: |
     - name: Official Website


### PR DESCRIPTION
## Summary
- Adds CNCF Sandbox readiness documents: Code of Conduct, Maintainers, Adopters, and Governance.
- Adds Deskbee and Bancorbras as production adopters with chart usage details.
- Aligns chart metadata, repository docs, Artifact Hub metadata, and project license to Apache-2.0.

## Validation
- [x] `helm lint` for all charts in `charts/`

## Context
Prepared as part of HelmForge CNCF Sandbox readiness work.