### PR TITLE
fix(upstream-watch): ensure all required labels exist before issue creation

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -166,6 +166,7 @@ jobs:
           ### Update Checklist
 
           - [ ] Verify new tag exists and is stable: `docker pull REPO_PLACEHOLDER:LATEST_PLACEHOLDER`
+          - [ ] Review upstream changelog/release notes for breaking changes
           - [ ] Update `values.yaml` image tag
           - [ ] Update `appVersion` in `Chart.yaml`
           - [ ] Run `helm lint charts/CHART_PLACEHOLDER --strict`
@@ -189,7 +190,13 @@ jobs:
               | sed "s|LATEST_PLACEHOLDER|$LATEST|g" \
               | sed "s|REGISTRY_PLACEHOLDER|$REGISTRY_NAME|g")
 
-            # Ensure chart-specific label exists (idempotent)
+            # Ensure all required labels exist (idempotent)
+            gh label create "upstream-update" \
+              --description "Upstream image version update available" \
+              --color "1D76DB" --force 2>/dev/null || true
+            gh label create "chore" \
+              --description "Maintenance and housekeeping" \
+              --color "C2E0C6" --force 2>/dev/null || true
             gh label create "chart:${CHART}" \
               --description "Issues related to the ${CHART} chart" \
               --color "0e8a16" --force 2>/dev/null || true


### PR DESCRIPTION
### Problem

The upstream-watch workflow failed to create issues because the labels **upstream-update** and **chore** didn't exist at workflow runtime. Only the chart-specific label was being auto-created.

### Fix

Added idempotent label creation for **all three required labels** (upstream-update, chore, chart:NAME) before calling gh issue create. Uses --force flag so it's safe to run repeatedly.

### Root Cause

Labels were created manually after the first workflow run. This fix makes the workflow fully self-contained — it will work on a fresh repo with zero pre-existing labels.