### PR TITLE
chore(elasticsearch): upgrade to 9.3.4

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.0.3
-appVersion: "9.3.3"
+appVersion: "9.3.4"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev
@@ -27,7 +27,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 9.3.3 (#194)"
+      description: "upgrade to 9.3.4 (#209)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -52,4 +52,3 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/kafka
-

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -1,6 +1,8 @@
 # Elasticsearch Helm Chart
 
-Production-ready Elasticsearch cluster chart using the **official Elastic image**. Deploys multi-role clusters (master, data, coordinating) from a single `clusterProfile` setting, with automated S3 backups, ILM lifecycle policies, cert-manager TLS, data tiers, and Grafana dashboards included out of the box.
+Production-ready Elasticsearch cluster chart using the **official Elastic image**. Deploys multi-role clusters from a single
+`clusterProfile` setting, with automated S3 backups, ILM lifecycle policies, cert-manager TLS, data tiers, and Grafana
+dashboards included out of the box.
 
 ## Install
 
@@ -158,7 +160,7 @@ dataTiers:
 | `clusterProfile` | Cluster preset: `dev`, `staging`, `production-ha` | `dev` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `8.17.4` |
+| `image.tag` | Image tag | `9.3.4` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -259,7 +261,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `8.17.4` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.3.4` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -230,6 +230,23 @@
         "replicaCount": {
           "type": "integer",
           "minimum": 1
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Kibana image repository"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Kibana image tag. Keep aligned with Elasticsearch."
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            }
+          }
         }
       }
     },

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -48,7 +48,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.3.3"
+  tag: "9.3.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -321,7 +321,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.3.3"
+    tag: "9.3.4"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}
@@ -520,4 +520,3 @@ externalSecrets:
   data: []
   # -- Skip the preflight CRD presence check (set true when CRDs are managed externally)
   skipCRDCheck: false
-


### PR DESCRIPTION
## Summary

- Updates Elasticsearch image from `9.3.3` to `9.3.4` for #209.
- Updates optional Kibana image tag to `9.3.4` so it stays aligned with Elasticsearch.
- Refreshes README value defaults and values schema coverage for `kibana.image`.

## Upstream Evidence

- Issue: #209
- Upstream release notes checked with Tavily against Elastic/GitHub sources.
- Image pulled: `docker.io/library/elasticsearch:9.3.4`
- Digest observed: `sha256:5dd1ab8e73bf66668abcde5892b10c2fef39269b80639a5cd0d5b224207a2ba3`

## Validation

- [x] `helm dependency list charts/elasticsearch` (`no dependencies` warning expected)
- [x] `helm lint --strict charts/elasticsearch`
- [x] `helm unittest charts/elasticsearch` (`12` suites, `88` tests)
- [x] `helm template elasticsearch-test charts/elasticsearch | kubeconform -strict -summary -ignore-missing-schemas`
- [x] strict kubeconform for every `charts/elasticsearch/ci/*.yaml`
  - `data-tiers-values.yaml`, `dev-values.yaml`, `dual-stack.yaml`, `external-secrets.yaml`, `gateway-api.yaml`, `production-ha-values.yaml`, `staging-values.yaml`
  - CRD-backed resources in ExternalSecret/Gateway scenarios were skipped by kubeconform as expected with missing schemas.
- [x] `npx --yes markdownlint-cli2 "charts/elasticsearch/README.md"`
- [x] `ah lint charts/elasticsearch` (`elasticsearch` package lint succeeded; repo scan reported `0` package errors)
- [x] Kubescape local manifest scan: compliance score `84`
- [x] k3d runtime install on `k3d-charts-test`, namespace `hf-elasticsearch-209`
  - Scenario: `ci/dev-values.yaml` with `master.persistence.enabled=false`
  - Pod: `elasticsearch-209-master-0` `1/1 Running`, `0` restarts
  - Logs inspected; Elasticsearch 9.3.4 started, selected health node, and applied templates without crash/error loops.

## Guardrails

- MCP HelmForge used for validation evidence and governance.
- GR-001: branch created from updated `main`.
- GR-007: chart README updated; no separate site docs directory exists in this repository for `/docs/charts/elasticsearch`.
- GR-017: NOTES.txt reviewed; existing notes already render chart/app version, topology, access, health, backup, and troubleshooting commands.
- GR-027: k3d runtime validation completed with pod logs/events inspected.
- GR-037: `.helmignore` reviewed and already uses explicit package lock filenames, not blanket `*.lock`.
- GR-066: Kubescape score recorded as `84`.

Closes #209