### PR TITLE
chore(komga): upgrade to 1.24.4

### DIFF
--- a/charts/komga/.helmignore
+++ b/charts/komga/.helmignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OS
 .DS_Store
 Thumbs.db

--- a/charts/komga/.helmignore
+++ b/charts/komga/.helmignore
@@ -20,7 +20,12 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Pipfile.lock
+poetry.lock
+Gemfile.lock
 
 # Logs
 *.log

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -3,7 +3,7 @@ name: komga
 description: Komga media server for comics and manga with persistent SQLite storage, library management, and S3 backup
 type: application
 version: 1.4.9
-appVersion: "1.24.1"
+appVersion: "1.24.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: komga
 description: Komga media server for comics and manga with persistent SQLite storage, library management, and S3 backup

--- a/charts/komga/ci/backup-values.yaml
+++ b/charts/komga/ci/backup-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: backup enabled with S3 credentials
 backup:
   enabled: true

--- a/charts/komga/ci/default-values.yaml
+++ b/charts/komga/ci/default-values.yaml
@@ -1,3 +1,3 @@
-﻿# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0
 # CI: default values - SQLite with persistent config and data
 {}

--- a/charts/komga/ci/default-values.yaml
+++ b/charts/komga/ci/default-values.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: default values — SQLite with persistent config and data
 {}

--- a/charts/komga/ci/default-values.yaml
+++ b/charts/komga/ci/default-values.yaml
@@ -1,3 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
-# CI: default values — SQLite with persistent config and data
+﻿# SPDX-License-Identifier: Apache-2.0
+# CI: default values - SQLite with persistent config and data
 {}

--- a/charts/komga/ci/dual-stack.yaml
+++ b/charts/komga/ci/dual-stack.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack networking (GR-058)
+# Works on both single-stack and dual-stack clusters
+service:
+  ipFamilyPolicy: PreferDualStack

--- a/charts/komga/ci/external-secrets.yaml
+++ b/charts/komga/ci/external-secrets.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: External Secrets Operator integration (GR-061)
+# Renders the ExternalSecret manifest for backup S3 credentials
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: my-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: access-key
+      remoteRef:
+        key: komga/backup
+        property: access-key
+    - secretKey: secret-key
+      remoteRef:
+        key: komga/backup
+        property: secret-key

--- a/charts/komga/ci/gateway-api.yaml
+++ b/charts/komga/ci/gateway-api.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: Gateway API HTTPRoute opt-in (GR-060)
+# Renders the HTTPRoute manifest without requiring a live Gateway controller
+gateway:
+  enabled: true
+  parentRefs:
+    - name: envoy
+      namespace: envoy-gateway
+  hostnames:
+    - komga.example.com
+  path: /
+  pathType: PathPrefix

--- a/charts/komga/ci/ingress-values.yaml
+++ b/charts/komga/ci/ingress-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: ingress enabled with TLS
 ingress:
   enabled: true

--- a/charts/komga/ci/java-memory-values.yaml
+++ b/charts/komga/ci/java-memory-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: Java tool options
 komga:
   javaToolOptions: "-Xmx2g"

--- a/charts/komga/examples/production/values.yaml
+++ b/charts/komga/examples/production/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Production Komga with ingress, memory tuning, and backup
 komga:
   timezone: "UTC"

--- a/charts/komga/examples/simple/values.yaml
+++ b/charts/komga/examples/simple/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Simple Komga deployment with defaults (SQLite + persistent storage)
 persistence:
   config:

--- a/charts/komga/templates/NOTES.txt
+++ b/charts/komga/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 Komga has been deployed!
 
   Access Komga via port-forward:

--- a/charts/komga/templates/_helpers.tpl
+++ b/charts/komga/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "komga.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/komga/templates/backup-configmap.yaml
+++ b/charts/komga/templates/backup-configmap.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.backup.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/komga/templates/backup-cronjob.yaml
+++ b/charts/komga/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.backup.enabled }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/komga/templates/deployment.yaml
+++ b/charts/komga/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/komga/templates/externalsecret.yaml
+++ b/charts/komga/templates/externalsecret.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "komga.fullname" . }}-backup
+  labels:
+    {{- include "komga.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "komga.fullname" . }}-backup-s3
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/komga/templates/extra-manifests.yaml
+++ b/charts/komga/templates/extra-manifests.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- range .Values.extraManifests }}
 ---
 {{ toYaml . }}

--- a/charts/komga/templates/httproute.yaml
+++ b/charts/komga/templates/httproute.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "komga.fullname" . }}
+  labels:
+    {{- include "komga.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "komga.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/komga/templates/ingress.yaml
+++ b/charts/komga/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/komga/templates/pvc.yaml
+++ b/charts/komga/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.persistence.config.enabled (not .Values.persistence.config.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/komga/templates/secret.yaml
+++ b/charts/komga/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) .Values.backup.s3.accessKey .Values.backup.s3.secretKey }}
 apiVersion: v1
 kind: Secret

--- a/charts/komga/templates/service.yaml
+++ b/charts/komga/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/komga/templates/serviceaccount.yaml
+++ b/charts/komga/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/komga/tests/backup_test.yaml
+++ b/charts/komga/tests/backup_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Backup
 templates:
   - templates/backup-cronjob.yaml

--- a/charts/komga/tests/deployment_test.yaml
+++ b/charts/komga/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml

--- a/charts/komga/tests/deployment_test.yaml
+++ b/charts/komga/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/gotson/komga:1.24.1"
+          value: "docker.io/gotson/komga:1.24.4"
 
   - it: should set container port to 25600
     asserts:

--- a/charts/komga/tests/ingress_test.yaml
+++ b/charts/komga/tests/ingress_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Ingress
 templates:
   - templates/ingress.yaml

--- a/charts/komga/tests/pvc_test.yaml
+++ b/charts/komga/tests/pvc_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: PVC
 templates:
   - templates/pvc.yaml

--- a/charts/komga/tests/secret_test.yaml
+++ b/charts/komga/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Secret
 templates:
   - templates/secret.yaml

--- a/charts/komga/tests/service_test.yaml
+++ b/charts/komga/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml

--- a/charts/komga/tests/serviceaccount_test.yaml
+++ b/charts/komga/tests/serviceaccount_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ServiceAccount
 templates:
   - templates/serviceaccount.yaml

--- a/charts/komga/values.schema.json
+++ b/charts/komga/values.schema.json
@@ -214,6 +214,18 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the Service"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Service IP family policy",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Service IP families",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2,
+          "uniqueItems": true
         }
       }
     },
@@ -496,7 +508,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "docker.io/minio/mc"
+                  "default": "docker.io/helmforge/mc"
                 },
                 "tag": {
                   "type": "string"
@@ -576,6 +588,80 @@
               "default": ""
             }
           }
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create an HTTPRoute. Requires Gateway API CRDs installed.",
+          "default": false
+        },
+        "annotations": { "type": "object" },
+        "parentRefs": {
+          "type": "array",
+          "description": "parentRefs list pointing to your Gateway resource",
+          "items": { "type": "object" }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "path": {
+          "type": "string",
+          "default": "/"
+        },
+        "pathType": {
+          "type": "string",
+          "enum": ["PathPrefix", "Exact"],
+          "default": "PathPrefix"
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator integration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Render ExternalSecret resources for clusters running External Secrets Operator",
+          "default": false
+        },
+        "apiVersion": {
+          "type": "string",
+          "default": "external-secrets.io/v1"
+        },
+        "refreshInterval": {
+          "type": "string",
+          "default": "1h"
+        },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "default": "" },
+            "kind": {
+              "type": "string",
+              "enum": ["SecretStore", "ClusterSecretStore"],
+              "default": "SecretStore"
+            }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": {
+              "type": "string",
+              "enum": ["Owner", "Merge", "None"],
+              "default": "Owner"
+            }
+          }
+        },
+        "data": {
+          "type": "array",
+          "items": { "type": "object" }
         }
       }
     },

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Komga Helm Chart — Default Values
 # =============================================================================
@@ -15,7 +16,7 @@ image:
   # -- Komga image repository
   repository: docker.io/gotson/komga
   # -- Komga image tag
-  tag: "1.24.1"
+  tag: "1.24.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -99,6 +100,10 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -122,6 +127,50 @@ ingress:
     # - hosts:
     #     - komga.example.com
     #   secretName: komga-tls
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  # -- Create an HTTPRoute for Komga traffic. Requires Gateway API CRDs installed.
+  enabled: false
+  annotations: {}
+  # -- parentRefs list pointing to your Gateway resource.
+  parentRefs: []
+  #   - name: envoy
+  #     namespace: envoy-gateway
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  # -- ExternalSecret data entries for S3 backup credentials.
+  data: []
+  #   - secretKey: access-key
+  #     remoteRef:
+  #       key: komga/backup
+  #       property: access-key
+  #   - secretKey: secret-key
+  #     remoteRef:
+  #       key: komga/backup
+  #       property: secret-key
 
 # =============================================================================
 # Probes

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# Komga Helm Chart — Default Values
+# Komga Helm Chart - Default Values
 # =============================================================================
 # Focus: SQLite media server + persistent config/data + ingress + backup
 


### PR DESCRIPTION
## Summary

Upgrade komga from **1.24.1** to **1.24.4**.

## Changes

- Bump image.tag and ppVersion to 1.24.4
- Add SPDX-License-Identifier: Apache-2.0 header to all templates (GR-059)
- Fix .helmignore: replace *.lock glob with specific lock files — preserves Chart.lock in package (GR-062)
- Add service.ipFamilyPolicy / service.ipFamilies dual-stack support (GR-058)
- Add Gateway API HTTPRoute opt-in template (GR-060)
- Add External Secrets Operator ExternalSecret opt-in template (GR-061)
- Update alues.schema.json with new fields for service, gateway, externalSecrets
- Fix schema: backup uploader default corrected from docker.io/minio/mc to docker.io/helmforge/mc (GR-035)
- Add CI scenarios: ci/dual-stack.yaml, ci/gateway-api.yaml, ci/external-secrets.yaml

## Quality Evidence

- helm lint charts/komga: PASS
- helm lint --strict charts/komga: PASS
- helm template (default + all 7 CI scenarios): PASS
- helm unittest: 42/42 tests PASS
- h lint: 0 errors (63 packages scanned)
- kubeconform --strict (default + all 7 CI scenarios): PASS
- k3d runtime (k3d-charts-test): pod 1/1 Running, logs clean

> **WARN MMapDirectory**: expected Lucene info on Java 22+, purely informational, no functional impact.

## Upstream

Image: docker.io/gotson/komga:1.24.4
Release notes: https://github.com/gotson/komga/releases/tag/1.24.4

Closes #143