### PR TITLE
feat(phpmyadmin)!: modernize production controls

### DIFF
--- a/charts/phpmyadmin/Chart.yaml
+++ b/charts/phpmyadmin/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: phpmyadmin
 type: application

--- a/charts/phpmyadmin/DESIGN.md
+++ b/charts/phpmyadmin/DESIGN.md
@@ -1,0 +1,196 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# phpMyAdmin Chart Design
+
+This document describes the architecture and operational model for the HelmForge phpMyAdmin chart.
+
+## Goals
+
+- Keep the default deployment simple for development and troubleshooting.
+- Provide opt-in production controls without forcing every install to be production-shaped.
+- Expose official phpMyAdmin Docker image capabilities through structured values.
+- Support current Kubernetes patterns: Gateway API, External Secrets Operator v1, NetworkPolicy, HPA,
+  PDB, Service dual-stack, and ServiceAccount token control.
+
+## Non-Goals
+
+- The chart does not install MySQL, MariaDB, External Secrets Operator, Gateway API CRDs, or a Gateway controller.
+- The chart does not make phpMyAdmin safe to expose publicly by itself.
+- The chart does not manage database users or privileges.
+
+## Default Development Architecture
+
+```text
+Developer
+   |
+   | kubectl port-forward
+   v
+Service ClusterIP
+   |
+   v
+phpMyAdmin Deployment
+   |
+   | PMA_HOST or login-entered host
+   v
+MySQL/MariaDB
+```
+
+Default characteristics:
+
+- one replica;
+- no Ingress or Gateway;
+- no NetworkPolicy;
+- no ExternalSecret;
+- ServiceAccount token not mounted;
+- access through port-forward.
+
+## Internal Production Architecture With Ingress
+
+```text
+User/VPN/SSO
+   |
+   v
+Ingress Controller + TLS
+   |
+   v
+Service
+   |
+   v
+phpMyAdmin replicas
+   |
+   | restricted egress
+   v
+MySQL/MariaDB
+
+External Secrets Operator
+   |
+   v
+Kubernetes Secret -> phpMyAdmin env
+```
+
+Recommended controls:
+
+- TLS at the Ingress layer.
+- SSO, VPN, or reverse proxy authentication before phpMyAdmin.
+- Existing Secret or ExternalSecret for credentials.
+- NetworkPolicy with only required ingress and database egress.
+- Least-privilege database accounts.
+- PDB and optional HPA.
+- Shared `/sessions` storage or sticky sessions when using multiple replicas.
+
+## Gateway API Architecture
+
+```text
+Client
+   |
+   v
+Gateway listener
+   |
+   v
+HTTPRoute
+   |
+   v
+phpMyAdmin Service
+   |
+   v
+phpMyAdmin Pod
+```
+
+The chart renders only `HTTPRoute`. Platform teams remain responsible for GatewayClass, Gateway
+listeners, TLS certificates, cross-namespace route attachment policy, and controller operations.
+
+## External Secrets Architecture
+
+```text
+External secret backend
+   |
+   v
+SecretStore or ClusterSecretStore
+   |
+   v
+ExternalSecret external-secrets.io/v1
+   |
+   v
+Kubernetes Secret
+   |
+   v
+phpMyAdmin environment variables
+```
+
+The chart supports External Secrets for:
+
+- auto-login username;
+- auto-login password;
+- cookie blowfish secret;
+- configuration-storage control password.
+
+Inline values are acceptable for local development only. Production should use `auth.existingSecret` or `externalSecrets.auth`.
+
+## Multi-Server Architecture
+
+```text
+phpMyAdmin
+   |
+   +-- PMA_HOSTS[0] -> MySQL primary
+   +-- PMA_HOSTS[1] -> MySQL replica
+   +-- PMA_HOSTS[2] -> MariaDB analytics
+```
+
+Use `phpmyadmin.hosts`, `phpmyadmin.ports`, and `phpmyadmin.verboses` to provide a curated server list.
+Use `phpmyadmin.arbitrary=true` only when the user population is trusted to choose valid database
+endpoints.
+
+## Session Strategy
+
+phpMyAdmin is mostly stateless, but web sessions can matter for multi-replica deployments.
+
+```text
+Replica A ----+
+              +--> /sessions shared volume
+Replica B ----+
+```
+
+Recommended choices:
+
+- single replica for simple admin use;
+- multiple replicas with shared `/sessions` storage when session continuity is required;
+- ingress stickiness as an alternative when storage is not available.
+
+## Service Dual Stack
+
+The chart leaves `service.ipFamilyPolicy` and `service.ipFamilies` empty by default so the cluster default applies. On IPv4/IPv6 clusters, use:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Use `RequireDualStack` only when the cluster is known to support dual-stack Services.
+
+## Security Model
+
+phpMyAdmin is a powerful database administration UI. The chart provides controls, but production safety depends on the platform configuration.
+
+Production baseline:
+
+- do not expose directly to the public internet;
+- require TLS;
+- put phpMyAdmin behind VPN, SSO, reverse proxy auth, or IP allowlists;
+- use least-privilege database users;
+- avoid auto-login unless the surrounding access controls are strong;
+- mount ServiceAccount tokens only when needed;
+- restrict ingress and egress with NetworkPolicy;
+- prefer External Secrets or existing Kubernetes Secrets.
+
+## Validation Matrix
+
+Each change should be validated with:
+
+- `helm lint`;
+- `helm unittest`;
+- `helm template` for default and example values;
+- MCP HelmForge validations for ExternalSecrets, Gateway API, values quality, and CI evidence;
+- K3D install for default, production, ExternalSecret, Gateway API, NetworkPolicy, and dual-stack scenarios where the local cluster supports them.

--- a/charts/phpmyadmin/DESIGN.md
+++ b/charts/phpmyadmin/DESIGN.md
@@ -115,6 +115,9 @@ Kubernetes Secret
    |
    v
 phpMyAdmin environment variables
+   |
+   v
+Generated config.user.inc.php when needed
 ```
 
 The chart supports External Secrets for:
@@ -125,6 +128,9 @@ The chart supports External Secrets for:
 - configuration-storage control password.
 
 Inline values are acceptable for local development only. Production should use `auth.existingSecret` or `externalSecrets.auth`.
+The phpMyAdmin Docker image does not consume every phpMyAdmin setting as an environment variable. For auth modes other than `cookie` and for
+a stable cookie blowfish secret, the chart writes a generated `config.user.inc.php` and reads secret material from a pod environment variable
+populated by Kubernetes Secret references.
 
 ## Multi-Server Architecture
 
@@ -139,6 +145,8 @@ phpMyAdmin
 Use `phpmyadmin.hosts`, `phpmyadmin.ports`, and `phpmyadmin.verboses` to provide a curated server list.
 Use `phpmyadmin.arbitrary=true` only when the user population is trusted to choose valid database
 endpoints.
+When database TLS is enabled with `phpmyadmin.hosts`, the chart renders the multi-host variables
+`PMA_SSLS`, `PMA_SSL_VERIFIES`, `PMA_SSL_CAS`, `PMA_SSL_CERTS`, and `PMA_SSL_KEYS` so TLS settings line up with the `PMA_HOSTS` order.
 
 ## Session Strategy
 

--- a/charts/phpmyadmin/README.md
+++ b/charts/phpmyadmin/README.md
@@ -62,7 +62,7 @@ The default values are intentionally simple for development: one replica, no Ing
 Production deployments should opt into the controls they need:
 
 - Use `auth.existingSecret` or `externalSecrets.auth` instead of inline passwords.
-- Prefer `phpmyadmin.authType: cookie` unless a controlled auto-login workflow is required.
+- Prefer `phpmyadmin.authType: cookie` unless a controlled `config`, `http`, or `signon` workflow is required.
 - Expose phpMyAdmin through private networking, VPN, SSO/reverse proxy auth, or IP allowlists.
 - Enable TLS at the Ingress or Gateway layer.
 - Enable NetworkPolicy and restrict egress to DNS and the target database.
@@ -107,6 +107,16 @@ auth:
   blowfishSecret: "use-a-32-byte-random-secret-here"
 ```
 
+Non-cookie auth modes are rendered into `config.user.inc.php` because the official phpMyAdmin image does not consume an auth-type environment variable:
+
+```yaml
+phpmyadmin:
+  authType: http
+```
+
+When `authType: http` is used, the chart automatically switches the default probes to TCP checks because the application root returns `401`
+until HTTP authentication succeeds.
+
 Auto-login with an existing Secret:
 
 ```yaml
@@ -132,6 +142,8 @@ stringData:
 ```
 
 Auto-login skips the login form and should only be used behind strong network and identity controls.
+When a blowfish secret is provided inline, by existing Secret, or by External Secrets Operator, the chart exposes it to the pod as
+`HELMFORGE_BLOWFISH_SECRET` and writes `$cfg['blowfish_secret']` through `config.user.inc.php`.
 
 ## External Secrets Operator
 
@@ -251,6 +263,10 @@ config:
     $cfg['ShowPhpInfo'] = false;
     $cfg['MaxRows'] = 100;
 ```
+
+The chart also generates `config.user.inc.php` when it needs to apply `phpmyadmin.authType` values other than `cookie` or a configured
+blowfish secret. If `config.customConfig` is set, the custom block is appended after the generated block so advanced users can still override
+phpMyAdmin settings deliberately.
 
 Or pass base64 configuration through the official image variable:
 

--- a/charts/phpmyadmin/README.md
+++ b/charts/phpmyadmin/README.md
@@ -1,10 +1,15 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # phpMyAdmin
 
-A Helm chart for deploying [phpMyAdmin](https://www.phpmyadmin.net/) on Kubernetes using the official [`phpmyadmin/phpmyadmin`](https://hub.docker.com/r/phpmyadmin/phpmyadmin) Docker image.
+A Helm chart for deploying [phpMyAdmin](https://www.phpmyadmin.net/) on Kubernetes with the official `phpmyadmin/phpmyadmin` image.
 
-## Installation
+phpMyAdmin is a web UI for administering MySQL and MariaDB. This chart supports development installs,
+internal administration portals, and hardened production-style deployments with External Secrets,
+Gateway API, NetworkPolicy, dual-stack Services, optional shared sessions, and Kubernetes-native
+availability controls.
 
-### HTTPS Repository
+## Install
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
@@ -12,7 +17,7 @@ helm repo update
 helm install phpmyadmin helmforge/phpmyadmin
 ```
 
-### OCI Registry
+OCI:
 
 ```bash
 helm install phpmyadmin oci://ghcr.io/helmforgedev/helm/phpmyadmin
@@ -25,19 +30,49 @@ helm install phpmyadmin oci://ghcr.io/helmforgedev/helm/phpmyadmin \
   --set phpmyadmin.host=mysql.default.svc.cluster.local
 ```
 
-## Features
+Local access:
 
-- **Official phpMyAdmin Image** — based on the official `phpmyadmin/phpmyadmin` container
-- **Single or Multi-Server** — connect to one MySQL host or multiple servers
-- **Auto-Login** — optional automatic authentication via PMA_USER/PMA_PASSWORD
-- **Custom Configuration** — mount custom `config.user.inc.php` via ConfigMap
-- **Upload Limit** — configurable max upload size for SQL imports
-- **Ingress Support** — configurable ingress with TLS for HTTPS access
-- **Stateless** — no persistent storage needed, scales horizontally
+```bash
+kubectl port-forward svc/phpmyadmin 8080:80
+```
 
-## Configuration
+Open `http://localhost:8080/`.
 
-### Connect to a MySQL Server
+## Feature Summary
+
+- Official `phpmyadmin/phpmyadmin` container image.
+- Single-server, multi-server, and arbitrary-server login modes.
+- Cookie, config, HTTP, and signon auth mode selection.
+- Optional auto-login with inline Secret, existing Secret, or External Secrets Operator.
+- External Secrets Operator support with `external-secrets.io/v1`.
+- Ingress and Kubernetes Gateway API `HTTPRoute`.
+- Service dual-stack options through `ipFamilyPolicy` and `ipFamilies`.
+- Optional NetworkPolicy for ingress and database egress.
+- Optional ServiceAccount token automount control.
+- Optional HPA and PodDisruptionBudget.
+- Optional `/sessions` mount for multi-replica session stability.
+- Optional custom phpMyAdmin config through ConfigMap or `PMA_CONFIG_BASE64`.
+- Optional configuration storage/control user variables.
+- Optional custom themes mounted at `/www/themes`.
+
+## Development vs Production
+
+The default values are intentionally simple for development: one replica, no Ingress/Gateway, no NetworkPolicy, no ExternalSecret, and access through port-forward. This keeps a local install easy.
+
+Production deployments should opt into the controls they need:
+
+- Use `auth.existingSecret` or `externalSecrets.auth` instead of inline passwords.
+- Prefer `phpmyadmin.authType: cookie` unless a controlled auto-login workflow is required.
+- Expose phpMyAdmin through private networking, VPN, SSO/reverse proxy auth, or IP allowlists.
+- Enable TLS at the Ingress or Gateway layer.
+- Enable NetworkPolicy and restrict egress to DNS and the target database.
+- Use least-privilege database accounts.
+- Enable `sessions.enabled` for multi-replica deployments that rely on cookie/session state.
+- Add requests, limits, PDB, HPA, topology spread, and anti-affinity where appropriate.
+
+## Database Connectivity
+
+Single MySQL/MariaDB server:
 
 ```yaml
 phpmyadmin:
@@ -45,24 +80,93 @@ phpmyadmin:
   port: 3306
 ```
 
-### Multi-Server Mode
+Multi-server dropdown:
 
 ```yaml
 phpmyadmin:
-  hosts: "mysql-primary.svc,mysql-replica.svc,mysql-analytics.svc"
+  hosts: "mysql-primary.default.svc,mysql-replica.default.svc,mariadb.default.svc"
+  ports: "3306,3306,3306"
+  verboses: "Primary,Replica,MariaDB"
 ```
 
-### Production with Ingress
+Arbitrary server mode:
+
+```yaml
+phpmyadmin:
+  arbitrary: true
+```
+
+## Authentication
+
+Default cookie login:
+
+```yaml
+phpmyadmin:
+  authType: cookie
+auth:
+  blowfishSecret: "use-a-32-byte-random-secret-here"
+```
+
+Auto-login with an existing Secret:
+
+```yaml
+auth:
+  existingSecret: phpmyadmin-auth
+  existingSecretUsernameKey: username
+  existingSecretPasswordKey: password
+  existingSecretBlowfishKey: blowfish-secret
+```
+
+The Secret should contain:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: phpmyadmin-auth
+type: Opaque
+stringData:
+  username: admin
+  password: change-me
+  blowfish-secret: use-a-32-byte-random-secret-here
+```
+
+Auto-login skips the login form and should only be used behind strong network and identity controls.
+
+## External Secrets Operator
+
+The chart can render an `ExternalSecret` using `external-secrets.io/v1`. The External Secrets Operator
+and the referenced SecretStore or ClusterSecretStore must already exist.
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  auth:
+    enabled: true
+    usernameRemoteRef:
+      key: prod/phpmyadmin
+      property: username
+    passwordRemoteRef:
+      key: prod/phpmyadmin
+      property: password
+    blowfishSecretRemoteRef:
+      key: prod/phpmyadmin
+      property: blowfish-secret
+```
+
+## Ingress
 
 ```yaml
 phpmyadmin:
   host: mysql.default.svc.cluster.local
   absoluteUri: "https://pma.example.com/"
-  uploadLimit: "128M"
 
 ingress:
   enabled: true
-  ingressClassName: traefik
+  ingressClassName: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
   hosts:
@@ -76,109 +180,143 @@ ingress:
         - pma.example.com
 ```
 
-### Auto-Login with Existing Secret
+## Gateway API
+
+Gateway API support is opt-in and creates an `HTTPRoute` attached to an existing Gateway.
 
 ```yaml
-phpmyadmin:
-  host: mysql.default.svc.cluster.local
-
-auth:
-  existingSecret: mysql-credentials
-  existingSecretUsernameKey: username
-  existingSecretPasswordKey: password
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - pma.example.com
 ```
 
-### Custom PHP Configuration
+## Service Dual Stack
+
+Dual-stack is disabled by default and inherits the cluster default. Enable it only on clusters configured
+for IPv4/IPv6 Services.
 
 ```yaml
-phpmyadmin:
-  host: mysql.default.svc.cluster.local
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
 
+## NetworkPolicy
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: true
+    databasePort: 3306
+```
+
+Use `extraFrom` and `extraTo` to restrict traffic to Gateway/Ingress controller namespaces and database CIDRs or pod selectors.
+
+## Sessions And Replicas
+
+phpMyAdmin is mostly stateless, but cookie/session flows benefit from a shared `/sessions` mount when running multiple replicas.
+
+```yaml
+replicaCount: 2
+sessions:
+  enabled: true
+  type: persistentVolumeClaim
+  accessModes:
+    - ReadWriteMany
+  size: 1Gi
+```
+
+For clusters without shared storage, keep `replicaCount: 1` or use ingress stickiness.
+
+## Custom Configuration
+
+Mount `config.user.inc.php`:
+
+```yaml
 config:
   customConfig: |
     <?php
-    $cfg['ShowPhpInfo'] = true;
+    $cfg['ShowPhpInfo'] = false;
     $cfg['MaxRows'] = 100;
-    $cfg['DefaultLang'] = 'en';
 ```
 
-## Parameters
+Or pass base64 configuration through the official image variable:
 
-### Application Settings
+```yaml
+phpmyadmin:
+  configBase64: "PD9waHAKJGNmZ1snU2hvd1BocEluZm8nXSA9IGZhbHNlOwo="
+```
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `phpmyadmin.host` | `""` | MySQL/MariaDB host to connect to |
-| `phpmyadmin.hosts` | `""` | Comma-separated list of MySQL hosts (multi-server mode) |
-| `phpmyadmin.port` | `3306` | MySQL port |
-| `phpmyadmin.uploadLimit` | `"64M"` | Max upload size for SQL imports |
-| `phpmyadmin.absoluteUri` | `""` | Absolute URI when behind a reverse proxy |
+## Production Example
 
-### Authentication
+See [examples/production.yaml](examples/production.yaml).
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `auth.username` | `""` | MySQL username for auto-login (leave empty for login form) |
-| `auth.password` | `""` | MySQL password for auto-login |
-| `auth.existingSecret` | `""` | Existing secret with auto-login credentials |
-
-### Custom Configuration
+## Main Parameters
 
 | Key | Default | Description |
-|-----|---------|-------------|
-| `config.customConfig` | `""` | Raw content for config.user.inc.php |
-| `config.existingConfigMap` | `""` | Existing ConfigMap with config.user.inc.php |
+| --- | --- | --- |
+| `phpmyadmin.host` | `""` | Single MySQL/MariaDB host |
+| `phpmyadmin.hosts` | `""` | Comma-separated multi-server hosts |
+| `phpmyadmin.ports` | `""` | Comma-separated multi-server ports |
+| `phpmyadmin.verboses` | `""` | Comma-separated server display names |
+| `phpmyadmin.arbitrary` | `false` | Let users enter a host at login |
+| `phpmyadmin.authType` | `cookie` | phpMyAdmin auth mode |
+| `phpmyadmin.uploadLimit` | `64M` | SQL import upload limit |
+| `phpmyadmin.absoluteUri` | `""` | External URL when behind a proxy |
+| `auth.existingSecret` | `""` | Existing auth Secret |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resources |
+| `gatewayAPI.enabled` | `false` | Render HTTPRoute |
+| `service.ipFamilyPolicy` | `""` | Service IP family policy |
+| `service.ipFamilies` | `[]` | Service IP families |
+| `networkPolicy.enabled` | `false` | Render NetworkPolicy |
+| `sessions.enabled` | `false` | Mount `/sessions` |
+| `autoscaling.enabled` | `false` | Render HPA |
+| `pdb.enabled` | `false` | Render PDB |
+| `serviceAccount.automountServiceAccountToken` | `false` | Mount SA token into pods |
 
-### Service
+## Validation
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `service.type` | `ClusterIP` | Service type |
-| `service.port` | `80` | Service port |
+Recommended checks before promotion:
 
-### Ingress
+```bash
+helm lint charts/phpmyadmin
+helm unittest charts/phpmyadmin
+helm template phpmyadmin charts/phpmyadmin -f charts/phpmyadmin/examples/production.yaml
+```
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `ingress.enabled` | `false` | Enable ingress |
-| `ingress.ingressClassName` | `""` | Ingress class (`traefik`, `nginx`, etc.) |
-| `ingress.hosts` | `[]` | Ingress hosts and paths |
-| `ingress.tls` | `[]` | TLS configuration |
+For cluster validation, install into K3D/K3S with a test MySQL/MariaDB target and check pods, logs,
+events, Service endpoints, Ingress or Gateway route, and ExternalSecret reconciliation when ESO is
+enabled.
 
-### Deployment
+## References
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `replicaCount` | `1` | Number of replicas |
-| `image.repository` | `phpmyadmin/phpmyadmin` | Container image |
-| `image.tag` | `""` | Image tag (defaults to appVersion) |
-| `resources` | `{}` | Resource requests and limits |
-
-## Notes
-
-- phpMyAdmin is **stateless** — no persistent volume is required
-- set `phpmyadmin.host` or `phpmyadmin.hosts` to point at your MySQL/MariaDB server
-- use `phpmyadmin.hosts` for the server selector dropdown in the login page
-- when using `phpmyadmin.absoluteUri`, ensure the value matches the external URL including the trailing slash
-- auto-login (`auth.username` + `auth.password`) skips the login form — use only in trusted networks
-- for large database imports, increase `phpmyadmin.uploadLimit` (e.g., `"256M"`)
-
-## More Information
-
-- [Source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/phpmyadmin)
+- [phpMyAdmin](https://www.phpmyadmin.net)
+- [Official Docker image](https://hub.docker.com/_/phpmyadmin)
+- [phpMyAdmin Docker setup](https://docs.phpmyadmin.net/en/latest/setup.html#installing-using-docker)
+- [External Secrets Operator](https://external-secrets.io/latest/api/externalsecret/)
+- [Kubernetes Gateway API HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/)
 
 <!-- @AI-METADATA
 type: chart-readme
 title: phpMyAdmin
 description: Installation guide, values reference, and operational overview for the phpMyAdmin Helm chart
-
-keywords: phpmyadmin, mysql, mariadb, database, admin, web-ui, helm, kubernetes
-
-purpose: User-facing chart documentation with install, examples, and values reference
+keywords: phpmyadmin, mysql, mariadb, database, admin, web-ui, helm, kubernetes, gateway-api, external-secrets, dual-stack
+purpose: User-facing chart documentation with install, examples, security posture, and values reference
 scope: Chart
-
 relations: []
 path: charts/phpmyadmin/README.md
-version: 1.0
-date: 2026-03-31
+version: 2.0
+date: 2026-05-06
 -->

--- a/charts/phpmyadmin/ci/auto-login.yaml
+++ b/charts/phpmyadmin/ci/auto-login.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 phpmyadmin:
   host: mysql.default.svc.cluster.local
 

--- a/charts/phpmyadmin/ci/custom-config.yaml
+++ b/charts/phpmyadmin/ci/custom-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 phpmyadmin:
   host: mysql.default.svc.cluster.local
 

--- a/charts/phpmyadmin/ci/external-secrets.yaml
+++ b/charts/phpmyadmin/ci/external-secrets.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+phpmyadmin:
+  host: mysql.default.svc.cluster.local
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+  auth:
+    enabled: true
+    usernameRemoteRef:
+      key: ci/phpmyadmin
+      property: username
+    passwordRemoteRef:
+      key: ci/phpmyadmin
+      property: password
+    blowfishSecretRemoteRef:
+      key: ci/phpmyadmin
+      property: blowfish-secret

--- a/charts/phpmyadmin/ci/gateway-api.yaml
+++ b/charts/phpmyadmin/ci/gateway-api.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+phpmyadmin:
+  host: mysql.default.svc.cluster.local
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - pma.example.local

--- a/charts/phpmyadmin/ci/ingress.yaml
+++ b/charts/phpmyadmin/ci/ingress.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 phpmyadmin:
   host: mysql.default.svc.cluster.local
   absoluteUri: "https://pma.example.com/"

--- a/charts/phpmyadmin/ci/multi-server.yaml
+++ b/charts/phpmyadmin/ci/multi-server.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 phpmyadmin:
   hosts: "mysql-primary.default.svc,mysql-replica.default.svc"
   port: 3306

--- a/charts/phpmyadmin/ci/production-hardening.yaml
+++ b/charts/phpmyadmin/ci/production-hardening.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+phpmyadmin:
+  host: mysql.default.svc.cluster.local
+
+auth:
+  existingSecret: phpmyadmin-auth
+
+replicaCount: 2
+
+sessions:
+  enabled: true
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+
+pdb:
+  enabled: true
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/phpmyadmin/examples/dual-stack.yaml
+++ b/charts/phpmyadmin/examples/dual-stack.yaml
@@ -1,3 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 phpmyadmin:
   host: mysql.default.svc.cluster.local
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/phpmyadmin/examples/external-secrets.yaml
+++ b/charts/phpmyadmin/examples/external-secrets.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+phpmyadmin:
+  host: mysql-primary.production.svc.cluster.local
+  authType: cookie
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  auth:
+    enabled: true
+    usernameRemoteRef:
+      key: prod/phpmyadmin
+      property: username
+    passwordRemoteRef:
+      key: prod/phpmyadmin
+      property: password
+    blowfishSecretRemoteRef:
+      key: prod/phpmyadmin
+      property: blowfish-secret

--- a/charts/phpmyadmin/examples/gateway-api.yaml
+++ b/charts/phpmyadmin/examples/gateway-api.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+phpmyadmin:
+  host: mysql-primary.production.svc.cluster.local
+  absoluteUri: "https://pma.example.com/"
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - pma.example.com

--- a/charts/phpmyadmin/examples/network-policy.yaml
+++ b/charts/phpmyadmin/examples/network-policy.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+phpmyadmin:
+  host: mysql.default.svc.cluster.local
+
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: true
+    databasePort: 3306

--- a/charts/phpmyadmin/examples/production.yaml
+++ b/charts/phpmyadmin/examples/production.yaml
@@ -1,29 +1,75 @@
-# Production deployment with ingress and auto-login via existing secret
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented example for an internal phpMyAdmin portal.
+# Keep phpMyAdmin behind VPN, SSO/reverse proxy auth, or strict IP allowlists.
+
 phpmyadmin:
   host: mysql-primary.production.svc.cluster.local
   port: 3306
   uploadLimit: "256M"
   absoluteUri: "https://pma.example.com/"
+  authType: cookie
+  hidePhpVersion: true
 
 auth:
-  existingSecret: mysql-admin-credentials
+  existingSecret: phpmyadmin-auth
   existingSecretUsernameKey: username
   existingSecretPasswordKey: password
+  existingSecretBlowfishKey: blowfish-secret
 
 replicaCount: 2
 
+sessions:
+  enabled: true
+  type: persistentVolumeClaim
+  accessModes:
+    - ReadWriteMany
+  size: 1Gi
+
 resources:
   requests:
-    cpu: 50m
+    cpu: 100m
     memory: 128Mi
   limits:
-    memory: 256Mi
+    memory: 512Mi
+
+serviceAccount:
+  create: true
+  automountServiceAccountToken: false
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: false
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: true
+    databasePort: 3306
 
 ingress:
   enabled: true
-  ingressClassName: traefik
+  ingressClassName: nginx
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "256m"
   hosts:
     - host: pma.example.com
       paths:

--- a/charts/phpmyadmin/templates/NOTES.txt
+++ b/charts/phpmyadmin/templates/NOTES.txt
@@ -1,6 +1,5 @@
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  phpMyAdmin has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+phpMyAdmin deployed
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
@@ -8,62 +7,59 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-{{- if .Values.ingress.enabled }}
+Access
+{{- if .Values.gatewayAPI.enabled }}
+Gateway API HTTPRoute is enabled.
+{{- range .Values.gatewayAPI.hostnames }}
+  URL: http(s)://{{ . }}/
+{{- end }}
+{{- else if .Values.ingress.enabled }}
+Ingress is enabled.
 {{- range $host := .Values.ingress.hosts }}
-WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  URL: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else }}
-Port-forward to access phpMyAdmin locally:
-
+Use port-forward for local access:
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "phpmyadmin.fullname" . }} 8080:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:8080/
+  URL: http://localhost:8080/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  CONFIGURATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Database Host:  {{ .Values.phpmyadmin.dbHost | default "Configure via phpmyadmin.dbHost" }}
-Database Port:  {{ .Values.phpmyadmin.dbPort | default 3306 }}
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  kubectl describe pod -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-SECURITY WARNING: Do NOT expose phpMyAdmin to the public internet without
-authentication (IP restriction, VPN, or reverse proxy auth).
-
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
+Database target
+{{- if .Values.phpmyadmin.hosts }}
+  Hosts: {{ .Values.phpmyadmin.hosts }}
+  Ports: {{ default (printf "%v" .Values.phpmyadmin.port) .Values.phpmyadmin.ports }}
+{{- else if .Values.phpmyadmin.host }}
+  Host:  {{ .Values.phpmyadmin.host }}
+  Port:  {{ .Values.phpmyadmin.port }}
+{{- else if .Values.phpmyadmin.arbitrary }}
+  Arbitrary server mode is enabled. Users choose the database host at login.
+{{- else }}
+  No database host is configured. Set phpmyadmin.host, phpmyadmin.hosts, or phpmyadmin.arbitrary=true.
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Operational checks
+  kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --timeout=300s
+  kubectl get deploy,po,svc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name=phpmyadmin -n {{ .Release.Namespace }} --all-containers --tail=100
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
 
-Documentation:  https://helmforge.dev/docs/charts/phpmyadmin
-phpMyAdmin:     https://www.phpmyadmin.net | https://github.com/phpmyadmin/phpmyadmin
+Production notes
+{{- if .Values.externalSecrets.auth.enabled }}
+  External Secrets Operator manages the auth Secret: {{ include "phpmyadmin.authSecretName" . }}
+{{- else if .Values.auth.existingSecret }}
+  Existing Secret used for auth: {{ .Values.auth.existingSecret }}
+{{- else if .Values.auth.password }}
+  Inline auth.password rendered a Kubernetes Secret. Prefer existingSecret or externalSecrets.auth in production.
+{{- end }}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.sessions.enabled) (not .Values.autoscaling.enabled) }}
+  Multiple replicas are enabled without sessions.enabled. Enable shared sessions when using cookie/session-heavy workflows.
+{{- end }}
+{{- if not .Values.networkPolicy.enabled }}
+  NetworkPolicy is disabled. Production deployments should restrict ingress and database egress.
+{{- end }}
 
-Happy Helmforging :)
+Security warning
+  Do not expose phpMyAdmin directly to the public internet without strong controls such as VPN, SSO/reverse proxy authentication, IP allowlists, TLS, and least-privilege database accounts.
+
+Documentation:
+  https://helmforge.dev/docs/charts/phpmyadmin

--- a/charts/phpmyadmin/templates/NOTES.txt
+++ b/charts/phpmyadmin/templates/NOTES.txt
@@ -44,12 +44,15 @@ Operational checks
   kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
 
 Production notes
-{{- if .Values.externalSecrets.auth.enabled }}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled }}
   External Secrets Operator manages the auth Secret: {{ include "phpmyadmin.authSecretName" . }}
 {{- else if .Values.auth.existingSecret }}
   Existing Secret used for auth: {{ .Values.auth.existingSecret }}
 {{- else if .Values.auth.password }}
   Inline auth.password rendered a Kubernetes Secret. Prefer existingSecret or externalSecrets.auth in production.
+{{- end }}
+{{- if eq (include "phpmyadmin.needsGeneratedConfig" .) "true" }}
+  config.user.inc.php is generated to apply auth type or blowfish-secret settings that are not handled by the official image environment contract.
 {{- end }}
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.sessions.enabled) (not .Values.autoscaling.enabled) }}
   Multiple replicas are enabled without sessions.enabled. Enable shared sessions when using cookie/session-heavy workflows.

--- a/charts/phpmyadmin/templates/_helpers.tpl
+++ b/charts/phpmyadmin/templates/_helpers.tpl
@@ -43,6 +43,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}
 
+{{/* ExternalSecret auth is active only when both flags are enabled */}}
+{{- define "phpmyadmin.externalSecretAuthEnabled" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled -}}true{{- end -}}
+{{- end -}}
+
 {{/* Auth secret name */}}
 {{- define "phpmyadmin.authSecretName" -}}
 {{- if and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled .Values.externalSecrets.auth.targetName -}}
@@ -61,6 +66,36 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- else -}}
 {{- printf "%s-config" (include "phpmyadmin.fullname" .) -}}
 {{- end -}}
+{{- end -}}
+
+{{/* phpMyAdmin settings that must be applied through config.user.inc.php */}}
+{{- define "phpmyadmin.needsGeneratedConfig" -}}
+{{- if or (ne .Values.phpmyadmin.authType "cookie") .Values.auth.blowfishSecret .Values.auth.existingSecret (eq (include "phpmyadmin.externalSecretAuthEnabled" .) "true") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "phpmyadmin.needsConfigMount" -}}
+{{- if or .Values.config.customConfig .Values.config.existingConfigMap (eq (include "phpmyadmin.needsGeneratedConfig" .) "true") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "phpmyadmin.csvRepeatForHosts" -}}
+{{- $items := list -}}
+{{- range splitList "," .hosts -}}
+{{- $items = append $items $.value -}}
+{{- end -}}
+{{- join "," $items -}}
+{{- end -}}
+
+{{- define "phpmyadmin.generatedConfig" -}}
+<?php
+{{- if ne .Values.phpmyadmin.authType "cookie" }}
+$cfg['Servers'][$i]['auth_type'] = {{ .Values.phpmyadmin.authType | quote }};
+{{- end }}
+{{- if or .Values.auth.blowfishSecret .Values.auth.existingSecret (eq (include "phpmyadmin.externalSecretAuthEnabled" .) "true") }}
+$helmforgeBlowfishSecret = getenv('HELMFORGE_BLOWFISH_SECRET');
+if ($helmforgeBlowfishSecret !== false && $helmforgeBlowfishSecret !== '') {
+    $cfg['blowfish_secret'] = $helmforgeBlowfishSecret;
+}
+{{- end }}
 {{- end -}}
 
 {{/* ExternalSecret remoteRef item */}}

--- a/charts/phpmyadmin/templates/_helpers.tpl
+++ b/charts/phpmyadmin/templates/_helpers.tpl
@@ -45,7 +45,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Auth secret name */}}
 {{- define "phpmyadmin.authSecretName" -}}
-{{- if .Values.externalSecrets.auth.targetName -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled .Values.externalSecrets.auth.targetName -}}
 {{- .Values.externalSecrets.auth.targetName -}}
 {{- else if .Values.auth.existingSecret -}}
 {{- .Values.auth.existingSecret -}}
@@ -87,6 +87,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Validate ExternalSecret settings */}}
 {{- define "phpmyadmin.validateExternalSecrets" -}}
+{{- if and .Values.externalSecrets.auth.enabled (not .Values.externalSecrets.enabled) -}}
+{{- fail "externalSecrets.enabled must be true when externalSecrets.auth.enabled=true" -}}
+{{- end -}}
 {{- if and .Values.externalSecrets.enabled .Values.auth.existingSecret .Values.externalSecrets.auth.enabled -}}
 {{- fail "auth.existingSecret and externalSecrets.auth.enabled are mutually exclusive" -}}
 {{- end -}}

--- a/charts/phpmyadmin/templates/_helpers.tpl
+++ b/charts/phpmyadmin/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "phpmyadmin.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -39,12 +40,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "phpmyadmin.image" -}}
-{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) -}}
 {{- end -}}
 
 {{/* Auth secret name */}}
 {{- define "phpmyadmin.authSecretName" -}}
-{{- if .Values.auth.existingSecret -}}
+{{- if .Values.externalSecrets.auth.targetName -}}
+{{- .Values.externalSecrets.auth.targetName -}}
+{{- else if .Values.auth.existingSecret -}}
 {{- .Values.auth.existingSecret -}}
 {{- else -}}
 {{- printf "%s-auth" (include "phpmyadmin.fullname" .) -}}
@@ -57,5 +60,44 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- .Values.config.existingConfigMap -}}
 {{- else -}}
 {{- printf "%s-config" (include "phpmyadmin.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* ExternalSecret remoteRef item */}}
+{{- define "phpmyadmin.externalSecretDataItem" -}}
+- secretKey: {{ .secretKey | quote }}
+  remoteRef:
+    {{- if not .remoteRef.key }}
+    {{- fail (printf "%s.key is required when externalSecrets.auth.enabled=true" .remoteRefName) }}
+    {{- end }}
+    key: {{ .remoteRef.key | quote }}
+    {{- with .remoteRef.property }}
+    property: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.version }}
+    version: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.decodingStrategy }}
+    decodingStrategy: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.conversionStrategy }}
+    conversionStrategy: {{ . | quote }}
+    {{- end }}
+{{- end -}}
+
+{{/* Validate ExternalSecret settings */}}
+{{- define "phpmyadmin.validateExternalSecrets" -}}
+{{- if and .Values.externalSecrets.enabled .Values.auth.existingSecret .Values.externalSecrets.auth.enabled -}}
+{{- fail "auth.existingSecret and externalSecrets.auth.enabled are mutually exclusive" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
+{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.auth.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate Gateway API settings */}}
+{{- define "phpmyadmin.validateGatewayAPI" -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
+{{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/phpmyadmin/templates/configmap.yaml
+++ b/charts/phpmyadmin/templates/configmap.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-{{- if and .Values.config.customConfig (not .Values.config.existingConfigMap) }}
+{{- if and (eq (include "phpmyadmin.needsConfigMount" .) "true") (not .Values.config.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,5 +8,10 @@ metadata:
     {{- include "phpmyadmin.labels" . | nindent 4 }}
 data:
   config.user.inc.php: |
+    {{- if eq (include "phpmyadmin.needsGeneratedConfig" .) "true" }}
+    {{- include "phpmyadmin.generatedConfig" . | nindent 4 }}
+    {{- end }}
+    {{- if .Values.config.customConfig }}
     {{- .Values.config.customConfig | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/phpmyadmin/templates/configmap.yaml
+++ b/charts/phpmyadmin/templates/configmap.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if and .Values.config.customConfig (not .Values.config.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap

--- a/charts/phpmyadmin/templates/deployment.yaml
+++ b/charts/phpmyadmin/templates/deployment.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,7 +6,9 @@ metadata:
   labels:
     {{- include "phpmyadmin.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "phpmyadmin.selectorLabels" . | nindent 6 }}
@@ -29,6 +32,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "phpmyadmin.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -53,12 +57,24 @@ spec:
             {{- if .Values.phpmyadmin.hosts }}
             - name: PMA_HOSTS
               value: {{ .Values.phpmyadmin.hosts | quote }}
+            {{- if .Values.phpmyadmin.verboses }}
+            - name: PMA_VERBOSES
+              value: {{ .Values.phpmyadmin.verboses | quote }}
+            {{- end }}
+            {{- if .Values.phpmyadmin.ports }}
+            - name: PMA_PORTS
+              value: {{ .Values.phpmyadmin.ports | quote }}
+            {{- end }}
             {{- else if .Values.phpmyadmin.host }}
             - name: PMA_HOST
               value: {{ .Values.phpmyadmin.host | quote }}
             {{- end }}
             - name: PMA_PORT
               value: {{ .Values.phpmyadmin.port | quote }}
+            {{- if .Values.phpmyadmin.arbitrary }}
+            - name: PMA_ARBITRARY
+              value: "1"
+            {{- end }}
             {{- if .Values.phpmyadmin.uploadLimit }}
             - name: UPLOAD_LIMIT
               value: {{ .Values.phpmyadmin.uploadLimit | quote }}
@@ -67,27 +83,87 @@ spec:
             - name: PMA_ABSOLUTE_URI
               value: {{ .Values.phpmyadmin.absoluteUri | quote }}
             {{- end }}
-            {{- if or .Values.auth.username .Values.auth.existingSecret }}
-            - name: PMA_USER
-              {{- if .Values.auth.existingSecret }}
+            - name: HIDE_PHP_VERSION
+              value: {{ ternary "1" "0" .Values.phpmyadmin.hidePhpVersion | quote }}
+            - name: PMA_AUTH_TYPE
+              value: {{ .Values.phpmyadmin.authType | quote }}
+            {{- if .Values.phpmyadmin.configBase64 }}
+            - name: PMA_CONFIG_BASE64
+              value: {{ .Values.phpmyadmin.configBase64 | quote }}
+            {{- end }}
+            {{- if .Values.phpmyadmin.controlHost }}
+            - name: PMA_CONTROLHOST
+              value: {{ .Values.phpmyadmin.controlHost | quote }}
+            - name: PMA_CONTROLPORT
+              value: {{ .Values.phpmyadmin.controlPort | quote }}
+            {{- end }}
+            {{- if .Values.phpmyadmin.controlUser }}
+            - name: PMA_CONTROLUSER
+              value: {{ .Values.phpmyadmin.controlUser | quote }}
+            - name: PMA_CONTROLPASS
+              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.auth.existingSecret }}
+                  name: {{ include "phpmyadmin.authSecretName" . }}
+                  key: {{ .Values.auth.existingSecretControlPasswordKey }}
+              {{- else }}
+              value: {{ .Values.phpmyadmin.controlPassword | quote }}
+              {{- end }}
+            {{- end }}
+            {{- if .Values.phpmyadmin.ssl.enabled }}
+            - name: PMA_SSL
+              value: "1"
+            - name: PMA_SSL_VERIFY
+              value: {{ ternary "1" "0" .Values.phpmyadmin.ssl.verify | quote }}
+            {{- with .Values.phpmyadmin.ssl.caPath }}
+            - name: PMA_SSL_CA
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.phpmyadmin.ssl.certPath }}
+            - name: PMA_SSL_CERT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.phpmyadmin.ssl.keyPath }}
+            - name: PMA_SSL_KEY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if or .Values.auth.username .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+            - name: PMA_USER
+              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "phpmyadmin.authSecretName" . }}
                   key: {{ .Values.auth.existingSecretUsernameKey }}
               {{- else }}
               value: {{ .Values.auth.username | quote }}
               {{- end }}
             - name: PMA_PASSWORD
-              {{- if .Values.auth.existingSecret }}
+              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.auth.existingSecret }}
+                  name: {{ include "phpmyadmin.authSecretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
               {{- else if .Values.auth.password }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "phpmyadmin.authSecretName" . }}
-                  key: password
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+              {{- end }}
+            {{- end }}
+            {{- if or .Values.auth.blowfishSecret .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+            - name: PMA_BLOWFISH_SECRET
+              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "phpmyadmin.authSecretName" . }}
+                  key: {{ .Values.auth.existingSecretBlowfishKey }}
+                  optional: true
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "phpmyadmin.authSecretName" . }}
+                  key: {{ .Values.auth.existingSecretBlowfishKey }}
               {{- end }}
             {{- end }}
             {{- with .Values.phpmyadmin.extraEnv }}
@@ -127,7 +203,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.config.customConfig .Values.config.existingConfigMap .Values.extraVolumeMounts }}
+          {{- if or .Values.config.customConfig .Values.config.existingConfigMap .Values.sessions.enabled .Values.themes.enabled .Values.extraVolumeMounts }}
           volumeMounts:
             {{- if or .Values.config.customConfig .Values.config.existingConfigMap }}
             - name: custom-config
@@ -135,16 +211,37 @@ spec:
               subPath: config.user.inc.php
               readOnly: true
             {{- end }}
+            {{- if .Values.sessions.enabled }}
+            - name: sessions
+              mountPath: /sessions
+            {{- end }}
+            {{- if .Values.themes.enabled }}
+            - name: themes
+              mountPath: /www/themes
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.config.customConfig .Values.config.existingConfigMap .Values.extraVolumes }}
+      {{- if or .Values.config.customConfig .Values.config.existingConfigMap .Values.sessions.enabled .Values.themes.enabled .Values.extraVolumes }}
       volumes:
         {{- if or .Values.config.customConfig .Values.config.existingConfigMap }}
         - name: custom-config
           configMap:
             name: {{ include "phpmyadmin.configMapName" . }}
+        {{- end }}
+        {{- if .Values.sessions.enabled }}
+        - name: sessions
+          {{- if eq .Values.sessions.type "persistentVolumeClaim" }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-sessions" (include "phpmyadmin.fullname" .)) .Values.sessions.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.themes.enabled }}
+        - name: themes
+          {{- toYaml .Values.themes.volume | nindent 10 }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/phpmyadmin/templates/deployment.yaml
+++ b/charts/phpmyadmin/templates/deployment.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+{{- include "phpmyadmin.validateExternalSecrets" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -105,7 +106,7 @@ spec:
             - name: PMA_CONTROLUSER
               value: {{ .Values.phpmyadmin.controlUser | quote }}
             - name: PMA_CONTROLPASS
-              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+              {{- if or .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "phpmyadmin.authSecretName" . }}
@@ -132,9 +133,9 @@ spec:
               value: {{ . | quote }}
             {{- end }}
             {{- end }}
-            {{- if or .Values.auth.username .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+            {{- if or .Values.auth.username .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
             - name: PMA_USER
-              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+              {{- if or .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "phpmyadmin.authSecretName" . }}
@@ -143,7 +144,7 @@ spec:
               value: {{ .Values.auth.username | quote }}
               {{- end }}
             - name: PMA_PASSWORD
-              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+              {{- if or .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "phpmyadmin.authSecretName" . }}
@@ -155,9 +156,9 @@ spec:
                   key: {{ .Values.auth.existingSecretPasswordKey }}
               {{- end }}
             {{- end }}
-            {{- if or .Values.auth.blowfishSecret .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+            {{- if or .Values.auth.blowfishSecret .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
             - name: PMA_BLOWFISH_SECRET
-              {{- if or .Values.auth.existingSecret .Values.externalSecrets.auth.enabled }}
+              {{- if or .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "phpmyadmin.authSecretName" . }}

--- a/charts/phpmyadmin/templates/deployment.yaml
+++ b/charts/phpmyadmin/templates/deployment.yaml
@@ -90,8 +90,6 @@ spec:
             - name: HIDE_PHP_VERSION
               value: "1"
             {{- end }}
-            - name: PMA_AUTH_TYPE
-              value: {{ .Values.phpmyadmin.authType | quote }}
             {{- if .Values.phpmyadmin.configBase64 }}
             - name: PMA_CONFIG_BASE64
               value: {{ .Values.phpmyadmin.configBase64 | quote }}
@@ -116,6 +114,24 @@ spec:
               {{- end }}
             {{- end }}
             {{- if .Values.phpmyadmin.ssl.enabled }}
+            {{- if .Values.phpmyadmin.hosts }}
+            - name: PMA_SSLS
+              value: {{ include "phpmyadmin.csvRepeatForHosts" (dict "hosts" .Values.phpmyadmin.hosts "value" "1") | quote }}
+            - name: PMA_SSL_VERIFIES
+              value: {{ include "phpmyadmin.csvRepeatForHosts" (dict "hosts" .Values.phpmyadmin.hosts "value" (ternary "1" "0" .Values.phpmyadmin.ssl.verify)) | quote }}
+            {{- with .Values.phpmyadmin.ssl.caPath }}
+            - name: PMA_SSL_CAS
+              value: {{ include "phpmyadmin.csvRepeatForHosts" (dict "hosts" $.Values.phpmyadmin.hosts "value" .) | quote }}
+            {{- end }}
+            {{- with .Values.phpmyadmin.ssl.certPath }}
+            - name: PMA_SSL_CERTS
+              value: {{ include "phpmyadmin.csvRepeatForHosts" (dict "hosts" $.Values.phpmyadmin.hosts "value" .) | quote }}
+            {{- end }}
+            {{- with .Values.phpmyadmin.ssl.keyPath }}
+            - name: PMA_SSL_KEYS
+              value: {{ include "phpmyadmin.csvRepeatForHosts" (dict "hosts" $.Values.phpmyadmin.hosts "value" .) | quote }}
+            {{- end }}
+            {{- else }}
             - name: PMA_SSL
               value: "1"
             - name: PMA_SSL_VERIFY
@@ -131,6 +147,7 @@ spec:
             {{- with .Values.phpmyadmin.ssl.keyPath }}
             - name: PMA_SSL_KEY
               value: {{ . | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- if or .Values.auth.username .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
@@ -157,7 +174,7 @@ spec:
               {{- end }}
             {{- end }}
             {{- if or .Values.auth.blowfishSecret .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
-            - name: PMA_BLOWFISH_SECRET
+            - name: HELMFORGE_BLOWFISH_SECRET
               {{- if or .Values.auth.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled) }}
               valueFrom:
                 secretKeyRef:
@@ -176,9 +193,14 @@ spec:
             {{- end }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
+            {{- if eq .Values.phpmyadmin.authType "http" }}
+            tcpSocket:
+              port: http
+            {{- else }}
             httpGet:
               path: {{ .Values.startupProbe.path }}
               port: http
+            {{- end }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
@@ -186,9 +208,14 @@ spec:
           {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+            {{- if eq .Values.phpmyadmin.authType "http" }}
+            tcpSocket:
+              port: http
+            {{- else }}
             httpGet:
               path: {{ .Values.livenessProbe.path }}
               port: http
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -196,9 +223,14 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+            {{- if eq .Values.phpmyadmin.authType "http" }}
+            tcpSocket:
+              port: http
+            {{- else }}
             httpGet:
               path: {{ .Values.readinessProbe.path }}
               port: http
+            {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -208,9 +240,9 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.config.customConfig .Values.config.existingConfigMap .Values.sessions.enabled .Values.themes.enabled .Values.extraVolumeMounts }}
+          {{- if or (eq (include "phpmyadmin.needsConfigMount" .) "true") .Values.sessions.enabled .Values.themes.enabled .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- if or .Values.config.customConfig .Values.config.existingConfigMap }}
+            {{- if eq (include "phpmyadmin.needsConfigMount" .) "true" }}
             - name: custom-config
               mountPath: /etc/phpmyadmin/config.user.inc.php
               subPath: config.user.inc.php
@@ -228,9 +260,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.config.customConfig .Values.config.existingConfigMap .Values.sessions.enabled .Values.themes.enabled .Values.extraVolumes }}
+      {{- if or (eq (include "phpmyadmin.needsConfigMount" .) "true") .Values.sessions.enabled .Values.themes.enabled .Values.extraVolumes }}
       volumes:
-        {{- if or .Values.config.customConfig .Values.config.existingConfigMap }}
+        {{- if eq (include "phpmyadmin.needsConfigMount" .) "true" }}
         - name: custom-config
           configMap:
             name: {{ include "phpmyadmin.configMapName" . }}

--- a/charts/phpmyadmin/templates/deployment.yaml
+++ b/charts/phpmyadmin/templates/deployment.yaml
@@ -69,8 +69,10 @@ spec:
             - name: PMA_HOST
               value: {{ .Values.phpmyadmin.host | quote }}
             {{- end }}
+            {{- if not (and .Values.phpmyadmin.hosts .Values.phpmyadmin.ports) }}
             - name: PMA_PORT
               value: {{ .Values.phpmyadmin.port | quote }}
+            {{- end }}
             {{- if .Values.phpmyadmin.arbitrary }}
             - name: PMA_ARBITRARY
               value: "1"
@@ -83,8 +85,10 @@ spec:
             - name: PMA_ABSOLUTE_URI
               value: {{ .Values.phpmyadmin.absoluteUri | quote }}
             {{- end }}
+            {{- if .Values.phpmyadmin.hidePhpVersion }}
             - name: HIDE_PHP_VERSION
-              value: {{ ternary "1" "0" .Values.phpmyadmin.hidePhpVersion | quote }}
+              value: "1"
+            {{- end }}
             - name: PMA_AUTH_TYPE
               value: {{ .Values.phpmyadmin.authType | quote }}
             {{- if .Values.phpmyadmin.configBase64 }}

--- a/charts/phpmyadmin/templates/externalsecret.yaml
+++ b/charts/phpmyadmin/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "phpmyadmin.validateExternalSecrets" . }}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "phpmyadmin.authSecretName" . }}
+  labels:
+    {{- include "phpmyadmin.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.auth.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "phpmyadmin.authSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "phpmyadmin.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretUsernameKey "remoteRefName" "externalSecrets.auth.usernameRemoteRef" "remoteRef" .Values.externalSecrets.auth.usernameRemoteRef) | nindent 4 }}
+    {{- include "phpmyadmin.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretPasswordKey "remoteRefName" "externalSecrets.auth.passwordRemoteRef" "remoteRef" .Values.externalSecrets.auth.passwordRemoteRef) | nindent 4 }}
+    {{- if .Values.externalSecrets.auth.blowfishSecretRemoteRef.key }}
+    {{- include "phpmyadmin.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretBlowfishKey "remoteRefName" "externalSecrets.auth.blowfishSecretRemoteRef" "remoteRef" .Values.externalSecrets.auth.blowfishSecretRemoteRef) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.externalSecrets.auth.controlPasswordRemoteRef.key }}
+    {{- include "phpmyadmin.externalSecretDataItem" (dict "secretKey" .Values.auth.existingSecretControlPasswordKey "remoteRefName" "externalSecrets.auth.controlPasswordRemoteRef" "remoteRef" .Values.externalSecrets.auth.controlPasswordRemoteRef) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/phpmyadmin/templates/extra-manifests.yaml
+++ b/charts/phpmyadmin/templates/extra-manifests.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- range .Values.extraManifests }}
 ---
 {{ toYaml . }}

--- a/charts/phpmyadmin/templates/gateway.yaml
+++ b/charts/phpmyadmin/templates/gateway.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "phpmyadmin.validateGatewayAPI" . }}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: {{ .Values.gatewayAPI.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "phpmyadmin.fullname" . }}
+  labels:
+    {{- include "phpmyadmin.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gatewayAPI.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ include "phpmyadmin.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/phpmyadmin/templates/hpa.yaml
+++ b/charts/phpmyadmin/templates/hpa.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "phpmyadmin.fullname" . }}
+  labels:
+    {{- include "phpmyadmin.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "phpmyadmin.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/phpmyadmin/templates/ingress.yaml
+++ b/charts/phpmyadmin/templates/ingress.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/phpmyadmin/templates/networkpolicy.yaml
+++ b/charts/phpmyadmin/templates/networkpolicy.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "phpmyadmin.fullname" . }}
+  labels:
+    {{- include "phpmyadmin.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "phpmyadmin.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 80
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSameNamespaceDatabase }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.databasePort }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/phpmyadmin/templates/networkpolicy.yaml
+++ b/charts/phpmyadmin/templates/networkpolicy.yaml
@@ -15,6 +15,7 @@ spec:
     {{- if .Values.networkPolicy.egress.enabled }}
     - Egress
     {{- end }}
+  {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
   ingress:
     - from:
         {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
@@ -29,6 +30,9 @@ spec:
       ports:
         - protocol: TCP
           port: 80
+  {{- else }}
+  ingress: []
+  {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
     {{- if .Values.networkPolicy.egress.allowDNS }}

--- a/charts/phpmyadmin/templates/pdb.yaml
+++ b/charts/phpmyadmin/templates/pdb.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "phpmyadmin.fullname" . }}
+  labels:
+    {{- include "phpmyadmin.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "phpmyadmin.selectorLabels" . | nindent 6 }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+{{- end }}

--- a/charts/phpmyadmin/templates/secret.yaml
+++ b/charts/phpmyadmin/templates/secret.yaml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-{{- if and (or .Values.auth.password .Values.auth.blowfishSecret .Values.phpmyadmin.controlPassword) (not .Values.auth.existingSecret) (not .Values.externalSecrets.auth.enabled) }}
+{{- include "phpmyadmin.validateExternalSecrets" . }}
+{{- if and (or .Values.auth.password .Values.auth.blowfishSecret .Values.phpmyadmin.controlPassword) (not .Values.auth.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.auth.enabled)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/phpmyadmin/templates/secret.yaml
+++ b/charts/phpmyadmin/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.auth.password (not .Values.auth.existingSecret) }}
+# SPDX-License-Identifier: Apache-2.0
+{{- if and (or .Values.auth.password .Values.auth.blowfishSecret .Values.phpmyadmin.controlPassword) (not .Values.auth.existingSecret) (not .Values.externalSecrets.auth.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +8,16 @@ metadata:
     {{- include "phpmyadmin.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  password: {{ .Values.auth.password | quote }}
+  {{- if .Values.auth.username }}
+  {{ .Values.auth.existingSecretUsernameKey }}: {{ .Values.auth.username | quote }}
+  {{- end }}
+  {{- if .Values.auth.password }}
+  {{ .Values.auth.existingSecretPasswordKey }}: {{ .Values.auth.password | quote }}
+  {{- end }}
+  {{- if .Values.auth.blowfishSecret }}
+  {{ .Values.auth.existingSecretBlowfishKey }}: {{ .Values.auth.blowfishSecret | quote }}
+  {{- end }}
+  {{- if .Values.phpmyadmin.controlPassword }}
+  {{ .Values.auth.existingSecretControlPasswordKey }}: {{ .Values.phpmyadmin.controlPassword | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/phpmyadmin/templates/service.yaml
+++ b/charts/phpmyadmin/templates/service.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/phpmyadmin/templates/serviceaccount.yaml
+++ b/charts/phpmyadmin/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/phpmyadmin/templates/sessions-pvc.yaml
+++ b/charts/phpmyadmin/templates/sessions-pvc.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if and .Values.sessions.enabled (eq .Values.sessions.type "persistentVolumeClaim") (not .Values.sessions.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "phpmyadmin.fullname" . }}-sessions
+  labels:
+    {{- include "phpmyadmin.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.sessions.accessModes | nindent 4 }}
+  {{- with .Values.sessions.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.sessions.size | quote }}
+{{- end }}

--- a/charts/phpmyadmin/tests/configmap_test.yaml
+++ b/charts/phpmyadmin/tests/configmap_test.yaml
@@ -19,6 +19,26 @@ tests:
           path: data["config.user.inc.php"]
           pattern: "ShowPhpInfo"
 
+  - it: should render auth type through config.user.inc.php
+    set:
+      phpmyadmin.authType: http
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.user.inc.php"]
+          pattern: "\\$cfg\\['Servers'\\]\\[\\$i\\]\\['auth_type'\\] = \"http\";"
+
+  - it: should render blowfish secret through config.user.inc.php
+    set:
+      auth.blowfishSecret: "use-a-32-byte-random-secret-here"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.user.inc.php"]
+          pattern: "HELMFORGE_BLOWFISH_SECRET"
+
   - it: should not render when using existing ConfigMap
     set:
       config.customConfig: "test"

--- a/charts/phpmyadmin/tests/configmap_test.yaml
+++ b/charts/phpmyadmin/tests/configmap_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: configmap
 templates:
   - templates/configmap.yaml

--- a/charts/phpmyadmin/tests/deployment_test.yaml
+++ b/charts/phpmyadmin/tests/deployment_test.yaml
@@ -119,6 +119,27 @@ tests:
             name: HIDE_PHP_VERSION
           any: true
 
+  - it: should not render unsupported PMA_AUTH_TYPE env
+    set:
+      phpmyadmin.authType: http
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_AUTH_TYPE
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-config
+            mountPath: /etc/phpmyadmin/config.user.inc.php
+            subPath: config.user.inc.php
+            readOnly: true
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.httpGet
+
   - it: should set auto-login env vars when auth is configured
     set:
       phpmyadmin.host: mysql.default.svc
@@ -160,6 +181,15 @@ tests:
               secretKeyRef:
                 name: my-auth-secret
                 key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HELMFORGE_BLOWFISH_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: my-auth-secret
+                key: blowfish-secret
+                optional: true
 
   - it: should use external secret target for auto-login
     set:
@@ -177,6 +207,36 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-phpmyadmin-auth
                 key: username
+
+  - it: should use multi-host SSL env vars with PMA_HOSTS
+    set:
+      phpmyadmin.hosts: "mysql-1.svc,mysql-2.svc"
+      phpmyadmin.ssl.enabled: true
+      phpmyadmin.ssl.verify: false
+      phpmyadmin.ssl.caPath: /etc/phpmyadmin/ssl/ca.crt
+      phpmyadmin.ssl.certPath: /etc/phpmyadmin/ssl/client.crt
+      phpmyadmin.ssl.keyPath: /etc/phpmyadmin/ssl/client.key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_SSLS
+            value: "1,1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_SSL_VERIFIES
+            value: "0,0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_SSL_CAS
+            value: "/etc/phpmyadmin/ssl/ca.crt,/etc/phpmyadmin/ssl/ca.crt"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_SSL
+          any: true
 
   - it: should not set auto-login env vars when auth is empty
     set:

--- a/charts/phpmyadmin/tests/deployment_test.yaml
+++ b/charts/phpmyadmin/tests/deployment_test.yaml
@@ -39,6 +39,11 @@ tests:
           content:
             name: PMA_PORTS
             value: "3306,3307"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_PORT
+          any: true
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -103,6 +108,16 @@ tests:
           content:
             name: PMA_ABSOLUTE_URI
             value: "https://pma.example.com/"
+
+  - it: should omit HIDE_PHP_VERSION when disabled
+    set:
+      phpmyadmin.hidePhpVersion: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HIDE_PHP_VERSION
+          any: true
 
   - it: should set auto-login env vars when auth is configured
     set:

--- a/charts/phpmyadmin/tests/deployment_test.yaml
+++ b/charts/phpmyadmin/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: deployment
 templates:
   - templates/deployment.yaml
@@ -25,12 +26,24 @@ tests:
   - it: should set PMA_HOSTS when hosts is configured
     set:
       phpmyadmin.hosts: "mysql-1.svc,mysql-2.svc"
+      phpmyadmin.ports: "3306,3307"
+      phpmyadmin.verboses: "Primary,Replica"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: PMA_HOSTS
             value: "mysql-1.svc,mysql-2.svc"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_PORTS
+            value: "3306,3307"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_VERBOSES
+            value: "Primary,Replica"
 
   - it: should prefer PMA_HOSTS over PMA_HOST when both are set
     set:
@@ -69,6 +82,16 @@ tests:
           content:
             name: UPLOAD_LIMIT
             value: "128M"
+
+  - it: should enable arbitrary server mode
+    set:
+      phpmyadmin.arbitrary: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_ARBITRARY
+            value: "1"
 
   - it: should set PMA_ABSOLUTE_URI
     set:
@@ -123,6 +146,23 @@ tests:
                 name: my-auth-secret
                 key: password
 
+  - it: should use external secret target for auto-login
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.auth.enabled: true
+      externalSecrets.auth.usernameRemoteRef.key: prod/phpmyadmin
+      externalSecrets.auth.passwordRemoteRef.key: prod/phpmyadmin
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PMA_USER
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-phpmyadmin-auth
+                key: username
+
   - it: should not set auto-login env vars when auth is empty
     set:
       phpmyadmin.host: mysql.default.svc
@@ -152,6 +192,21 @@ tests:
             name: custom-config
             configMap:
               name: RELEASE-NAME-phpmyadmin-config
+
+  - it: should mount sessions when enabled
+    set:
+      sessions.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: sessions
+            mountPath: /sessions
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: sessions
+            emptyDir: {}
 
   - it: should not mount config volume when not configured
     set:

--- a/charts/phpmyadmin/tests/externalsecret_test.yaml
+++ b/charts/phpmyadmin/tests/externalsecret_test.yaml
@@ -35,3 +35,13 @@ tests:
       - equal:
           path: spec.target.name
           value: RELEASE-NAME-phpmyadmin-auth
+
+  - it: should fail when auth ExternalSecret is enabled without the global flag
+    set:
+      externalSecrets.enabled: false
+      externalSecrets.auth.enabled: true
+      externalSecrets.auth.usernameRemoteRef.key: prod/phpmyadmin
+      externalSecrets.auth.passwordRemoteRef.key: prod/phpmyadmin
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.enabled must be true when externalSecrets.auth.enabled=true

--- a/charts/phpmyadmin/tests/externalsecret_test.yaml
+++ b/charts/phpmyadmin/tests/externalsecret_test.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: externalsecret
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret with v1 api
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.secretStoreRef.kind: ClusterSecretStore
+      externalSecrets.auth.enabled: true
+      externalSecrets.auth.usernameRemoteRef.key: prod/phpmyadmin
+      externalSecrets.auth.usernameRemoteRef.property: username
+      externalSecrets.auth.passwordRemoteRef.key: prod/phpmyadmin
+      externalSecrets.auth.passwordRemoteRef.property: password
+      externalSecrets.auth.blowfishSecretRemoteRef.key: prod/phpmyadmin
+      externalSecrets.auth.blowfishSecretRemoteRef.property: blowfish-secret
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-phpmyadmin-auth

--- a/charts/phpmyadmin/tests/gateway_test.yaml
+++ b/charts/phpmyadmin/tests/gateway_test.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: gateway
+templates:
+  - templates/gateway.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public
+          namespace: gateway-system
+      gatewayAPI.hostnames:
+        - pma.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.hostnames[0]
+          value: pma.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80

--- a/charts/phpmyadmin/tests/hpa_pdb_sessions_test.yaml
+++ b/charts/phpmyadmin/tests/hpa_pdb_sessions_test.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: hpa pdb sessions
+templates:
+  - templates/hpa.yaml
+  - templates/pdb.yaml
+  - templates/sessions-pvc.yaml
+tests:
+  - it: should render HPA when autoscaling is enabled
+    template: templates/hpa.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 1
+      - equal:
+          path: spec.maxReplicas
+          value: 3
+
+  - it: should render PDB when enabled
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should render sessions PVC when persistent sessions are enabled
+    template: templates/sessions-pvc.yaml
+    set:
+      sessions.enabled: true
+      sessions.type: persistentVolumeClaim
+      sessions.size: 2Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 2Gi

--- a/charts/phpmyadmin/tests/ingress_test.yaml
+++ b/charts/phpmyadmin/tests/ingress_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ingress
 templates:
   - templates/ingress.yaml

--- a/charts/phpmyadmin/tests/networkpolicy_test.yaml
+++ b/charts/phpmyadmin/tests/networkpolicy_test.yaml
@@ -27,3 +27,12 @@ tests:
       - equal:
           path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: NAMESPACE
+
+  - it: should deny ingress when no ingress peers are configured
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.allowSameNamespace: false
+    asserts:
+      - equal:
+          path: spec.ingress
+          value: []

--- a/charts/phpmyadmin/tests/networkpolicy_test.yaml
+++ b/charts/phpmyadmin/tests/networkpolicy_test.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: networkpolicy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ingress and egress policy
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 80
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: NAMESPACE

--- a/charts/phpmyadmin/tests/secret_test.yaml
+++ b/charts/phpmyadmin/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: secret
 templates:
   - templates/secret.yaml
@@ -16,6 +17,16 @@ tests:
       - equal:
           path: stringData.password
           value: "secret123"
+
+  - it: should render blowfish secret when configured
+    set:
+      auth.blowfishSecret: "0123456789abcdef0123456789abcdef"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData["blowfish-secret"]
+          value: "0123456789abcdef0123456789abcdef"
 
   - it: should not render when using existing secret
     set:

--- a/charts/phpmyadmin/tests/service_test.yaml
+++ b/charts/phpmyadmin/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: service
 templates:
   - templates/service.yaml
@@ -39,3 +40,20 @@ tests:
             targetPort: http
             protocol: TCP
             name: http
+
+  - it: should support dual-stack service settings
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/phpmyadmin/tests/serviceaccount_test.yaml
+++ b/charts/phpmyadmin/tests/serviceaccount_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: serviceaccount
 templates:
   - templates/serviceaccount.yaml
@@ -18,3 +19,15 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-phpmyadmin
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should allow automounting the service account token
+    set:
+      serviceAccount.create: true
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/phpmyadmin/values.schema.json
+++ b/charts/phpmyadmin/values.schema.json
@@ -1,249 +1,218 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "phpMyAdmin Helm Chart Values",
-  "description": "Configuration values for the phpMyAdmin Helm chart",
+  "description": "Configuration values for the phpMyAdmin Helm chart.",
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "nameOverride": {
-      "type": "string",
-      "description": "Override the chart name"
-    },
-    "fullnameOverride": {
-      "type": "string",
-      "description": "Override the full release name"
-    },
-    "commonLabels": {
-      "type": "object",
-      "description": "Labels to add to all resources"
-    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
     "image": {
       "type": "object",
-      "description": "Container image configuration",
       "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Container image repository"
-        },
-        "tag": {
-          "type": "string",
-          "description": "Image tag (defaults to Chart.appVersion)"
-        },
-        "pullPolicy": {
-          "type": "string",
-          "description": "Image pull policy",
-          "enum": ["Always", "IfNotPresent", "Never"]
-        }
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
       }
     },
-    "imagePullSecrets": {
-      "type": "array",
-      "description": "Image pull secrets for private registries"
-    },
-    "replicaCount": {
-      "type": "integer",
-      "description": "Number of replicas"
-    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "replicaCount": { "type": "integer", "minimum": 1 },
     "phpmyadmin": {
       "type": "object",
-      "description": "phpMyAdmin application configuration",
       "properties": {
-        "host": {
-          "type": "string",
-          "description": "MySQL/MariaDB host to connect to"
+        "host": { "type": "string" },
+        "hosts": { "type": "string" },
+        "verboses": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ports": { "type": "string" },
+        "arbitrary": { "type": "boolean" },
+        "uploadLimit": { "type": "string" },
+        "absoluteUri": { "type": "string" },
+        "hidePhpVersion": { "type": "boolean" },
+        "configBase64": { "type": "string" },
+        "authType": { "type": "string", "enum": ["cookie", "config", "http", "signon"] },
+        "controlHost": { "type": "string" },
+        "controlPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "controlUser": { "type": "string" },
+        "controlPassword": { "type": "string" },
+        "ssl": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "verify": { "type": "boolean" },
+            "caPath": { "type": "string" },
+            "certPath": { "type": "string" },
+            "keyPath": { "type": "string" }
+          }
         },
-        "hosts": {
-          "type": "string",
-          "description": "Comma-separated list of MySQL hosts for multi-server mode"
-        },
-        "port": {
-          "type": "integer",
-          "description": "MySQL port"
-        },
-        "uploadLimit": {
-          "type": "string",
-          "description": "Max upload size for SQL imports"
-        },
-        "absoluteUri": {
-          "type": "string",
-          "description": "Absolute URI when behind a reverse proxy"
-        },
-        "extraEnv": {
-          "type": "array",
-          "description": "Extra environment variables"
-        }
+        "extraEnv": { "type": "array", "items": { "type": "object" } }
       }
     },
     "auth": {
       "type": "object",
-      "description": "Authentication configuration for auto-login",
       "properties": {
-        "username": {
-          "type": "string",
-          "description": "MySQL username for auto-login"
-        },
-        "password": {
-          "type": "string",
-          "description": "MySQL password for auto-login"
-        },
-        "existingSecret": {
-          "type": "string",
-          "description": "Existing secret containing auto-login credentials"
-        },
-        "existingSecretUsernameKey": {
-          "type": "string",
-          "description": "Key in existing secret for the username"
-        },
-        "existingSecretPasswordKey": {
-          "type": "string",
-          "description": "Key in existing secret for the password"
-        }
+        "username": { "type": "string" },
+        "password": { "type": "string" },
+        "blowfishSecret": { "type": "string" },
+        "existingSecret": { "type": "string" },
+        "existingSecretUsernameKey": { "type": "string" },
+        "existingSecretPasswordKey": { "type": "string" },
+        "existingSecretBlowfishKey": { "type": "string" },
+        "existingSecretControlPasswordKey": { "type": "string" }
       }
     },
     "config": {
       "type": "object",
-      "description": "Custom phpMyAdmin configuration",
       "properties": {
-        "customConfig": {
-          "type": "string",
-          "description": "Raw content for config.user.inc.php"
-        },
-        "existingConfigMap": {
-          "type": "string",
-          "description": "Existing ConfigMap with config.user.inc.php"
-        }
+        "customConfig": { "type": "string" },
+        "existingConfigMap": { "type": "string" }
       }
     },
-    "resources": {
-      "type": "object",
-      "description": "Resource requests and limits"
-    },
-    "podSecurityContext": {
-      "type": "object",
-      "description": "Pod security context"
-    },
-    "securityContext": {
-      "type": "object",
-      "description": "Container security context"
-    },
-    "startupProbe": {
-      "type": "object",
-      "description": "Startup probe configuration"
-    },
-    "livenessProbe": {
-      "type": "object",
-      "description": "Liveness probe configuration"
-    },
-    "readinessProbe": {
-      "type": "object",
-      "description": "Readiness probe configuration"
-    },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "startupProbe": { "type": "object" },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" },
     "service": {
       "type": "object",
-      "description": "Service configuration",
       "properties": {
-        "type": {
-          "type": "string",
-          "description": "Service type",
-          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
-        },
-        "port": {
-          "type": "integer",
-          "description": "Service port"
-        },
-        "annotations": {
-          "type": "object",
-          "description": "Service annotations"
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2,
+          "uniqueItems": true
         }
       }
     },
-    "ingress": {
+    "ingress": { "type": "object" },
+    "gatewayAPI": {
       "type": "object",
-      "description": "Ingress configuration",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable ingress"
-        },
-        "ingressClassName": {
-          "type": "string",
-          "description": "Ingress class name"
-        },
-        "annotations": {
-          "type": "object",
-          "description": "Ingress annotations"
-        },
-        "hosts": {
-          "type": "array",
-          "description": "Ingress hosts"
-        },
-        "tls": {
-          "type": "array",
-          "description": "TLS configuration"
-        }
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string", "enum": ["gateway.networking.k8s.io/v1"] },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "matches": { "type": "array", "items": { "type": "object" }, "minItems": 1 }
       }
     },
     "serviceAccount": {
       "type": "object",
-      "description": "Service account configuration",
       "properties": {
-        "create": {
-          "type": "boolean",
-          "description": "Create a service account"
-        },
-        "name": {
-          "type": "string",
-          "description": "Service account name"
-        },
-        "annotations": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"] },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] },
+        "maxUnavailable": { "type": ["integer", "string"] }
+      }
+    },
+    "sessions": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "type": { "type": "string", "enum": ["emptyDir", "persistentVolumeClaim"] },
+        "existingClaim": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "size": { "type": "string" }
+      }
+    },
+    "themes": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "volume": { "type": "object" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingress": {
           "type": "object",
-          "description": "Service account annotations"
+          "properties": {
+            "allowSameNamespace": { "type": "boolean" },
+            "extraFrom": { "type": "array", "items": { "type": "object" } }
+          }
+        },
+        "egress": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowDNS": { "type": "boolean" },
+            "allowSameNamespaceDatabase": { "type": "boolean" },
+            "databasePort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "allowHTTPS": { "type": "boolean" },
+            "extraTo": { "type": "array", "items": { "type": "object" } }
+          }
         }
       }
     },
-    "nodeSelector": {
+    "externalSecrets": {
       "type": "object",
-      "description": "Node selector"
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string", "enum": ["external-secrets.io/v1"] },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "None", "Orphan"] }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "targetName": { "type": "string" },
+            "usernameRemoteRef": { "type": "object" },
+            "passwordRemoteRef": { "type": "object" },
+            "blowfishSecretRemoteRef": { "type": "object" },
+            "controlPasswordRemoteRef": { "type": "object" }
+          }
+        }
+      }
     },
-    "tolerations": {
-      "type": "array",
-      "description": "Tolerations"
-    },
-    "affinity": {
-      "type": "object",
-      "description": "Affinity rules"
-    },
-    "topologySpreadConstraints": {
-      "type": "array",
-      "description": "Topology spread constraints"
-    },
-    "priorityClassName": {
-      "type": "string",
-      "description": "Priority class name"
-    },
-    "terminationGracePeriodSeconds": {
-      "type": "integer",
-      "description": "Termination grace period in seconds"
-    },
-    "podLabels": {
-      "type": "object",
-      "description": "Additional pod labels"
-    },
-    "podAnnotations": {
-      "type": "object",
-      "description": "Additional pod annotations"
-    },
-    "extraVolumeMounts": {
-      "type": "array",
-      "description": "Extra volume mounts"
-    },
-    "extraVolumes": {
-      "type": "array",
-      "description": "Extra volumes"
-    },
-    "extraManifests": {
-      "type": "array",
-      "description": "Extra Kubernetes manifests"
-    }
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer" },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
   }
 }

--- a/charts/phpmyadmin/values.yaml
+++ b/charts/phpmyadmin/values.yaml
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # phpMyAdmin Helm Chart
 # =============================================================================
 # Uses the official phpmyadmin/phpmyadmin Docker image.
-# Stateless — no persistent storage required.
+# Stateless - no persistent storage required.
 # Connects to any MySQL/MariaDB server via PMA_HOST.
 # =============================================================================
 
@@ -36,12 +37,39 @@ phpmyadmin:
   host: ""
   # -- Comma-separated list of MySQL hosts for multi-server mode
   hosts: ""
+  # -- Comma-separated display names for PMA_HOSTS entries
+  verboses: ""
   # -- MySQL port
   port: 3306
+  # -- Comma-separated ports for PMA_HOSTS entries. Empty uses phpmyadmin.port.
+  ports: ""
+  # -- Allow users to enter an arbitrary database host on the login screen
+  arbitrary: false
   # -- Max upload size for SQL imports (e.g., "64M", "128M")
   uploadLimit: "64M"
   # -- Absolute URI when behind a reverse proxy (e.g., https://pma.example.com/)
   absoluteUri: ""
+  # -- Hide the PHP version from the web server response headers
+  hidePhpVersion: true
+  # -- Base64-encoded phpMyAdmin configuration passed through PMA_CONFIG_BASE64
+  configBase64: ""
+  # -- Authentication type used by phpMyAdmin: cookie | config | http | signon
+  authType: cookie
+  # -- Optional control host for phpMyAdmin configuration storage
+  controlHost: ""
+  # -- Optional control port for phpMyAdmin configuration storage
+  controlPort: 3306
+  # -- Optional control user for phpMyAdmin configuration storage
+  controlUser: ""
+  # -- Optional control user password. Prefer auth.existingSecret or externalSecrets.auth for production.
+  controlPassword: ""
+  # -- Enable MySQL client TLS variables for phpMyAdmin
+  ssl:
+    enabled: false
+    verify: true
+    caPath: ""
+    certPath: ""
+    keyPath: ""
   # -- Extra environment variables
   extraEnv: []
   # - name: PMA_VERBOSE
@@ -56,12 +84,18 @@ auth:
   username: ""
   # -- MySQL password for auto-login
   password: ""
+  # -- Blowfish secret used by cookie authentication. Prefer existingSecret or externalSecrets.auth in production.
+  blowfishSecret: ""
   # -- Existing secret containing auto-login credentials
   existingSecret: ""
   # -- Key in existing secret for the username
   existingSecretUsernameKey: username
   # -- Key in existing secret for the password
   existingSecretPasswordKey: password
+  # -- Key in existing secret for the blowfish secret
+  existingSecretBlowfishKey: blowfish-secret
+  # -- Key in existing secret for the control user password
+  existingSecretControlPasswordKey: control-password
 
 # =============================================================================
 # Custom Configuration
@@ -129,6 +163,10 @@ service:
   port: 80
   # -- Annotations for the service
   annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Ordered Service IP families: IPv4 | IPv6. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -155,6 +193,31 @@ ingress:
     #     - pma.example.com
 
 # =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Create an HTTPRoute. Requires Gateway API CRDs and an existing Gateway.
+  enabled: false
+  # -- API version for HTTPRoute
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- HTTPRoute annotations
+  annotations: {}
+  # -- Parent Gateway references
+  parentRefs: []
+    # - name: public
+    #   namespace: gateway-system
+    #   sectionName: https
+  # -- Optional HTTPRoute hostnames
+  hostnames: []
+    # - pma.example.com
+  # -- Path matches routed to phpMyAdmin
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
+# =============================================================================
 # Service Account
 # =============================================================================
 
@@ -165,6 +228,46 @@ serviceAccount:
   name: ""
   # -- Annotations for the service account
   annotations: {}
+  # -- Mount the ServiceAccount token into workload pods. Keep false unless an extension needs Kubernetes API access.
+  automountServiceAccountToken: false
+
+# =============================================================================
+# Autoscaling and Availability
+# =============================================================================
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: ""
+
+pdb:
+  # -- Enable PodDisruptionBudget
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+# =============================================================================
+# Sessions and Themes
+# =============================================================================
+
+sessions:
+  # -- Mount /sessions. Recommended for multi-replica deployments using cookie/session based auth.
+  enabled: false
+  # -- Session storage type: emptyDir | persistentVolumeClaim
+  type: emptyDir
+  existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+
+themes:
+  # -- Mount custom themes into /www/themes from an existing volume
+  enabled: false
+  volume: {}
 
 # =============================================================================
 # Scheduling
@@ -176,6 +279,67 @@ affinity: {}
 topologySpreadConstraints: []
 priorityClassName: ""
 terminationGracePeriodSeconds: 30
+
+# =============================================================================
+# NetworkPolicy
+# =============================================================================
+
+networkPolicy:
+  # -- Create a NetworkPolicy for phpMyAdmin pods
+  enabled: false
+  ingress:
+    # -- Allow ingress from pods in the same namespace
+    allowSameNamespace: true
+    # -- Additional ingress "from" rules
+    extraFrom: []
+  egress:
+    # -- Add egress rules. Disabled keeps CNI default egress behavior.
+    enabled: false
+    # -- Allow DNS egress to kube-dns/CoreDNS
+    allowDNS: true
+    # -- Allow TCP egress to database pods in the same namespace
+    allowSameNamespaceDatabase: true
+    # -- Database port allowed when allowSameNamespaceDatabase=true
+    databasePort: 3306
+    # -- Allow HTTPS egress for external dependencies such as identity providers
+    allowHTTPS: false
+    # -- Additional egress "to" rules
+    extraTo: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion. Use external-secrets.io/v1 for current ESO releases.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval for ExternalSecret resources.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  auth:
+    # -- Manage the phpMyAdmin auth Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-phpmyadmin-auth.
+    targetName: ""
+    usernameRemoteRef: {}
+      # key: prod/phpmyadmin
+      # property: username
+    passwordRemoteRef: {}
+      # key: prod/phpmyadmin
+      # property: password
+    blowfishSecretRemoteRef: {}
+      # key: prod/phpmyadmin
+      # property: blowfish-secret
+    controlPasswordRemoteRef: {}
+      # key: prod/phpmyadmin
+      # property: control-password
 
 # =============================================================================
 # Extra


### PR DESCRIPTION
## Summary

- Modernizes the phpMyAdmin chart with production-oriented controls: External Secrets Operator v1, Gateway API HTTPRoute, Service dual-stack values, NetworkPolicy, ServiceAccount token automount control, HPA, PDB, optional shared sessions, and extended phpMyAdmin runtime settings.
- Updates README, NOTES, DESIGN, examples, ci values, values schema, and unit tests.
- Adds SPDX license headers across the phpMyAdmin chart files.

## Breaking Change

`serviceAccount.automountServiceAccountToken` now defaults to `false` and is also applied to the workload pod. Set it to `true` if a custom extension, sidecar, or extra manifest requires Kubernetes API credentials mounted into the pod.

## Validation

- `helm dependency build charts/phpmyadmin`
- `helm lint --strict charts/phpmyadmin`
- `helm unittest charts/phpmyadmin` -> 50 tests, 10 suites passed
- Rendered all `charts/phpmyadmin/ci/*.yaml`
- Rendered all `charts/phpmyadmin/examples/*.yaml`
- `ah lint -p charts/phpmyadmin -k helm` -> passed
- `helm template ... -f charts/phpmyadmin/examples/production.yaml | kubectl apply --dry-run=server -f -` -> passed on k3d v1.31.5
- MCP Helmforge validations:
  - GR-060 Gateway API -> PASS
  - GR-061 External Secrets -> PASS
  - GR-065 values/schema quality -> PASS
  - GR-027/063/067 CI evidence -> PASS

## K3D Evidence

Validated on local k3d `charts-test`:

- Default install with local MySQL service: phpMyAdmin returned HTTP 200 and `logged_in:true`.
- Production/hardening install: Deployment 2/2, PDB, NetworkPolicy, ServiceAccount and session mount rendered/installed; HTTP access returned `logged_in:true` using an explicit local CNI `extraFrom` rule.
- External Secrets Operator v1: real ESO reconciliation with `SecretStore` fake provider, `ExternalSecret` status `SecretSynced=True`, generated Secret consumed by the pod, HTTP returned `logged_in:true`.
- Gateway API: HTTPRoute created successfully against installed Gateway API CRDs; no GatewayClass/controller is installed in the local cluster, so external routing was not expected.
- Service dual-stack: render/schema passed. The existing `charts-test` cluster is single-stack and rejects IPv6 Service families (`IPv6: not configured on this cluster`). A temporary dual-stack cluster creation was attempted but did not become usable within the local timeout, so this remains validated by render/schema/server API behavior where supported.

## Notes

`kubeconform -strict` was attempted, but the local kubeconform binary could not resolve `raw.githubusercontent.com` through `1.1.1.1`. The rendered production manifest was validated with Kubernetes server-side dry-run against k3d v1.31.5 as the deterministic local fallback.