### PR TITLE
fix(redis): support custom cluster domain

### DIFF
--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,6 +1,6 @@
 # Redis
 
-Redis for Kubernetes with support for `standalone`, `replication`, `sentinel`, and `cluster` architectures.
+Redis for Kubernetes with explicit support for `standalone`, `replication`, `sentinel`, and `cluster` topologies.
 
 ## Install
 
@@ -20,62 +20,44 @@ helm install redis oci://ghcr.io/helmforgedev/helm/redis -f values.yaml
 
 ## What this chart covers
 
-- explicit architecture selection through `architecture`
-- password authentication managed by the chart or through `existingSecret`
-- persistence by topology
-- optional metrics with `redis_exporter`
-- optional `ServiceMonitor` for Prometheus Operator
-- availability objects such as `PodDisruptionBudget`
-- examples and CI scenarios separated by operational mode
+- topology selection with `architecture`
+- password authentication through generated, inline, existing, or externally reconciled secrets
+- optional External Secrets Operator integration
+- persistence settings by topology
+- internal service DNS customization with `clusterDomain`
+- dual-stack service fields through `service.ipFamilyPolicy` and `service.ipFamilies`
+- optional TLS file wiring for Redis server configuration
+- optional Redis exporter sidecar and `ServiceMonitor`
+- optional `PodDisruptionBudget`
+- topology-specific Services, StatefulSets, and Redis Cluster bootstrap Job
+- `extraEnv`, `extraVolumes`, `extraVolumeMounts`, and `extraManifests` extension points
 
 ## Supported architectures
 
-| Architecture | When to use | Document |
-|-------------|-------------|----------|
-| `standalone` | development, simple environments, or workloads without HA requirements | [docs/standalone.md](docs/standalone.md) |
-| `replication` | fixed primary with read replicas, without Sentinel failover | [docs/replication.md](docs/replication.md) |
-| `sentinel` | automatic failover with primary discovery through Sentinel | [docs/sentinel.md](docs/sentinel.md) |
-| `cluster` | native sharding and high availability through Redis Cluster protocol | [docs/cluster.md](docs/cluster.md) |
+| Architecture | Contract | Primary resources | Document |
+|-------------|----------|-------------------|----------|
+| `standalone` | One Redis pod, lowest operational complexity, no HA contract | headless Service, client Service, StatefulSet | [docs/standalone.md](docs/standalone.md) |
+| `replication` | One fixed primary with read replicas, no automatic promotion | headless Service, primary Service, replica Service, primary and replica StatefulSets | [docs/replication.md](docs/replication.md) |
+| `sentinel` | Redis replication plus Sentinel primary discovery and failover for compatible clients | replication resources, Sentinel Service, Sentinel StatefulSet | [docs/sentinel.md](docs/sentinel.md) |
+| `cluster` | Redis Cluster sharding and HA for Redis Cluster-compatible clients | headless Service, client Service, cluster StatefulSet, cluster init Job | [docs/cluster.md](docs/cluster.md) |
 
 ## How to choose the architecture
 
-- use `standalone` when operational simplicity matters more than HA
-- use `replication` when you need separate write and read roles, but automatic primary promotion is not required
-- use `sentinel` when the client can talk to Redis Sentinel and you need primary discovery and failover
-- use `cluster` when the client supports Redis Cluster and you need real horizontal sharding
+- Use `standalone` for development, simple workloads, and systems that do not need Redis-level HA.
+- Use `replication` when applications can tolerate a fixed primary endpoint and only need read replicas.
+- Use `sentinel` when clients can query Sentinel and need automatic primary discovery after failover.
+- Use `cluster` when clients support Redis Cluster and data must be sharded across nodes.
 
-Recommended reading before installation:
+Read the topology document before production use:
 
 - [Standalone](docs/standalone.md)
 - [Replication](docs/replication.md)
 - [Sentinel](docs/sentinel.md)
 - [Cluster](docs/cluster.md)
 
-## Official product references
-
-- Redis Sentinel: <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>
-- Redis Cluster: <https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/>
-
-## Features
-
-- password authentication with `existingSecret`
-- persistence by architecture
-- topology-specific services
-- dedicated `StatefulSet` resources for stateful modes
-- cluster bootstrap through `Job`
-- optional metrics with `redis_exporter`
-- optional `ServiceMonitor` integration
-
-## Operational requirements
-
-- a valid storage class for environments with persistence
-- clients compatible with the selected architecture
-- `existingSecret` when credentials are managed outside the chart
-- careful affinity and pod distribution in HA modes
-
 ## Quick start
 
-Minimal example with a secret-managed password:
+Minimal standalone deployment with an existing password Secret:
 
 ```yaml
 architecture: standalone
@@ -91,87 +73,192 @@ standalone:
     size: 8Gi
 ```
 
-Apply:
+Install:
 
 ```bash
 helm install redis helmforge/redis -f redis-values.yaml
 ```
 
-## Best practices
+## Authentication
 
-### Security
+The chart supports four credential patterns:
 
-- prefer `auth.enabled=true`
-- in production, use `auth.existingSecret` instead of inline passwords
-- enable TLS only when certificate material is already defined
-- restrict port exposure to the minimum necessary
+| Pattern | Values | Notes |
+|---------|--------|-------|
+| Generated password | `auth.enabled=true`, empty `auth.password`, empty `auth.existingSecret` | Useful for quick starts. The generated value is stored in the chart-managed Secret. |
+| Inline password | `auth.password` | Acceptable for local testing. Avoid committing real credentials. |
+| Existing Secret | `auth.existingSecret` and `auth.existingSecretPasswordKey` | Recommended for production when another process owns the Secret. |
+| ExternalSecret | `externalSecrets.enabled=true` and `auth.existingSecret` | Recommended when External Secrets Operator reconciles the Secret from an external provider. |
 
-### Persistence
+When `externalSecrets.enabled=true`, set `auth.existingSecret` to the same target Secret name. This avoids drift between a chart-managed Secret and an externally reconciled Secret.
 
-- use persistent volumes for all relevant stateful architectures
-- treat `cluster` and `sentinel` as production topologies, not ephemeral test modes
-- align volume sizing with real retention and load expectations
+Example:
 
-### Scheduling
+```yaml
+auth:
+  enabled: true
+  existingSecret: redis-auth
+  existingSecretPasswordKey: redis-password
 
-- enable anti-affinity for `replication`, `sentinel`, and `cluster`
-- enable `pdb.enabled=true` in HA modes
-- spread pods with `topologySpreadConstraints` when supported by the cluster
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: redis-password
+      remoteRef:
+        key: redis/auth
+        property: password
+```
 
-### Observability
+## Networking
 
-- enable `metrics.enabled=true` in monitored environments
-- enable `metrics.serviceMonitor.enabled=true` with Prometheus Operator
-- monitor latency, memory usage, replication lag, and cluster state
+The chart creates a headless Service for stable StatefulSet pod DNS and topology-specific client Services.
 
-## Security patterns
+| Mode | Client-facing service |
+|------|-----------------------|
+| `standalone` | `<release>-redis-client` |
+| `replication` | `<release>-redis-primary` for writes, `<release>-redis-replicas` for reads |
+| `sentinel` | `<release>-redis-sentinel` for Sentinel, plus replication services |
+| `cluster` | `<release>-redis-client` |
 
-- prefer `auth.existingSecret` in production
-- avoid exposing Redis outside the cluster network without a strong reason
-- use external `NetworkPolicy` or equivalent cluster controls when applicable
-- combine requests/limits, anti-affinity, and PDB for better maintenance resilience
+### Cluster domain
 
-## Operations by architecture
+Set `clusterDomain` when the Kubernetes cluster does not use `cluster.local`:
 
-- `standalone`: lowest operational cost, no failover
-- `replication`: one fixed primary with read replicas
-- `sentinel`: automatic failover for Sentinel-compatible clients
-- `cluster`: sharding and high availability through Redis Cluster
+```yaml
+clusterDomain: corp.internal
+```
 
-Each mode has different client, failover, discovery, and scaling contracts. Choose the topology for the application behavior you need, not just for the desire to have HA.
+The value is used for internal FQDNs rendered into Redis replication, Sentinel, Redis Cluster announce hostnames, cluster bootstrap commands, and `NOTES.txt`.
+
+### Dual-stack services
+
+Service dual-stack fields are available through:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Leave these values empty to use the cluster defaults.
+
+## Persistence
+
+Persistence is configured under each topology:
+
+- `standalone.persistence`
+- `replication.primary.persistence`
+- `replication.replica.persistence`
+- `sentinel.persistence`
+- `cluster.persistence`
+
+Use persistent volumes for production stateful modes. Disable persistence only for ephemeral tests and short-lived environments.
+
+## Observability
+
+Enable the Redis exporter sidecar with:
+
+```yaml
+metrics:
+  enabled: true
+```
+
+When Prometheus Operator is installed, enable a `ServiceMonitor`:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      prometheus: monitoring
+```
+
+Monitor memory usage, connected clients, command latency, replication lag, Sentinel state, and Redis Cluster health depending on the selected topology.
+
+## Scheduling and availability
+
+For HA-oriented modes, configure:
+
+- `pdb.enabled=true`
+- `affinity` or pod anti-affinity
+- `topologySpreadConstraints`
+- resource requests and limits
+- a storage class with the required availability profile
+
+The chart exposes scheduling knobs but does not enforce a single cluster layout. Match these values to your node topology and maintenance policy.
+
+## Extension points
+
+Use the generic extension values when platform-specific integration is needed:
+
+- `commonLabels`
+- `podLabels`
+- `podAnnotations`
+- `annotations`
+- `extraEnv`
+- `extraVolumes`
+- `extraVolumeMounts`
+- `extraManifests`
+
+`extraManifests` are rendered with `tpl`.
 
 ## Main values
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `architecture` | `standalone`, `replication`, `sentinel`, `cluster` | `standalone` |
-| `image.repository` | Redis image repository | `redis` |
-| `image.tag` | Redis image tag | `8.6.0` |
-| `auth.enabled` | Enable password auth | `true` |
-| `auth.password` | Redis password | `""` |
-| `auth.existingSecret` | Existing auth secret | `""` |
-| `auth.existingSecretPasswordKey` | Secret key used for the password | `redis-password` |
-| `tls.enabled` | Enable TLS | `false` |
-| `standalone.persistence.enabled` | Enable persistence for standalone | `true` |
-| `replication.replicaCount` | Number of replica pods | `2` |
+| `architecture` | Redis topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
+| `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
+| `image.repository` | Redis image repository | `docker.io/library/redis` |
+| `image.tag` | Redis image tag | `8.6.2` |
+| `auth.enabled` | Enable password authentication | `true` |
+| `auth.password` | Inline Redis password | `""` |
+| `auth.existingSecret` | Existing Secret containing the Redis password | `""` |
+| `auth.existingSecretPasswordKey` | Secret key used for the Redis password | `redis-password` |
+| `tls.enabled` | Enable Redis TLS settings. Requires `tls.existingSecret`. | `false` |
+| `standalone.persistence.enabled` | Enable persistence for standalone mode | `true` |
+| `replication.replicaCount` | Number of replica pods in replication and sentinel modes | `2` |
 | `sentinel.replicaCount` | Number of Sentinel pods | `3` |
 | `sentinel.quorum` | Sentinel quorum | `2` |
 | `cluster.nodes` | Number of Redis Cluster nodes | `6` |
-| `cluster.replicasPerMaster` | Replicas per master in cluster bootstrap | `1` |
-| `metrics.enabled` | Enable redis exporter sidecar | `false` |
-| `metrics.serviceMonitor.enabled` | Enable ServiceMonitor | `false` |
-| `pdb.enabled` | Enable PodDisruptionBudget | `false` |
+| `cluster.replicasPerMaster` | Redis Cluster replicas per master | `1` |
+| `service.type` | Client Service type where applicable | `ClusterIP` |
+| `service.ipFamilyPolicy` | Service IP family policy for dual-stack clusters | `null` |
+| `service.ipFamilies` | Service IP families for dual-stack clusters | `[]` |
+| `metrics.enabled` | Enable redis_exporter sidecar | `false` |
+| `metrics.serviceMonitor.enabled` | Create ServiceMonitor | `false` |
+| `pdb.enabled` | Create PodDisruptionBudget for HA modes | `false` |
+| `externalSecrets.enabled` | Render an ExternalSecret for the auth Secret | `false` |
+| `externalSecrets.secretStoreRef.name` | SecretStore or ClusterSecretStore name | `""` |
+| `extraManifests` | Extra Kubernetes manifests rendered with `tpl` | `[]` |
 
 ## CI scenarios
 
-The `ci/` scenarios validate specific behaviors:
+The `ci/` scenarios validate chart behavior across common configurations:
 
 - `standalone.yaml`
 - `replication.yaml`
 - `sentinel.yaml`
 - `cluster.yaml`
 - `existing-secret.yaml`
+- `external-secrets.yaml`
 - `metrics.yaml`
+- `dual-stack.yaml`
+
+Local validation should include:
+
+```bash
+helm dependency build charts/redis
+helm lint charts/redis --strict
+helm unittest charts/redis
+helm template redis charts/redis
+for f in charts/redis/ci/*.yaml; do helm template redis charts/redis -f "$f" >/dev/null; done
+```
 
 ## Examples
 
@@ -181,21 +268,29 @@ See `examples/`:
 - `replication-production.yaml`
 - `cluster.yaml`
 
-## Important notes
+## Operational notes
 
-- `replication` and `sentinel` are different operational contracts
-- `cluster` requires a Redis Cluster-compatible client
-- if `auth.password` is not set and `auth.existingSecret` is not used, the chart generates a password automatically
-- for production operation, read the architecture document before installing
+- `replication` and `sentinel` are different operational contracts.
+- `sentinel` requires Sentinel-compatible clients for automatic primary discovery.
+- `cluster` requires Redis Cluster-compatible clients.
+- If `auth.password` is not set and `auth.existingSecret` is not used, the chart generates a password automatically.
+- If your cluster domain is not `cluster.local`, set `clusterDomain` before installing stateful topologies.
+- For production, verify storage, credentials, scheduling, network policy, monitoring, backup strategy, and client compatibility before exposing Redis to applications.
+
+## Official product references
+
+- Redis Sentinel: <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>
+- Redis Cluster: <https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/>
+- Redis security: <https://redis.io/docs/latest/operate/oss_and_stack/management/security/>
 
 <!-- @AI-METADATA
 type: chart-readme
 title: Redis Helm Chart
-description: Redis chart with standalone, replication, sentinel, cluster architectures
+description: Redis chart with standalone, replication, sentinel, and cluster architectures
 
-keywords: redis, cache, in-memory, replication, sentinel, cluster
+keywords: redis, cache, in-memory, replication, sentinel, cluster, dual-stack, external-secrets
 
-purpose: Usage guide for the Redis Helm chart with standalone, replication, sentinel, and cluster modes
+purpose: Usage guide for the Redis Helm chart with authentication, networking, observability, and topology guidance
 scope: Chart
 
 relations:
@@ -205,6 +300,6 @@ relations:
   - charts/redis/docs/sentinel.md
   - charts/redis/docs/cluster.md
 path: charts/redis/README.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-05-05
 -->

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -1,54 +1,190 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
---------------------------------------------------------------------
-  Redis has been successfully deployed!
---------------------------------------------------------------------
+Redis has been installed.
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+1. Installation summary
+=======================
 
---------------------------------------------------------------------
-  CONNECTION INFORMATION
---------------------------------------------------------------------
+- Release: {{ .Release.Name }}
+- Namespace: {{ .Release.Namespace }}
+- Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+- App version: {{ .Chart.AppVersion }}
+- Architecture: {{ .Values.architecture }}
+- Image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+- Cluster domain: {{ include "redis.clusterDomain" . }}
+- ServiceAccount: {{ include "redis.serviceAccountName" . }}
+- Authentication enabled: {{ .Values.auth.enabled }}
+- Metrics enabled: {{ .Values.metrics.enabled }}
+- ServiceMonitor enabled: {{ and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+- PodDisruptionBudget enabled: {{ .Values.pdb.enabled }}
+- External Secrets enabled: {{ .Values.externalSecrets.enabled }}
 
-Redis endpoint (internal):
-  {{ include "redis.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:6379
+2. Access
+=========
 
-Redis client endpoint (if replication mode):
-  {{ include "redis.fullname" . }}-client.{{ .Release.Namespace }}.svc.cluster.local:6379
+Headless service:
+- Name: {{ include "redis.headlessServiceName" . }}
+- DNS: {{ include "redis.headlessServiceFqdn" . }}
+- Port: {{ .Values.service.ports.redis }}
 
-Redis password (retrieve from secret):
-  kubectl get secret {{ include "redis.fullname" . }}-auth \
-    -n {{ .Release.Namespace }} \
-    -o jsonpath='{.data.redis-password}' | base64 -d
+{{- if include "redis.isStandalone" . }}
+Standalone client service:
+- Name: {{ include "redis.clientServiceName" . }}
+- Type: {{ .Values.service.type }}
+- DNS: {{ include "redis.clientServiceFqdn" . }}
+- Port: {{ .Values.service.ports.redis }}
+{{- end }}
 
---------------------------------------------------------------------
-  GETTING STARTED
---------------------------------------------------------------------
+{{- if or (include "redis.isReplication" .) (include "redis.isSentinel" .) }}
+Primary service:
+- Name: {{ include "redis.primaryServiceName" . }}
+- DNS: {{ include "redis.primaryServiceFqdn" . }}
+- Port: {{ .Values.service.ports.redis }}
 
-1. kubectl get pods -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }}
-2. kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+Replica service:
+- Name: {{ include "redis.replicaServiceName" . }}
+- DNS: {{ include "redis.replicaServiceFqdn" . }}
+- Port: {{ .Values.service.ports.redis }}
+{{- end }}
 
-Test connectivity:
-  kubectl exec -n {{ .Release.Namespace }} \
-    -it sts/{{ include "redis.fullname" . }} -- redis-cli ping
+{{- if include "redis.isSentinel" . }}
+Sentinel service:
+- Name: {{ include "redis.sentinelServiceName" . }}
+- DNS: {{ include "redis.sentinelServiceFqdn" . }}
+- Port: {{ .Values.service.ports.sentinel }}
+- Monitored primary: {{ include "redis.primaryPodFqdn" . }}:{{ .Values.service.ports.redis }}
+{{- end }}
 
---------------------------------------------------------------------
-  TROUBLESHOOTING
---------------------------------------------------------------------
+{{- if include "redis.isCluster" . }}
+Redis Cluster client service:
+- Name: {{ include "redis.clientServiceName" . }}
+- Type: ClusterIP
+- DNS: {{ include "redis.clientServiceFqdn" . }}
+- Port: {{ .Values.service.ports.redis }}
+- Nodes: {{ .Values.cluster.nodes }}
+- Replicas per master: {{ .Values.cluster.replicasPerMaster }}
+{{- end }}
 
-  kubectl describe pod -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+{{- if .Values.service.ipFamilyPolicy }}
+Service IP family policy: {{ .Values.service.ipFamilyPolicy }}
+{{- end }}
+{{- if .Values.service.ipFamilies }}
+Service IP families: {{ join ", " .Values.service.ipFamilies }}
+{{- end }}
 
---------------------------------------------------------------------
-  ADDITIONAL RESOURCES
---------------------------------------------------------------------
+3. Credentials
+==============
 
-Documentation:  https://helmforge.dev/docs/charts/redis
-Redis:          https://redis.io | https://github.com/redis/redis
+{{- if .Values.auth.enabled }}
+Redis password:
+
+  kubectl get secret {{ include "redis.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretPasswordKey }}}" | base64 -d
+
+Secret name: {{ include "redis.secretName" . }}
+Secret key: {{ .Values.auth.existingSecretPasswordKey }}
+{{- else }}
+Authentication is disabled.
+{{- end }}
+
+{{- if .Values.externalSecrets.enabled }}
+ExternalSecret:
+- SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+- Target Secret: {{ include "redis.secretName" . }}
+- Refresh interval: {{ .Values.externalSecrets.refreshInterval }}
+{{- end }}
+
+4. Getting started
+==================
+
+Wait for Redis pods:
+
+  kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "redis.name" . }} --timeout=10m
+
+Check release resources:
+
+  kubectl get sts,svc,secret,cm,pdb -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if include "redis.isStandalone" . }}
+Check standalone connectivity:
+
+  kubectl run {{ include "redis.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.image.repository }}:{{ .Values.image.tag }} -- redis-cli -h {{ include "redis.clientServiceName" . }} -p {{ .Values.service.ports.redis }}{{ if .Values.auth.enabled }} -a "$(kubectl get secret {{ include "redis.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.auth.existingSecretPasswordKey }}}' | base64 -d)"{{ end }} ping
+{{- end }}
+
+{{- if include "redis.isReplication" . }}
+Use the primary service for writes and the replica service for read-only workloads:
+
+  {{ include "redis.primaryServiceFqdn" . }}:{{ .Values.service.ports.redis }}
+  {{ include "redis.replicaServiceFqdn" . }}:{{ .Values.service.ports.redis }}
+{{- end }}
+
+{{- if include "redis.isSentinel" . }}
+Use the Sentinel service for Sentinel-aware clients:
+
+  {{ include "redis.sentinelServiceFqdn" . }}:{{ .Values.service.ports.sentinel }}
+
+Verify Sentinel can see the primary:
+
+  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "redis.sentinelStatefulSetName" . }} -- redis-cli -p {{ .Values.service.ports.sentinel }} SENTINEL masters
+{{- end }}
+
+{{- if include "redis.isCluster" . }}
+Use a Redis Cluster-compatible client and connect through:
+
+  {{ include "redis.clientServiceFqdn" . }}:{{ .Values.service.ports.redis }}
+
+Check cluster state:
+
+  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "redis.clusterStatefulSetName" . }} -- redis-cli{{ if .Values.auth.enabled }} -a "$(kubectl get secret {{ include "redis.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.auth.existingSecretPasswordKey }}}' | base64 -d)"{{ end }} cluster info
+{{- end }}
+
+5. Configuration summary
+========================
+
+Persistence:
+- Standalone persistence: {{ .Values.standalone.persistence.enabled }}
+- Primary persistence: {{ .Values.replication.primary.persistence.enabled }}
+- Replica persistence: {{ .Values.replication.replica.persistence.enabled }}
+- Sentinel persistence: {{ .Values.sentinel.persistence.enabled }}
+- Cluster persistence: {{ .Values.cluster.persistence.enabled }}
+
+Networking:
+- Service type: {{ .Values.service.type }}
+- Redis port: {{ .Values.service.ports.redis }}
+- Sentinel port: {{ .Values.service.ports.sentinel }}
+- Metrics port: {{ .Values.service.ports.metrics }}
+
+Scheduling:
+- PriorityClass: {{ default "(not configured)" .Values.priorityClassName }}
+- Termination grace period: {{ .Values.terminationGracePeriodSeconds }}s
+
+6. Troubleshooting
+==================
+
+Inspect pods and events:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+  kubectl describe pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+Inspect logs:
+
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200
+
+Common checks:
+
+- If replicas cannot connect, verify headless Service DNS and `clusterDomain`.
+- If Sentinel does not start, verify the primary pod FQDN and auth Secret.
+- If Redis Cluster bootstrap is stuck, inspect the cluster init Job logs.
+- If clients cannot authenticate, verify Secret name, key, and password content.
+- If dual-stack fields are rejected, verify the Kubernetes version and cluster network configuration.
+- If metrics are missing, verify `metrics.enabled`, Service ports, and ServiceMonitor labels.
+
+7. Resources
+============
+
+- HelmForge chart docs: https://helmforge.dev/docs/charts/redis
+- Redis docs: https://redis.io/docs/latest/
+- Redis Sentinel: https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/
+- Redis Cluster: https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/
+- HelmForge chart issues: https://github.com/helmforgedev/charts/issues
 
 Happy Helmforging :)

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -136,6 +136,46 @@ Common names.
 {{- printf "%s-config" (include "redis.fullname" .) -}}
 {{- end -}}
 
+{{- define "redis.clusterDomain" -}}
+{{- default "cluster.local" .Values.clusterDomain -}}
+{{- end -}}
+
+{{- define "redis.serviceFqdn" -}}
+{{- printf "%s.%s.svc.%s" .name .root.Release.Namespace (include "redis.clusterDomain" .root) -}}
+{{- end -}}
+
+{{- define "redis.headlessServiceFqdn" -}}
+{{- include "redis.serviceFqdn" (dict "root" . "name" (include "redis.headlessServiceName" .)) -}}
+{{- end -}}
+
+{{- define "redis.fullnameFqdn" -}}
+{{- include "redis.serviceFqdn" (dict "root" . "name" (include "redis.fullname" .)) -}}
+{{- end -}}
+
+{{- define "redis.clientServiceFqdn" -}}
+{{- include "redis.serviceFqdn" (dict "root" . "name" (include "redis.clientServiceName" .)) -}}
+{{- end -}}
+
+{{- define "redis.primaryServiceFqdn" -}}
+{{- include "redis.serviceFqdn" (dict "root" . "name" (include "redis.primaryServiceName" .)) -}}
+{{- end -}}
+
+{{- define "redis.replicaServiceFqdn" -}}
+{{- include "redis.serviceFqdn" (dict "root" . "name" (include "redis.replicaServiceName" .)) -}}
+{{- end -}}
+
+{{- define "redis.sentinelServiceFqdn" -}}
+{{- include "redis.serviceFqdn" (dict "root" . "name" (include "redis.sentinelServiceName" .)) -}}
+{{- end -}}
+
+{{- define "redis.primaryPodFqdn" -}}
+{{- printf "%s-0.%s" (include "redis.primaryStatefulSetName" .) (include "redis.headlessServiceFqdn" .) -}}
+{{- end -}}
+
+{{- define "redis.clusterPodFqdn" -}}
+{{- printf "%s.%s" .podName (include "redis.headlessServiceFqdn" .root) -}}
+{{- end -}}
+
 {{/*
 Secret value helpers.
 */}}

--- a/charts/redis/templates/cluster-init-job.yaml
+++ b/charts/redis/templates/cluster-init-job.yaml
@@ -28,18 +28,18 @@ spec:
           args:
             - |
               for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
-                until redis-cli -h "{{ include "redis.clusterStatefulSetName" . }}-${i}.{{ include "redis.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local" {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" {{- end }} ping; do
+                until redis-cli -h "{{ include "redis.clusterStatefulSetName" . }}-${i}.{{ include "redis.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" {{- end }} ping; do
                   echo "waiting for node $i"
                   sleep 5
                 done
               done
-              if redis-cli -h "{{ include "redis.clusterStatefulSetName" . }}-0.{{ include "redis.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local" {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" {{- end }} cluster info | grep -q cluster_state:ok; then
+              if redis-cli -h "{{ include "redis.clusterStatefulSetName" . }}-0.{{ include "redis.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" {{- end }} cluster info | grep -q cluster_state:ok; then
                 echo "cluster already initialized"
                 exit 0
               fi
               yes yes | redis-cli --cluster create \
               {{- range $i, $_ := until (.Values.cluster.nodes | int) }}
-                {{ include "redis.clusterStatefulSetName" $ }}-{{ $i }}.{{ include "redis.headlessServiceName" $ }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.service.ports.redis }} \
+                {{ include "redis.clusterStatefulSetName" $ }}-{{ $i }}.{{ include "redis.headlessServiceFqdn" $ }}:{{ $.Values.service.ports.redis }} \
               {{- end }}
               --cluster-replicas {{ .Values.cluster.replicasPerMaster }} {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" {{- end }}
           env:

--- a/charts/redis/templates/cluster-statefulset.yaml
+++ b/charts/redis/templates/cluster-statefulset.yaml
@@ -40,7 +40,7 @@ spec:
             - $(REDIS_PASSWORD)
             {{- end }}
             - --cluster-announce-hostname
-            - $(POD_NAME).{{ include "redis.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local
+            - $(POD_NAME).{{ include "redis.headlessServiceFqdn" . }}
           ports:
             - name: redis
               containerPort: {{ .Values.service.ports.redis }}

--- a/charts/redis/templates/configmap.yaml
+++ b/charts/redis/templates/configmap.yaml
@@ -34,7 +34,8 @@ data:
   sentinel.conf: |
     port {{ .Values.service.ports.sentinel }}
     dir /tmp
-    sentinel monitor mymaster {{ include "redis.primaryStatefulSetName" . }}-0.{{ include "redis.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.service.ports.redis }} {{ .Values.sentinel.quorum }}
+    sentinel resolve-hostnames yes
+    sentinel monitor mymaster {{ include "redis.primaryPodFqdn" . }} {{ .Values.service.ports.redis }} {{ .Values.sentinel.quorum }}
     sentinel down-after-milliseconds mymaster {{ .Values.sentinel.downAfterMilliseconds }}
     sentinel failover-timeout mymaster {{ .Values.sentinel.failoverTimeout }}
     sentinel parallel-syncs mymaster {{ .Values.sentinel.parallelSyncs }}

--- a/charts/redis/templates/replication-replica-statefulset.yaml
+++ b/charts/redis/templates/replication-replica-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               exec redis-server /etc/redis/redis.conf \
-                --replicaof {{ include "redis.primaryStatefulSetName" . }}-0.{{ include "redis.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.cluster.local {{ .Values.service.ports.redis }} \
+                --replicaof {{ include "redis.primaryPodFqdn" . }} {{ .Values.service.ports.redis }} \
               {{- if .Values.auth.enabled }}
                 --masterauth "$REDIS_PASSWORD" \
                 --requirepass "$REDIS_PASSWORD"

--- a/charts/redis/templates/sentinel-statefulset.yaml
+++ b/charts/redis/templates/sentinel-statefulset.yaml
@@ -34,6 +34,10 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
+              until redis-cli -h "$REDIS_PRIMARY_HOST" -p "$REDIS_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+                echo "waiting for primary $REDIS_PRIMARY_HOST:$REDIS_PRIMARY_PORT"
+                sleep 5
+              done
               cp /etc/redis-base/sentinel.conf /tmp/sentinel.conf
               {{- if .Values.auth.enabled }}
               echo "sentinel auth-pass mymaster ${REDIS_PASSWORD}" >> /tmp/sentinel.conf
@@ -44,11 +48,21 @@ spec:
               containerPort: {{ .Values.service.ports.sentinel }}
           {{- if .Values.auth.enabled }}
           env:
+            - name: REDIS_PRIMARY_HOST
+              value: {{ include "redis.primaryPodFqdn" . | quote }}
+            - name: REDIS_PRIMARY_PORT
+              value: {{ .Values.service.ports.redis | quote }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redis.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
+          {{- else }}
+          env:
+            - name: REDIS_PRIMARY_HOST
+              value: {{ include "redis.primaryPodFqdn" . | quote }}
+            - name: REDIS_PRIMARY_PORT
+              value: {{ .Values.service.ports.redis | quote }}
           {{- end }}
           {{- with .Values.sentinel.resources }}
           resources:

--- a/charts/redis/tests/cluster_domain_test.yaml
+++ b/charts/redis/tests/cluster_domain_test.yaml
@@ -1,0 +1,77 @@
+suite: Cluster Domain
+templates:
+  - configmap.yaml
+  - replication-replica-statefulset.yaml
+  - sentinel-statefulset.yaml
+  - cluster-statefulset.yaml
+  - cluster-init-job.yaml
+release:
+  name: test
+  namespace: custom-ns
+tests:
+  - it: should use custom cluster domain in sentinel configuration
+    template: configmap.yaml
+    set:
+      architecture: sentinel
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel monitor mymaster test-redis-primary-0\\.test-redis-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel resolve-hostnames yes"
+      - notMatchRegex:
+          path: data["sentinel.conf"]
+          pattern: "svc\\.cluster\\.local"
+
+  - it: should use custom cluster domain in replication replica args
+    template: replication-replica-statefulset.yaml
+    set:
+      architecture: replication
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--replicaof test-redis-primary-0\\.test-redis-headless\\.custom-ns\\.svc\\.corp\\.internal 6379"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "svc\\.cluster\\.local"
+
+  - it: should wait for custom primary FQDN before starting sentinel
+    template: sentinel-statefulset.yaml
+    set:
+      architecture: sentinel
+      clusterDomain: corp.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PRIMARY_HOST
+            value: test-redis-primary-0.test-redis-headless.custom-ns.svc.corp.internal
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "until redis-cli -h \"\\$REDIS_PRIMARY_HOST\""
+
+  - it: should use custom cluster domain in cluster announce hostname
+    template: cluster-statefulset.yaml
+    set:
+      architecture: cluster
+      clusterDomain: corp.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "$(POD_NAME).test-redis-headless.custom-ns.svc.corp.internal"
+
+  - it: should use custom cluster domain in cluster init job
+    template: cluster-init-job.yaml
+    set:
+      architecture: cluster
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "test-redis-cluster-\\$\\{i\\}\\.test-redis-headless\\.custom-ns\\.svc\\.corp\\.internal"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "svc\\.cluster\\.local"

--- a/charts/redis/tests/cluster_domain_test.yaml
+++ b/charts/redis/tests/cluster_domain_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Cluster Domain
 templates:
   - configmap.yaml

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -18,6 +18,11 @@
       "type": "string",
       "description": "Override full release name"
     },
+    "clusterDomain": {
+      "type": "string",
+      "description": "Kubernetes cluster DNS domain used for internal service FQDNs",
+      "default": "cluster.local"
+    },
     "commonLabels": {
       "type": "object",
       "description": "Extra labels applied to all resources"

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -16,6 +16,9 @@ nameOverride: ""
 # -- Override full release name
 fullnameOverride: ""
 
+# -- Kubernetes cluster DNS domain used for internal service FQDNs
+clusterDomain: cluster.local
+
 # -- Extra labels applied to all resources
 commonLabels: {}
 


### PR DESCRIPTION
Fixes #217

## Summary
- add `clusterDomain` support to Redis internal FQDNs used by replication, Sentinel, Redis Cluster announce hostnames, cluster bootstrap, and NOTES
- enable Redis Sentinel hostname resolution and wait for the primary before starting Sentinel
- refresh Redis README and NOTES to document architectures, auth, ExternalSecrets, dual-stack services, clusterDomain, validation, and troubleshooting

## Validation
- `helm dependency build charts/redis`
- `helm lint charts/redis --strict`
- `helm unittest charts/redis`
- `helm template redis charts/redis`
- `helm template redis charts/redis -f charts/redis/ci/*.yaml`
- `kubeconform -strict` for default and all Redis CI values
- `npx --yes markdownlint-cli2 "charts/redis/README.md"`
- `ah lint -p charts/redis`
- Kubescape score: 78
- k3d runtime validation on `k3d-charts-test`: Sentinel scenario with primary, replica, and sentinel all `1/1 Running`

## Runtime notes
The k3d log review showed transient replica DNS/connection retries before the primary StatefulSet DNS was ready. The replica then synchronized successfully. Sentinel started cleanly after the fix and logged `+monitor master mymaster`.