### PR TITLE
fix(upstream-watch): ensure labels exist, add changelog review, migrate keycloak to docker.io

### DIFF
--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -83,6 +83,26 @@ jobs:
                 | sed "s/^v//; s/${TAG_VARIANT:-\$}$//" \
                 | sort -t. -k1,1n -k2,2n -k3,3n \
                 | tail -1)
+            elif echo "$REPO" | grep -q "quay.io"; then
+              # Quay.io — OCI distribution API with anonymous token
+              IMAGE_PATH="${REPO#quay.io/}"
+              QUAY_TOKEN=$(curl -sf \
+                "https://quay.io/v2/auth?scope=repository:${IMAGE_PATH}:pull&service=quay.io" \
+                2>/dev/null | jq -r '.token // empty' 2>/dev/null || echo "")
+              if [ -z "$QUAY_TOKEN" ]; then
+                echo "⚠️ Failed to obtain Quay token for $IMAGE_PATH — skipping"
+                echo "::endgroup::"
+                sleep 2
+                continue
+              fi
+              TAGS_JSON=$(curl -sf -H "Authorization: Bearer $QUAY_TOKEN" \
+                "https://quay.io/v2/${IMAGE_PATH}/tags/list" 2>/dev/null || echo "{}")
+              LATEST=$(echo "$TAGS_JSON" | jq -r '.tags[]? // empty' 2>/dev/null \
+                | { if [ -n "$TAG_VARIANT" ]; then grep -E "^v?[0-9]+\.[0-9]+(\.[0-9]+)?${TAG_VARIANT}$"; else grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$'; fi; } \
+                | grep -vE '(-rc|-alpha|-beta|-dev|-snapshot|-pre)' \
+                | sed "s/^v//; s/${TAG_VARIANT:-\$}$//" \
+                | sort -t. -k1,1n -k2,2n -k3,3n \
+                | tail -1)
             elif echo "$REPO" | grep -qE "^(docker\.io/|[^./]+/[^./]+$)"; then
               # Docker Hub
               NAMESPACE=$(echo "$REPO" | sed 's|docker\.io/||' | cut -d'/' -f1)
@@ -166,6 +186,7 @@ jobs:
           ### Update Checklist
 
           - [ ] Verify new tag exists and is stable: `docker pull REPO_PLACEHOLDER:LATEST_PLACEHOLDER`
+          - [ ] Review upstream changelog/release notes for breaking changes
           - [ ] Update `values.yaml` image tag
           - [ ] Update `appVersion` in `Chart.yaml`
           - [ ] Run `helm lint charts/CHART_PLACEHOLDER --strict`
@@ -189,7 +210,13 @@ jobs:
               | sed "s|LATEST_PLACEHOLDER|$LATEST|g" \
               | sed "s|REGISTRY_PLACEHOLDER|$REGISTRY_NAME|g")
 
-            # Ensure chart-specific label exists (idempotent)
+            # Ensure all required labels exist (idempotent)
+            gh label create "upstream-update" \
+              --description "Upstream image version update available" \
+              --color "1D76DB" --force 2>/dev/null || true
+            gh label create "chore" \
+              --description "Maintenance and housekeeping" \
+              --color "C2E0C6" --force 2>/dev/null || true
             gh label create "chart:${CHART}" \
               --description "Issues related to the ${CHART} chart" \
               --color "0e8a16" --force 2>/dev/null || true


### PR DESCRIPTION
Follow-up fixes after first upstream-watch run:

1. **Self-contained label creation** - ensures upstream-update and chore labels exist before creating issues (was the root cause of the failures)
2. **Changelog review step** - added to the issue checklist so maintainers review breaking changes before bumping
3. **Keycloak image migration** - switched from quay.io/keycloak/keycloak to docker.io/keycloak/keycloak per GR-005 (fully qualified registry) and to enable upstream-watch monitoring