### PR TITLE
feat(mysql)!: harden production deployments

### DIFF
--- a/charts/mysql/DESIGN.md
+++ b/charts/mysql/DESIGN.md
@@ -1,41 +1,155 @@
 # MySQL Chart Design
 
-## v1 Scope
+## Scope
 
-- `architecture: standalone | replication`
-- official `mysql` image
-- standalone or fixed source plus asynchronous read replicas
-- init scripts through generated scripts or an existing ConfigMap
-- optional `mysqld-exporter` and `ServiceMonitor`
-- passwords through generated secrets or `existingSecret`
+The chart provides a pragmatic MySQL deployment for Kubernetes with two explicit modes:
+
+- `standalone`: one writable MySQL instance for development, test, and simple stateful workloads.
+- `replication`: one fixed writable source plus asynchronous read replicas for read scaling and recovery assistance.
+
+The chart uses the official `docker.io/library/mysql` image and keeps database topology management inside Helm templates. It does not attempt to become a MySQL operator.
+
+## Architecture
+
+### Standalone
+
+```text
+Applications
+     |
+     v
++------------------+
+| Service          |
+| <release>-mysql  |
++------------------+
+     |
+     v
++------------------+
+| StatefulSet      |
+| mysql-0          |
+| role=standalone  |
++------------------+
+     |
+     v
++------------------+
+| PVC / data dir   |
++------------------+
+```
+
+Standalone mode is intentionally simple. It is valid for development and for production cases where a single writable instance is an accepted risk and external backup/restore processes are in place.
+
+### Replication
+
+```text
+                 writes
+Applications ----------------+
+                              v
+                    +------------------+
+                    | Source Service   |
+                    +------------------+
+                              |
+                              v
+                    +------------------+
+                    | source-0         |
+                    | read_only=OFF    |
+                    | GTID/binlog ON   |
+                    +------------------+
+                              |
+                  async replication
+                              |
+             +----------------+----------------+
+             v                                 v
+    +------------------+              +------------------+
+    | replica-0        |              | replica-1        |
+    | read_only=ON     |              | read_only=ON     |
+    +------------------+              +------------------+
+             ^                                 ^
+             +---------------+-----------------+
+                             |
+                       reads through
+                    Replicas Service
+```
+
+Replication mode is for read scaling and operational recovery support. It does not provide automatic source election, source promotion, or transparent client failover.
+
+### Secret and TLS Flow
+
+```text
+External secret store
+        |
+        | ExternalSecret (optional)
+        v
+Kubernetes Secrets
+  - auth Secret
+  - TLS Secret
+  - backup Secret
+        |
+        +--> MySQL pods
+        |      |
+        |      +--> optional TLS permission init container
+        |              copies Secret files to emptyDir
+        |              chown 999:999, key chmod 0600
+        |
+        +--> Backup CronJob
+```
+
+The chart supports regular Kubernetes Secrets, existing Secrets, and External Secrets Operator v1. External Secrets are optional and disabled by default.
+
+## Production Controls
+
+Production-ready deployments are possible through values, but the default values are intentionally development-friendly. A production profile should usually enable or configure:
+
+- externally managed auth credentials through `auth.existingSecret` or `externalSecrets.auth.enabled`.
+- TLS with `tls.enabled`, `tls.requireSecureTransport`, and `tls.client.enabled`.
+- `tls.volumePermissions.enabled` when projected TLS private-key modes are incompatible with the non-root MySQL process.
+- persistent volumes sized for the workload and storage class.
+- resource requests/limits or chart resource presets.
+- `networkPolicy.enabled` and, where supported by the CNI, `networkPolicy.egress.enabled`.
+- `serviceAccount.automountServiceAccountToken=false` unless an extension needs Kubernetes API access.
+- metrics and alerts for availability, replica lag, connection count, disk growth, and backup failures.
+- backup and restore runbooks with regular restore tests.
+
+## Design Decisions
+
+- Official image only: the chart does not depend on vendor-specific MySQL images.
+- Fixed source replication: Helm owns a predictable source StatefulSet and replica StatefulSet.
+- No raw secret material in values for production: use existing Kubernetes Secrets or External Secrets.
+- TLS key permission normalization is opt-in because some clusters do not require it and it adds an init container.
+- NetworkPolicy egress is opt-in because egress behavior varies by CNI and cluster policy.
+- `service.ipFamilyPolicy` and `service.ipFamilies` are exposed for dual-stack clusters without changing single-stack defaults.
 
 ## Explicit Non-Goals
 
 - InnoDB Cluster
 - Group Replication
 - automatic source promotion
-- operator-style topology management
+- operator-style topology reconciliation
+- physical backup orchestration
+- point-in-time recovery automation
+- cross-region disaster recovery
 
-## Product Direction
+## Related Documents
 
-- keep the chart smaller than Bitnami
-- document replication as read scaling and operational recovery support
-- expose dedicated endpoints for source and read replicas
-- keep MySQL configuration centered on `my.cnf`, binlog, and replication semantics
+- [README.md](README.md)
+- [docs/production.md](docs/production.md)
+- [docs/replication.md](docs/replication.md)
+- [docs/replication-operations.md](docs/replication-operations.md)
+- [docs/backup-restore.md](docs/backup-restore.md)
+- [docs/secret-rotation.md](docs/secret-rotation.md)
 
 <!-- @AI-METADATA
 type: design
 title: MySQL Chart Design
 description: Design document for MySQL Helm chart with standalone and replication architectures
 
-keywords: mysql, design, architecture, standalone, replication
+keywords: mysql, design, architecture, standalone, replication, production, tls, external-secrets
 
 purpose: Document design decisions and non-goals for the MySQL chart
 scope: Chart Design
 
 relations:
   - charts/mysql/README.md
+  - charts/mysql/docs/production.md
 path: charts/mysql/DESIGN.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-05-06
 -->

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -1,6 +1,7 @@
 # MySQL
 
-MySQL for Kubernetes with explicit `standalone` and `replication` modes, documented bootstrap behavior, optional init scripts, and optional metrics.
+MySQL for Kubernetes with explicit `standalone` and `replication` modes, documented bootstrap behavior, optional init scripts,
+optional metrics, TLS hardening, External Secrets Operator integration, and production-oriented controls.
 
 ## Install
 
@@ -39,6 +40,11 @@ helm install mysql oci://ghcr.io/helmforgedev/helm/mysql -f values.yaml
 - built-in S3 backup CronJob using `mysqldump --all-databases`
 - dedicated metrics Services separated from client traffic
 - topology-specific Services for client traffic, source traffic, and read replicas
+- dual-stack Service options through `service.ipFamilyPolicy` and `service.ipFamilies`
+- External Secrets Operator v1 integration for auth, TLS, and backup Secrets
+- optional NetworkPolicy egress rules
+- optional TLS private-key permission normalization before MySQL startup
+- ServiceAccount token automount control
 
 ## How to choose the architecture
 
@@ -53,6 +59,7 @@ Recommended reading before installation:
 - [Backup and Restore](docs/backup-restore.md)
 - [Secret Rotation](docs/secret-rotation.md)
 - [Configuration Profiles](docs/configuration-profiles.md)
+- [Production Hardening](docs/production.md)
 
 ## Official product references
 
@@ -129,10 +136,14 @@ metrics:
 ### Security
 
 - prefer `auth.existingSecret` in production
+- use `externalSecrets.auth.enabled=true` when credentials are sourced from an external secret store
 - keep client access internal unless there is a strong reason to expose MySQL outside the cluster network
 - enable `tls.enabled=true` with an externally-managed certificate secret when clients must use encrypted TCP connections
+- enable `tls.volumePermissions.enabled=true` when projected TLS Secret modes or ownership are not compatible with the non-root MySQL process
 - use `tls.requireSecureTransport=true` only when your clients and replication flows are ready to use TLS
 - use `networkPolicy.enabled=true` or external platform controls when possible
+- use `networkPolicy.egress.enabled=true` when the CNI enforces egress and explicitly allow DNS, same-namespace MySQL traffic, and any required HTTPS destinations
+- keep `serviceAccount.automountServiceAccountToken=false` unless an added sidecar or extension needs Kubernetes API access
 - if metrics are scraped through Prometheus, pair `networkPolicy.enabled=true` with `networkPolicy.metrics.enabled=true`
 - rotate passwords through secret management workflows instead of editing values inline
 
@@ -168,7 +179,10 @@ metrics:
 ## Production notes
 
 - use `auth.existingSecret` instead of inline passwords
+- alternatively use `externalSecrets.auth.enabled=true` with `external-secrets.io/v1` and a preconfigured `SecretStore` or `ClusterSecretStore`
 - use `tls.existingSecret` for server certificates instead of trying to inline PEM material in values
+- use `externalSecrets.tls.enabled=true` when the TLS Secret should be reconciled by External Secrets Operator
+- use `externalSecrets.backup.enabled=true` for S3 credentials when the backup Secret should be reconciled by External Secrets Operator
 - keep persistence enabled for every stateful topology
 - define node placement rules for `replication`, especially when the cluster spans multiple nodes or zones
 - use the `client` or `source` Service only for writes
@@ -178,6 +192,7 @@ metrics:
 - built-in backup dumps all MySQL databases from the writable source endpoint and uploads the compressed archive to S3-compatible storage
 - treat restore validation, retention policy, and failover as operational workflows that still require explicit runbooks
 - review the architecture guides before promoting `replication` to production
+- start from [examples/production.yaml](examples/production.yaml) for a complete production-oriented values file
 
 Operational documents:
 
@@ -185,14 +200,15 @@ Operational documents:
 - [Backup and Restore](docs/backup-restore.md)
 - [Secret Rotation](docs/secret-rotation.md)
 - [Configuration Profiles](docs/configuration-profiles.md)
+- [Production Hardening](docs/production.md)
 
 ## Main values
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `architecture` | `standalone` or `replication` | `standalone` |
-| `image.repository` | MySQL image repository | `mysql` |
-| `image.tag` | MySQL image tag | `8.4` |
+| `image.repository` | MySQL image repository | `docker.io/library/mysql` |
+| `image.tag` | MySQL image tag | `9.7.0` |
 | `auth.database` | App database created at bootstrap | `app` |
 | `auth.username` | App user created at bootstrap | `app` |
 | `auth.existingSecret` | Existing secret for passwords | `""` |
@@ -203,13 +219,25 @@ Operational documents:
 | `replication.readReplicas.resourcesPreset` | Replica resource preset | `none` |
 | `metrics.resourcesPreset` | Exporter resource preset | `none` |
 | `initdb.existingConfigMap` | External ConfigMap for extra init scripts | `""` |
-| `networkPolicy.enabled` | Enable ingress-only NetworkPolicy | `false` |
+| `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 | `networkPolicy.metrics.enabled` | Allow metrics scraping through NetworkPolicy | `false` |
+| `networkPolicy.egress.enabled` | Add egress policy rules | `false` |
+| `networkPolicy.egress.allowDNS` | Allow DNS egress | `true` |
+| `networkPolicy.egress.allowSameNamespaceMySQL` | Allow same-namespace MySQL egress | `true` |
+| `networkPolicy.egress.allowHTTPS` | Allow TCP/443 egress | `false` |
 | `tls.enabled` | Enable server TLS from an existing secret | `false` |
 | `tls.existingSecret` | Existing secret with CA, certificate, and key | `""` |
 | `tls.requireSecureTransport` | Require TLS for TCP client connections | `false` |
+| `tls.volumePermissions.enabled` | Normalize TLS Secret file ownership and modes before startup | `false` |
 | `tls.client.enabled` | Use TLS for chart-managed TCP clients | `false` |
 | `tls.client.sslMode` | MySQL CLI SSL mode for internal chart-managed clients | `REQUIRED` |
+| `serviceAccount.create` | Create a ServiceAccount | `false` |
+| `serviceAccount.automountServiceAccountToken` | Mount Kubernetes API token into workload pods | `false` |
+| `externalSecrets.enabled` | Render ExternalSecret resources | `false` |
+| `externalSecrets.apiVersion` | ExternalSecret API version | `external-secrets.io/v1` |
+| `externalSecrets.auth.enabled` | Manage the auth Secret through External Secrets Operator | `false` |
+| `externalSecrets.tls.enabled` | Manage the TLS Secret through External Secrets Operator | `false` |
+| `externalSecrets.backup.enabled` | Manage the backup Secret through External Secrets Operator | `false` |
 | `backup.enabled` | Enable built-in S3 backup CronJob | `false` |
 | `backup.schedule` | Backup schedule | `"0 3 * * *"` |
 | `backup.s3.endpoint` | S3-compatible endpoint URL | `""` |
@@ -249,6 +277,8 @@ The `ci/` scenarios validate the main chart behaviors:
 - `resources-preset.yaml`
 - `tls.yaml`
 - `tls-networkpolicy.yaml`
+- `external-secrets.yaml`
+- `production-hardening.yaml`
 
 ## Examples
 
@@ -261,6 +291,8 @@ See `examples/`:
 - `resources-preset.yaml`
 - `tls.yaml`
 - `replication-production.yaml`
+- `production.yaml`
+- `external-secrets.yaml`
 
 ## Important notes
 

--- a/charts/mysql/ci/external-secrets.yaml
+++ b/charts/mysql/ci/external-secrets.yaml
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: ExternalSecrets integration for MySQL credentials.
 #
-# Enables the ExternalSecret template which renders credentials
-# (root-password, user-password, replication-password) via the
-# External Secrets Operator. The auth.existingSecret points to
-# the secret produced by the ExternalSecret.
+# Enables the structured ExternalSecret templates for auth, TLS, and backup
+# credentials via External Secrets Operator v1.
 #
 architecture: standalone
 
@@ -12,24 +10,19 @@ standalone:
   persistence:
     enabled: false
 
-auth:
-  existingSecret: test-mysql-mysql-auth
-
 externalSecrets:
   enabled: true
   secretStoreRef:
     name: local-store
     kind: SecretStore
-  data:
-    - secretKey: mysql-root-password
-      remoteRef:
-        key: mysql/credentials
-        property: root-password
-    - secretKey: mysql-user-password
-      remoteRef:
-        key: mysql/credentials
-        property: user-password
-    - secretKey: mysql-replication-password
-      remoteRef:
-        key: mysql/credentials
-        property: replication-password
+  auth:
+    enabled: true
+    rootPasswordRemoteRef:
+      key: mysql/credentials
+      property: root-password
+    userPasswordRemoteRef:
+      key: mysql/credentials
+      property: user-password
+    replicationPasswordRemoteRef:
+      key: mysql/credentials
+      property: replication-password

--- a/charts/mysql/ci/production-hardening.yaml
+++ b/charts/mysql/ci/production-hardening.yaml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: production-oriented hardening without requiring cloud services.
+
+architecture: replication
+
+auth:
+  rootPassword: root-password
+  password: app-password
+  replicationPassword: replication-password
+
+tls:
+  enabled: true
+  existingSecret: mysql-tls
+  requireSecureTransport: true
+  volumePermissions:
+    enabled: true
+  client:
+    enabled: true
+    sslMode: REQUIRED
+
+replication:
+  source:
+    resourcesPreset: small
+    persistence:
+      enabled: false
+  readReplicas:
+    replicaCount: 1
+    resourcesPreset: small
+    persistence:
+      enabled: false
+    probes:
+      requireRunningReplication: true
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceMySQL: true
+    allowHTTPS: true
+
+metrics:
+  enabled: true
+  resourcesPreset: small
+
+backup:
+  enabled: true
+  suspend: true
+  s3:
+    endpoint: https://s3.example.com
+    bucket: mysql-backups
+    existingSecret: mysql-backup

--- a/charts/mysql/docs/backup-restore.md
+++ b/charts/mysql/docs/backup-restore.md
@@ -22,9 +22,13 @@ Use the built-in S3 backup for regular logical dumps, and add external tooling w
 - physical backup workflows
 - centralized retention enforcement across many database instances
 
+Backup object-storage credentials can come from `backup.s3.existingSecret`, inline values for non-production testing, or
+`externalSecrets.backup.enabled=true` when External Secrets Operator manages the Kubernetes Secret.
+
 ## Minimum production practices
 
 - keep regular full backups
+- keep backup credentials in a Kubernetes Secret or External Secrets Operator source, not inline values
 - keep bucket retention and object lifecycle aligned with recovery goals
 - keep a binary log retention policy aligned with recovery goals
 - test restores periodically

--- a/charts/mysql/docs/production.md
+++ b/charts/mysql/docs/production.md
@@ -1,0 +1,75 @@
+# Production Hardening
+
+The default values are intentionally useful for development. For production, start from `examples/production.yaml` and tune the
+settings for your storage, networking, secret management, and operational requirements.
+
+## Baseline production profile
+
+Use these controls together:
+
+- `architecture: replication` when read scaling is required.
+- persistent storage enabled for the source and replicas.
+- `auth.existingSecret` or `externalSecrets.auth.enabled=true` for credentials.
+- `tls.enabled=true`, `tls.requireSecureTransport=true`, and `tls.client.enabled=true` for encrypted client and internal chart traffic.
+- `tls.volumePermissions.enabled=true` when the TLS private key must be copied to a writable `emptyDir` and set to mode `0600` for the non-root MySQL process.
+- `serviceAccount.automountServiceAccountToken=false` unless a sidecar explicitly needs Kubernetes API access.
+- `networkPolicy.enabled=true`; add `networkPolicy.egress.enabled=true` when your CNI enforces egress.
+- metrics, alerts, backup scheduling, and restore tests.
+
+## External Secrets Operator
+
+The chart renders `external-secrets.io/v1` resources when `externalSecrets.enabled=true`.
+
+Structured blocks are available for separate secret lifecycles:
+
+- `externalSecrets.auth` creates the MySQL auth Secret.
+- `externalSecrets.tls` creates the TLS Secret used by MySQL.
+- `externalSecrets.backup` creates the object-storage credentials Secret.
+
+The `SecretStore` or `ClusterSecretStore` must exist before install. The chart does not install External Secrets Operator or provider credentials.
+
+## TLS
+
+TLS requires a Kubernetes Secret with:
+
+- `ca.crt`
+- `tls.crt`
+- `tls.key`
+
+Set `tls.requireSecureTransport=true` only after clients and replication bootstrap paths are configured for TLS. If MySQL rejects the projected private key due to permissions, enable `tls.volumePermissions.enabled=true`.
+
+## NetworkPolicy
+
+`networkPolicy.enabled=true` restricts ingress to the MySQL port and optional metrics port. `networkPolicy.egress.enabled=true` adds explicit egress rules for:
+
+- DNS to kube-system.
+- MySQL traffic to pods in the same namespace.
+- optional HTTPS for external services.
+- custom `extraTo` rules for environment-specific destinations.
+
+Exact enforcement depends on the cluster CNI.
+
+## Backup and Restore
+
+The built-in backup is a logical `mysqldump --all-databases` to S3-compatible storage. It does not replace physical backup, binlog archival, or point-in-time recovery tooling for strict recovery objectives.
+
+Validate restores regularly and treat failover, promotion, and rollback as documented operational runbooks.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: MySQL - Production Hardening
+description: Production hardening guidance for the MySQL Helm chart
+
+keywords: mysql, production, tls, networkpolicy, external-secrets, backup
+
+purpose: Explain production-oriented values and operational expectations
+scope: Chart Architecture
+
+relations:
+  - charts/mysql/README.md
+  - charts/mysql/DESIGN.md
+  - charts/mysql/examples/production.yaml
+path: charts/mysql/docs/production.md
+version: 1.0
+date: 2026-05-06
+-->

--- a/charts/mysql/docs/secret-rotation.md
+++ b/charts/mysql/docs/secret-rotation.md
@@ -2,11 +2,12 @@
 
 ## Scope
 
-This chart supports password and TLS material through existing Kubernetes secrets. Rotation remains an operational workflow outside the chart.
+This chart supports password and TLS material through existing Kubernetes secrets or External Secrets Operator v1. Rotation remains an operational workflow outside the chart.
 
 ## Password rotation
 
 - update the secret referenced by `auth.existingSecret`
+- or rotate the remote values referenced by `externalSecrets.auth` and wait for External Secrets Operator reconciliation
 - restart MySQL workloads in a controlled maintenance window
 - verify application connectivity after the rollout
 - if replication is enabled, rotate replication credentials with care and confirm replicas can reconnect to the source
@@ -14,6 +15,7 @@ This chart supports password and TLS material through existing Kubernetes secret
 ## TLS rotation
 
 - update the secret referenced by `tls.existingSecret`
+- or rotate the remote values referenced by `externalSecrets.tls` and wait for External Secrets Operator reconciliation
 - roll the MySQL pods so the new certificates are mounted and loaded
 - validate client connectivity and replication health after the rollout
 - if `tls.requireSecureTransport=true`, confirm internal clients and application clients are ready before restarting traffic
@@ -24,6 +26,7 @@ This chart supports password and TLS material through existing Kubernetes secret
 - validate one environment at a time
 - document rollback steps before rotation
 - for production, use an external secret manager or an automated secret delivery workflow
+- when `tls.volumePermissions.enabled=true`, the rollout recreates normalized TLS files from the reconciled Secret before mysqld starts
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/mysql/examples/external-secrets.yaml
+++ b/charts/mysql/examples/external-secrets.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# External Secrets Operator v1 example. The SecretStore/ClusterSecretStore must
+# already exist and be allowed to read the referenced remote keys.
+
+auth:
+  database: app
+  username: app
+
+tls:
+  enabled: true
+  requireSecureTransport: true
+  volumePermissions:
+    enabled: true
+  client:
+    enabled: true
+    sslMode: REQUIRED
+
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-mysql-backups
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: production-secrets
+    kind: ClusterSecretStore
+  auth:
+    enabled: true
+    rootPasswordRemoteRef:
+      key: prod/mysql/auth
+      property: root-password
+    userPasswordRemoteRef:
+      key: prod/mysql/auth
+      property: user-password
+    replicationPasswordRemoteRef:
+      key: prod/mysql/auth
+      property: replication-password
+  tls:
+    enabled: true
+    caRemoteRef:
+      key: prod/mysql/tls
+      property: ca.crt
+    certRemoteRef:
+      key: prod/mysql/tls
+      property: tls.crt
+    keyRemoteRef:
+      key: prod/mysql/tls
+      property: tls.key
+  backup:
+    enabled: true
+    accessKeyRemoteRef:
+      key: prod/mysql/backup
+      property: access-key
+    secretKeyRemoteRef:
+      key: prod/mysql/backup
+      property: secret-key

--- a/charts/mysql/examples/production.yaml
+++ b/charts/mysql/examples/production.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented example. Tune storage classes, sizes, resource presets,
+# NetworkPolicy peers, and backup destinations for your environment.
+
+architecture: replication
+
+auth:
+  existingSecret: mysql-auth
+
+tls:
+  enabled: true
+  existingSecret: mysql-tls
+  requireSecureTransport: true
+  volumePermissions:
+    enabled: true
+  client:
+    enabled: true
+    sslMode: REQUIRED
+
+config:
+  preset: oltp
+
+replication:
+  source:
+    resourcesPreset: medium
+    persistence:
+      enabled: true
+      storageClass: fast-ssd
+      size: 100Gi
+  readReplicas:
+    replicaCount: 2
+    resourcesPreset: medium
+    persistence:
+      enabled: true
+      storageClass: fast-ssd
+      size: 100Gi
+    probes:
+      requireRunningReplication: true
+  binlog:
+    retentionDays: 7
+    syncBinlog: 1
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: false
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: applications
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceMySQL: true
+    allowHTTPS: true
+
+metrics:
+  enabled: true
+  resourcesPreset: small
+  serviceMonitor:
+    enabled: true
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-mysql-backups
+    prefix: mysql/prod
+    existingSecret: mysql-backup

--- a/charts/mysql/templates/NOTES.txt
+++ b/charts/mysql/templates/NOTES.txt
@@ -17,6 +17,24 @@ Root password:
 TLS secret:
 
   {{ include "mysql.tlsSecretName" . }}
+{{- if .Values.tls.volumePermissions.enabled }}
+
+TLS volume permissions:
+
+  Enabled. The chart copies TLS files to an emptyDir, owns them as {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}, and sets the private key mode to 0600 before mysqld starts.
+{{- end }}
+{{- end }}
+{{- if include "mysql.externalSecretsEnabled" . }}
+
+External Secrets:
+
+  ExternalSecret resources are enabled. Confirm the External Secrets Operator and {{ .Values.externalSecrets.secretStoreRef.kind }} `{{ .Values.externalSecrets.secretStoreRef.name }}` are ready before expecting reconciled Kubernetes Secrets.
+{{- end }}
+{{- if .Values.networkPolicy.enabled }}
+
+NetworkPolicy:
+
+  Enabled for MySQL pods. Review allowed ingress peers and{{ if .Values.networkPolicy.egress.enabled }} configured egress rules{{ else }} default egress behavior in your CNI{{ end }} before exposing workloads.
 {{- end }}
 
 Connection examples:
@@ -45,6 +63,7 @@ Important:
 
 - replication mode provides one fixed source and asynchronous read replicas
 - the chart does not implement automatic source promotion or operator-style HA
+- default values are suitable for development; production installs should provide external credentials, persistence, TLS, NetworkPolicy, resources, backups, and operational runbooks
 {{- with .Values.service.ipFamilyPolicy }}
 - Service IP family policy: `{{ . }}`{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
 {{- end }}

--- a/charts/mysql/templates/_helpers.tpl
+++ b/charts/mysql/templates/_helpers.tpl
@@ -312,6 +312,9 @@ true
 {{- end -}}
 
 {{- define "mysql.externalSecretDataItem" -}}
+{{- if or (not .remoteRef) (eq (len .remoteRef) 0) -}}
+{{- fail (printf "%s is required and must contain at least one remoteRef field" .remoteRefName) -}}
+{{- end -}}
 - secretKey: {{ .secretKey }}
   remoteRef:
     {{- toYaml .remoteRef | nindent 4 }}

--- a/charts/mysql/templates/_helpers.tpl
+++ b/charts/mysql/templates/_helpers.tpl
@@ -51,13 +51,21 @@ app.kubernetes.io/role: {{ .role }}
 {{- define "mysql.secretName" -}}
 {{- if .Values.auth.existingSecret -}}
 {{- .Values.auth.existingSecret -}}
+{{- else if include "mysql.authSecretManagedByExternalSecret" . -}}
+{{- default (printf "%s-auth" (include "mysql.fullname" .)) .Values.externalSecrets.auth.targetName -}}
 {{- else -}}
 {{- printf "%s-auth" (include "mysql.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "mysql.tlsSecretName" -}}
-{{- required "tls.existingSecret is required when tls.enabled=true" .Values.tls.existingSecret -}}
+{{- if .Values.tls.existingSecret -}}
+{{- .Values.tls.existingSecret -}}
+{{- else if include "mysql.tlsSecretManagedByExternalSecret" . -}}
+{{- default (printf "%s-tls" (include "mysql.fullname" .)) .Values.externalSecrets.tls.targetName -}}
+{{- else -}}
+{{- required "tls.existingSecret or externalSecrets.tls.enabled is required when tls.enabled=true" .Values.tls.existingSecret -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "mysql.configMapName" -}}
@@ -122,7 +130,7 @@ app.kubernetes.io/role: {{ .role }}
 
 {{- define "mysql.rootPassword" -}}
 {{- $secretName := include "mysql.secretName" . -}}
-{{- if .Values.auth.existingSecret -}}
+{{- if or .Values.auth.existingSecret (include "mysql.authSecretManagedByExternalSecret" .) -}}
 {{- "" -}}
 {{- else if .Values.auth.rootPassword -}}
 {{- .Values.auth.rootPassword -}}
@@ -138,7 +146,7 @@ app.kubernetes.io/role: {{ .role }}
 
 {{- define "mysql.userPassword" -}}
 {{- $secretName := include "mysql.secretName" . -}}
-{{- if .Values.auth.existingSecret -}}
+{{- if or .Values.auth.existingSecret (include "mysql.authSecretManagedByExternalSecret" .) -}}
 {{- "" -}}
 {{- else if .Values.auth.password -}}
 {{- .Values.auth.password -}}
@@ -154,7 +162,7 @@ app.kubernetes.io/role: {{ .role }}
 
 {{- define "mysql.replicationPassword" -}}
 {{- $secretName := include "mysql.secretName" . -}}
-{{- if .Values.auth.existingSecret -}}
+{{- if or .Values.auth.existingSecret (include "mysql.authSecretManagedByExternalSecret" .) -}}
 {{- "" -}}
 {{- else if .Values.auth.replicationPassword -}}
 {{- .Values.auth.replicationPassword -}}
@@ -197,13 +205,20 @@ MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -h 127.0.0.1 -P {{ .Values.service.port
 {{- end -}}
 
 {{- define "mysql.metricsEnv" -}}
-- name: DATA_SOURCE_NAME
-  value: root:$(MYSQL_ROOT_PASSWORD)@(127.0.0.1:{{ .Values.service.port }})/{{ if or .Values.tls.client.enabled .Values.tls.requireSecureTransport }}?tls=skip-verify{{ end }}
-- name: MYSQL_ROOT_PASSWORD
+- name: MYSQLD_EXPORTER_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "mysql.secretName" . }}
       key: {{ .Values.auth.existingSecretRootPasswordKey }}
+{{- end -}}
+
+{{- define "mysql.metricsArgs" -}}
+- --web.listen-address=:{{ .Values.service.metricsPort }}
+- --mysqld.address=127.0.0.1:{{ .Values.service.port }}
+- --mysqld.username=root
+{{- if or .Values.tls.client.enabled .Values.tls.requireSecureTransport }}
+- --tls.insecure-skip-verify
+{{- end }}
 {{- end -}}
 
 {{- define "mysql.tlsClientEnabled" -}}
@@ -223,6 +238,8 @@ MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -h 127.0.0.1 -P {{ .Values.service.port
 {{- define "mysql.backupSecretName" -}}
 {{- if .Values.backup.s3.existingSecret -}}
 {{- .Values.backup.s3.existingSecret -}}
+{{- else if include "mysql.backupSecretManagedByExternalSecret" . -}}
+{{- default (printf "%s-backup" (include "mysql.fullname" .)) .Values.externalSecrets.backup.targetName -}}
 {{- else -}}
 {{- printf "%s-backup" (include "mysql.fullname" .) -}}
 {{- end -}}
@@ -236,7 +253,7 @@ MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -h 127.0.0.1 -P {{ .Values.service.port
   {{- if not .Values.backup.s3.bucket -}}
     {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
   {{- end -}}
-  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (not (include "mysql.backupSecretManagedByExternalSecret" .)) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
     {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
   {{- end -}}
 true
@@ -249,6 +266,112 @@ true
 
 {{- define "mysql.backupTlsVolumeEnabled" -}}
 {{- if include "mysql.tlsClientEnabled" . -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mysql.externalSecretsEnabled" -}}
+{{- if .Values.externalSecrets.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mysql.legacyExternalSecretEnabled" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.data (not .Values.externalSecrets.auth.enabled) (not .Values.externalSecrets.tls.enabled) (not .Values.externalSecrets.backup.enabled) -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mysql.authSecretManagedByExternalSecret" -}}
+{{- if and .Values.externalSecrets.enabled (or .Values.externalSecrets.auth.enabled (include "mysql.legacyExternalSecretEnabled" .)) -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mysql.tlsSecretManagedByExternalSecret" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.tls.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mysql.backupSecretManagedByExternalSecret" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.backup.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "mysql.validateExternalSecrets" -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if ne .Values.externalSecrets.apiVersion "external-secrets.io/v1" -}}
+    {{- fail "externalSecrets.apiVersion must be external-secrets.io/v1" -}}
+  {{- end -}}
+  {{- if not .Values.externalSecrets.secretStoreRef.name -}}
+    {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+  {{- end -}}
+  {{- if and (include "mysql.legacyExternalSecretEnabled" .) (not .Values.auth.existingSecret) -}}
+    {{- fail "legacy externalSecrets.data requires auth.existingSecret to prevent credential drift; prefer externalSecrets.auth.enabled for chart-owned target names" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.auth.enabled .Values.auth.existingSecret -}}
+    {{- fail "externalSecrets.auth.enabled cannot be combined with auth.existingSecret; set externalSecrets.auth.targetName instead" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.tls.enabled .Values.tls.existingSecret -}}
+    {{- fail "externalSecrets.tls.enabled cannot be combined with tls.existingSecret; set externalSecrets.tls.targetName instead" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.backup.enabled .Values.backup.s3.existingSecret -}}
+    {{- fail "externalSecrets.backup.enabled cannot be combined with backup.s3.existingSecret; set externalSecrets.backup.targetName instead" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mysql.externalSecretDataItem" -}}
+- secretKey: {{ .secretKey }}
+  remoteRef:
+    {{- toYaml .remoteRef | nindent 4 }}
+{{- end -}}
+
+{{- define "mysql.tlsVolumeMountName" -}}
+{{- if .Values.tls.volumePermissions.enabled -}}tls-workdir{{- else -}}tls{{- end -}}
+{{- end -}}
+
+{{- define "mysql.tlsVolumeMount" -}}
+- name: {{ include "mysql.tlsVolumeMountName" . }}
+  mountPath: /tls
+  readOnly: true
+{{- end -}}
+
+{{- define "mysql.tlsVolumePermissionsInitContainer" -}}
+{{- if and .Values.tls.enabled .Values.tls.volumePermissions.enabled }}
+- name: tls-volume-permissions
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  command:
+    - sh
+    - -ec
+    - |
+      cp "/tls-secret/{{ .Values.tls.caFilename }}" "/tls-workdir/{{ .Values.tls.caFilename }}"
+      cp "/tls-secret/{{ .Values.tls.certFilename }}" "/tls-workdir/{{ .Values.tls.certFilename }}"
+      cp "/tls-secret/{{ .Values.tls.keyFilename }}" "/tls-workdir/{{ .Values.tls.keyFilename }}"
+      chmod 0644 "/tls-workdir/{{ .Values.tls.caFilename }}" "/tls-workdir/{{ .Values.tls.certFilename }}"
+      chmod 0600 "/tls-workdir/{{ .Values.tls.keyFilename }}"
+      chown {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }} /tls-workdir/*
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - CHOWN
+  volumeMounts:
+    - name: tls
+      mountPath: /tls-secret
+      readOnly: true
+    - name: tls-workdir
+      mountPath: /tls-workdir
+{{- end -}}
+{{- end -}}
+
+{{- define "mysql.tlsVolumes" -}}
+{{- if .Values.tls.enabled }}
+- name: tls
+  secret:
+    secretName: {{ include "mysql.tlsSecretName" . }}
+{{- if .Values.tls.volumePermissions.enabled }}
+- name: tls-workdir
+  emptyDir: {}
+{{- end }}
+{{- end -}}
 {{- end -}}
 
 {{- define "mysql.replicationTlsClause" -}}
@@ -364,6 +487,7 @@ imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 serviceAccountName: {{ include "mysql.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}

--- a/charts/mysql/templates/backup-cronjob.yaml
+++ b/charts/mysql/templates/backup-cronjob.yaml
@@ -22,6 +22,7 @@ spec:
         spec:
           restartPolicy: Never
           serviceAccountName: {{ include "mysql.serviceAccountName" . }}
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/mysql/templates/externalsecret.yaml
+++ b/charts/mysql/templates/externalsecret.yaml
@@ -36,9 +36,9 @@ spec:
     name: {{ include "mysql.secretName" . }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
   data:
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretRootPasswordKey "remoteRef" (required "externalSecrets.auth.rootPasswordRemoteRef is required" .Values.externalSecrets.auth.rootPasswordRemoteRef)) | nindent 4 }}
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretUserPasswordKey "remoteRef" (required "externalSecrets.auth.userPasswordRemoteRef is required" .Values.externalSecrets.auth.userPasswordRemoteRef)) | nindent 4 }}
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretReplicationPasswordKey "remoteRef" (required "externalSecrets.auth.replicationPasswordRemoteRef is required" .Values.externalSecrets.auth.replicationPasswordRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretRootPasswordKey "remoteRefName" "externalSecrets.auth.rootPasswordRemoteRef" "remoteRef" .Values.externalSecrets.auth.rootPasswordRemoteRef) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretUserPasswordKey "remoteRefName" "externalSecrets.auth.userPasswordRemoteRef" "remoteRef" .Values.externalSecrets.auth.userPasswordRemoteRef) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretReplicationPasswordKey "remoteRefName" "externalSecrets.auth.replicationPasswordRemoteRef" "remoteRef" .Values.externalSecrets.auth.replicationPasswordRemoteRef) | nindent 4 }}
 {{- end }}
 {{- if .Values.externalSecrets.tls.enabled }}
 ---
@@ -57,9 +57,9 @@ spec:
     name: {{ include "mysql.tlsSecretName" . }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
   data:
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.caFilename "remoteRef" (required "externalSecrets.tls.caRemoteRef is required" .Values.externalSecrets.tls.caRemoteRef)) | nindent 4 }}
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.certFilename "remoteRef" (required "externalSecrets.tls.certRemoteRef is required" .Values.externalSecrets.tls.certRemoteRef)) | nindent 4 }}
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.keyFilename "remoteRef" (required "externalSecrets.tls.keyRemoteRef is required" .Values.externalSecrets.tls.keyRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.caFilename "remoteRefName" "externalSecrets.tls.caRemoteRef" "remoteRef" .Values.externalSecrets.tls.caRemoteRef) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.certFilename "remoteRefName" "externalSecrets.tls.certRemoteRef" "remoteRef" .Values.externalSecrets.tls.certRemoteRef) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.keyFilename "remoteRefName" "externalSecrets.tls.keyRemoteRef" "remoteRef" .Values.externalSecrets.tls.keyRemoteRef) | nindent 4 }}
 {{- end }}
 {{- if .Values.externalSecrets.backup.enabled }}
 ---
@@ -78,7 +78,7 @@ spec:
     name: {{ include "mysql.backupSecretName" . }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
   data:
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretAccessKeyKey "remoteRef" (required "externalSecrets.backup.accessKeyRemoteRef is required" .Values.externalSecrets.backup.accessKeyRemoteRef)) | nindent 4 }}
-    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretSecretKeyKey "remoteRef" (required "externalSecrets.backup.secretKeyRemoteRef is required" .Values.externalSecrets.backup.secretKeyRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretAccessKeyKey "remoteRefName" "externalSecrets.backup.accessKeyRemoteRef" "remoteRef" .Values.externalSecrets.backup.accessKeyRemoteRef) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretSecretKeyKey "remoteRefName" "externalSecrets.backup.secretKeyRemoteRef" "remoteRef" .Values.externalSecrets.backup.secretKeyRemoteRef) | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/mysql/templates/externalsecret.yaml
+++ b/charts/mysql/templates/externalsecret.yaml
@@ -1,15 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "mysql.validateExternalSecrets" . }}
 {{- if .Values.externalSecrets.enabled }}
-{{- /*
-  Guard: when externalSecrets.enabled=true the chart-managed Secret (secret.yaml)
-  is still rendered unless auth.existingSecret is set. Without this guard both
-  resources target the same name via mysql.secretName, creating two writers for
-  the credentials. ESO reconciling after MySQL init overwrites bootstrapped
-  passwords, causing auth/probe failures after pod restarts.
-*/}}
-{{- if not .Values.auth.existingSecret }}
-  {{- fail "externalSecrets.enabled requires auth.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
-{{- end }}
+{{- if include "mysql.legacyExternalSecretEnabled" . }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
@@ -26,4 +18,67 @@ spec:
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
   data:
     {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.auth.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "mysql.secretName" . }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "mysql.secretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretRootPasswordKey "remoteRef" (required "externalSecrets.auth.rootPasswordRemoteRef is required" .Values.externalSecrets.auth.rootPasswordRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretUserPasswordKey "remoteRef" (required "externalSecrets.auth.userPasswordRemoteRef is required" .Values.externalSecrets.auth.userPasswordRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretReplicationPasswordKey "remoteRef" (required "externalSecrets.auth.replicationPasswordRemoteRef is required" .Values.externalSecrets.auth.replicationPasswordRemoteRef)) | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.tls.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "mysql.tlsSecretName" . }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "mysql.tlsSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.caFilename "remoteRef" (required "externalSecrets.tls.caRemoteRef is required" .Values.externalSecrets.tls.caRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.certFilename "remoteRef" (required "externalSecrets.tls.certRemoteRef is required" .Values.externalSecrets.tls.certRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.tls.keyFilename "remoteRef" (required "externalSecrets.tls.keyRemoteRef is required" .Values.externalSecrets.tls.keyRemoteRef)) | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.backup.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "mysql.backupSecretName" . }}
+  labels:
+    {{- include "mysql.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "mysql.backupSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretAccessKeyKey "remoteRef" (required "externalSecrets.backup.accessKeyRemoteRef is required" .Values.externalSecrets.backup.accessKeyRemoteRef)) | nindent 4 }}
+    {{- include "mysql.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretSecretKeyKey "remoteRef" (required "externalSecrets.backup.secretKeyRemoteRef is required" .Values.externalSecrets.backup.secretKeyRemoteRef)) | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/mysql/templates/networkpolicy.yaml
+++ b/charts/mysql/templates/networkpolicy.yaml
@@ -12,6 +12,9 @@ spec:
       {{- include "mysql.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
   ingress:
     - from:
         {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
@@ -35,4 +38,36 @@ spec:
         - protocol: TCP
           port: {{ .Values.service.metricsPort }}
     {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSameNamespaceMySQL }}
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/mysql/templates/networkpolicy.yaml
+++ b/charts/mysql/templates/networkpolicy.yaml
@@ -67,7 +67,8 @@ spec:
           port: 443
     {{- end }}
     {{- with .Values.networkPolicy.egress.extraTo }}
-    {{- toYaml . | nindent 4 }}
+    - to:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mysql/templates/secret.yaml
+++ b/charts/mysql/templates/secret.yaml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-{{- if not .Values.auth.existingSecret }}
+{{- include "mysql.validateExternalSecrets" . }}
+{{- if not (or .Values.auth.existingSecret (include "mysql.authSecretManagedByExternalSecret" .)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,7 +13,7 @@ data:
   {{ .Values.auth.existingSecretUserPasswordKey }}: {{ include "mysql.userPassword" . | b64enc | quote }}
   {{ .Values.auth.existingSecretReplicationPasswordKey }}: {{ include "mysql.replicationPassword" . | b64enc | quote }}
 {{- end }}
-{{- if and (include "mysql.backupEnabled" .) (not .Values.backup.s3.existingSecret) }}
+{{- if and (include "mysql.backupEnabled" .) (not .Values.backup.s3.existingSecret) (not (include "mysql.backupSecretManagedByExternalSecret" .)) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/mysql/templates/statefulset-replicas.yaml
+++ b/charts/mysql/templates/statefulset-replicas.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
       {{- include "mysql.podSpecCommon" . | nindent 6 }}
       initContainers:
+        {{- include "mysql.tlsVolumePermissionsInitContainer" . | nindent 8 }}
         - name: clone-source
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -61,7 +62,7 @@ spec:
               done
 
               mysqld --initialize-insecure --user=mysql --datadir="${DATA_DIR}"
-              mysqld --user=mysql --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mysql.pid --skip-networking &
+              mysqld --user=mysql --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mysql.pid --skip-networking --read-only=OFF --super-read-only=OFF &
 
               until mysqladmin --socket=/tmp/mysql.sock ping --silent; do
                 sleep 2
@@ -69,6 +70,8 @@ spec:
 
               mysql --socket=/tmp/mysql.sock -uroot <<EOSQL
               ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+              CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
               FLUSH PRIVILEGES;
               EOSQL
 
@@ -87,16 +90,13 @@ spec:
 
               MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql --socket=/tmp/mysql.sock -uroot < /tmp/source.sql
 
-              MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql --socket=/tmp/mysql.sock -uroot <<EOSQL
-              CHANGE REPLICATION SOURCE TO
-                SOURCE_HOST='{{ include "mysql.sourceServiceName" . }}',
-                SOURCE_PORT={{ .Values.service.port }},
-                SOURCE_USER='{{ .Values.auth.replicationUsername }}',
-                SOURCE_PASSWORD='${REPLICATION_PASSWORD}',
-                {{ include "mysql.replicationTlsClause" . | nindent 16 }}
-                SOURCE_AUTO_POSITION=1,
-                GET_SOURCE_PUBLIC_KEY=1;
-              START REPLICA;
+              mysql --socket=/tmp/mysql.sock -uroot <<EOSQL
+              SET GLOBAL super_read_only = OFF;
+              SET GLOBAL read_only = OFF;
+              ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+              CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+              FLUSH PRIVILEGES;
               EOSQL
 
               mysqladmin --socket=/tmp/mysql.sock -uroot -p"${MYSQL_ROOT_PASSWORD}" shutdown
@@ -121,9 +121,7 @@ spec:
             - name: mysql-conf
               mountPath: /etc/mysql/conf.d
             {{- if .Values.tls.enabled }}
-            - name: tls
-              mountPath: /tls
-              readOnly: true
+            {{- include "mysql.tlsVolumeMount" . | nindent 12 }}
             {{- end }}
       containers:
         - name: mysql
@@ -157,6 +155,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "mysql.secretName" . }}
                   key: {{ .Values.auth.existingSecretRootPasswordKey }}
+            - name: REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mysql.secretName" . }}
+                  key: {{ .Values.auth.existingSecretReplicationPasswordKey }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -198,6 +201,34 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - sh
+                  - -ec
+                  - |
+                    until MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysqladmin ping -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --silent; do
+                      sleep 2
+                    done
+                    configured="$(MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -h 127.0.0.1 -P {{ .Values.service.port }} -uroot -Nse "SELECT COUNT(*) FROM performance_schema.replication_connection_configuration WHERE CHANNEL_NAME = ''")"
+                    if [ "${configured}" = "0" ]; then
+                      MYSQL_PWD="${MYSQL_ROOT_PASSWORD}" mysql -h 127.0.0.1 -P {{ .Values.service.port }} -uroot <<EOSQL
+                      SET GLOBAL super_read_only = OFF;
+                      SET GLOBAL read_only = OFF;
+                      CHANGE REPLICATION SOURCE TO
+                        SOURCE_HOST='{{ include "mysql.sourceServiceName" . }}',
+                        SOURCE_PORT={{ .Values.service.port }},
+                        SOURCE_USER='{{ .Values.auth.replicationUsername }}',
+                        SOURCE_PASSWORD='${REPLICATION_PASSWORD}',
+                        {{ include "mysql.replicationTlsClause" . | nindent 24 }}
+                        SOURCE_AUTO_POSITION=1,
+                        GET_SOURCE_PUBLIC_KEY=1;
+                      START REPLICA;
+                      SET GLOBAL read_only = ON;
+                      SET GLOBAL super_read_only = ON;
+                    EOSQL
+                    fi
           resources:
             {{- if .Values.replication.readReplicas.resources }}
             {{- toYaml .Values.replication.readReplicas.resources | nindent 12 }}
@@ -212,9 +243,7 @@ spec:
             - name: mysql-conf
               mountPath: /etc/mysql/conf.d
             {{- if .Values.tls.enabled }}
-            - name: tls
-              mountPath: /tls
-              readOnly: true
+            {{- include "mysql.tlsVolumeMount" . | nindent 12 }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -224,7 +253,7 @@ spec:
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           args:
-            - --web.listen-address=:{{ .Values.service.metricsPort }}
+            {{- include "mysql.metricsArgs" . | nindent 12 }}
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
@@ -246,9 +275,7 @@ spec:
           configMap:
             name: {{ include "mysql.configMapName" . }}
         {{- if .Values.tls.enabled }}
-        - name: tls
-          secret:
-            secretName: {{ include "mysql.tlsSecretName" . }}
+        {{- include "mysql.tlsVolumes" . | nindent 8 }}
         {{- end }}
         {{- if not .Values.replication.readReplicas.persistence.enabled }}
         - name: data

--- a/charts/mysql/templates/statefulset-source.yaml
+++ b/charts/mysql/templates/statefulset-source.yaml
@@ -25,6 +25,10 @@ spec:
         {{- end }}
     spec:
       {{- include "mysql.podSpecCommon" . | nindent 6 }}
+      {{- if and .Values.tls.enabled .Values.tls.volumePermissions.enabled }}
+      initContainers:
+        {{- include "mysql.tlsVolumePermissionsInitContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: mysql
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -142,9 +146,7 @@ spec:
             - name: initdb
               mountPath: /docker-entrypoint-initdb.d
             {{- if .Values.tls.enabled }}
-            - name: tls
-              mountPath: /tls
-              readOnly: true
+            {{- include "mysql.tlsVolumeMount" . | nindent 12 }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -154,7 +156,7 @@ spec:
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           args:
-            - --web.listen-address=:{{ .Values.service.metricsPort }}
+            {{- include "mysql.metricsArgs" . | nindent 12 }}
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
@@ -186,9 +188,7 @@ spec:
                   name: {{ .Values.initdb.existingConfigMap }}
               {{- end }}
         {{- if .Values.tls.enabled }}
-        - name: tls
-          secret:
-            secretName: {{ include "mysql.tlsSecretName" . }}
+        {{- include "mysql.tlsVolumes" . | nindent 8 }}
         {{- end }}
         {{- if not (ternary .Values.replication.source.persistence.enabled .Values.standalone.persistence.enabled (eq .Values.architecture "replication")) }}
         - name: data

--- a/charts/mysql/tests/externalsecret_test.yaml
+++ b/charts/mysql/tests/externalsecret_test.yaml
@@ -112,3 +112,38 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: legacy externalSecrets.data requires auth.existingSecret to prevent credential drift; prefer externalSecrets.auth.enabled for chart-owned target names
+
+  - it: should fail structured auth ExternalSecret with empty remoteRef
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.auth.enabled: true
+      externalSecrets.auth.userPasswordRemoteRef.key: mysql/credentials
+      externalSecrets.auth.replicationPasswordRemoteRef.key: mysql/credentials
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.auth.rootPasswordRemoteRef is required and must contain at least one remoteRef field
+
+  - it: should fail TLS ExternalSecret with empty remoteRef
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.tls.enabled: true
+      externalSecrets.tls.caRemoteRef.key: mysql/tls
+      externalSecrets.tls.certRemoteRef.key: mysql/tls
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.tls.keyRemoteRef is required and must contain at least one remoteRef field
+
+  - it: should fail backup ExternalSecret with empty remoteRef
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.backup.enabled: true
+      externalSecrets.backup.accessKeyRemoteRef.key: mysql/backup
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.backup.secretKeyRemoteRef is required and must contain at least one remoteRef field

--- a/charts/mysql/tests/externalsecret_test.yaml
+++ b/charts/mysql/tests/externalsecret_test.yaml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create ExternalSecret by default
+    template: externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create structured auth ExternalSecret
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.auth.enabled: true
+      externalSecrets.auth.rootPasswordRemoteRef.key: mysql/credentials
+      externalSecrets.auth.rootPasswordRemoteRef.property: root-password
+      externalSecrets.auth.userPasswordRemoteRef.key: mysql/credentials
+      externalSecrets.auth.userPasswordRemoteRef.property: user-password
+      externalSecrets.auth.replicationPasswordRemoteRef.key: mysql/credentials
+      externalSecrets.auth.replicationPasswordRemoteRef.property: replication-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.target.name
+          value: test-mysql-auth
+      - contains:
+          path: spec.data
+          content:
+            secretKey: mysql-root-password
+            remoteRef:
+              key: mysql/credentials
+              property: root-password
+
+  - it: should create TLS ExternalSecret with chart TLS target name
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.tls.enabled: true
+      externalSecrets.tls.caRemoteRef.key: mysql/tls
+      externalSecrets.tls.caRemoteRef.property: ca.crt
+      externalSecrets.tls.certRemoteRef.key: mysql/tls
+      externalSecrets.tls.certRemoteRef.property: tls.crt
+      externalSecrets.tls.keyRemoteRef.key: mysql/tls
+      externalSecrets.tls.keyRemoteRef.property: tls.key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-mysql-tls
+      - equal:
+          path: spec.target.name
+          value: test-mysql-tls
+
+  - it: should create backup ExternalSecret with chart backup target name
+    template: externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.backup.enabled: true
+      externalSecrets.backup.accessKeyRemoteRef.key: mysql/backup
+      externalSecrets.backup.accessKeyRemoteRef.property: access-key
+      externalSecrets.backup.secretKeyRemoteRef.key: mysql/backup
+      externalSecrets.backup.secretKeyRemoteRef.property: secret-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-mysql-backup
+      - equal:
+          path: spec.target.name
+          value: test-mysql-backup
+
+  - it: should keep legacy data mode when auth.existingSecret is set
+    template: externalsecret.yaml
+    set:
+      auth.existingSecret: test-mysql-auth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.data[0].secretKey: mysql-root-password
+      externalSecrets.data[0].remoteRef.key: mysql/credentials
+      externalSecrets.data[0].remoteRef.property: root-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.target.name
+          value: test-mysql-auth
+
+  - it: should fail legacy data mode without auth.existingSecret
+    template: secret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.data[0].secretKey: mysql-root-password
+      externalSecrets.data[0].remoteRef.key: mysql/credentials
+    asserts:
+      - failedTemplate:
+          errorMessage: legacy externalSecrets.data requires auth.existingSecret to prevent credential drift; prefer externalSecrets.auth.enabled for chart-owned target names

--- a/charts/mysql/tests/networkpolicy_test.yaml
+++ b/charts/mysql/tests/networkpolicy_test.yaml
@@ -29,3 +29,34 @@ tests:
           content:
             protocol: TCP
             port: 3306
+
+  - it: should add egress policy types and default egress rules when enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 3306
+
+  - it: should add HTTPS egress when enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowHTTPS: true
+    asserts:
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            protocol: TCP
+            port: 443

--- a/charts/mysql/tests/networkpolicy_test.yaml
+++ b/charts/mysql/tests/networkpolicy_test.yaml
@@ -60,3 +60,13 @@ tests:
           content:
             protocol: TCP
             port: 443
+
+  - it: should nest extra egress peers under a to rule
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.extraTo[0].podSelector.matchLabels.app: external-secrets
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].podSelector.matchLabels.app
+          value: external-secrets

--- a/charts/mysql/tests/secret_test.yaml
+++ b/charts/mysql/tests/secret_test.yaml
@@ -38,3 +38,15 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should not be created when auth is managed by External Secrets Operator
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: local-store
+      externalSecrets.auth.enabled: true
+      externalSecrets.auth.rootPasswordRemoteRef.key: mysql/credentials
+      externalSecrets.auth.userPasswordRemoteRef.key: mysql/credentials
+      externalSecrets.auth.replicationPasswordRemoteRef.key: mysql/credentials
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/mysql/tests/statefulset_replicas_test.yaml
+++ b/charts/mysql/tests/statefulset_replicas_test.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: StatefulSet Replicas
+templates:
+  - statefulset-replicas.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should seed a TCP-capable root account for local probes
+    template: statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--read-only=OFF --super-read-only=OFF"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "MYSQL_PWD=\"\\$\\{MYSQL_ROOT_PASSWORD\\}\" mysql --socket=/tmp/mysql.sock -uroot < /tmp/source.sql[\\s\\S]*SET GLOBAL super_read_only = OFF;[\\s\\S]*CREATE USER IF NOT EXISTS 'root'@'%'"
+
+  - it: should disable service account token automount by default
+    template: statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false

--- a/charts/mysql/tests/statefulset_source_test.yaml
+++ b/charts/mysql/tests/statefulset_source_test.yaml
@@ -69,6 +69,13 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 999
 
+  - it: should disable service account token automount by default
+    template: statefulset-source.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
   - it: should have probes by default
     template: statefulset-source.yaml
     asserts:
@@ -115,3 +122,36 @@ tests:
       - lengthEqual:
           path: spec.template.spec.containers
           count: 2
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --mysqld.username=root
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: MYSQLD_EXPORTER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-mysql-auth
+                key: mysql-root-password
+
+  - it: should normalize TLS volume permissions when enabled
+    template: statefulset-source.yaml
+    set:
+      tls.enabled: true
+      tls.existingSecret: mysql-tls
+      tls.volumePermissions.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: tls-volume-permissions
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls-workdir
+            mountPath: /tls
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-workdir
+            emptyDir: {}

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -44,7 +44,7 @@
         "tag": {
           "type": "string",
           "description": "MySQL image tag",
-          "default": "8.4"
+          "default": "9.7.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -603,6 +603,18 @@
           "description": "Require TLS for TCP client connections handled by mysqld",
           "default": false
         },
+        "volumePermissions": {
+          "type": "object",
+          "description": "TLS volume permission normalization",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Copy TLS files to an emptyDir and normalize ownership/mode before mysqld starts",
+              "default": false
+            }
+          }
+        },
         "client": {
           "type": "object",
           "description": "Client TLS configuration",
@@ -688,7 +700,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "RELEASE.2025-08-13T08-35-41Z"
+                  "default": "1.0.0"
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -838,6 +850,41 @@
               "default": []
             }
           }
+        },
+        "egress": {
+          "type": "object",
+          "description": "Egress rules for the NetworkPolicy",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Add egress rules to the NetworkPolicy",
+              "default": false
+            },
+            "allowDNS": {
+              "type": "boolean",
+              "description": "Allow DNS egress to kube-dns/CoreDNS",
+              "default": true
+            },
+            "allowSameNamespaceMySQL": {
+              "type": "boolean",
+              "description": "Allow MySQL egress to pods in the same namespace",
+              "default": true
+            },
+            "allowHTTPS": {
+              "type": "boolean",
+              "description": "Allow TCP/443 egress",
+              "default": false
+            },
+            "extraTo": {
+              "type": "array",
+              "description": "Additional egress rules appended to the generated policy",
+              "items": {
+                "type": "object"
+              },
+              "default": []
+            }
+          }
         }
       }
     },
@@ -882,6 +929,11 @@
           "type": "object",
           "description": "Annotations on the ServiceAccount",
           "default": {}
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Mount the ServiceAccount token into workload pods",
+          "default": false
         }
       }
     },
@@ -1084,7 +1136,36 @@
             "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "None", "Orphan"], "default": "Owner" }
           }
         },
-        "data": { "type": "array", "items": { "type": "object" } }
+        "data": { "type": "array", "items": { "type": "object" } },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "targetName": { "type": "string", "default": "" },
+            "rootPasswordRemoteRef": { "type": "object" },
+            "userPasswordRemoteRef": { "type": "object" },
+            "replicationPasswordRemoteRef": { "type": "object" }
+          }
+        },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "targetName": { "type": "string", "default": "" },
+            "caRemoteRef": { "type": "object" },
+            "certRemoteRef": { "type": "object" },
+            "keyRemoteRef": { "type": "object" }
+          }
+        },
+        "backup": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "targetName": { "type": "string", "default": "" },
+            "accessKeyRemoteRef": { "type": "object" },
+            "secretKeyRemoteRef": { "type": "object" }
+          }
+        }
       }
     }
   }

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -238,6 +238,9 @@ tls:
   keyFilename: tls.key
   # -- Require TLS for TCP client connections handled by mysqld
   requireSecureTransport: false
+  volumePermissions:
+    # -- Copy TLS files to an emptyDir and normalize ownership/mode before mysqld starts. This is useful when Secrets are projected with modes that MySQL rejects for private keys.
+    enabled: false
   client:
     # -- Enable TLS for internal chart-managed TCP clients such as replication bootstrap commands
     enabled: false
@@ -304,7 +307,7 @@ backup:
 # =============================================================================
 
 networkPolicy:
-  # -- Create an ingress-only NetworkPolicy for MySQL pods
+  # -- Create a NetworkPolicy for MySQL pods
   enabled: false
   ingress:
     # -- Allow ingress from the same namespace
@@ -318,6 +321,17 @@ networkPolicy:
     allowSameNamespace: true
     # -- Additional ingress "from" rules appended to the generated metrics policy rule
     extraFrom: []
+  egress:
+    # -- Add egress rules to the NetworkPolicy. Disabled keeps Kubernetes/CNI default behavior for egress.
+    enabled: false
+    # -- Allow DNS egress to kube-dns/CoreDNS.
+    allowDNS: true
+    # -- Allow MySQL egress to pods in the same namespace for source/replica and client sidecars.
+    allowSameNamespaceMySQL: true
+    # -- Allow TCP/443 egress for object storage, external secret stores, or monitored endpoints reached by sidecars/jobs.
+    allowHTTPS: false
+    # -- Additional egress "to" rules appended to the generated policy.
+    extraTo: []
 
 # =============================================================================
 # Pod Disruption Budget
@@ -340,6 +354,8 @@ serviceAccount:
   create: false
   name: ""
   annotations: {}
+  # -- Mount the ServiceAccount token into workload pods. Keep false unless a sidecar or extension needs Kubernetes API access.
+  automountServiceAccountToken: false
 
 # =============================================================================
 # Probes
@@ -413,7 +429,7 @@ extraVolumeMounts: []
 # =============================================================================
 
 externalSecrets:
-  # -- Render ExternalSecret for clusters running External Secrets Operator.
+  # -- Render ExternalSecret resources for clusters running External Secrets Operator.
   enabled: false
   # -- ExternalSecret apiVersion.
   apiVersion: external-secrets.io/v1
@@ -425,10 +441,48 @@ externalSecrets:
     kind: SecretStore
   target:
     creationPolicy: Owner
-  # -- ExternalSecret data entries for MySQL passwords.
+  # -- Legacy ExternalSecret data entries for MySQL passwords. Prefer externalSecrets.auth for new installs.
   data: []
   #   - secretKey: mysql-root-password
   #     remoteRef:
   #       key: mysql/credentials
   #       property: root-password
-
+  auth:
+    # -- Manage the MySQL auth Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-mysql-auth.
+    targetName: ""
+    rootPasswordRemoteRef: {}
+      # key: prod/mysql
+      # property: root-password
+    userPasswordRemoteRef: {}
+      # key: prod/mysql
+      # property: user-password
+    replicationPasswordRemoteRef: {}
+      # key: prod/mysql
+      # property: replication-password
+  tls:
+    # -- Manage the MySQL TLS Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-mysql-tls.
+    targetName: ""
+    caRemoteRef: {}
+      # key: prod/mysql-tls
+      # property: ca.crt
+    certRemoteRef: {}
+      # key: prod/mysql-tls
+      # property: tls.crt
+    keyRemoteRef: {}
+      # key: prod/mysql-tls
+      # property: tls.key
+  backup:
+    # -- Manage the backup object-storage Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-mysql-backup.
+    targetName: ""
+    accessKeyRemoteRef: {}
+      # key: prod/mysql-backup
+      # property: access-key
+    secretKeyRemoteRef: {}
+      # key: prod/mysql-backup
+      # property: secret-key


### PR DESCRIPTION
## Summary
- Adds production hardening controls for the MySQL chart.
- Adds structured External Secrets Operator v1 integration for auth, TLS, and backup Secrets.
- Adds TLS private-key permission normalization, ServiceAccount token automount control, and optional NetworkPolicy egress.
- Updates MySQL exporter configuration for mysqld_exporter v0.17.2.
- Updates production documentation, examples, NOTES, and design docs.

## Breaking Change
- BREAKING CHANGE: MySQL replica bootstrapping now configures replication from the final container lifecycle and metrics use the current mysqld_exporter connection flags instead of DATA_SOURCE_NAME.

## Validation
- `helm dependency build charts/mysql`
- `helm lint charts/mysql`
- `helm lint --strict charts/mysql`
- `helm unittest charts/mysql` - 10 suites, 55 tests
- `helm template mysql charts/mysql -f charts/mysql/ci/production-hardening.yaml | kubeconform -strict -summary -ignore-missing-schemas`
- `ah lint -p charts/mysql`
- `npx markdownlint-cli charts/mysql/README.md charts/mysql/DESIGN.md charts/mysql/docs/*.md`
- K3D standalone dev: pod Ready, SQL `SELECT 1`
- K3D production replication with TLS: source/replica `2/2 Running`, TLS required, key mode `600`, exporter `mysql_up 1`, replication connection/applier `ON`
- K3D production replication without TLS: source/replica `2/2 Running`, replication connection/applier `ON`, exporter `mysql_up 1`
- K3D production standalone with TLS: pod `2/2 Running`, TLS required, key mode `600`, exporter `mysql_up 1`

Closes #234