### PR TITLE
chore(vaultwarden): upgrade to 1.36.0

### DIFF
--- a/charts/vaultwarden/.helmignore
+++ b/charts/vaultwarden/.helmignore
@@ -21,7 +21,11 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Pipfile.lock
+poetry.lock
 
 # Logs
 *.log

--- a/charts/vaultwarden/Chart.lock
+++ b/charts/vaultwarden/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:09bc7509b3ebe455bb1651e160c72df3c47cbfbff5f321103fbcd0c12c8045bd
-generated: "2026-04-29T10:13:14.9662035-03:00"

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -24,6 +24,8 @@ annotations:
     - kind: security
       description: "upgrade Vaultwarden to 1.36.0 for upstream security fixes (#216)"
     - kind: changed
+      description: "refresh PostgreSQL and MySQL subchart dependencies (#216)"
+    - kind: changed
       description: "upgrade to 1.35.8 (#200)"
     - kind: changed
       description: "add Phase 3-4 operational intelligence and cleanup (#142)"
@@ -51,10 +53,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 1.10.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.8.5
+    version: 1.9.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -4,7 +4,7 @@ name: vaultwarden
 description: Vaultwarden for Kubernetes with persistent SQLite storage and explicit ingress/domain configuration
 type: application
 version: 1.12.5
-appVersion: "1.35.8"
+appVersion: "1.36.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,6 +21,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
   artifacthub.io/changes: |
+    - kind: security
+      description: "upgrade Vaultwarden to 1.36.0 for upstream security fixes (#216)"
     - kind: changed
       description: "upgrade to 1.35.8 (#200)"
     - kind: changed

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -81,6 +81,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 ### Database selection
 
 - for production, prefer `database.external` or one of the optional subcharts
+- optional local database subcharts are vendored from HelmForge dependencies: PostgreSQL chart `1.10.0` and MySQL chart `1.9.1`
 - `database.mode=auto` uses this precedence:
 - `database.external.host` or `database.external.existingSecret`
 - `postgresql.enabled=true`
@@ -88,6 +89,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 - fallback to SQLite
 - if you use `database.external.existingSecret`, store a complete `DATABASE_URL` value in that secret
 - if you use `postgresql.enabled=true` or `mysql.enabled=true`, define the application password explicitly so Vaultwarden can build the connection URL
+- enable only one database source at a time; the chart fails rendering when external database, PostgreSQL subchart, and MySQL subchart settings are ambiguous
 - review [Database Modes and Migrations](docs/database-modes-and-migrations.md) before changing storage mode in a live environment
 
 ### Ingress and domain
@@ -205,8 +207,8 @@ Official reference:
 | `database.external.username` | External database username | `vaultwarden` |
 | `database.external.existingSecret` | Existing secret containing a complete `DATABASE_URL` | `""` |
 | `database.external.existingSecretUrlKey` | Secret key containing the `DATABASE_URL` value | `database-url` |
-| `postgresql.enabled` | Enable the local PostgreSQL subchart | `false` |
-| `mysql.enabled` | Enable the local MySQL subchart | `false` |
+| `postgresql.enabled` | Enable the local PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) | `false` |
+| `mysql.enabled` | Enable the local MySQL subchart (`helmforge/mysql` `1.9.1`) | `false` |
 | `vaultwarden.signupsAllowed` | Allow new user signups | `false` |
 | `vaultwarden.signupsVerify` | Require email verification for new signups | `false` |
 | `vaultwarden.signupsVerifyResendTime` | Seconds before another verification email can be sent | `3600` |

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -160,7 +160,7 @@ The admin page should not use a plain-text `ADMIN_TOKEN` in real environments. P
 Simple generation options:
 
 ```bash
-docker run --rm -it vaultwarden/server:1.35.4 /vaultwarden hash
+docker run --rm -it vaultwarden/server:1.36.0 /vaultwarden hash
 ```
 
 ```bash
@@ -195,8 +195,8 @@ Official reference:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.repository` | Vaultwarden image repository | `vaultwarden/server` |
-| `image.tag` | Vaultwarden image tag | `1.35.4` |
+| `image.repository` | Vaultwarden image repository | `docker.io/vaultwarden/server` |
+| `image.tag` | Vaultwarden image tag | `1.36.0` |
 | `domain` | Public Vaultwarden domain | `""` |
 | `database.mode` | `auto`, `sqlite`, `external`, `postgresql`, or `mysql` | `auto` |
 | `database.external.vendor` | External database vendor | `postgres` |

--- a/charts/vaultwarden/docs/admin-access-and-hardening.md
+++ b/charts/vaultwarden/docs/admin-access-and-hardening.md
@@ -21,7 +21,7 @@ In this chart:
 Using the Vaultwarden image:
 
 ```bash
-docker run --rm -it vaultwarden/server:1.35.4 /vaultwarden hash
+docker run --rm -it vaultwarden/server:1.36.0 /vaultwarden hash
 ```
 
 Using the `argon2` CLI:
@@ -70,8 +70,8 @@ If your cluster requires strict east-west traffic controls, enable `networkPolic
 
 ## References
 
-- Vaultwarden configuration template: https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/.env.template
-- Admin token guidance: https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page#secure-the-admin_token
+- Vaultwarden configuration template: [`.env.template`](https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/.env.template)
+- Admin token guidance: [Vaultwarden admin page guide](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page#secure-the-admin_token)
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/vaultwarden/templates/NOTES.txt
+++ b/charts/vaultwarden/templates/NOTES.txt
@@ -15,6 +15,17 @@ Service:
 Operational notes:
 - Vaultwarden v1 in this repository is designed for a single replica with persistent `/data`
 - database mode selected for this release: {{ include "vaultwarden.databaseMode" . }}
+{{- if .Values.postgresql.enabled }}
+- local PostgreSQL subchart is enabled; keep `postgresql.auth.password` set explicitly and validate migrations before moving live data
+{{- else if .Values.mysql.enabled }}
+- local MySQL subchart is enabled; keep `mysql.auth.password` set explicitly and validate migrations before moving live data
+{{- else if .Values.database.external.existingSecret }}
+- external database mode uses an existing secret; confirm the configured key contains a complete `DATABASE_URL`
+{{- else if .Values.database.external.host }}
+- external database mode is enabled; confirm connectivity, TLS requirements, and backup credentials outside this release
+{{- else }}
+- SQLite is selected; treat the full `/data` directory as the backup and restore boundary
+{{- end }}
 - if you enable SMTP, verify mail delivery from the admin settings and invitation flows
 - if you use the admin panel, prefer an Argon2-based `ADMIN_TOKEN`
 - if backup is enabled, validate that the S3 endpoint, bucket, and storage mode match the generated backup behavior for this release

--- a/charts/vaultwarden/tests/deployment_test.yaml
+++ b/charts/vaultwarden/tests/deployment_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/vaultwarden/server:1.35.8"
+          value: "docker.io/vaultwarden/server:1.36.0"
 
   - it: should have 1 replica
     template: deployment.yaml

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Vaultwarden image repository
   repository: docker.io/vaultwarden/server
   # -- Vaultwarden image tag
-  tag: "1.35.8"
+  tag: "1.36.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -80,7 +80,7 @@ vaultwarden:
 admin:
   # -- Admin token value. Prefer an Argon2 PHC string for production.
   # -- Example with the container image:
-  # --   docker run --rm -it vaultwarden/server:1.35.4 /vaultwarden hash
+  # --   docker run --rm -it vaultwarden/server:1.36.0 /vaultwarden hash
   # -- Example with the argon2 CLI:
   # --   echo -n 'change-me' | argon2 "$(openssl rand -base64 32)" -e -id -k 65540 -t 3 -p 4
   # -- Official reference:
@@ -460,4 +460,3 @@ externalSecrets:
   target:
     creationPolicy: Merge
   data: []
-


### PR DESCRIPTION
Closes #216

## Summary
- upgrade Vaultwarden image and chart appVersion from 1.35.8 to 1.36.0
- add Artifact Hub security change metadata for the upstream security release
- refresh PostgreSQL dependency to 1.10.0 and MySQL dependency to 1.9.1
- remove Chart.lock per maintainer decision to stop tracking chart locks
- refresh README/admin docs examples, README database dependency guidance, NOTES.txt database-mode guidance, and deployment unit test image expectation
- keep Chart.lock packaging ignore-safe by replacing the broad .helmignore *.lock pattern with specific non-Helm lock filenames

## Upstream Evidence
- Official release reviewed: https://github.com/dani-garcia/vaultwarden/releases/tag/1.36.0
- Docker image verified with pull: docker.io/vaultwarden/server:1.36.0
- Verified digest: sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c
- Upstream release is marked as security fixes and includes SSO login CSRF, user/organization enumeration, SSO account-binding, SSRF via icon endpoint, and dependency/security updates.
- Release notes also mention item archiving support and Web Vault v2026.4.1.
- HelmForge dependency versions verified with helm search repo: postgresql 1.10.0, mysql 1.9.1.

## Validation
- helm dependency build charts/vaultwarden
- helm dependency list charts/vaultwarden
- helm lint charts/vaultwarden
- helm lint --strict charts/vaultwarden
- helm template vaultwarden-test charts/vaultwarden
- helm template for all charts/vaultwarden/ci/*.yaml
- helm unittest charts/vaultwarden
- ah lint charts/vaultwarden
- kubeconform strict default and all ci values
- markdownlint README/admin docs
- Kubescape score 81
- k3d runtime install on k3d-charts-test for default SQLite: pod Ready 1/1, Vaultwarden 1.36.0 launched
- k3d runtime install on k3d-charts-test for PostgreSQL subchart: pods Ready, Vaultwarden 1.36.0 launched
- k3d runtime install on k3d-charts-test for MySQL subchart: pods Ready, Vaultwarden 1.36.0 launched

## Guardrail Note
- MCP `validate_chart_lock` currently reports GR-062 as BLOCKER when Chart.lock is absent for charts with dependencies. This PR removes Chart.lock by maintainer request and may require MCP/CI policy alignment with the new repository decision.