### PR TITLE
ci(charts): run tests only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,6 @@ on:
       - '!charts/**/examples/**'
       - '!charts/**/docs/**'
       - '.github/workflows/ci.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'charts/**'
-      - '!charts/**/README.md'
-      - '!charts/**/examples/**'
-      - '!charts/**/docs/**'
-      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Remove the `push` trigger from the chart `Tests` workflow.
- Keep chart validation on pull requests targeting `main`.

## Validation
- `git diff --check`
- HelmForge MCP `validate_compliance`: 41/41 passed
- HelmForge MCP `check_release_readiness`: passed

## Notes
- This is a CI trigger-only change. No chart templates, values, runtime behavior, or chart documentation changed.