### PR TITLE
chore(mariadb): upgrade to 12.2.2

### DIFF
--- a/charts/mariadb/.helmignore
+++ b/charts/mariadb/.helmignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OS
 .DS_Store
 Thumbs.db
@@ -20,7 +21,12 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Pipfile.lock
+poetry.lock
+Gemfile.lock
 
 # Logs
 *.log

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: mariadb
 description: MariaDB for Kubernetes with explicit standalone and replication modes
 type: application
 version: 1.1.7
-appVersion: "11.4"
+appVersion: "12.2.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "prepare sandbox governance and Apache licensing (#124)"
+      description: "upgrade MariaDB to 12.2.2, add dual-stack service and ExternalSecrets support"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -25,6 +25,8 @@ Helm chart for deploying [MariaDB](https://mariadb.org/) on Kubernetes using the
 - **NetworkPolicy** for ingress traffic control
 - **PodDisruptionBudget** for availability during maintenance
 - **Password management** auto-generated or from existing Secret
+- **Dual-stack networking** — IPv4/IPv6 service support across all 6 Service objects
+- **External Secrets Operator** — ExternalSecret for Vault, AWS Secrets Manager, and more
 
 ## Installation
 
@@ -83,6 +85,52 @@ replication:
 | `backup.schedule` | `"0 3 * * *"` | Backup cron schedule |
 | `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
 | `pdb.enabled` | `false` | Enable PodDisruptionBudget |
+| `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
+| `service.ipFamilies` | `[]` | IP families override (`IPv4`, `IPv6`) |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resource |
+| `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
+| `externalSecrets.refreshInterval` | `1h` | Refresh interval |
+| `externalSecrets.secretStoreRef.name` | `""` | SecretStore name (required when enabled) |
+| `externalSecrets.secretStoreRef.kind` | `SecretStore` | SecretStore kind |
+| `externalSecrets.data` | `[]` | Remote key mappings |
+
+## Dual-Stack Services
+
+All 6 Service objects (client, metrics, source, source-metrics, replicas, replicas-metrics)
+carry the same `ipFamilyPolicy` and `ipFamilies` settings.
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## External Secrets Operator (ESO)
+
+`auth.existingSecret` is required alongside `externalSecrets.enabled=true` to prevent
+credential drift between the chart-managed Secret and the ExternalSecret.
+
+```yaml
+auth:
+  existingSecret: mariadb-credentials
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  data:
+    - secretKey: mariadb-root-password
+      remoteRef:
+        key: mariadb/credentials
+        property: root-password
+    - secretKey: mariadb-user-password
+      remoteRef:
+        key: mariadb/credentials
+        property: user-password
+```
 
 ## Differences from MySQL Chart
 
@@ -109,6 +157,8 @@ This chart uses MariaDB-native features:
 | `tls.yaml` | TLS with existingSecret |
 | `tls-networkpolicy.yaml` | TLS + replication + NetworkPolicy |
 | `backup.yaml` | Backup with S3 |
+| `dual-stack.yaml` | Dual-stack IPv4/IPv6 services |
+| `external-secrets.yaml` | External Secrets Operator integration |
 
 ## More Information
 
@@ -120,7 +170,7 @@ type: chart-readme
 title: MariaDB Helm Chart
 description: MariaDB with standalone and GTID-based replication modes, TLS, metrics, backup, and configuration presets
 
-keywords: mariadb, database, replication, gtid, backup
+keywords: mariadb, database, replication, gtid, backup, dual-stack, external-secrets
 
 purpose: Chart README with install, config, architecture, and values reference
 scope: Chart
@@ -130,5 +180,5 @@ relations:
   - charts/mysql/README.md
 path: charts/mariadb/README.md
 version: 1.0
-date: 2026-03-31
+date: 2026-04-30
 -->

--- a/charts/mariadb/ci/backup.yaml
+++ b/charts/mariadb/ci/backup.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 backup:
   enabled: true
   s3:

--- a/charts/mariadb/ci/config-preset.yaml
+++ b/charts/mariadb/ci/config-preset.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 config:
   preset: oltp

--- a/charts/mariadb/ci/dual-stack.yaml
+++ b/charts/mariadb/ci/dual-stack.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack IPv6 service (GR-058)
+architecture: standalone
+
+standalone:
+  persistence:
+    enabled: false
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/mariadb/ci/existing-secret.yaml
+++ b/charts/mariadb/ci/existing-secret.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 auth:
   existingSecret: my-mariadb-secret

--- a/charts/mariadb/ci/external-secrets.yaml
+++ b/charts/mariadb/ci/external-secrets.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: External Secrets Operator integration (GR-061).
+# auth.existingSecret is required alongside externalSecrets.enabled=true
+# to prevent credential drift between the chart-managed Secret and the ExternalSecret.
+architecture: standalone
+
+standalone:
+  persistence:
+    enabled: false
+
+auth:
+  existingSecret: my-mariadb-auth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: my-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: mariadb-root-password
+      remoteRef:
+        key: mariadb/credentials
+        property: root-password
+    - secretKey: mariadb-user-password
+      remoteRef:
+        key: mariadb/credentials
+        property: user-password
+    - secretKey: mariadb-replication-password
+      remoteRef:
+        key: mariadb/credentials
+        property: replication-password

--- a/charts/mariadb/ci/initdb.yaml
+++ b/charts/mariadb/ci/initdb.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 auth:
   rootPassword: testrootpw
   database: testdb

--- a/charts/mariadb/ci/metrics.yaml
+++ b/charts/mariadb/ci/metrics.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 metrics:
   enabled: true
   serviceMonitor:

--- a/charts/mariadb/ci/replication-metrics.yaml
+++ b/charts/mariadb/ci/replication-metrics.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 auth:
   rootPassword: testrootpw

--- a/charts/mariadb/ci/replication.yaml
+++ b/charts/mariadb/ci/replication.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 auth:
   rootPassword: testrootpw

--- a/charts/mariadb/ci/resources-preset.yaml
+++ b/charts/mariadb/ci/resources-preset.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 auth:
   rootPassword: testrootpw

--- a/charts/mariadb/ci/standalone.yaml
+++ b/charts/mariadb/ci/standalone.yaml
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: standalone

--- a/charts/mariadb/ci/tls-networkpolicy.yaml
+++ b/charts/mariadb/ci/tls-networkpolicy.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 auth:
   rootPassword: testrootpw

--- a/charts/mariadb/ci/tls.yaml
+++ b/charts/mariadb/ci/tls.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 tls:
   enabled: true
   existingSecret: mariadb-tls

--- a/charts/mariadb/examples/replication-production.yaml
+++ b/charts/mariadb/examples/replication-production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/mariadb/examples/replication.yaml
+++ b/charts/mariadb/examples/replication.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/mariadb/examples/standalone.yaml
+++ b/charts/mariadb/examples/standalone.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: standalone
 
 auth:

--- a/charts/mariadb/templates/NOTES.txt
+++ b/charts/mariadb/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 MariaDB has been installed.
 
 Useful Services:

--- a/charts/mariadb/templates/NOTES.txt
+++ b/charts/mariadb/templates/NOTES.txt
@@ -41,6 +41,15 @@ Initial troubleshooting:
   kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.replicaStatefulSetName" . }}-0
 {{- end }}
 
+{{- if .Values.externalSecrets.enabled }}
+
+ExternalSecrets:
+
+  SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+  Target Secret: {{ include "mariadb.secretName" . }}
+  Refresh: {{ .Values.externalSecrets.refreshInterval }}
+{{- end }}
+
 Important:
 
 - replication mode provides one fixed source and asynchronous read replicas

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "mariadb.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/mariadb/templates/backup-configmap.yaml
+++ b/charts/mariadb/templates/backup-configmap.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if include "mariadb.backupEnabled" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/mariadb/templates/backup-cronjob.yaml
+++ b/charts/mariadb/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if include "mariadb.backupEnabled" . }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/mariadb/templates/configmap.yaml
+++ b/charts/mariadb/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/mariadb/templates/externalsecret.yaml
+++ b/charts/mariadb/templates/externalsecret.yaml
@@ -1,0 +1,30 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- /*
+  Guard: when externalSecrets.enabled=true the chart-managed Secret (secret.yaml)
+  is still rendered unless auth.existingSecret is set. Without this guard both
+  resources target the same name via mariadb.secretName, creating two writers for
+  the credentials. ESO reconciling after MariaDB init can overwrite bootstrapped
+  passwords, causing auth/probe failures after pod restarts.
+  MariaDB auth is always active (no auth.enabled flag), so the guard is unconditional.
+*/}}
+{{- if not .Values.auth.existingSecret }}
+  {{- fail "externalSecrets.enabled requires auth.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "mariadb.secretName" . }}
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "mariadb.secretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/mariadb/templates/networkpolicy.yaml
+++ b/charts/mariadb/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/mariadb/templates/pdb.yaml
+++ b/charts/mariadb/templates/pdb.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if include "mariadb.pdbEnabled" . }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/mariadb/templates/secret.yaml
+++ b/charts/mariadb/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if not .Values.auth.existingSecret }}
 apiVersion: v1
 kind: Secret

--- a/charts/mariadb/templates/service-headless.yaml
+++ b/charts/mariadb/templates/service-headless.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/mariadb/templates/service.yaml
+++ b/charts/mariadb/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mariadb
       port: {{ .Values.service.port }}
@@ -31,6 +39,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
@@ -52,6 +67,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mariadb
       port: {{ .Values.service.port }}
@@ -74,6 +96,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}
@@ -95,6 +124,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: mariadb
       port: {{ .Values.service.port }}
@@ -117,6 +153,13 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: metrics
       port: {{ .Values.service.metricsPort }}

--- a/charts/mariadb/templates/serviceaccount.yaml
+++ b/charts/mariadb/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/mariadb/templates/servicemonitor.yaml
+++ b/charts/mariadb/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and (eq .Values.architecture "replication") (gt (int .Values.replication.readReplicas.replicaCount) 0) }}
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/mariadb/templates/statefulset-source.yaml
+++ b/charts/mariadb/templates/statefulset-source.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/mariadb/tests/backup_test.yaml
+++ b/charts/mariadb/tests/backup_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: backup
 templates:
   - templates/backup-cronjob.yaml

--- a/charts/mariadb/tests/networkpolicy_test.yaml
+++ b/charts/mariadb/tests/networkpolicy_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: networkpolicy
 templates:
   - templates/networkpolicy.yaml

--- a/charts/mariadb/tests/pdb_test.yaml
+++ b/charts/mariadb/tests/pdb_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: pdb
 templates:
   - templates/pdb.yaml

--- a/charts/mariadb/tests/secret_test.yaml
+++ b/charts/mariadb/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: secret
 templates:
   - templates/secret.yaml

--- a/charts/mariadb/tests/service_test.yaml
+++ b/charts/mariadb/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: service
 templates:
   - templates/service.yaml

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: statefulset-source
 templates:
   - templates/statefulset-source.yaml
@@ -28,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mariadb:11.4"
+          value: "docker.io/library/mariadb:12.2.2"
 
   - it: should always have 1 replica
     template: templates/statefulset-source.yaml

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -88,7 +88,9 @@
         "metricsPort": { "type": "integer" },
         "annotations": { "type": "object" },
         "sourceAnnotations": { "type": "object" },
-        "replicasAnnotations": { "type": "object" }
+        "replicasAnnotations": { "type": "object" },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
       }
     },
     "metrics": {
@@ -131,6 +133,29 @@
     "terminationGracePeriodSeconds": { "type": "integer" },
     "extraEnv": { "type": "array" },
     "extraVolumes": { "type": "array" },
-    "extraVolumeMounts": { "type": "array" }
+    "extraVolumeMounts": { "type": "array" },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator integration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"], "default": "SecretStore" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "None", "Orphan"], "default": "Owner" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } }
+      }
+    }
   }
 }

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -89,8 +89,8 @@
         "annotations": { "type": "object" },
         "sourceAnnotations": { "type": "object" },
         "replicasAnnotations": { "type": "object" },
-        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
-        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+        "ipFamilyPolicy": { "type": ["string", "null"], "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"], "default": null },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] }, "maxItems": 2 }
       }
     },
     "metrics": {

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -189,8 +189,8 @@ service:
   port: 3306
   # -- Metrics port exposed when metrics.enabled=true
   metricsPort: 9104
-  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
-  ipFamilyPolicy: ""
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Null uses cluster default.
+  ipFamilyPolicy: ~
   # -- Service IP families override. Empty uses cluster default.
   ipFamilies: []
 

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # MariaDB Helm Chart - Default Values
 # =============================================================================
@@ -27,7 +28,7 @@ image:
   # -- MariaDB image repository
   repository: docker.io/library/mariadb
   # -- MariaDB image tag
-  tag: "11.4"
+  tag: "12.2.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -188,6 +189,10 @@ service:
   port: 3306
   # -- Metrics port exposed when metrics.enabled=true
   metricsPort: 9104
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Metrics
@@ -268,7 +273,7 @@ backup:
       pullPolicy: IfNotPresent
     mariadb:
       repository: docker.io/library/mariadb
-      tag: "11.4"
+      tag: "12.2.2"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com
@@ -401,3 +406,32 @@ terminationGracePeriodSeconds: 120
 extraEnv: []
 extraVolumes: []
 extraVolumeMounts: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for clusters running External Secrets Operator.
+  # Requires auth.existingSecret to be set to prevent credential drift.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  # -- ExternalSecret data entries mapping remote keys to mariadb Secret keys.
+  data: []
+  #   - secretKey: mariadb-root-password
+  #     remoteRef:
+  #       key: mariadb/credentials
+  #       property: root-password
+  #   - secretKey: mariadb-user-password
+  #     remoteRef:
+  #       key: mariadb/credentials
+  #       property: user-password


### PR DESCRIPTION
## Summary

Upgrade MariaDB from 11.4 to 12.2.2 (major version) with full HelmForge compliance.

## Changes

- **Image**: \docker.io/library/mariadb:12.2.2\
- **Dual-stack**: Added \ipFamilyPolicy\/\ipFamilies\ to all 6 Service objects (client, metrics, source, source-metrics, replicas, replicas-metrics)
- **ExternalSecrets**: Added opt-in \externalsecret.yaml\ template with credential drift guard — \uth.existingSecret\ is required when \externalSecrets.enabled=true\ (MariaDB auth is always active, no \uth.enabled\ flag, guard is unconditional unlike MongoDB)
- **SPDX**: Added \# SPDX-License-Identifier: Apache-2.0\ to all 34 chart files
- **Helmignore**: Removed \*.lock\ rule; replaced with specific lock file names per GR-037/GR-062
- No Gateway API — MariaDB is a TCP database (port 3306), HTTPRoute is not applicable

## Validation

- \helm lint --strict\: PASS
- \helm unittest\: 22/22 PASS
- **k3d runtime**: Deployed standalone, \VERSION()=12.2.2-MariaDB-ubu2404\, no error logs

Closes #144