### PR TITLE
feat(drupal): add dual-stack ipFamilyPolicy/ipFamilies support

### DIFF
--- a/charts/drupal/ci/dual-stack-values.yaml
+++ b/charts/drupal/ci/dual-stack-values.yaml
@@ -1,0 +1,26 @@
+# CI scenario: dual-stack networking via service.ipFamilyPolicy.
+#
+# Uses PreferDualStack policy without explicit ipFamilies so this scenario
+# works on both single-stack (IPv4-only) and dual-stack clusters. The
+# Kubernetes API rejects an explicit ipFamilies entry that the cluster
+# does not advertise, so the explicit-families variant requires a
+# dual-stack cluster (e.g. k3d --k3s-arg "--cluster-cidr=...IPv6...").
+#
+# To test explicit families on a dual-stack cluster, also set:
+#   service:
+#     ipFamilies:
+#       - IPv4
+#       - IPv6
+#
+service:
+  ipFamilyPolicy: PreferDualStack
+
+# Use SQLite so this scenario does not depend on an external database.
+database:
+  mode: sqlite
+
+mysql:
+  enabled: false
+
+persistence:
+  enabled: false

--- a/charts/drupal/templates/service.yaml
+++ b/charts/drupal/templates/service.yaml
@@ -11,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "drupal.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: drupal

--- a/charts/drupal/tests/service_dualstack_test.yaml
+++ b/charts/drupal/tests/service_dualstack_test.yaml
@@ -1,0 +1,73 @@
+suite: Service dual-stack
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should omit ipFamilyPolicy and ipFamilies by default
+    asserts:
+      - notExists:
+          path: spec.ipFamilyPolicy
+      - notExists:
+          path: spec.ipFamilies
+
+  - it: should set ipFamilyPolicy when configured
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+
+  - it: should set ipFamilies in declared order
+    set:
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
+  - it: should accept SingleStack policy with IPv6
+    set:
+      service.ipFamilyPolicy: SingleStack
+      service.ipFamilies:
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6
+
+  - it: should accept RequireDualStack policy
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: RequireDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+
+  - it: should preserve service type alongside dual-stack fields
+    set:
+      service.type: NodePort
+      service.ipFamilyPolicy: PreferDualStack
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack

--- a/charts/drupal/values.schema.json
+++ b/charts/drupal/values.schema.json
@@ -113,7 +113,22 @@
           "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
         },
         "port": { "type": "integer" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Service IP family policy. One of SingleStack, PreferDualStack, RequireDualStack. Omit for cluster default.",
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Ordered list of IP families for the Service. Each entry is IPv4 or IPv6. Omit for cluster default.",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          },
+          "maxItems": 2,
+          "uniqueItems": true
+        }
       }
     },
     "ingress": {

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -134,6 +134,14 @@ service:
   port: 80
   # -- Annotations for the service
   annotations: {}
+  # -- IP family policy. One of: SingleStack | PreferDualStack | RequireDualStack. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilyPolicy: PreferDualStack
+  # -- Ordered list of IP families for the Service. Each entry: IPv4 | IPv6. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
 
 # =============================================================================
 # Ingress


### PR DESCRIPTION
## Summary

Adds Kubernetes dual-stack (IPv4/IPv6) networking support to the drupal chart by exposing `service.ipFamilyPolicy` and `service.ipFamilies`. Both default to nil — existing installs render identically and inherit whatever the cluster advertises. Pattern matches the postgresql (helmforgedev/charts#127) and mysql (helmforgedev/charts#128) implementations and the reference shipped in the `generic` chart.

Drupal exposes a single Service, so the change is scoped to that one spec.

## Changes

| File | Change |
|---|---|
| `templates/service.yaml` | Inject `ipFamilyPolicy` / `ipFamilies` into the Service spec |
| `values.yaml` | Add documented commented stubs under `service:` |
| `values.schema.json` | Add enum-validated `service.ipFamilyPolicy` and `service.ipFamilies` array |
| `tests/service_dualstack_test.yaml` | 6 helm-unittest cases (default, each policy, mixed with NodePort type) |
| `ci/dual-stack-values.yaml` | New CI scenario exercising `PreferDualStack` (SQLite mode for self-contained CI) |

NOTES.txt is intentionally unchanged: drupal's NOTES is a user-facing access dashboard (URLs, install steps); the dual-stack values are a network-layer detail covered by site documentation.

## Quality evidence

- `helm lint charts/drupal --strict`: 0 chart(s) failed (after `helm dependency update`)
- `helm unittest charts/drupal`: 53/53 tests pass (10 suites; +6 new dual-stack tests)
- `kubeconform -strict -kubernetes-version 1.30.0` on `ci/dual-stack-values.yaml`: 2/2 valid
- `kubeconform` on `ci/sqlite-values.yaml`: 2/2 valid
- MCP `validate_chart`: 0 blockers (1 pre-existing GR-003 warn about manual version field, unchanged by this PR)
- Chart.yaml `version` field untouched (GR-003): verified via `git diff main`

## k3d local validation (GR-027)

Cluster: `k3d-charts-test` (single-stack IPv4, k3s v1.31.5).

**Scenario — `ci/dual-stack-values.yaml` (PreferDualStack policy):**
```
helm install drupal-ds ./charts/drupal -f charts/drupal/ci/dual-stack-values.yaml -n drupal-ds --create-namespace --wait --timeout 5m
```
Result: pod Running 1/1 in ~32s; Apache serving `/core/install.php` with HTTP 200 to kube-probe; Service shows `ipFamilyPolicy=PreferDualStack` with `ipFamilies=[IPv4]` (graceful single-stack fallback).

Note on `RequireDualStack` and explicit `ipFamilies: [IPv4, IPv6]`: validating those paths requires a dual-stack k3d cluster; the `ci/dual-stack-values.yaml` scenario uses `PreferDualStack` without explicit families so it works on any cluster (the K8s API rejects an explicit family the cluster does not advertise, regardless of policy).

## Site documentation (GR-007)

Companion site PR: helmforgedev/site#179

Adds a "Dual-stack Networking" section and two rows in the Service values table.

## Resolves

Related to #125