### PR TITLE
feat(hoppscotch): add Hoppscotch Community Edition chart 2026.3.1

### DIFF
--- a/charts/hoppscotch/.helmignore
+++ b/charts/hoppscotch/.helmignore
@@ -1,0 +1,34 @@
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+
+# Logs
+*.log
+
+# CI / misc
+*.bak
+
+# Lock files (package managers — Chart.lock must NOT be listed here per GR-062)
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock

--- a/charts/hoppscotch/Chart.lock
+++ b/charts/hoppscotch/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.9.13
+digest: sha256:b6749905484afbfaa2eb91878f9aa53b00bc0bf7e18a54e2951c7d91995216f4
+generated: "2026-04-29T03:48:03.3802791-03:00"

--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: hoppscotch
+description: Hoppscotch Community Edition for Kubernetes — open-source API development platform with REST, GraphQL, and WebSocket support
+home: https://helmforge.dev/docs/charts/hoppscotch
+icon: https://helmforge.dev/icons/charts/hoppscotch.png
+type: application
+version: 0.1.0
+appVersion: "2026.3.1"
+kubeVersion: ">=1.26.0-0"
+
+keywords:
+  - hoppscotch
+  - api
+  - rest
+  - graphql
+  - websocket
+  - developer-tools
+
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+
+dependencies:
+  - name: postgresql
+    version: 1.9.13
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "feat: initial Hoppscotch Community Edition chart (#183)"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: integration-delivery
+  helmforge.dev/maturity: beta
+  helmforge.dev/signed: gpg+cosign
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://hoppscotch.io
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/hoppscotch
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/hoppscotch
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -114,6 +114,7 @@ First-time setup: the **first user to log in** via `/admin` becomes the administ
 ## Non-Goals
 
 This chart does not:
+
 - Deploy the three-container split architecture (use the AIO image instead)
 - Manage OAuth provider registration (do this in the provider's developer console)
 - Provide built-in backup for PostgreSQL (use the HelmForge PostgreSQL chart with backup enabled)

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -1,0 +1,123 @@
+# Hoppscotch
+
+Hoppscotch Community Edition for Kubernetes — open-source API development platform with REST, GraphQL, and WebSocket support.
+
+## Installation
+
+### Helm HTTPS Repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install hoppscotch helmforge/hoppscotch
+```
+
+### OCI Registry
+
+```bash
+helm install hoppscotch oci://ghcr.io/helmforgedev/helm/hoppscotch \
+  --version 0.1.0
+```
+
+## Quick Start
+
+### Minimal (dev mode)
+
+```bash
+helm install hoppscotch helmforge/hoppscotch \
+  --set ingress.enabled=true \
+  --set ingress.host=hoppscotch.local
+```
+
+### Production
+
+```bash
+helm install hoppscotch helmforge/hoppscotch \
+  --set mode=production \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.host=hoppscotch.example.com \
+  --set "ingress.tls[0].secretName=hoppscotch-tls" \
+  --set "ingress.tls[0].hosts[0]=hoppscotch.example.com" \
+  --set "ingress.annotations.cert-manager\\.io/cluster-issuer=letsencrypt-prod"
+```
+
+## Features
+
+- **All-in-One image** — single Deployment, three services (frontend, backend, admin) via subpath routing
+- **Automatic URL derivation** — all VITE_* URLs derived from `ingress.host`
+- **Prisma migrations** — automatic via init container on every deploy
+- **OAuth providers** — GitHub, Google, Microsoft, EMAIL (magic links)
+- **SMTP support** — URL mode or field-by-field
+- **ExternalSecrets Operator** — native support
+- **Gateway API** — HTTPRoute support
+- **Dual-stack networking** — `ipFamilyPolicy` and `ipFamilies` on Service
+- **Production hardening** — non-root, capability drop, PDB, NetworkPolicy
+- **Monitoring** — ServiceMonitor for Prometheus
+
+## Architecture
+
+Hoppscotch AIO uses subpath-based routing (`ENABLE_SUBPATH_BASED_ACCESS=true`):
+
+| Path | Service |
+|------|---------|
+| `/` | Frontend (main app) |
+| `/backend` | REST API + GraphQL + WebSocket |
+| `/admin` | Admin Dashboard |
+
+All traffic goes through a single Ingress/Service on port 80.
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mode` | Chart mode: `dev` or `production` | `dev` |
+| `image.tag` | Hoppscotch image tag | `2026.3.1` |
+| `replicaCount` | Number of replicas | `1` |
+| `ingress.enabled` | Enable Ingress | `false` |
+| `ingress.host` | Primary hostname (auto-derives all URLs) | `""` |
+| `postgresql.enabled` | Enable PostgreSQL subchart | `true` |
+| `database.external.enabled` | Use external PostgreSQL | `false` |
+| `encryption.key` | 32-char encryption key (auto-generated) | `""` |
+| `auth.providers` | Enabled auth providers | `EMAIL` |
+| `mailer.enabled` | Enable SMTP | `false` |
+| `gatewayAPI.enabled` | Enable HTTPRoute | `false` |
+| `externalSecrets.enabled` | Enable ExternalSecret | `false` |
+| `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
+| `podDisruptionBudget.enabled` | Enable PDB | `false` |
+
+## Examples
+
+- [Minimal dev](examples/minimal.yaml)
+- [Production with TLS](examples/production.yaml)
+- [External database](examples/external-db.yaml)
+- [Full enterprise](examples/full-production.yaml)
+
+## Feature Guides
+
+- [Database](docs/database.md)
+- [Authentication](docs/authentication.md)
+- [SMTP](docs/smtp.md)
+- [Production Hardening](docs/production.md)
+
+## Connecting
+
+After install, port-forward to test:
+
+```bash
+kubectl port-forward svc/hoppscotch 8080:80 -n <namespace>
+# Open http://localhost:8080
+```
+
+First-time setup: the **first user to log in** via `/admin` becomes the administrator.
+
+## Non-Goals
+
+This chart does not:
+- Deploy the three-container split architecture (use the AIO image instead)
+- Manage OAuth provider registration (do this in the provider's developer console)
+- Provide built-in backup for PostgreSQL (use the HelmForge PostgreSQL chart with backup enabled)
+
+## License
+
+Apache-2.0

--- a/charts/hoppscotch/ci/dual-stack.yaml
+++ b/charts/hoppscotch/ci/dual-stack.yaml
@@ -1,0 +1,5 @@
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/hoppscotch/ci/dual-stack.yaml
+++ b/charts/hoppscotch/ci/dual-stack.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack
   ipFamilies:

--- a/charts/hoppscotch/ci/external-db.yaml
+++ b/charts/hoppscotch/ci/external-db.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 postgresql:
   enabled: false
 database:

--- a/charts/hoppscotch/ci/external-db.yaml
+++ b/charts/hoppscotch/ci/external-db.yaml
@@ -1,0 +1,10 @@
+postgresql:
+  enabled: false
+database:
+  external:
+    enabled: true
+    host: postgres.example.local
+    port: 5432
+    name: hoppscotch
+    username: hoppscotch
+    password: test-password

--- a/charts/hoppscotch/ci/external-secrets.yaml
+++ b/charts/hoppscotch/ci/external-secrets.yaml
@@ -1,0 +1,14 @@
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: example-secret-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: database-url
+      remoteRef:
+        key: prod/hoppscotch
+        property: database-url
+    - secretKey: data-encryption-key
+      remoteRef:
+        key: prod/hoppscotch
+        property: data-encryption-key

--- a/charts/hoppscotch/ci/external-secrets.yaml
+++ b/charts/hoppscotch/ci/external-secrets.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 externalSecrets:
   enabled: true
   secretStoreRef:

--- a/charts/hoppscotch/ci/gateway-api.yaml
+++ b/charts/hoppscotch/ci/gateway-api.yaml
@@ -1,0 +1,7 @@
+gatewayAPI:
+  enabled: true
+  hostnames:
+    - hoppscotch.example.local
+  parentRefs:
+    - name: example-gateway
+      namespace: gateway-system

--- a/charts/hoppscotch/ci/gateway-api.yaml
+++ b/charts/hoppscotch/ci/gateway-api.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 gatewayAPI:
   enabled: true
   hostnames:

--- a/charts/hoppscotch/ci/minimal.yaml
+++ b/charts/hoppscotch/ci/minimal.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 # Test: defaults only, PostgreSQL subchart enabled
-# No overrides needed — all defaults work in dev mode
+# No overrides needed - all defaults work in dev mode

--- a/charts/hoppscotch/ci/minimal.yaml
+++ b/charts/hoppscotch/ci/minimal.yaml
@@ -1,0 +1,2 @@
+# Test: defaults only, PostgreSQL subchart enabled
+# No overrides needed — all defaults work in dev mode

--- a/charts/hoppscotch/ci/oauth.yaml
+++ b/charts/hoppscotch/ci/oauth.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 auth:
   providers: "GOOGLE,GITHUB,MICROSOFT,EMAIL"
   github:

--- a/charts/hoppscotch/ci/oauth.yaml
+++ b/charts/hoppscotch/ci/oauth.yaml
@@ -1,0 +1,17 @@
+auth:
+  providers: "GOOGLE,GITHUB,MICROSOFT,EMAIL"
+  github:
+    enabled: true
+    clientId: test-github-id
+    clientSecret: test-github-secret
+  google:
+    enabled: true
+    clientId: test-google-id
+    clientSecret: test-google-secret
+  microsoft:
+    enabled: true
+    clientId: test-microsoft-id
+    clientSecret: test-microsoft-secret
+ingress:
+  enabled: true
+  host: hoppscotch.example.local

--- a/charts/hoppscotch/ci/production.yaml
+++ b/charts/hoppscotch/ci/production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mode: production
 ingress:
   enabled: true

--- a/charts/hoppscotch/ci/production.yaml
+++ b/charts/hoppscotch/ci/production.yaml
@@ -1,0 +1,10 @@
+mode: production
+ingress:
+  enabled: true
+  host: hoppscotch.example.local
+  tls:
+    - secretName: hoppscotch-tls
+      hosts:
+        - hoppscotch.example.local
+postgresql:
+  enabled: true

--- a/charts/hoppscotch/ci/smtp.yaml
+++ b/charts/hoppscotch/ci/smtp.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mailer:
   enabled: true
   from: noreply@example.com

--- a/charts/hoppscotch/ci/smtp.yaml
+++ b/charts/hoppscotch/ci/smtp.yaml
@@ -1,0 +1,9 @@
+mailer:
+  enabled: true
+  from: noreply@example.com
+  useCustomConfigs: true
+  host: smtp.example.com
+  port: 587
+  secure: true
+  user: smtp-user
+  password: smtp-password

--- a/charts/hoppscotch/docs/authentication.md
+++ b/charts/hoppscotch/docs/authentication.md
@@ -21,7 +21,7 @@ Always available. Users enter their email and receive a magic link. Requires SMT
 
 ## GitHub OAuth
 
-1. Create a GitHub OAuth App at https://github.com/settings/applications/new
+1. Create a GitHub OAuth App at <https://github.com/settings/applications/new>
 2. Set Authorization callback URL to `<backendApiUrl>/auth/github/callback`
 
 ```yaml
@@ -49,7 +49,7 @@ auth:
 
 ## Google OAuth
 
-1. Create credentials at https://console.developers.google.com/
+1. Create credentials at <https://console.developers.google.com/>
 2. Add callback URL: `<backendApiUrl>/auth/google/callback`
 
 ```yaml
@@ -64,7 +64,7 @@ auth:
 
 ## Microsoft OAuth
 
-1. Register app at https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps
+1. Register app at <https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps>
 2. Add redirect URI: `<backendApiUrl>/auth/microsoft/callback`
 
 ```yaml
@@ -80,12 +80,14 @@ auth:
 ## Callback URL Pattern
 
 All OAuth callback URLs follow:
-```
+
+```text
 <VITE_BACKEND_API_URL>/auth/<provider>/callback
 ```
 
 When `ingress.host` is set and TLS is configured, this resolves to:
-```
+
+```text
 https://<ingress.host>/backend/v1/auth/<provider>/callback
 ```
 
@@ -96,6 +98,7 @@ The **first user to log in** via the Admin Dashboard becomes the administrator a
 Admin Dashboard URL: `<ingress.host>/admin` (subpath mode)
 
 After becoming admin:
+
 - Configure allowed auth providers via Admin Dashboard > Settings
 - Generate InfraTokens for API/CI access: Admin > InfraTokens
 - Manage user invitations: Admin > User Invitations

--- a/charts/hoppscotch/docs/authentication.md
+++ b/charts/hoppscotch/docs/authentication.md
@@ -1,0 +1,116 @@
+# Authentication Guide
+
+Hoppscotch supports four authentication providers: EMAIL, GITHUB, GOOGLE, MICROSOFT.
+
+## Configuration
+
+```yaml
+auth:
+  providers: "EMAIL"          # comma-separated list of enabled providers
+  github:
+    enabled: false
+  google:
+    enabled: false
+  microsoft:
+    enabled: false
+```
+
+## EMAIL Provider (Magic Links)
+
+Always available. Users enter their email and receive a magic link. Requires SMTP to be configured for link delivery; without SMTP, links appear in server logs only.
+
+## GitHub OAuth
+
+1. Create a GitHub OAuth App at https://github.com/settings/applications/new
+2. Set Authorization callback URL to `<backendApiUrl>/auth/github/callback`
+
+```yaml
+auth:
+  providers: "EMAIL,GITHUB"
+  github:
+    enabled: true
+    clientId: "your-client-id"
+    clientSecret: "your-client-secret"
+    scope: "user:email"
+```
+
+Auto-derived callback URL: `https://<ingress.host>/backend/v1/auth/github/callback`
+
+### Using ExistingSecret
+
+```yaml
+auth:
+  github:
+    enabled: true
+    existingSecret: hoppscotch-oauth
+    existingSecretClientIdKey: github-client-id
+    existingSecretClientSecretKey: github-client-secret
+```
+
+## Google OAuth
+
+1. Create credentials at https://console.developers.google.com/
+2. Add callback URL: `<backendApiUrl>/auth/google/callback`
+
+```yaml
+auth:
+  providers: "EMAIL,GOOGLE"
+  google:
+    enabled: true
+    clientId: "your-client-id"
+    clientSecret: "your-client-secret"
+    scope: "email,profile"
+```
+
+## Microsoft OAuth
+
+1. Register app at https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps
+2. Add redirect URI: `<backendApiUrl>/auth/microsoft/callback`
+
+```yaml
+auth:
+  providers: "EMAIL,MICROSOFT"
+  microsoft:
+    enabled: true
+    clientId: "your-client-id"
+    clientSecret: "your-client-secret"
+    scope: "user.read"
+```
+
+## Callback URL Pattern
+
+All OAuth callback URLs follow:
+```
+<VITE_BACKEND_API_URL>/auth/<provider>/callback
+```
+
+When `ingress.host` is set and TLS is configured, this resolves to:
+```
+https://<ingress.host>/backend/v1/auth/<provider>/callback
+```
+
+## First Admin User
+
+The **first user to log in** via the Admin Dashboard becomes the administrator automatically. No seeding or manual configuration required.
+
+Admin Dashboard URL: `<ingress.host>/admin` (subpath mode)
+
+After becoming admin:
+- Configure allowed auth providers via Admin Dashboard > Settings
+- Generate InfraTokens for API/CI access: Admin > InfraTokens
+- Manage user invitations: Admin > User Invitations
+
+## VITE_ALLOWED_AUTH_PROVIDERS
+
+This variable controls which providers appear on the login page. It must match the providers you have configured. Example:
+
+```yaml
+auth:
+  providers: "EMAIL,GITHUB,GOOGLE"
+  github:
+    enabled: true
+    # ...
+  google:
+    enabled: true
+    # ...
+```

--- a/charts/hoppscotch/docs/database.md
+++ b/charts/hoppscotch/docs/database.md
@@ -20,7 +20,8 @@ postgresql:
 ```
 
 The `DATABASE_URL` is constructed automatically as:
-```
+
+```text
 postgresql://<username>:<password>@<release-name>-postgresql:5432/<database>
 ```
 
@@ -76,7 +77,7 @@ database:
 
 Prisma migrations run automatically on every deploy via the `migrate` init container:
 
-```
+```bash
 pnpm exec prisma migrate deploy
 ```
 

--- a/charts/hoppscotch/docs/database.md
+++ b/charts/hoppscotch/docs/database.md
@@ -1,0 +1,102 @@
+# Database Guide
+
+Hoppscotch requires PostgreSQL. The chart supports two modes: bundled subchart (default) or external.
+
+## PostgreSQL Subchart (Default)
+
+By default, the chart deploys a PostgreSQL instance using the HelmForge PostgreSQL subchart.
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    database: hoppscotch
+    username: hoppscotch
+    password: ""        # auto-generated if empty
+  primary:
+    persistence:
+      enabled: true
+      size: 10Gi
+```
+
+The `DATABASE_URL` is constructed automatically as:
+```
+postgresql://<username>:<password>@<release-name>-postgresql:5432/<database>
+```
+
+### Sizing
+
+| Environment | Storage | CPU | RAM |
+|-------------|---------|-----|-----|
+| Dev/Test    | 10Gi    | 200m | 256Mi |
+| Production  | 20Gi+   | 500m+ | 512Mi+ |
+
+## External PostgreSQL
+
+Disable the subchart and point to your managed instance (RDS, Cloud SQL, Supabase, etc.):
+
+```yaml
+postgresql:
+  enabled: false
+database:
+  external:
+    enabled: true
+    host: db.example.com
+    port: 5432
+    name: hoppscotch
+    username: hoppscotch
+    password: "your-password"   # or use existingSecret
+```
+
+### Using ExistingSecret (recommended for production)
+
+```yaml
+postgresql:
+  enabled: false
+database:
+  external:
+    enabled: true
+    host: db.example.com
+    existingSecret: hoppscotch-db-secret
+    existingSecretPasswordKey: postgres-password
+```
+
+Or provide the full URL in a secret:
+
+```yaml
+database:
+  external:
+    enabled: true
+    host: db.example.com
+    existingSecret: hoppscotch-db-secret
+    existingSecretUrlKey: database-url
+```
+
+## Migrations
+
+Prisma migrations run automatically on every deploy via the `migrate` init container:
+
+```
+pnpm exec prisma migrate deploy
+```
+
+The container runs before the main Hoppscotch container, and after `wait-for-db` confirms the database is accessible.
+
+### Manual Migration (major version upgrades)
+
+For major version upgrades, run migrations manually:
+
+```bash
+kubectl exec -n <namespace> deploy/<release>-hoppscotch -- \
+  sh -c "pnpm exec prisma migrate deploy"
+```
+
+### Hard Reset (emergency)
+
+To reset Hoppscotch configuration (does NOT delete user data):
+
+```sql
+TRUNCATE "InfraConfig";
+```
+
+Connect to PostgreSQL and run the above. This resets all admin-configured settings (SMTP, OAuth, etc.) back to defaults.

--- a/charts/hoppscotch/docs/production.md
+++ b/charts/hoppscotch/docs/production.md
@@ -5,9 +5,10 @@
 The `DATA_ENCRYPTION_KEY` encrypts sensitive data (OAuth tokens, etc.) stored in PostgreSQL.
 
 **Critical rules:**
+
 - Must be exactly 32 characters
 - Auto-generated on first install if not provided
-- **Never change after first install** — it will corrupt all encrypted data
+- **Never change after first install** - it will corrupt all encrypted data
 - Back up this key alongside your database backup
 
 ### Generating a Secure Key
@@ -103,6 +104,7 @@ networkPolicy:
 ```
 
 The default policy allows:
+
 - Ingress: from any pod in the same namespace on port 80
 - Egress: DNS (port 53) + database port
 

--- a/charts/hoppscotch/docs/production.md
+++ b/charts/hoppscotch/docs/production.md
@@ -1,0 +1,135 @@
+# Production Hardening Guide
+
+## DATA_ENCRYPTION_KEY
+
+The `DATA_ENCRYPTION_KEY` encrypts sensitive data (OAuth tokens, etc.) stored in PostgreSQL.
+
+**Critical rules:**
+- Must be exactly 32 characters
+- Auto-generated on first install if not provided
+- **Never change after first install** — it will corrupt all encrypted data
+- Back up this key alongside your database backup
+
+### Generating a Secure Key
+
+```bash
+openssl rand -hex 16   # 32 hex characters
+```
+
+### Using ExternalSecrets (recommended)
+
+```yaml
+encryption:
+  existingSecret: hoppscotch-secrets
+  existingSecretKey: data-encryption-key
+```
+
+Do not store the key in values.yaml in production.
+
+## ExternalSecrets Operator
+
+With the External Secrets Operator, all sensitive values are fetched from a secret manager:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  data:
+    - secretKey: database-url
+      remoteRef:
+        key: prod/hoppscotch
+        property: database-url
+    - secretKey: data-encryption-key
+      remoteRef:
+        key: prod/hoppscotch
+        property: data-encryption-key
+```
+
+When `externalSecrets.enabled=true`, the chart creates an ExternalSecret resource instead of a Secret. The secret.yaml still renders (for checksums), but credentials come from the store.
+
+## TLS via cert-manager
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  host: hoppscotch.example.com
+  tls:
+    - secretName: hoppscotch-tls
+      hosts:
+        - hoppscotch.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+```
+
+## WebSocket Support
+
+WebSocket is required for real-time collaboration. Add these annotations to your ingress:
+
+```yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+```
+
+For Traefik, use middleware with websocket passthrough configured.
+
+## Multi-Replica Deployment
+
+Hoppscotch is fully stateless — all state lives in PostgreSQL. Horizontal scaling is safe:
+
+```yaml
+replicaCount: 3
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+```
+
+For HA PostgreSQL, use an external managed database or the PostgreSQL subchart with replication enabled.
+
+## Network Policy
+
+Restrict ingress/egress to only what Hoppscotch needs:
+
+```yaml
+networkPolicy:
+  enabled: true
+```
+
+The default policy allows:
+- Ingress: from any pod in the same namespace on port 80
+- Egress: DNS (port 53) + database port
+
+## Telemetry
+
+Hoppscotch collects anonymous usage data weekly (instance UUID, user count, workspace count, version). No API content or personal data is collected.
+
+**To disable:** Admin Dashboard > Settings > Data Sharing
+
+There is no environment variable to disable telemetry — it must be done via the Admin UI.
+
+## Security Context
+
+The chart enforces non-root execution and drops all capabilities:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1000
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsNonRoot: true
+  runAsUser: 1000
+```
+
+`readOnlyRootFilesystem` is set to `false` because Hoppscotch writes temporary files at runtime.

--- a/charts/hoppscotch/docs/smtp.md
+++ b/charts/hoppscotch/docs/smtp.md
@@ -1,0 +1,83 @@
+# SMTP / Email Guide
+
+Hoppscotch uses email for magic link authentication and user invitations.
+
+## Without SMTP
+
+Without SMTP configured, magic links and invitation emails are printed to the container logs. Users can copy the links manually in development environments.
+
+## Enabling SMTP
+
+### URL Mode (simple)
+
+```yaml
+mailer:
+  enabled: true
+  from: noreply@example.com
+  useCustomConfigs: false
+  smtpUrl: "smtps://user@example.com:password@smtp.example.com"
+```
+
+### Custom Config Mode (field-by-field)
+
+```yaml
+mailer:
+  enabled: true
+  from: noreply@example.com
+  useCustomConfigs: true
+  host: smtp.example.com
+  port: 587
+  secure: true
+  user: smtp-user
+  password: smtp-password
+  tlsRejectUnauthorized: true
+```
+
+## Using ExistingSecret (production)
+
+```yaml
+mailer:
+  enabled: true
+  from: noreply@example.com
+  useCustomConfigs: false
+  existingSecret: hoppscotch-smtp
+  existingSecretSmtpUrlKey: smtp-url
+```
+
+Or for custom config mode:
+
+```yaml
+mailer:
+  enabled: true
+  from: noreply@example.com
+  useCustomConfigs: true
+  host: smtp.example.com
+  port: 587
+  existingSecret: hoppscotch-smtp
+  existingSecretPasswordKey: smtp-password
+```
+
+## Tested Providers
+
+| Provider | Notes |
+|----------|-------|
+| SendGrid | Use API key as password, user=`apikey` |
+| AWS SES  | Use SMTP credentials from IAM |
+| Mailcatcher | Dev only: `smtp://mailcatcher:1025` |
+
+## Environment Variables
+
+The chart sets these when `mailer.enabled=true`:
+
+| Variable | Source |
+|----------|--------|
+| `MAILER_SMTP_ENABLE` | `"true"` |
+| `MAILER_ADDRESS_FROM` | `mailer.from` |
+| `MAILER_USE_CUSTOM_CONFIGS` | `mailer.useCustomConfigs` |
+| `MAILER_SMTP_URL` | Secret (when `useCustomConfigs=false`) |
+| `MAILER_SMTP_HOST` | ConfigMap (when `useCustomConfigs=true`) |
+| `MAILER_SMTP_PORT` | ConfigMap |
+| `MAILER_SMTP_SECURE` | ConfigMap |
+| `MAILER_SMTP_USER` | ConfigMap |
+| `MAILER_SMTP_PASSWORD` | Secret |
+| `MAILER_TLS_REJECT_UNAUTHORIZED` | ConfigMap |

--- a/charts/hoppscotch/examples/external-db.yaml
+++ b/charts/hoppscotch/examples/external-db.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # External PostgreSQL database
 # Use case: managed PostgreSQL (e.g., RDS, Cloud SQL, Supabase)
 postgresql:

--- a/charts/hoppscotch/examples/external-db.yaml
+++ b/charts/hoppscotch/examples/external-db.yaml
@@ -1,0 +1,13 @@
+# External PostgreSQL database
+# Use case: managed PostgreSQL (e.g., RDS, Cloud SQL, Supabase)
+postgresql:
+  enabled: false
+database:
+  external:
+    enabled: true
+    host: db.example.com
+    port: 5432
+    name: hoppscotch
+    username: hoppscotch
+    existingSecret: hoppscotch-db-credentials
+    existingSecretPasswordKey: postgres-password

--- a/charts/hoppscotch/examples/full-production.yaml
+++ b/charts/hoppscotch/examples/full-production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Full production hardened deployment
 # Use case: enterprise with ExternalSecrets, OAuth, SMTP, Gateway API
 mode: production

--- a/charts/hoppscotch/examples/full-production.yaml
+++ b/charts/hoppscotch/examples/full-production.yaml
@@ -1,0 +1,61 @@
+# Full production hardened deployment
+# Use case: enterprise with ExternalSecrets, OAuth, SMTP, Gateway API
+mode: production
+replicaCount: 2
+
+encryption:
+  existingSecret: hoppscotch-secrets
+  existingSecretKey: data-encryption-key
+
+postgresql:
+  enabled: false
+database:
+  external:
+    enabled: true
+    host: postgres.internal.svc
+    existingSecret: hoppscotch-db
+    existingSecretUrlKey: database-url
+
+auth:
+  providers: "GOOGLE,GITHUB,EMAIL"
+  github:
+    enabled: true
+    existingSecret: hoppscotch-oauth
+    existingSecretClientIdKey: github-client-id
+    existingSecretClientSecretKey: github-client-secret
+  google:
+    enabled: true
+    existingSecret: hoppscotch-oauth
+    existingSecretClientIdKey: google-client-id
+    existingSecretClientSecretKey: google-client-secret
+
+mailer:
+  enabled: true
+  from: noreply@example.com
+  existingSecret: hoppscotch-smtp
+
+gatewayAPI:
+  enabled: true
+  hostnames:
+    - hoppscotch.example.com
+  parentRefs:
+    - name: prod-gateway
+      namespace: gateway-system
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 2000m
+    memory: 1Gi

--- a/charts/hoppscotch/examples/minimal.yaml
+++ b/charts/hoppscotch/examples/minimal.yaml
@@ -1,0 +1,6 @@
+# Minimal local development setup
+# Use case: local dev, no TLS, PostgreSQL subchart
+mode: dev
+ingress:
+  enabled: true
+  host: hoppscotch.local

--- a/charts/hoppscotch/examples/minimal.yaml
+++ b/charts/hoppscotch/examples/minimal.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Minimal local development setup
 # Use case: local dev, no TLS, PostgreSQL subchart
 mode: dev

--- a/charts/hoppscotch/examples/production.yaml
+++ b/charts/hoppscotch/examples/production.yaml
@@ -1,0 +1,26 @@
+# Production deployment with subchart PostgreSQL
+# Use case: single-domain production, TLS via cert-manager
+mode: production
+ingress:
+  enabled: true
+  className: nginx
+  host: hoppscotch.example.com
+  tls:
+    - secretName: hoppscotch-tls
+      hosts:
+        - hoppscotch.example.com
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+postgresql:
+  primary:
+    persistence:
+      size: 20Gi
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 2000m
+    memory: 1Gi

--- a/charts/hoppscotch/examples/production.yaml
+++ b/charts/hoppscotch/examples/production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Production deployment with subchart PostgreSQL
 # Use case: single-domain production, TLS via cert-manager
 mode: production

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -1,0 +1,118 @@
+1. Hoppscotch has been installed
+================================
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ .Release.Namespace }}
+  Mode:           {{ .Values.mode }}
+  Version:        {{ .Chart.AppVersion }}
+  Auth Providers: {{ include "hoppscotch.authProviders" . }}
+
+2. Access
+=========
+[ClusterIP] Port-forward:
+  kubectl port-forward svc/{{ include "hoppscotch.fullname" . }} 8080:80 -n {{ .Release.Namespace }}
+  Open: http://localhost:8080
+
+{{- if .Values.ingress.enabled }}
+[Ingress]
+  App:     {{ include "hoppscotch.baseUrl" . }}
+  Backend: {{ include "hoppscotch.backendApiUrl" . }}
+  Admin:   {{ include "hoppscotch.adminUrl" . }}
+{{- end }}
+
+NOTE: WebSocket requires your ingress controller to support connection upgrade.
+For nginx-ingress, add these annotations to your ingress:
+  nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+  nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  nginx.ingress.kubernetes.io/configuration-snippet: |
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+3. First-time Setup
+===================
+  - The FIRST user to log in via the Admin Dashboard becomes the administrator.
+  - Admin URL: {{ include "hoppscotch.adminUrl" . }}
+  - No seed required — just navigate to /admin and log in.
+  - After setup, generate an InfraToken for API access: Admin > InfraTokens
+
+4. Configuration Summary
+========================
+  Database:         {{- if .Values.postgresql.enabled }} PostgreSQL subchart{{- else if .Values.database.external.enabled }} External PostgreSQL{{- else }} Not configured{{- end }}
+  SMTP:             {{- if .Values.mailer.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:      {{- if .Values.gatewayAPI.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets: {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+  Network Policy:   {{- if .Values.networkPolicy.enabled }} enabled{{- else }} disabled{{- end }}
+  PDB:              {{- if .Values.podDisruptionBudget.enabled }} enabled (minAvailable={{ .Values.podDisruptionBudget.minAvailable }}){{- else }} disabled{{- end }}
+
+5. Getting Started
+==================
+  Step 1: Access the Admin Dashboard at {{ include "hoppscotch.adminUrl" . }}
+  Step 2: Log in with your auth provider to become the first admin
+  Step 3: Configure Server Settings (auth providers, SMTP) via the UI
+  Step 4: Invite users via Admin > User Invitations
+
+6. Validation Commands
+======================
+  # Check pods are ready
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name=hoppscotch
+
+  # Check all container logs (including init containers)
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name=hoppscotch -c wait-for-db
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name=hoppscotch -c migrate
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name=hoppscotch -c hoppscotch
+
+  # Test backend health
+  kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "hoppscotch.fullname" . }} -- \
+    sh -c "wget -qO- http://localhost/backend/v1" 2>/dev/null || echo "backend not ready"
+
+7. Troubleshooting
+==================
+  Migration error (prisma migrate deploy failed):
+    -> Check DATABASE_URL is correct
+    -> Ensure PostgreSQL is running: kubectl get pods -n {{ .Release.Namespace }}
+    -> Check migrate init container logs
+
+  CORS error (WHITELISTED_ORIGINS mismatch):
+    -> Ensure ingress.host matches the URL you are accessing from
+    -> Or set baseUrl/adminUrl/backendApiUrl explicitly
+
+  WebSocket not connecting:
+    -> Your ingress controller must support WebSocket upgrade
+    -> Add proxy-read-timeout and upgrade annotations (see section 2)
+
+  DATA_ENCRYPTION_KEY warning:
+    -> Never change this key after first install — it will corrupt encrypted data
+    -> Use encryption.existingSecret in production to manage the key externally
+
+  Database connection refused:
+    -> wait-for-db init container will keep retrying — check PostgreSQL pod status
+    -> If using external DB: verify host, port, credentials
+
+  Admin dashboard shows 403:
+    -> Clear cookies and retry — first login always succeeds
+    -> Check VITE_ADMIN_URL matches actual admin URL
+
+  PostgreSQL subchart "database does not exist":
+    -> Ensure postgresql.auth.database is set (default: hoppscotch)
+    -> If PVC already existed from a prior install with different DB name,
+       delete the PVC and reinstall: kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/name=postgresql
+
+8. Telemetry
+============
+  Hoppscotch collects anonymous usage data (no API content, no personal data).
+  Frequency: once per week. Payload: instance UUID, user count, workspace count, version.
+  To disable: Admin Dashboard > Settings > Data Sharing (UI only — no env var available).
+
+9. Upgrading
+============
+  Minor version upgrades: migrations run automatically via init container on each deploy.
+  Major version upgrades: run migrations manually if needed:
+    kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "hoppscotch.fullname" . }} -- \
+      sh -c "pnpm exec prisma migrate deploy"
+
+10. Documentation
+=================
+  HelmForge docs: https://helmforge.dev/docs/charts/hoppscotch
+  Upstream docs:  https://docs.hoppscotch.io
+  GitHub source:  https://github.com/helmforgedev/charts/tree/main/charts/hoppscotch
+
+Happy Helmforging :)

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -286,11 +286,11 @@ databaseSecretName — name of the secret holding database-url
 {{- end -}}
 
 {{/*
-databaseSecretUrlKey — key within the secret for database-url
+databaseSecretUrlKey — key within the secret for the full DATABASE_URL value
 */}}
 {{- define "hoppscotch.databaseSecretUrlKey" -}}
-{{- if .Values.database.external.existingSecret -}}
-{{- .Values.database.external.existingSecretUrlKey | default "database-url" -}}
+{{- if and .Values.database.external.existingSecret .Values.database.external.existingSecretUrlKey -}}
+{{- .Values.database.external.existingSecretUrlKey -}}
 {{- else -}}
 database-url
 {{- end -}}
@@ -305,4 +305,40 @@ encryptionSecretName — name of the secret holding data-encryption-key
 {{- else -}}
 {{- include "hoppscotch.fullname" . -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+encryptionSecretKey — key within the secret for data-encryption-key
+*/}}
+{{- define "hoppscotch.encryptionSecretKey" -}}
+{{- if .Values.encryption.existingSecret -}}
+{{- .Values.encryption.existingSecretKey | default "data-encryption-key" -}}
+{{- else -}}
+data-encryption-key
+{{- end -}}
+{{- end -}}
+
+{{/*
+databaseEnv — env entries for DATABASE_URL (and DB_PASSWORD helper for password-only mode).
+Handles three cases:
+  1. existingSecret with full URL key → single secretKeyRef
+  2. existingSecret password-only → K8s env-var substitution using $(DB_PASSWORD)
+  3. chart-managed secret → single secretKeyRef to chart secret
+*/}}
+{{- define "hoppscotch.databaseEnv" -}}
+{{- if and .Values.database.external.enabled .Values.database.external.existingSecret (not .Values.database.external.existingSecretUrlKey) }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.database.external.existingSecret }}
+      key: {{ .Values.database.external.existingSecretPasswordKey }}
+- name: DATABASE_URL
+  value: {{ printf "postgresql://%s:$(DB_PASSWORD)@%s:%s/%s" .Values.database.external.username (include "hoppscotch.databaseHost" .) (include "hoppscotch.databasePort" .) (include "hoppscotch.databaseName" .) | quote }}
+{{- else }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "hoppscotch.databaseSecretName" . }}
+      key: {{ include "hoppscotch.databaseSecretUrlKey" . }}
+{{- end }}
 {{- end -}}

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -1,0 +1,308 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{- define "hoppscotch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "hoppscotch.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "hoppscotch.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "hoppscotch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "hoppscotch.labels" -}}
+helm.sh/chart: {{ include "hoppscotch.chart" . }}
+{{ include "hoppscotch.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "hoppscotch.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hoppscotch.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "hoppscotch.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "hoppscotch.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "hoppscotch.isProduction" -}}
+{{- if eq .Values.mode "production" -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+validateAll — fail-fast on misconfigured values
+*/}}
+{{- define "hoppscotch.validateAll" -}}
+{{- $mode := .Values.mode | default "dev" -}}
+{{- if not (has $mode (list "dev" "production")) -}}
+  {{- fail "mode must be one of: dev, production" -}}
+{{- end -}}
+{{- if eq $mode "production" -}}
+  {{- if and (not .Values.ingress.host) (not .Values.baseUrl) -}}
+    {{- fail "production mode requires ingress.host or baseUrl to be set" -}}
+  {{- end -}}
+  {{- if and (not .Values.postgresql.enabled) (not .Values.database.external.enabled) -}}
+    {{- fail "production mode requires postgresql.enabled=true or database.external.enabled=true" -}}
+  {{- end -}}
+  {{- if and .Values.database.external.enabled (not .Values.database.external.host) (not .Values.database.external.url) (not .Values.database.external.existingSecret) -}}
+    {{- fail "database.external.host or database.external.url or database.external.existingSecret is required when database.external.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.encryption.key (ne (len .Values.encryption.key) 32) -}}
+  {{- fail "encryption.key must be exactly 32 characters when set" -}}
+{{- end -}}
+{{- if and .Values.auth.github.enabled (not .Values.auth.github.existingSecret) -}}
+  {{- if not .Values.auth.github.clientId -}}
+    {{- fail "auth.github.clientId is required when auth.github.enabled=true (or set auth.github.existingSecret)" -}}
+  {{- end -}}
+  {{- if not .Values.auth.github.clientSecret -}}
+    {{- fail "auth.github.clientSecret is required when auth.github.enabled=true (or set auth.github.existingSecret)" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.auth.google.enabled (not .Values.auth.google.existingSecret) -}}
+  {{- if not .Values.auth.google.clientId -}}
+    {{- fail "auth.google.clientId is required when auth.google.enabled=true (or set auth.google.existingSecret)" -}}
+  {{- end -}}
+  {{- if not .Values.auth.google.clientSecret -}}
+    {{- fail "auth.google.clientSecret is required when auth.google.enabled=true (or set auth.google.existingSecret)" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.auth.microsoft.enabled (not .Values.auth.microsoft.existingSecret) -}}
+  {{- if not .Values.auth.microsoft.clientId -}}
+    {{- fail "auth.microsoft.clientId is required when auth.microsoft.enabled=true (or set auth.microsoft.existingSecret)" -}}
+  {{- end -}}
+  {{- if not .Values.auth.microsoft.clientSecret -}}
+    {{- fail "auth.microsoft.clientSecret is required when auth.microsoft.enabled=true (or set auth.microsoft.existingSecret)" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.mailer.enabled .Values.mailer.useCustomConfigs (not .Values.mailer.host) (not .Values.mailer.existingSecret) -}}
+  {{- fail "mailer.host is required when mailer.enabled=true and mailer.useCustomConfigs=true" -}}
+{{- end -}}
+{{- if and .Values.mailer.enabled (not .Values.mailer.useCustomConfigs) (not .Values.mailer.smtpUrl) (not .Values.mailer.existingSecret) -}}
+  {{- fail "mailer.smtpUrl is required when mailer.enabled=true and mailer.useCustomConfigs=false (or set mailer.existingSecret)" -}}
+{{- end -}}
+{{- if and .Values.gatewayAPI.enabled (not .Values.gatewayAPI.parentRefs) -}}
+  {{- fail "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
+  {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+protocol — https if TLS configured, else http
+*/}}
+{{- define "hoppscotch.protocol" -}}
+{{- if .Values.ingress.tls -}}https{{- else -}}http{{- end -}}
+{{- end -}}
+
+{{/*
+baseUrl — VITE_BASE_URL
+*/}}
+{{- define "hoppscotch.baseUrl" -}}
+{{- if .Values.baseUrl -}}
+{{- .Values.baseUrl -}}
+{{- else if .Values.ingress.host -}}
+{{- printf "%s://%s" (include "hoppscotch.protocol" .) .Values.ingress.host -}}
+{{- else -}}
+http://localhost:3000
+{{- end -}}
+{{- end -}}
+
+{{/*
+adminUrl — VITE_ADMIN_URL
+*/}}
+{{- define "hoppscotch.adminUrl" -}}
+{{- if .Values.adminUrl -}}
+{{- .Values.adminUrl -}}
+{{- else if .Values.ingress.host -}}
+{{- printf "%s://%s/admin" (include "hoppscotch.protocol" .) .Values.ingress.host -}}
+{{- else -}}
+http://localhost:3100
+{{- end -}}
+{{- end -}}
+
+{{/*
+backendGqlUrl — VITE_BACKEND_GQL_URL
+*/}}
+{{- define "hoppscotch.backendGqlUrl" -}}
+{{- if .Values.backendGqlUrl -}}
+{{- .Values.backendGqlUrl -}}
+{{- else if .Values.ingress.host -}}
+{{- printf "%s://%s/backend/graphql" (include "hoppscotch.protocol" .) .Values.ingress.host -}}
+{{- else -}}
+http://localhost:3170/graphql
+{{- end -}}
+{{- end -}}
+
+{{/*
+backendWsUrl — VITE_BACKEND_WS_URL (wss:// in production)
+*/}}
+{{- define "hoppscotch.backendWsUrl" -}}
+{{- if .Values.backendWsUrl -}}
+{{- .Values.backendWsUrl -}}
+{{- else if .Values.ingress.host -}}
+{{- if .Values.ingress.tls -}}
+{{- printf "wss://%s/backend/graphql" .Values.ingress.host -}}
+{{- else -}}
+{{- printf "ws://%s/backend/graphql" .Values.ingress.host -}}
+{{- end -}}
+{{- else -}}
+ws://localhost:3170/graphql
+{{- end -}}
+{{- end -}}
+
+{{/*
+backendApiUrl — VITE_BACKEND_API_URL
+*/}}
+{{- define "hoppscotch.backendApiUrl" -}}
+{{- if .Values.backendApiUrl -}}
+{{- .Values.backendApiUrl -}}
+{{- else if .Values.ingress.host -}}
+{{- printf "%s://%s/backend/v1" (include "hoppscotch.protocol" .) .Values.ingress.host -}}
+{{- else -}}
+http://localhost:3170/v1
+{{- end -}}
+{{- end -}}
+
+{{/*
+shortcodeBaseUrl — VITE_SHORTCODE_BASE_URL
+*/}}
+{{- define "hoppscotch.shortcodeBaseUrl" -}}
+{{- if .Values.shortcodeBaseUrl -}}
+{{- .Values.shortcodeBaseUrl -}}
+{{- else -}}
+{{- include "hoppscotch.baseUrl" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+whitelistedOrigins — WHITELISTED_ORIGINS CSV
+*/}}
+{{- define "hoppscotch.whitelistedOrigins" -}}
+{{- $base := include "hoppscotch.baseUrl" . -}}
+{{- $admin := include "hoppscotch.adminUrl" . -}}
+{{- $api := include "hoppscotch.backendApiUrl" . -}}
+{{- printf "%s,%s,%s,app://localhost_3200,app://hoppscotch" $base $admin $api -}}
+{{- end -}}
+
+{{/*
+authProviders — VITE_ALLOWED_AUTH_PROVIDERS
+*/}}
+{{- define "hoppscotch.authProviders" -}}
+{{- .Values.auth.providers | default "EMAIL" -}}
+{{- end -}}
+
+{{/*
+githubCallbackUrl
+*/}}
+{{- define "hoppscotch.githubCallbackUrl" -}}
+{{- if .Values.auth.github.callbackUrl -}}
+{{- .Values.auth.github.callbackUrl -}}
+{{- else -}}
+{{- printf "%s/auth/github/callback" (include "hoppscotch.backendApiUrl" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+googleCallbackUrl
+*/}}
+{{- define "hoppscotch.googleCallbackUrl" -}}
+{{- if .Values.auth.google.callbackUrl -}}
+{{- .Values.auth.google.callbackUrl -}}
+{{- else -}}
+{{- printf "%s/auth/google/callback" (include "hoppscotch.backendApiUrl" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+microsoftCallbackUrl
+*/}}
+{{- define "hoppscotch.microsoftCallbackUrl" -}}
+{{- if .Values.auth.microsoft.callbackUrl -}}
+{{- .Values.auth.microsoft.callbackUrl -}}
+{{- else -}}
+{{- printf "%s/auth/microsoft/callback" (include "hoppscotch.backendApiUrl" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+databaseHost — resolves subchart or external host
+*/}}
+{{- define "hoppscotch.databaseHost" -}}
+{{- if .Values.database.external.enabled -}}
+{{- .Values.database.external.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+databasePort
+*/}}
+{{- define "hoppscotch.databasePort" -}}
+{{- if .Values.database.external.enabled -}}
+{{- .Values.database.external.port | default 5432 | toString -}}
+{{- else -}}
+5432
+{{- end -}}
+{{- end -}}
+
+{{/*
+databaseName
+*/}}
+{{- define "hoppscotch.databaseName" -}}
+{{- if .Values.database.external.enabled -}}
+{{- .Values.database.external.name | default "hoppscotch" -}}
+{{- else -}}
+{{- .Values.postgresql.auth.database | default "hoppscotch" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+databaseSecretName — name of the secret holding database-url
+*/}}
+{{- define "hoppscotch.databaseSecretName" -}}
+{{- if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- include "hoppscotch.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+databaseSecretUrlKey — key within the secret for database-url
+*/}}
+{{- define "hoppscotch.databaseSecretUrlKey" -}}
+{{- if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretUrlKey | default "database-url" -}}
+{{- else -}}
+database-url
+{{- end -}}
+{{- end -}}
+
+{{/*
+encryptionSecretName — name of the secret holding data-encryption-key
+*/}}
+{{- define "hoppscotch.encryptionSecretName" -}}
+{{- if .Values.encryption.existingSecret -}}
+{{- .Values.encryption.existingSecret -}}
+{{- else -}}
+{{- include "hoppscotch.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/hoppscotch/templates/configmap.yaml
+++ b/charts/hoppscotch/templates/configmap.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+data:
+  VITE_BASE_URL: {{ include "hoppscotch.baseUrl" . | quote }}
+  VITE_SHORTCODE_BASE_URL: {{ include "hoppscotch.shortcodeBaseUrl" . | quote }}
+  VITE_ADMIN_URL: {{ include "hoppscotch.adminUrl" . | quote }}
+  VITE_BACKEND_GQL_URL: {{ include "hoppscotch.backendGqlUrl" . | quote }}
+  VITE_BACKEND_WS_URL: {{ include "hoppscotch.backendWsUrl" . | quote }}
+  VITE_BACKEND_API_URL: {{ include "hoppscotch.backendApiUrl" . | quote }}
+  VITE_ALLOWED_AUTH_PROVIDERS: {{ include "hoppscotch.authProviders" . | quote }}
+  ENABLE_SUBPATH_BASED_ACCESS: "true"
+  WHITELISTED_ORIGINS: {{ include "hoppscotch.whitelistedOrigins" . | quote }}
+  {{- with .Values.tosLink }}
+  VITE_APP_TOS_LINK: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.privacyPolicyLink }}
+  VITE_APP_PRIVACY_POLICY_LINK: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.mailer.enabled }}
+  MAILER_SMTP_ENABLE: "true"
+  MAILER_ADDRESS_FROM: {{ .Values.mailer.from | quote }}
+  MAILER_USE_CUSTOM_CONFIGS: {{ .Values.mailer.useCustomConfigs | toString | quote }}
+  {{- if .Values.mailer.useCustomConfigs }}
+  MAILER_SMTP_HOST: {{ .Values.mailer.host | quote }}
+  MAILER_SMTP_PORT: {{ .Values.mailer.port | toString | quote }}
+  MAILER_SMTP_SECURE: {{ .Values.mailer.secure | toString | quote }}
+  MAILER_SMTP_USER: {{ .Values.mailer.user | quote }}
+  MAILER_TLS_REJECT_UNAUTHORIZED: {{ .Values.mailer.tlsRejectUnauthorized | toString | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.auth.github.enabled }}
+  GITHUB_SCOPE: {{ .Values.auth.github.scope | quote }}
+  GITHUB_CALLBACK_URL: {{ include "hoppscotch.githubCallbackUrl" . | quote }}
+  {{- end }}
+  {{- if .Values.auth.google.enabled }}
+  GOOGLE_SCOPE: {{ .Values.auth.google.scope | quote }}
+  GOOGLE_CALLBACK_URL: {{ include "hoppscotch.googleCallbackUrl" . | quote }}
+  {{- end }}
+  {{- if .Values.auth.microsoft.enabled }}
+  MICROSOFT_SCOPE: {{ .Values.auth.microsoft.scope | quote }}
+  MICROSOFT_CALLBACK_URL: {{ include "hoppscotch.microsoftCallbackUrl" . | quote }}
+  {{- end }}

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -1,0 +1,126 @@
+{{- include "hoppscotch.validateAll" . -}}
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deployment.strategy.type }}
+    {{- if eq .Values.deployment.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.deployment.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.deployment.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  selector:
+    matchLabels: {{ include "hoppscotch.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{ include "hoppscotch.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "hoppscotch.serviceAccountName" . }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-db
+          image: docker.io/library/busybox:1.37
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z -w2 {{ include "hoppscotch.databaseHost" . }} {{ include "hoppscotch.databasePort" . }}; do
+                echo "waiting for database..."; sleep 2;
+              done
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [sh, -c, "pnpm exec prisma migrate deploy"]
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hoppscotch.databaseSecretName" . }}
+                  key: {{ include "hoppscotch.databaseSecretUrlKey" . }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: hoppscotch
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "hoppscotch.fullname" . }}
+            - secretRef:
+                name: {{ include "hoppscotch.fullname" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnv }}
+          env: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /backend/v1
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /backend/v1
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /backend/v1
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -59,11 +59,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: [sh, -c, "pnpm exec prisma migrate deploy"]
           env:
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "hoppscotch.databaseSecretName" . }}
-                  key: {{ include "hoppscotch.databaseSecretUrlKey" . }}
+            {{- include "hoppscotch.databaseEnv" . | nindent 12 }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
         {{- with .Values.initContainers }}
@@ -81,14 +77,70 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "hoppscotch.fullname" . }}
-            - secretRef:
-                name: {{ include "hoppscotch.fullname" . }}
             {{- with .Values.extraEnvFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.extraEnv }}
-          env: {{- toYaml . | nindent 12 }}
-          {{- end }}
+          env:
+            {{- include "hoppscotch.databaseEnv" . | nindent 12 }}
+            - name: DATA_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hoppscotch.encryptionSecretName" . }}
+                  key: {{ include "hoppscotch.encryptionSecretKey" . }}
+            {{- if .Values.auth.github.enabled }}
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.github.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.auth.github.existingSecretClientIdKey }}
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.github.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.auth.github.existingSecretClientSecretKey }}
+            {{- end }}
+            {{- if .Values.auth.google.enabled }}
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.google.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.auth.google.existingSecretClientIdKey }}
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.google.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.auth.google.existingSecretClientSecretKey }}
+            {{- end }}
+            {{- if .Values.auth.microsoft.enabled }}
+            - name: MICROSOFT_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.microsoft.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.auth.microsoft.existingSecretClientIdKey }}
+            - name: MICROSOFT_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.microsoft.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.auth.microsoft.existingSecretClientSecretKey }}
+            {{- end }}
+            {{- if .Values.mailer.enabled }}
+            {{- if .Values.mailer.useCustomConfigs }}
+            - name: MAILER_SMTP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mailer.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.mailer.existingSecretPasswordKey }}
+            {{- else }}
+            - name: MAILER_SMTP_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mailer.existingSecret | default (include "hoppscotch.fullname" .) }}
+                  key: {{ .Values.mailer.existingSecretSmtpUrlKey }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /backend/v1

--- a/charts/hoppscotch/templates/externalsecret.yaml
+++ b/charts/hoppscotch/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind }}
+  target:
+    name: {{ include "hoppscotch.fullname" . }}
+    creationPolicy: Owner
+  {{- with .Values.externalSecrets.data }}
+  data: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.externalSecrets.dataFrom }}
+  dataFrom: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/hoppscotch/templates/httproute.yaml
+++ b/charts/hoppscotch/templates/httproute.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs: {{- toYaml (required "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true" .Values.gatewayAPI.parentRefs) | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.gatewayAPI.paths }}
+    - matches:
+        - path:
+            type: {{ .type }}
+            value: {{ .value }}
+      backendRefs:
+        - name: {{ include "hoppscotch.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/hoppscotch/templates/ingress.yaml
+++ b/charts/hoppscotch/templates/ingress.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "hoppscotch.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/hoppscotch/templates/networkpolicy.yaml
+++ b/charts/hoppscotch/templates/networkpolicy.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels: {{ include "hoppscotch.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - port: http
+          protocol: TCP
+    {{- with .Values.networkPolicy.ingress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - ports:
+        - port: {{ include "hoppscotch.databasePort" . | int }}
+          protocol: TCP
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/hoppscotch/templates/pdb.yaml
+++ b/charts/hoppscotch/templates/pdb.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels: {{ include "hoppscotch.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/hoppscotch/templates/secret.yaml
+++ b/charts/hoppscotch/templates/secret.yaml
@@ -7,13 +7,13 @@ metadata:
   labels: {{ include "hoppscotch.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- /* database-url: only when not using existingSecret with full URL override */}}
+  {{- /* database-url: skipped when caller provides full URL via existingSecret */}}
   {{- if not (and .Values.database.external.existingSecret .Values.database.external.existingSecretUrlKey) }}
   {{- if .Values.database.external.enabled }}
   {{- if .Values.database.external.url }}
   database-url: {{ .Values.database.external.url | b64enc | quote }}
   {{- else if .Values.database.external.existingSecret }}
-  {{- /* existingSecret with password key — still build the URL */}}
+  {{- /* password-only existingSecret: DATABASE_URL is assembled in the pod via env-var substitution */}}
   {{- else }}
   database-url: {{ printf "postgresql://%s:%s@%s:%s/%s" .Values.database.external.username .Values.database.external.password (include "hoppscotch.databaseHost" .) (include "hoppscotch.databasePort" .) (include "hoppscotch.databaseName" .) | b64enc | quote }}
   {{- end }}
@@ -22,9 +22,17 @@ data:
   database-url: {{ printf "postgresql://%s:%s@%s:%s/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "hoppscotch.databaseHost" .) "5432" .Values.postgresql.auth.database | b64enc | quote }}
   {{- end }}
   {{- end }}
-  {{- /* data-encryption-key */}}
+  {{- /* data-encryption-key: preserve across upgrades via lookup */}}
   {{- if not .Values.encryption.existingSecret }}
-  {{- $encKey := .Values.encryption.key | default (randAlphaNum 32) }}
+  {{- $encKey := .Values.encryption.key }}
+  {{- if not $encKey }}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "hoppscotch.fullname" .) }}
+  {{- if and $existing $existing.data (index $existing.data "data-encryption-key") }}
+  {{- $encKey = index $existing.data "data-encryption-key" | b64dec }}
+  {{- else }}
+  {{- $encKey = randAlphaNum 32 }}
+  {{- end }}
+  {{- end }}
   data-encryption-key: {{ $encKey | b64enc | quote }}
   {{- end }}
   {{- /* GitHub OAuth */}}

--- a/charts/hoppscotch/templates/secret.yaml
+++ b/charts/hoppscotch/templates/secret.yaml
@@ -1,0 +1,52 @@
+{{- $fullname := include "hoppscotch.fullname" . }}
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullname }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- /* database-url: only when not using existingSecret with full URL override */}}
+  {{- if not (and .Values.database.external.existingSecret .Values.database.external.existingSecretUrlKey) }}
+  {{- if .Values.database.external.enabled }}
+  {{- if .Values.database.external.url }}
+  database-url: {{ .Values.database.external.url | b64enc | quote }}
+  {{- else if .Values.database.external.existingSecret }}
+  {{- /* existingSecret with password key — still build the URL */}}
+  {{- else }}
+  database-url: {{ printf "postgresql://%s:%s@%s:%s/%s" .Values.database.external.username .Values.database.external.password (include "hoppscotch.databaseHost" .) (include "hoppscotch.databasePort" .) (include "hoppscotch.databaseName" .) | b64enc | quote }}
+  {{- end }}
+  {{- else }}
+  {{- /* subchart PostgreSQL: build URL with auto password */}}
+  database-url: {{ printf "postgresql://%s:%s@%s:%s/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "hoppscotch.databaseHost" .) "5432" .Values.postgresql.auth.database | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- /* data-encryption-key */}}
+  {{- if not .Values.encryption.existingSecret }}
+  {{- $encKey := .Values.encryption.key | default (randAlphaNum 32) }}
+  data-encryption-key: {{ $encKey | b64enc | quote }}
+  {{- end }}
+  {{- /* GitHub OAuth */}}
+  {{- if and .Values.auth.github.enabled (not .Values.auth.github.existingSecret) }}
+  github-client-id: {{ .Values.auth.github.clientId | b64enc | quote }}
+  github-client-secret: {{ .Values.auth.github.clientSecret | b64enc | quote }}
+  {{- end }}
+  {{- /* Google OAuth */}}
+  {{- if and .Values.auth.google.enabled (not .Values.auth.google.existingSecret) }}
+  google-client-id: {{ .Values.auth.google.clientId | b64enc | quote }}
+  google-client-secret: {{ .Values.auth.google.clientSecret | b64enc | quote }}
+  {{- end }}
+  {{- /* Microsoft OAuth */}}
+  {{- if and .Values.auth.microsoft.enabled (not .Values.auth.microsoft.existingSecret) }}
+  microsoft-client-id: {{ .Values.auth.microsoft.clientId | b64enc | quote }}
+  microsoft-client-secret: {{ .Values.auth.microsoft.clientSecret | b64enc | quote }}
+  {{- end }}
+  {{- /* SMTP */}}
+  {{- if and .Values.mailer.enabled (not .Values.mailer.existingSecret) }}
+  {{- if .Values.mailer.useCustomConfigs }}
+  smtp-password: {{ .Values.mailer.password | b64enc | quote }}
+  {{- else }}
+  smtp-url: {{ .Values.mailer.smtpUrl | b64enc | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/hoppscotch/templates/service.yaml
+++ b/charts/hoppscotch/templates/service.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector: {{ include "hoppscotch.selectorLabels" . | nindent 4 }}

--- a/charts/hoppscotch/templates/serviceaccount.yaml
+++ b/charts/hoppscotch/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hoppscotch.serviceAccountName" . }}
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/hoppscotch/templates/servicemonitor.yaml
+++ b/charts/hoppscotch/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}
+  labels:
+    {{ include "hoppscotch.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels: {{ include "hoppscotch.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /backend/v1
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/charts/hoppscotch/templates/tests/connection-test.yaml
+++ b/charts/hoppscotch/templates/tests/connection-test.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}-test-connection
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: docker.io/library/busybox:1.37
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+        - -c
+        - |
+          wget -qO- http://{{ include "hoppscotch.fullname" . }}:{{ .Values.service.port }}/backend/v1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        runAsUser: 1000

--- a/charts/hoppscotch/tests/configmap_test.yaml
+++ b/charts/hoppscotch/tests/configmap_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: configmap tests
 templates:
   - configmap.yaml

--- a/charts/hoppscotch/tests/configmap_test.yaml
+++ b/charts/hoppscotch/tests/configmap_test.yaml
@@ -1,0 +1,94 @@
+suite: configmap tests
+templates:
+  - configmap.yaml
+  - secret.yaml
+tests:
+  - it: should enable subpath access
+    asserts:
+      - equal:
+          path: data.ENABLE_SUBPATH_BASED_ACCESS
+          value: "true"
+        template: configmap.yaml
+
+  - it: should set EMAIL as default auth provider
+    asserts:
+      - equal:
+          path: data.VITE_ALLOWED_AUTH_PROVIDERS
+          value: EMAIL
+        template: configmap.yaml
+
+  - it: should derive URLs from ingress.host
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+        tls:
+          - secretName: hoppscotch-tls
+            hosts:
+              - hoppscotch.example.com
+    asserts:
+      - equal:
+          path: data.VITE_BASE_URL
+          value: "https://hoppscotch.example.com"
+        template: configmap.yaml
+      - equal:
+          path: data.VITE_ADMIN_URL
+          value: "https://hoppscotch.example.com/admin"
+        template: configmap.yaml
+      - equal:
+          path: data.VITE_BACKEND_API_URL
+          value: "https://hoppscotch.example.com/backend/v1"
+        template: configmap.yaml
+      - equal:
+          path: data.VITE_BACKEND_WS_URL
+          value: "wss://hoppscotch.example.com/backend/graphql"
+        template: configmap.yaml
+
+  - it: should not set MAILER when disabled
+    asserts:
+      - notExists:
+          path: data.MAILER_SMTP_ENABLE
+        template: configmap.yaml
+
+  - it: should set MAILER when enabled
+    set:
+      mailer:
+        enabled: true
+        from: test@example.com
+        useCustomConfigs: false
+        smtpUrl: "smtps://test@example.com"
+    asserts:
+      - equal:
+          path: data.MAILER_SMTP_ENABLE
+          value: "true"
+        template: configmap.yaml
+
+  - it: should set GitHub auth config when enabled
+    set:
+      auth:
+        providers: "EMAIL,GITHUB"
+        github:
+          enabled: true
+          clientId: test-id
+          clientSecret: test-secret
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+    asserts:
+      - equal:
+          path: data.GITHUB_SCOPE
+          value: "user:email"
+        template: configmap.yaml
+      - isNotNull:
+          path: data.GITHUB_CALLBACK_URL
+        template: configmap.yaml
+
+  - it: should set WHITELISTED_ORIGINS
+    asserts:
+      - isNotNull:
+          path: data.WHITELISTED_ORIGINS
+        template: configmap.yaml
+      - matchRegex:
+          path: data.WHITELISTED_ORIGINS
+          pattern: "app://hoppscotch"
+        template: configmap.yaml

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -1,0 +1,98 @@
+suite: deployment tests
+templates:
+  - deployment.yaml
+  - secret.yaml
+  - configmap.yaml
+tests:
+  - it: should create a Deployment
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: deployment.yaml
+      - isKind:
+          of: Deployment
+        template: deployment.yaml
+
+  - it: should use correct replicaCount
+    set:
+      replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: deployment.yaml
+
+  - it: should use pinned image tag
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.3.1"
+        template: deployment.yaml
+
+  - it: should have wait-for-db init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/busybox:1.37
+        template: deployment.yaml
+
+  - it: should have migrate init container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: migrate
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[1].image
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.3.1"
+        template: deployment.yaml
+
+  - it: should run as non-root
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+        template: deployment.yaml
+
+  - it: should have resources defined
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+        template: deployment.yaml
+      - isNotNull:
+          path: spec.template.spec.containers[0].resources.requests.memory
+        template: deployment.yaml
+
+  - it: should have checksum annotations
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations["checksum/config"]
+        template: deployment.yaml
+      - isNotNull:
+          path: spec.template.metadata.annotations["checksum/secret"]
+        template: deployment.yaml
+
+  - it: should use RollingUpdate strategy by default
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+        template: deployment.yaml
+
+  - it: should expose port 80
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 80
+            protocol: TCP
+        template: deployment.yaml

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: deployment tests
 templates:
   - deployment.yaml

--- a/charts/hoppscotch/tests/ingress_test.yaml
+++ b/charts/hoppscotch/tests/ingress_test.yaml
@@ -1,0 +1,65 @@
+suite: ingress tests
+templates:
+  - ingress.yaml
+  - secret.yaml
+  - configmap.yaml
+tests:
+  - it: should not create Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: ingress.yaml
+
+  - it: should create Ingress when enabled
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: ingress.yaml
+      - isKind:
+          of: Ingress
+        template: ingress.yaml
+
+  - it: should use correct host
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: hoppscotch.example.com
+        template: ingress.yaml
+
+  - it: should configure TLS when set
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+        tls:
+          - secretName: hoppscotch-tls
+            hosts:
+              - hoppscotch.example.com
+    asserts:
+      - isNotNull:
+          path: spec.tls
+        template: ingress.yaml
+      - equal:
+          path: spec.tls[0].secretName
+          value: hoppscotch-tls
+        template: ingress.yaml
+
+  - it: should set ingressClassName when provided
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+        className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+        template: ingress.yaml

--- a/charts/hoppscotch/tests/ingress_test.yaml
+++ b/charts/hoppscotch/tests/ingress_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ingress tests
 templates:
   - ingress.yaml

--- a/charts/hoppscotch/tests/secret_test.yaml
+++ b/charts/hoppscotch/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: secret tests
 templates:
   - secret.yaml

--- a/charts/hoppscotch/tests/secret_test.yaml
+++ b/charts/hoppscotch/tests/secret_test.yaml
@@ -1,0 +1,56 @@
+suite: secret tests
+templates:
+  - secret.yaml
+  - configmap.yaml
+tests:
+  - it: should create a Secret
+    asserts:
+      - isKind:
+          of: Secret
+        template: secret.yaml
+
+  - it: should include database-url
+    asserts:
+      - isNotNull:
+          path: data["database-url"]
+        template: secret.yaml
+
+  - it: should include data-encryption-key
+    asserts:
+      - isNotNull:
+          path: data["data-encryption-key"]
+        template: secret.yaml
+
+  - it: should include GitHub OAuth keys when enabled
+    set:
+      auth:
+        github:
+          enabled: true
+          clientId: test-id
+          clientSecret: test-secret
+    asserts:
+      - isNotNull:
+          path: data["github-client-id"]
+        template: secret.yaml
+      - isNotNull:
+          path: data["github-client-secret"]
+        template: secret.yaml
+
+  - it: should not include GitHub OAuth keys when disabled
+    asserts:
+      - notExists:
+          path: data["github-client-id"]
+        template: secret.yaml
+
+  - it: should include SMTP password when mailer custom configs enabled
+    set:
+      mailer:
+        enabled: true
+        from: test@example.com
+        useCustomConfigs: true
+        host: smtp.example.com
+        password: test-password
+    asserts:
+      - isNotNull:
+          path: data["smtp-password"]
+        template: secret.yaml

--- a/charts/hoppscotch/tests/service_test.yaml
+++ b/charts/hoppscotch/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: service tests
 templates:
   - service.yaml

--- a/charts/hoppscotch/tests/service_test.yaml
+++ b/charts/hoppscotch/tests/service_test.yaml
@@ -1,0 +1,56 @@
+suite: service tests
+templates:
+  - service.yaml
+  - secret.yaml
+  - configmap.yaml
+tests:
+  - it: should create a ClusterIP Service
+    asserts:
+      - isKind:
+          of: Service
+        template: service.yaml
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        template: service.yaml
+
+  - it: should expose port 80
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP
+        template: service.yaml
+
+  - it: should have correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: hoppscotch
+        template: service.yaml
+
+  - it: should not set ipFamilyPolicy by default
+    asserts:
+      - notExists:
+          path: spec.ipFamilyPolicy
+        template: service.yaml
+
+  - it: should set ipFamilyPolicy when configured
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        template: service.yaml
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        template: service.yaml

--- a/charts/hoppscotch/tests/validation_test.yaml
+++ b/charts/hoppscotch/tests/validation_test.yaml
@@ -1,0 +1,83 @@
+suite: validation tests
+templates:
+  - deployment.yaml
+  - secret.yaml
+  - configmap.yaml
+tests:
+  - it: should succeed in dev mode (default)
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: deployment.yaml
+
+  - it: should fail in production mode without hostname
+    set:
+      mode: production
+    asserts:
+      - failedTemplate:
+          errorMessage: "production mode requires ingress.host or baseUrl to be set"
+        template: deployment.yaml
+
+  - it: should fail in production mode without database
+    set:
+      mode: production
+      ingress:
+        host: hoppscotch.example.com
+      postgresql:
+        enabled: false
+      database:
+        external:
+          enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "production mode requires postgresql.enabled=true or database.external.enabled=true"
+        template: deployment.yaml
+
+  - it: should pass in production mode with hostname and postgresql
+    set:
+      mode: production
+      ingress:
+        host: hoppscotch.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: deployment.yaml
+
+  - it: should fail when encryption key is wrong length
+    set:
+      encryption:
+        key: "tooshort"
+    asserts:
+      - failedTemplate:
+          errorMessage: "encryption.key must be exactly 32 characters when set"
+        template: deployment.yaml
+
+  - it: should pass with valid 32-char encryption key
+    set:
+      encryption:
+        key: "12345678901234567890123456789012"
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: deployment.yaml
+
+  - it: should fail when gatewayAPI enabled without parentRefs
+    set:
+      gatewayAPI:
+        enabled: true
+        parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true"
+        template: deployment.yaml
+
+  - it: should fail when externalSecrets enabled without secretStoreRef.name
+    set:
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true"
+        template: deployment.yaml

--- a/charts/hoppscotch/tests/validation_test.yaml
+++ b/charts/hoppscotch/tests/validation_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: validation tests
 templates:
   - deployment.yaml

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -1,0 +1,402 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Hoppscotch Chart Values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["dev", "production"],
+      "description": "Chart mode: dev or production"
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "clusterDomain": {
+      "type": "string",
+      "minLength": 1
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      },
+      "required": ["repository", "tag", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"}
+        }
+      }
+    },
+    "baseUrl": {"type": "string"},
+    "adminUrl": {"type": "string"},
+    "backendGqlUrl": {"type": "string"},
+    "backendWsUrl": {"type": "string"},
+    "backendApiUrl": {"type": "string"},
+    "shortcodeBaseUrl": {"type": "string"},
+    "tosLink": {"type": "string"},
+    "privacyPolicyLink": {"type": "string"},
+    "encryption": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "maxLength": 32
+        },
+        "existingSecret": {"type": "string"},
+        "existingSecretKey": {"type": "string"}
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "auth": {
+          "type": "object",
+          "properties": {
+            "database": {"type": "string"},
+            "username": {"type": "string"},
+            "password": {"type": "string"}
+          }
+        },
+        "primary": {
+          "type": "object",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "properties": {
+                "enabled": {"type": "boolean"},
+                "size": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "external": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "host": {"type": "string"},
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "name": {"type": "string"},
+            "username": {"type": "string"},
+            "password": {"type": "string"},
+            "existingSecret": {"type": "string"},
+            "existingSecretPasswordKey": {"type": "string"},
+            "url": {"type": "string"},
+            "existingSecretUrlKey": {"type": "string"}
+          }
+        }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "providers": {
+          "type": "string",
+          "minLength": 1
+        },
+        "github": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "clientId": {"type": "string"},
+            "clientSecret": {"type": "string"},
+            "existingSecret": {"type": "string"},
+            "existingSecretClientIdKey": {"type": "string"},
+            "existingSecretClientSecretKey": {"type": "string"},
+            "scope": {"type": "string"},
+            "callbackUrl": {"type": "string"}
+          }
+        },
+        "google": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "clientId": {"type": "string"},
+            "clientSecret": {"type": "string"},
+            "existingSecret": {"type": "string"},
+            "existingSecretClientIdKey": {"type": "string"},
+            "existingSecretClientSecretKey": {"type": "string"},
+            "scope": {"type": "string"},
+            "callbackUrl": {"type": "string"}
+          }
+        },
+        "microsoft": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "clientId": {"type": "string"},
+            "clientSecret": {"type": "string"},
+            "existingSecret": {"type": "string"},
+            "existingSecretClientIdKey": {"type": "string"},
+            "existingSecretClientSecretKey": {"type": "string"},
+            "scope": {"type": "string"},
+            "callbackUrl": {"type": "string"}
+          }
+        }
+      }
+    },
+    "mailer": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "from": {"type": "string"},
+        "useCustomConfigs": {"type": "boolean"},
+        "smtpUrl": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "secure": {"type": "boolean"},
+        "user": {"type": "string"},
+        "password": {"type": "string"},
+        "tlsRejectUnauthorized": {"type": "boolean"},
+        "existingSecret": {"type": "string"},
+        "existingSecretSmtpUrlKey": {"type": "string"},
+        "existingSecretPasswordKey": {"type": "string"}
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "deployment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "strategy": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RollingUpdate", "Recreate"]
+            },
+            "rollingUpdate": {
+              "type": "object",
+              "properties": {
+                "maxUnavailable": {},
+                "maxSurge": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {"type": "boolean"},
+        "name": {"type": "string"},
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "containerSecurityContext": {
+      "type": "object"
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(m|[0-9]*)$"
+            },
+            "memory": {
+              "type": "string",
+              "pattern": "^[0-9]+(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E)?$"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(m|[0-9]*)$"
+            },
+            "memory": {
+              "type": "string",
+              "pattern": "^[0-9]+(Ki|Mi|Gi|Ti|Pi|Ei|k|M|G|T|P|E)?$"
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "ipFamilyPolicy": {
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["SingleStack", "PreferDualStack", "RequireDualStack"]
+            },
+            {"type": "null"}
+          ]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "className": {"type": "string"},
+        "host": {"type": "string"},
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "tls": {
+          "type": "array"
+        }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "parentRefs": {"type": "array"},
+        "hostnames": {"type": "array", "items": {"type": "string"}},
+        "paths": {"type": "array"},
+        "annotations": {"type": "object"},
+        "tls": {"type": "object"}
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "secretStoreRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {"type": "string"},
+            "kind": {
+              "type": "string",
+              "enum": ["SecretStore", "ClusterSecretStore"]
+            }
+          }
+        },
+        "refreshInterval": {"type": "string"},
+        "data": {"type": "array"},
+        "dataFrom": {"type": "array"},
+        "annotations": {"type": "object"}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "interval": {"type": "string"},
+            "labels": {"type": "object"}
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "ingress": {"type": "array"},
+        "egress": {"type": "array"}
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "minAvailable": {}
+      }
+    },
+    "podAnnotations": {"type": "object"},
+    "podLabels": {"type": "object"},
+    "nodeSelector": {"type": "object"},
+    "tolerations": {"type": "array"},
+    "affinity": {"type": "object"},
+    "topologySpreadConstraints": {"type": "array"},
+    "initContainers": {"type": "array"},
+    "extraEnv": {"type": "array"},
+    "extraEnvFrom": {"type": "array"}
+  }
+}

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -88,7 +88,7 @@ encryption:
 # Database
 # =============================================================================
 
-# PostgreSQL subchart — enabled by default for dev mode.
+# PostgreSQL subchart - enabled by default for dev mode.
 # Disable and configure database.external for production with an external DB.
 postgresql:
   enabled: true
@@ -218,7 +218,7 @@ mailer:
 # Deployment
 # =============================================================================
 
-# -- Number of Hoppscotch replicas. App is stateless — horizontal scaling is safe.
+# -- Number of Hoppscotch replicas. App is stateless - horizontal scaling is safe.
 replicaCount: 1
 
 deployment:
@@ -296,7 +296,7 @@ ingress:
   # -- Primary hostname. Used to auto-derive VITE_* URLs when set.
   host: ""
   # -- Additional annotations
-  # Note: WebSocket requires proxy-read-timeout and upgrade annotations — see NOTES.txt
+  # Note: WebSocket requires proxy-read-timeout and upgrade annotations - see NOTES.txt
   annotations: {}
   # -- TLS configuration
   tls: []

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -124,7 +124,9 @@ database:
     # Format: postgresql://user:pass@host:5432/db
     url: ""
     # -- Key within existingSecret that holds the full DATABASE_URL.
-    existingSecretUrlKey: database-url
+    # Set this when the external secret contains a complete DATABASE_URL string.
+    # Leave empty when the secret only contains the password (existingSecretPasswordKey).
+    existingSecretUrlKey: ""
 
 # =============================================================================
 # Authentication Providers

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Hoppscotch Helm Chart - Default Values
+# =============================================================================
+# Supported modes:
+# - dev        Single replica, PostgreSQL subchart, EMAIL auth, minimal resources
+# - production Requires hostname + database, full auth support
+
+# -- Chart mode: dev | production
+mode: dev
+
+# -- Override chart name
+nameOverride: ""
+# -- Override full release name
+fullnameOverride: ""
+
+# -- Labels added to all resources
+commonLabels: {}
+
+# -- Kubernetes cluster domain
+clusterDomain: cluster.local
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  # -- Hoppscotch AIO image repository
+  repository: docker.io/hoppscotch/hoppscotch
+  # -- Hoppscotch image tag
+  tag: "2026.3.1"
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# URLs
+# =============================================================================
+# All URL values are auto-derived from ingress.host when left empty.
+# Override individually if needed.
+
+# -- Public URL where the frontend is accessible (VITE_BASE_URL).
+# Auto-derived as https://<ingress.host> when empty.
+baseUrl: ""
+
+# -- URL for the admin dashboard (VITE_ADMIN_URL).
+# Auto-derived as https://<ingress.host>/admin when empty.
+adminUrl: ""
+
+# -- Backend GraphQL URL (VITE_BACKEND_GQL_URL).
+# Auto-derived as https://<ingress.host>/backend/graphql when empty.
+backendGqlUrl: ""
+
+# -- Backend WebSocket URL (VITE_BACKEND_WS_URL). Must use wss:// in production.
+# Auto-derived as wss://<ingress.host>/backend/graphql when empty.
+backendWsUrl: ""
+
+# -- Backend REST API URL (VITE_BACKEND_API_URL).
+# Auto-derived as https://<ingress.host>/backend/v1 when empty.
+backendApiUrl: ""
+
+# -- Shortcode base URL (VITE_SHORTCODE_BASE_URL). Defaults to baseUrl.
+shortcodeBaseUrl: ""
+
+# -- Optional Terms of Service URL (VITE_APP_TOS_LINK).
+tosLink: ""
+
+# -- Optional Privacy Policy URL (VITE_APP_PRIVACY_POLICY_LINK).
+privacyPolicyLink: ""
+
+# =============================================================================
+# Encryption
+# =============================================================================
+
+encryption:
+  # -- Exactly 32-character key for encrypting sensitive data in the database.
+  # Auto-generated on first install if empty and no existingSecret is set.
+  # WARNING: changing this key after first install will corrupt all existing
+  # encrypted data in the database. Treat this key as immutable after first use.
+  key: ""
+  # -- Existing secret containing the DATA_ENCRYPTION_KEY.
+  existingSecret: ""
+  # -- Key within existingSecret that holds the encryption key.
+  existingSecretKey: data-encryption-key
+
+# =============================================================================
+# Database
+# =============================================================================
+
+# PostgreSQL subchart — enabled by default for dev mode.
+# Disable and configure database.external for production with an external DB.
+postgresql:
+  enabled: true
+  auth:
+    database: hoppscotch
+    username: hoppscotch
+    # -- PostgreSQL password. Auto-generated if empty.
+    password: ""
+  primary:
+    persistence:
+      enabled: true
+      size: 10Gi
+
+database:
+  # -- Use an external PostgreSQL instance instead of the bundled subchart.
+  external:
+    enabled: false
+    # -- External PostgreSQL host
+    host: ""
+    # -- External PostgreSQL port
+    port: 5432
+    # -- Database name
+    name: hoppscotch
+    # -- Database username
+    username: hoppscotch
+    # -- Database password (inline; use existingSecret for production)
+    password: ""
+    # -- Existing secret containing the database password.
+    existingSecret: ""
+    # -- Key within existingSecret that holds the password.
+    existingSecretPasswordKey: postgres-password
+    # -- Full DATABASE_URL override. Takes precedence over individual fields.
+    # Format: postgresql://user:pass@host:5432/db
+    url: ""
+    # -- Key within existingSecret that holds the full DATABASE_URL.
+    existingSecretUrlKey: database-url
+
+# =============================================================================
+# Authentication Providers
+# =============================================================================
+
+auth:
+  # -- Comma-separated list of enabled authentication providers.
+  # Valid values: GOOGLE, GITHUB, MICROSOFT, EMAIL
+  providers: "EMAIL"
+
+  github:
+    # -- Enable GitHub OAuth authentication
+    enabled: false
+    # -- GitHub OAuth App client ID
+    clientId: ""
+    # -- GitHub OAuth App client secret
+    clientSecret: ""
+    # -- Existing secret with GitHub credentials (keys: github-client-id, github-client-secret)
+    existingSecret: ""
+    existingSecretClientIdKey: github-client-id
+    existingSecretClientSecretKey: github-client-secret
+    # -- GitHub OAuth scope
+    scope: "user:email"
+    # -- Callback URL. Auto-derived from backendApiUrl when empty.
+    callbackUrl: ""
+
+  google:
+    # -- Enable Google OAuth authentication
+    enabled: false
+    # -- Google OAuth client ID
+    clientId: ""
+    # -- Google OAuth client secret
+    clientSecret: ""
+    # -- Existing secret with Google credentials
+    existingSecret: ""
+    existingSecretClientIdKey: google-client-id
+    existingSecretClientSecretKey: google-client-secret
+    # -- Google OAuth scope
+    scope: "email,profile"
+    # -- Callback URL. Auto-derived from backendApiUrl when empty.
+    callbackUrl: ""
+
+  microsoft:
+    # -- Enable Microsoft OAuth authentication
+    enabled: false
+    # -- Microsoft/Azure AD app client ID
+    clientId: ""
+    # -- Microsoft/Azure AD app client secret
+    clientSecret: ""
+    # -- Existing secret with Microsoft credentials
+    existingSecret: ""
+    existingSecretClientIdKey: microsoft-client-id
+    existingSecretClientSecretKey: microsoft-client-secret
+    # -- Microsoft OAuth scope
+    scope: "user.read"
+    # -- Callback URL. Auto-derived from backendApiUrl when empty.
+    callbackUrl: ""
+
+# =============================================================================
+# SMTP / Email
+# =============================================================================
+
+mailer:
+  # -- Enable SMTP email delivery
+  enabled: false
+  # -- From address for outgoing emails
+  from: ""
+  # -- Use custom field-by-field SMTP config instead of a URL
+  useCustomConfigs: false
+  # -- Full SMTP URL (used when useCustomConfigs=false)
+  # Format: smtps://user@domain.com:pass@smtp.domain.com
+  smtpUrl: ""
+  # -- SMTP host (used when useCustomConfigs=true)
+  host: ""
+  # -- SMTP port (used when useCustomConfigs=true)
+  port: 587
+  # -- Enable TLS/SSL (used when useCustomConfigs=true)
+  secure: true
+  # -- SMTP username (used when useCustomConfigs=true)
+  user: ""
+  # -- SMTP password (used when useCustomConfigs=true)
+  password: ""
+  # -- Reject unauthorized TLS certificates
+  tlsRejectUnauthorized: true
+  # -- Existing secret with SMTP credentials
+  existingSecret: ""
+  existingSecretSmtpUrlKey: smtp-url
+  existingSecretPasswordKey: smtp-password
+
+# =============================================================================
+# Deployment
+# =============================================================================
+
+# -- Number of Hoppscotch replicas. App is stateless — horizontal scaling is safe.
+replicaCount: 1
+
+deployment:
+  strategy:
+    # -- Rollout strategy type
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+# =============================================================================
+# Service Account
+# =============================================================================
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- ServiceAccount name override
+  name: ""
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+
+# =============================================================================
+# Security Context
+# =============================================================================
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# =============================================================================
+# Resources
+# =============================================================================
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+# =============================================================================
+# Service
+# =============================================================================
+
+service:
+  type: ClusterIP
+  port: 80
+  # -- Service IP family policy (GR-058 dual-stack)
+  # @default -- null (cluster default)
+  ipFamilyPolicy: null
+  # -- Service IP families (GR-058 dual-stack)
+  # @default -- [] (cluster default)
+  ipFamilies: []
+
+# =============================================================================
+# Ingress
+# =============================================================================
+
+ingress:
+  # -- Enable Ingress
+  enabled: false
+  # -- IngressClass name
+  className: ""
+  # -- Primary hostname. Used to auto-derive VITE_* URLs when set.
+  host: ""
+  # -- Additional annotations
+  # Note: WebSocket requires proxy-read-timeout and upgrade annotations — see NOTES.txt
+  annotations: {}
+  # -- TLS configuration
+  tls: []
+
+# =============================================================================
+# Gateway API (GR-060)
+# =============================================================================
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute
+  enabled: false
+  # -- References to Gateway listeners (required when enabled)
+  parentRefs: []
+  # -- Hostnames for the HTTPRoute
+  hostnames: []
+  paths:
+    - type: PathPrefix
+      value: /
+  annotations: {}
+  tls: {}
+
+# =============================================================================
+# External Secrets Operator (GR-061)
+# =============================================================================
+
+externalSecrets:
+  # -- Enable ExternalSecret resource
+  enabled: false
+  secretStoreRef:
+    # -- Name of the SecretStore or ClusterSecretStore (required when enabled)
+    name: ""
+    kind: SecretStore
+  refreshInterval: "1h"
+  data: []
+  dataFrom: []
+  annotations: {}
+
+# =============================================================================
+# Monitoring
+# =============================================================================
+
+metrics:
+  enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}
+
+# =============================================================================
+# Network Policy
+# =============================================================================
+
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []
+
+# =============================================================================
+# Pod Disruption Budget
+# =============================================================================
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# =============================================================================
+# Extras
+# =============================================================================
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+# -- Extra init containers (appended after wait-for-db and migrate)
+initContainers: []
+
+# -- Extra environment variables injected into the main container
+extraEnv: []
+
+# -- Extra envFrom entries (ConfigMaps, Secrets)
+extraEnvFrom: []


### PR DESCRIPTION
## Summary

- Add production-ready Hoppscotch Community Edition chart (`2026.3.1`)
- AIO image with `ENABLE_SUBPATH_BASED_ACCESS=true` — single Deployment, subpath routing for frontend, backend, and admin
- Automatic Prisma migrations via init container (`wait-for-db` + `migrate`)
- Full OAuth support (GitHub, Google, Microsoft, EMAIL), SMTP, ExternalSecrets, Gateway API, dual-stack, NetworkPolicy, PDB

## Quality Gates

- `helm lint --strict` ✓
- `helm template` (default + all 8 ci/ scenarios) ✓
- `helm unittest` — 41 tests, 100% passing ✓
- `ah lint` ✓
- `kubeconform --strict` (k8s 1.30, all scenarios) ✓
- Image policy (GR-005): only `docker.io/hoppscotch/hoppscotch:2026.3.1` + `docker.io/library/busybox:1.37` ✓
- No `latest` tags (GR-040) ✓
- No Bitnami references (GR-039) ✓
- `Chart.lock` committed (GR-062) ✓
- `.helmignore` present and correct (GR-037) ✓
- NOTES.txt ~150 lines, ends with `Happy Helmforging :)` (GR-017) ✓
- Site sync: 5/5 required updates covered (GR-007) ✓


Resolves #183