### PR TITLE
chore(docmost): upgrade to 0.80.2

### DIFF
--- a/charts/docmost/.helmignore
+++ b/charts/docmost/.helmignore
@@ -21,7 +21,10 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock
 
 # Logs
 *.log

--- a/charts/docmost/Chart.lock
+++ b/charts/docmost/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.6.9
-digest: sha256:9e1865ee4ab8182a1d3fb04c2b45db3ee7b1d5253fb8132bef8764654c129e18
-generated: "2026-04-29T04:55:37.0583384-03:00"

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -4,7 +4,7 @@ name: docmost
 description: Docmost collaborative wiki and documentation software with PostgreSQL, Redis, local storage, and optional S3
 type: application
 version: 1.1.10
-appVersion: "0.80.1"
+appVersion: "0.80.2"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/docmost.png
 home: https://helmforge.dev
@@ -26,7 +26,11 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 0.80.1 (#192)"
+      description: "upgrade Docmost to 0.80.2 (#208)"
+    - kind: changed
+      description: "update PostgreSQL and Redis chart dependencies"
+    - kind: changed
+      description: "refresh README and post-install notes"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -54,10 +58,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 1.10.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.9
+    version: 1.6.14
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/docmost/README.md
+++ b/charts/docmost/README.md
@@ -1,6 +1,6 @@
 # Docmost
 
-A Helm chart for deploying [Docmost](https://docmost.com/) on Kubernetes with PostgreSQL, Redis, local storage, and optional S3-compatible object storage.
+A Helm chart for deploying [Docmost](https://docmost.com/) on Kubernetes with PostgreSQL, Redis, local storage, Gateway API, Ingress, External Secrets, and optional S3-compatible object storage.
 
 ## Installation
 
@@ -21,11 +21,15 @@ helm install docmost oci://ghcr.io/helmforgedev/helm/docmost
 ## Features
 
 - **Official Docmost image** based on `docmost/docmost`
-- **PostgreSQL subchart** bundled PostgreSQL for default installs
-- **Redis subchart** bundled Redis for default installs
+- **PostgreSQL subchart** bundled PostgreSQL `1.10.0` for default installs
+- **Redis subchart** bundled Redis `1.6.14` for default installs
 - **External services** support for managed PostgreSQL and Redis
 - **Local or S3 storage** for uploaded files
 - **Ingress support** configurable ingress with TLS
+- **Gateway API HTTPRoute** support for clusters using Gateway API
+- **External Secrets Operator** integration for secret material sourced outside Helm
+- **Dual-stack service controls** through `service.ipFamilyPolicy` and `service.ipFamilies`
+- **Optional backup CronJob** for PostgreSQL dumps uploaded to S3-compatible storage
 - **Values schema** `values.schema.json` validates chart inputs and improves Artifact Hub rendering
 
 ## Important Notes
@@ -34,7 +38,8 @@ helm install docmost oci://ghcr.io/helmforgedev/helm/docmost
 - Docmost requires PostgreSQL and Redis
 - local storage uses `/app/data/storage`
 - S3 mode uses the official `AWS_S3_*` environment variables documented by Docmost
-- Docker Hub exposed `0.71.0` while the official GitHub releases page showed `v0.70.3`, so the chart pins `0.70.3` under the repository release-validation rule
+- the default image tag is `0.80.2`, validated against the published `docmost/docmost:0.80.2` container image
+- this chart intentionally does not keep `Chart.lock`; dependencies are resolved by the repository release workflow
 
 ## Quick Start
 
@@ -91,22 +96,91 @@ storage:
     existingSecret: docmost-s3
 ```
 
+### Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+  hostnames:
+    - docmost.example.com
+```
+
+### Dual-Stack Service
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+### External Secrets
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: database-password
+      remoteRef:
+        key: docmost/database
+        property: password
+```
+
+### PostgreSQL Backup to S3
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://minio.example.internal
+    bucket: backups
+    prefix: docmost
+    existingSecret: docmost-backup-s3
+```
+
 ## Key Values
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Docmost application pods |
+| `image.repository` | `docker.io/docmost/docmost` | Docmost container image repository |
+| `image.tag` | `0.80.2` | Docmost image tag |
 | `docmost.appUrl` | `""` | External Docmost URL |
+| `docmost.appSecret` | `""` | Application secret, auto-generated when empty |
 | `docmost.jwtTokenExpiresIn` | `30d` | JWT expiration |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `postgresql` |
 | `postgresql.enabled` | `true` | Deploy PostgreSQL subchart |
+| `postgresql.auth.database` | `docmost` | PostgreSQL database created by the subchart |
+| `postgresql.auth.username` | `docmost` | PostgreSQL application user created by the subchart |
 | `redis.enabled` | `true` | Deploy Redis subchart |
+| `redis.auth.enabled` | `true` | Enable Redis password authentication |
 | `storage.mode` | `local` | File storage mode: `local` or `s3` |
+| `storage.local.enabled` | `true` | Create or mount local uploads storage |
 | `storage.local.size` | `10Gi` | Local uploads PVC size |
 | `storage.s3.bucket` | `""` | S3 bucket name |
+| `backup.enabled` | `false` | Enable the PostgreSQL backup CronJob |
+| `backup.schedule` | `0 3 * * *` | Backup Cron schedule |
 | `service.port` | `80` | Service port exposed by Kubernetes |
+| `service.ipFamilyPolicy` | `""` | Kubernetes service IP family policy |
+| `service.ipFamilies` | `[]` | Kubernetes service IP families |
 | `ingress.enabled` | `false` | Enable ingress |
 | `ingress.ingressClassName` | `""` | Ingress class (`traefik`, `nginx`, etc.) |
+| `gateway.enabled` | `false` | Render a Gateway API HTTPRoute |
+| `externalSecrets.enabled` | `false` | Render an ExternalSecret for application credentials |
+
+## Operations
+
+The post-install notes include port-forward, application logs, PostgreSQL logs, Redis logs, and upgrade reminders.
+For production upgrades, take a database backup first and verify the secret references used by `database.external.*`,
+`redis.external.*`, `storage.s3.*`, and `backup.s3.*`.
 
 ## More Information
 
@@ -119,7 +193,7 @@ type: chart-readme
 title: Docmost
 description: Installation guide, values reference, and operational overview for the Docmost Helm chart
 
-keywords: docmost, wiki, documentation, postgres, redis, s3, helm
+keywords: docmost, wiki, documentation, postgres, redis, s3, gateway-api, external-secrets, dual-stack, backup, helm
 
 purpose: User-facing chart documentation with install instructions, examples, and values reference
 scope: Chart
@@ -128,5 +202,5 @@ relations:
   - charts/docmost/docs/architecture.md
 path: charts/docmost/README.md
 version: 1.0
-date: 2026-04-01
+date: 2026-05-05
 -->

--- a/charts/docmost/docs/architecture.md
+++ b/charts/docmost/docs/architecture.md
@@ -1,6 +1,7 @@
 # Docmost Architecture Notes
 
-This chart packages Docmost as a single application Deployment backed by PostgreSQL and Redis. It is designed as an alpha chart with clear defaults, simple local validation, and explicit external-service support.
+This chart packages Docmost as a single application Deployment backed by PostgreSQL and Redis. It is designed as an alpha chart
+with clear defaults, local validation, explicit external-service support, and optional S3-compatible object storage.
 
 ## Supported Model
 
@@ -8,6 +9,9 @@ This chart packages Docmost as a single application Deployment backed by Postgre
 - PostgreSQL provided by the bundled subchart or an external PostgreSQL service
 - Redis provided by the bundled subchart or an external Redis service
 - uploaded files stored on a local PVC or an S3-compatible object store
+- HTTP exposed through a ClusterIP Service, optional Ingress, or optional Gateway API HTTPRoute
+- optional External Secrets Operator integration for credentials managed outside Helm
+- optional PostgreSQL backup CronJob that uploads dumps to S3-compatible storage
 
 ## Why Single Replica
 
@@ -40,16 +44,30 @@ You can disable the bundled `postgresql` and `redis` subcharts and point Docmost
 - set `redis.enabled=false`
 - configure `redis.external.*`
 
+## Network Exposure
+
+The chart always renders an internal HTTP Service. Operators can add one of the supported north-south routing options:
+
+- `ingress.enabled=true` for standard Kubernetes Ingress controllers
+- `gateway.enabled=true` for Gateway API HTTPRoute
+- `service.ipFamilyPolicy` and `service.ipFamilies` for explicit single-stack or dual-stack Service behavior
+
+## Database Bootstrap
+
+The bundled PostgreSQL configuration initializes the Docmost database with required privileges and extensions on first boot.
+The bootstrap script uses the configured `postgresql.auth.database` and `postgresql.auth.username` values, so renamed databases
+and users are supported without editing SQL manually.
+
 ## Version Pinning Note
 
-At the time this chart was created, Docker Hub exposed `0.71.0` while the official GitHub releases page showed `v0.70.3` as the latest release. Following repository rules, the chart pins `0.70.3`, the latest version confirmed on both sources used for release validation.
+The chart pins the upstream application image through `image.tag` and `appVersion`. For this release, `docmost/docmost:0.80.2` was verified as available on Docker Hub before updating the chart.
 
 <!-- @AI-METADATA
 type: chart-docs
 title: Docmost - Architecture Notes
 description: Architecture and deployment notes for the Docmost Helm chart
 
-keywords: docmost, architecture, postgresql, redis, s3, local-storage
+keywords: docmost, architecture, postgresql, redis, s3, local-storage, gateway-api, external-secrets, dual-stack, backup
 
 purpose: Explain the supported Docmost deployment model and key architectural constraints
 scope: Chart
@@ -58,5 +76,5 @@ relations:
   - charts/docmost/README.md
 path: charts/docmost/docs/architecture.md
 version: 1.0
-date: 2026-04-01
+date: 2026-05-05
 -->

--- a/charts/docmost/templates/NOTES.txt
+++ b/charts/docmost/templates/NOTES.txt
@@ -1,12 +1,48 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-Docmost has been deployed.
+Docmost {{ .Chart.AppVersion }} has been deployed.
 
-Service:
+Access:
   HTTP: {{ include "docmost.fullname" . }}:{{ .Values.service.port }}
 
 {{- if include "docmost.appUrl" . }}
 Configured application URL:
   {{ include "docmost.appUrl" . }}
 {{- else }}
-Set docmost.appUrl or enable ingress for a stable external URL.
+No external application URL is configured. Set docmost.appUrl or enable ingress for a stable URL.
 {{- end }}
+
+Runtime:
+  Database mode: {{ include "docmost.databaseMode" . }}
+  PostgreSQL subchart: {{ ternary "enabled" "disabled" .Values.postgresql.enabled }}
+  Redis subchart: {{ ternary "enabled" "disabled" .Values.redis.enabled }}
+  Storage mode: {{ .Values.storage.mode }}
+  Backup CronJob: {{ ternary "enabled" "disabled" .Values.backup.enabled }}
+
+Getting started:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "docmost.fullname" . }} 8080:{{ .Values.service.port }}
+  http://127.0.0.1:8080
+
+Configuration:
+  Image: {{ include "docmost.image" . }}
+  App URL: {{ default "not configured" (include "docmost.appUrl" .) }}
+  Service type: {{ .Values.service.type }}
+
+Resources:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl -n {{ .Release.Namespace }} get svc,pvc -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Troubleshooting:
+  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "docmost.fullname" . }} --tail=100
+{{- if .Values.postgresql.enabled }}
+  kubectl -n {{ .Release.Namespace }} logs statefulset/{{ .Release.Name }}-postgresql --tail=100
+{{- end }}
+{{- if .Values.redis.enabled }}
+  kubectl -n {{ .Release.Namespace }} logs statefulset/{{ .Release.Name }}-redis --tail=100
+{{- end }}
+  kubectl -n {{ .Release.Namespace }} get events --sort-by=.lastTimestamp
+
+Upgrade notes:
+  Confirm PostgreSQL and Redis backups before upgrading production releases.
+  If using external services, validate database.external.* and redis.external.* secret references before rollout.
+
+Happy Helmforging :)

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- Docmost container image repository
   repository: docker.io/docmost/docmost
   # -- Docmost image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
-  tag: "0.80.1"
+  tag: "0.80.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -75,11 +75,22 @@ postgresql:
   initdb:
     scripts:
       # -- Bootstrap Docmost database privileges and extensions on first PostgreSQL initialization.
-      10-docmost-bootstrap.sql: |
-        GRANT CREATE ON DATABASE docmost TO docmost;
-        \connect docmost
+      10-docmost-bootstrap.sh: |
+        #!/bin/sh
+        set -e
+
+        if [ -n "${APP_DATABASE}" ] && [ -n "${APP_USERNAME}" ]; then
+          psql --username "${POSTGRES_USER}" --dbname postgres \
+            --set=app_database="${APP_DATABASE}" \
+            --set=app_username="${APP_USERNAME}" <<'SQL'
+        SELECT format('GRANT CREATE ON DATABASE %I TO %I', :'app_database', :'app_username') \gexec
+        SQL
+
+          psql --username "${POSTGRES_USER}" --dbname "${APP_DATABASE}" <<'SQL'
         CREATE EXTENSION IF NOT EXISTS unaccent;
         CREATE EXTENSION IF NOT EXISTS pg_trgm;
+        SQL
+        fi
   standalone:
     persistence:
       # -- Enable persistence for PostgreSQL data


### PR DESCRIPTION
## Summary
- upgrade Docmost image/appVersion from `0.80.1` to `0.80.2`
- update bundled PostgreSQL dependency to `1.10.0` and Redis dependency to `1.6.14`
- remove `Chart.lock` per maintainer policy and narrow `.helmignore` lock patterns
- make PostgreSQL bootstrap dynamic for renamed app database/user values
- refresh README, architecture notes, and `NOTES.txt`

## Upstream evidence
- Tavily checked Docker Hub/GitHub/Docmost sources for `docmost/docmost:0.80.2`
- `docker pull docker.io/docmost/docmost:0.80.2` succeeded
- digest: `sha256:0376e0cd5b82b5f7d221a537e33886c09d1523ca54dbda29c6100106b90ce4e9`

## Local validation
- [x] `helm dependency update charts/docmost` and `helm dependency list charts/docmost`
  - PostgreSQL `1.10.0`: ok
  - Redis `1.6.14`: ok
  - `Chart.lock` intentionally removed after dependency resolution per maintainer policy
- [x] `helm lint --strict charts/docmost`
- [x] `helm unittest charts/docmost` (`6` suites, `25` tests)
- [x] `helm template docmost-test charts/docmost | kubeconform -strict -summary -ignore-missing-schemas`
- [x] all `charts/docmost/ci/*.yaml` rendered and passed strict kubeconform
- [x] `ah lint charts/docmost` (`64` packages, `0` errors)
- [x] `npx --yes markdownlint-cli2 charts/docmost/README.md charts/docmost/docs/architecture.md`
- [x] Kubescape score `79`

## k3d runtime
Context: `k3d-charts-test`

Command:

```bash
helm upgrade --install docmost-208 charts/docmost -n hf-docmost-208 \
  --set postgresql.standalone.persistence.enabled=false \
  --set redis.standalone.persistence.enabled=false \
  --wait --timeout 10m
```

Evidence:
- Docmost, PostgreSQL, and Redis pods Ready `1/1`
- Docmost logs show Redis connection, database connection, no pending migrations after upgrade, and Nest application started
- PostgreSQL logs show `GRANT` and `CREATE EXTENSION` from the Docmost bootstrap script
- Redis logs show ready to accept connections
- namespace events inspected; no runtime errors found

## MCP HelmForge
- `verify_context` edit/runtime: `CLEAR`
- `detect_changed_charts`: `docmost`
- `validate_chart_security_evidence`: `PASS`
- `validate_pr_governance`: `PASS`
- `validate_chart_lock`: expected GR-062 `BLOCKER` because this repository policy for this work is to not keep `Chart.lock`
- `validate_chart_ci_evidence` and `validate_upstream_update` reported evidence parsing blockers despite the local evidence listed above; raw command evidence is included in this PR
- `check_site_sync` timed out after 120s; chart README and architecture docs were updated in this PR

Closes #208