### PR TITLE
chore(mysql): upgrade to 9.7.0

### DIFF
--- a/charts/mysql/.helmignore
+++ b/charts/mysql/.helmignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OS
 .DS_Store
 Thumbs.db
@@ -20,7 +21,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: mysql
 description: MySQL for Kubernetes with explicit standalone and replication modes
 type: application
-version: 1.8.7
-appVersion: "8.4"
+version: 1.9.0
+appVersion: "9.7.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "prepare sandbox governance and Apache licensing (#124)"
+      description: "upgrade MySQL to 9.7.0, add dual-stack service and ExternalSecrets support"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mysql/ci/backup.yaml
+++ b/charts/mysql/ci/backup.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: Backup enabled
 backup:
   enabled: true

--- a/charts/mysql/ci/config-preset.yaml
+++ b/charts/mysql/ci/config-preset.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 config:
   preset: oltp
 

--- a/charts/mysql/ci/dual-stack.yaml
+++ b/charts/mysql/ci/dual-stack.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI scenario: dual-stack networking via service.ipFamilyPolicy.
 #
 # Uses PreferDualStack policy without explicit ipFamilies so this scenario

--- a/charts/mysql/ci/existing-configmap.yaml
+++ b/charts/mysql/ci/existing-configmap.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 initdb:
   existingConfigMap: mysql-initdb-extra

--- a/charts/mysql/ci/existing-secret.yaml
+++ b/charts/mysql/ci/existing-secret.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 auth:
   existingSecret: mysql-auth

--- a/charts/mysql/ci/external-secrets.yaml
+++ b/charts/mysql/ci/external-secrets.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: ExternalSecrets integration for MySQL credentials.
+#
+# Enables the ExternalSecret template which renders credentials
+# (root-password, user-password, replication-password) via the
+# External Secrets Operator. The auth.existingSecret points to
+# the secret produced by the ExternalSecret.
+#
+architecture: standalone
+
+standalone:
+  persistence:
+    enabled: false
+
+auth:
+  existingSecret: test-mysql-mysql-auth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: local-store
+    kind: SecretStore
+  data:
+    - secretKey: mysql-root-password
+      remoteRef:
+        key: mysql/credentials
+        property: root-password
+    - secretKey: mysql-user-password
+      remoteRef:
+        key: mysql/credentials
+        property: user-password
+    - secretKey: mysql-replication-password
+      remoteRef:
+        key: mysql/credentials
+        property: replication-password

--- a/charts/mysql/ci/initdb.yaml
+++ b/charts/mysql/ci/initdb.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 initdb:
   scripts:
     10-extra.sql: |

--- a/charts/mysql/ci/metrics.yaml
+++ b/charts/mysql/ci/metrics.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 metrics:
   enabled: true
   serviceMonitor:

--- a/charts/mysql/ci/replication-binlog-tuning.yaml
+++ b/charts/mysql/ci/replication-binlog-tuning.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 replication:

--- a/charts/mysql/ci/replication-metrics.yaml
+++ b/charts/mysql/ci/replication-metrics.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 replication:

--- a/charts/mysql/ci/replication-recovery-check.yaml
+++ b/charts/mysql/ci/replication-recovery-check.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 replication:

--- a/charts/mysql/ci/replication.yaml
+++ b/charts/mysql/ci/replication.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 replication:

--- a/charts/mysql/ci/resources-preset.yaml
+++ b/charts/mysql/ci/resources-preset.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 replication:

--- a/charts/mysql/ci/standalone.yaml
+++ b/charts/mysql/ci/standalone.yaml
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: standalone

--- a/charts/mysql/ci/tls-networkpolicy.yaml
+++ b/charts/mysql/ci/tls-networkpolicy.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/mysql/ci/tls.yaml
+++ b/charts/mysql/ci/tls.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 auth:
   existingSecret: mysql-auth
 

--- a/charts/mysql/examples/config-preset.yaml
+++ b/charts/mysql/examples/config-preset.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 config:
   preset: read-heavy
 

--- a/charts/mysql/examples/initdb-metrics.yaml
+++ b/charts/mysql/examples/initdb-metrics.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: standalone
 
 auth:

--- a/charts/mysql/examples/replication-production.yaml
+++ b/charts/mysql/examples/replication-production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/mysql/examples/replication.yaml
+++ b/charts/mysql/examples/replication.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/mysql/examples/resources-preset.yaml
+++ b/charts/mysql/examples/resources-preset.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/mysql/examples/standalone.yaml
+++ b/charts/mysql/examples/standalone.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: standalone
 
 auth:

--- a/charts/mysql/examples/tls.yaml
+++ b/charts/mysql/examples/tls.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 auth:
   existingSecret: mysql-auth
 

--- a/charts/mysql/templates/NOTES.txt
+++ b/charts/mysql/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 MySQL has been installed.
 
 Useful Services:

--- a/charts/mysql/templates/_helpers.tpl
+++ b/charts/mysql/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "mysql.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/mysql/templates/backup-configmap.yaml
+++ b/charts/mysql/templates/backup-configmap.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if include "mysql.backupEnabled" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/mysql/templates/backup-cronjob.yaml
+++ b/charts/mysql/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if include "mysql.backupEnabled" . }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/mysql/templates/configmap.yaml
+++ b/charts/mysql/templates/configmap.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/mysql/templates/externalsecret.yaml
+++ b/charts/mysql/templates/externalsecret.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "mysql.secretName" . }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "mysql.secretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/mysql/templates/networkpolicy.yaml
+++ b/charts/mysql/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/mysql/templates/pdb.yaml
+++ b/charts/mysql/templates/pdb.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if include "mysql.pdbEnabled" . }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/mysql/templates/secret.yaml
+++ b/charts/mysql/templates/secret.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if not .Values.auth.existingSecret }}
 apiVersion: v1
 kind: Secret

--- a/charts/mysql/templates/service-headless.yaml
+++ b/charts/mysql/templates/service-headless.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/mysql/templates/service.yaml
+++ b/charts/mysql/templates/service.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/mysql/templates/serviceaccount.yaml
+++ b/charts/mysql/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/mysql/templates/servicemonitor.yaml
+++ b/charts/mysql/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/mysql/templates/statefulset-replicas.yaml
+++ b/charts/mysql/templates/statefulset-replicas.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if and (eq .Values.architecture "replication") (gt (int .Values.replication.readReplicas.replicaCount) 0) }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/mysql/templates/statefulset-source.yaml
+++ b/charts/mysql/templates/statefulset-source.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/mysql/tests/backup_test.yaml
+++ b/charts/mysql/tests/backup_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Backup
 templates:
   - templates/backup-configmap.yaml

--- a/charts/mysql/tests/networkpolicy_test.yaml
+++ b/charts/mysql/tests/networkpolicy_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: NetworkPolicy
 templates:
   - networkpolicy.yaml

--- a/charts/mysql/tests/pdb_test.yaml
+++ b/charts/mysql/tests/pdb_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: PodDisruptionBudget
 templates:
   - pdb.yaml

--- a/charts/mysql/tests/secret_test.yaml
+++ b/charts/mysql/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Secret
 templates:
   - secret.yaml

--- a/charts/mysql/tests/service_dualstack_test.yaml
+++ b/charts/mysql/tests/service_dualstack_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service dual-stack
 templates:
   - service.yaml

--- a/charts/mysql/tests/service_headless_dualstack_test.yaml
+++ b/charts/mysql/tests/service_headless_dualstack_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service headless dual-stack
 templates:
   - service-headless.yaml

--- a/charts/mysql/tests/service_test.yaml
+++ b/charts/mysql/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - service.yaml

--- a/charts/mysql/tests/statefulset_source_test.yaml
+++ b/charts/mysql/tests/statefulset_source_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: StatefulSet Source
 templates:
   - statefulset-source.yaml
@@ -33,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mysql:8.4"
+          value: "docker.io/library/mysql:9.7.0"
 
   - it: should always have 1 replica
     template: statefulset-source.yaml

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -475,7 +475,7 @@
         "ipFamilyPolicy": {
           "type": "string",
           "description": "Service IP family policy. One of SingleStack, PreferDualStack, RequireDualStack. Omit for cluster default.",
-          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack"]
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
         },
         "ipFamilies": {
           "type": "array",
@@ -684,7 +684,7 @@
               "properties": {
                 "repository": {
                   "type": "string",
-                  "default": "docker.io/minio/mc"
+                  "default": "docker.io/helmforge/mc"
                 },
                 "tag": {
                   "type": "string",
@@ -707,7 +707,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "8.4"
+                  "default": "9.7.0"
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -1063,6 +1063,29 @@
         "type": "object"
       },
       "default": []
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator integration for MySQL credential management",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "default": "" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"], "default": "SecretStore" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "None"], "default": "Owner" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } }
+      }
     }
   }
 }

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # MySQL Helm Chart - Default Values
 # =============================================================================
@@ -27,7 +28,7 @@ image:
   # -- MySQL image repository
   repository: docker.io/library/mysql
   # -- MySQL image tag
-  tag: "8.4"
+  tag: "9.7.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -189,14 +190,10 @@ service:
   port: 3306
   # -- Metrics port exposed when metrics.enabled=true
   metricsPort: 9104
-  # -- IP family policy. One of: SingleStack | PreferDualStack | RequireDualStack. Omit for cluster default.
-  # @default -- omitted
-  # ipFamilyPolicy: PreferDualStack
-  # -- Ordered list of IP families for the Service. Each entry: IPv4 | IPv6. Omit for cluster default.
-  # @default -- omitted
-  # ipFamilies:
-  #   - IPv4
-  #   - IPv6
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Ordered list of IP families for the Service: IPv4 | IPv6. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Metrics
@@ -277,7 +274,7 @@ backup:
       pullPolicy: IfNotPresent
     mysql:
       repository: docker.io/library/mysql
-      tag: "8.4"
+      tag: "9.7.0"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com
@@ -410,3 +407,28 @@ terminationGracePeriodSeconds: 120
 extraEnv: []
 extraVolumes: []
 extraVolumeMounts: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  # -- ExternalSecret data entries for MySQL passwords.
+  data: []
+  #   - secretKey: mysql-root-password
+  #     remoteRef:
+  #       key: mysql/credentials
+  #       property: root-password
+


### PR DESCRIPTION
## Summary

Upgrade MySQL from 8.4 to 9.7.0 with full HelmForge compliance.

## Changes

- **Image**: \docker.io/library/mysql:9.7.0\
- **Dual-stack**: Added \ipFamilyPolicy\/\ipFamilies\ to all Service objects (client, source, replicas, metrics variants)
- **ExternalSecrets**: Added opt-in \externalsecret.yaml\ template for ESO-managed credentials (root, app user, replication password)
- No Gateway API - MySQL is a TCP database (port 3306), HTTPRoute is not applicable
- **SPDX**: Added \# SPDX-License-Identifier: Apache-2.0\ to all 48 chart files
- **Helmignore**: Removed \*.lock\ rule to allow Chart.lock packaging
- **Schema**: Updated backup image defaults and \ipFamilyPolicy\ enum

## Validation

- \helm lint --strict\: PASS
- \helm unittest\: 42/42 PASS
- **k3d runtime**: Deployed standalone, \VERSION()=9.7.0\, testdb created, users configured

Closes #148