### PR TITLE
chore(countly): upgrade to 25.05.4

### DIFF
--- a/charts/countly/.helmignore
+++ b/charts/countly/.helmignore
@@ -10,6 +10,7 @@ Thumbs.db
 
 # Helm
 .helmignore
+Chart.lock
 
 # Editors / IDE
 .vscode/

--- a/charts/countly/.helmignore
+++ b/charts/countly/.helmignore
@@ -21,7 +21,10 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock
 
 # Logs
 *.log

--- a/charts/countly/Chart.lock
+++ b/charts/countly/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mongodb
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.6.3
-digest: sha256:3c8703926266cc579f3305cb26f0daa5f612e667e3ce8a96c2618a2a31c46ca0
-generated: "2026-04-29T09:48:23.3903428-03:00"

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -4,7 +4,7 @@ name: countly
 description: Countly product analytics platform with MongoDB, event tracking, crash reporting, and plugin system
 type: application
 version: 1.1.9
-appVersion: "25.03.43"
+appVersion: "25.05.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,13 +24,17 @@ sources:
   - https://github.com/Countly/countly-server
 dependencies:
   - name: mongodb
-    version: 1.6.3
+    version: 1.7.10
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 25.03.43 (#196)"
+      description: "upgrade Countly to 25.05.4 (#206)"
+    - kind: changed
+      description: "update MongoDB chart dependency to 1.7.10"
+    - kind: changed
+      description: "refresh README and post-install notes"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/countly/README.md
+++ b/charts/countly/README.md
@@ -1,14 +1,22 @@
 # Countly Helm Chart
 
-Deploy [Countly](https://count.ly) on Kubernetes using the official [countly/countly-server](https://hub.docker.com/r/countly/countly-server) container image. Product analytics platform with event tracking, crash reporting, push notifications, A/B testing, and 41+ plugins.
+Deploy [Countly](https://count.ly) on Kubernetes using the official
+[countly/countly-server](https://hub.docker.com/r/countly/countly-server) container image. Countly is a product analytics
+platform with event tracking, crash reporting, push notifications, A/B testing, and 41+ plugins.
+
+This chart currently deploys `countly/countly-server:25.05.4`.
 
 ## Features
 
 - **MongoDB backend** — uses HelmForge MongoDB subchart or external MongoDB
+- **Bundled MongoDB** — uses HelmForge MongoDB `1.7.10` by default
 - **Dual ports** — API (3001) and Dashboard (6001) on the same container
 - **Plugin system** — configurable plugin list via values
 - **Worker scaling** — configurable API worker count
 - **Ingress support** — TLS with cert-manager
+- **Gateway API and External Secrets** — optional HTTPRoute and secret integration
+- **Dual-stack service controls** — optional `service.ipFamilyPolicy` and `service.ipFamilies`
+- **S3 backups** — optional scheduled MongoDB dumps uploaded to S3-compatible storage
 
 ## Installation
 
@@ -51,20 +59,58 @@ externalMongodb:
   uri: "mongodb://user:password@your-mongodb:27017/countly?authSource=admin"
 ```
 
+## Backup to S3
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://minio.example.internal
+    bucket: countly-backups
+    existingSecret: countly-backup-s3
+```
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+  hostnames:
+    - countly.example.com
+```
+
 ## Key Values
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `image.repository` | `docker.io/countly/countly-server` | Countly container image repository |
+| `image.tag` | `25.05.4` | Countly container image tag |
 | `countly.apiPort` | `3001` | API port |
 | `countly.dashboardPort` | `6001` | Dashboard port |
 | `countly.apiWorkers` | `4` | API worker processes |
 | `countly.plugins` | `""` | Plugins to enable (comma-separated) |
 | `mongodb.enabled` | `true` | Enable bundled MongoDB |
+| `mongodb.auth.enabled` | `true` | Enable MongoDB authentication |
 | `externalMongodb.enabled` | `false` | Use external MongoDB |
 | `externalMongodb.uri` | `""` | External MongoDB URI |
+| `backup.enabled` | `false` | Enable scheduled MongoDB backups |
+| `backup.schedule` | `0 3 * * *` | Backup Cron schedule |
 | `service.port` | `80` | Dashboard service port |
 | `service.apiPort` | `3001` | API service port |
+| `service.ipFamilyPolicy` | `""` | Kubernetes service IP family policy |
+| `service.ipFamilies` | `[]` | Kubernetes service IP families |
 | `ingress.enabled` | `false` | Enable ingress |
+| `gateway.enabled` | `false` | Render a Gateway API HTTPRoute |
+| `externalSecrets.enabled` | `false` | Render an ExternalSecret for MongoDB URI credentials |
+
+## Operations
+
+For production upgrades, take a MongoDB backup first and confirm that Countly plugins are compatible with the target version.
+When using external MongoDB, prefer `externalMongodb.existingSecret` so credentials are not stored in values files.
 
 ## Limitations
 
@@ -81,7 +127,7 @@ type: chart-readme
 title: Countly Helm Chart
 description: README for the Countly product analytics platform Helm chart
 
-keywords: countly, analytics, product-analytics, event-tracking, mongodb
+keywords: countly, analytics, product-analytics, event-tracking, mongodb, gateway-api, external-secrets, backup
 
 purpose: Chart installation, configuration, and usage documentation
 scope: Chart
@@ -90,5 +136,5 @@ relations:
   - charts/countly/values.yaml
 path: charts/countly/README.md
 version: 1.0
-date: 2026-04-01
+date: 2026-05-05
 -->

--- a/charts/countly/templates/NOTES.txt
+++ b/charts/countly/templates/NOTES.txt
@@ -8,6 +8,7 @@ Version:    {{ .Chart.Version }}
 AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
+Image:      {{ include "countly.image" . }}
 
 --------------------------------------------------------------------
   ACCESS INFORMATION
@@ -33,6 +34,11 @@ Port-forward to access Countly locally:
 2. kubectl get pods -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }}
 3. kubectl logs -l app.kubernetes.io/name=countly -n {{ .Release.Namespace }} --all-containers --tail=50 -f
 
+Runtime configuration:
+  MongoDB subchart: {{ ternary "enabled" "disabled" .Values.mongodb.enabled }}
+  External MongoDB: {{ ternary "enabled" "disabled" .Values.externalMongodb.enabled }}
+  Backup CronJob:  {{ ternary "enabled" "disabled" .Values.backup.enabled }}
+
 --------------------------------------------------------------------
   TROUBLESHOOTING
 --------------------------------------------------------------------
@@ -49,6 +55,9 @@ View MongoDB logs:
 {{- if .Values.backup.enabled }}
 Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
 {{- end }}
+
+Upgrade reminder:
+  Take a MongoDB backup before production upgrades and verify enabled Countly plugins after rollout.
 
 --------------------------------------------------------------------
   ADDITIONAL RESOURCES

--- a/charts/countly/tests/deployment_test.yaml
+++ b/charts/countly/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/countly/countly-server:25.03.43"
+          value: "docker.io/countly/countly-server:25.05.4"
 
   - it: should expose both API and dashboard ports
     asserts:

--- a/charts/countly/values.yaml
+++ b/charts/countly/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Countly container image
   repository: docker.io/countly/countly-server
   # -- Image tag
-  tag: "25.03.43"
+  tag: "25.05.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -255,4 +255,3 @@ externalSecrets:
   target:
     creationPolicy: Owner
   data: []
-


### PR DESCRIPTION
## Summary
- upgrade Countly image/appVersion from `25.03.43` to `25.05.4`
- update bundled MongoDB chart dependency from `1.6.3` to `1.7.10`
- remove `Chart.lock` per maintainer policy and narrow `.helmignore` lock patterns
- refresh README and `NOTES.txt`
- update rendered image unit test expectation

## Upstream evidence
- Tavily searched Countly Docker Hub/GitHub/support Countly context for `25.05.4`
- `docker pull docker.io/countly/countly-server:25.05.4` succeeded
- digest: `sha256:e3c238248f99289290e954ecd1898faf4ba74dfb25bf97a88e957e42bd1017c1`

## Local validation
- [x] `helm dependency update charts/countly` and `helm dependency list charts/countly`
  - MongoDB `1.7.10`: ok
  - `Chart.lock` intentionally removed after dependency resolution per maintainer policy
- [x] `helm lint --strict charts/countly`
- [x] `helm unittest charts/countly` (`4` suites, `21` tests)
- [x] `helm template countly-test charts/countly | kubeconform -strict -summary -ignore-missing-schemas`
- [x] all `charts/countly/ci/*.yaml` rendered and passed strict kubeconform
- [x] `ah lint charts/countly` (`64` packages, `0` errors)
- [x] `npx --yes markdownlint-cli2 charts/countly/README.md`
- [x] Kubescape score `75`

## k3d runtime
Context: `k3d-charts-test`

Command:

```bash
helm upgrade --install countly-206 charts/countly -n hf-countly-206 \
  --set mongodb.standalone.persistence.enabled=false \
  --wait --timeout 10m
```

Evidence:
- Countly and MongoDB pods Ready `1/1`
- events show `docker.io/countly/countly-server:25.05.4` pulled successfully
- Countly logs show plugin installation and scheduler startup
- MongoDB logs show successful SCRAM authentication from Countly clients
- namespace events inspected; no runtime errors found

## MCP HelmForge
- `verify_context` edit/runtime: `CLEAR`
- `detect_changed_charts`: `countly`
- `validate_chart_security_evidence`: `PASS`
- `validate_pr_governance`: `PASS`
- `check_pr_validity`: allowed
- `validate_chart_lock`: expected GR-062 `BLOCKER` because this repository policy for this work is to not keep `Chart.lock`

Closes #206