### PR TITLE
feat(keycloak)!: harden production chart for 26.6.1

### DIFF
--- a/charts/keycloak/.helmignore
+++ b/charts/keycloak/.helmignore
@@ -20,6 +20,7 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
+# Chart.lock remains versioned in Git for reproducible dependencies; lock files are omitted from packaged chart archives.
 *.lock
 
 # Logs

--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.1
+  version: 1.9.13
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.7.1
-digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
-generated: "2026-04-01T09:04:46.974886-03:00"
+  version: 1.8.7
+digest: sha256:22734ff1510c7f19765692a117dfb7ef7ab23ba9e4bb65a8302b223d000b3744
+generated: "2026-04-28T18:45:27.6275749-03:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -5,7 +5,7 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 2.7.6
-appVersion: "26.5.5"
+appVersion: "26.6.1"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - keycloak
@@ -46,10 +46,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 1.9.13
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.8.5
+    version: 1.8.7
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: keycloak
 description: Keycloak for Kubernetes with explicit dev and production modes

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -76,15 +76,15 @@ Recommended reading before installation:
 
 ## Official product references
 
-- Keycloak downloads: https://www.keycloak.org/downloads
-- Keycloak release notes: https://www.keycloak.org/docs/latest/release_notes/index.html
-- Keycloak production configuration: https://www.keycloak.org/server/configuration-production
-- Keycloak hostname configuration: https://www.keycloak.org/server/hostname
-- Keycloak caching and transport stacks: https://www.keycloak.org/server/caching
-- Keycloak general configuration: https://www.keycloak.org/server/configuration
-- Keycloak all configuration: https://www.keycloak.org/server/all-config
-- Kubernetes Gateway API: https://kubernetes.io/docs/concepts/services-networking/gateway/
-- External Secrets Operator: https://external-secrets.io/latest/
+- [Keycloak downloads](https://www.keycloak.org/downloads)
+- [Keycloak release notes](https://www.keycloak.org/docs/latest/release_notes/index.html)
+- [Keycloak production configuration](https://www.keycloak.org/server/configuration-production)
+- [Keycloak hostname configuration](https://www.keycloak.org/server/hostname)
+- [Keycloak caching and transport stacks](https://www.keycloak.org/server/caching)
+- [Keycloak general configuration](https://www.keycloak.org/server/configuration)
+- [Keycloak all configuration](https://www.keycloak.org/server/all-config)
+- [Kubernetes Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/)
+- [External Secrets Operator](https://external-secrets.io/latest/)
 
 ## Keycloak 26.6.x alignment
 
@@ -116,7 +116,10 @@ This chart exposes common Keycloak production options as first-class values:
 
 Gateway API support is optional and renders only `HTTPRoute` resources. The chart does not create `GatewayClass` or `Gateway` resources.
 
-External Secrets support is optional and intended only for clusters that already have External Secrets Operator and a `SecretStore` or `ClusterSecretStore`. The chart renders `ExternalSecret` resources that materialize the Kubernetes Secrets consumed by the existing `admin`, `database`, and `truststore` paths; it does not install the operator or create provider stores.
+External Secrets support is optional and intended only for clusters that already have External Secrets Operator and a
+`SecretStore` or `ClusterSecretStore`. The chart renders `ExternalSecret` resources that materialize the Kubernetes
+Secrets consumed by the existing `admin`, `database`, and `truststore` paths; it does not install the operator or create
+provider stores.
 
 ## Operational direction
 

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -47,10 +47,15 @@ helm install keycloak oci://ghcr.io/helmforgedev/helm/keycloak -f values.yaml
 - optional realm import through `/opt/keycloak/data/import`
 - optional provider and theme mounts
 - optional separate ingresses for public and admin traffic
+- optional Gateway API `HTTPRoute` resources for public and admin traffic
 - optional truststore and external database TLS material
+- optional External Secrets Operator `ExternalSecret` resources for clusters that already run the operator
+- optional IPv4/IPv6 dual-stack Service fields
 - optional database-aware S3 backup CronJob for PostgreSQL/MySQL-backed modes
 - controlled extension hooks through `extraEnvFrom`, `initContainers`, and `extraContainers`
 - optional `ServiceMonitor`
+- first-class production options for trusted proxies, management relative path, database pool/schema/timeouts, features, logging, telemetry, and tracing
+- rollout strategy, service account token mounting, capacity profiles, and optional egress NetworkPolicy controls
 
 ## How to choose the mode
 
@@ -71,10 +76,47 @@ Recommended reading before installation:
 
 ## Official product references
 
+- Keycloak downloads: https://www.keycloak.org/downloads
+- Keycloak release notes: https://www.keycloak.org/docs/latest/release_notes/index.html
 - Keycloak production configuration: https://www.keycloak.org/server/configuration-production
 - Keycloak hostname configuration: https://www.keycloak.org/server/hostname
 - Keycloak caching and transport stacks: https://www.keycloak.org/server/caching
 - Keycloak general configuration: https://www.keycloak.org/server/configuration
+- Keycloak all configuration: https://www.keycloak.org/server/all-config
+- Kubernetes Gateway API: https://kubernetes.io/docs/concepts/services-networking/gateway/
+- External Secrets Operator: https://external-secrets.io/latest/
+
+## Keycloak 26.6.x alignment
+
+This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.6.1`.
+
+Relevant 26.6.x operational changes to account for during rollout:
+
+- zero-downtime patch releases are supported within the same minor stream, but still require readiness, proxy, and database validation
+- the HTTP stack supports graceful shutdown, so keep `terminationGracePeriodSeconds` aligned with connection draining at the proxy layer
+- Kubernetes and OpenShift truststore initialization improved upstream; keep custom `truststore` and database CA mounts explicit when the platform uses private CAs
+- database operations and timeout behavior changed in the 26.6 stream; validate startup, migration, and failover logs before widening traffic
+- `KCRAW_` is available upstream for preserving literal environment values; continue using `extraEnv` for advanced options that are not first-class chart values yet
+
+## Phase 3 production controls
+
+This chart exposes common Keycloak production options as first-class values:
+
+- `proxy.trustedAddresses` maps to `KC_PROXY_TRUSTED_ADDRESSES`
+- `proxy.protocolEnabled` maps to `KC_PROXY_PROTOCOL_ENABLED` and cannot be used with `proxy.headers`
+- `management.relativePath` maps to `KC_HTTP_MANAGEMENT_RELATIVE_PATH` and updates probes and ServiceMonitor paths
+- `database.external.schema`, `database.external.pool.*`, `database.external.logSlowQueriesThreshold`, and `database.external.transaction.*` map to Keycloak database runtime settings
+- `features.enabled` and `features.disabled` map to `KC_FEATURES` and `KC_FEATURES_DISABLED`
+- `optimized.enabled` adds `--optimized` for custom pre-built production images
+- `metrics.userEvents`, `metrics.cacheHistograms`, `telemetry.*`, `tracing.*`, and `logging.*` map to Keycloak observability settings
+- `deployment.strategy.*` controls Kubernetes rollout behavior
+- `serviceAccount.automountServiceAccountToken` controls whether Kubernetes mounts the service account token and cluster CA files
+- `truststore.kubernetes.enabled` maps to `KC_TRUSTSTORE_KUBERNETES_ENABLED`
+- `capacity.profile` can render conservative `small`, `medium`, or `large` resource presets when `resources` is not set
+
+Gateway API support is optional and renders only `HTTPRoute` resources. The chart does not create `GatewayClass` or `Gateway` resources.
+
+External Secrets support is optional and intended only for clusters that already have External Secrets Operator and a `SecretStore` or `ClusterSecretStore`. The chart renders `ExternalSecret` resources that materialize the Kubernetes Secrets consumed by the existing `admin`, `database`, and `truststore` paths; it does not install the operator or create provider stores.
 
 ## Operational direction
 
@@ -199,23 +241,34 @@ postgresql:
 |-----------|-------------|---------|
 | `mode` | `dev` or `production` | `dev` |
 | `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `26.5.5` |
+| `image.tag` | Keycloak image tag | `26.6.1` |
 | `admin.existingSecret` | Existing secret for bootstrap admin credentials | `""` |
 | `http.port` | Application HTTP port | `8080` |
 | `http.managementPort` | Management port for health and metrics | `9000` |
 | `http.relativePath` | Relative HTTP path | `/` |
+| `management.relativePath` | Optional management relative path | `""` |
+| `deployment.strategy.type` | Deployment strategy | `RollingUpdate` |
+| `deployment.strategy.rollingUpdate.maxUnavailable` | Max unavailable pods during rollout | `0` |
+| `deployment.strategy.rollingUpdate.maxSurge` | Max surge pods during rollout | `1` |
 | `hostname.hostname` | Public hostname or URL | `""` |
 | `hostname.admin` | Dedicated admin hostname or URL | `""` |
 | `proxy.headers` | Proxy headers mode | `xforwarded` |
+| `proxy.trustedAddresses` | Trusted proxy IPs/CIDRs | `""` |
+| `proxy.protocolEnabled` | Enable HAProxy PROXY protocol | `false` |
 | `database.external.vendor` | External database vendor | `postgres` |
 | `database.external.host` | External database host | `""` |
 | `database.external.name` | External database name | `keycloak` |
 | `database.external.username` | External database username | `keycloak` |
 | `database.external.existingSecret` | Existing secret for database password | `""` |
+| `database.external.schema` | Database schema | `""` |
+| `database.external.pool.maxSize` | Maximum database pool size | `""` |
 | `database.tls.enabled` | Enable database TLS settings | `false` |
+| `database.tls.mode` | Keycloak database TLS mode | `""` |
 | `database.tls.sslMode` | PostgreSQL SSL mode | `verify-full` |
 | `database.tls.existingSecret` | Secret with database CA material | `""` |
 | `database.tls.existingConfigMap` | ConfigMap with database CA material | `""` |
+| `features.enabled` | Keycloak features to enable | `[]` |
+| `optimized.enabled` | Add `--optimized` startup arg | `false` |
 | `backup.enabled` | Enable built-in S3 backup CronJob for database-backed modes | `false` |
 | `backup.schedule` | Backup schedule | `"0 3 * * *"` |
 | `backup.s3.endpoint` | S3-compatible endpoint URL | `""` |
@@ -232,11 +285,14 @@ postgresql:
 | `truststore.existingSecret` | Secret with PEM or PKCS12 trust material | `""` |
 | `truststore.existingConfigMap` | ConfigMap with PEM or PKCS12 trust material | `""` |
 | `truststore.tlsHostnameVerifier` | Outbound TLS hostname verification mode | `DEFAULT` |
+| `truststore.kubernetes.enabled` | Trust Kubernetes/OpenShift service account CAs when mounted | `true` |
 | `replicaCount` | Number of Keycloak replicas | `1` |
 | `cache.stack` | Cache stack for multi-replica production | `jdbc-ping` |
 | `cache.multiReplicaDefaults.enabled` | Apply default scheduling hints for multi-replica workloads | `true` |
 | `cache.multiReplicaDefaults.podAntiAffinity` | Generated pod anti-affinity mode | `preferred` |
 | `resources` | Explicit CPU and memory requests/limits for the main container | `{}` |
+| `capacity.profile` | Resource preset: `custom`, `small`, `medium`, `large` | `custom` |
+| `serviceAccount.automountServiceAccountToken` | Mount Kubernetes service account token into the pod | `true` |
 | `probes.liveness.enabled` | Enable liveness probe | `true` |
 | `probes.readiness.enabled` | Enable readiness probe | `true` |
 | `probes.startup.enabled` | Enable startup probe | `true` |
@@ -251,9 +307,17 @@ postgresql:
 | `ingress.public.ingressClassName` | Public ingress class name | `traefik` |
 | `ingress.admin.enabled` | Enable separate admin ingress | `false` |
 | `ingress.admin.ingressClassName` | Admin ingress class name | `traefik` |
+| `gateway.public.enabled` | Enable public Gateway API HTTPRoute | `false` |
+| `gateway.admin.enabled` | Enable admin Gateway API HTTPRoute | `false` |
 | `metrics.enabled` | Enable Keycloak metrics | `false` |
+| `metrics.userEvents` | Enable user event metrics | `false` |
 | `metrics.serviceMonitor.enabled` | Enable ServiceMonitor | `false` |
+| `telemetry.metricsEnabled` | Enable OpenTelemetry metrics export | `false` |
+| `tracing.enabled` | Enable tracing | `false` |
+| `logging.access.enabled` | Enable HTTP access logs | `false` |
+| `externalSecrets.enabled` | Render ExternalSecret resources for existing ESO installs | `false` |
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
+| `networkPolicy.egress.enabled` | Add egress NetworkPolicy rules | `false` |
 
 ## CI scenarios
 
@@ -267,6 +331,12 @@ The `ci/` scenarios validate the main chart behaviors:
 - `multi-replica.yaml`
 - `relative-path.yaml`
 - `database-tls.yaml`
+- `dual-stack-values.yaml`
+- `gateway-api.yaml`
+- `external-secrets.yaml`
+- `production-hardening.yaml`
+- `lifecycle-security.yaml`
+- `networkpolicy-egress.yaml`
 - `multi-replica-observability.yaml`
 - `extensions.yaml`
 - `heavy-startup.yaml`

--- a/charts/keycloak/ci/dual-stack-values.yaml
+++ b/charts/keycloak/ci/dual-stack-values.yaml
@@ -1,0 +1,3 @@
+service:
+  ipFamilyPolicy: PreferDualStack
+  managementIpFamilyPolicy: PreferDualStack

--- a/charts/keycloak/ci/dual-stack-values.yaml
+++ b/charts/keycloak/ci/dual-stack-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack
   managementIpFamilyPolicy: PreferDualStack

--- a/charts/keycloak/ci/external-secrets.yaml
+++ b/charts/keycloak/ci/external-secrets.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 
 hostname:

--- a/charts/keycloak/ci/external-secrets.yaml
+++ b/charts/keycloak/ci/external-secrets.yaml
@@ -1,0 +1,27 @@
+mode: production
+
+hostname:
+  hostname: https://sso.example.com
+
+database:
+  external:
+    host: postgresql.example.com
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  admin:
+    enabled: true
+    usernameRemoteRef:
+      key: keycloak/admin
+      property: username
+    passwordRemoteRef:
+      key: keycloak/admin
+      property: password
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: keycloak/database
+      property: password

--- a/charts/keycloak/ci/gateway-api.yaml
+++ b/charts/keycloak/ci/gateway-api.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 
 hostname:

--- a/charts/keycloak/ci/gateway-api.yaml
+++ b/charts/keycloak/ci/gateway-api.yaml
@@ -1,0 +1,26 @@
+mode: production
+
+hostname:
+  hostname: https://sso.example.com
+  admin: https://admin-sso.example.com
+
+database:
+  external:
+    host: postgresql.example.com
+    password: change-me
+
+gateway:
+  public:
+    enabled: true
+    parentRefs:
+      - name: public-gateway
+        namespace: gateway-system
+    hostnames:
+      - sso.example.com
+  admin:
+    enabled: true
+    parentRefs:
+      - name: internal-gateway
+        namespace: gateway-system
+    hostnames:
+      - admin-sso.example.com

--- a/charts/keycloak/ci/lifecycle-security.yaml
+++ b/charts/keycloak/ci/lifecycle-security.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 
 hostname:

--- a/charts/keycloak/ci/lifecycle-security.yaml
+++ b/charts/keycloak/ci/lifecycle-security.yaml
@@ -1,0 +1,26 @@
+mode: production
+
+hostname:
+  hostname: https://sso.example.com
+
+database:
+  external:
+    host: postgresql.example.com
+    password: change-me
+
+deployment:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+serviceAccount:
+  automountServiceAccountToken: false
+
+truststore:
+  kubernetes:
+    enabled: false
+
+capacity:
+  profile: small

--- a/charts/keycloak/ci/networkpolicy-egress.yaml
+++ b/charts/keycloak/ci/networkpolicy-egress.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 
 hostname:

--- a/charts/keycloak/ci/networkpolicy-egress.yaml
+++ b/charts/keycloak/ci/networkpolicy-egress.yaml
@@ -1,0 +1,24 @@
+mode: production
+
+hostname:
+  hostname: https://sso.example.com
+
+database:
+  external:
+    host: postgresql.example.com
+    password: change-me
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    databaseTo:
+      - ipBlock:
+          cidr: 10.10.0.0/16
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 10.20.0.0/16
+        ports:
+          - protocol: TCP
+            port: 443

--- a/charts/keycloak/ci/production-capacity.yaml
+++ b/charts/keycloak/ci/production-capacity.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 
 hostname:

--- a/charts/keycloak/ci/production-capacity.yaml
+++ b/charts/keycloak/ci/production-capacity.yaml
@@ -11,11 +11,6 @@ database:
     username: keycloak
     existingSecret: keycloak-db
 
-resources:
-  requests:
-    cpu: "1"
-    memory: 2Gi
-  limits:
-    cpu: "2"
-    memory: 4Gi
+capacity:
+  profile: medium
 priorityClassName: platform-critical

--- a/charts/keycloak/ci/production-hardening.yaml
+++ b/charts/keycloak/ci/production-hardening.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 
 hostname:

--- a/charts/keycloak/ci/production-hardening.yaml
+++ b/charts/keycloak/ci/production-hardening.yaml
@@ -1,0 +1,66 @@
+mode: production
+
+hostname:
+  hostname: https://sso.example.com
+
+proxy:
+  trustedAddresses: 10.0.0.0/8,192.168.0.0/16
+
+management:
+  relativePath: /management
+
+database:
+  external:
+    host: postgresql.example.com
+    password: change-me
+    schema: keycloak
+    pool:
+      initialSize: 2
+      minSize: 1
+      maxSize: 20
+      maxLifetime: 30m
+    logSlowQueriesThreshold: 500ms
+    transaction:
+      xaEnabled: "false"
+      timeout: 60s
+
+features:
+  enabled:
+    - opentelemetry-metrics
+    - user-event-metrics
+
+metrics:
+  enabled: true
+  userEvents: true
+  cacheHistograms: true
+  serviceMonitor:
+    enabled: true
+    scrapeTimeout: 10s
+    annotations:
+      monitoring.helmforge.dev/profile: keycloak
+    relabelings:
+      - action: labeldrop
+        regex: pod_template_hash
+    metricRelabelings:
+      - action: keep
+        sourceLabels:
+          - __name__
+        regex: keycloak_.*
+
+telemetry:
+  metricsEnabled: true
+  endpoint: http://otel-collector.observability.svc:4317
+
+tracing:
+  enabled: true
+  endpoint: http://tempo.observability.svc:4317
+  samplerType: parentbased_traceidratio
+  samplerRatio: "0.1"
+  resourceAttributes: service.namespace=identity
+
+logging:
+  console:
+    output: json
+    jsonFormat: ecs
+  access:
+    enabled: true

--- a/charts/keycloak/docs/backup.md
+++ b/charts/keycloak/docs/backup.md
@@ -24,6 +24,39 @@ When `backup.enabled=true`, the chart:
 
 The built-in workflow is intentionally focused on backup creation, not restore orchestration.
 
+## Backup scope
+
+Keycloak stores its operational state in the configured database. The built-in backup job is therefore database-only by design.
+
+The chart does not package or back up external inputs such as:
+
+- custom provider JARs mounted from a ConfigMap or Secret
+- custom themes mounted from a ConfigMap or Secret
+- realm import files managed by GitOps or another source-of-truth
+- TLS, truststore, database, S3, or External Secrets backend material
+
+Keep those inputs in their own source-of-truth and backup workflow. A database dump is not enough to reconstruct an environment that depends on external provider, theme, truststore, or secret material.
+
+## On-demand backup
+
+The chart creates a CronJob. To execute the same backup flow immediately, create a Job from the CronJob:
+
+```bash
+kubectl create job keycloak-backup-manual \
+  --from=cronjob/<release-name>-keycloak-backup \
+  -n <namespace>
+
+kubectl wait --for=condition=Complete job/keycloak-backup-manual \
+  -n <namespace> \
+  --timeout=15m
+
+kubectl logs job/keycloak-backup-manual \
+  -n <namespace> \
+  --all-containers
+```
+
+Inspect the S3-compatible target after the Job completes and verify that the compressed SQL archive exists under the configured `backup.s3.prefix`.
+
 ## Operational recommendation
 
 - use PostgreSQL for production whenever possible

--- a/charts/keycloak/docs/production-capacity.md
+++ b/charts/keycloak/docs/production-capacity.md
@@ -6,14 +6,34 @@ Read this guide before choosing CPU, memory, and scheduling priority for a produ
 
 ## Current chart model
 
-The chart leaves container sizing entirely under operator control through explicit `resources`.
+The chart leaves container sizing under operator control through either explicit `resources` or an optional `capacity.profile`.
 
 Default behavior:
 
 - if `resources` is not set, the chart renders with `resources: {}`
+- `capacity.profile` defaults to `custom`
 - no CPU or memory requests/limits are imposed by default
 
 This keeps capacity decisions aligned with the real platform and workload instead of hiding them behind presets.
+
+## Capacity profiles
+
+Use `capacity.profile` only as a starting point:
+
+```yaml
+capacity:
+  profile: medium
+```
+
+Profiles are conservative presets:
+
+| Profile | Requests | Limits |
+|---------|----------|--------|
+| `small` | `500m`, `1Gi` | `1`, `2Gi` |
+| `medium` | `1`, `2Gi` | `2`, `4Gi` |
+| `large` | `2`, `3Gi` | `4`, `6Gi` |
+
+Do not combine `capacity.profile` with explicit `resources`. If you need exact values, keep `capacity.profile: custom` and set `resources`.
 
 ## Priority class
 
@@ -32,13 +52,8 @@ Do not set a high-priority class casually. Priority must be aligned with the res
 For a serious production environment, a reasonable starting point is:
 
 ```yaml
-resources:
-  requests:
-    cpu: "1"
-    memory: 2Gi
-  limits:
-    cpu: "2"
-    memory: 4Gi
+capacity:
+  profile: medium
 priorityClassName: platform-critical
 ```
 

--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -13,6 +13,9 @@ Use `mode: production` for real reverse-proxy deployments where Keycloak is back
 - optional multi-replica runtime
 - optional realm import
 - optional providers and themes mounting
+- optional Gateway API `HTTPRoute` resources that attach to existing Gateways
+- optional External Secrets Operator `ExternalSecret` resources for clusters that already run the operator
+- first-class production runtime controls for proxy trust, management path, database pool/schema/timeouts, features, logging, telemetry, and tracing
 
 ## What it does not deliver
 
@@ -44,6 +47,132 @@ Use `mode: production` for real reverse-proxy deployments where Keycloak is back
 - external secret and truststore rotation require a controlled rollout plan
 - HPA is intentionally not modeled by the current chart scope
 - `hostname.admin` must be set when the admin ingress is enabled in production mode
+- Gateway API support creates only `HTTPRoute`; platform teams must provide Gateway API CRDs, controller, `GatewayClass`, and `Gateway`
+- External Secrets support creates only `ExternalSecret`; platform teams must provide External Secrets Operator and the referenced `SecretStore` or `ClusterSecretStore`
+- `serviceAccount.automountServiceAccountToken=false` is available for hardening, but it also prevents Keycloak from seeing the Kubernetes service account CA files used by upstream truststore auto-discovery
+- NetworkPolicy egress is disabled by default; enabling it requires explicit DNS, database, S3, telemetry, and other destination rules
+
+## Lifecycle strategy
+
+The default Deployment strategy is:
+
+```yaml
+deployment:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+```
+
+Keep readiness probes enabled when using rolling updates. For slower bootstrap profiles, use `probes.profile: heavy-startup` rather than disabling probes.
+
+## Production hardening values
+
+Use the first-class values when the platform contract is known:
+
+```yaml
+mode: production
+
+hostname:
+  hostname: https://sso.example.com
+
+proxy:
+  headers: xforwarded
+  trustedAddresses: 10.0.0.0/8
+
+management:
+  relativePath: /management
+
+database:
+  external:
+    host: postgresql.example.com
+    password: change-me
+    schema: keycloak
+    pool:
+      initialSize: 2
+      minSize: 1
+      maxSize: 20
+      maxLifetime: 30m
+    transaction:
+      xaEnabled: "false"
+      timeout: 60s
+
+metrics:
+  enabled: true
+  cacheHistograms: true
+
+logging:
+  console:
+    output: json
+    jsonFormat: ecs
+```
+
+Use `optimized.enabled=true` only with a custom image that was built for optimized startup.
+
+## Gateway API
+
+Gateway API support is opt-in:
+
+```yaml
+gateway:
+  public:
+    enabled: true
+    parentRefs:
+      - name: public-gateway
+        namespace: gateway-system
+    hostnames:
+      - sso.example.com
+```
+
+The chart does not create a `Gateway` and never routes the management service through Gateway API.
+
+## External Secrets Operator
+
+External Secrets support is opt-in for clusters that already run https://github.com/external-secrets/external-secrets:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  admin:
+    enabled: true
+    usernameRemoteRef:
+      key: keycloak/admin
+      property: username
+    passwordRemoteRef:
+      key: keycloak/admin
+      property: password
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: keycloak/database
+      property: password
+```
+
+When an ExternalSecret owns a target Secret, the native generated Secret for that credential is suppressed and Keycloak consumes the materialized Kubernetes Secret.
+
+## Keycloak 26.6.x rollout notes
+
+The default image is `quay.io/keycloak/keycloak:26.6.1`.
+
+Before rolling this version into production:
+
+- read the official 26.6.x release notes
+- validate database startup and migration logs
+- validate readiness and liveness on the management service
+- validate login, token refresh, logout, and admin console access through the real reverse proxy path
+- keep `terminationGracePeriodSeconds` and proxy connection draining aligned with the upstream graceful HTTP shutdown behavior
+- verify private CA and truststore behavior when running on Kubernetes or OpenShift with internal certificate authorities
+- keep a rollback plan that covers image, chart values, database migration expectations, proxy routing, and mounted providers/themes
+
+Official references:
+
+- Keycloak downloads: https://www.keycloak.org/downloads
+- Keycloak release notes: https://www.keycloak.org/docs/latest/release_notes/index.html
+- Keycloak production configuration: https://www.keycloak.org/server/configuration-production
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/keycloak/docs/reverse-proxy.md
+++ b/charts/keycloak/docs/reverse-proxy.md
@@ -26,6 +26,19 @@ This separation is useful when:
 
 Both ingresses still route only to the application service. They do not expose the management interface.
 
+Gateway API can be used instead of Ingress when the cluster already provides Gateway API CRDs and a controller. The chart creates optional `HTTPRoute` resources and expects the platform to provide the referenced `Gateway`.
+
+```yaml
+gateway:
+  public:
+    enabled: true
+    parentRefs:
+      - name: public-gateway
+        namespace: gateway-system
+    hostnames:
+      - sso.example.com
+```
+
 ## Hostname model
 
 Use these values together:
@@ -46,7 +59,12 @@ hostname:
 
 proxy:
   headers: xforwarded
+  trustedAddresses: 10.0.0.0/8
 ```
+
+Set `proxy.trustedAddresses` whenever the ingress or gateway source ranges are known. Keycloak ignores proxy headers from other addresses when this value is set.
+
+`proxy.protocolEnabled=true` is available for platforms that use the HAProxy PROXY protocol. It cannot be combined with `proxy.headers`; set `proxy.headers: ""` when enabling PROXY protocol.
 
 ## Ingress guidance
 
@@ -137,6 +155,8 @@ Do not change the relative path in production without validating discovery docum
 
 - Keycloak production configuration: https://www.keycloak.org/server/configuration-production
 - Keycloak hostname configuration: https://www.keycloak.org/server/hostname
+- Keycloak reverse proxy configuration: https://www.keycloak.org/server/reverseproxy
+- Kubernetes Gateway API: https://kubernetes.io/docs/concepts/services-networking/gateway/
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/keycloak/docs/scaling-and-clustering.md
+++ b/charts/keycloak/docs/scaling-and-clustering.md
@@ -91,10 +91,12 @@ That profile keeps the same probe structure but gives the pod more time to becom
 For production rollouts:
 
 - update one Keycloak version at a time
+- for patch releases in the same 26.6 minor stream, use rolling updates but still validate readiness, proxy behavior, and database logs before widening traffic
 - validate readiness on the management service
 - validate public login and admin console access before widening traffic
 - confirm the database schema migration path is understood before rollout
 - keep a rollback plan for image, chart values, ingress, and proxy behavior together
+- keep `terminationGracePeriodSeconds` high enough for graceful HTTP shutdown and proxy connection draining
 
 If providers or themes are mounted:
 
@@ -130,6 +132,7 @@ pdb:
 
 - Keycloak caching and transport stacks: https://www.keycloak.org/server/caching
 - Keycloak production configuration: https://www.keycloak.org/server/configuration-production
+- Keycloak release notes: https://www.keycloak.org/docs/latest/release_notes/index.html
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/keycloak/docs/security-and-trust.md
+++ b/charts/keycloak/docs/security-and-trust.md
@@ -26,16 +26,21 @@ Example:
 
 ```yaml
 database:
-  vendor: postgres
-  host: postgresql-rw.default.svc
-  name: keycloak
-  username: keycloak
-  existingSecret: keycloak-db
+  external:
+    vendor: postgres
+    host: postgresql-rw.default.svc
+    name: keycloak
+    username: keycloak
+    existingSecret: keycloak-db
   tls:
     enabled: true
     sslMode: verify-full
     existingConfigMap: keycloak-db-ca
     rootCertFilename: ca.crt
+    mode: verify-server
+    trustStoreFile: /opt/keycloak/conf/db-truststore.p12
+    trustStorePasswordSecret: keycloak-db-truststore
+    trustStoreType: PKCS12
 ```
 
 What the chart does in this case:
@@ -60,6 +65,20 @@ truststore:
 ```
 
 This chart mounts the referenced files and exposes them through `KC_TRUSTSTORE_PATHS`.
+
+Keycloak 26.6.x includes upstream improvements around automatic truststore initialization on Kubernetes and OpenShift. Keep chart-managed `truststore` values explicit when the deployment needs deterministic private CA material, database CA bundles, or provider/theme integration trust paths.
+
+The upstream Kubernetes/OpenShift CA auto-discovery is controlled by:
+
+```yaml
+truststore:
+  kubernetes:
+    enabled: true
+```
+
+This renders `KC_TRUSTSTORE_KUBERNETES_ENABLED`. If `serviceAccount.automountServiceAccountToken=false`, Kubernetes service account CA files are not mounted, so Keycloak cannot discover them even if the truststore option remains enabled.
+
+Disable service account token automount only after confirming the deployment does not need the implicit Kubernetes CA files, Kubernetes service account identity provider behavior, external Infinispan integrations, or custom provider code that talks to the Kubernetes API.
 
 Accepted formats follow the official Keycloak guidance:
 
@@ -87,6 +106,33 @@ Examples:
 - the database CA bundle is replaced
 - internal CA certificates are updated in the truststore
 
+## External Secrets Operator
+
+The chart can render `ExternalSecret` resources for clusters that already run External Secrets Operator. This is optional and does not install the operator or create a `SecretStore`.
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  admin:
+    enabled: true
+    usernameRemoteRef:
+      key: keycloak/admin
+      property: username
+    passwordRemoteRef:
+      key: keycloak/admin
+      property: password
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: keycloak/database
+      property: password
+```
+
+Use this only when the platform team already operates https://github.com/external-secrets/external-secrets and the referenced store exists before the Helm release is installed.
+
 ## Rollout checklist for trust changes
 
 - confirm the new certificate chain is present in the referenced Secret or ConfigMap
@@ -99,6 +145,8 @@ Examples:
 
 - Keycloak trusted certificates: https://www.keycloak.org/server/keycloak-truststore
 - Keycloak production configuration: https://www.keycloak.org/server/configuration-production
+- Keycloak release notes: https://www.keycloak.org/docs/latest/release_notes/index.html
+- External Secrets Operator: https://external-secrets.io/latest/
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/keycloak/templates/NOTES.txt
+++ b/charts/keycloak/templates/NOTES.txt
@@ -1,13 +1,125 @@
 Keycloak has been installed.
 
-Useful Services:
+1. Installation summary
+=======================
 
-- Application Service: {{ include "keycloak.fullname" . }}
-- Management Service: {{ include "keycloak.fullname" . }}-management
+- Release: {{ .Release.Name }}
+- Namespace: {{ .Release.Namespace }}
+- Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+- App version: {{ .Chart.AppVersion }}
+- Mode: {{ .Values.mode }}
+- Image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+- Replicas: {{ .Values.replicaCount }}
+- Database mode: {{ include "keycloak.databaseMode" . }}
+- ServiceAccount: {{ include "keycloak.serviceAccountName" . }}
+- ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
+- Deployment strategy: {{ .Values.deployment.strategy.type }}
 
-Mode:
+2. Access
+=========
 
-  {{ .Values.mode }}
+Application service:
+- Name: {{ include "keycloak.fullname" . }}
+- Type: {{ .Values.service.type }}
+- Port: {{ .Values.http.port }}
+- Cluster DNS: http://{{ include "keycloak.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.http.port }}
+{{- if .Values.service.ipFamilyPolicy }}
+- IP family policy: {{ .Values.service.ipFamilyPolicy }}
+{{- end }}
+{{- if .Values.service.ipFamilies }}
+- IP families: {{ join ", " .Values.service.ipFamilies }}
+{{- end }}
+
+Management service:
+- Name: {{ include "keycloak.fullname" . }}-management
+- Type: ClusterIP
+- Port: {{ .Values.http.managementPort }}
+- Cluster DNS: http://{{ include "keycloak.fullname" . }}-management.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.http.managementPort }}
+- Keep this service private; Keycloak management endpoints are not meant for public ingress.
+{{- if .Values.service.managementIpFamilyPolicy }}
+- IP family policy: {{ .Values.service.managementIpFamilyPolicy }}
+{{- end }}
+{{- if .Values.service.managementIpFamilies }}
+- IP families: {{ join ", " .Values.service.managementIpFamilies }}
+{{- end }}
+
+Port-forward commands:
+
+  kubectl port-forward svc/{{ include "keycloak.fullname" . }} {{ .Values.http.port }}:{{ .Values.http.port }} -n {{ .Release.Namespace }}
+  kubectl port-forward svc/{{ include "keycloak.fullname" . }}-management {{ .Values.http.managementPort }}:{{ .Values.http.managementPort }} -n {{ .Release.Namespace }}
+
+Local URLs after port-forward:
+
+  http://127.0.0.1:{{ .Values.http.port }}{{ include "keycloak.relativePath" . }}
+  http://127.0.0.1:{{ .Values.http.managementPort }}{{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/health/ready") }}
+  http://127.0.0.1:{{ .Values.http.managementPort }}{{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/health/live") }}
+{{- if .Values.metrics.enabled }}
+  http://127.0.0.1:{{ .Values.http.managementPort }}{{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/metrics") }}
+{{- end }}
+
+{{- if .Values.ingress.public.enabled }}
+Public ingress is enabled.
+{{- range .Values.ingress.public.hosts }}
+- Host: {{ .host }}
+{{- range .paths }}
+  Path: {{ .path }} ({{ .pathType }})
+{{- end }}
+{{- end }}
+{{- else }}
+Public ingress is disabled.
+{{- end }}
+
+{{- if .Values.ingress.admin.enabled }}
+Admin ingress is enabled.
+{{- range .Values.ingress.admin.hosts }}
+- Host: {{ .host }}
+{{- range .paths }}
+  Path: {{ .path }} ({{ .pathType }})
+{{- end }}
+{{- end }}
+{{- else }}
+Admin ingress is disabled.
+{{- end }}
+
+{{- if .Values.gateway.public.enabled }}
+Public Gateway API HTTPRoute is enabled.
+{{- range .Values.gateway.public.hostnames }}
+- Hostname: {{ . }}
+{{- end }}
+{{- else }}
+Public Gateway API HTTPRoute is disabled.
+{{- end }}
+
+{{- if .Values.gateway.admin.enabled }}
+Admin Gateway API HTTPRoute is enabled.
+{{- range .Values.gateway.admin.hostnames }}
+- Hostname: {{ . }}
+{{- end }}
+{{- else }}
+Admin Gateway API HTTPRoute is disabled.
+{{- end }}
+
+3. Getting started
+==================
+
+1. Wait for the Keycloak pod to become ready:
+
+   kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "keycloak.name" . }} --timeout=10m
+
+2. Read the bootstrap admin credentials from the Kubernetes Secret.
+
+3. Port-forward the application service:
+
+   kubectl port-forward svc/{{ include "keycloak.fullname" . }} {{ .Values.http.port }}:{{ .Values.http.port }} -n {{ .Release.Namespace }}
+
+4. Open the Keycloak UI:
+
+   http://127.0.0.1:{{ .Values.http.port }}{{ include "keycloak.relativePath" . }}
+
+5. For production, verify hostname, database, proxy headers, ingress or Gateway routing, health, metrics, backup, and NetworkPolicy before exposing traffic.
+
+4. Credentials
+==============
 
 Bootstrap admin username:
 
@@ -17,16 +129,151 @@ Bootstrap admin password:
 
   kubectl get secret {{ include "keycloak.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.admin.existingSecretPasswordKey }}}" | base64 -d
 
-Application URL:
+{{- if include "keycloak.hasDatabase" . }}
+Database password secret:
 
-  http://{{ include "keycloak.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.http.port }}
+  kubectl get secret {{ include "keycloak.databaseSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "keycloak.databaseSecretPasswordKey" . }}}" | base64 -d
+{{- end }}
 
-Management URL:
+5. Configuration summary
+========================
 
-  http://{{ include "keycloak.fullname" . }}-management.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.http.managementPort }}
+HTTP:
+- HTTP enabled: {{ .Values.http.enabled }}
+- HTTP port: {{ .Values.http.port }}
+- Management port: {{ .Values.http.managementPort }}
+- Relative path: {{ include "keycloak.relativePath" . }}
 
-Important:
+Hostname and proxy:
+- Public hostname: {{ default "(not configured)" .Values.hostname.hostname }}
+- Admin hostname: {{ default "(not configured)" .Values.hostname.admin }}
+- Strict hostname: {{ .Values.hostname.strict }}
+- Backchannel dynamic: {{ .Values.hostname.backchannelDynamic }}
+- Proxy headers: {{ default "(not configured)" .Values.proxy.headers }}
+- Trusted proxies: {{ default "(not configured)" .Values.proxy.trustedAddresses }}
+- PROXY protocol: {{ .Values.proxy.protocolEnabled }}
 
-- production mode expects a trusted reverse proxy or ingress in front of Keycloak
-- the management interface is not meant to be published through ingress
-- realm import is a startup-oriented workflow, not a full reconciliation control plane
+Database:
+- Mode: {{ include "keycloak.databaseMode" . }}
+{{- if include "keycloak.hasDatabase" . }}
+- Vendor: {{ include "keycloak.databaseVendor" . }}
+- Host: {{ include "keycloak.databaseHost" . }}
+- Port: {{ include "keycloak.databasePort" . }}
+- Name: {{ include "keycloak.databaseName" . }}
+- Username: {{ include "keycloak.databaseUsername" . }}
+{{- else }}
+- Embedded H2 is active. Use only for dev mode.
+{{- end }}
+
+Clustering:
+- Cache enabled: {{ .Values.cache.enabled }}
+- Cache stack: {{ .Values.cache.stack }}
+- Multi-replica scheduling defaults: {{ .Values.cache.multiReplicaDefaults.enabled }}
+{{- if gt (int .Values.replicaCount) 1 }}
+- Cluster transport ports are exposed on the pod: 7800 and 57800.
+{{- end }}
+
+Observability:
+- Health enabled: {{ .Values.health.enabled }}
+- Management health enabled: {{ .Values.management.healthEnabled }}
+- Metrics enabled: {{ .Values.metrics.enabled }}
+- ServiceMonitor enabled: {{ and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+- Tracing enabled: {{ .Values.tracing.enabled }}
+- Telemetry metrics enabled: {{ .Values.telemetry.metricsEnabled }}
+
+Optional features:
+- Realm import: {{ .Values.realmImport.enabled }}
+- Providers ConfigMap: {{ default "(not configured)" .Values.extensions.providers.existingConfigMap }}
+- Providers Secret: {{ default "(not configured)" .Values.extensions.providers.existingSecret }}
+- Themes ConfigMap: {{ default "(not configured)" .Values.extensions.themes.existingConfigMap }}
+- Themes Secret: {{ default "(not configured)" .Values.extensions.themes.existingSecret }}
+- Truststore enabled: {{ .Values.truststore.enabled }}
+- Kubernetes truststore auto-discovery: {{ .Values.truststore.kubernetes.enabled }}
+- Database TLS enabled: {{ .Values.database.tls.enabled }}
+- Backup enabled: {{ .Values.backup.enabled }}
+- NetworkPolicy enabled: {{ .Values.networkPolicy.enabled }}
+- NetworkPolicy egress enabled: {{ .Values.networkPolicy.egress.enabled }}
+- PodDisruptionBudget enabled: {{ .Values.pdb.enabled }}
+- External Secrets enabled: {{ .Values.externalSecrets.enabled }}
+
+6. Validation commands
+======================
+
+Check release status:
+
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Check rendered resources:
+
+  kubectl get deploy,svc,secret,cm,pdb,networkpolicy -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Wait for Keycloak pods:
+
+  kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "keycloak.name" . }} --timeout=10m
+
+Check endpoints:
+
+  kubectl get endpoints {{ include "keycloak.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl get endpoints {{ include "keycloak.fullname" . }}-management -n {{ .Release.Namespace }}
+
+Check health through the management service:
+
+  kubectl run {{ include "keycloak.fullname" . }}-health-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "keycloak.fullname" . }}-management:{{ .Values.http.managementPort }}{{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/health/ready") }}
+
+Check OIDC discovery through the application service:
+
+  kubectl run {{ include "keycloak.fullname" . }}-oidc-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "keycloak.fullname" . }}:{{ .Values.http.port }}{{ include "keycloak.relativePath" . }}{{ if ne (include "keycloak.relativePath" .) "/" }}/{{ end }}realms/master/.well-known/openid-configuration
+
+{{- if and .Values.metrics.enabled }}
+Check metrics:
+
+  kubectl run {{ include "keycloak.fullname" . }}-metrics-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "keycloak.fullname" . }}-management:{{ .Values.http.managementPort }}{{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/metrics") }}
+{{- end }}
+
+{{- if .Values.backup.enabled }}
+Check backup CronJob:
+
+  kubectl get cronjob {{ include "keycloak.fullname" . }}-backup -n {{ .Release.Namespace }}
+  kubectl create job {{ include "keycloak.fullname" . }}-backup-manual --from=cronjob/{{ include "keycloak.fullname" . }}-backup -n {{ .Release.Namespace }}
+  kubectl logs job/{{ include "keycloak.fullname" . }}-backup-manual -n {{ .Release.Namespace }} --all-containers
+{{- end }}
+
+7. Troubleshooting
+==================
+
+Inspect pods and events:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+  kubectl describe pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "keycloak.name" . }}
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+Inspect Keycloak logs:
+
+  kubectl logs deploy/{{ include "keycloak.fullname" . }} -n {{ .Release.Namespace }} -c keycloak --tail=200
+  kubectl logs deploy/{{ include "keycloak.fullname" . }} -n {{ .Release.Namespace }} -c keycloak --previous --tail=200
+
+Inspect init container logs when a database is configured:
+
+  kubectl logs deploy/{{ include "keycloak.fullname" . }} -n {{ .Release.Namespace }} -c wait-for-db --tail=200
+
+Common checks:
+
+- If pods wait for the database, verify host, port, credentials, NetworkPolicy, and database service readiness.
+- If production mode fails early, verify `hostname.hostname` and database configuration.
+- If the admin console is unreachable, verify public/admin ingress hosts, proxy headers, DNS, and TLS.
+- If health checks fail, inspect the management service and confirm port {{ .Values.http.managementPort }} is not blocked.
+- If multi-replica clustering is unstable, verify the database, cache stack, NetworkPolicy, and pod-to-pod connectivity on ports 7800 and 57800.
+- If realm import did not apply, inspect startup logs and confirm the mounted files under `/opt/keycloak/data/import`.
+- If provider or theme changes do not roll out, update the corresponding rollout token value.
+
+8. Resources
+============
+
+- HelmForge chart docs: https://helmforge.dev/docs/charts/keycloak
+- Keycloak docs: https://www.keycloak.org/documentation
+- Keycloak production guide: https://www.keycloak.org/server/configuration-production
+- Keycloak reverse proxy guide: https://www.keycloak.org/server/reverseproxy
+- Keycloak health and metrics: https://www.keycloak.org/observability/health
+- HelmForge chart issues: https://github.com/helmforgedev/charts/issues
+
+Happy Helmforging :)

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -42,12 +42,144 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if eq .Values.mode "production" -}}true{{- end -}}
 {{- end -}}
 
+{{- define "keycloak.validateAll" -}}
+{{- $mode := .Values.mode | default "dev" -}}
+{{- if not (has $mode (list "dev" "production")) -}}
+  {{- fail "mode must be one of: dev, production" -}}
+{{- end -}}
+{{- $databaseMode := include "keycloak.databaseMode" . -}}
+{{- if and (eq $mode "dev") (gt (int .Values.replicaCount) 1) -}}
+  {{- fail "mode=dev does not support replicaCount > 1; use mode=production with a real database for multi-replica deployments" -}}
+{{- end -}}
+{{- if eq $mode "production" -}}
+  {{- if not .Values.hostname.hostname -}}
+    {{- fail "hostname.hostname is required in production mode" -}}
+  {{- end -}}
+  {{- if eq $databaseMode "embedded" -}}
+    {{- fail "production mode requires a database: set postgresql.enabled, mysql.enabled, or database.external.host" -}}
+  {{- end -}}
+  {{- if and .Values.ingress.admin.enabled (not .Values.hostname.admin) -}}
+    {{- fail "hostname.admin is required when ingress.admin.enabled is true in production mode" -}}
+  {{- end -}}
+  {{- if and .Values.gateway.admin.enabled (not .Values.hostname.admin) (not .Values.gateway.admin.hostnames) -}}
+    {{- fail "hostname.admin or gateway.admin.hostnames is required when gateway.admin.enabled is true in production mode" -}}
+  {{- end -}}
+  {{- if and (gt (int .Values.replicaCount) 1) (not .Values.cache.enabled) -}}
+    {{- fail "production multi-replica deployments require cache.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.proxy.trustedAddresses (not .Values.proxy.headers) -}}
+  {{- fail "proxy.trustedAddresses requires proxy.headers to be set" -}}
+{{- end -}}
+{{- if and .Values.proxy.protocolEnabled .Values.proxy.headers -}}
+  {{- fail "proxy.protocolEnabled cannot be used together with proxy.headers; set proxy.headers to an empty string" -}}
+{{- end -}}
+{{- if and .Values.optimized.enabled (ne $mode "production") -}}
+  {{- fail "optimized.enabled requires mode=production" -}}
+{{- end -}}
+{{- range $feature := .Values.features.enabled -}}
+  {{- if has $feature $.Values.features.disabled -}}
+    {{- fail (printf "feature %s cannot be present in both features.enabled and features.disabled" $feature) -}}
+  {{- end -}}
+{{- end -}}
+{{- $strategyType := .Values.deployment.strategy.type | default "RollingUpdate" -}}
+{{- if not (has $strategyType (list "RollingUpdate" "Recreate")) -}}
+  {{- fail "deployment.strategy.type must be one of: RollingUpdate, Recreate" -}}
+{{- end -}}
+{{- $capacityProfile := .Values.capacity.profile | default "custom" -}}
+{{- if not (has $capacityProfile (list "custom" "small" "medium" "large")) -}}
+  {{- fail "capacity.profile must be one of: custom, small, medium, large" -}}
+{{- end -}}
+{{- if and (ne $capacityProfile "custom") .Values.resources -}}
+  {{- fail "capacity.profile cannot be used together with explicit resources; set capacity.profile=custom or remove resources" -}}
+{{- end -}}
+{{- if and .Values.management.relativePath (not (hasPrefix "/" .Values.management.relativePath)) -}}
+  {{- fail "management.relativePath must start with / when set" -}}
+{{- end -}}
+{{- if and .Values.telemetry.metricsEnabled (not .Values.metrics.enabled) -}}
+  {{- fail "telemetry.metricsEnabled requires metrics.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.metrics.userEvents (not .Values.metrics.enabled) -}}
+  {{- fail "metrics.userEvents requires metrics.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.metrics.cacheHistograms (not .Values.metrics.enabled) -}}
+  {{- fail "metrics.cacheHistograms requires metrics.enabled=true" -}}
+{{- end -}}
+{{- if .Values.database.tls.trustStorePasswordSecret -}}
+  {{- if not .Values.database.tls.trustStoreFile -}}
+    {{- fail "database.tls.trustStorePasswordSecret requires database.tls.trustStoreFile" -}}
+  {{- end -}}
+{{- end -}}
+{{- with .Values.database.external.pool -}}
+  {{- if and .minSize .initialSize (gt (int .minSize) (int .initialSize)) -}}
+    {{- fail "database.external.pool.minSize must be lower than or equal to initialSize" -}}
+  {{- end -}}
+  {{- if and .initialSize .maxSize (gt (int .initialSize) (int .maxSize)) -}}
+    {{- fail "database.external.pool.initialSize must be lower than or equal to maxSize" -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.gateway.public.enabled -}}
+  {{- if not .Values.gateway.public.parentRefs -}}
+    {{- fail "gateway.public.parentRefs is required when gateway.public.enabled is true" -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.gateway.admin.enabled -}}
+  {{- if not .Values.gateway.admin.parentRefs -}}
+    {{- fail "gateway.admin.parentRefs is required when gateway.admin.enabled is true" -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if not .Values.externalSecrets.secretStoreRef.name -}}
+    {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled is true" -}}
+  {{- end -}}
+  {{- if .Values.externalSecrets.admin.enabled -}}
+    {{- if not .Values.externalSecrets.admin.usernameRemoteRef.key -}}
+      {{- fail "externalSecrets.admin.usernameRemoteRef.key is required when externalSecrets.admin.enabled is true" -}}
+    {{- end -}}
+    {{- if not .Values.externalSecrets.admin.passwordRemoteRef.key -}}
+      {{- fail "externalSecrets.admin.passwordRemoteRef.key is required when externalSecrets.admin.enabled is true" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if .Values.externalSecrets.database.enabled -}}
+    {{- if not (include "keycloak.hasDatabase" .) -}}
+      {{- fail "externalSecrets.database.enabled requires a configured database" -}}
+    {{- end -}}
+    {{- if not .Values.externalSecrets.database.passwordRemoteRef.key -}}
+      {{- fail "externalSecrets.database.passwordRemoteRef.key is required when externalSecrets.database.enabled is true" -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if .Values.externalSecrets.truststore.enabled -}}
+    {{- if not .Values.truststore.enabled -}}
+      {{- fail "externalSecrets.truststore.enabled requires truststore.enabled=true" -}}
+    {{- end -}}
+    {{- if and (not .Values.externalSecrets.truststore.targetName) (not .Values.truststore.existingSecret) -}}
+      {{- fail "externalSecrets.truststore.targetName or truststore.existingSecret is required when externalSecrets.truststore.enabled is true" -}}
+    {{- end -}}
+    {{- if not .Values.externalSecrets.truststore.data -}}
+      {{- fail "externalSecrets.truststore.data is required when externalSecrets.truststore.enabled is true" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.pdb.enabled .Values.pdb.minAvailable (ge (int .Values.pdb.minAvailable) (int .Values.replicaCount)) -}}
+  {{- fail "pdb.minAvailable must be lower than replicaCount to avoid blocking voluntary disruptions" -}}
+{{- end -}}
+{{- if .Values.backup.enabled -}}
+  {{- $_ := include "keycloak.backupEnabled" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "keycloak.adminSecretName" -}}
 {{- if .Values.admin.existingSecret -}}
 {{- .Values.admin.existingSecret -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.admin.enabled .Values.externalSecrets.admin.targetName -}}
+{{- .Values.externalSecrets.admin.targetName -}}
 {{- else -}}
 {{- printf "%s-admin" (include "keycloak.fullname" .) -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "keycloak.adminSecretManagedByExternalSecret" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.admin.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{- define "keycloak.databaseMode" -}}
@@ -159,9 +291,15 @@ mysql
 {{- $mode := include "keycloak.databaseMode" . -}}
 {{- if and (eq $mode "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}
+{{- .Values.externalSecrets.database.targetName -}}
 {{- else -}}
 {{- printf "%s-db" (include "keycloak.fullname" .) -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "keycloak.databaseSecretManagedByExternalSecret" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{- define "keycloak.databaseSecretPasswordKey" -}}
@@ -283,7 +421,21 @@ true
 {{- end -}}
 
 {{- define "keycloak.hasTruststoreVolume" -}}
-{{- if and .Values.truststore.enabled (or .Values.truststore.existingSecret .Values.truststore.existingConfigMap) -}}true{{- end -}}
+{{- if and .Values.truststore.enabled (or .Values.truststore.existingSecret .Values.truststore.existingConfigMap (include "keycloak.truststoreSecretManagedByExternalSecret" .)) -}}true{{- end -}}
+{{- end -}}
+
+{{- define "keycloak.truststoreSecretName" -}}
+{{- if .Values.truststore.existingSecret -}}
+{{- .Values.truststore.existingSecret -}}
+{{- else if .Values.externalSecrets.truststore.targetName -}}
+{{- .Values.externalSecrets.truststore.targetName -}}
+{{- else -}}
+{{- printf "%s-truststore" (include "keycloak.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "keycloak.truststoreSecretManagedByExternalSecret" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.truststore.enabled -}}true{{- end -}}
 {{- end -}}
 
 {{- define "keycloak.startCommand" -}}
@@ -296,9 +448,27 @@ true
 
 {{- define "keycloak.commandArgs" -}}
 - {{ include "keycloak.startCommand" . }}
+{{- if .Values.optimized.enabled }}
+- --optimized
+{{- end }}
 {{- if .Values.realmImport.enabled }}
 - --import-realm
 {{- end }}
+{{- end -}}
+
+{{- define "keycloak.managementRelativePath" -}}
+{{- if not .Values.management.relativePath -}}
+{{- "" -}}
+{{- else if eq .Values.management.relativePath "/" -}}
+{{- "" -}}
+{{- else -}}
+{{- trimSuffix "/" .Values.management.relativePath -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "keycloak.managementEndpointPath" -}}
+{{- $base := include "keycloak.managementRelativePath" .root -}}
+{{- if $base -}}{{ printf "%s%s" $base .path }}{{- else -}}{{ .path }}{{- end -}}
 {{- end -}}
 
 {{- define "keycloak.httpEnv" -}}
@@ -310,6 +480,17 @@ true
   value: {{ .Values.http.managementPort | quote }}
 - name: KC_HTTP_RELATIVE_PATH
   value: {{ include "keycloak.relativePath" . | quote }}
+{{- if .Values.management.healthEnabled }}
+- name: KC_HTTP_MANAGEMENT_HEALTH_ENABLED
+  value: "true"
+{{- else }}
+- name: KC_HTTP_MANAGEMENT_HEALTH_ENABLED
+  value: "false"
+{{- end }}
+{{- if .Values.management.relativePath }}
+- name: KC_HTTP_MANAGEMENT_RELATIVE_PATH
+  value: {{ .Values.management.relativePath | quote }}
+{{- end }}
 {{- if include "keycloak.isProduction" . }}
 - name: KC_HOSTNAME
   value: {{ required "hostname.hostname is required in production mode" .Values.hostname.hostname | quote }}
@@ -327,6 +508,14 @@ true
 {{- if .Values.proxy.headers }}
 - name: KC_PROXY_HEADERS
   value: {{ .Values.proxy.headers | quote }}
+{{- end }}
+{{- if .Values.proxy.trustedAddresses }}
+- name: KC_PROXY_TRUSTED_ADDRESSES
+  value: {{ .Values.proxy.trustedAddresses | quote }}
+{{- end }}
+{{- if .Values.proxy.protocolEnabled }}
+- name: KC_PROXY_PROTOCOL_ENABLED
+  value: "true"
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -347,12 +536,86 @@ true
   value: {{ ternary "true" "false" .Values.health.enabled | quote }}
 - name: KC_METRICS_ENABLED
   value: {{ ternary "true" "false" .Values.metrics.enabled | quote }}
+{{- if .Values.metrics.userEvents }}
+- name: KC_EVENT_METRICS_USER_ENABLED
+  value: "true"
+{{- end }}
+{{- if .Values.metrics.cacheHistograms }}
+- name: KC_CACHE_METRICS_HISTOGRAMS_ENABLED
+  value: "true"
+{{- end }}
+{{- if .Values.telemetry.metricsEnabled }}
+- name: KC_TELEMETRY_METRICS_ENABLED
+  value: "true"
+{{- end }}
+{{- if .Values.telemetry.endpoint }}
+- name: KC_TELEMETRY_ENDPOINT
+  value: {{ .Values.telemetry.endpoint | quote }}
+{{- end }}
+{{- if .Values.telemetry.metricsEndpoint }}
+- name: KC_TELEMETRY_METRICS_ENDPOINT
+  value: {{ .Values.telemetry.metricsEndpoint | quote }}
+{{- end }}
+{{- if .Values.tracing.enabled }}
+- name: KC_TRACING_ENABLED
+  value: "true"
+{{- with .Values.tracing.endpoint }}
+- name: KC_TRACING_ENDPOINT
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.tracing.samplerType }}
+- name: KC_TRACING_SAMPLER_TYPE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.tracing.samplerRatio }}
+- name: KC_TRACING_SAMPLER_RATIO
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.tracing.resourceAttributes }}
+- name: KC_TRACING_RESOURCE_ATTRIBUTES
+  value: {{ . | quote }}
+{{- end }}
+- name: KC_TRACING_JDBC_ENABLED
+  value: {{ ternary "true" "false" .Values.tracing.jdbcEnabled | quote }}
+- name: KC_TRACING_INFINISPAN_ENABLED
+  value: {{ ternary "true" "false" .Values.tracing.infinispanEnabled | quote }}
+{{- end }}
+{{- if .Values.logging.level }}
+- name: KC_LOG_LEVEL
+  value: {{ .Values.logging.level | quote }}
+{{- end }}
+{{- if .Values.logging.console.output }}
+- name: KC_LOG_CONSOLE_OUTPUT
+  value: {{ .Values.logging.console.output | quote }}
+{{- end }}
+{{- if .Values.logging.console.level }}
+- name: KC_LOG_CONSOLE_LEVEL
+  value: {{ .Values.logging.console.level | quote }}
+{{- end }}
+{{- if and (eq .Values.logging.console.output "json") .Values.logging.console.jsonFormat }}
+- name: KC_LOG_CONSOLE_JSON_FORMAT
+  value: {{ .Values.logging.console.jsonFormat | quote }}
+{{- end }}
+{{- if .Values.logging.access.enabled }}
+- name: KC_HTTP_ACCESS_LOG_ENABLED
+  value: "true"
+{{- with .Values.logging.access.pattern }}
+- name: KC_HTTP_ACCESS_LOG_PATTERN
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.logging.access.exclude }}
+- name: KC_HTTP_ACCESS_LOG_EXCLUDE
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.truststore.enabled }}
 - name: KC_TRUSTSTORE_PATHS
   value: {{ .Values.truststore.mountPath | quote }}
 - name: KC_TLS_HOSTNAME_VERIFIER
   value: {{ .Values.truststore.tlsHostnameVerifier | quote }}
 {{- end }}
+- name: KC_TRUSTSTORE_KUBERNETES_ENABLED
+  value: {{ ternary "true" "false" .Values.truststore.kubernetes.enabled | quote }}
 {{- if include "keycloak.hasDatabase" . }}
 - name: KC_DB
   value: {{ include "keycloak.databaseVendor" . | quote }}
@@ -365,6 +628,57 @@ true
     secretKeyRef:
       name: {{ include "keycloak.databaseSecretName" . }}
       key: {{ include "keycloak.databaseSecretPasswordKey" . }}
+{{- with .Values.database.external.schema }}
+- name: KC_DB_SCHEMA
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.external.pool.initialSize }}
+- name: KC_DB_POOL_INITIAL_SIZE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.external.pool.minSize }}
+- name: KC_DB_POOL_MIN_SIZE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.external.pool.maxSize }}
+- name: KC_DB_POOL_MAX_SIZE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.external.pool.maxLifetime }}
+- name: KC_DB_POOL_MAX_LIFETIME
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.external.logSlowQueriesThreshold }}
+- name: KC_DB_LOG_SLOW_QUERIES_THRESHOLD
+  value: {{ . | quote }}
+{{- end }}
+{{- if ne (toString .Values.database.external.transaction.xaEnabled) "" }}
+- name: KC_TRANSACTION_XA_ENABLED
+  value: {{ .Values.database.external.transaction.xaEnabled | quote }}
+{{- end }}
+{{- with .Values.database.external.transaction.timeout }}
+- name: KC_TRANSACTION_TIMEOUT
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.tls.mode }}
+- name: KC_DB_TLS_MODE
+  value: {{ . | quote }}
+{{- end }}
+{{- with .Values.database.tls.trustStoreFile }}
+- name: KC_DB_TLS_TRUST_STORE_FILE
+  value: {{ . | quote }}
+{{- end }}
+{{- if .Values.database.tls.trustStorePasswordSecret }}
+- name: KC_DB_TLS_TRUST_STORE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.database.tls.trustStorePasswordSecret }}
+      key: {{ .Values.database.tls.trustStorePasswordKey }}
+{{- end }}
+{{- with .Values.database.tls.trustStoreType }}
+- name: KC_DB_TLS_TRUST_STORE_TYPE
+  value: {{ . | quote }}
+{{- end }}
 {{- else if include "keycloak.isProduction" . }}
 {{- fail "production mode requires a database: set postgresql.enabled, mysql.enabled, or database.external.host" }}
 {{- end }}
@@ -374,6 +688,14 @@ true
 - name: KC_CACHE_STACK
   value: {{ .Values.cache.stack | quote }}
 {{- end }}
+{{- if .Values.features.enabled }}
+- name: KC_FEATURES
+  value: {{ join "," .Values.features.enabled | quote }}
+{{- end }}
+{{- if .Values.features.disabled }}
+- name: KC_FEATURES_DISABLED
+  value: {{ join "," .Values.features.disabled | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "keycloak.podSpecCommon" -}}
@@ -382,6 +704,7 @@ imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 serviceAccountName: {{ include "keycloak.serviceAccountName" . }}
+automountServiceAccountToken: {{ ternary "true" "false" .Values.serviceAccount.automountServiceAccountToken }}
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
@@ -432,6 +755,15 @@ topologySpreadConstraints:
       matchLabels:
         {{- include "keycloak.selectorLabels" . | nindent 8 }}
 {{- end }}
+{{- end -}}
+
+{{- define "keycloak.resources" -}}
+{{- $profile := .Values.capacity.profile | default "custom" -}}
+{{- if ne $profile "custom" -}}
+{{- toYaml (index .Values.capacity.profiles $profile) -}}
+{{- else -}}
+{{- toYaml .Values.resources -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "keycloak.defaultAffinityEnabled" -}}

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "keycloak.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- include "keycloak.validateAll" . -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "keycloak.validateAll" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,6 +7,13 @@ metadata:
     {{- include "keycloak.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deployment.strategy.type }}
+    {{- if eq .Values.deployment.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.deployment.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.deployment.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}
@@ -70,33 +78,33 @@ spec:
             {{- if gt (int .Values.replicaCount) 1 }}
             - name: jgroups
               containerPort: 7800
-            - name: failure-detector
+            - name: jgroups-fd
               containerPort: 57800
             {{- end }}
-          {{- if and .Values.health.enabled .Values.probes.liveness.enabled }}
+          {{- if and .Values.health.enabled .Values.management.healthEnabled .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /health/live
+              path: {{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/health/live") }}
               port: management
             initialDelaySeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "liveness" "field" "initialDelaySeconds") }}
             periodSeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "liveness" "field" "periodSeconds") }}
             timeoutSeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "liveness" "field" "timeoutSeconds") }}
             failureThreshold: {{ include "keycloak.probeValue" (dict "root" . "probe" "liveness" "field" "failureThreshold") }}
           {{- end }}
-          {{- if and .Values.health.enabled .Values.probes.readiness.enabled }}
+          {{- if and .Values.health.enabled .Values.management.healthEnabled .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /health/ready
+              path: {{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/health/ready") }}
               port: management
             initialDelaySeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "readiness" "field" "initialDelaySeconds") }}
             periodSeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "readiness" "field" "periodSeconds") }}
             timeoutSeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "readiness" "field" "timeoutSeconds") }}
             failureThreshold: {{ include "keycloak.probeValue" (dict "root" . "probe" "readiness" "field" "failureThreshold") }}
           {{- end }}
-          {{- if and .Values.health.enabled .Values.probes.startup.enabled }}
+          {{- if and .Values.health.enabled .Values.management.healthEnabled .Values.probes.startup.enabled }}
           startupProbe:
             httpGet:
-              path: /health/started
+              path: {{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/health/started") }}
               port: management
             initialDelaySeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "startup" "field" "initialDelaySeconds") }}
             periodSeconds: {{ include "keycloak.probeValue" (dict "root" . "probe" "startup" "field" "periodSeconds") }}
@@ -106,7 +114,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- include "keycloak.resources" . | nindent 12 }}
           volumeMounts:
             {{- if .Values.realmImport.enabled }}
             - name: realm-import
@@ -203,7 +211,11 @@ spec:
               {{- end }}
               {{- if .Values.truststore.existingSecret }}
               - secret:
-                  name: {{ .Values.truststore.existingSecret }}
+                  name: {{ include "keycloak.truststoreSecretName" . }}
+              {{- end }}
+              {{- if and (not .Values.truststore.existingSecret) (include "keycloak.truststoreSecretManagedByExternalSecret" .) }}
+              - secret:
+                  name: {{ include "keycloak.truststoreSecretName" . }}
               {{- end }}
         {{- end }}
         {{- with .Values.extraVolumes }}

--- a/charts/keycloak/templates/externalsecret.yaml
+++ b/charts/keycloak/templates/externalsecret.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.externalSecrets.enabled }}
+{{- include "keycloak.validateAll" . -}}
+{{- if .Values.externalSecrets.admin.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak.fullname" . }}-admin
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "keycloak.adminSecretName" . | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    - secretKey: {{ .Values.admin.existingSecretUsernameKey | quote }}
+      remoteRef:
+        {{- toYaml .Values.externalSecrets.admin.usernameRemoteRef | nindent 8 }}
+    - secretKey: {{ .Values.admin.existingSecretPasswordKey | quote }}
+      remoteRef:
+        {{- toYaml .Values.externalSecrets.admin.passwordRemoteRef | nindent 8 }}
+{{- end }}
+{{- if .Values.externalSecrets.database.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak.fullname" . }}-database
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "keycloak.databaseSecretName" . | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    - secretKey: {{ include "keycloak.databaseSecretPasswordKey" . | quote }}
+      remoteRef:
+        {{- toYaml .Values.externalSecrets.database.passwordRemoteRef | nindent 8 }}
+{{- end }}
+{{- if .Values.externalSecrets.truststore.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "keycloak.fullname" . }}-truststore
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "keycloak.truststoreSecretName" . | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.truststore.data | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/keycloak/templates/externalsecret.yaml
+++ b/charts/keycloak/templates/externalsecret.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- include "keycloak.validateAll" . -}}
 {{- if .Values.externalSecrets.admin.enabled }}

--- a/charts/keycloak/templates/httproute-admin.yaml
+++ b/charts/keycloak/templates/httproute-admin.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.gateway.admin.enabled }}
+{{- include "keycloak.validateAll" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "keycloak.fullname" . }}-admin
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin
+  {{- with .Values.gateway.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.admin.parentRefs | nindent 4 }}
+  {{- if .Values.gateway.admin.hostnames }}
+  hostnames:
+    {{- toYaml .Values.gateway.admin.hostnames | nindent 4 }}
+  {{- else if .Values.hostname.admin }}
+  hostnames:
+    - {{ .Values.hostname.admin | quote }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.admin.pathType }}
+            value: {{ .Values.gateway.admin.path | quote }}
+      {{- with .Values.gateway.admin.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "keycloak.fullname" . }}
+          port: {{ .Values.http.port }}
+{{- end }}

--- a/charts/keycloak/templates/httproute-admin.yaml
+++ b/charts/keycloak/templates/httproute-admin.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.admin.enabled }}
 {{- include "keycloak.validateAll" . -}}
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/keycloak/templates/httproute-public.yaml
+++ b/charts/keycloak/templates/httproute-public.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.gateway.public.enabled }}
+{{- include "keycloak.validateAll" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "keycloak.fullname" . }}-public
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: public
+  {{- with .Values.gateway.public.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.public.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.public.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.public.pathType }}
+            value: {{ .Values.gateway.public.path | quote }}
+      {{- with .Values.gateway.public.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "keycloak.fullname" . }}
+          port: {{ .Values.http.port }}
+{{- end }}

--- a/charts/keycloak/templates/httproute-public.yaml
+++ b/charts/keycloak/templates/httproute-public.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.public.enabled }}
 {{- include "keycloak.validateAll" . -}}
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/keycloak/templates/networkpolicy.yaml
+++ b/charts/keycloak/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/keycloak/templates/networkpolicy.yaml
+++ b/charts/keycloak/templates/networkpolicy.yaml
@@ -11,6 +11,9 @@ spec:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
   ingress:
     - from:
         {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
@@ -43,4 +46,31 @@ spec:
         - protocol: TCP
           port: 57800
     {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDns }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.egress.dnsNamespaceSelector | nindent 14 }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.egress.dnsPodSelector | nindent 14 }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if and .Values.networkPolicy.egress.allowDatabase (include "keycloak.hasDatabase" .) .Values.networkPolicy.egress.databaseTo }}
+    - to:
+        {{- toYaml .Values.networkPolicy.egress.databaseTo | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ include "keycloak.databasePort" . }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/keycloak/templates/secret.yaml
+++ b/charts/keycloak/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.admin.existingSecret }}
+{{- if and (not .Values.admin.existingSecret) (not (include "keycloak.adminSecretManagedByExternalSecret" .)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +10,7 @@ data:
   {{ .Values.admin.existingSecretUsernameKey }}: {{ .Values.admin.username | b64enc | quote }}
   {{ .Values.admin.existingSecretPasswordKey }}: {{ include "keycloak.adminPassword" . | b64enc | quote }}
 {{- end }}
-{{- if and (include "keycloak.hasDatabase" .) (not (and (eq (include "keycloak.databaseMode" .) "external") .Values.database.external.existingSecret)) }}
+{{- if and (include "keycloak.hasDatabase" .) (not (and (eq (include "keycloak.databaseMode" .) "external") .Values.database.external.existingSecret)) (not (include "keycloak.databaseSecretManagedByExternalSecret" .)) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/keycloak/templates/secret.yaml
+++ b/charts/keycloak/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and (not .Values.admin.existingSecret) (not (include "keycloak.adminSecretManagedByExternalSecret" .)) }}
 apiVersion: v1
 kind: Secret

--- a/charts/keycloak/templates/service-management.yaml
+++ b/charts/keycloak/templates/service-management.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/keycloak/templates/service-management.yaml
+++ b/charts/keycloak/templates/service-management.yaml
@@ -11,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.managementIpFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.managementIpFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: management
       port: {{ .Values.http.managementPort }}

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.http.port }}

--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -15,6 +19,17 @@ spec:
       app.kubernetes.io/component: management
   endpoints:
     - port: management
-      path: /metrics
+      path: {{ include "keycloak.managementEndpointPath" (dict "root" . "path" "/metrics") }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/keycloak/templates/servicemonitor.yaml
+++ b/charts/keycloak/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - deployment.yaml

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.5.5"
+          value: "quay.io/keycloak/keycloak:26.6.1"
 
   - it: should have 1 replica by default
     template: deployment.yaml
@@ -33,6 +33,26 @@ tests:
       - equal:
           path: spec.replicas
           value: 1
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+
+  - it: should render Recreate deployment strategy
+    template: deployment.yaml
+    set:
+      deployment.strategy.type: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
 
   - it: should use start-dev in dev mode
     template: deployment.yaml
@@ -53,6 +73,19 @@ tests:
           path: spec.template.spec.containers[0].args
           content: start
 
+  - it: should add optimized startup arg in production mode
+    template: deployment.yaml
+    set:
+      mode: production
+      optimized.enabled: true
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: testpass
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --optimized
+
   - it: should set pod security context
     template: deployment.yaml
     asserts:
@@ -62,6 +95,18 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroupChangePolicy
           value: OnRootMismatch
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  - it: should allow disabling service account token automount
+    template: deployment.yaml
+    set:
+      serviceAccount.automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
 
   - it: should have probes by default
     template: deployment.yaml
@@ -72,6 +117,21 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
       - isNotNull:
           path: spec.template.spec.containers[0].startupProbe
+
+  - it: should prefix probe paths with management relative path
+    template: deployment.yaml
+    set:
+      management.relativePath: /management
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /management/health/live
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /management/health/ready
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /management/health/started
 
   - it: should reference admin secret
     template: deployment.yaml
@@ -109,6 +169,22 @@ tests:
           content:
             name: KC_DB
           any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_TRUSTSTORE_KUBERNETES_ENABLED
+            value: "true"
+
+  - it: should disable Kubernetes truststore auto-discovery when configured
+    template: deployment.yaml
+    set:
+      truststore.kubernetes.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_TRUSTSTORE_KUBERNETES_ENABLED
+            value: "false"
 
   - it: should inject database env with postgresql subchart in dev mode
     template: deployment.yaml
@@ -177,6 +253,88 @@ tests:
             name: KC_DB_URL
             value: "jdbc:postgresql://pg-host:5432/keycloak"
 
+  - it: should render production hardening env vars
+    template: deployment.yaml
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      proxy.trustedAddresses: 10.0.0.0/8
+      database.external.schema: keycloak_schema
+      database.external.pool.initialSize: 2
+      database.external.pool.minSize: 1
+      database.external.pool.maxSize: 10
+      database.external.pool.maxLifetime: 30m
+      database.external.logSlowQueriesThreshold: 500ms
+      database.external.transaction.xaEnabled: "false"
+      database.external.transaction.timeout: 60s
+      database.tls.mode: verify-server
+      database.tls.trustStoreFile: /opt/keycloak/conf/db-truststore.p12
+      database.tls.trustStorePasswordSecret: db-tls-secret
+      database.tls.trustStoreType: PKCS12
+      features.enabled:
+        - opentelemetry-metrics
+      metrics.enabled: true
+      metrics.userEvents: true
+      metrics.cacheHistograms: true
+      telemetry.metricsEnabled: true
+      telemetry.endpoint: http://otel:4317
+      tracing.enabled: true
+      tracing.endpoint: http://tempo:4317
+      logging.console.output: json
+      logging.console.jsonFormat: ecs
+      logging.access.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_PROXY_TRUSTED_ADDRESSES
+            value: 10.0.0.0/8
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DB_SCHEMA
+            value: keycloak_schema
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DB_POOL_MAX_SIZE
+            value: "10"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_DB_TLS_TRUST_STORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: db-tls-secret
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_EVENT_METRICS_USER_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_TELEMETRY_ENDPOINT
+            value: http://otel:4317
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_TRACING_ENDPOINT
+            value: http://tempo:4317
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_LOG_CONSOLE_JSON_FORMAT
+            value: ecs
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_HTTP_ACCESS_LOG_ENABLED
+            value: "true"
+
   - it: should reference db secret with subchart postgresql
     template: deployment.yaml
     set:
@@ -209,3 +367,78 @@ tests:
               secretKeyRef:
                 name: my-db-secret
                 key: custom-key
+
+  - it: should use valid multi-replica cache transport port names
+    template: deployment.yaml
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      replicaCount: 3
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: jgroups
+            containerPort: 7800
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: jgroups-fd
+            containerPort: 57800
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: failure-detector
+          any: true
+
+  - it: should render overridden security contexts
+    template: deployment.yaml
+    set:
+      podSecurityContext.fsGroup: 2000
+      podSecurityContext.fsGroupChangePolicy: Always
+      podSecurityContext.seccompProfile.type: RuntimeDefault
+      securityContext.runAsUser: 2000
+      securityContext.runAsGroup: 2000
+      securityContext.runAsNonRoot: true
+      securityContext.allowPrivilegeEscalation: false
+      securityContext.readOnlyRootFilesystem: true
+      securityContext.capabilities.drop[0]: ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: Always
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should render capacity profile resources
+    template: deployment.yaml
+    set:
+      capacity.profile: medium
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "1"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "2"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 4Gi

--- a/charts/keycloak/tests/externalsecret_test.yaml
+++ b/charts/keycloak/tests/externalsecret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ExternalSecrets
 templates:
   - externalsecret.yaml

--- a/charts/keycloak/tests/externalsecret_test.yaml
+++ b/charts/keycloak/tests/externalsecret_test.yaml
@@ -1,0 +1,115 @@
+suite: ExternalSecrets
+templates:
+  - externalsecret.yaml
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render ExternalSecret by default
+    template: externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render admin ExternalSecret and suppress native admin Secret
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.usernameRemoteRef:
+        key: keycloak/admin
+        property: username
+      externalSecrets.admin.passwordRemoteRef:
+        key: keycloak/admin
+        property: password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: test-keycloak-admin
+      - equal:
+          path: spec.data[0].secretKey
+          value: admin-username
+
+  - it: should suppress native admin Secret when admin ExternalSecret is enabled
+    template: secret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.usernameRemoteRef:
+        key: keycloak/admin
+        property: username
+      externalSecrets.admin.passwordRemoteRef:
+        key: keycloak/admin
+        property: password
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render database ExternalSecret
+    template: externalsecret.yaml
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef:
+        key: keycloak/database
+        property: password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.target.name
+          value: test-keycloak-db
+      - equal:
+          path: spec.data[0].secretKey
+          value: db-password
+
+  - it: should suppress native db Secret when database ExternalSecret is enabled
+    template: secret.yaml
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef:
+        key: keycloak/database
+        property: password
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render truststore ExternalSecret
+    template: externalsecret.yaml
+    set:
+      truststore.enabled: true
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.truststore.enabled: true
+      externalSecrets.truststore.targetName: keycloak-truststore
+      externalSecrets.truststore.data:
+        - secretKey: ca.crt
+          remoteRef:
+            key: keycloak/truststore
+            property: ca.crt
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.target.name
+          value: keycloak-truststore
+      - equal:
+          path: spec.data[0].secretKey
+          value: ca.crt

--- a/charts/keycloak/tests/gateway_test.yaml
+++ b/charts/keycloak/tests/gateway_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Gateway API
 templates:
   - httproute-public.yaml

--- a/charts/keycloak/tests/gateway_test.yaml
+++ b/charts/keycloak/tests/gateway_test.yaml
@@ -1,0 +1,79 @@
+suite: Gateway API
+templates:
+  - httproute-public.yaml
+  - httproute-admin.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render public HTTPRoute by default
+    template: httproute-public.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render public HTTPRoute when enabled
+    template: httproute-public.yaml
+    set:
+      gateway.public.enabled: true
+      gateway.public.parentRefs:
+        - name: public-gateway
+          namespace: gateway-system
+      gateway.public.hostnames:
+        - sso.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: sso.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-keycloak
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should render admin HTTPRoute with admin hostname fallback
+    template: httproute-admin.yaml
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      hostname.admin: admin-sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      gateway.admin.enabled: true
+      gateway.admin.parentRefs:
+        - name: internal-gateway
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: admin-sso.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-keycloak
+
+  - it: should render HTTPRoute filters
+    template: httproute-public.yaml
+    set:
+      gateway.public.enabled: true
+      gateway.public.parentRefs:
+        - name: public-gateway
+      gateway.public.filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier

--- a/charts/keycloak/tests/networkpolicy_test.yaml
+++ b/charts/keycloak/tests/networkpolicy_test.yaml
@@ -16,3 +16,60 @@ tests:
     asserts:
       - isKind:
           of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+
+  - it: should render DNS egress when enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 53
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: kube-system
+
+  - it: should render database egress when destination peers are configured
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      networkPolicy.egress.databaseTo:
+        - ipBlock:
+            cidr: 10.10.0.0/16
+    asserts:
+      - equal:
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 10.10.0.0/16
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 5432
+
+  - it: should append extra egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowDns: false
+      networkPolicy.egress.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 0.0.0.0/0
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].ipBlock.cidr
+          value: 0.0.0.0/0
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 443

--- a/charts/keycloak/tests/networkpolicy_test.yaml
+++ b/charts/keycloak/tests/networkpolicy_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: NetworkPolicy
 templates:
   - networkpolicy.yaml

--- a/charts/keycloak/tests/service_test.yaml
+++ b/charts/keycloak/tests/service_test.yaml
@@ -1,28 +1,37 @@
 suite: Service
 templates:
   - service.yaml
+  - service-management.yaml
 release:
   name: test
   namespace: default
 tests:
   - it: should be a Service
+    template: service.yaml
     asserts:
       - isKind:
           of: Service
 
   - it: should have correct name
+    template: service.yaml
     asserts:
       - equal:
           path: metadata.name
           value: test-keycloak
 
   - it: should be ClusterIP by default
+    template: service.yaml
     asserts:
       - equal:
           path: spec.type
           value: ClusterIP
+      - notExists:
+          path: spec.ipFamilyPolicy
+      - notExists:
+          path: spec.ipFamilies
 
   - it: should expose HTTP port 8080
+    template: service.yaml
     asserts:
       - contains:
           path: spec.ports
@@ -30,3 +39,53 @@ tests:
             name: http
             port: 8080
             targetPort: http
+
+  - it: should set application Service dual-stack fields when configured
+    template: service.yaml
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
+  - it: should set management Service dual-stack fields when configured
+    template: service-management.yaml
+    set:
+      service.managementIpFamilyPolicy: PreferDualStack
+      service.managementIpFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
+  - it: should support SingleStack IPv6 on the application Service
+    template: service.yaml
+    set:
+      service.ipFamilyPolicy: SingleStack
+      service.ipFamilies:
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6

--- a/charts/keycloak/tests/service_test.yaml
+++ b/charts/keycloak/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - service.yaml

--- a/charts/keycloak/tests/servicemonitor_test.yaml
+++ b/charts/keycloak/tests/servicemonitor_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ServiceMonitor
 templates:
   - servicemonitor.yaml

--- a/charts/keycloak/tests/servicemonitor_test.yaml
+++ b/charts/keycloak/tests/servicemonitor_test.yaml
@@ -1,0 +1,52 @@
+suite: ServiceMonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render extended ServiceMonitor settings
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.interval: 15s
+      metrics.serviceMonitor.scrapeTimeout: 10s
+      metrics.serviceMonitor.labels:
+        release: prometheus
+      metrics.serviceMonitor.annotations:
+        team: platform
+      metrics.serviceMonitor.relabelings:
+        - action: labeldrop
+          regex: pod_template_hash
+      metrics.serviceMonitor.metricRelabelings:
+        - action: keep
+          regex: keycloak_.*
+          sourceLabels:
+            - __name__
+      management.relativePath: /management
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.labels.release
+          value: prometheus
+      - equal:
+          path: metadata.annotations.team
+          value: platform
+      - equal:
+          path: spec.endpoints[0].path
+          value: /management/metrics
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 10s
+      - equal:
+          path: spec.endpoints[0].relabelings[0].action
+          value: labeldrop
+      - equal:
+          path: spec.endpoints[0].metricRelabelings[0].action
+          value: keep

--- a/charts/keycloak/tests/validation_test.yaml
+++ b/charts/keycloak/tests/validation_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Validations
 templates:
   - deployment.yaml

--- a/charts/keycloak/tests/validation_test.yaml
+++ b/charts/keycloak/tests/validation_test.yaml
@@ -1,0 +1,173 @@
+suite: Validations
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should fail when more than one database mode is configured
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: devpass
+      mysql.enabled: true
+      mysql.auth.password: devpass
+    asserts:
+      - failedTemplate:
+          errorMessage: "keycloak database selection is ambiguous: configure only one of database.external.host, postgresql.enabled, or mysql.enabled"
+
+  - it: should fail production mode without hostname
+    set:
+      mode: production
+      database.external.host: pg-host
+      database.external.password: prodpass
+    asserts:
+      - failedTemplate:
+          errorMessage: "hostname.hostname is required in production mode"
+
+  - it: should fail production mode without a real database
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "production mode requires a database: set postgresql.enabled, mysql.enabled, or database.external.host"
+
+  - it: should fail admin ingress in production without admin hostname
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      ingress.admin.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "hostname.admin is required when ingress.admin.enabled is true in production mode"
+
+  - it: should fail dev mode with multiple replicas
+    set:
+      mode: dev
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "mode=dev does not support replicaCount > 1; use mode=production with a real database for multi-replica deployments"
+
+  - it: should fail production multi-replica when cache is disabled
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      replicaCount: 2
+      cache.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "production multi-replica deployments require cache.enabled=true"
+
+  - it: should fail PDB minAvailable equal to replicaCount
+    set:
+      pdb.enabled: true
+      replicaCount: 1
+      pdb.minAvailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "pdb.minAvailable must be lower than replicaCount to avoid blocking voluntary disruptions"
+
+  - it: should fail backup without S3 endpoint
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: devpass
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail backup with embedded H2
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.enabled requires a real database; embedded H2 is not supported for backups"
+
+  - it: should fail backup without S3 bucket
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: devpass
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.bucket is required when backup.enabled is true"
+
+  - it: should fail backup with incomplete S3 credentials
+    set:
+      postgresql.enabled: true
+      postgresql.auth.password: devpass
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey"
+
+  - it: should fail proxy protocol when proxy headers are enabled
+    set:
+      mode: production
+      hostname.hostname: sso.example.com
+      database.external.host: pg-host
+      database.external.password: prodpass
+      proxy.protocolEnabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "proxy.protocolEnabled cannot be used together with proxy.headers; set proxy.headers to an empty string"
+
+  - it: should fail optimized startup outside production
+    set:
+      optimized.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "optimized.enabled requires mode=production"
+
+  - it: should fail duplicate feature flags
+    set:
+      features.enabled:
+        - preview
+      features.disabled:
+        - preview
+    asserts:
+      - failedTemplate:
+          errorMessage: "feature preview cannot be present in both features.enabled and features.disabled"
+
+  - it: should fail Gateway public without parentRefs
+    set:
+      gateway.public.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.public.parentRefs is required when gateway.public.enabled is true"
+
+  - it: should fail ExternalSecrets without SecretStore reference
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.usernameRemoteRef.key: keycloak/admin
+      externalSecrets.admin.passwordRemoteRef.key: keycloak/admin
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled is true"
+
+  - it: should fail capacity profile with explicit resources
+    set:
+      capacity.profile: small
+      resources.requests.cpu: 500m
+    asserts:
+      - failedTemplate:
+          errorMessage: "capacity.profile cannot be used together with explicit resources; set capacity.profile=custom or remove resources"

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -98,6 +98,39 @@
         }
       }
     },
+    "management": {
+      "type": "object",
+      "description": "Keycloak management interface configuration",
+      "properties": {
+        "healthEnabled": {
+          "type": "boolean",
+          "description": "Serve health endpoints from the management interface"
+        },
+        "relativePath": {
+          "type": "string",
+          "description": "Optional management interface relative path"
+        }
+      }
+    },
+    "deployment": {
+      "type": "object",
+      "description": "Deployment lifecycle settings",
+      "properties": {
+        "strategy": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["RollingUpdate", "Recreate"] },
+            "rollingUpdate": {
+              "type": "object",
+              "properties": {
+                "maxUnavailable": { "type": ["string", "integer"] },
+                "maxSurge": { "type": ["string", "integer"] }
+              }
+            }
+          }
+        }
+      }
+    },
     "hostname": {
       "type": "object",
       "description": "Hostname and reverse proxy configuration",
@@ -127,7 +160,15 @@
         "headers": {
           "type": "string",
           "description": "Proxy headers mode passed to Keycloak, for example xforwarded or forwarded",
-          "enum": ["xforwarded", "forwarded"]
+          "enum": ["", "xforwarded", "forwarded"]
+        },
+        "trustedAddresses": {
+          "type": "string",
+          "description": "Comma-separated trusted proxy IPs/CIDRs used by Keycloak when proxy.headers is set"
+        },
+        "protocolEnabled": {
+          "type": "boolean",
+          "description": "Enable HAProxy PROXY protocol support"
         }
       }
     },
@@ -175,6 +216,32 @@
             "jdbcParameters": {
               "type": "string",
               "description": "Additional JDBC properties appended to the generated JDBC URL"
+            },
+            "schema": {
+              "type": "string",
+              "description": "Optional database schema passed to KC_DB_SCHEMA"
+            },
+            "pool": {
+              "type": "object",
+              "description": "Database connection pool settings",
+              "properties": {
+                "initialSize": { "type": ["string", "integer"], "description": "Initial database connection pool size" },
+                "minSize": { "type": ["string", "integer"], "description": "Minimum database connection pool size" },
+                "maxSize": { "type": ["string", "integer"], "description": "Maximum database connection pool size" },
+                "maxLifetime": { "type": "string", "description": "Maximum database connection lifetime" }
+              }
+            },
+            "logSlowQueriesThreshold": {
+              "type": "string",
+              "description": "Slow query threshold passed to Keycloak"
+            },
+            "transaction": {
+              "type": "object",
+              "description": "Database transaction settings",
+              "properties": {
+                "xaEnabled": { "type": ["string", "boolean"], "description": "Enable or disable XA transactions" },
+                "timeout": { "type": "string", "description": "Transaction timeout" }
+              }
             }
           }
         },
@@ -185,6 +252,11 @@
             "enabled": {
               "type": "boolean",
               "description": "Enable database TLS settings"
+            },
+            "mode": {
+              "type": "string",
+              "description": "Keycloak database TLS mode",
+              "enum": ["", "disabled", "verify-server"]
             },
             "sslMode": {
               "type": "string",
@@ -205,6 +277,22 @@
             "existingConfigMap": {
               "type": "string",
               "description": "Existing ConfigMap holding database CA material"
+            },
+            "trustStoreFile": {
+              "type": "string",
+              "description": "Database TLS truststore file path passed to Keycloak"
+            },
+            "trustStorePasswordSecret": {
+              "type": "string",
+              "description": "Existing Secret containing the database TLS truststore password"
+            },
+            "trustStorePasswordKey": {
+              "type": "string",
+              "description": "Secret key for database TLS truststore password"
+            },
+            "trustStoreType": {
+              "type": "string",
+              "description": "Database TLS truststore type"
             }
           }
         }
@@ -330,6 +418,16 @@
           "type": "string",
           "description": "TLS hostname verification mode for outbound HTTPS and SMTP traffic",
           "enum": ["DEFAULT", "ANY", "WILDCARD", "STRICT"]
+        },
+        "kubernetes": {
+          "type": "object",
+          "description": "Kubernetes/OpenShift service account CA truststore handling",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Let Keycloak trust Kubernetes/OpenShift service account CA files when mounted"
+            }
+          }
         }
       }
     },
@@ -381,6 +479,32 @@
               }
             }
           }
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "description": "Keycloak feature flags",
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Keycloak features to enable"
+        },
+        "disabled": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Keycloak features to disable"
+        }
+      }
+    },
+    "optimized": {
+      "type": "object",
+      "description": "Optimized startup settings",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Add --optimized to Keycloak startup args"
         }
       }
     },
@@ -440,6 +564,58 @@
         "managementAnnotations": {
           "type": "object",
           "description": "Annotations for the management service"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Application Service IP family policy",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Application Service IP families",
+          "maxItems": 2,
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] }
+        },
+        "managementIpFamilyPolicy": {
+          "type": "string",
+          "description": "Management Service IP family policy",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "managementIpFamilies": {
+          "type": "array",
+          "description": "Management Service IP families",
+          "maxItems": 2,
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "public": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "annotations": { "type": "object" },
+            "parentRefs": { "type": "array", "items": { "type": "object" } },
+            "hostnames": { "type": "array", "items": { "type": "string" } },
+            "path": { "type": "string" },
+            "pathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] },
+            "filters": { "type": "array", "items": { "type": "object" } }
+          }
+        },
+        "admin": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "annotations": { "type": "object" },
+            "parentRefs": { "type": "array", "items": { "type": "object" } },
+            "hostnames": { "type": "array", "items": { "type": "string" } },
+            "path": { "type": "string" },
+            "pathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] },
+            "filters": { "type": "array", "items": { "type": "object" } }
+          }
         }
       }
     },
@@ -588,12 +764,69 @@
           "type": "boolean",
           "description": "Enable Keycloak metrics endpoint"
         },
+        "userEvents": {
+          "type": "boolean",
+          "description": "Create metrics based on user events"
+        },
+        "cacheHistograms": {
+          "type": "boolean",
+          "description": "Enable cache metrics histograms"
+        },
         "serviceMonitor": {
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean", "description": "Create a ServiceMonitor targeting the management service" },
             "interval": { "type": "string", "description": "Scrape interval" },
-            "labels": { "type": "object", "description": "Additional labels for the ServiceMonitor" }
+            "scrapeTimeout": { "type": "string", "description": "Scrape timeout" },
+            "labels": { "type": "object", "description": "Additional labels for the ServiceMonitor" },
+            "annotations": { "type": "object", "description": "Additional annotations for the ServiceMonitor" },
+            "relabelings": { "type": "array", "items": { "type": "object" } },
+            "metricRelabelings": { "type": "array", "items": { "type": "object" } }
+          }
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "description": "OpenTelemetry metrics export settings",
+      "properties": {
+        "metricsEnabled": { "type": "boolean" },
+        "endpoint": { "type": "string" },
+        "metricsEndpoint": { "type": "string" }
+      }
+    },
+    "tracing": {
+      "type": "object",
+      "description": "OpenTelemetry tracing settings",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "endpoint": { "type": "string" },
+        "samplerType": { "type": "string" },
+        "samplerRatio": { "type": ["string", "number"] },
+        "resourceAttributes": { "type": "string" },
+        "jdbcEnabled": { "type": "boolean" },
+        "infinispanEnabled": { "type": "boolean" }
+      }
+    },
+    "logging": {
+      "type": "object",
+      "description": "Keycloak logging settings",
+      "properties": {
+        "level": { "type": "string" },
+        "console": {
+          "type": "object",
+          "properties": {
+            "output": { "type": "string", "enum": ["default", "json"] },
+            "level": { "type": "string" },
+            "jsonFormat": { "type": "string", "enum": ["default", "ecs"] }
+          }
+        },
+        "access": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "pattern": { "type": "string" },
+            "exclude": { "type": "string" }
           }
         }
       }
@@ -643,6 +876,19 @@
           "properties": {
             "enabled": { "type": "boolean", "description": "Allow intra-cluster cache transport traffic between Keycloak pods when replicaCount > 1" }
           }
+        },
+        "egress": {
+          "type": "object",
+          "description": "Optional egress NetworkPolicy rules",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowDns": { "type": "boolean" },
+            "dnsNamespaceSelector": { "type": "object" },
+            "dnsPodSelector": { "type": "object" },
+            "allowDatabase": { "type": "boolean" },
+            "databaseTo": { "type": "array", "items": { "type": "object" } },
+            "extraEgress": { "type": "array", "items": { "type": "object" } }
+          }
         }
       }
     },
@@ -652,20 +898,105 @@
       "properties": {
         "create": { "type": "boolean", "description": "Create a ServiceAccount" },
         "name": { "type": "string" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
       }
     },
     "resources": {
       "type": "object",
       "description": "CPU and memory requests/limits for the Keycloak container"
     },
+    "capacity": {
+      "type": "object",
+      "description": "Optional resource profiles",
+      "properties": {
+        "profile": { "type": "string", "enum": ["custom", "small", "medium", "large"] },
+        "profiles": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
     "podSecurityContext": {
       "type": "object",
-      "description": "Pod-level security context"
+      "description": "Pod-level security context",
+      "properties": {
+        "fsGroup": {
+          "type": "integer",
+          "description": "File system group ID applied to mounted volumes",
+          "minimum": 0
+        },
+        "fsGroupChangePolicy": {
+          "type": "string",
+          "description": "Policy for changing ownership and permissions of mounted volumes",
+          "enum": ["Always", "OnRootMismatch"]
+        },
+        "seccompProfile": {
+          "type": "object",
+          "description": "Pod seccomp profile",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Seccomp profile type",
+              "enum": ["RuntimeDefault", "Localhost", "Unconfined"]
+            },
+            "localhostProfile": {
+              "type": "string",
+              "description": "Localhost seccomp profile path when type is Localhost"
+            }
+          }
+        }
+      }
     },
     "securityContext": {
       "type": "object",
-      "description": "Container-level security context"
+      "description": "Container-level security context",
+      "properties": {
+        "runAsUser": {
+          "type": "integer",
+          "description": "User ID used to run the Keycloak container",
+          "minimum": 0
+        },
+        "runAsGroup": {
+          "type": "integer",
+          "description": "Group ID used to run the Keycloak container",
+          "minimum": 0
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "description": "Require the container to run as a non-root user"
+        },
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "description": "Allow privilege escalation in the Keycloak container"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "description": "Mount the container root filesystem as read-only"
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "Linux capabilities configuration",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "description": "Linux capabilities dropped from the container",
+              "items": {
+                "type": "string"
+              }
+            },
+            "add": {
+              "type": "array",
+              "description": "Linux capabilities added to the container",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "nodeSelector": {
       "type": "object",
@@ -734,6 +1065,53 @@
       "type": "array",
       "description": "Additional volume mounts for the Keycloak container",
       "items": { "type": "object" }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator integration for clusters that already run ESO",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string", "enum": ["external-secrets.io/v1"] },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "None"] }
+          }
+        },
+        "admin": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "targetName": { "type": "string" },
+            "usernameRemoteRef": { "type": "object" },
+            "passwordRemoteRef": { "type": "object" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "targetName": { "type": "string" },
+            "passwordRemoteRef": { "type": "object" }
+          }
+        },
+        "truststore": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "targetName": { "type": "string" },
+            "data": { "type": "array", "items": { "type": "object" } }
+          }
+        }
+      }
     },
     "postgresql": {
       "type": "object",

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # -- Keycloak image tag
-  tag: "26.5.5"
+  tag: "26.6.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -62,6 +62,22 @@ http:
   # -- HTTP relative path, for example `/auth`
   relativePath: /
 
+management:
+  # -- Serve health endpoints from the management interface.
+  healthEnabled: true
+  # -- Optional management interface relative path. Leave empty to use Keycloak defaults.
+  relativePath: ""
+
+deployment:
+  strategy:
+    # -- Deployment rollout strategy type.
+    type: RollingUpdate
+    rollingUpdate:
+      # -- Maximum unavailable pods during RollingUpdate.
+      maxUnavailable: 0
+      # -- Maximum surge pods during RollingUpdate.
+      maxSurge: 1
+
 # =============================================================================
 # Hostname and Reverse Proxy
 # =============================================================================
@@ -79,6 +95,10 @@ hostname:
 proxy:
   # -- Proxy headers mode passed to Keycloak, for example `xforwarded` or `forwarded`
   headers: xforwarded
+  # -- Comma-separated trusted proxy IPs/CIDRs used by Keycloak when proxy.headers is set.
+  trustedAddresses: ""
+  # -- Enable HAProxy PROXY protocol support. Cannot be used together with proxy.headers.
+  protocolEnabled: false
 
 # =============================================================================
 # Database
@@ -112,9 +132,29 @@ database:
     existingSecretPasswordKey: db-password
     # -- Additional JDBC properties appended to the generated JDBC URL
     jdbcParameters: ""
+    # -- Optional database schema passed to KC_DB_SCHEMA
+    schema: ""
+    pool:
+      # -- Initial database connection pool size
+      initialSize: ""
+      # -- Minimum database connection pool size
+      minSize: ""
+      # -- Maximum database connection pool size
+      maxSize: ""
+      # -- Maximum database connection lifetime
+      maxLifetime: ""
+    # -- Slow query threshold passed to Keycloak
+    logSlowQueriesThreshold: ""
+    transaction:
+      # -- Enable or disable XA transactions
+      xaEnabled: ""
+      # -- Transaction timeout
+      timeout: ""
   tls:
     # -- Enable database TLS settings. Automatic JDBC parameter wiring is production-ready for PostgreSQL and can be extended manually through database.external.jdbcParameters for other vendors.
     enabled: false
+    # -- Keycloak database TLS mode. Empty omits KC_DB_TLS_MODE.
+    mode: ""
     # -- PostgreSQL SSL mode used when database.tls.enabled is true
     sslMode: verify-full
     # -- Mount path for database TLS material
@@ -125,6 +165,14 @@ database:
     existingSecret: ""
     # -- Existing ConfigMap holding database CA material
     existingConfigMap: ""
+    # -- Database TLS truststore file path passed to Keycloak.
+    trustStoreFile: ""
+    # -- Existing Secret containing the database TLS truststore password.
+    trustStorePasswordSecret: ""
+    # -- Secret key for database TLS truststore password.
+    trustStorePasswordKey: password
+    # -- Database TLS truststore type.
+    trustStoreType: ""
 
 # =============================================================================
 # Backup
@@ -202,6 +250,9 @@ truststore:
   existingConfigMap: ""
   # -- TLS hostname verification mode for outbound HTTPS and SMTP traffic
   tlsHostnameVerifier: DEFAULT
+  kubernetes:
+    # -- Let Keycloak trust Kubernetes/OpenShift service account CA files when mounted.
+    enabled: true
 
 # =============================================================================
 # Runtime and Clustering
@@ -227,6 +278,16 @@ cache:
       topologyKey: kubernetes.io/hostname
       # -- whenUnsatisfiable policy used by the generated spread constraint
       whenUnsatisfiable: ScheduleAnyway
+
+features:
+  # -- Keycloak features to enable, rendered as KC_FEATURES.
+  enabled: []
+  # -- Keycloak features to disable, rendered as KC_FEATURES_DISABLED.
+  disabled: []
+
+optimized:
+  # -- Add --optimized to Keycloak startup args. Use only with pre-built/custom optimized images.
+  enabled: false
 
 # =============================================================================
 # Realm Import
@@ -272,6 +333,38 @@ service:
   # -- Annotations for the application service
   annotations: {}
   managementAnnotations: {}
+  # -- Application Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Application Service IP families. Empty uses cluster default.
+  ipFamilies: []
+  # -- Management Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  managementIpFamilyPolicy: ""
+  # -- Management Service IP families. Empty uses cluster default.
+  managementIpFamilies: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  public:
+    # -- Create an HTTPRoute for public Keycloak traffic. Requires Gateway API CRDs/controller installed.
+    enabled: false
+    annotations: {}
+    parentRefs: []
+    hostnames: []
+    path: /
+    pathType: PathPrefix
+    filters: []
+  admin:
+    # -- Create an HTTPRoute for admin Keycloak traffic. Requires Gateway API CRDs/controller installed.
+    enabled: false
+    annotations: {}
+    parentRefs: []
+    hostnames: []
+    path: /
+    pathType: PathPrefix
+    filters: []
 
 # =============================================================================
 # Ingress
@@ -351,11 +444,59 @@ probes:
 metrics:
   # -- Enable Keycloak metrics endpoint
   enabled: false
+  # -- Create metrics based on user events. Requires the Keycloak user-event-metrics feature.
+  userEvents: false
+  # -- Enable cache metrics histograms.
+  cacheHistograms: false
   serviceMonitor:
     # -- Create a ServiceMonitor targeting the management service
     enabled: false
     interval: 30s
+    scrapeTimeout: ""
     labels: {}
+    annotations: {}
+    relabelings: []
+    metricRelabelings: []
+
+telemetry:
+  # -- Enable OpenTelemetry metrics export.
+  metricsEnabled: false
+  # -- General OpenTelemetry endpoint inherited by enabled telemetry components.
+  endpoint: ""
+  # -- Metrics-specific OpenTelemetry endpoint.
+  metricsEndpoint: ""
+
+tracing:
+  # -- Enable Keycloak OpenTelemetry tracing.
+  enabled: false
+  endpoint: ""
+  samplerType: ""
+  samplerRatio: ""
+  resourceAttributes: ""
+  jdbcEnabled: true
+  infinispanEnabled: true
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+logging:
+  # -- Global Keycloak log level.
+  level: info
+  console:
+    # -- Console log output: default | json.
+    output: default
+    # -- Console handler log level.
+    level: all
+    # -- JSON log format: default | ecs.
+    jsonFormat: default
+  access:
+    # -- Enable HTTP access logs.
+    enabled: false
+    # -- Optional access log pattern.
+    pattern: ""
+    # -- Optional regex for paths excluded from access logs.
+    exclude: ""
 
 # =============================================================================
 # Pod Disruption Budget
@@ -389,6 +530,23 @@ networkPolicy:
   clustering:
     # -- Allow intra-cluster cache transport traffic between Keycloak pods when replicaCount > 1
     enabled: true
+  egress:
+    # -- Add egress rules. Disabled by default to avoid blocking unknown DB/S3/OTel endpoints.
+    enabled: false
+    # -- Allow DNS egress on TCP/UDP 53.
+    allowDns: true
+    # -- Namespace selector for DNS pods.
+    dnsNamespaceSelector:
+      kubernetes.io/metadata.name: kube-system
+    # -- Pod selector for DNS pods.
+    dnsPodSelector:
+      k8s-app: kube-dns
+    # -- Allow egress to the configured database host port by IP/CIDR rules listed in databaseTo.
+    allowDatabase: true
+    # -- Destination peers for database egress. Use ipBlock/namespaceSelector/podSelector entries.
+    databaseTo: []
+    # -- Additional egress rules appended verbatim.
+    extraEgress: []
 
 # =============================================================================
 # Service Account
@@ -399,12 +557,40 @@ serviceAccount:
   create: false
   name: ""
   annotations: {}
+  # -- Mount the Kubernetes service account token into the Keycloak pod.
+  automountServiceAccountToken: true
 
 # =============================================================================
 # Resources and Security
 # =============================================================================
 
 resources: {}
+
+capacity:
+  # -- Optional resource profile: custom | small | medium | large. `custom` uses resources as-is.
+  profile: custom
+  profiles:
+    small:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+    medium:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 4Gi
+    large:
+      requests:
+        cpu: "2"
+        memory: 3Gi
+      limits:
+        cpu: "4"
+        memory: 6Gi
 
 podSecurityContext:
   fsGroup: 1000
@@ -447,6 +633,46 @@ initContainers: []
 extraContainers: []
 extraVolumes: []
 extraVolumeMounts: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources for clusters that already run External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval used by rendered ExternalSecrets.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name. The chart does not create it.
+    name: ""
+    # -- SecretStore kind: SecretStore | ClusterSecretStore.
+    kind: SecretStore
+  target:
+    # -- ExternalSecret target creationPolicy.
+    creationPolicy: Owner
+  admin:
+    # -- Materialize the bootstrap admin Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Defaults to the chart-generated admin Secret name.
+    targetName: ""
+    usernameRemoteRef: {}
+    passwordRemoteRef: {}
+  database:
+    # -- Materialize the database password Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Defaults to the chart-generated database Secret name.
+    targetName: ""
+    passwordRemoteRef: {}
+  truststore:
+    # -- Materialize a truststore Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Defaults to truststore.existingSecret when set.
+    targetName: ""
+    # -- ExternalSecret data entries for truststore material.
+    data: []
 
 # =============================================================================
 # Optional subcharts

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# Keycloak Helm Chart — Default Values
+# Keycloak Helm Chart - Default Values
 # =============================================================================
 # Supported modes:
 # - dev


### PR DESCRIPTION
## Summary

- Updates Keycloak to `quay.io/keycloak/keycloak:26.6.1` and bumps HelmForge PostgreSQL/MySQL dependencies to PostgreSQL chart `1.9.13` and MySQL chart `1.8.7`.
- Fixes issue #131 by renaming the invalid JGroups failure-detector port to the Kubernetes-valid `jgroups-fd` name.
- Adds production hardening for proxy, management, DB pool/TLS/transactions, truststore, rollout strategy, capacity profiles, ServiceAccount token mounting, NetworkPolicy egress, metrics, ServiceMonitor, Gateway API, External Secrets Operator, and dual-stack Services.
- Keeps `Chart.lock` versioned for reproducible dependency builds; `.helmignore` still omits lock files from packaged chart archives.

Resolves #131
Resolves #133

## Breaking change

This is a breaking feature PR because the chart now aligns more strictly with Keycloak production requirements and validates production mode, database, routing, backup, and HA behavior more aggressively.

## Validation

- `helm dependency list charts/keycloak`
- `helm lint charts/keycloak --strict`
- `helm unittest charts/keycloak` -> 11 suites, 89 tests
- Rendered all `ci/*.yaml` scenarios and all examples
- Server dry-run for database TLS and dual-stack scenarios
- MCP `validate_chart` -> WARN only for CI-managed chart version, no blockers
- MCP `check_site_sync` -> PASS for defaults, architecture, install path, backup
- MCP `validate_compliance` -> 40/41 PASS, 0 blockers, 1 warning for CI-managed version
- MCP `check_release_readiness` -> PASS with accepted warnings

## Local k3d evidence

Validated on local context `k3d-charts-test` with External Secrets Operator installed:

- default/dev install
- production PostgreSQL HA with 2 Keycloak replicas
- metrics and ServiceMonitor
- Gateway API HTTPRoute rendering and backend refs
- External Secrets Operator materializing admin/database Secrets
- database TLS server dry-run
- dual-stack server dry-run
- PostgreSQL backup to local MinIO

Logs and events were reviewed for the Keycloak, PostgreSQL, MinIO, External Secrets, manual backup job, and init containers. Known benign warnings are documented in the plan evidence.

## Backup evidence

- Created a marker realm with `kcadm.sh`.
- Ran a manual Job from the backup CronJob.
- Verified upload to MinIO: `keycloak-postgresql-20260428T225635Z.sql.gz`.
- Downloaded and decompressed the dump.
- Confirmed the SQL dump contains the marker `backup-marker`.

## Notes

- `Chart.yaml.version` was not manually bumped; release automation should own the published chart version.
- Gateway API and External Secrets are optional and require CRDs/controllers already installed in the cluster.
- Dual-stack support follows the same pattern applied to Gophish: optional Service fields, omitted by default, with CI coverage.
- The site documentation update is in a separate repository PR because `site` is a separate Git repository.