### PR TITLE
chore(hoppscotch): upgrade to 2026.4.0

### DIFF
--- a/charts/hoppscotch/.helmignore
+++ b/charts/hoppscotch/.helmignore
@@ -9,6 +9,7 @@ Thumbs.db
 
 # Helm
 .helmignore
+Chart.lock
 
 # Editors / IDE
 .vscode/
@@ -27,7 +28,7 @@ Thumbs.db
 # CI / misc
 *.bak
 
-# Lock files (package managers — Chart.lock must NOT be listed here per GR-062)
+# Lock files (application package managers)
 package-lock.json
 yarn.lock
 Pipfile.lock

--- a/charts/hoppscotch/Chart.lock
+++ b/charts/hoppscotch/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.13
-digest: sha256:b6749905484afbfaa2eb91878f9aa53b00bc0bf7e18a54e2951c7d91995216f4
-generated: "2026-04-29T03:48:03.3802791-03:00"

--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
 version: 1.0.0
-appVersion: "2026.3.1"
+appVersion: "2026.4.0"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -23,12 +23,16 @@ maintainers:
 
 dependencies:
   - name: postgresql
-    version: 1.9.13
+    version: 1.10.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
 
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade Hoppscotch to 2026.4.0 (#211)"
+    - kind: changed
+      description: "refresh PostgreSQL subchart dependency (#211)"
     - kind: added
       description: "add Hoppscotch Community Edition chart 2026.3.1 (#185)"
   artifacthub.io/maintainers: |

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -79,8 +79,11 @@ All traffic goes through a single Ingress/Service on port 80.
 | `postgresql.enabled` | Enable PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) | `true` |
 | `postgresql.initdb.scripts` | Bootstrap Hoppscotch PostgreSQL extensions | `pg_trgm` |
 | `postgresqlExtensionsJob.enabled` | Run the pre-upgrade hook that ensures `pg_trgm` exists on bundled PostgreSQL PVCs before Prisma migrations | `true` |
+| `postgresqlExtensionsJob.requireExistingResources` | Only render the `pg_trgm` pre-upgrade hook when bundled PostgreSQL resources already exist | `true` |
 | `database.external.enabled` | Use external PostgreSQL | `false` |
 | `encryption.key` | 32-char encryption key (auto-generated) | `""` |
+| `signingKey.existingSecret` | Existing Secret that contains `WEBAPP_SERVER_SIGNING_KEY` | `""` |
+| `signingKey.existingSecretKey` | Secret key used for `WEBAPP_SERVER_SIGNING_KEY` | `webapp-server-signing-key` |
 | `auth.providers` | Enabled auth providers | `EMAIL` |
 | `mailer.enabled` | Enable SMTP | `false` |
 | `gatewayAPI.enabled` | Enable HTTPRoute | `false` |
@@ -99,7 +102,10 @@ user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs
 a pre-upgrade hook to apply `pg_trgm` to existing bundled PostgreSQL PVCs before
 Prisma migrations run.
 The chart also persists `WEBAPP_SERVER_SIGNING_KEY` in the chart Secret so
-signed web bundles remain valid across pod restarts.
+signed web bundles remain valid across pod restarts. When using External
+Secrets, include `webapp-server-signing-key` in `externalSecrets.data`, or set
+`signingKey.existingSecret` and `signingKey.existingSecretKey` to reference a
+separately managed Secret.
 
 ## Examples
 

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -78,6 +78,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | `ingress.host` | Primary hostname (auto-derives all URLs) | `""` |
 | `postgresql.enabled` | Enable PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) | `true` |
 | `postgresql.initdb.scripts` | Bootstrap Hoppscotch PostgreSQL extensions | `pg_trgm` |
+| `postgresqlExtensionsJob.enabled` | Run the pre-upgrade hook that ensures `pg_trgm` exists on bundled PostgreSQL PVCs before Prisma migrations | `true` |
 | `database.external.enabled` | Use external PostgreSQL | `false` |
 | `encryption.key` | 32-char encryption key (auto-generated) | `""` |
 | `auth.providers` | Enabled auth providers | `EMAIL` |
@@ -94,7 +95,9 @@ API documentation publishing refinements, self-hosted SMTP OAuth2 support,
 desktop settings improvements, security patches, and bug fixes. Back up the
 PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
 The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
-user password Secret and bootstraps `pg_trgm` before Prisma migrations run.
+user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs
+a pre-upgrade hook to apply `pg_trgm` to existing bundled PostgreSQL PVCs before
+Prisma migrations run.
 The chart also persists `WEBAPP_SERVER_SIGNING_KEY` in the chart Secret so
 signed web bundles remain valid across pod restarts.
 

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -72,11 +72,12 @@ All traffic goes through a single Ingress/Service on port 80.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.3.1` |
+| `image.tag` | Hoppscotch image tag | `2026.4.0` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.host` | Primary hostname (auto-derives all URLs) | `""` |
-| `postgresql.enabled` | Enable PostgreSQL subchart | `true` |
+| `postgresql.enabled` | Enable PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) | `true` |
+| `postgresql.initdb.scripts` | Bootstrap Hoppscotch PostgreSQL extensions | `pg_trgm` |
 | `database.external.enabled` | Use external PostgreSQL | `false` |
 | `encryption.key` | 32-char encryption key (auto-generated) | `""` |
 | `auth.providers` | Enabled auth providers | `EMAIL` |
@@ -85,6 +86,17 @@ All traffic goes through a single Ingress/Service on port 80.
 | `externalSecrets.enabled` | Enable ExternalSecret | `false` |
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 | `podDisruptionBudget.enabled` | Enable PDB | `false` |
+
+## Upgrade Notes
+
+Hoppscotch `2026.4.0` adds collection-level pre-request and test scripts,
+API documentation publishing refinements, self-hosted SMTP OAuth2 support,
+desktop settings improvements, security patches, and bug fixes. Back up the
+PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
+The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
+user password Secret and bootstraps `pg_trgm` before Prisma migrations run.
+The chart also persists `WEBAPP_SERVER_SIGNING_KEY` in the chart Secret so
+signed web bundles remain valid across pod restarts.
 
 ## Examples
 

--- a/charts/hoppscotch/ci/external-secrets.yaml
+++ b/charts/hoppscotch/ci/external-secrets.yaml
@@ -13,3 +13,7 @@ externalSecrets:
       remoteRef:
         key: prod/hoppscotch
         property: data-encryption-key
+    - secretKey: webapp-server-signing-key
+      remoteRef:
+        key: prod/hoppscotch
+        property: webapp-server-signing-key

--- a/charts/hoppscotch/docs/production.md
+++ b/charts/hoppscotch/docs/production.md
@@ -46,9 +46,18 @@ externalSecrets:
       remoteRef:
         key: prod/hoppscotch
         property: data-encryption-key
+    - secretKey: webapp-server-signing-key
+      remoteRef:
+        key: prod/hoppscotch
+        property: webapp-server-signing-key
 ```
 
-When `externalSecrets.enabled=true`, the chart creates an ExternalSecret resource instead of a Secret. The secret.yaml still renders (for checksums), but credentials come from the store.
+When `externalSecrets.enabled=true`, the chart creates an ExternalSecret
+resource instead of a Secret. The secret.yaml still renders (for checksums), but
+credentials come from the store. Include `webapp-server-signing-key` in the
+ExternalSecret data, or set `signingKey.existingSecret` and
+`signingKey.existingSecretKey` to reference a separate Secret that contains
+`WEBAPP_SERVER_SIGNING_KEY`.
 
 ## TLS via cert-manager
 

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -56,9 +56,12 @@ Upgrade reminder:
   before upgrading production.
   The bundled PostgreSQL subchart bootstraps pg_trgm for fresh data directories,
   and the pre-upgrade hook applies pg_trgm to existing bundled PostgreSQL PVCs
-  before Prisma migrations run.
+  before Prisma migrations run. By default, the hook renders only when the
+  bundled PostgreSQL Secret and Service already exist.
   WEBAPP_SERVER_SIGNING_KEY is persisted in the chart Secret to keep web
-  bundle signatures stable across pod restarts.
+  bundle signatures stable across pod restarts. With External Secrets, provide
+  webapp-server-signing-key in externalSecrets.data or point signingKey.* to a
+  separately managed Secret.
 
 6. Validation Commands
 ======================

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -54,8 +54,9 @@ Upgrade reminder:
   Hoppscotch {{ .Chart.AppVersion }} includes upstream feature, security, and
   bug-fix changes. Back up PostgreSQL and keep DATA_ENCRYPTION_KEY stable
   before upgrading production.
-  The bundled PostgreSQL subchart bootstraps pg_trgm for Hoppscotch search
-  migrations on fresh data directories.
+  The bundled PostgreSQL subchart bootstraps pg_trgm for fresh data directories,
+  and the pre-upgrade hook applies pg_trgm to existing bundled PostgreSQL PVCs
+  before Prisma migrations run.
   WEBAPP_SERVER_SIGNING_KEY is persisted in the chart Secret to keep web
   bundle signatures stable across pod restarts.
 
@@ -78,6 +79,8 @@ Upgrade reminder:
   Migration error (prisma migrate deploy failed):
     -> Check DATABASE_URL is correct
     -> Ensure PostgreSQL is running: kubectl get pods -n {{ .Release.Namespace }}
+    -> On bundled PostgreSQL upgrades, inspect the pg_trgm hook:
+       kubectl logs -n {{ .Release.Namespace }} job/{{ include "hoppscotch.fullname" . }}-postgresql-extensions
     -> Check migrate init container logs
 
   CORS error (WHITELISTED_ORIGINS mismatch):

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -50,6 +50,15 @@ For nginx-ingress, add these annotations to your ingress:
   Step 3: Configure Server Settings (auth providers, SMTP) via the UI
   Step 4: Invite users via Admin > User Invitations
 
+Upgrade reminder:
+  Hoppscotch {{ .Chart.AppVersion }} includes upstream feature, security, and
+  bug-fix changes. Back up PostgreSQL and keep DATA_ENCRYPTION_KEY stable
+  before upgrading production.
+  The bundled PostgreSQL subchart bootstraps pg_trgm for Hoppscotch search
+  migrations on fresh data directories.
+  WEBAPP_SERVER_SIGNING_KEY is persisted in the chart Secret to keep web
+  bundle signatures stable across pod restarts.
+
 6. Validation Commands
 ======================
   # Check pods are ready
@@ -62,7 +71,7 @@ For nginx-ingress, add these annotations to your ingress:
 
   # Test backend health
   kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "hoppscotch.fullname" . }} -- \
-    sh -c "wget -qO- http://localhost/backend/v1" 2>/dev/null || echo "backend not ready"
+    sh -c "wget -qO- http://localhost/backend/health" 2>/dev/null || echo "backend not ready"
 
 7. Troubleshooting
 ==================

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -297,6 +297,19 @@ database-url
 {{- end -}}
 
 {{/*
+postgresqlSecretName — secret created by the bundled PostgreSQL subchart.
+*/}}
+{{- define "hoppscotch.postgresqlSecretName" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- else if .Values.postgresql.fullnameOverride -}}
+{{- printf "%s-auth" .Values.postgresql.fullnameOverride -}}
+{{- else -}}
+{{- printf "%s-%s-auth" .Release.Name (.Values.postgresql.nameOverride | default "postgresql") -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 encryptionSecretName — name of the secret holding data-encryption-key
 */}}
 {{- define "hoppscotch.encryptionSecretName" -}}
@@ -323,7 +336,8 @@ databaseEnv — env entries for DATABASE_URL (and DB_PASSWORD helper for passwor
 Handles three cases:
   1. existingSecret with full URL key → single secretKeyRef
   2. existingSecret password-only → K8s env-var substitution using $(DB_PASSWORD)
-  3. chart-managed secret → single secretKeyRef to chart secret
+  3. bundled PostgreSQL subchart → K8s env-var substitution from PostgreSQL user-password
+  4. chart-managed external URL secret → single secretKeyRef to chart secret
 */}}
 {{- define "hoppscotch.databaseEnv" -}}
 {{- if and .Values.database.external.enabled .Values.database.external.existingSecret (not .Values.database.external.existingSecretUrlKey) }}
@@ -334,6 +348,14 @@ Handles three cases:
       key: {{ .Values.database.external.existingSecretPasswordKey }}
 - name: DATABASE_URL
   value: {{ printf "postgresql://%s:$(DB_PASSWORD)@%s:%s/%s" .Values.database.external.username (include "hoppscotch.databaseHost" .) (include "hoppscotch.databasePort" .) (include "hoppscotch.databaseName" .) | quote }}
+{{- else if and .Values.postgresql.enabled (not .Values.database.external.enabled) }}
+- name: DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "hoppscotch.postgresqlSecretName" . }}
+      key: {{ .Values.postgresql.auth.existingSecretUserPasswordKey | default "user-password" }}
+- name: DATABASE_URL
+  value: {{ printf "postgresql://%s:$(DB_PASSWORD)@%s:%s/%s" .Values.postgresql.auth.username (include "hoppscotch.databaseHost" .) (include "hoppscotch.databasePort" .) (include "hoppscotch.databaseName" .) | quote }}
 {{- else }}
 - name: DATABASE_URL
   valueFrom:

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -332,6 +332,39 @@ data-encryption-key
 {{- end -}}
 
 {{/*
+signingSecretName — name of the secret holding WEBAPP_SERVER_SIGNING_KEY
+*/}}
+{{- define "hoppscotch.signingSecretName" -}}
+{{- if .Values.signingKey.existingSecret -}}
+{{- .Values.signingKey.existingSecret -}}
+{{- else -}}
+{{- include "hoppscotch.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+signingSecretKey — key within the secret for WEBAPP_SERVER_SIGNING_KEY
+*/}}
+{{- define "hoppscotch.signingSecretKey" -}}
+{{- .Values.signingKey.existingSecretKey | default "webapp-server-signing-key" -}}
+{{- end -}}
+
+{{/*
+shouldRunPostgresqlExtensionsJob — only run upgrade hook against existing bundled PostgreSQL resources by default.
+*/}}
+{{- define "hoppscotch.shouldRunPostgresqlExtensionsJob" -}}
+{{- if and .Values.postgresql.enabled .Values.postgresqlExtensionsJob.enabled -}}
+  {{- if not .Values.postgresqlExtensionsJob.requireExistingResources -}}
+true
+  {{- else -}}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace (include "hoppscotch.postgresqlSecretName" .) -}}
+    {{- $service := lookup "v1" "Service" .Release.Namespace (include "hoppscotch.databaseHost" .) -}}
+    {{- if and $secret $service -}}true{{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 databaseEnv — env entries for DATABASE_URL (and DB_PASSWORD helper for password-only mode).
 Handles three cases:
   1. existingSecret with full URL key → single secretKeyRef

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -119,8 +119,8 @@ spec:
             - name: WEBAPP_SERVER_SIGNING_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hoppscotch.fullname" . }}
-                  key: webapp-server-signing-key
+                  name: {{ include "hoppscotch.signingSecretName" . }}
+                  key: {{ include "hoppscotch.signingSecretKey" . }}
             {{- if .Values.auth.github.enabled }}
             - name: GITHUB_CLIENT_ID
               valueFrom:

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -62,6 +62,35 @@ spec:
             {{- include "hoppscotch.databaseEnv" . | nindent 12 }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
+        - name: prepare-runtime-files
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              cp -R /dist/backend/. /runtime-backend/
+              cp -R /site/. /runtime-site/
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          volumeMounts:
+            - name: backend-runtime
+              mountPath: /runtime-backend
+            - name: site-runtime
+              mountPath: /runtime-site
         {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -87,6 +116,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "hoppscotch.encryptionSecretName" . }}
                   key: {{ include "hoppscotch.encryptionSecretKey" . }}
+            - name: WEBAPP_SERVER_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hoppscotch.fullname" . }}
+                  key: webapp-server-signing-key
             {{- if .Values.auth.github.enabled }}
             - name: GITHUB_CLIENT_ID
               valueFrom:
@@ -141,9 +175,14 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          volumeMounts:
+            - name: backend-runtime
+              mountPath: /dist/backend
+            - name: site-runtime
+              mountPath: /site
           livenessProbe:
             httpGet:
-              path: /backend/v1
+              path: /backend/health
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
@@ -151,7 +190,7 @@ spec:
             failureThreshold: 6
           readinessProbe:
             httpGet:
-              path: /backend/v1
+              path: /backend/health
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
@@ -159,11 +198,16 @@ spec:
             failureThreshold: 3
           startupProbe:
             httpGet:
-              path: /backend/v1
+              path: /backend/health
               port: http
             failureThreshold: 30
             periodSeconds: 10
           resources: {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: backend-runtime
+          emptyDir: {}
+        - name: site-runtime
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/hoppscotch/templates/postgresql-extensions-job.yaml
+++ b/charts/hoppscotch/templates/postgresql-extensions-job.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.postgresql.enabled .Values.postgresqlExtensionsJob.enabled }}
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "hoppscotch.fullname" . }}-postgresql-extensions
+  labels: {{ include "hoppscotch.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.postgresqlExtensionsJob.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.postgresqlExtensionsJob.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels: {{ include "hoppscotch.selectorLabels" . | nindent 8 }}
+      {{- with .Values.postgresqlExtensionsJob.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "hoppscotch.serviceAccountName" . }}
+      securityContext: {{- toYaml .Values.postgresqlExtensionsJob.podSecurityContext | nindent 8 }}
+      containers:
+        - name: postgresql-extensions
+          image: "{{ .Values.postgresqlExtensionsJob.image.repository }}:{{ .Values.postgresqlExtensionsJob.image.tag }}"
+          imagePullPolicy: {{ .Values.postgresqlExtensionsJob.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              until pg_isready --host="${PGHOST}" --port="${PGPORT}" --username="${PGUSER}" --dbname="${PGDATABASE}"; do
+                echo "waiting for postgresql..."; sleep 2;
+              done
+              psql --set=ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
+          env:
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hoppscotch.postgresqlSecretName" . }}
+                  key: {{ .Values.postgresql.auth.existingSecretUserPasswordKey | default "user-password" }}
+            - name: PGHOST
+              value: {{ include "hoppscotch.databaseHost" . | quote }}
+            - name: PGPORT
+              value: {{ include "hoppscotch.databasePort" . | quote }}
+            - name: PGDATABASE
+              value: {{ include "hoppscotch.databaseName" . | quote }}
+            - name: PGUSER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: PGPASSWORD
+              value: "$(DB_PASSWORD)"
+          securityContext: {{- toYaml .Values.postgresqlExtensionsJob.securityContext | nindent 12 }}
+          resources: {{- toYaml .Values.postgresqlExtensionsJob.resources | nindent 12 }}
+{{- end }}

--- a/charts/hoppscotch/templates/postgresql-extensions-job.yaml
+++ b/charts/hoppscotch/templates/postgresql-extensions-job.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.postgresql.enabled .Values.postgresqlExtensionsJob.enabled }}
 # SPDX-License-Identifier: Apache-2.0
+{{- if include "hoppscotch.shouldRunPostgresqlExtensionsJob" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/hoppscotch/templates/secret.yaml
+++ b/charts/hoppscotch/templates/secret.yaml
@@ -8,8 +8,8 @@ metadata:
 type: Opaque
 data:
   {{- /* database-url: skipped when caller provides full URL via existingSecret */}}
-  {{- if not (and .Values.database.external.existingSecret .Values.database.external.existingSecretUrlKey) }}
   {{- if .Values.database.external.enabled }}
+  {{- if not (and .Values.database.external.existingSecret .Values.database.external.existingSecretUrlKey) }}
   {{- if .Values.database.external.url }}
   database-url: {{ .Values.database.external.url | b64enc | quote }}
   {{- else if .Values.database.external.existingSecret }}
@@ -17,9 +17,6 @@ data:
   {{- else }}
   database-url: {{ printf "postgresql://%s:%s@%s:%s/%s" .Values.database.external.username .Values.database.external.password (include "hoppscotch.databaseHost" .) (include "hoppscotch.databasePort" .) (include "hoppscotch.databaseName" .) | b64enc | quote }}
   {{- end }}
-  {{- else }}
-  {{- /* subchart PostgreSQL: build URL with auto password */}}
-  database-url: {{ printf "postgresql://%s:%s@%s:%s/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "hoppscotch.databaseHost" .) "5432" .Values.postgresql.auth.database | b64enc | quote }}
   {{- end }}
   {{- end }}
   {{- /* data-encryption-key: preserve across upgrades via lookup */}}
@@ -35,6 +32,14 @@ data:
   {{- end }}
   data-encryption-key: {{ $encKey | b64enc | quote }}
   {{- end }}
+  {{- $signingKey := "" }}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "hoppscotch.fullname" .) }}
+  {{- if and $existing $existing.data (index $existing.data "webapp-server-signing-key") }}
+  {{- $signingKey = index $existing.data "webapp-server-signing-key" | b64dec }}
+  {{- else }}
+  {{- $signingKey = randBytes 64 }}
+  {{- end }}
+  webapp-server-signing-key: {{ $signingKey | b64enc | quote }}
   {{- /* GitHub OAuth */}}
   {{- if and .Values.auth.github.enabled (not .Values.auth.github.existingSecret) }}
   github-client-id: {{ .Values.auth.github.clientId | b64enc | quote }}

--- a/charts/hoppscotch/templates/secret.yaml
+++ b/charts/hoppscotch/templates/secret.yaml
@@ -32,14 +32,17 @@ data:
   {{- end }}
   data-encryption-key: {{ $encKey | b64enc | quote }}
   {{- end }}
+  {{- if not .Values.signingKey.existingSecret }}
   {{- $signingKey := "" }}
   {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "hoppscotch.fullname" .) }}
-  {{- if and $existing $existing.data (index $existing.data "webapp-server-signing-key") }}
-  {{- $signingKey = index $existing.data "webapp-server-signing-key" | b64dec }}
+  {{- $signingSecretKey := include "hoppscotch.signingSecretKey" . }}
+  {{- if and $existing $existing.data (index $existing.data $signingSecretKey) }}
+  {{- $signingKey = index $existing.data $signingSecretKey | b64dec }}
   {{- else }}
   {{- $signingKey = randBytes 64 }}
   {{- end }}
-  webapp-server-signing-key: {{ $signingKey | b64enc | quote }}
+  {{ $signingSecretKey }}: {{ $signingKey | b64enc | quote }}
+  {{- end }}
   {{- /* GitHub OAuth */}}
   {{- if and .Values.auth.github.enabled (not .Values.auth.github.existingSecret) }}
   github-client-id: {{ .Values.auth.github.clientId | b64enc | quote }}

--- a/charts/hoppscotch/templates/servicemonitor.yaml
+++ b/charts/hoppscotch/templates/servicemonitor.yaml
@@ -14,6 +14,6 @@ spec:
     matchLabels: {{ include "hoppscotch.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
-      path: /backend/v1
+      path: /backend/health
       interval: {{ .Values.metrics.serviceMonitor.interval }}
 {{- end }}

--- a/charts/hoppscotch/templates/tests/connection-test.yaml
+++ b/charts/hoppscotch/templates/tests/connection-test.yaml
@@ -17,7 +17,7 @@ spec:
         - sh
         - -c
         - |
-          wget -qO- http://{{ include "hoppscotch.fullname" . }}:{{ .Values.service.port }}/backend/v1
+          wget -qO- http://{{ include "hoppscotch.fullname" . }}:{{ .Values.service.port }}/backend/health
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -101,6 +101,22 @@ tests:
                 key: webapp-server-signing-key
         template: deployment.yaml
 
+  - it: should allow the webapp server signing key to come from an external secret
+    set:
+      signingKey:
+        existingSecret: hoppscotch-managed-secret
+        existingSecretKey: signing-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEBAPP_SERVER_SIGNING_KEY
+            valueFrom:
+              secretKeyRef:
+                name: hoppscotch-managed-secret
+                key: signing-key
+        template: deployment.yaml
+
   - it: should probe the backend health endpoint
     asserts:
       - equal:

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.3.1"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.0"
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -49,7 +49,63 @@ tests:
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[1].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.3.1"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.0"
+        template: deployment.yaml
+
+  - it: should prepare writable runtime files for non-root startup
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[2].name
+          value: prepare-runtime-files
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: backend-runtime
+            mountPath: /dist/backend
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: site-runtime
+            mountPath: /site
+        template: deployment.yaml
+
+  - it: should build DATABASE_URL from bundled PostgreSQL user password secret
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-postgresql-auth
+                key: user-password
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: DATABASE_URL
+            value: postgresql://hoppscotch:$(DB_PASSWORD)@RELEASE-NAME-postgresql:5432/hoppscotch
+        template: deployment.yaml
+
+  - it: should expose stable webapp server signing key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WEBAPP_SERVER_SIGNING_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-hoppscotch
+                key: webapp-server-signing-key
+        template: deployment.yaml
+
+  - it: should probe the backend health endpoint
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /backend/health
         template: deployment.yaml
 
   - it: should run as non-root

--- a/charts/hoppscotch/tests/externalsecret_test.yaml
+++ b/charts/hoppscotch/tests/externalsecret_test.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: external secret tests
+templates:
+  - externalsecret.yaml
+tests:
+  - it: should render ExternalSecret data including the webapp server signing key
+    set:
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: example-secret-store
+          kind: ClusterSecretStore
+        data:
+          - secretKey: database-url
+            remoteRef:
+              key: prod/hoppscotch
+              property: database-url
+          - secretKey: data-encryption-key
+            remoteRef:
+              key: prod/hoppscotch
+              property: data-encryption-key
+          - secretKey: webapp-server-signing-key
+            remoteRef:
+              key: prod/hoppscotch
+              property: webapp-server-signing-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ExternalSecret
+      - contains:
+          path: spec.data
+          content:
+            secretKey: webapp-server-signing-key
+            remoteRef:
+              key: prod/hoppscotch
+              property: webapp-server-signing-key

--- a/charts/hoppscotch/tests/postgresql_extensions_job_test.yaml
+++ b/charts/hoppscotch/tests/postgresql_extensions_job_test.yaml
@@ -4,6 +4,9 @@ templates:
   - postgresql-extensions-job.yaml
 tests:
   - it: should render a pre-upgrade hook job for bundled PostgreSQL
+    set:
+      postgresqlExtensionsJob:
+        requireExistingResources: false
     asserts:
       - hasDocuments:
           count: 1
@@ -31,6 +34,13 @@ tests:
     set:
       postgresql:
         enabled: false
+      postgresqlExtensionsJob:
+        requireExistingResources: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render by default without existing bundled PostgreSQL resources
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/hoppscotch/tests/postgresql_extensions_job_test.yaml
+++ b/charts/hoppscotch/tests/postgresql_extensions_job_test.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: postgresql extensions hook tests
+templates:
+  - postgresql-extensions-job.yaml
+tests:
+  - it: should render a pre-upgrade hook job for bundled PostgreSQL
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: postgresql-extensions
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PGPASSWORD
+            value: $(DB_PASSWORD)
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+
+  - it: should not render when bundled PostgreSQL is disabled
+    set:
+      postgresql:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when the hook is disabled
+    set:
+      postgresqlExtensionsJob:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/hoppscotch/tests/secret_test.yaml
+++ b/charts/hoppscotch/tests/secret_test.yaml
@@ -42,6 +42,15 @@ tests:
           path: data["webapp-server-signing-key"]
         template: secret.yaml
 
+  - it: should not include webapp server signing key when using an existing signing secret
+    set:
+      signingKey:
+        existingSecret: hoppscotch-managed-secret
+    asserts:
+      - notExists:
+          path: data["webapp-server-signing-key"]
+        template: secret.yaml
+
   - it: should include GitHub OAuth keys when enabled
     set:
       auth:

--- a/charts/hoppscotch/tests/secret_test.yaml
+++ b/charts/hoppscotch/tests/secret_test.yaml
@@ -10,7 +10,21 @@ tests:
           of: Secret
         template: secret.yaml
 
-  - it: should include database-url
+  - it: should not include database-url when using bundled PostgreSQL
+    asserts:
+      - notExists:
+          path: data["database-url"]
+        template: secret.yaml
+
+  - it: should include database-url for chart-managed external database
+    set:
+      postgresql:
+        enabled: false
+      database:
+        external:
+          enabled: true
+          host: postgres.example.com
+          password: test-password
     asserts:
       - isNotNull:
           path: data["database-url"]
@@ -20,6 +34,12 @@ tests:
     asserts:
       - isNotNull:
           path: data["data-encryption-key"]
+        template: secret.yaml
+
+  - it: should include webapp server signing key
+    asserts:
+      - isNotNull:
+          path: data["webapp-server-signing-key"]
         template: secret.yaml
 
   - it: should include GitHub OAuth keys when enabled

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -94,6 +94,12 @@
               }
             }
           }
+        },
+        "initdb": {
+          "type": "object",
+          "properties": {
+            "scripts": {"type": "object"}
+          }
         }
       }
     },

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -71,6 +71,14 @@
         "existingSecretKey": {"type": "string"}
       }
     },
+    "signingKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": {"type": "string"},
+        "existingSecretKey": {"type": "string"}
+      }
+    },
     "postgresql": {
       "type": "object",
       "properties": {
@@ -108,6 +116,7 @@
       "additionalProperties": false,
       "properties": {
         "enabled": {"type": "boolean"},
+        "requireExistingResources": {"type": "boolean"},
         "image": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -103,6 +103,28 @@
         }
       }
     },
+    "postgresqlExtensionsJob": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {"type": "string", "minLength": 1},
+            "tag": {"type": "string", "minLength": 1},
+            "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"]}
+          }
+        },
+        "backoffLimit": {"type": "integer", "minimum": 0},
+        "activeDeadlineSeconds": {"type": "integer", "minimum": 1},
+        "podAnnotations": {"type": "object"},
+        "podSecurityContext": {"type": "object"},
+        "securityContext": {"type": "object"},
+        "resources": {"type": "object"}
+      }
+    },
     "database": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.3.1"
+  tag: "2026.4.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -101,6 +101,13 @@ postgresql:
     persistence:
       enabled: true
       size: 10Gi
+  initdb:
+    scripts:
+      02-hoppscotch-extensions.sh: |
+        #!/bin/bash
+        set -euo pipefail
+        psql --username "${POSTGRES_USER}" --dbname "${APP_DATABASE}" \
+          -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
 
 database:
   # -- Use an external PostgreSQL instance instead of the bundled subchart.

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -109,6 +109,45 @@ postgresql:
         psql --username "${POSTGRES_USER}" --dbname "${APP_DATABASE}" \
           -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
 
+postgresqlExtensionsJob:
+  # -- Run a pre-upgrade hook that ensures pg_trgm exists on bundled PostgreSQL databases with existing PVCs.
+  enabled: true
+  image:
+    # -- PostgreSQL client image used by the extension hook
+    repository: docker.io/library/postgres
+    # -- PostgreSQL client image tag
+    tag: "18.3-trixie"
+    pullPolicy: IfNotPresent
+  # -- Job retry limit
+  backoffLimit: 6
+  # -- Maximum seconds for the hook job
+  activeDeadlineSeconds: 300
+  # -- Pod annotations for the hook job
+  podAnnotations: {}
+  # -- Pod security context for the hook job
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    fsGroup: 999
+    seccompProfile:
+      type: RuntimeDefault
+  # -- Container security context for the hook job
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 999
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
 database:
   # -- Use an external PostgreSQL instance instead of the bundled subchart.
   external:

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -84,6 +84,12 @@ encryption:
   # -- Key within existingSecret that holds the encryption key.
   existingSecretKey: data-encryption-key
 
+signingKey:
+  # -- Existing secret containing WEBAPP_SERVER_SIGNING_KEY. Useful with ExternalSecret-managed secrets.
+  existingSecret: ""
+  # -- Key within existingSecret that holds WEBAPP_SERVER_SIGNING_KEY.
+  existingSecretKey: webapp-server-signing-key
+
 # =============================================================================
 # Database
 # =============================================================================
@@ -106,12 +112,15 @@ postgresql:
       02-hoppscotch-extensions.sh: |
         #!/bin/bash
         set -euo pipefail
+        export PGPASSWORD="${POSTGRES_PASSWORD}"
         psql --username "${POSTGRES_USER}" --dbname "${APP_DATABASE}" \
           -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
 
 postgresqlExtensionsJob:
   # -- Run a pre-upgrade hook that ensures pg_trgm exists on bundled PostgreSQL databases with existing PVCs.
   enabled: true
+  # -- Only run the hook when the bundled PostgreSQL Secret and Service already exist. Set to false only for controlled migrations where PostgreSQL is created before the upgrade hook runs.
+  requireExistingResources: true
   image:
     # -- PostgreSQL client image used by the extension hook
     repository: docker.io/library/postgres


### PR DESCRIPTION
## Summary
- Fixes #211
- Upgrade Hoppscotch from 2026.3.1 to 2026.4.0
- Refresh the bundled PostgreSQL dependency to HelmForge `postgresql` 1.10.0
- Remove Chart.lock per maintainer policy
- Update README and NOTES for the new release, ExternalSecret signing-key behavior, and PostgreSQL upgrade behavior

## Runtime fixes from k3d/log analysis
- Fixed bundled PostgreSQL auth by deriving `DATABASE_URL` from the PostgreSQL subchart `user-password` Secret instead of an empty inline value
- Bootstrapped PostgreSQL `pg_trgm` for fresh data directories and export `PGPASSWORD` before initdb `psql`
- Added a guarded pre-upgrade hook that applies `pg_trgm` only when bundled PostgreSQL Secret and Service already exist by default
- Added `signingKey.existingSecret` / `signingKey.existingSecretKey` and documented `webapp-server-signing-key` for ExternalSecret-managed deployments
- Added writable runtime copies for `/dist/backend` and `/site` so 2026.4.0 starts under the non-root container security context
- Updated probes, ServiceMonitor, and Helm test hook from `/backend/v1` to `/backend/health`
- Persisted `WEBAPP_SERVER_SIGNING_KEY` in the chart Secret so web bundle signatures remain stable across restarts

## Upstream Evidence
- Tavily/GitHub release review: `2026.4.0` is a non-prerelease published on 2026-04-30T08:52:18Z
- Release notes reviewed: collection-level pre-request/test scripts, API docs publishing UX, SMTP OAuth2 support, self-hosted timeout configuration, security patches, and bug fixes
- Image pull verified: `docker.io/hoppscotch/hoppscotch:2026.4.0` digest `sha256:550a4a31e818c4ae19482f8d667e17622c4d9b0a73bb056ebfe844168ebd1f7f`

## Validation
- `helm dependency build charts/hoppscotch`
- `helm lint charts/hoppscotch`
- `helm lint --strict charts/hoppscotch`
- `helm unittest charts/hoppscotch` (54 tests)
- `helm template hoppscotch charts/hoppscotch | kubeconform -strict -summary -ignore-missing-schemas`
- All `charts/hoppscotch/ci/*.yaml` rendered through `kubeconform -strict -summary -ignore-missing-schemas`
- `npx -y markdownlint-cli2 charts/hoppscotch/README.md charts/hoppscotch/docs/production.md`
- `git diff --check`
- `ah lint -p charts/hoppscotch`
- k3d runtime on `k3d-charts-test`: fresh bundled PostgreSQL install created `pg_trgm`; real `helm upgrade` rendered and completed the pre-upgrade hook; Deployment and StatefulSet rolled out; pods were `1/1 Running` with 0 restarts; Prisma reported no pending migrations; backend `/health` returned 200
- Kubescape manifest scan score: 87.22944%, PASS

## Guardrails
- MCP HelmForge runtime context: CLEAR for `k3d-charts-test`
- MCP HelmForge chart CI evidence: PASS
- MCP HelmForge security evidence: PASS
- MCP GR-062 flags missing Chart.lock because the chart has dependencies; this is intentional per maintainer instruction to stop using Chart.lock