### PR TITLE
feat(mysql): add dual-stack ipFamilyPolicy/ipFamilies support

### DIFF
--- a/charts/mysql/ci/dual-stack.yaml
+++ b/charts/mysql/ci/dual-stack.yaml
@@ -1,0 +1,22 @@
+# CI scenario: dual-stack networking via service.ipFamilyPolicy.
+#
+# Uses PreferDualStack policy without explicit ipFamilies so this scenario
+# works on both single-stack (IPv4-only) and dual-stack clusters. The
+# Kubernetes API rejects an explicit ipFamilies entry that the cluster
+# does not advertise, so the explicit-families variant requires a
+# dual-stack cluster (e.g. k3d --k3s-arg "--cluster-cidr=...IPv6...").
+#
+# To test explicit families on a dual-stack cluster, also set:
+#   service:
+#     ipFamilies:
+#       - IPv4
+#       - IPv6
+#
+architecture: standalone
+
+standalone:
+  persistence:
+    enabled: false
+
+service:
+  ipFamilyPolicy: PreferDualStack

--- a/charts/mysql/templates/NOTES.txt
+++ b/charts/mysql/templates/NOTES.txt
@@ -44,3 +44,6 @@ Important:
 
 - replication mode provides one fixed source and asynchronous read replicas
 - the chart does not implement automatic source promotion or operator-style HA
+{{- with .Values.service.ipFamilyPolicy }}
+- Service IP family policy: `{{ . }}`{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
+{{- end }}

--- a/charts/mysql/templates/service-headless.yaml
+++ b/charts/mysql/templates/service-headless.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mysql
       port: {{ .Values.service.port }}
@@ -24,6 +31,13 @@ metadata:
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mysql
       port: {{ .Values.service.port }}

--- a/charts/mysql/templates/service.yaml
+++ b/charts/mysql/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mysql
       port: {{ .Values.service.port }}
@@ -31,6 +38,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
@@ -52,6 +66,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mysql
       port: {{ .Values.service.port }}
@@ -74,6 +95,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
@@ -95,6 +123,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mysql
       port: {{ .Values.service.port }}
@@ -117,6 +152,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}

--- a/charts/mysql/tests/service_dualstack_test.yaml
+++ b/charts/mysql/tests/service_dualstack_test.yaml
@@ -1,0 +1,104 @@
+suite: Service dual-stack
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should omit ipFamilyPolicy and ipFamilies by default
+    asserts:
+      - notExists:
+          path: spec.ipFamilyPolicy
+      - notExists:
+          path: spec.ipFamilies
+
+  - it: should set ipFamilyPolicy on client service when configured
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+
+  - it: should set ipFamilies in declared order
+    set:
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
+  - it: should accept SingleStack policy
+    set:
+      service.ipFamilyPolicy: SingleStack
+      service.ipFamilies:
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6
+
+  - it: should accept RequireDualStack policy
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: RequireDualStack
+
+  - it: should propagate ipFamilyPolicy to all 6 services in replication+metrics mode
+    set:
+      architecture: replication
+      metrics.enabled: true
+      replication.readReplicas.replicaCount: 1
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      # Document 0: client service
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        documentIndex: 0
+      # Document 1: metrics service
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+        documentIndex: 1
+      # Document 2: source service (mysql calls primary "source")
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 2
+      # Document 3: source metrics service
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 3
+      # Document 4: replicas service
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 4
+      # Document 5: replicas metrics service
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 5

--- a/charts/mysql/tests/service_headless_dualstack_test.yaml
+++ b/charts/mysql/tests/service_headless_dualstack_test.yaml
@@ -1,0 +1,65 @@
+suite: Service headless dual-stack
+templates:
+  - service-headless.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should omit ipFamilyPolicy and ipFamilies on source headless by default
+    asserts:
+      - notExists:
+          path: spec.ipFamilyPolicy
+      - notExists:
+          path: spec.ipFamilies
+
+  - it: should preserve clusterIP=None when dual-stack is configured
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+
+  - it: should set ipFamilyPolicy on both headless services in replication mode
+    set:
+      architecture: replication
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      # Document 0: source headless
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        documentIndex: 0
+      - equal:
+          path: spec.clusterIP
+          value: None
+        documentIndex: 0
+      # Document 1: replicas headless
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        documentIndex: 1
+      - equal:
+          path: spec.clusterIP
+          value: None
+        documentIndex: 1

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -471,6 +471,21 @@
           "type": "integer",
           "description": "Metrics port exposed when metrics.enabled=true",
           "default": 9104
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Service IP family policy. One of SingleStack, PreferDualStack, RequireDualStack. Omit for cluster default.",
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Ordered list of IP families for the Service. Each entry is IPv4 or IPv6. Omit for cluster default.",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          },
+          "maxItems": 2,
+          "uniqueItems": true
         }
       }
     },

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -189,6 +189,14 @@ service:
   port: 3306
   # -- Metrics port exposed when metrics.enabled=true
   metricsPort: 9104
+  # -- IP family policy. One of: SingleStack | PreferDualStack | RequireDualStack. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilyPolicy: PreferDualStack
+  # -- Ordered list of IP families for the Service. Each entry: IPv4 | IPv6. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
 
 # =============================================================================
 # Metrics


### PR DESCRIPTION
## Summary

Adds Kubernetes dual-stack (IPv4/IPv6) networking support to the mysql chart by exposing `service.ipFamilyPolicy` and `service.ipFamilies`. Both default to nil — existing installs render identically and inherit whatever the cluster advertises. Pattern matches the postgresql implementation (helmforgedev/charts#127) and the reference shipped in the `generic` chart.

The two values propagate to **every chart-managed Service**:
- client (`mysql.clientServiceName`)
- metrics (when `metrics.enabled=true`)
- source + source-metrics (replication mode)
- replicas + replicas-metrics (replication mode)
- source headless + replicas headless (StatefulSet head)

## Changes

| File | Change |
|---|---|
| `templates/service.yaml` | Inject `ipFamilyPolicy` / `ipFamilies` into all 6 Service specs |
| `templates/service-headless.yaml` | Inject into both headless variants |
| `values.yaml` | Add documented commented stubs under `service:` |
| `values.schema.json` | Add enum-validated `service.ipFamilyPolicy` and `service.ipFamilies` array |
| `templates/NOTES.txt` | Surface the active policy when set |
| `tests/service_dualstack_test.yaml` | 6 helm-unittest cases |
| `tests/service_headless_dualstack_test.yaml` | 3 helm-unittest cases |
| `ci/dual-stack.yaml` | New CI scenario exercising `PreferDualStack` |

## Quality evidence

- `helm lint charts/mysql --strict`: 0 chart(s) failed
- `helm unittest charts/mysql`: 42/42 tests pass (8 suites; +9 new dual-stack tests)
- `kubeconform -strict -kubernetes-version 1.30.0` on default render: 6/6 valid
- `kubeconform` on `ci/dual-stack.yaml`: 6/6 valid
- MCP `validate_chart`: 0 blockers (1 pre-existing GR-003 warn about manual version field, unchanged by this PR)
- Chart.yaml `version` field untouched (GR-003): verified via `git diff main`

## k3d local validation (GR-027)

Cluster: `k3d-charts-test` (single-stack IPv4, k3s v1.31.5).

**Scenario — `ci/dual-stack.yaml` (PreferDualStack policy):**
```
helm install my-ds ./charts/mysql -f charts/mysql/ci/dual-stack.yaml -n my-ds --create-namespace --wait --timeout 5m
```
Result: pod `my-ds-mysql-0` Running 1/1 in ~45s; logs clean (mysql 8.4.8 ready for connections); both Services show `ipFamilyPolicy=PreferDualStack` with `ipFamilies=[IPv4]` (graceful single-stack fallback). Headless Service preserves `clusterIP=None`.

Note on `RequireDualStack` and explicit `ipFamilies: [IPv4, IPv6]`: validating those paths requires a dual-stack k3d cluster; the `ci/dual-stack.yaml` scenario uses `PreferDualStack` without explicit families so it works on any cluster (the K8s API rejects an explicit family the cluster does not advertise, regardless of policy).

## Site documentation (GR-007)

Companion site PR: helmforgedev/site#178

Adds a "Dual-stack Networking" section and two rows in the Key Values table.

## Resolves

Related to #125