### PR TITLE
feat(wordpress)!: modernize production deployment

### DIFF
--- a/charts/wordpress/Chart.lock
+++ b/charts/wordpress/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.7.1
-digest: sha256:3558a90e6dd568ee8d05fe650184fe04a6188c901d5ae5093150266f0fc2dda9
-generated: "2026-04-01T09:05:37.817902-03:00"

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -49,6 +49,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 1.8.5
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
+  - name: redis
+    version: 1.6.14
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: objectCache.redis.subchart.enabled

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: wordpress
 type: application

--- a/charts/wordpress/DESIGN.md
+++ b/charts/wordpress/DESIGN.md
@@ -1,0 +1,178 @@
+# WordPress Chart Design
+
+This chart packages WordPress for Kubernetes using the official Apache image and HelmForge platform conventions. The default install optimizes for a fast working environment, while production controls are opt-in and explicit.
+
+## Goals
+
+- Keep development installs simple.
+- Provide a production path without forcing production defaults.
+- Avoid raw overrides for common operational needs.
+- Support both modern Kubernetes Gateway API and classic Ingress.
+- Support native Kubernetes Secrets and External Secrets Operator.
+- Make database, storage, cron, backup, and network choices visible.
+
+## Default Architecture
+
+```text
+User
+  |
+  | port-forward or Service
+  v
++-------------------+        +----------------------+
+| WordPress Service | -----> | WordPress Deployment |
++-------------------+        | official apache img  |
+                             | /var/www/html PVC    |
+                             +----------+-----------+
+                                        |
+                                        | TCP 3306
+                                        v
+                             +----------------------+
+                             | HelmForge MySQL      |
+                             | StatefulSet + PVC    |
+                             +----------------------+
+```
+
+This mode is useful for development, previews, and small internal installs. Credentials can be generated or supplied through values.
+
+## Production Architecture With External Database
+
+```text
+Internet
+  |
+  v
++-------------------+       +-------------------+
+| Gateway / Ingress | ----> | WordPress Service |
++-------------------+       +---------+---------+
+                                      |
+                                      v
+                           +----------------------+
+                           | WordPress Deployment |
+                           | HPA optional         |
+                           | PDB optional         |
+                           | wp-cron CronJob      |
+                           +----------+-----------+
+                                      |
+               +----------------------+------------------+
+               |                                         |
+               v                                         v
+    +----------------------+                 +----------------------+
+    | RWX shared storage   |                 | External MySQL or    |
+    | or object media flow |                 | managed MariaDB      |
+    +----------------------+                 +----------------------+
+```
+
+For more than one WordPress replica, the content strategy must be explicit. Use ReadWriteMany storage for shared files, or operate plugins/themes/media through a deployment and object-storage strategy.
+
+## Secrets Architecture
+
+```text
+External secret store
+  |
+  | External Secrets Operator
+  v
++----------------+       +----------------------+
+| ExternalSecret | ----> | Kubernetes Secret    |
++----------------+       | admin/database/S3    |
+                         +----------+-----------+
+                                    |
+                                    v
+                         +----------------------+
+                         | WordPress / Backup   |
+                         +----------------------+
+```
+
+External Secrets is optional. Native Secrets remain available for development and simple clusters. The chart prevents using an existing Secret and an ExternalSecret for the same credential at the same time.
+
+## Plugin Installer Architecture
+
+```text
+Helm post-install/post-upgrade
+  |
+  v
++----------------------+
+| Plugin Installer Job |
+| wordpress:cli        |
++----------+-----------+
+           |
+           | mounts same PVC
+           v
++----------------------+
+| WordPress files      |
+| wp-content/plugins   |
+| object-cache.php     |
++----------------------+
+```
+
+The installer is idempotent. It checks whether each plugin exists before installing it and activates plugins only after WordPress core has completed installation. Before `wp core install`, it downloads official WordPress.org plugin archives and extracts them without using database-backed WP-CLI plugin operations. It runs as UID/GID 33 (`www-data`) by default to match the official WordPress image file ownership on the shared PVC. When persistence uses `ReadWriteOnce`, the Job uses pod affinity to schedule on the same node as the WordPress pod. The Job is intentionally fail-fast with a 60 second active deadline and one retry by default.
+
+## Redis Object Cache Architecture
+
+```text
+WordPress Deployment
+  |
+  | WP_REDIS_* constants
+  | object-cache.php drop-in
+  v
++-------------------------+
+| Redis Object Cache      |
+| plugin/drop-in          |
++------------+------------+
+             |
+             | TCP 6379
+             v
++-------------------------+
+| HelmForge Redis subchart|
+| or external Redis       |
++-------------------------+
+```
+
+Redis integration is considered functional only when the drop-in exists and Redis receives cache keys after WordPress requests. A running Redis pod alone is not enough.
+
+## Routing Architecture
+
+```text
+Gateway API path
+Client -> Gateway -> HTTPRoute -> Service -> WordPress Pod
+
+Ingress path
+Client -> Ingress Controller -> Ingress -> Service -> WordPress Pod
+```
+
+Gateway API is preferred for clusters that already standardize on Gateway resources. Ingress remains supported for broad compatibility.
+
+## Security Model
+
+- ServiceAccount token automount is disabled by default.
+- NetworkPolicy is optional and starts with ingress isolation when enabled.
+- Egress can be explicitly allowed for DNS, database, HTTPS, SMTP, and custom destinations.
+- WordPress file editing can be disabled with `wordpress.disallowFileEdit`.
+- Admin SSL can be enforced with `wordpress.forceSSLAdmin`.
+- Secrets can be sourced from External Secrets Operator using `external-secrets.io/v1`.
+
+## Availability Model
+
+The chart exposes HPA and PDB, but it does not assume WordPress is safely horizontally scalable by default. Autoscaling is valid only when content writes are safe across replicas.
+
+Use this order for production decisions:
+
+1. Choose database mode and backup ownership.
+2. Choose content storage/media strategy.
+3. Enable TLS routing.
+4. Enable explicit resources, NetworkPolicy, metrics, and backups.
+5. Add HPA/PDB only after storage and plugin behavior are safe for multiple pods.
+
+## Backup Model
+
+```text
+Backup CronJob
+  |
+  +-- mysqldump database -> sql.gz
+  +-- archive wp-content -> tar.gz
+  +-- upload both artifacts -> S3-compatible bucket
+```
+
+The backup CronJob is designed as a practical baseline, not a full disaster recovery program. Production users should test restores, retention, object lock, and database consistency in their own environment.
+
+## Dependency Policy
+
+The chart depends on HelmForge MySQL through `Chart.yaml`. The repository workflow does not commit `Chart.lock` for this chart, so dependency resolution is performed during validation and packaging.

--- a/charts/wordpress/DESIGN.md
+++ b/charts/wordpress/DESIGN.md
@@ -1,6 +1,7 @@
 # WordPress Chart Design
 
-This chart packages WordPress for Kubernetes using the official Apache image and HelmForge platform conventions. The default install optimizes for a fast working environment, while production controls are opt-in and explicit.
+This chart packages WordPress for Kubernetes using the official Apache image and HelmForge platform conventions.
+The default install optimizes for a fast working environment, while production controls are opt-in and explicit.
 
 ## Goals
 
@@ -61,7 +62,8 @@ Internet
     +----------------------+                 +----------------------+
 ```
 
-For more than one WordPress replica, the content strategy must be explicit. Use ReadWriteMany storage for shared files, or operate plugins/themes/media through a deployment and object-storage strategy.
+For more than one WordPress replica, the content strategy must be explicit.
+Use ReadWriteMany storage for shared files, or operate plugins/themes/media through a deployment and object-storage strategy.
 
 ## Secrets Architecture
 
@@ -81,7 +83,8 @@ External secret store
                          +----------------------+
 ```
 
-External Secrets is optional. Native Secrets remain available for development and simple clusters. The chart prevents using an existing Secret and an ExternalSecret for the same credential at the same time.
+External Secrets is optional. Native Secrets remain available for development and simple clusters.
+The chart prevents using an existing Secret and an ExternalSecret for the same credential at the same time.
 
 ## Plugin Installer Architecture
 
@@ -103,7 +106,13 @@ Helm post-install/post-upgrade
 +----------------------+
 ```
 
-The installer is idempotent. It checks whether each plugin exists before installing it and activates plugins only after WordPress core has completed installation. Before `wp core install`, it downloads official WordPress.org plugin archives and extracts them without using database-backed WP-CLI plugin operations. It runs as UID/GID 33 (`www-data`) by default to match the official WordPress image file ownership on the shared PVC. When persistence uses `ReadWriteOnce`, the Job uses pod affinity to schedule on the same node as the WordPress pod. The Job is intentionally fail-fast with a 60 second active deadline and one retry by default.
+The installer is idempotent. It checks whether each plugin exists before installing it and activates plugins only after
+WordPress core has completed installation.
+Before `wp core install`, it downloads official WordPress.org plugin archives and extracts them without using
+database-backed WP-CLI plugin operations.
+It runs as UID/GID 33 (`www-data`) by default to match the official WordPress image file ownership on the shared PVC.
+When persistence uses `ReadWriteOnce`, the Job uses pod affinity to schedule on the same node as the WordPress pod.
+The Job is intentionally fail-fast with a 60 second active deadline and one retry by default.
 
 ## Redis Object Cache Architecture
 
@@ -171,8 +180,10 @@ Backup CronJob
   +-- upload both artifacts -> S3-compatible bucket
 ```
 
-The backup CronJob is designed as a practical baseline, not a full disaster recovery program. Production users should test restores, retention, object lock, and database consistency in their own environment.
+The backup CronJob is designed as a practical baseline, not a full disaster recovery program.
+Production users should test restores, retention, object lock, and database consistency in their own environment.
 
 ## Dependency Policy
 
-The chart depends on HelmForge MySQL through `Chart.yaml`. The repository workflow does not commit `Chart.lock` for this chart, so dependency resolution is performed during validation and packaging.
+The chart depends on HelmForge MySQL through `Chart.yaml`.
+The repository workflow does not commit `Chart.lock` for this chart, so dependency resolution is performed during validation and packaging.

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -201,6 +201,7 @@ plugins:
 The installer uses a `post-install,post-upgrade` Helm hook and pod affinity to run on the same node as the WordPress pod
 when persistence is enabled. This improves compatibility with `ReadWriteOnce` PVCs.
 The default installer deadline is 60 seconds with one retry, so failed official plugin downloads fail quickly during Helm installs.
+Because the Job writes plugin files to the WordPress volume, `plugins.installer.enabled` requires `persistence.enabled=true`.
 
 Only official WordPress.org plugin slugs are supported. When WordPress core is not installed yet,
 the Job downloads the official plugin archive from `downloads.wordpress.org`, extracts it into `wp-content/plugins`,

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -123,6 +123,11 @@ wpCron:
 
 networkPolicy:
   enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
   egress:
     enabled: true
     allowDNS: true

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -1,6 +1,8 @@
 # WordPress
 
-A Helm chart for deploying [WordPress](https://wordpress.org/) on Kubernetes with the official `wordpress` Apache image, HelmForge MySQL, external database support, backups, metrics, Gateway API, dual-stack Services, NetworkPolicy, and External Secrets Operator integration.
+A Helm chart for deploying [WordPress](https://wordpress.org/) on Kubernetes with the official `wordpress` Apache image,
+HelmForge MySQL, external database support, backups, metrics, Gateway API, dual-stack Services, NetworkPolicy,
+and External Secrets Operator integration.
 
 ## Installation
 
@@ -16,7 +18,8 @@ helm install wordpress oci://ghcr.io/helmforgedev/helm/wordpress
 
 ## Quick Start
 
-The default path is intentionally convenient for development and evaluation: one WordPress Deployment, a bundled MySQL subchart, a persistent volume for `/var/www/html`, and generated credentials.
+The default path is intentionally convenient for development and evaluation: one WordPress Deployment,
+a bundled MySQL subchart, a persistent volume for `/var/www/html`, and generated credentials.
 
 ```bash
 helm install wordpress oci://ghcr.io/helmforgedev/helm/wordpress \
@@ -26,7 +29,9 @@ helm install wordpress oci://ghcr.io/helmforgedev/helm/wordpress \
 
 ## Dev vs Production
 
-Defaults are not intended to be a complete production baseline. They provide a fast working install. For production, enable explicit credentials, TLS at the edge, resource requests and limits, backups, metrics, restricted network flow, and a storage/database strategy that matches your availability target.
+Defaults are not intended to be a complete production baseline. They provide a fast working install.
+For production, enable explicit credentials, TLS at the edge, resource requests and limits, backups, metrics,
+restricted network flow, and a storage/database strategy that matches your availability target.
 
 Production-ready options are available through values:
 
@@ -171,11 +176,13 @@ database:
     existingSecretPasswordKey: database-password
 ```
 
-The chart validates that `externalSecrets.apiVersion` is `external-secrets.io/v1`, a SecretStore is configured, and ExternalSecret-managed credentials are not combined with `existingSecret` for the same credential.
+The chart validates that `externalSecrets.apiVersion` is `external-secrets.io/v1`, a SecretStore is configured,
+and ExternalSecret-managed credentials are not combined with `existingSecret` for the same credential.
 
 ## Plugins
 
-The chart can run an idempotent plugin installer Job after install and upgrade. The Job mounts the WordPress PVC and skips plugins that already exist, so upgrades do not reinstall the same plugin repeatedly.
+The chart can run an idempotent plugin installer Job after install and upgrade.
+The Job mounts the WordPress PVC and skips plugins that already exist, so upgrades do not reinstall the same plugin repeatedly.
 
 ```yaml
 plugins:
@@ -191,9 +198,14 @@ plugins:
       skipIfInstalled: true
 ```
 
-The installer uses a `post-install,post-upgrade` Helm hook and pod affinity to run on the same node as the WordPress pod when persistence is enabled. This improves compatibility with `ReadWriteOnce` PVCs. The default installer deadline is 60 seconds with one retry, so failed official plugin downloads fail quickly during Helm installs.
+The installer uses a `post-install,post-upgrade` Helm hook and pod affinity to run on the same node as the WordPress pod
+when persistence is enabled. This improves compatibility with `ReadWriteOnce` PVCs.
+The default installer deadline is 60 seconds with one retry, so failed official plugin downloads fail quickly during Helm installs.
 
-Only official WordPress.org plugin slugs are supported. When WordPress core is not installed yet, the Job downloads the official plugin archive from `downloads.wordpress.org`, extracts it into `wp-content/plugins`, and defers activation until a later upgrade. The installer runs as `www-data` by default so it can write to the same PVC paths initialized by the official WordPress image.
+Only official WordPress.org plugin slugs are supported. When WordPress core is not installed yet,
+the Job downloads the official plugin archive from `downloads.wordpress.org`, extracts it into `wp-content/plugins`,
+and defers activation until a later upgrade.
+The installer runs as `www-data` by default so it can write to the same PVC paths initialized by the official WordPress image.
 
 ## Redis Object Cache
 
@@ -235,9 +247,12 @@ objectCache:
       existingSecretPasswordKey: redis-password
 ```
 
-The chart configures `WP_CACHE`, `WP_REDIS_HOST`, `WP_REDIS_PORT`, `WP_REDIS_DATABASE`, `WP_REDIS_PREFIX`, `WP_REDIS_CLIENT`, and optional `WP_REDIS_PASSWORD`. It also installs `redis-cache` and creates `wp-content/object-cache.php`.
+The chart configures `WP_CACHE`, `WP_REDIS_HOST`, `WP_REDIS_PORT`, `WP_REDIS_DATABASE`, `WP_REDIS_PREFIX`,
+`WP_REDIS_CLIENT`, and optional `WP_REDIS_PASSWORD`.
+It also installs `redis-cache` and creates `wp-content/object-cache.php`.
 
-For immutable production deployments, prefer a custom WordPress image with required plugins and drop-ins already packaged. The installer Job is a practical operational convenience for development, labs, and mutable PVC-based installs.
+For immutable production deployments, prefer a custom WordPress image with required plugins and drop-ins already packaged.
+The installer Job is a practical operational convenience for development, labs, and mutable PVC-based installs.
 
 ## Gateway API
 
@@ -378,9 +393,12 @@ The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 
 ## Production Notes
 
-Horizontal scaling requires shared writable storage for uploads/plugins/themes, or an operational model that moves media to object storage and deploys code/plugins immutably. With the default `ReadWriteOnce` PVC, keep `replicaCount: 1` and leave autoscaling disabled.
+Horizontal scaling requires shared writable storage for uploads/plugins/themes, or an operational model that moves media
+to object storage and deploys code/plugins immutably.
+With the default `ReadWriteOnce` PVC, keep `replicaCount: 1` and leave autoscaling disabled.
 
-For high-traffic production, prefer an external managed MySQL/MariaDB service or a separately operated database chart with backup, monitoring, and failover validated for your environment.
+For high-traffic production, prefer an external managed MySQL/MariaDB service or a separately operated database chart
+with backup, monitoring, and failover validated for your environment.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -1,10 +1,8 @@
 # WordPress
 
-A Helm chart for deploying [WordPress](https://wordpress.org/) on Kubernetes using the official [wordpress](https://hub.docker.com/_/wordpress) Docker image (Apache variant).
+A Helm chart for deploying [WordPress](https://wordpress.org/) on Kubernetes with the official `wordpress` Apache image, HelmForge MySQL, external database support, backups, metrics, Gateway API, dual-stack Services, NetworkPolicy, and External Secrets Operator integration.
 
 ## Installation
-
-### HTTPS Repository
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
@@ -12,93 +10,119 @@ helm repo update
 helm install wordpress helmforge/wordpress
 ```
 
-### OCI Registry
-
 ```bash
 helm install wordpress oci://ghcr.io/helmforgedev/helm/wordpress
 ```
 
 ## Quick Start
 
+The default path is intentionally convenient for development and evaluation: one WordPress Deployment, a bundled MySQL subchart, a persistent volume for `/var/www/html`, and generated credentials.
+
 ```bash
 helm install wordpress oci://ghcr.io/helmforgedev/helm/wordpress \
-  --set wordpress.adminPassword=changeme \
-  --set mysql.auth.password=dbpassword
+  --set wordpress.adminPassword=change-me \
+  --set mysql.auth.password=db-password
 ```
+
+## Dev vs Production
+
+Defaults are not intended to be a complete production baseline. They provide a fast working install. For production, enable explicit credentials, TLS at the edge, resource requests and limits, backups, metrics, restricted network flow, and a storage/database strategy that matches your availability target.
+
+Production-ready options are available through values:
+
+- External or bundled MySQL with existing Secrets or External Secrets Operator.
+- Gateway API `HTTPRoute` or classic Ingress.
+- Service dual-stack fields (`ipFamilyPolicy`, `ipFamilies`).
+- NetworkPolicy ingress and optional egress allow lists.
+- PodDisruptionBudget and HorizontalPodAutoscaler.
+- Kubernetes CronJob for deterministic `wp-cron.php` execution.
+- S3-compatible scheduled backups for database and `wp-content`.
+- Structured `wp-config.php` settings for SSL admin, file editor lockout, cron, and memory limits.
 
 ## Features
 
-- **Official WordPress Image** — Apache variant with PHP, ready for production
-- **MySQL Subchart** — Bundled MySQL via HelmForge subchart dependency
-- **External Database** — Connect to existing MySQL/MariaDB instances
-- **Auto Database Detection** — Automatic mode selection (external vs subchart)
-- **Persistent Storage** — PVC for WordPress files (themes, plugins, uploads)
-- **Scheduled Backups** — CronJob-based mysqldump + wp-content archive to S3
-- **Ingress Support** — Configurable ingress with TLS for HTTPS
-- **PHP Configuration** — Custom php.ini via ConfigMap
-- **Prometheus Metrics** — Apache exporter sidecar with ServiceMonitor
-- **Wait-for-DB** — Init container ensures database is ready before WordPress starts
-- **Secret Preservation** — Passwords preserved across upgrades via `lookup`
+- Official WordPress Apache image.
+- HelmForge MySQL subchart or external MySQL/MariaDB.
+- External Secrets Operator support with `external-secrets.io/v1`.
+- Secret preservation across upgrades with `lookup` for chart-managed Secrets.
+- Persistent storage for themes, plugins, uploads, and core files.
+- Ingress and Gateway API exposure patterns.
+- Dual-stack Service support.
+- Optional NetworkPolicy for ingress and egress control.
+- Optional HPA and PDB for production availability.
+- Optional Prometheus metrics through Apache exporter and ServiceMonitor.
+- Optional scheduled backups to S3-compatible storage.
+- Extensibility through `extraEnv`, `extraEnvFrom`, extra volumes, extra init containers, extra containers, and extra manifests.
+- Idempotent post-install/post-upgrade plugin installer Job.
+- Redis Object Cache integration with HelmForge Redis subchart or external Redis.
 
-## Configuration
-
-### Minimal (Simple Setup)
-
-```yaml
-wordpress:
-  adminPassword: "change-me"
-
-mysql:
-  enabled: true
-  auth:
-    password: "db-password"
-```
-
-### Production (Full Setup)
+## Production Example
 
 ```yaml
 wordpress:
-  siteUrl: "https://blog.example.com"
+  siteUrl: https://blog.example.com
   adminEmail: admin@example.com
-  configExtra: |
-    define('WP_MEMORY_LIMIT', '256M');
-    define('DISALLOW_FILE_EDIT', true);
+  forceSSLAdmin: true
+  disallowFileEdit: true
+  disableWpCron: true
+  memoryLimit: 256M
+  maxMemoryLimit: 512M
 
 admin:
   existingSecret: wordpress-admin
 
 mysql:
-  enabled: true
-  auth:
-    existingSecret: wordpress-mysql
-  primary:
-    persistence:
-      size: 20Gi
+  enabled: false
+
+database:
+  external:
+    host: mysql.example.com
+    port: 3306
+    name: wordpress
+    username: wordpress
+    existingSecret: wordpress-db
+    existingSecretPasswordKey: password
 
 persistence:
   enabled: true
-  size: 10Gi
+  accessMode: ReadWriteMany
+  storageClass: nfs-rwx
+  size: 20Gi
 
-php:
-  ini: |
-    upload_max_filesize = 64M
-    post_max_size = 64M
-    memory_limit = 256M
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
 
-ingress:
+gatewayAPI:
   enabled: true
-  ingressClassName: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: blog.example.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: wordpress-tls
-      hosts:
-        - blog.example.com
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - blog.example.com
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+wpCron:
+  cronJob:
+    enabled: true
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: false
+    allowHTTPS: true
 
 backup:
   enabled: true
@@ -111,172 +135,267 @@ backup:
 resources:
   requests:
     cpu: 250m
-    memory: 256Mi
+    memory: 512Mi
   limits:
     cpu: "1"
-    memory: 512Mi
+    memory: 1Gi
 ```
 
-### External Database
+## External Secrets Operator
+
+External Secrets is optional. When enabled, the chart renders `ExternalSecret` resources and stops rendering the matching native Secret.
 
 ```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  admin:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/wordpress
+      property: admin-password
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/wordpress
+      property: database-password
+
 mysql:
   enabled: false
 
 database:
   external:
-    host: db.example.com
-    port: 3306
-    name: wordpress
-    username: wordpress
-    existingSecret: wordpress-db
-    existingSecretPasswordKey: password
+    host: mysql.example.com
+    existingSecretPasswordKey: database-password
 ```
+
+The chart validates that `externalSecrets.apiVersion` is `external-secrets.io/v1`, a SecretStore is configured, and ExternalSecret-managed credentials are not combined with `existingSecret` for the same credential.
+
+## Plugins
+
+The chart can run an idempotent plugin installer Job after install and upgrade. The Job mounts the WordPress PVC and skips plugins that already exist, so upgrades do not reinstall the same plugin repeatedly.
+
+```yaml
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+  items:
+    - slug: classic-editor
+      activate: true
+      skipIfInstalled: true
+    - slug: contact-form-7
+      activate: true
+      skipIfInstalled: true
+```
+
+The installer uses a `post-install,post-upgrade` Helm hook and pod affinity to run on the same node as the WordPress pod when persistence is enabled. This improves compatibility with `ReadWriteOnce` PVCs. The default installer deadline is 60 seconds with one retry, so failed official plugin downloads fail quickly during Helm installs.
+
+Only official WordPress.org plugin slugs are supported. When WordPress core is not installed yet, the Job downloads the official plugin archive from `downloads.wordpress.org`, extracts it into `wp-content/plugins`, and defers activation until a later upgrade. The installer runs as `www-data` by default so it can write to the same PVC paths initialized by the official WordPress image.
+
+## Redis Object Cache
+
+Enable Redis Object Cache with the HelmForge Redis subchart:
+
+```yaml
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  redis:
+    mode: subchart
+    subchart:
+      enabled: true
+
+redis:
+  architecture: standalone
+```
+
+Or connect to external Redis:
+
+```yaml
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  redis:
+    mode: external
+    external:
+      host: redis.example.com
+    auth:
+      existingSecret: wordpress-redis
+      existingSecretPasswordKey: redis-password
+```
+
+The chart configures `WP_CACHE`, `WP_REDIS_HOST`, `WP_REDIS_PORT`, `WP_REDIS_DATABASE`, `WP_REDIS_PREFIX`, `WP_REDIS_CLIENT`, and optional `WP_REDIS_PASSWORD`. It also installs `redis-cache` and creates `wp-content/object-cache.php`.
+
+For immutable production deployments, prefer a custom WordPress image with required plugins and drop-ins already packaged. The installer Job is a practical operational convenience for development, labs, and mutable PVC-based installs.
+
+## Gateway API
+
+Use Gateway API when your cluster exposes applications through Gateway controllers instead of Ingress.
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - blog.example.com
+```
+
+The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 
 ## Parameters
 
-### Core Settings
+### Core
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `wordpress.siteUrl` | `""` | Full site URL (auto-detected from ingress if empty) |
+| `replicaCount` | `1` | WordPress replicas when HPA is disabled |
+| `wordpress.siteUrl` | `""` | Full site URL |
 | `wordpress.siteTitle` | `WordPress` | Site title |
-| `wordpress.adminUser` | `admin` | Admin username |
-| `wordpress.adminPassword` | `""` | Admin password (auto-generated if empty) |
+| `wordpress.adminUser` | `admin` | Initial admin username |
+| `wordpress.adminPassword` | `""` | Initial admin password, generated when empty |
 | `wordpress.adminEmail` | `admin@example.com` | Admin email |
 | `wordpress.tablePrefix` | `wp_` | Database table prefix |
-| `wordpress.debug` | `false` | Enable WP_DEBUG |
-| `wordpress.configExtra` | `""` | Extra PHP for wp-config.php |
+| `wordpress.debug` | `false` | Enables `WP_DEBUG` |
+| `wordpress.forceSSLAdmin` | `false` | Sets `FORCE_SSL_ADMIN` |
+| `wordpress.disallowFileEdit` | `false` | Sets `DISALLOW_FILE_EDIT` |
+| `wordpress.disableWpCron` | `false` | Sets `DISABLE_WP_CRON` |
+| `wordpress.memoryLimit` | `""` | Sets `WP_MEMORY_LIMIT` |
+| `wordpress.maxMemoryLimit` | `""` | Sets `WP_MAX_MEMORY_LIMIT` |
+| `wordpress.configExtra` | `""` | Extra PHP appended to `wp-config.php` |
 | `wordpress.extraEnv` | `[]` | Extra environment variables |
+| `wordpress.extraEnvFrom` | `[]` | Extra `envFrom` references |
 
 ### Database
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `database.mode` | `auto` | Database mode (auto, external, mysql) |
-| `database.external.host` | `""` | External database host |
+| `database.mode` | `auto` | `auto`, `external`, or `mysql` |
+| `database.external.host` | `""` | External MySQL/MariaDB host |
 | `database.external.port` | `3306` | External database port |
 | `database.external.name` | `wordpress` | Database name |
 | `database.external.username` | `wordpress` | Database username |
-| `database.external.password` | `""` | Database password |
-| `database.external.existingSecret` | `""` | Existing secret for DB password |
+| `database.external.password` | `""` | Inline password for chart-managed Secret |
+| `database.external.existingSecret` | `""` | Existing database Secret |
+| `database.external.existingSecretPasswordKey` | `database-password` | Password key |
+| `mysql.enabled` | `true` | Deploy HelmForge MySQL subchart |
+| `mysql.auth.database` | `wordpress` | Subchart database name |
+| `mysql.auth.username` | `wordpress` | Subchart database user |
 
-### MySQL Subchart
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `mysql.enabled` | `true` | Deploy MySQL subchart |
-| `mysql.architecture` | `standalone` | MySQL architecture |
-| `mysql.auth.database` | `wordpress` | Database name |
-| `mysql.auth.username` | `wordpress` | Database user |
-| `mysql.auth.password` | `""` | Database password (auto-generated) |
-| `mysql.primary.persistence.size` | `8Gi` | MySQL PVC size |
-
-### Persistence
+### Exposure
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `persistence.enabled` | `true` | Enable persistent storage |
-| `persistence.storageClass` | `""` | Storage class |
-| `persistence.accessMode` | `ReadWriteOnce` | PVC access mode |
-| `persistence.size` | `5Gi` | PVC size |
-| `persistence.existingClaim` | `""` | Use existing PVC |
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `80` | HTTP Service port |
+| `service.ipFamilyPolicy` | `""` | `SingleStack`, `PreferDualStack`, or `RequireDualStack` |
+| `service.ipFamilies` | `[]` | Ordered IP families, for example `["IPv4", "IPv6"]` |
+| `ingress.enabled` | `false` | Create an Ingress |
+| `gatewayAPI.enabled` | `false` | Create an HTTPRoute |
+| `gatewayAPI.parentRefs` | `[]` | Gateway parent references |
+| `gatewayAPI.hostnames` | `[]` | HTTPRoute hostnames |
 
-### Ingress
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `ingress.enabled` | `false` | Enable ingress |
-| `ingress.ingressClassName` | `""` | Ingress class (traefik, nginx, etc.) |
-| `ingress.hosts` | `[]` | Ingress hosts and paths |
-| `ingress.tls` | `[]` | TLS configuration |
-
-### PHP
+### Production Controls
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `php.ini` | `""` | Custom php.ini settings |
-
-### Metrics
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `metrics.enabled` | `false` | Enable apache-exporter sidecar |
-| `metrics.image.tag` | `v1.0.8` | apache-exporter version |
-| `metrics.port` | `9117` | Metrics port |
+| `serviceAccount.create` | `false` | Create a dedicated ServiceAccount |
+| `serviceAccount.automountServiceAccountToken` | `false` | Mount Kubernetes API token |
+| `autoscaling.enabled` | `false` | Create HPA |
+| `pdb.enabled` | `false` | Create PodDisruptionBudget |
+| `wpCron.cronJob.enabled` | `false` | Create deterministic WordPress cron CronJob |
+| `networkPolicy.enabled` | `false` | Create NetworkPolicy |
+| `networkPolicy.egress.enabled` | `false` | Manage egress allow list |
+| `metrics.enabled` | `false` | Enable Apache exporter sidecar |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor |
+| `plugins.enabled` | `false` | Enable plugin installer support |
+| `plugins.installer.enabled` | `false` | Create plugin installer Job |
+| `objectCache.enabled` | `false` | Enable Redis Object Cache integration |
+| `objectCache.redis.mode` | `subchart` | Redis source: `subchart` or `external` |
 
-### Backup
+### Storage and Backup
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `backup.enabled` | `false` | Enable S3 backups |
-| `backup.schedule` | `0 3 * * *` | Cron schedule |
-| `backup.archivePrefix` | `wordpress` | Archive filename prefix |
+| `persistence.enabled` | `true` | Create PVC for `/var/www/html` |
+| `persistence.accessMode` | `ReadWriteOnce` | PVC access mode |
+| `persistence.size` | `5Gi` | WordPress PVC size |
+| `backup.enabled` | `false` | Create backup CronJob |
+| `backup.schedule` | `0 3 * * *` | Backup schedule |
 | `backup.s3.endpoint` | `""` | S3-compatible endpoint |
-| `backup.s3.bucket` | `""` | Target bucket |
-| `backup.s3.prefix` | `wordpress` | Key prefix in bucket |
-| `backup.s3.existingSecret` | `""` | Existing S3 credentials secret |
-| `backup.database.mysqldumpArgs` | `--single-transaction...` | Extra mysqldump flags |
-
-### Scheduling
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `nodeSelector` | `{}` | Node selector |
-| `tolerations` | `[]` | Tolerations |
-| `affinity` | `{}` | Affinity rules |
-| `terminationGracePeriodSeconds` | `30` | Shutdown grace period |
+| `backup.s3.bucket` | `""` | Backup bucket |
+| `backup.s3.existingSecret` | `""` | Existing S3 credentials Secret |
 
 ## Resources Generated
 
-| Resource | Condition | Description |
-|----------|-----------|-------------|
-| Deployment | Always | WordPress + wait-for-db init container |
-| Service | Always | HTTP port 80 (ClusterIP) |
+| Resource | Condition | Purpose |
+|----------|-----------|---------|
+| Deployment | Always | WordPress workload |
+| Service | Always | Internal HTTP endpoint |
 | PersistentVolumeClaim | `persistence.enabled` | WordPress files |
-| Secret (admin) | No `admin.existingSecret` | Admin password |
-| Secret (database) | No external `existingSecret` | Database password |
-| Secret (backup) | `backup.enabled`, no S3 `existingSecret` | S3 credentials |
-| ConfigMap | `php.ini` set | Custom PHP configuration |
-| Ingress | `ingress.enabled` | HTTPS access |
-| CronJob | `backup.enabled` | mysqldump + wp-content archive to S3 |
-| ConfigMap (backup) | `backup.enabled` | Backup shell scripts |
-| ServiceAccount | `serviceAccount.create` | Dedicated SA |
-| ServiceMonitor | `metrics.serviceMonitor.enabled` | Prometheus scrape config |
+| Secret | Native credentials enabled | Admin, database, or backup credentials |
+| ExternalSecret | `externalSecrets.*.enabled` | Sync credentials from external stores |
+| Ingress | `ingress.enabled` | Classic HTTP routing |
+| HTTPRoute | `gatewayAPI.enabled` | Gateway API routing |
+| NetworkPolicy | `networkPolicy.enabled` | Network isolation |
+| HorizontalPodAutoscaler | `autoscaling.enabled` | Replica scaling |
+| PodDisruptionBudget | `pdb.enabled` | Disruption protection |
+| CronJob | `wpCron.cronJob.enabled` | WordPress cron trigger |
+| CronJob | `backup.enabled` | Database and content backup |
+| Job | `plugins.installer.enabled` | Idempotent plugin installation and activation |
+| ServiceMonitor | `metrics.serviceMonitor.enabled` | Prometheus scrape configuration |
 
 ## Examples
 
-- [Simple](examples/simple.yaml) — minimal with MySQL subchart
-- [Production](examples/production.yaml) — ingress, backup, metrics, custom PHP
-- [External DB](examples/external-db.yaml) — existing MySQL/MariaDB
+- [Simple](examples/simple.yaml)
+- [External database](examples/external-db.yaml)
+- [Production](examples/production.yaml)
+- [External Secrets](examples/external-secrets.yaml)
+- [Gateway API](examples/gateway-api.yaml)
+- [Dual stack](examples/dual-stack.yaml)
+- [Redis Object Cache](examples/redis-object-cache.yaml)
+- [Custom plugins](examples/custom-plugins.yaml)
 
 ## Architecture Guides
 
-- [Database Modes](docs/database.md) — subchart vs external database
-- [Backup & Restore](docs/backup.md) — S3 backup strategy and restore procedures
+- [Design](DESIGN.md)
+- [Database Modes](docs/database.md)
+- [Backup & Restore](docs/backup.md)
+- [Production Guide](docs/production.md)
 
-## Non-Goals
+## Production Notes
 
-This chart intentionally does not support:
+Horizontal scaling requires shared writable storage for uploads/plugins/themes, or an operational model that moves media to object storage and deploys code/plugins immutably. With the default `ReadWriteOnce` PVC, keep `replicaCount: 1` and leave autoscaling disabled.
 
-- **FPM variant** — Use the Apache variant for simplicity in Kubernetes
-- **Multisite** — WordPress multisite requires complex URL rewriting
-- **Horizontal scaling** — WordPress with shared storage has write contention issues
-- **Built-in CDN** — Use a CDN plugin or external CDN service
+For high-traffic production, prefer an external managed MySQL/MariaDB service or a separately operated database chart with backup, monitoring, and failover validated for your environment.
 
 <!-- @AI-METADATA
 type: chart-readme
 title: WordPress Helm Chart
-description: Deploy WordPress on Kubernetes with MySQL, S3 backup, and Prometheus metrics
-keywords: wordpress, cms, blog, php, mysql, helm, kubernetes, backup, metrics
+description: Deploy WordPress on Kubernetes with MySQL, External Secrets, Gateway API, backups, metrics, and production controls
+keywords: wordpress, cms, blog, php, mysql, helm, kubernetes, gateway-api, external-secrets, dual-stack, backup, metrics
 purpose: Installation guide, configuration reference, and operational documentation for the wordpress Helm chart
 scope: Chart
 relations:
+  - charts/wordpress/DESIGN.md
   - charts/wordpress/docs/database.md
   - charts/wordpress/docs/backup.md
+  - charts/wordpress/docs/production.md
   - charts/wordpress/values.yaml
 path: charts/wordpress/README.md
-version: 1.0
-date: 2026-03-23
+version: 2.0
+date: 2026-05-06
 -->

--- a/charts/wordpress/ci/dual-stack-values.yaml
+++ b/charts/wordpress/ci/dual-stack-values.yaml
@@ -1,0 +1,5 @@
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/wordpress/ci/dual-stack-values.yaml
+++ b/charts/wordpress/ci/dual-stack-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack
   ipFamilies:

--- a/charts/wordpress/ci/external-secrets-values.yaml
+++ b/charts/wordpress/ci/external-secrets-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 mysql:
   enabled: false
 

--- a/charts/wordpress/ci/external-secrets-values.yaml
+++ b/charts/wordpress/ci/external-secrets-values.yaml
@@ -1,0 +1,22 @@
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: mysql.example.com
+    existingSecretPasswordKey: database-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+  admin:
+    enabled: true
+    passwordRemoteRef:
+      key: ci/wordpress
+      property: admin-password
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: ci/wordpress
+      property: database-password

--- a/charts/wordpress/ci/gateway-api-values.yaml
+++ b/charts/wordpress/ci/gateway-api-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 gatewayAPI:
   enabled: true
   parentRefs:

--- a/charts/wordpress/ci/gateway-api-values.yaml
+++ b/charts/wordpress/ci/gateway-api-values.yaml
@@ -1,0 +1,7 @@
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - wordpress.example.com

--- a/charts/wordpress/ci/plugins-values.yaml
+++ b/charts/wordpress/ci/plugins-values.yaml
@@ -1,0 +1,8 @@
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+  items:
+    - slug: classic-editor
+      activate: true
+      skipIfInstalled: true

--- a/charts/wordpress/ci/plugins-values.yaml
+++ b/charts/wordpress/ci/plugins-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 plugins:
   enabled: true
   installer:

--- a/charts/wordpress/ci/production-values.yaml
+++ b/charts/wordpress/ci/production-values.yaml
@@ -1,0 +1,34 @@
+wordpress:
+  siteUrl: https://wordpress.example.com
+  forceSSLAdmin: true
+  disallowFileEdit: true
+  disableWpCron: true
+  memoryLimit: 256M
+  maxMemoryLimit: 512M
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+autoscaling:
+  enabled: true
+
+pdb:
+  enabled: true
+
+wpCron:
+  cronJob:
+    enabled: true
+
+networkPolicy:
+  enabled: true
+  metrics:
+    enabled: true
+  egress:
+    enabled: true
+    allowHTTPS: true
+
+metrics:
+  enabled: true

--- a/charts/wordpress/ci/production-values.yaml
+++ b/charts/wordpress/ci/production-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 wordpress:
   siteUrl: https://wordpress.example.com
   forceSSLAdmin: true

--- a/charts/wordpress/ci/redis-external-values.yaml
+++ b/charts/wordpress/ci/redis-external-values.yaml
@@ -1,0 +1,13 @@
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  redis:
+    mode: external
+    external:
+      host: redis.example.com
+    auth:
+      password: ci-redis-password

--- a/charts/wordpress/ci/redis-external-values.yaml
+++ b/charts/wordpress/ci/redis-external-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 plugins:
   enabled: true
   installer:

--- a/charts/wordpress/ci/redis-subchart-values.yaml
+++ b/charts/wordpress/ci/redis-subchart-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 plugins:
   enabled: true
   installer:

--- a/charts/wordpress/ci/redis-subchart-values.yaml
+++ b/charts/wordpress/ci/redis-subchart-values.yaml
@@ -1,0 +1,19 @@
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  redis:
+    mode: subchart
+    subchart:
+      enabled: true
+
+redis:
+  architecture: standalone
+  auth:
+    password: ci-redis-password
+  standalone:
+    persistence:
+      enabled: false

--- a/charts/wordpress/docs/backup.md
+++ b/charts/wordpress/docs/backup.md
@@ -42,6 +42,32 @@ backup:
 
 The secret must contain `access-key` and `secret-key` keys.
 
+With External Secrets Operator:
+
+```yaml
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: wordpress-backups
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  backup:
+    enabled: true
+    accessKeyRemoteRef:
+      key: prod/wordpress-backup
+      property: access-key
+    secretKeyRemoteRef:
+      key: prod/wordpress-backup
+      property: secret-key
+```
+
+When `externalSecrets.backup.enabled` is true, the chart renders the S3 credentials through `external-secrets.io/v1` and does not render the native backup Secret.
+
 ## Database Credential Overrides
 
 By default, the backup uses the same database credentials as the application. To use a read-only user for backups:

--- a/charts/wordpress/docs/backup.md
+++ b/charts/wordpress/docs/backup.md
@@ -4,11 +4,11 @@ The chart includes a CronJob-based backup system that creates database dumps and
 
 ## How It Works
 
-```
+```text
 CronJob (scheduled)
-├── Init 1: mysqldump → database dump (.sql.gz)
-├── Init 2: tar wp-content → content archive (.tar.gz)
-└── Main: minio/mc upload both to S3
+|-- Init 1: mysqldump -> database dump (.sql.gz)
+|-- Init 2: tar wp-content -> content archive (.tar.gz)
+`-- Main: minio/mc upload both to S3
 ```
 
 1. **dump-database** (init container, `mysql:8.4`): Runs `mysqldump` against the database, compresses with gzip

--- a/charts/wordpress/docs/database.md
+++ b/charts/wordpress/docs/database.md
@@ -74,6 +74,33 @@ database:
     existingSecretPasswordKey: password
 ```
 
+With External Secrets Operator:
+
+```yaml
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: db.example.com
+    name: wordpress
+    username: wordpress
+    existingSecretPasswordKey: database-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/wordpress
+      property: database-password
+```
+
+`externalSecrets.database.enabled` requires an external database. The chart renders an `ExternalSecret` targeting the same Secret name WordPress reads from.
+
 ## Wait-for-DB Init Container
 
 The deployment includes a `wait-for-db` init container that checks database connectivity before starting WordPress. This prevents CrashLoopBackOff when the database takes time to initialize (common with the MySQL subchart on first install).
@@ -91,6 +118,6 @@ relations:
   - charts/wordpress/README.md
   - charts/wordpress/values.yaml
 path: charts/wordpress/docs/database.md
-version: 1.0
-date: 2026-03-23
+version: 1.1
+date: 2026-05-06
 -->

--- a/charts/wordpress/docs/database.md
+++ b/charts/wordpress/docs/database.md
@@ -6,9 +6,9 @@ WordPress requires MySQL or MariaDB. This chart supports two database modes with
 
 When `database.mode` is `auto` (default), the chart detects the database source:
 
-1. **External** — if `database.external.host` or `database.external.existingSecret` is set
-2. **MySQL subchart** — if `mysql.enabled: true`
-3. **Fail** — WordPress cannot run without a database
+1. **External** - if `database.external.host` or `database.external.existingSecret` is set
+2. **MySQL subchart** - if `mysql.enabled: true`
+3. **Fail** - WordPress cannot run without a database
 
 You can also set `database.mode` explicitly to `external` or `mysql` to skip auto-detection.
 
@@ -103,7 +103,9 @@ externalSecrets:
 
 ## Wait-for-DB Init Container
 
-The deployment includes a `wait-for-db` init container that checks database connectivity before starting WordPress. This prevents CrashLoopBackOff when the database takes time to initialize (common with the MySQL subchart on first install).
+The deployment includes a `wait-for-db` init container that checks database connectivity before starting WordPress.
+This prevents CrashLoopBackOff when the database takes time to initialize, which is common with the MySQL subchart
+on first install.
 
 The init container uses `busybox nc` to verify TCP connectivity to the database host and port.
 

--- a/charts/wordpress/docs/plugins.md
+++ b/charts/wordpress/docs/plugins.md
@@ -1,0 +1,65 @@
+# Plugins and Object Cache
+
+The chart can install WordPress plugins through an idempotent post-install/post-upgrade Job. This is useful for mutable PVC-based installs and labs. For immutable production, prefer a custom WordPress image with plugins already packaged.
+
+The installer defaults to a 60 second active deadline and one retry. Slow official plugin downloads or network blocks fail quickly instead of leaving a Helm install pending for several minutes.
+
+## Custom Plugins
+
+Only official WordPress.org plugin slugs are supported. The chart does not install arbitrary ZIP URLs or plugins from GitHub.
+The installer runs as UID/GID 33 (`www-data`) by default, matching the file ownership created by the official WordPress image on the shared PVC.
+
+```yaml
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+  items:
+    - slug: classic-editor
+      activate: true
+      skipIfInstalled: true
+```
+
+## Redis Object Cache
+
+```yaml
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  redis:
+    mode: subchart
+    subchart:
+      enabled: true
+```
+
+The chart installs the official `redis-cache` plugin, configures `WP_REDIS_*`, and creates `wp-content/object-cache.php`. If WordPress core is not installed yet, plugin files are downloaded directly from WordPress.org and activation is retried on a future upgrade, but the drop-in can still be created from plugin files.
+
+## Validation
+
+Functional Redis validation requires:
+
+- WordPress pod Ready.
+- Redis pod Ready.
+- Plugin installer Job completed.
+- `wp-content/object-cache.php` present.
+- Requests made to WordPress.
+- Redis contains keys with the configured prefix.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: WordPress Plugins and Object Cache
+description: Plugin installer and Redis Object Cache guide for the WordPress Helm chart
+keywords: wordpress, plugins, redis, object-cache, wp-cli, helm
+purpose: Documents mutable plugin installation and Redis object cache integration
+scope: Chart
+relations:
+  - charts/wordpress/README.md
+  - charts/wordpress/values.yaml
+path: charts/wordpress/docs/plugins.md
+version: 1.0
+date: 2026-05-06
+-->

--- a/charts/wordpress/docs/plugins.md
+++ b/charts/wordpress/docs/plugins.md
@@ -1,8 +1,11 @@
 # Plugins and Object Cache
 
-The chart can install WordPress plugins through an idempotent post-install/post-upgrade Job. This is useful for mutable PVC-based installs and labs. For immutable production, prefer a custom WordPress image with plugins already packaged.
+The chart can install WordPress plugins through an idempotent post-install/post-upgrade Job.
+This is useful for mutable PVC-based installs and labs.
+For immutable production, prefer a custom WordPress image with plugins already packaged.
 
-The installer defaults to a 60 second active deadline and one retry. Slow official plugin downloads or network blocks fail quickly instead of leaving a Helm install pending for several minutes.
+The installer defaults to a 60 second active deadline and one retry.
+Slow official plugin downloads or network blocks fail quickly instead of leaving a Helm install pending for several minutes.
 
 ## Custom Plugins
 
@@ -36,7 +39,9 @@ objectCache:
       enabled: true
 ```
 
-The chart installs the official `redis-cache` plugin, configures `WP_REDIS_*`, and creates `wp-content/object-cache.php`. If WordPress core is not installed yet, plugin files are downloaded directly from WordPress.org and activation is retried on a future upgrade, but the drop-in can still be created from plugin files.
+The chart installs the official `redis-cache` plugin, configures `WP_REDIS_*`, and creates `wp-content/object-cache.php`.
+If WordPress core is not installed yet, plugin files are downloaded directly from WordPress.org and activation is retried
+on a future upgrade, but the drop-in can still be created from plugin files.
 
 ## Validation
 

--- a/charts/wordpress/docs/plugins.md
+++ b/charts/wordpress/docs/plugins.md
@@ -6,6 +6,7 @@ For immutable production, prefer a custom WordPress image with plugins already p
 
 The installer defaults to a 60 second active deadline and one retry.
 Slow official plugin downloads or network blocks fail quickly instead of leaving a Helm install pending for several minutes.
+The installer requires `persistence.enabled=true` because it writes plugin files and drop-ins to the shared WordPress volume.
 
 ## Custom Plugins
 

--- a/charts/wordpress/docs/production.md
+++ b/charts/wordpress/docs/production.md
@@ -43,7 +43,8 @@ backup:
 
 ## Storage
 
-With `persistence.accessMode: ReadWriteOnce`, keep a single WordPress pod. Use ReadWriteMany storage or an object-storage media strategy before enabling HPA or replicas greater than one.
+With `persistence.accessMode: ReadWriteOnce`, keep a single WordPress pod.
+Use ReadWriteMany storage or an object-storage media strategy before enabling HPA or replicas greater than one.
 
 ## Database
 
@@ -55,7 +56,8 @@ For production, prefer one of these patterns:
 
 ## Secrets
 
-Use `admin.existingSecret`, `database.external.existingSecret`, and `backup.s3.existingSecret` for simple clusters. Use `externalSecrets` when the cluster runs External Secrets Operator and credentials are managed in an external store.
+Use `admin.existingSecret`, `database.external.existingSecret`, and `backup.s3.existingSecret` for simple clusters.
+Use `externalSecrets` when the cluster runs External Secrets Operator and credentials are managed in an external store.
 
 ## Routing
 
@@ -63,7 +65,9 @@ Use either Ingress or Gateway API. Do not enable both for the same hostname unle
 
 ## NetworkPolicy
 
-Enable `networkPolicy.enabled` to isolate inbound traffic. Enable `networkPolicy.egress.enabled` only after listing required destinations such as DNS, database, HTTPS APIs, object storage, and SMTP.
+Enable `networkPolicy.enabled` to isolate inbound traffic.
+Enable `networkPolicy.egress.enabled` only after listing required destinations such as DNS, database, HTTPS APIs,
+object storage, and SMTP.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/wordpress/docs/production.md
+++ b/charts/wordpress/docs/production.md
@@ -1,0 +1,82 @@
+# Production Guide
+
+This chart can be used in development and production, but production requires explicit choices. The default values are intentionally small and convenient.
+
+## Recommended Production Baseline
+
+```yaml
+wordpress:
+  siteUrl: https://blog.example.com
+  forceSSLAdmin: true
+  disallowFileEdit: true
+  disableWpCron: true
+  memoryLimit: 256M
+  maxMemoryLimit: 512M
+
+wpCron:
+  cronJob:
+    enabled: true
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+networkPolicy:
+  enabled: true
+  metrics:
+    enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+
+metrics:
+  enabled: true
+
+backup:
+  enabled: true
+```
+
+## Storage
+
+With `persistence.accessMode: ReadWriteOnce`, keep a single WordPress pod. Use ReadWriteMany storage or an object-storage media strategy before enabling HPA or replicas greater than one.
+
+## Database
+
+For production, prefer one of these patterns:
+
+- External managed MySQL/MariaDB with automated backups and failover.
+- A separately operated database release with tested backup, restore, monitoring, and upgrade procedures.
+- HelmForge MySQL subchart for smaller environments where the operational tradeoff is acceptable.
+
+## Secrets
+
+Use `admin.existingSecret`, `database.external.existingSecret`, and `backup.s3.existingSecret` for simple clusters. Use `externalSecrets` when the cluster runs External Secrets Operator and credentials are managed in an external store.
+
+## Routing
+
+Use either Ingress or Gateway API. Do not enable both for the same hostname unless you intentionally want two routing paths.
+
+## NetworkPolicy
+
+Enable `networkPolicy.enabled` to isolate inbound traffic. Enable `networkPolicy.egress.enabled` only after listing required destinations such as DNS, database, HTTPS APIs, object storage, and SMTP.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: WordPress Production Guide
+description: Production deployment guidance for the WordPress Helm chart
+keywords: wordpress, production, kubernetes, helm, gateway-api, external-secrets, networkpolicy
+purpose: Production hardening guide for the wordpress Helm chart
+scope: Chart
+relations:
+  - charts/wordpress/README.md
+  - charts/wordpress/DESIGN.md
+  - charts/wordpress/values.yaml
+path: charts/wordpress/docs/production.md
+version: 1.0
+date: 2026-05-06
+-->

--- a/charts/wordpress/examples/custom-plugins.yaml
+++ b/charts/wordpress/examples/custom-plugins.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Install custom WordPress plugins through an idempotent post-install/post-upgrade Job
 
 plugins:

--- a/charts/wordpress/examples/custom-plugins.yaml
+++ b/charts/wordpress/examples/custom-plugins.yaml
@@ -1,0 +1,13 @@
+# Install custom WordPress plugins through an idempotent post-install/post-upgrade Job
+
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+  items:
+    - slug: classic-editor
+      activate: true
+      skipIfInstalled: true
+    - slug: contact-form-7
+      activate: true
+      skipIfInstalled: true

--- a/charts/wordpress/examples/dual-stack.yaml
+++ b/charts/wordpress/examples/dual-stack.yaml
@@ -1,0 +1,7 @@
+# WordPress Service with IPv4/IPv6 dual-stack preference
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/wordpress/examples/dual-stack.yaml
+++ b/charts/wordpress/examples/dual-stack.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # WordPress Service with IPv4/IPv6 dual-stack preference
 
 service:

--- a/charts/wordpress/examples/external-secrets.yaml
+++ b/charts/wordpress/examples/external-secrets.yaml
@@ -1,0 +1,32 @@
+# WordPress credentials managed by External Secrets Operator
+
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: mysql.example.com
+    port: 3306
+    name: wordpress
+    username: wordpress
+    existingSecretPasswordKey: database-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  admin:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/wordpress
+      property: admin-password
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/wordpress
+      property: database-password
+
+wordpress:
+  siteUrl: https://blog.example.com
+  adminEmail: admin@example.com

--- a/charts/wordpress/examples/external-secrets.yaml
+++ b/charts/wordpress/examples/external-secrets.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # WordPress credentials managed by External Secrets Operator
 
 mysql:

--- a/charts/wordpress/examples/gateway-api.yaml
+++ b/charts/wordpress/examples/gateway-api.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # WordPress exposed through Kubernetes Gateway API
 
 gatewayAPI:

--- a/charts/wordpress/examples/gateway-api.yaml
+++ b/charts/wordpress/examples/gateway-api.yaml
@@ -1,0 +1,17 @@
+# WordPress exposed through Kubernetes Gateway API
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - blog.example.com
+
+wordpress:
+  siteUrl: https://blog.example.com
+  forceSSLAdmin: true
+
+service:
+  type: ClusterIP

--- a/charts/wordpress/examples/network-policy.yaml
+++ b/charts/wordpress/examples/network-policy.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # WordPress with ingress isolation and controlled egress
 
 networkPolicy:

--- a/charts/wordpress/examples/network-policy.yaml
+++ b/charts/wordpress/examples/network-policy.yaml
@@ -1,0 +1,13 @@
+# WordPress with ingress isolation and controlled egress
+
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: true
+    allowHTTPS: true
+    allowSMTP: true
+    smtpPort: 587

--- a/charts/wordpress/examples/production.yaml
+++ b/charts/wordpress/examples/production.yaml
@@ -4,10 +4,13 @@ wordpress:
   siteUrl: "https://blog.example.com"
   siteTitle: "My Production Blog"
   adminEmail: admin@example.com
+  forceSSLAdmin: true
+  disallowFileEdit: true
+  disableWpCron: true
+  memoryLimit: 256M
+  maxMemoryLimit: 512M
   configExtra: |
-    define('WP_MEMORY_LIMIT', '256M');
     define('WP_POST_REVISIONS', 10);
-    define('DISALLOW_FILE_EDIT', true);
 
 admin:
   existingSecret: wordpress-admin
@@ -31,6 +34,8 @@ mysql:
 
 persistence:
   enabled: true
+  accessMode: ReadWriteMany
+  storageClass: nfs-rwx
   size: 10Gi
 
 resources:
@@ -49,7 +54,7 @@ php:
     max_execution_time = 300
 
 ingress:
-  enabled: true
+  enabled: false
   ingressClassName: traefik
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
@@ -62,6 +67,43 @@ ingress:
     - secretName: wordpress-tls
       hosts:
         - blog.example.com
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - blog.example.com
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+wpCron:
+  cronJob:
+    enabled: true
+
+networkPolicy:
+  enabled: true
+  metrics:
+    enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
 
 metrics:
   enabled: true

--- a/charts/wordpress/examples/production.yaml
+++ b/charts/wordpress/examples/production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Production WordPress with ingress, backup, and monitoring
 
 wordpress:

--- a/charts/wordpress/examples/production.yaml
+++ b/charts/wordpress/examples/production.yaml
@@ -99,6 +99,11 @@ wpCron:
 
 networkPolicy:
   enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
   metrics:
     enabled: true
   egress:

--- a/charts/wordpress/examples/redis-object-cache.yaml
+++ b/charts/wordpress/examples/redis-object-cache.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # WordPress with Redis Object Cache using HelmForge Redis subchart
 
 plugins:

--- a/charts/wordpress/examples/redis-object-cache.yaml
+++ b/charts/wordpress/examples/redis-object-cache.yaml
@@ -1,0 +1,23 @@
+# WordPress with Redis Object Cache using HelmForge Redis subchart
+
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  redis:
+    mode: subchart
+    subchart:
+      enabled: true
+
+redis:
+  architecture: standalone
+  auth:
+    existingSecret: wordpress-redis-auth
+    existingSecretPasswordKey: redis-password
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi

--- a/charts/wordpress/examples/wp-cron.yaml
+++ b/charts/wordpress/examples/wp-cron.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Run WordPress cron through a Kubernetes CronJob
 
 wordpress:

--- a/charts/wordpress/examples/wp-cron.yaml
+++ b/charts/wordpress/examples/wp-cron.yaml
@@ -1,0 +1,9 @@
+# Run WordPress cron through a Kubernetes CronJob
+
+wordpress:
+  disableWpCron: true
+
+wpCron:
+  cronJob:
+    enabled: true
+    schedule: "*/5 * * * *"

--- a/charts/wordpress/templates/NOTES.txt
+++ b/charts/wordpress/templates/NOTES.txt
@@ -1,7 +1,12 @@
 WordPress has been deployed!
 
 Web Interface:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.gatewayAPI.enabled }}
+  Gateway API HTTPRoute:
+  {{- range .Values.gatewayAPI.hostnames }}
+  http(s)://{{ . }}
+  {{- end }}
+{{- else if .Values.ingress.enabled }}
   {{- range .Values.ingress.hosts }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
   {{- end }}
@@ -21,7 +26,9 @@ Admin Panel:
 
 Admin Credentials:
   Username: {{ .Values.wordpress.adminUser }}
-{{- if .Values.admin.existingSecret }}
+{{- if eq (include "wordpress.externalSecretAdminEnabled" .) "true" }}
+  Password: Managed by ExternalSecret {{ include "wordpress.adminSecretName" . }}
+{{- else if .Values.admin.existingSecret }}
   Password: Using existing secret {{ .Values.admin.existingSecret }}
 {{- else if .Values.wordpress.adminPassword }}
   Password: Using the password from values.
@@ -34,6 +41,46 @@ Database:
   Mode: {{ include "wordpress.databaseMode" . }}
   Host: {{ include "wordpress.databaseHost" . }}:{{ include "wordpress.databasePort" . }}
   Name: {{ include "wordpress.databaseName" . }}
+{{- if eq (include "wordpress.externalSecretDatabaseEnabled" .) "true" }}
+  Password: Managed by ExternalSecret {{ include "wordpress.databaseSecretName" . }}
+{{- end }}
+
+{{- if .Values.service.ipFamilyPolicy }}
+
+Service:
+  IP Family Policy: {{ .Values.service.ipFamilyPolicy }}
+  {{- with .Values.service.ipFamilies }}
+  IP Families: {{ join ", " . }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.wpCron.cronJob.enabled }}
+
+WordPress Cron:
+  Kubernetes CronJob is enabled.
+  WordPress pseudo-cron is disabled through DISABLE_WP_CRON.
+{{- end }}
+
+{{- if .Values.plugins.installer.enabled }}
+
+Plugins:
+  Installer Job is enabled as a post-install/post-upgrade hook.
+  If WordPress core is not installed yet, activation is deferred until a later upgrade.
+{{- end }}
+
+{{- if .Values.objectCache.enabled }}
+
+Object Cache:
+  Redis Object Cache is enabled.
+  Redis host: {{ include "wordpress.redisHost" . }}:{{ .Values.objectCache.redis.port }}
+  Verify functionality by checking wp-content/object-cache.php and Redis keys after web requests.
+{{- end }}
+
+{{- if .Values.networkPolicy.enabled }}
+
+NetworkPolicy:
+  Enabled. Review egress rules if plugins, SMTP, object storage, or update checks need outbound access.
+{{- end }}
 
 {{- if .Values.backup.enabled }}
 
@@ -41,6 +88,9 @@ Backup:
   Schedule: {{ .Values.backup.schedule }}
   S3 Endpoint: {{ .Values.backup.s3.endpoint }}
   S3 Bucket: {{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+  {{- if eq (include "wordpress.externalSecretBackupEnabled" .) "true" }}
+  Credentials: Managed by ExternalSecret {{ include "wordpress.backupSecretName" . }}
+  {{- end }}
 {{- end }}
 
 {{- if .Values.metrics.enabled }}
@@ -51,3 +101,7 @@ Metrics:
   A ServiceMonitor has been created for Prometheus Operator.
   {{- end }}
 {{- end }}
+
+Production reminder:
+  Defaults are suitable for development. For production, set explicit resources,
+  TLS routing, backups, metrics, credentials, and a storage strategy before scaling replicas.

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -71,6 +71,21 @@ Image string with tag fallback to appVersion.
 {{- end }}
 
 {{/*
+ExternalSecret feature flags.
+*/}}
+{{- define "wordpress.externalSecretAdminEnabled" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.admin.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.externalSecretDatabaseEnabled" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.externalSecretBackupEnabled" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.backup.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Database mode detection (auto | external | mysql).
 Auto precedence:
   1. database.external.host or database.external.existingSecret → external
@@ -163,7 +178,11 @@ Database password secret name.
 */}}
 {{- define "wordpress.databaseSecretName" -}}
 {{- $mode := include "wordpress.databaseMode" . -}}
-{{- if and (eq $mode "external") .Values.database.external.existingSecret -}}
+{{- if and (eq (include "wordpress.externalSecretDatabaseEnabled" .) "true") .Values.externalSecrets.database.targetName -}}
+{{- .Values.externalSecrets.database.targetName -}}
+{{- else if eq (include "wordpress.externalSecretDatabaseEnabled" .) "true" -}}
+{{- printf "%s-database" (include "wordpress.fullname" .) -}}
+{{- else if and (eq $mode "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
 {{- else if eq $mode "mysql" -}}
 {{- printf "%s-mysql-auth" .Release.Name -}}
@@ -202,7 +221,11 @@ Database password value (for generating secrets).
 Admin secret name.
 */}}
 {{- define "wordpress.adminSecretName" -}}
-{{- if .Values.admin.existingSecret -}}
+{{- if and (eq (include "wordpress.externalSecretAdminEnabled" .) "true") .Values.externalSecrets.admin.targetName -}}
+{{- .Values.externalSecrets.admin.targetName -}}
+{{- else if eq (include "wordpress.externalSecretAdminEnabled" .) "true" -}}
+{{- printf "%s-admin" (include "wordpress.fullname" .) -}}
+{{- else if .Values.admin.existingSecret -}}
 {{- .Values.admin.existingSecret -}}
 {{- else -}}
 {{- printf "%s-admin" (include "wordpress.fullname" .) -}}
@@ -242,7 +265,11 @@ true
 Backup S3 secret name.
 */}}
 {{- define "wordpress.backupSecretName" -}}
-{{- if .Values.backup.s3.existingSecret -}}
+{{- if and (eq (include "wordpress.externalSecretBackupEnabled" .) "true") .Values.externalSecrets.backup.targetName -}}
+{{- .Values.externalSecrets.backup.targetName -}}
+{{- else if eq (include "wordpress.externalSecretBackupEnabled" .) "true" -}}
+{{- printf "%s-backup" (include "wordpress.fullname" .) -}}
+{{- else if .Values.backup.s3.existingSecret -}}
 {{- .Values.backup.s3.existingSecret -}}
 {{- else -}}
 {{- printf "%s-backup" (include "wordpress.fullname" .) -}}
@@ -320,4 +347,211 @@ ConfigMap name.
 */}}
 {{- define "wordpress.configMapName" -}}
 {{- printf "%s-config" (include "wordpress.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Redis object cache helpers.
+*/}}
+{{- define "wordpress.objectCacheRedisEnabled" -}}
+{{- if and .Values.objectCache.enabled (eq .Values.objectCache.provider "redis-cache") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.redisSubchartFullname" -}}
+{{- $redisValues := default dict .Values.redis -}}
+{{- $fullnameOverride := default "" (get $redisValues "fullnameOverride") -}}
+{{- $nameOverride := default "" (get $redisValues "nameOverride") -}}
+{{- if $fullnameOverride -}}
+{{- $fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "redis" $nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.redisHost" -}}
+{{- if eq .Values.objectCache.redis.mode "external" -}}
+{{- .Values.objectCache.redis.external.host -}}
+{{- else -}}
+{{- printf "%s-client" (include "wordpress.redisSubchartFullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.redisSecretName" -}}
+{{- if .Values.objectCache.redis.auth.existingSecret -}}
+{{- .Values.objectCache.redis.auth.existingSecret -}}
+{{- else if eq .Values.objectCache.redis.mode "external" -}}
+{{- printf "%s-redis-auth" (include "wordpress.fullname" .) -}}
+{{- else -}}
+{{- printf "%s-auth" (include "wordpress.redisSubchartFullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.redisSecretKey" -}}
+{{- .Values.objectCache.redis.auth.existingSecretPasswordKey -}}
+{{- end -}}
+
+{{- define "wordpress.redisPasswordEnabled" -}}
+{{- if and (eq (include "wordpress.objectCacheRedisEnabled" .) "true") .Values.objectCache.redis.auth.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.redisPrefix" -}}
+{{- if .Values.objectCache.redis.prefix -}}
+{{- .Values.objectCache.redis.prefix -}}
+{{- else -}}
+{{- printf "%s:" (include "wordpress.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.pluginsJobEnabled" -}}
+{{- if and .Values.plugins.enabled .Values.plugins.installer.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Generated wp-config.php additions derived from structured values.
+*/}}
+{{- define "wordpress.generatedConfigExtra" -}}
+{{- if .Values.wordpress.forceSSLAdmin }}
+define('FORCE_SSL_ADMIN', true);
+{{- end }}
+{{- if .Values.wordpress.disallowFileEdit }}
+define('DISALLOW_FILE_EDIT', true);
+{{- end }}
+{{- if or .Values.wordpress.disableWpCron .Values.wpCron.cronJob.enabled }}
+define('DISABLE_WP_CRON', true);
+{{- end }}
+{{- with .Values.wordpress.memoryLimit }}
+define('WP_MEMORY_LIMIT', {{ . | quote }});
+{{- end }}
+{{- with .Values.wordpress.maxMemoryLimit }}
+define('WP_MAX_MEMORY_LIMIT', {{ . | quote }});
+{{- end }}
+{{- if eq (include "wordpress.objectCacheRedisEnabled" .) "true" }}
+define('WP_CACHE', true);
+define('WP_REDIS_CLIENT', {{ .Values.objectCache.redis.client | quote }});
+define('WP_REDIS_SCHEME', {{ .Values.objectCache.redis.scheme | quote }});
+define('WP_REDIS_HOST', {{ include "wordpress.redisHost" . | quote }});
+define('WP_REDIS_PORT', {{ int .Values.objectCache.redis.port }});
+define('WP_REDIS_DATABASE', {{ int .Values.objectCache.redis.database }});
+define('WP_REDIS_PREFIX', {{ include "wordpress.redisPrefix" . | quote }});
+{{- if eq (include "wordpress.redisPasswordEnabled" .) "true" }}
+define('WP_REDIS_PASSWORD', getenv('WP_REDIS_PASSWORD'));
+{{- end }}
+{{- with .Values.objectCache.redis.maxTtl }}
+define('WP_REDIS_MAXTTL', {{ int . }});
+{{- end }}
+{{- end }}
+{{- with .Values.wordpress.configExtra }}
+{{ . }}
+{{- end }}
+{{- end -}}
+
+{{/* ExternalSecret remoteRef item */}}
+{{- define "wordpress.externalSecretDataItem" -}}
+- secretKey: {{ .secretKey | quote }}
+  remoteRef:
+    {{- if not .remoteRef.key }}
+    {{- fail (printf "%s.key is required when %s=true" .remoteRefName .enabledName) }}
+    {{- end }}
+    key: {{ .remoteRef.key | quote }}
+    {{- with .remoteRef.property }}
+    property: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.version }}
+    version: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.decodingStrategy }}
+    decodingStrategy: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.conversionStrategy }}
+    conversionStrategy: {{ . | quote }}
+    {{- end }}
+{{- end -}}
+
+{{/* Validate ExternalSecret settings */}}
+{{- define "wordpress.validateExternalSecrets" -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if ne .Values.externalSecrets.apiVersion "external-secrets.io/v1" -}}
+    {{- fail "externalSecrets.apiVersion must be external-secrets.io/v1" -}}
+  {{- end -}}
+  {{- if not .Values.externalSecrets.secretStoreRef.name -}}
+    {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.admin.enabled (not .Values.externalSecrets.enabled) -}}
+{{- fail "externalSecrets.enabled must be true when externalSecrets.admin.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.database.enabled (not .Values.externalSecrets.enabled) -}}
+{{- fail "externalSecrets.enabled must be true when externalSecrets.database.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.backup.enabled (not .Values.externalSecrets.enabled) -}}
+{{- fail "externalSecrets.enabled must be true when externalSecrets.backup.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.admin.existingSecret (eq (include "wordpress.externalSecretAdminEnabled" .) "true") -}}
+{{- fail "admin.existingSecret and externalSecrets.admin.enabled are mutually exclusive" -}}
+{{- end -}}
+{{- if and .Values.database.external.existingSecret (eq (include "wordpress.externalSecretDatabaseEnabled" .) "true") -}}
+{{- fail "database.external.existingSecret and externalSecrets.database.enabled are mutually exclusive" -}}
+{{- end -}}
+{{- if and .Values.backup.s3.existingSecret (eq (include "wordpress.externalSecretBackupEnabled" .) "true") -}}
+{{- fail "backup.s3.existingSecret and externalSecrets.backup.enabled are mutually exclusive" -}}
+{{- end -}}
+{{- if and (eq (include "wordpress.externalSecretDatabaseEnabled" .) "true") (ne (include "wordpress.databaseMode" .) "external") -}}
+{{- fail "externalSecrets.database.enabled requires database.mode=external or database.external.host" -}}
+{{- end -}}
+{{- if and (eq (include "wordpress.externalSecretBackupEnabled" .) "true") (not .Values.backup.enabled) -}}
+{{- fail "externalSecrets.backup.enabled requires backup.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate object cache and plugin settings */}}
+{{- define "wordpress.validatePlugins" -}}
+{{- if .Values.objectCache.enabled -}}
+  {{- if not .Values.plugins.enabled -}}
+    {{- fail "plugins.enabled must be true when objectCache.enabled is true" -}}
+  {{- end -}}
+  {{- if not .Values.plugins.installer.enabled -}}
+    {{- fail "plugins.installer.enabled must be true when objectCache.enabled is true" -}}
+  {{- end -}}
+{{- end -}}
+{{- range .Values.plugins.items -}}
+  {{- if hasKey . "source" -}}
+    {{- fail "plugins.items[].source is not supported; use official WordPress.org plugin slugs only" -}}
+  {{- end -}}
+  {{- if hasKey . "activateSlug" -}}
+    {{- fail "plugins.items[].activateSlug is not supported; use official WordPress.org plugin slugs only" -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.objectCache.enabled -}}
+  {{- if ne .Values.objectCache.provider "redis-cache" -}}
+    {{- fail "objectCache.provider currently supports only redis-cache" -}}
+  {{- end -}}
+  {{- if not (has .Values.objectCache.redis.mode (list "subchart" "external")) -}}
+    {{- fail "objectCache.redis.mode must be subchart or external" -}}
+  {{- end -}}
+  {{- if and (eq .Values.objectCache.redis.mode "subchart") (not .Values.objectCache.redis.subchart.enabled) -}}
+    {{- fail "objectCache.redis.subchart.enabled must be true when objectCache.redis.mode=subchart" -}}
+  {{- end -}}
+  {{- if and (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.external.host) -}}
+    {{- fail "objectCache.redis.external.host is required when objectCache.redis.mode=external" -}}
+  {{- end -}}
+  {{- if and .Values.objectCache.redis.auth.enabled (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.auth.existingSecret) (not .Values.objectCache.redis.auth.password) -}}
+    {{- fail "objectCache.redis.auth.existingSecret or objectCache.redis.auth.password is required when external Redis auth is enabled" -}}
+  {{- end -}}
+{{- end -}}
+{{- range $i, $plugin := .Values.plugins.items }}
+  {{- if not $plugin.slug -}}
+    {{- fail (printf "plugins.items[%d].slug is required" $i) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate Gateway API settings */}}
+{{- define "wordpress.validateGatewayAPI" -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
+{{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
+{{- end -}}
 {{- end -}}

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -522,6 +522,9 @@ define('WP_REDIS_MAXTTL', {{ int . }});
 
 {{/* Validate object cache and plugin settings */}}
 {{- define "wordpress.validatePlugins" -}}
+{{- if and (eq (include "wordpress.pluginsJobEnabled" .) "true") (not .Values.persistence.enabled) -}}
+  {{- fail "plugins.installer.enabled requires persistence.enabled=true so installed plugins are written to the WordPress volume" -}}
+{{- end -}}
 {{- if .Values.objectCache.enabled -}}
   {{- if not .Values.plugins.enabled -}}
     {{- fail "plugins.enabled must be true when objectCache.enabled is true" -}}

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -255,8 +255,8 @@ Backup enabled (with validation).
   {{- if not .Values.backup.s3.bucket -}}
     {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
   {{- end -}}
-  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
-    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
+  {{- if and (ne (include "wordpress.externalSecretBackupEnabled" .) "true") (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires backup.s3.existingSecret, externalSecrets.backup.enabled, or both backup.s3.accessKey and backup.s3.secretKey" -}}
   {{- end -}}
 true
 {{- end -}}
@@ -382,17 +382,29 @@ Redis object cache helpers.
 {{- end -}}
 
 {{- define "wordpress.redisSecretName" -}}
+{{- $redisValues := default dict .Values.redis -}}
+{{- $redisAuth := default dict (get $redisValues "auth") -}}
 {{- if .Values.objectCache.redis.auth.existingSecret -}}
 {{- .Values.objectCache.redis.auth.existingSecret -}}
 {{- else if eq .Values.objectCache.redis.mode "external" -}}
 {{- printf "%s-redis-auth" (include "wordpress.fullname" .) -}}
+{{- else if get $redisAuth "existingSecret" -}}
+{{- get $redisAuth "existingSecret" -}}
 {{- else -}}
 {{- printf "%s-auth" (include "wordpress.redisSubchartFullname" .) -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "wordpress.redisSecretKey" -}}
+{{- $redisValues := default dict .Values.redis -}}
+{{- $redisAuth := default dict (get $redisValues "auth") -}}
+{{- if .Values.objectCache.redis.auth.existingSecret -}}
 {{- .Values.objectCache.redis.auth.existingSecretPasswordKey -}}
+{{- else if and (eq .Values.objectCache.redis.mode "subchart") (get $redisAuth "existingSecret") -}}
+{{- default "redis-password" (get $redisAuth "existingSecretPasswordKey") -}}
+{{- else -}}
+{{- .Values.objectCache.redis.auth.existingSecretPasswordKey -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "wordpress.redisPasswordEnabled" -}}

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{/*
 Chart name, truncated to 63 characters.
 */}}

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -408,7 +408,15 @@ Redis object cache helpers.
 {{- end -}}
 
 {{- define "wordpress.redisPasswordEnabled" -}}
-{{- if and (eq (include "wordpress.objectCacheRedisEnabled" .) "true") .Values.objectCache.redis.auth.enabled -}}true{{- end -}}
+{{- $redisValues := default dict .Values.redis -}}
+{{- $redisAuth := default dict (get $redisValues "auth") -}}
+{{- $subchartAuthEnabled := true -}}
+{{- if hasKey $redisAuth "enabled" -}}
+{{- $subchartAuthEnabled = get $redisAuth "enabled" -}}
+{{- end -}}
+{{- if and (eq (include "wordpress.objectCacheRedisEnabled" .) "true") .Values.objectCache.redis.auth.enabled -}}
+{{- if or (eq .Values.objectCache.redis.mode "external") $subchartAuthEnabled -}}true{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "wordpress.redisPrefix" -}}

--- a/charts/wordpress/templates/backup-cronjob.yaml
+++ b/charts/wordpress/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if (include "wordpress.backupEnabled" .) }}
 apiVersion: batch/v1
 kind: CronJob

--- a/charts/wordpress/templates/backup-cronjob.yaml
+++ b/charts/wordpress/templates/backup-cronjob.yaml
@@ -22,6 +22,7 @@ spec:
             app.kubernetes.io/component: backup
         spec:
           restartPolicy: Never
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           initContainers:
             - name: dump-database
               image: {{ .Values.backup.images.worker | quote }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "wordpress.labels" . | nindent 4 }}
     app.kubernetes.io/component: wordpress
 spec:
-  replicas: 1
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:
@@ -36,6 +38,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -59,6 +62,9 @@ spec:
               value: {{ include "wordpress.databaseHost" . | quote }}
             - name: DB_PORT
               value: {{ include "wordpress.databasePort" . | quote }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: wordpress
           image: {{ include "wordpress.image" . }}
@@ -85,13 +91,24 @@ spec:
             - name: WORDPRESS_DEBUG
               value: "1"
             {{- end }}
-            {{- if .Values.wordpress.configExtra }}
+            {{- if eq (include "wordpress.redisPasswordEnabled" .) "true" }}
+            - name: WP_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.redisSecretName" . }}
+                  key: {{ include "wordpress.redisSecretKey" . }}
+            {{- end }}
+            {{- if include "wordpress.generatedConfigExtra" . }}
             - name: WORDPRESS_CONFIG_EXTRA
-              value: {{ .Values.wordpress.configExtra | quote }}
+              value: {{ include "wordpress.generatedConfigExtra" . | quote }}
             {{- end }}
             {{- with .Values.wordpress.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.wordpress.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -152,6 +169,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
+        {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       volumes:
         - name: wordpress-data

--- a/charts/wordpress/templates/externalsecret.yaml
+++ b/charts/wordpress/templates/externalsecret.yaml
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- include "wordpress.validateExternalSecrets" . }}
+{{- if eq (include "wordpress.externalSecretAdminEnabled" .) "true" }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "wordpress.adminSecretName" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "wordpress.adminSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "wordpress.externalSecretDataItem" (dict "secretKey" "admin-password" "remoteRefName" "externalSecrets.admin.passwordRemoteRef" "enabledName" "externalSecrets.admin.enabled" "remoteRef" .Values.externalSecrets.admin.passwordRemoteRef) | nindent 4 }}
+{{- end }}
+{{- if eq (include "wordpress.externalSecretDatabaseEnabled" .) "true" }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "wordpress.databaseSecretName" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "wordpress.databaseSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "wordpress.externalSecretDataItem" (dict "secretKey" .Values.database.external.existingSecretPasswordKey "remoteRefName" "externalSecrets.database.passwordRemoteRef" "enabledName" "externalSecrets.database.enabled" "remoteRef" .Values.externalSecrets.database.passwordRemoteRef) | nindent 4 }}
+{{- end }}
+{{- if eq (include "wordpress.externalSecretBackupEnabled" .) "true" }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "wordpress.backupSecretName" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "wordpress.backupSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "wordpress.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretAccessKeyKey "remoteRefName" "externalSecrets.backup.accessKeyRemoteRef" "enabledName" "externalSecrets.backup.enabled" "remoteRef" .Values.externalSecrets.backup.accessKeyRemoteRef) | nindent 4 }}
+    {{- include "wordpress.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretSecretKeyKey "remoteRefName" "externalSecrets.backup.secretKeyRemoteRef" "enabledName" "externalSecrets.backup.enabled" "remoteRef" .Values.externalSecrets.backup.secretKeyRemoteRef) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/wordpress/templates/hpa.yaml
+++ b/charts/wordpress/templates/hpa.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "wordpress.fullname" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "wordpress.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/wordpress/templates/httproute.yaml
+++ b/charts/wordpress/templates/httproute.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "wordpress.validateGatewayAPI" . }}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: {{ .Values.gatewayAPI.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "wordpress.fullname" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gatewayAPI.matches | nindent 8 }}
+      backendRefs:
+        - name: {{ include "wordpress.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/wordpress/templates/networkpolicy.yaml
+++ b/charts/wordpress/templates/networkpolicy.yaml
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wordpress.fullname" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wordpress.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: wordpress
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  {{- $allowAppIngress := or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
+  {{- $allowMetricsIngress := and .Values.metrics.enabled .Values.networkPolicy.metrics.enabled }}
+  ingress:
+    {{- if or $allowAppIngress $allowMetricsIngress }}
+    {{- if $allowAppIngress }}
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- if $allowMetricsIngress }}
+    - from:
+        {{- if .Values.networkPolicy.metrics.allowSameNamespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.metrics.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.metrics.port }}
+    {{- end }}
+    {{- else }}
+    []
+    {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespaceDatabase .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowSMTP .Values.networkPolicy.egress.extraTo }}
+  egress:
+    {{- if $allowEgress }}
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSameNamespaceDatabase }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.databasePort }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSMTP }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.smtpPort }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- else }}
+    []
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/wordpress/templates/pdb.yaml
+++ b/charts/wordpress/templates/pdb.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wordpress.fullname" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "wordpress.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: wordpress
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+{{- end }}

--- a/charts/wordpress/templates/plugin-installer-job.yaml
+++ b/charts/wordpress/templates/plugin-installer-job.yaml
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- include "wordpress.validatePlugins" . }}
+{{- if eq (include "wordpress.pluginsJobEnabled" .) "true" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wordpress.fullname" . }}-plugins
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: plugin-installer
+  {{- if .Values.plugins.installer.useHelmHooks }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": {{ .Values.plugins.installer.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.plugins.installer.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.plugins.installer.activeDeadlineSeconds }}
+  {{- with .Values.plugins.installer.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "wordpress.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: plugin-installer
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- if and .Values.plugins.installer.preferWordPressPodNode .Values.persistence.enabled }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "wordpress.selectorLabels" . | nindent 18 }}
+                  app.kubernetes.io/component: wordpress
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
+      containers:
+        - name: plugin-installer
+          image: "{{ .Values.plugins.installer.image.repository }}:{{ .Values.plugins.installer.image.tag }}"
+          imagePullPolicy: {{ .Values.plugins.installer.image.pullPolicy }}
+          workingDir: /var/www/html
+          {{- with .Values.plugins.installer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -ec
+            - |
+              wait_for_wordpress_files() {
+                for i in $(seq 1 20); do
+                  if [ -f /var/www/html/wp-config.php ] && [ -d /var/www/html/wp-content ]; then
+                    return 0
+                  fi
+                  echo "Waiting for WordPress files on the shared volume..."
+                  sleep 2
+                done
+                echo "WordPress files were not initialized in time." >&2
+                return 1
+              }
+
+              is_installed() {
+                wp core is-installed --path=/var/www/html >/dev/null 2>&1
+              }
+
+              plugin_dir_exists() {
+                [ -n "$1" ] && [ -d "/var/www/html/wp-content/plugins/$1" ]
+              }
+
+              download_plugin() {
+                slug="$1"
+                source="https://downloads.wordpress.org/plugin/${slug}.latest-stable.zip"
+
+                tmp="/tmp/${slug}.zip"
+                mkdir -p /var/www/html/wp-content/plugins
+                echo "Downloading plugin archive from $source"
+                php -r 'copy($argv[1], $argv[2]) || exit(1);' "$source" "$tmp"
+
+                if command -v unzip >/dev/null 2>&1; then
+                  unzip -oq "$tmp" -d /var/www/html/wp-content/plugins
+                else
+                  php -r '$zip = new ZipArchive(); if ($zip->open($argv[1]) !== true) { exit(1); } $zip->extractTo($argv[2]); $zip->close();' "$tmp" /var/www/html/wp-content/plugins
+                fi
+              }
+
+              install_plugin() {
+                slug="$1"
+                activate="$2"
+                skip_if_installed="$3"
+
+                if [ "$skip_if_installed" = "true" ] && { wp plugin is-installed "$slug" --path=/var/www/html --allow-root >/dev/null 2>&1 || plugin_dir_exists "$slug"; }; then
+                  echo "Plugin $slug already installed."
+                else
+                  if is_installed; then
+                    echo "Installing official WordPress.org plugin $slug"
+                    wp plugin install "$slug" --path=/var/www/html --allow-root
+                  else
+                    echo "WordPress is not installed yet; installing plugin files for $slug without activation."
+                    download_plugin "$slug"
+                  fi
+                fi
+
+                if [ "$activate" = "true" ]; then
+                  if is_installed; then
+                    if wp plugin is-active "$slug" --path=/var/www/html --allow-root >/dev/null 2>&1; then
+                      echo "Plugin $slug already active."
+                    else
+                      echo "Activating plugin $slug"
+                      wp plugin activate "$slug" --path=/var/www/html --allow-root
+                    fi
+                  else
+                    echo "WordPress is not installed yet; plugin activation for $slug will be retried on a later upgrade."
+                  fi
+                fi
+              }
+
+              wait_for_wordpress_files
+
+              {{ range .Values.plugins.items }}
+              {{- $activate := true -}}
+              {{- if hasKey . "activate" -}}{{- $activate = .activate -}}{{- end -}}
+              {{- $skipIfInstalled := true -}}
+              {{- if hasKey . "skipIfInstalled" -}}{{- $skipIfInstalled = .skipIfInstalled -}}{{- end -}}
+              install_plugin {{ default "" .slug | quote }} {{ $activate | quote }} {{ $skipIfInstalled | quote }}
+              {{- end }}
+              {{- if and .Values.objectCache.enabled .Values.objectCache.installPlugin }}
+              install_plugin "redis-cache" "true" "true"
+              {{- end }}
+
+              {{- if and .Values.objectCache.enabled .Values.objectCache.enableDropIn }}
+              if [ -f /var/www/html/wp-content/object-cache.php ]; then
+                echo "Redis object-cache.php drop-in already exists."
+              elif [ -f /var/www/html/wp-content/plugins/redis-cache/includes/object-cache.php ]; then
+                echo "Creating Redis object-cache.php drop-in."
+                cp /var/www/html/wp-content/plugins/redis-cache/includes/object-cache.php /var/www/html/wp-content/object-cache.php
+              elif is_installed; then
+                echo "Enabling Redis Object Cache drop-in through WP-CLI."
+                wp redis enable --path=/var/www/html --allow-root || true
+              else
+                echo "Redis plugin files are missing; cannot create object-cache.php." >&2
+                exit 1
+              fi
+              {{- end }}
+          env:
+            - name: WORDPRESS_DB_HOST
+              value: {{ printf "%s:%s" (include "wordpress.databaseHost" .) (include "wordpress.databasePort" .) | quote }}
+            - name: WORDPRESS_DB_NAME
+              value: {{ include "wordpress.databaseName" . | quote }}
+            - name: WORDPRESS_DB_USER
+              value: {{ include "wordpress.databaseUsername" . | quote }}
+            - name: WORDPRESS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.databaseSecretName" . }}
+                  key: {{ include "wordpress.databaseSecretKey" . }}
+            {{- if eq (include "wordpress.redisPasswordEnabled" .) "true" }}
+            - name: WP_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.redisSecretName" . }}
+                  key: {{ include "wordpress.redisSecretKey" . }}
+            {{- end }}
+          {{- with .Values.plugins.installer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: wordpress-data
+              mountPath: /var/www/html
+      volumes:
+        - name: wordpress-data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "wordpress.fullname" .) .Values.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- end }}

--- a/charts/wordpress/templates/plugin-installer-job.yaml
+++ b/charts/wordpress/templates/plugin-installer-job.yaml
@@ -173,10 +173,6 @@ spec:
               mountPath: /var/www/html
       volumes:
         - name: wordpress-data
-          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ default (include "wordpress.fullname" .) .Values.persistence.existingClaim }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
 {{- end }}

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- include "wordpress.validateExternalSecrets" . }}
 {{- if and (not .Values.admin.existingSecret) (ne (include "wordpress.externalSecretAdminEnabled" .) "true") }}
 {{- $adminSecretName := printf "%s-admin" (include "wordpress.fullname" .) }}

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.admin.existingSecret }}
+{{- include "wordpress.validateExternalSecrets" . }}
+{{- if and (not .Values.admin.existingSecret) (ne (include "wordpress.externalSecretAdminEnabled" .) "true") }}
 {{- $adminSecretName := printf "%s-admin" (include "wordpress.fullname" .) }}
 {{- $existingAdminSecret := lookup "v1" "Secret" .Release.Namespace $adminSecretName }}
 apiVersion: v1
@@ -19,7 +20,7 @@ data:
 {{- end }}
 ---
 {{- $mode := include "wordpress.databaseMode" . }}
-{{- if and (not (and (eq $mode "external") .Values.database.external.existingSecret)) true }}
+{{- if and (not (and (eq $mode "external") .Values.database.external.existingSecret)) (ne (include "wordpress.externalSecretDatabaseEnabled" .) "true") }}
 {{- $dbSecretName := printf "%s-database" (include "wordpress.fullname" .) }}
 {{- $existingDbSecret := lookup "v1" "Secret" .Release.Namespace $dbSecretName }}
 apiVersion: v1
@@ -42,7 +43,7 @@ data:
   {{- end }}
 {{- end }}
 ---
-{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) (ne (include "wordpress.externalSecretBackupEnabled" .) "true") }}
 {{- $backupSecretName := printf "%s-backup" (include "wordpress.fullname" .) }}
 {{- $existingBackupSecret := lookup "v1" "Secret" .Release.Namespace $backupSecretName }}
 apiVersion: v1
@@ -60,4 +61,16 @@ data:
   access-key: {{ .Values.backup.s3.accessKey | b64enc }}
   secret-key: {{ .Values.backup.s3.secretKey | b64enc }}
   {{- end }}
+{{- end }}
+---
+{{- if and (eq (include "wordpress.objectCacheRedisEnabled" .) "true") .Values.objectCache.redis.auth.enabled (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wordpress.redisSecretName" . }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ include "wordpress.redisSecretKey" . }}: {{ .Values.objectCache.redis.auth.password | b64enc }}
 {{- end }}

--- a/charts/wordpress/templates/service.yaml
+++ b/charts/wordpress/templates/service.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/wordpress/templates/service.yaml
+++ b/charts/wordpress/templates/service.yaml
@@ -11,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "wordpress.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: wordpress

--- a/charts/wordpress/templates/serviceaccount.yaml
+++ b/charts/wordpress/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/wordpress/templates/serviceaccount.yaml
+++ b/charts/wordpress/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/wordpress/templates/wp-cronjob.yaml
+++ b/charts/wordpress/templates/wp-cronjob.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.wpCron.cronJob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "wordpress.fullname" . }}-wp-cron
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: wp-cron
+spec:
+  schedule: {{ .Values.wpCron.cronJob.schedule | quote }}
+  suspend: {{ .Values.wpCron.cronJob.suspend }}
+  concurrencyPolicy: {{ .Values.wpCron.cronJob.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.wpCron.cronJob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.wpCron.cronJob.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.wpCron.cronJob.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "wordpress.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: wp-cron
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+          containers:
+            - name: wp-cron
+              image: "{{ .Values.wpCron.cronJob.image.repository }}:{{ .Values.wpCron.cronJob.image.tag }}"
+              imagePullPolicy: {{ .Values.wpCron.cronJob.image.pullPolicy }}
+              args:
+                - --fail
+                - --silent
+                - --show-error
+                - http://{{ include "wordpress.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/wp-cron.php?doing_wp_cron
+              {{- with .Values.wpCron.cronJob.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+{{- end }}

--- a/charts/wordpress/tests/availability_test.yaml
+++ b/charts/wordpress/tests/availability_test.yaml
@@ -1,0 +1,50 @@
+suite: Availability
+templates:
+  - templates/hpa.yaml
+  - templates/pdb.yaml
+  - templates/wp-cronjob.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render HPA when enabled
+    template: templates/hpa.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+
+  - it: should render PDB when enabled
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should render wp-cron CronJob when enabled
+    template: templates/wp-cronjob.yaml
+    set:
+      wpCron.cronJob.enabled: true
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
+          value: false

--- a/charts/wordpress/tests/availability_test.yaml
+++ b/charts/wordpress/tests/availability_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Availability
 templates:
   - templates/hpa.yaml

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Backup
 templates:
   - templates/backup-cronjob.yaml
@@ -34,6 +35,33 @@ tests:
       - equal:
           path: metadata.name
           value: test-wordpress-backup
+
+  - it: should render CronJob with ExternalSecret-managed S3 credentials
+    template: templates/backup-cronjob.yaml
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.example.com
+      backup.s3.bucket: test-bucket
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.backup.enabled: true
+      externalSecrets.backup.accessKeyRemoteRef:
+        key: prod/wordpress-backup
+        property: access-key
+      externalSecrets.backup.secretKeyRemoteRef:
+        key: prod/wordpress-backup
+        property: secret-key
+    asserts:
+      - isKind:
+          of: CronJob
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: S3_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-wordpress-backup
+                key: access-key
 
   - it: should set backup schedule
     template: templates/backup-cronjob.yaml

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -29,6 +29,21 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should omit replicas when autoscaling is enabled
+    template: templates/deployment.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas
+
+  - it: should disable service account token automount by default
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
   - it: should use default image tag with appVersion
     template: templates/deployment.yaml
     asserts:
@@ -109,11 +124,54 @@ tests:
     set:
       wordpress.configExtra: "define('WP_MEMORY_LIMIT', '256M');"
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: WORDPRESS_CONFIG_EXTRA
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "WP_MEMORY_LIMIT"
+
+  - it: should generate structured wp-config options
+    template: templates/deployment.yaml
+    set:
+      wordpress.forceSSLAdmin: true
+      wordpress.disallowFileEdit: true
+      wordpress.disableWpCron: true
+      wordpress.memoryLimit: 256M
+      wordpress.maxMemoryLimit: 512M
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "FORCE_SSL_ADMIN"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "DISALLOW_FILE_EDIT"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "DISABLE_WP_CRON"
+
+  - it: should configure Redis object cache env and wp-config constants
+    template: templates/deployment.yaml
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+    asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: WORDPRESS_CONFIG_EXTRA
-            value: "define('WP_MEMORY_LIMIT', '256M');"
+            name: WP_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-redis-auth
+                key: redis-password
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[6].value
+          pattern: "WP_REDIS_HOST"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[6].value
+          pattern: "test-redis-client"
 
   - it: should include extra env vars
     template: templates/deployment.yaml
@@ -127,6 +185,41 @@ tests:
           content:
             name: PHP_MEMORY_LIMIT
             value: "256M"
+
+  - it: should include extra envFrom sources
+    template: templates/deployment.yaml
+    set:
+      wordpress.extraEnvFrom:
+        - secretRef:
+            name: wordpress-extra-env
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: wordpress-extra-env
+
+  - it: should append extra init containers
+    template: templates/deployment.yaml
+    set:
+      extraInitContainers:
+        - name: prepare-content
+          image: busybox:1.37
+          command: ["sh", "-c", "true"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: prepare-content
+
+  - it: should append extra containers
+    template: templates/deployment.yaml
+    set:
+      extraContainers:
+        - name: sidecar
+          image: busybox:1.37
+          command: ["sh", "-c", "sleep 3600"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: sidecar
 
   - it: should expose HTTP port
     template: templates/deployment.yaml

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -193,6 +193,26 @@ tests:
                 name: wordpress-redis-auth
                 key: redis-password
 
+  - it: should not set Redis password when subchart auth is disabled
+    template: templates/deployment.yaml
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+      redis.auth.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WP_REDIS_PASSWORD
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "WP_REDIS_HOST"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "WP_REDIS_PASSWORD"
+
   - it: should include extra env vars
     template: templates/deployment.yaml
     set:

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -174,6 +174,25 @@ tests:
           path: spec.template.spec.containers[0].env[6].value
           pattern: "test-redis-client"
 
+  - it: should use Redis subchart existingSecret for object cache password
+    template: templates/deployment.yaml
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+      redis.auth.existingSecret: wordpress-redis-auth
+      redis.auth.existingSecretPasswordKey: redis-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WP_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: wordpress-redis-auth
+                key: redis-password
+
   - it: should include extra env vars
     template: templates/deployment.yaml
     set:

--- a/charts/wordpress/tests/externalsecret_test.yaml
+++ b/charts/wordpress/tests/externalsecret_test.yaml
@@ -1,0 +1,74 @@
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    template: templates/externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render admin ExternalSecret
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.passwordRemoteRef:
+        key: prod/wordpress
+        property: admin-password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: vault
+      - equal:
+          path: spec.target.name
+          value: test-wordpress-admin
+      - equal:
+          path: spec.data[0].secretKey
+          value: admin-password
+
+  - it: should render database ExternalSecret with external database
+    template: templates/externalsecret.yaml
+    set:
+      mysql.enabled: false
+      database.external.host: mysql.example.com
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef:
+        key: prod/wordpress
+        property: database-password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.target.name
+          value: test-wordpress-database
+      - equal:
+          path: spec.data[0].secretKey
+          value: database-password
+
+  - it: should not render native admin secret when admin ExternalSecret is enabled
+    template: templates/secret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.passwordRemoteRef:
+        key: prod/wordpress
+        property: admin-password
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-wordpress-database

--- a/charts/wordpress/tests/externalsecret_test.yaml
+++ b/charts/wordpress/tests/externalsecret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ExternalSecret
 templates:
   - templates/externalsecret.yaml

--- a/charts/wordpress/tests/gateway_test.yaml
+++ b/charts/wordpress/tests/gateway_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Gateway API
 templates:
   - templates/httproute.yaml

--- a/charts/wordpress/tests/gateway_test.yaml
+++ b/charts/wordpress/tests/gateway_test.yaml
@@ -1,0 +1,38 @@
+suite: Gateway API
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when enabled
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public
+          namespace: gateway-system
+      gatewayAPI.hostnames:
+        - wordpress.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.hostnames[0]
+          value: wordpress.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-wordpress
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80

--- a/charts/wordpress/tests/networkpolicy_test.yaml
+++ b/charts/wordpress/tests/networkpolicy_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: NetworkPolicy
 templates:
   - templates/networkpolicy.yaml

--- a/charts/wordpress/tests/networkpolicy_test.yaml
+++ b/charts/wordpress/tests/networkpolicy_test.yaml
@@ -1,0 +1,55 @@
+suite: NetworkPolicy
+templates:
+  - templates/networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ingress-only NetworkPolicy
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.policyTypes
+          value:
+            - Ingress
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 80
+
+  - it: should render egress rules when enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowHTTPS: true
+      networkPolicy.egress.allowSMTP: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            protocol: TCP
+            port: 443
+
+  - it: should render empty ingress list for default deny ingress
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.allowSameNamespace: false
+    asserts:
+      - equal:
+          path: spec.ingress
+          value: []

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -53,6 +53,24 @@ tests:
                 name: test-redis-auth
                 key: redis-password
 
+  - it: should use Redis subchart existingSecret in installer job
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+      redis.auth.existingSecret: wordpress-redis-auth
+      redis.auth.existingSecretPasswordKey: redis-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WP_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: wordpress-redis-auth
+                key: redis-password
+
   - it: should reject non-official plugin sources
     set:
       plugins.enabled: true

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -89,3 +89,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "plugins.enabled must be true when objectCache.enabled is true"
+
+  - it: should require persistence for installer job writes
+    set:
+      persistence.enabled: false
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      plugins.items:
+        - slug: classic-editor
+          activate: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "plugins.installer.enabled requires persistence.enabled=true so installed plugins are written to the WordPress volume"

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -1,0 +1,72 @@
+suite: Plugin Installer
+templates:
+  - templates/plugin-installer-job.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a post-install and post-upgrade hook job
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      plugins.items:
+        - slug: classic-editor
+          activate: true
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: test-wordpress-plugins
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "install_plugin \"classic-editor\""
+
+  - it: should add Redis Object Cache plugin and drop-in command
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "install_plugin \"redis-cache\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "object-cache.php"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WP_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-redis-auth
+                key: redis-password
+
+  - it: should reject non-official plugin sources
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      plugins.items:
+        - slug: custom-plugin
+          source: https://example.com/custom-plugin.zip
+    asserts:
+      - failedTemplate:
+          errorMessage: "plugins.items[].source is not supported; use official WordPress.org plugin slugs only"
+
+  - it: should require plugins when object cache is enabled
+    set:
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "plugins.enabled must be true when objectCache.enabled is true"

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -71,6 +71,19 @@ tests:
                 name: wordpress-redis-auth
                 key: redis-password
 
+  - it: should not set Redis password in installer when subchart auth is disabled
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+      redis.auth.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WP_REDIS_PASSWORD
+
   - it: should reject non-official plugin sources
     set:
       plugins.enabled: true

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Plugin Installer
 templates:
   - templates/plugin-installer-job.yaml

--- a/charts/wordpress/tests/service_test.yaml
+++ b/charts/wordpress/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml

--- a/charts/wordpress/tests/service_test.yaml
+++ b/charts/wordpress/tests/service_test.yaml
@@ -59,3 +59,19 @@ tests:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
           value: nlb
+
+  - it: should configure dual-stack service fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6

--- a/charts/wordpress/tests/serviceaccount_test.yaml
+++ b/charts/wordpress/tests/serviceaccount_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ServiceAccount
 templates:
   - templates/serviceaccount.yaml

--- a/charts/wordpress/tests/serviceaccount_test.yaml
+++ b/charts/wordpress/tests/serviceaccount_test.yaml
@@ -19,6 +19,9 @@ tests:
       - equal:
           path: metadata.name
           value: test-wordpress
+      - equal:
+          path: automountServiceAccountToken
+          value: false
 
   - it: should use custom name
     set:
@@ -38,3 +41,12 @@ tests:
       - equal:
           path: metadata.annotations["eks.amazonaws.com/role-arn"]
           value: arn:aws:iam::role/wordpress
+
+  - it: should allow automount token when explicitly enabled
+    set:
+      serviceAccount.create: true
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -17,6 +17,11 @@
       "type": "object",
       "description": "Labels added to every resource created by this chart"
     },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of WordPress replicas"
+    },
     "image": {
       "type": "object",
       "description": "WordPress container image settings",
@@ -73,6 +78,26 @@
           "type": "boolean",
           "description": "Enable WordPress debug mode (WP_DEBUG)"
         },
+        "forceSSLAdmin": {
+          "type": "boolean",
+          "description": "Force SSL for the WordPress admin area (FORCE_SSL_ADMIN)"
+        },
+        "disallowFileEdit": {
+          "type": "boolean",
+          "description": "Disable the built-in theme/plugin editor from wp-admin (DISALLOW_FILE_EDIT)"
+        },
+        "disableWpCron": {
+          "type": "boolean",
+          "description": "Disable WordPress pseudo-cron (DISABLE_WP_CRON)"
+        },
+        "memoryLimit": {
+          "type": "string",
+          "description": "WordPress frontend memory limit (WP_MEMORY_LIMIT)"
+        },
+        "maxMemoryLimit": {
+          "type": "string",
+          "description": "WordPress admin memory limit (WP_MAX_MEMORY_LIMIT)"
+        },
         "configExtra": {
           "type": "string",
           "description": "Extra PHP code injected into wp-config.php via WORDPRESS_CONFIG_EXTRA"
@@ -80,6 +105,11 @@
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables for the WordPress container",
+          "items": { "type": "object" }
+        },
+        "extraEnvFrom": {
+          "type": "array",
+          "description": "Additional envFrom sources for the WordPress container",
           "items": { "type": "object" }
         }
       }
@@ -273,6 +303,19 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the service"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Service IP family policy",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Ordered Service IP families",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
         }
       }
     },
@@ -325,6 +368,40 @@
         }
       }
     },
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create an HTTPRoute for WordPress"
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "HTTPRoute API version",
+          "enum": ["gateway.networking.k8s.io/v1"]
+        },
+        "annotations": {
+          "type": "object",
+          "description": "HTTPRoute annotations"
+        },
+        "parentRefs": {
+          "type": "array",
+          "description": "Parent Gateway references",
+          "items": { "type": "object" }
+        },
+        "hostnames": {
+          "type": "array",
+          "description": "HTTPRoute hostnames",
+          "items": { "type": "string" }
+        },
+        "matches": {
+          "type": "array",
+          "description": "HTTPRoute path matches",
+          "items": { "type": "object" }
+        }
+      }
+    },
     "serviceAccount": {
       "type": "object",
       "description": "ServiceAccount configuration",
@@ -340,7 +417,152 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the ServiceAccount"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Mount the ServiceAccount token into workload pods"
         }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "description": "HorizontalPodAutoscaler configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Create a HorizontalPodAutoscaler" },
+        "minReplicas": { "type": "integer", "minimum": 1, "description": "Minimum replicas" },
+        "maxReplicas": { "type": "integer", "minimum": 1, "description": "Maximum replicas" },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"], "description": "Target average CPU utilization percentage" },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"], "description": "Target average memory utilization percentage" }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "description": "PodDisruptionBudget configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Create a PodDisruptionBudget" },
+        "minAvailable": { "type": ["integer", "string"], "description": "Minimum available pods" },
+        "maxUnavailable": { "type": ["integer", "string"], "description": "Maximum unavailable pods" }
+      }
+    },
+    "wpCron": {
+      "type": "object",
+      "description": "WordPress cron configuration",
+      "properties": {
+        "cronJob": {
+          "type": "object",
+          "description": "Kubernetes CronJob that calls wp-cron.php",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Create the wp-cron CronJob" },
+            "schedule": { "type": "string", "description": "Cron schedule" },
+            "suspend": { "type": "boolean", "description": "Suspend the CronJob" },
+            "concurrencyPolicy": { "type": "string", "enum": ["Forbid", "Replace", "Allow"], "description": "CronJob concurrency policy" },
+            "successfulJobsHistoryLimit": { "type": "integer", "description": "Successful job history limit" },
+            "failedJobsHistoryLimit": { "type": "integer", "description": "Failed job history limit" },
+            "backoffLimit": { "type": "integer", "description": "Maximum retries per job" },
+            "image": {
+              "type": "object",
+              "description": "curl image used by wp-cron",
+              "properties": {
+                "repository": { "type": "string", "description": "Image repository" },
+                "tag": { "type": "string", "description": "Image tag" },
+                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Image pull policy" }
+              }
+            },
+            "resources": { "type": "object", "description": "CronJob container resources" }
+          }
+        }
+      }
+    },
+    "plugins": {
+      "type": "object",
+      "description": "WordPress plugin installer configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable plugin installer support" },
+        "installer": {
+          "type": "object",
+          "description": "Post-install/post-upgrade plugin installer Job",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Create the plugin installer Job" },
+            "useHelmHooks": { "type": "boolean", "description": "Run the Job as a Helm post-install/post-upgrade hook" },
+            "hookWeight": { "type": "string", "description": "Helm hook weight" },
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": { "type": "string", "description": "Installer image repository" },
+                "tag": { "type": "string", "description": "Installer image tag" },
+                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Installer image pull policy" }
+              }
+            },
+            "backoffLimit": { "type": "integer", "description": "Job backoff limit" },
+            "activeDeadlineSeconds": { "type": "integer", "description": "Job active deadline" },
+            "ttlSecondsAfterFinished": { "type": ["integer", "null"], "description": "Job TTL after finish" },
+            "resources": { "type": "object", "description": "Installer resources" },
+            "securityContext": { "type": "object", "description": "Installer container security context" },
+            "preferWordPressPodNode": { "type": "boolean", "description": "Schedule near WordPress pods for ReadWriteOnce PVCs" }
+          }
+        },
+        "items": {
+          "type": "array",
+          "description": "Plugins to install",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": { "type": "string", "description": "Official WordPress.org plugin slug" },
+              "activate": { "type": "boolean", "description": "Activate plugin when WordPress is installed" },
+              "skipIfInstalled": { "type": "boolean", "description": "Skip install when plugin is already present" }
+            }
+          }
+        }
+      }
+    },
+    "objectCache": {
+      "type": "object",
+      "description": "WordPress persistent object cache integration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable object cache integration" },
+        "provider": { "type": "string", "enum": ["redis-cache"], "description": "Object cache provider" },
+        "installPlugin": { "type": "boolean", "description": "Install the object cache plugin" },
+        "enableDropIn": { "type": "boolean", "description": "Create the object-cache.php drop-in" },
+        "redis": {
+          "type": "object",
+          "description": "Redis object cache settings",
+          "properties": {
+            "mode": { "type": "string", "enum": ["subchart", "external"], "description": "Redis deployment mode" },
+            "subchart": { "type": "object", "description": "HelmForge Redis subchart settings" },
+            "external": { "type": "object", "description": "External Redis settings" },
+            "port": { "type": "integer", "description": "Redis port" },
+            "database": { "type": "integer", "description": "Redis logical database" },
+            "prefix": { "type": "string", "description": "Redis key prefix" },
+            "client": { "type": "string", "description": "Redis client used by the plugin" },
+            "scheme": { "type": "string", "description": "Redis scheme" },
+            "maxTtl": { "type": ["integer", "string"], "description": "Maximum TTL for Redis cache keys" },
+            "auth": { "type": "object", "description": "Redis authentication settings" }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Create a NetworkPolicy for WordPress pods" },
+        "ingress": { "type": "object", "description": "Ingress policy rules" },
+        "metrics": { "type": "object", "description": "Metrics ingress policy rules" },
+        "egress": { "type": "object", "description": "Egress policy rules" }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator integration",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Render ExternalSecret resources" },
+        "apiVersion": { "type": "string", "enum": ["external-secrets.io/v1"], "description": "ExternalSecret API version" },
+        "refreshInterval": { "type": "string", "description": "Refresh interval" },
+        "secretStoreRef": { "type": "object", "description": "SecretStore or ClusterSecretStore reference" },
+        "target": { "type": "object", "description": "Target Secret options" },
+        "admin": { "type": "object", "description": "Admin password ExternalSecret mapping" },
+        "database": { "type": "object", "description": "Database password ExternalSecret mapping" },
+        "backup": { "type": "object", "description": "Backup S3 credential ExternalSecret mapping" }
       }
     },
     "metrics": {
@@ -507,6 +729,16 @@
     "extraVolumes": {
       "type": "array",
       "description": "Additional volumes for the pod",
+      "items": { "type": "object" }
+    },
+    "extraInitContainers": {
+      "type": "array",
+      "description": "Additional init containers appended after wait-for-db",
+      "items": { "type": "object" }
+    },
+    "extraContainers": {
+      "type": "array",
+      "description": "Additional containers appended after WordPress and metrics containers",
       "items": { "type": "object" }
     },
     "extraManifests": {

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # WordPress Helm Chart
 # =============================================================================
@@ -110,9 +111,9 @@ admin:
 # WordPress requires MySQL or MariaDB.
 #
 # Mode detection (when mode is auto):
-# 1. database.external.host or database.external.existingSecret → external
-# 2. mysql.enabled → MySQL subchart
-# 3. Fail — WordPress cannot run without a database
+# 1. database.external.host or database.external.existingSecret -> external
+# 2. mysql.enabled -> MySQL subchart
+# 3. Fail - WordPress cannot run without a database
 # =============================================================================
 
 database:

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -15,6 +15,9 @@ fullnameOverride: ""
 # -- Labels added to every resource created by this chart
 commonLabels: {}
 
+# -- Number of WordPress replicas. Keep 1 unless uploads/themes/plugins are backed by ReadWriteMany storage or an external object-storage strategy.
+replicaCount: 1
+
 # =============================================================================
 # Image
 # =============================================================================
@@ -57,6 +60,21 @@ wordpress:
   # -- Enable WordPress debug mode (WP_DEBUG)
   debug: false
 
+  # -- Force SSL for the WordPress admin area (FORCE_SSL_ADMIN)
+  forceSSLAdmin: false
+
+  # -- Disable the built-in theme/plugin editor from wp-admin (DISALLOW_FILE_EDIT)
+  disallowFileEdit: false
+
+  # -- Disable WordPress pseudo-cron. Pair with wpCron.cronJob.enabled for scheduled execution.
+  disableWpCron: false
+
+  # -- WordPress frontend memory limit (WP_MEMORY_LIMIT)
+  memoryLimit: ""
+
+  # -- WordPress admin memory limit (WP_MAX_MEMORY_LIMIT)
+  maxMemoryLimit: ""
+
   # -- Extra PHP code injected into wp-config.php via WORDPRESS_CONFIG_EXTRA
   # configExtra: |
   #   define('WP_MEMORY_LIMIT', '256M');
@@ -68,6 +86,12 @@ wordpress:
   #   - name: PHP_MEMORY_LIMIT
   #     value: "256M"
   extraEnv: []
+
+  # -- Additional envFrom sources for the WordPress container
+  # extraEnvFrom:
+  #   - secretRef:
+  #       name: wordpress-extra-env
+  extraEnvFrom: []
 
 # =============================================================================
 # Admin Credentials
@@ -240,6 +264,12 @@ service:
   # -- Annotations for the service
   annotations: {}
 
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+
+  # -- Ordered Service IP families: IPv4 | IPv6. Empty uses cluster default.
+  ipFamilies: []
+
 # =============================================================================
 # Ingress
 # =============================================================================
@@ -273,6 +303,31 @@ ingress:
   tls: []
 
 # =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Create an HTTPRoute. Requires Gateway API CRDs and an existing Gateway.
+  enabled: false
+  # -- API version for HTTPRoute
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- HTTPRoute annotations
+  annotations: {}
+  # -- Parent Gateway references
+  parentRefs: []
+    # - name: public
+    #   namespace: gateway-system
+    #   sectionName: https
+  # -- Optional HTTPRoute hostnames
+  hostnames: []
+    # - wordpress.example.com
+  # -- Path matches routed to WordPress
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
+# =============================================================================
 # Service Account
 # =============================================================================
 
@@ -285,6 +340,188 @@ serviceAccount:
 
   # -- Annotations for the ServiceAccount
   annotations: {}
+
+  # -- Mount the ServiceAccount token into workload pods. Keep false unless an extension needs Kubernetes API access.
+  automountServiceAccountToken: false
+
+# =============================================================================
+# Autoscaling and Availability
+# =============================================================================
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler. Only use with shared uploads/storage or another replicated content strategy.
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: ""
+
+pdb:
+  # -- Enable PodDisruptionBudget
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+# =============================================================================
+# WordPress Cron
+# =============================================================================
+
+wpCron:
+  cronJob:
+    # -- Create a Kubernetes CronJob that calls wp-cron.php through the internal Service.
+    enabled: false
+    schedule: "*/5 * * * *"
+    suspend: false
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 3
+    failedJobsHistoryLimit: 3
+    backoffLimit: 1
+    image:
+      repository: docker.io/curlimages/curl
+      tag: "8.17.0"
+      pullPolicy: IfNotPresent
+    resources: {}
+
+# =============================================================================
+# Plugins and Object Cache
+# =============================================================================
+
+plugins:
+  # -- Run an idempotent post-install/post-upgrade Job to install and activate WordPress plugins.
+  enabled: false
+  installer:
+    # -- Create the plugin installer Job.
+    enabled: false
+    # -- Hook annotations make the Job run after install/upgrade and avoid rerunning unless the release changes.
+    useHelmHooks: true
+    hookWeight: "10"
+    # -- WordPress CLI image used by the installer Job.
+    image:
+      repository: docker.io/library/wordpress
+      tag: cli-php8.3
+      pullPolicy: IfNotPresent
+    backoffLimit: 1
+    activeDeadlineSeconds: 60
+    ttlSecondsAfterFinished: 300
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 33
+      runAsGroup: 33
+    # -- Prefer scheduling the Job on nodes already running WordPress pods. Useful with ReadWriteOnce PVCs.
+    preferWordPressPodNode: true
+  # -- Official WordPress.org plugin list. Use the plugin directory slug from wordpress.org/plugins.
+  items: []
+    # - slug: classic-editor
+    #   activate: true
+    #   skipIfInstalled: true
+
+objectCache:
+  # -- Enable WordPress persistent object cache integration.
+  enabled: false
+  provider: redis-cache
+  # -- Install/activate the Redis Object Cache plugin and enable the object-cache.php drop-in.
+  installPlugin: true
+  enableDropIn: true
+  redis:
+    # -- Redis mode: subchart or external.
+    mode: subchart
+    subchart:
+      # -- Deploy HelmForge Redis as a subchart when objectCache.enabled=true.
+      enabled: false
+    external:
+      host: ""
+    port: 6379
+    database: 0
+    prefix: ""
+    client: predis
+    scheme: tcp
+    maxTtl: ""
+    auth:
+      enabled: true
+      password: ""
+      existingSecret: ""
+      existingSecretPasswordKey: redis-password
+
+# =============================================================================
+# NetworkPolicy
+# =============================================================================
+
+networkPolicy:
+  # -- Create a NetworkPolicy for WordPress pods
+  enabled: false
+  ingress:
+    # -- Allow ingress from pods in the same namespace
+    allowSameNamespace: true
+    # -- Additional ingress "from" rules
+    extraFrom: []
+  metrics:
+    # -- Allow metrics scraping through NetworkPolicy when metrics.enabled=true
+    enabled: false
+    allowSameNamespace: true
+    extraFrom: []
+  egress:
+    # -- Add egress rules. Disabled keeps CNI default egress behavior.
+    enabled: false
+    # -- Allow DNS egress to kube-dns/CoreDNS
+    allowDNS: true
+    # -- Allow TCP egress to database pods in the same namespace
+    allowSameNamespaceDatabase: true
+    # -- Database port allowed when allowSameNamespaceDatabase=true
+    databasePort: 3306
+    # -- Allow HTTPS egress for updates, plugin/theme downloads, APIs, and object storage endpoints
+    allowHTTPS: false
+    # -- Allow SMTP egress when a mail plugin or SMTP configuration needs it
+    allowSMTP: false
+    smtpPort: 587
+    # -- Additional egress "to" rules
+    extraTo: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion. Use external-secrets.io/v1 for current ESO releases.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval for ExternalSecret resources.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  admin:
+    # -- Manage the WordPress admin Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-wordpress-admin.
+    targetName: ""
+    passwordRemoteRef: {}
+      # key: prod/wordpress
+      # property: admin-password
+  database:
+    # -- Manage the WordPress external database Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-wordpress-database.
+    targetName: ""
+    passwordRemoteRef: {}
+      # key: prod/wordpress
+      # property: database-password
+  backup:
+    # -- Manage the WordPress backup S3 Secret with External Secrets Operator.
+    enabled: false
+    # -- Target Kubernetes Secret name. Empty defaults to <release>-wordpress-backup.
+    targetName: ""
+    accessKeyRemoteRef: {}
+      # key: prod/wordpress-backup
+      # property: access-key
+    secretKeyRemoteRef: {}
+      # key: prod/wordpress-backup
+      # property: secret-key
 
 # =============================================================================
 # Metrics (Apache Exporter)
@@ -459,6 +696,12 @@ extraVolumeMounts: []
 
 # -- Additional volumes for the pod
 extraVolumes: []
+
+# -- Additional init containers appended after wait-for-db
+extraInitContainers: []
+
+# -- Additional containers appended after WordPress and metrics containers
+extraContainers: []
 
 # -- Extra Kubernetes manifests to deploy alongside the chart
 extraManifests: []


### PR DESCRIPTION
## Summary
- Modernize the WordPress chart with production-oriented controls: Gateway API, External Secrets Operator, NetworkPolicy, dual-stack Service fields, HPA, PDB, service account token control, deterministic wp-cron, and expanded docs/examples.
- Add official WordPress.org plugin installation through a fail-fast post-install/post-upgrade Job that works with ReadWriteOnce PVCs.
- Add Redis Object Cache support with the HelmForge Redis subchart or external Redis, including `WP_REDIS_*` configuration, drop-in creation, docs, CI values, and tests.
- Remove `Chart.lock` from the WordPress chart workflow per project direction.

## Breaking Change
- `charts/wordpress/Chart.lock` is removed.
- The plugin installer only supports official WordPress.org plugin slugs. Arbitrary ZIP/GitHub plugin sources are rejected.

## Validation
- `helm unittest charts\wordpress` passed: 14 suites, 106 tests.
- `helm lint --strict charts\wordpress` passed after temporary `helm dependency build`.
- `kubeconform -strict -summary` passed for default, plugins, Redis subchart, and external Redis renders.
- `ah lint charts\wordpress` passed.
- K3D runtime validation passed with local Redis subchart using `--timeout 1m`.
- Functional Redis validation passed: WordPress installed, `redis-cache` activated, `wp redis enable`, `wp_cache_set/get` returned `cache validation ok`, Redis had keys.
- Official plugin installer validation passed with `classic-editor` installed on the shared PVC.

## Guardrail Note
- HelmForge MCP currently reports GR-062 as BLOCKER when dependencies exist without `Chart.lock`. This PR intentionally removes `Chart.lock` from the WordPress chart per the requested project direction, so that guardrail needs to be updated to match the new policy.