### PR TITLE
chore(docmost): upgrade to 0.80.1

### DIFF
--- a/charts/docmost/.helmignore
+++ b/charts/docmost/.helmignore
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OS
 .DS_Store
 Thumbs.db

--- a/charts/docmost/Chart.lock
+++ b/charts/docmost/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.1
+  version: 1.9.11
 - name: redis
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.2
-digest: sha256:7de5e97c1d37c08509210bebff2dfbd987abc5c7418a65d24725575d6d6d3aa4
-generated: "2026-04-01T09:03:13.5640851-03:00"
+  version: 1.6.9
+digest: sha256:9e1865ee4ab8182a1d3fb04c2b45db3ee7b1d5253fb8132bef8764654c129e18
+generated: "2026-04-29T04:55:37.0583384-03:00"

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: docmost
 description: Docmost collaborative wiki and documentation software with PostgreSQL, Redis, local storage, and optional S3
 type: application
-version: 1.1.7
+version: 1.1.6
 appVersion: "0.80.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/docmost.png

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: docmost
 description: Docmost collaborative wiki and documentation software with PostgreSQL, Redis, local storage, and optional S3
 type: application
-version: 1.1.6
-appVersion: "0.70.3"
+version: 1.1.7
+appVersion: "0.80.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/docmost.png
 home: https://helmforge.dev

--- a/charts/docmost/ci/backup-values.yaml
+++ b/charts/docmost/ci/backup-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 backup:
   enabled: true
   schedule: "0 3 * * *"

--- a/charts/docmost/ci/default.yaml
+++ b/charts/docmost/ci/default.yaml
@@ -1,1 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
 {}

--- a/charts/docmost/ci/dual-stack.yaml
+++ b/charts/docmost/ci/dual-stack.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack for HTTP service (GR-058)
+postgresql:
+  standalone:
+    persistence:
+      enabled: false
+
+redis:
+  standalone:
+    persistence:
+      enabled: false
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/docmost/ci/external-secrets.yaml
+++ b/charts/docmost/ci/external-secrets.yaml
@@ -4,6 +4,7 @@ postgresql:
   enabled: false
 
 database:
+  mode: external
   external:
     host: "postgres-external"
     existingSecret: docmost-database-credentials

--- a/charts/docmost/ci/external-secrets.yaml
+++ b/charts/docmost/ci/external-secrets.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: ExternalSecrets with drift guard (GR-061)
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: "postgres-external"
+    existingSecret: docmost-database-credentials
+
+redis:
+  enabled: false
+  external:
+    host: "redis-external"
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: my-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: database-password
+      remoteRef:
+        key: docmost/database
+        property: password

--- a/charts/docmost/ci/external-services.yaml
+++ b/charts/docmost/ci/external-services.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 database:
   mode: external
   external:

--- a/charts/docmost/ci/gateway-api.yaml
+++ b/charts/docmost/ci/gateway-api.yaml
@@ -12,5 +12,8 @@ redis:
 
 gateway:
   enabled: true
+  parentRefs:
+    - name: envoy
+      namespace: envoy-gateway
   hostnames:
     - docmost.local

--- a/charts/docmost/ci/gateway-api.yaml
+++ b/charts/docmost/ci/gateway-api.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: Gateway API (GR-060)
+postgresql:
+  standalone:
+    persistence:
+      enabled: false
+
+redis:
+  standalone:
+    persistence:
+      enabled: false
+
+gateway:
+  enabled: true
+  hostnames:
+    - docmost.local

--- a/charts/docmost/ci/gateway-api.yaml
+++ b/charts/docmost/ci/gateway-api.yaml
@@ -13,7 +13,7 @@ redis:
 gateway:
   enabled: true
   parentRefs:
-    - name: envoy
-      namespace: envoy-gateway
+    - name: my-gateway
+      namespace: default
   hostnames:
     - docmost.local

--- a/charts/docmost/ci/ingress.yaml
+++ b/charts/docmost/ci/ingress.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 ingress:
   enabled: true
   ingressClassName: traefik

--- a/charts/docmost/templates/NOTES.txt
+++ b/charts/docmost/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 Docmost has been deployed.
 
 Service:

--- a/charts/docmost/templates/_helpers.tpl
+++ b/charts/docmost/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "docmost.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/docmost/templates/backup-configmap.yaml
+++ b/charts/docmost/templates/backup-configmap.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if include "docmost.backupEnabled" . }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/docmost/templates/backup-cronjob.yaml
+++ b/charts/docmost/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if include "docmost.backupEnabled" . }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/docmost/templates/deployment.yaml
+++ b/charts/docmost/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/docmost/templates/externalsecret.yaml
+++ b/charts/docmost/templates/externalsecret.yaml
@@ -8,6 +8,17 @@
 {{- if not .Values.database.external.existingSecret }}
   {{- fail "externalSecrets.enabled requires database.external.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
 {{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
+{{- $passKey := .Values.database.external.existingSecretPasswordKey | default "database-password" -}}
+{{- $hasPass := false -}}
+{{- range .Values.externalSecrets.data -}}
+  {{- if eq .secretKey $passKey }}{{ $hasPass = true }}{{ end -}}
+{{- end -}}
+{{- if not $hasPass -}}
+  {{- fail (printf "externalSecrets.data must include a mapping for key '%s' (database password)" $passKey) -}}
+{{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:

--- a/charts/docmost/templates/externalsecret.yaml
+++ b/charts/docmost/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- /*
+  Guard: when externalSecrets.enabled=true the chart-managed auth Secret is still rendered
+  unless database.external.existingSecret is set. Without this guard, both resources target the same
+  Secret name, creating credential drift. Require database.external.existingSecret explicitly.
+*/}}
+{{- if not .Values.database.external.existingSecret }}
+  {{- fail "externalSecrets.enabled requires database.external.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "docmost.fullname" . }}-database
+  labels:
+    {{- include "docmost.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.database.external.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/docmost/templates/extra-manifests.yaml
+++ b/charts/docmost/templates/extra-manifests.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- with .Values.extraManifests }}
 {{- toYaml . }}
 {{- end }}

--- a/charts/docmost/templates/httproute.yaml
+++ b/charts/docmost/templates/httproute.yaml
@@ -11,10 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.gateway.parentRefs }}
+  {{- $parentRefs := required "docmost: gateway.parentRefs must be set when gateway.enabled=true" .Values.gateway.parentRefs }}
   parentRefs:
-    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
-  {{- end }}
+    {{- toYaml $parentRefs | nindent 4 }}
   {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/docmost/templates/httproute.yaml
+++ b/charts/docmost/templates/httproute.yaml
@@ -3,6 +3,11 @@
 {{- if not .Values.gateway.parentRefs }}
   {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
 {{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/docmost/templates/httproute.yaml
+++ b/charts/docmost/templates/httproute.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "docmost.fullname" . }}
+  labels:
+    {{- include "docmost.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "docmost.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/docmost/templates/httproute.yaml
+++ b/charts/docmost/templates/httproute.yaml
@@ -1,5 +1,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -11,9 +14,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- $parentRefs := required "docmost: gateway.parentRefs must be set when gateway.enabled=true" .Values.gateway.parentRefs }}
   parentRefs:
-    {{- toYaml $parentRefs | nindent 4 }}
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
   {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/docmost/templates/httproute.yaml
+++ b/charts/docmost/templates/httproute.yaml
@@ -11,11 +11,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.gateway.parentRefs }}
   parentRefs:
-    {{- if not .Values.gateway.parentRefs }}
-    {{- fail "gateway.enabled requires gateway.parentRefs to be set." }}
-    {{- end }}
     {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- end }}
   {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/docmost/templates/httproute.yaml
+++ b/charts/docmost/templates/httproute.yaml
@@ -12,6 +12,9 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if not .Values.gateway.parentRefs }}
+    {{- fail "gateway.enabled requires gateway.parentRefs to be set." }}
+    {{- end }}
     {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
   {{- with .Values.gateway.hostnames }}
   hostnames:

--- a/charts/docmost/templates/ingress.yaml
+++ b/charts/docmost/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/docmost/templates/pvc.yaml
+++ b/charts/docmost/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and (eq .Values.storage.mode "local") .Values.storage.local.enabled (not .Values.storage.local.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/docmost/templates/secret.yaml
+++ b/charts/docmost/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and (eq (include "docmost.databaseMode" .) "external") (not .Values.database.external.existingSecret) }}
 apiVersion: v1
 kind: Secret

--- a/charts/docmost/templates/service.yaml
+++ b/charts/docmost/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "docmost.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/docmost/templates/serviceaccount.yaml
+++ b/charts/docmost/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/docmost/templates/validate.yaml
+++ b/charts/docmost/templates/validate.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if ne (int .Values.replicaCount) 1 -}}
 {{- fail "docmost: replicaCount must be 1 in this alpha chart" -}}
 {{- end -}}

--- a/charts/docmost/tests/backup_secret_test.yaml
+++ b/charts/docmost/tests/backup_secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Backup Secret
 templates:
   - templates/secret.yaml

--- a/charts/docmost/tests/backup_test.yaml
+++ b/charts/docmost/tests/backup_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Backup
 templates:
   - templates/backup-configmap.yaml

--- a/charts/docmost/tests/deployment_test.yaml
+++ b/charts/docmost/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml

--- a/charts/docmost/tests/ingress_test.yaml
+++ b/charts/docmost/tests/ingress_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Ingress
 templates:
   - templates/ingress.yaml

--- a/charts/docmost/tests/secret_test.yaml
+++ b/charts/docmost/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Secret
 templates:
   - templates/secret.yaml

--- a/charts/docmost/tests/service_test.yaml
+++ b/charts/docmost/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml

--- a/charts/docmost/values.schema.json
+++ b/charts/docmost/values.schema.json
@@ -216,6 +216,8 @@
       "properties": {
         "type": { "type": "string", "description": "Service type for the Docmost HTTP service", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
         "port": { "type": "integer", "description": "Service port exposed by the Docmost service" },
+        "ipFamilyPolicy": { "type": "string", "description": "Service IP family policy (GR-058)", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "description": "Service IP families (GR-058)", "items": { "type": "string", "enum": ["IPv4", "IPv6"] }, "maxItems": 2, "uniqueItems": true },
         "annotations": { "type": "object", "description": "Annotations for the Docmost service" }
       }
     },

--- a/charts/docmost/values.schema.json
+++ b/charts/docmost/values.schema.json
@@ -254,6 +254,41 @@
     "podAnnotations": { "type": "object", "description": "Additional annotations for the Docmost pod" },
     "extraVolumeMounts": { "type": "array", "description": "Additional volume mounts for the Docmost container", "items": { "type": "object" } },
     "extraVolumes": { "type": "array", "description": "Additional volumes for the Docmost pod", "items": { "type": "object" } },
-    "extraManifests": { "type": "array", "description": "Extra Kubernetes manifests to deploy alongside the chart", "items": { "type": "object" } }
+    "extraManifests": { "type": "array", "description": "Extra Kubernetes manifests to deploy alongside the chart", "items": { "type": "object" } },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration.",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "path": { "type": "string", "default": "/" },
+        "pathType": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"], "default": "PathPrefix" }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator configuration.",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } }
+      }
+    }
   }
 }

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Docmost Helm Chart
 # =============================================================================
@@ -22,7 +23,7 @@ image:
   # -- Docmost container image repository
   repository: docker.io/docmost/docmost
   # -- Docmost image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
-  tag: "0.70.3"
+  tag: "0.80.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -203,6 +204,10 @@ service:
   port: 80
   # -- Annotations for the Docmost service
   annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
 
 ingress:
   # -- Enable ingress for Docmost
@@ -296,3 +301,39 @@ extraVolumes: []
 
 # -- Extra Kubernetes manifests to deploy alongside the chart
 extraManifests: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  # -- Enable Gateway API HTTPRoute for Docmost HTTP (requires Gateway API CRDs)
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for Docmost authentication.
+  # Requires auth.existingSecret to be set to prevent drift between
+  # the chart-managed Secret and the ExternalSecret.
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  # -- Data entries mapping remote keys to auth credentials.
+  data: []
+  #   - secretKey: app-secret
+  #     remoteRef:
+  #       key: docmost/auth
+  #       property: appSecret

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -320,8 +320,8 @@ gateway:
 # =============================================================================
 
 externalSecrets:
-  # -- Render ExternalSecret for Docmost authentication.
-  # Requires auth.existingSecret to be set to prevent drift between
+  # Render ExternalSecret for Docmost authentication.
+  # Requires database.external.existingSecret to be set to prevent drift between
   # the chart-managed Secret and the ExternalSecret.
   enabled: false
   apiVersion: external-secrets.io/v1
@@ -333,7 +333,7 @@ externalSecrets:
     creationPolicy: Owner
   # -- Data entries mapping remote keys to auth credentials.
   data: []
-  #   - secretKey: app-secret
+  #   - secretKey: database-password
   #     remoteRef:
-  #       key: docmost/auth
-  #       property: appSecret
+  #       key: docmost/database
+  #       property: password

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -325,7 +325,7 @@ externalSecrets:
   # the chart-managed Secret and the ExternalSecret.
   enabled: false
   apiVersion: external-secrets.io/v1
-  refreshInterval: 1h
+  refreshInterval: "0"
   secretStoreRef:
     name: ""
     kind: SecretStore


### PR DESCRIPTION
## Summary

Upgrade Docmost from 0.70.3 to 0.80.1.

## Changes

- **Image**: \docker.io/docmost/docmost:0.80.1\
- **Dual-stack**: Added \ipFamilyPolicy\/\ipFamilies\ to HTTP service (GR-058)
- **Gateway API**: Added \	emplates/httproute.yaml\ for the HTTP service (\gateway.enabled=false\ default) (GR-060)
- **ExternalSecrets**: Opt-in template with drift guard — \database.external.existingSecret\ required when \externalSecrets.enabled=true\ (GR-061)
- **SPDX**: Added to all chart files; removed non-ASCII characters.
- **Chart.lock**: Committed lock file tracking postgresql and redis dependencies (GR-037/GR-062).
- **Schema**: Added \ipFamilyPolicy\/\ipFamilies\ to service HTTP, plus \gateway\ and \externalSecrets\ objects.

## Validation

- \helm lint --strict\: PASS
- \helm unittest\: 25/25 PASS
- **k3d runtime**: Pod 1/1 Running, logs clean

Closes #163