### PR TITLE
ci(workflows): add Phase 1 GitHub automation — community, PR governance, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    open-pull-requests-limit: 5

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,0 +1,44 @@
+name: Community
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 6:00 AM UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Close stale issues and PRs
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Mark stale after 20 days of inactivity
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: |
+            👋 This issue has been automatically marked as **stale** because it has not had recent activity for 20 days.
+
+            It will be closed in 10 days if no further activity occurs.
+            If this is still relevant, please add a comment or remove the `stale` label.
+
+            Thank you for helping improve HelmForge! 🔥
+          stale-pr-message: |
+            👋 This Pull Request has been automatically marked as **stale** because it has not had recent activity for 20 days.
+
+            It will be closed in 10 days if no further activity occurs.
+            Please rebase and update if you'd like to keep this open.
+          close-issue-message: |
+            🔒 This issue was closed automatically after 30 days of inactivity.
+            Feel free to reopen if the issue persists — we're always here to help!
+          close-pr-message: |
+            🔒 This PR was closed automatically after 30 days of inactivity.
+            Feel free to reopen with updated changes when you're ready.
+          days-before-stale: 20
+          days-before-close: 10
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'on-hold,critical,security,work-in-progress'
+          exempt-pr-labels: 'on-hold,critical,security,work-in-progress'
+          operations-per-run: 100

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,131 @@
+name: PR Governance
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-label:
+    name: Auto Label
+    runs-on: ubuntu-latest
+    if: github.event.action != 'edited'
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+
+            const labels = new Set();
+            const charts = new Set();
+
+            for (const file of files) {
+              // Detect chart scope
+              const chartMatch = file.filename.match(/^charts\/([^/]+)\//);
+              if (chartMatch) {
+                charts.add(chartMatch[1]);
+                labels.add(`chart:${chartMatch[1]}`);
+              }
+
+              // Detect area
+              if (file.filename.includes('values.yaml')) labels.add('area:values');
+              if (file.filename.includes('values.schema.json')) labels.add('area:schema');
+              if (file.filename.includes('/templates/')) labels.add('area:templates');
+              if (file.filename.includes('/tests/')) labels.add('area:tests');
+              if (file.filename.includes('.github/')) labels.add('area:ci');
+              if (file.filename.endsWith('.md')) labels.add('area:docs');
+            }
+
+            // Size labels based on total lines changed
+            const totalChanges = files.reduce((acc, f) => acc + f.changes, 0);
+            if (totalChanges <= 10) labels.add('size:XS');
+            else if (totalChanges <= 50) labels.add('size:S');
+            else if (totalChanges <= 200) labels.add('size:M');
+            else if (totalChanges <= 500) labels.add('size:L');
+            else labels.add('size:XL');
+
+            // Multi-chart detection
+            if (charts.size > 3) labels.add('multi-chart');
+
+            const labelsArray = [...labels];
+            if (labelsArray.length > 0) {
+              // Create labels that don't exist yet
+              const { data: existingLabels } = await github.rest.issues.listLabelsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              });
+              const existingNames = new Set(existingLabels.map(l => l.name));
+
+              for (const label of labelsArray) {
+                if (!existingNames.has(label)) {
+                  let color = '0e8a16'; // green default
+                  if (label.startsWith('chart:')) color = '1d76db';
+                  else if (label.startsWith('area:')) color = 'e4e669';
+                  else if (label.startsWith('size:')) color = 'c5def5';
+                  else if (label === 'multi-chart') color = 'd93f0b';
+
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: label,
+                      color: color
+                    });
+                  } catch (e) {
+                    // Label may have been created concurrently
+                    if (e.status !== 422) throw e;
+                  }
+                }
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labelsArray
+              });
+
+              core.info(`Applied labels: ${labelsArray.join(', ')}`);
+            }
+
+  conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            release
+          requireScope: true
+          subjectPattern: ^.{1,80}$
+          subjectPatternError: |
+            PR title subject must be between 1 and 80 characters.
+            Expected format: type(scope): description
+            
+            Examples:
+              feat(n8n): add dual-stack support
+              fix(redis): correct password encoding
+              ci(workflows): add auto-labeling
+              docs(readme): update chart catalog


### PR DESCRIPTION
## Summary

- Add `dependabot.yml` for weekly GitHub Actions dependency updates
- Add `community.yml` workflow for stale issue/PR management (20d stale + 10d close)
- Add `pr-governance.yml` workflow with auto-labeling (chart, area, size) and conventional commits enforcement

Resolves Phase 1 of the GitHub Automation Roadmap.

## Type Of Change

- [ ] New chart
- [ ] Existing chart change
- [ ] Documentation only
- [x] CI / repository workflow

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually

## Local Validation

- [x] All new workflow files pass YAML syntax validation
- [x] All guardrails validated via MCP (41/41 PASS)
- [x] Release readiness check passed

## Notes

### Phase 1 Deliverables

| File | Purpose |
|---|---|
| `.github/dependabot.yml` | Weekly auto-update PRs for GitHub Actions |
| `.github/workflows/community.yml` | Stale bot: 20d mark + 10d close, exempt labels |
| `.github/workflows/pr-governance.yml` | Auto-labeling (chart/area/size) + conventional commits |