### PR TITLE
chore(gitea): upgrade to 1.26.1

### DIFF
--- a/charts/gitea/.helmignore
+++ b/charts/gitea/.helmignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OS
 .DS_Store
 Thumbs.db

--- a/charts/gitea/Chart.lock
+++ b/charts/gitea/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.1
+  version: 1.9.11
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.7.1
-digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
-generated: "2026-04-01T09:04:01.4443392-03:00"
+  version: 1.8.5
+digest: sha256:09bc7509b3ebe455bb1651e160c72df3c47cbfbff5f321103fbcd0c12c8045bd
+generated: "2026-04-29T04:19:34.7550243-03:00"

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: gitea
 description: Gitea  self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
-version: 1.1.7
+version: 1.1.6
 appVersion: "1.26.1"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: gitea
-description: Gitea â€” self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
+description: Gitea  self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
-version: 1.1.6
-appVersion: "1.25.5"
+version: 1.1.7
+appVersion: "1.26.1"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:

--- a/charts/gitea/ci/backup.yaml
+++ b/charts/gitea/ci/backup.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # SQLite with S3 backup
 backup:
   enabled: true

--- a/charts/gitea/ci/default.yaml
+++ b/charts/gitea/ci/default.yaml
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 # Default: SQLite standalone (zero config)

--- a/charts/gitea/ci/dual-stack.yaml
+++ b/charts/gitea/ci/dual-stack.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack for HTTP and SSH services (GR-058)
+persistence:
+  enabled: false
+
+service:
+  http:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv4
+      - IPv6
+  ssh:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv4
+      - IPv6

--- a/charts/gitea/ci/external-db.yaml
+++ b/charts/gitea/ci/external-db.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # External PostgreSQL
 database:
   external:

--- a/charts/gitea/ci/external-secrets.yaml
+++ b/charts/gitea/ci/external-secrets.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: ExternalSecrets with drift guard (GR-061).
+# admin.existingSecret is required when externalSecrets.enabled=true.
+persistence:
+  enabled: false
+
+admin:
+  existingSecret: my-gitea-admin
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: my-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: admin-username
+      remoteRef:
+        key: gitea/admin
+        property: username
+    - secretKey: admin-password
+      remoteRef:
+        key: gitea/admin
+        property: password
+    - secretKey: admin-email
+      remoteRef:
+        key: gitea/admin
+        property: email

--- a/charts/gitea/ci/mysql.yaml
+++ b/charts/gitea/ci/mysql.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # MySQL subchart
 mysql:
   enabled: true

--- a/charts/gitea/ci/postgresql.yaml
+++ b/charts/gitea/ci/postgresql.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # PostgreSQL subchart
 postgresql:
   enabled: true

--- a/charts/gitea/ci/ssh-nodeport.yaml
+++ b/charts/gitea/ci/ssh-nodeport.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # SSH via NodePort
 service:
   ssh:

--- a/charts/gitea/templates/NOTES.txt
+++ b/charts/gitea/templates/NOTES.txt
@@ -1,6 +1,7 @@
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+--------------------------------------------------------------------
   Gitea has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
@@ -8,9 +9,9 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -29,18 +30,18 @@ SSH (if enabled):
 
   SSH:  ssh://git@localhost:2222/<org>/<repo>.git
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --timeout=300s
 2. kubectl get pods -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }}
 3. kubectl logs -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --all-containers --tail=50 -f
 4. Open the Web UI and complete the Gitea setup wizard (first access)
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
   kubectl describe pod -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --all-containers --tail=100
@@ -56,18 +57,18 @@ View MySQL logs:
   kubectl logs -l app.kubernetes.io/name=mysql -n {{ .Release.Namespace }} --all-containers --tail=50
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 {{- if not .Values.ingress.enabled }}
 
 NOTE: Ingress is not enabled. Access via port-forward (see above).
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Documentation:  https://helmforge.dev/docs/charts/gitea
 Gitea:          https://gitea.com | https://github.com/go-gitea/gitea

--- a/charts/gitea/templates/_helpers.tpl
+++ b/charts/gitea/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{/*
 Expand the name of the chart.
 */}}
@@ -72,7 +73,7 @@ Image reference with tag defaulting to appVersion-rootless
 
 {{/*
 Resolve the effective database mode.
-Auto-detection priority: external → postgresql → mysql → sqlite
+Auto-detection priority: external - postgresql - mysql - sqlite
 */}}
 {{- define "gitea.databaseMode" -}}
 {{- $mode := .Values.database.mode | default "auto" -}}

--- a/charts/gitea/templates/admin-job.yaml
+++ b/charts/gitea/templates/admin-job.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.admin.username }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/gitea/templates/backup-configmap.yaml
+++ b/charts/gitea/templates/backup-configmap.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.backup.enabled }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/gitea/templates/backup-cronjob.yaml
+++ b/charts/gitea/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.backup.enabled }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/gitea/templates/deployment.yaml
+++ b/charts/gitea/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/gitea/templates/externalsecret.yaml
+++ b/charts/gitea/templates/externalsecret.yaml
@@ -8,6 +8,9 @@
 {{- if not .Values.admin.existingSecret }}
   {{- fail "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
 {{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:

--- a/charts/gitea/templates/externalsecret.yaml
+++ b/charts/gitea/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- /*
+  Guard: when externalSecrets.enabled=true the chart-managed admin Secret is still rendered
+  unless admin.existingSecret is set. Without this guard, both resources target the same
+  Secret name, creating credential drift. Require admin.existingSecret explicitly.
+*/}}
+{{- if not .Values.admin.existingSecret }}
+  {{- fail "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "gitea.fullname" . }}-admin
+  labels:
+    {{- include "gitea.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.admin.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/gitea/templates/extra-manifests.yaml
+++ b/charts/gitea/templates/extra-manifests.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- range .Values.extraManifests }}
 ---
 {{ toYaml . }}

--- a/charts/gitea/templates/httproute.yaml
+++ b/charts/gitea/templates/httproute.yaml
@@ -3,6 +3,11 @@
 {{- if not .Values.gateway.parentRefs }}
   {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
 {{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/gitea/templates/httproute.yaml
+++ b/charts/gitea/templates/httproute.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "gitea.fullname" . }}
+  labels:
+    {{- include "gitea.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "gitea.fullname" . }}-http
+          port: {{ .Values.service.http.port }}
+{{- end }}

--- a/charts/gitea/templates/httproute.yaml
+++ b/charts/gitea/templates/httproute.yaml
@@ -1,5 +1,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/gitea/templates/ingress.yaml
+++ b/charts/gitea/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/gitea/templates/pvc.yaml
+++ b/charts/gitea/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/gitea/templates/secret.yaml
+++ b/charts/gitea/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- $mode := include "gitea.databaseMode" . }}
 {{- if and (ne $mode "sqlite") (not (and (eq $mode "external") .Values.database.external.existingSecret)) }}
 apiVersion: v1

--- a/charts/gitea/templates/service.yaml
+++ b/charts/gitea/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.http.type }}
+  {{- with .Values.service.http.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.http.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.http.port }}
       targetPort: http
@@ -31,6 +39,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.ssh.type }}
+  {{- with .Values.service.ssh.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ssh.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.ssh.port }}
       targetPort: ssh

--- a/charts/gitea/templates/serviceaccount.yaml
+++ b/charts/gitea/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/gitea/tests/admin-job_test.yaml
+++ b/charts/gitea/tests/admin-job_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: admin-job
 templates:
   - templates/admin-job.yaml

--- a/charts/gitea/tests/backup-cronjob_test.yaml
+++ b/charts/gitea/tests/backup-cronjob_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: backup-cronjob
 templates:
   - templates/backup-cronjob.yaml

--- a/charts/gitea/tests/deployment_test.yaml
+++ b/charts/gitea/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: deployment
 templates:
   - templates/deployment.yaml

--- a/charts/gitea/tests/ingress_test.yaml
+++ b/charts/gitea/tests/ingress_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ingress
 templates:
   - templates/ingress.yaml

--- a/charts/gitea/tests/pvc_test.yaml
+++ b/charts/gitea/tests/pvc_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: pvc
 templates:
   - templates/pvc.yaml

--- a/charts/gitea/tests/secret_test.yaml
+++ b/charts/gitea/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: secret
 templates:
   - templates/secret.yaml

--- a/charts/gitea/tests/service_test.yaml
+++ b/charts/gitea/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: service
 templates:
   - templates/service.yaml

--- a/charts/gitea/values.schema.json
+++ b/charts/gitea/values.schema.json
@@ -283,8 +283,8 @@
             "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
             "port": { "type": "integer" },
             "annotations": { "type": "object" },
-            "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
-            "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+            "ipFamilyPolicy": { "type": ["string", "null"], "description": "Dual-stack ipFamilyPolicy (GR-058)", "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"] },
+            "ipFamilies": { "type": "array", "description": "Dual-stack ipFamilies (GR-058)", "items": { "type": "string", "enum": ["IPv4", "IPv6"] }, "maxItems": 2 }
           }
         },
         "ssh": {
@@ -295,8 +295,8 @@
             "port": { "type": "integer" },
             "nodePort": { "type": ["string", "integer"] },
             "annotations": { "type": "object" },
-            "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
-            "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+            "ipFamilyPolicy": { "type": ["string", "null"], "description": "Dual-stack ipFamilyPolicy (GR-058)", "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"] },
+            "ipFamilies": { "type": "array", "description": "Dual-stack ipFamilies (GR-058)", "items": { "type": "string", "enum": ["IPv4", "IPv6"] }, "maxItems": 2 }
           }
         }
       }

--- a/charts/gitea/values.schema.json
+++ b/charts/gitea/values.schema.json
@@ -282,7 +282,9 @@
           "properties": {
             "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
             "port": { "type": "integer" },
-            "annotations": { "type": "object" }
+            "annotations": { "type": "object" },
+            "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
+            "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
           }
         },
         "ssh": {
@@ -292,7 +294,9 @@
             "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
             "port": { "type": "integer" },
             "nodePort": { "type": ["string", "integer"] },
-            "annotations": { "type": "object" }
+            "annotations": { "type": "object" },
+            "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
+            "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
           }
         }
       }
@@ -351,6 +355,41 @@
     "nodeSelector": { "type": "object" },
     "tolerations": { "type": "array" },
     "affinity": { "type": "object" },
-    "extraManifests": { "type": "array" }
+    "extraManifests": { "type": "array" },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration.",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "path": { "type": "string", "default": "/" },
+        "pathType": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"], "default": "PathPrefix" }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator configuration.",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } }
+      }
+    }
   }
 }

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -447,7 +447,7 @@ externalSecrets:
   # the chart-managed admin credentials and the ExternalSecret.
   enabled: false
   apiVersion: external-secrets.io/v1
-  refreshInterval: 1h
+  refreshInterval: "0"
   secretStoreRef:
     name: ""
     kind: SecretStore

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -238,7 +238,7 @@ service:
     # -- Annotations for the HTTP service
     annotations: {}
     # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack
-    ipFamilyPolicy: ""
+    ipFamilyPolicy: ~
     # -- Service IP families override
     ipFamilies: []
 
@@ -254,7 +254,7 @@ service:
     # -- Annotations for the SSH service
     annotations: {}
     # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack
-    ipFamilyPolicy: ""
+    ipFamilyPolicy: ~
     # -- Service IP families override
     ipFamilies: []
 

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Gitea Configuration
 # =============================================================================
@@ -5,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.25.5-rootless"
+  tag: "1.26.1-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets
@@ -77,7 +78,7 @@ admin:
 # Use `database.mode` to select explicitly, or leave as `auto` to auto-detect
 # based on which database section is configured.
 #
-# Auto-detection priority: external → postgresql → mysql → sqlite
+# Auto-detection priority: external - postgresql - mysql - sqlite
 # =============================================================================
 
 database:
@@ -236,6 +237,10 @@ service:
     port: 3000
     # -- Annotations for the HTTP service
     annotations: {}
+    # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack
+    ipFamilyPolicy: ""
+    # -- Service IP families override
+    ipFamilies: []
 
   ssh:
     # -- Enable SSH service
@@ -248,6 +253,10 @@ service:
     nodePort: ""
     # -- Annotations for the SSH service
     annotations: {}
+    # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack
+    ipFamilyPolicy: ""
+    # -- Service IP families override
+    ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -414,3 +423,43 @@ extraManifests: []
   #     name: extra-config
   #   data:
   #     key: value
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  # -- Enable Gateway API HTTPRoute for Gitea HTTP (requires Gateway API CRDs)
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for Gitea admin credentials.
+  # Requires admin.existingSecret to be set to prevent drift between
+  # the chart-managed admin credentials and the ExternalSecret.
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  # -- Data entries mapping remote keys to admin credentials.
+  data: []
+  #   - secretKey: admin-username
+  #     remoteRef:
+  #       key: gitea/admin
+  #       property: username
+  #   - secretKey: admin-password
+  #     remoteRef:
+  #       key: gitea/admin
+  #       property: password


### PR DESCRIPTION
## Summary

Upgrade Gitea from 1.25.5 to 1.26.1.

## Changes

- **Image**: \docker.io/gitea/gitea:1.26.1-rootless\
- **Dual-stack**: Added \ipFamilyPolicy\/\ipFamilies\ to **both** HTTP and SSH services (GR-058)
- **Gateway API**: Added \	emplates/httproute.yaml\ for the HTTP service (\gateway.enabled=false\ default) (GR-060)
- **ExternalSecrets**: Opt-in template with drift guard — \dmin.existingSecret\ required when \externalSecrets.enabled=true\ (GR-061)
- **SPDX**: Added to all chart files; removed non-ASCII characters from \Chart.yaml\, \alues.yaml\ and schema.
- **Chart.lock**: Committed lock file tracking postgresql and mysql dependencies (GR-037/GR-062).
- **Schema**: Added \ipFamilyPolicy\/\ipFamilies\ to service HTTP/SSH, plus \gateway\ and \externalSecrets\ objects.

## Validation

- \helm lint --strict\: PASS
- \helm unittest\: 48/48 PASS
- **k3d runtime**: Pod 1/1 Running, logs clean

Closes #170