### PR TITLE
feat(discount-bandit)!: modernize production chart

### DIFF
--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: discount-bandit
-description: Deal aggregator and price tracker for self-hosted deal hunting
+description: Discount Bandit price tracking for Kubernetes with MySQL, Gateway API, External Secrets, and SQLite dev mode
 icon: https://helmforge.dev/icons/charts/discount-bandit.png
 type: application
 version: 1.2.4
@@ -15,6 +15,9 @@ keywords:
   - shopping
   - discount-bandit
   - self-hosted
+  - mysql
+  - gateway-api
+  - external-secrets
 home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
@@ -22,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "prepare sandbox governance and Apache licensing (#124)"
+      description: "BREAKING: make MySQL subchart the primary database and add production deployment controls"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -44,3 +47,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/tree/main/charts/discount-bandit
     - name: support
       url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/mysql
+dependencies:
+  - name: mysql
+    version: 2.0.0
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: mysql.enabled

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: discount-bandit
 description: Discount Bandit price tracking for Kubernetes with MySQL, Gateway API, External Secrets, and SQLite dev mode

--- a/charts/discount-bandit/DESIGN.md
+++ b/charts/discount-bandit/DESIGN.md
@@ -1,0 +1,164 @@
+# Discount Bandit Chart Design
+
+## Purpose
+
+This chart packages Discount Bandit for Kubernetes while exposing the operational choices that matter in production:
+database ownership, public routing, outbound crawler access, secrets, storage, and pod hardening.
+
+## Application Model
+
+Discount Bandit is a Laravel application running on FrankenPHP. The upstream container starts Supervisor, which runs:
+
+- FrankenPHP/Octane for the web UI
+- Laravel scheduler for recurring crawls and maintenance
+- Laravel queue worker for background jobs
+- Chromium/Xvfb for stores that require browser-based crawling
+
+The application stores data in SQLite by default upstream, but it also supports MySQL/MariaDB through Laravel database
+environment variables. For Kubernetes production, this chart makes MySQL the primary path.
+
+## Architecture: Primary MySQL
+
+```text
+Users
+  |
+  v
+Gateway API / Ingress
+  |
+  v
+Service discount-bandit
+  |
+  v
+Deployment discount-bandit
+  |-- FrankenPHP web UI
+  |-- Laravel scheduler
+  |-- Laravel queue worker
+  |-- Chromium crawler runtime
+  |
+  v
+Service <release>-mysql
+  |
+  v
+StatefulSet mysql
+  |
+  v
+PVC MySQL data
+```
+
+Use this for most installations. The MySQL subchart owns database lifecycle, credentials, persistence, and future production
+controls from the HelmForge MySQL chart.
+
+## Architecture: External MySQL
+
+```text
+Users -> Gateway/Ingress -> Discount Bandit Deployment
+                                  |
+                                  v
+                       External MySQL or MariaDB
+                                  |
+                                  v
+                    Secret or ExternalSecret with password
+```
+
+Use this when a platform team already operates MySQL/MariaDB. This mode disables the MySQL subchart and requires an external
+database host plus password Secret.
+
+## Architecture: SQLite Dev Mode
+
+```text
+Users -> Port-forward/Ingress -> Discount Bandit Deployment
+                                  |
+                                  v
+                         PVC /app/database/sqlite
+```
+
+SQLite is kept for development and small personal installs. It must remain single replica because SQLite is single-writer and
+the PVC normally uses `ReadWriteOnce`.
+
+## Routing
+
+The chart supports two public HTTP options:
+
+- Ingress for classic ingress controllers.
+- Gateway API `HTTPRoute` for clusters using the Kubernetes Gateway API.
+
+Gateway API is appropriate here because Discount Bandit is an HTTP web application. The chart does not create Gateway objects;
+it attaches to a platform-owned Gateway through `gatewayAPI.parentRefs`.
+
+## Secrets
+
+The chart manages these sensitive values:
+
+- `APP_KEY`
+- external database password
+- optional `EXCHANGE_RATE_API_KEY`
+
+Native Kubernetes Secrets are supported for simple installs. External Secrets Operator v1 is supported for production clusters
+that source secrets from Vault, cloud secret managers, or other external stores.
+
+## Supervisor Runtime
+
+The upstream image generates Supervisor configuration from `docker/base_supervisord.conf`. That upstream file enables an
+unauthenticated loopback `inet_http_server`, which creates a critical log entry even though it is not exposed through the
+Service. This chart mounts a sanitized base config at the same path by default:
+
+```text
+ConfigMap discount-bandit-supervisor
+  |
+  v
+/app/docker/base_supervisord.conf
+  |
+  v
+php artisan discount:fill-supervisor-workers
+  |
+  v
+/etc/supervisor/conf.d/supervisord.conf
+```
+
+The generated runtime config still keeps the web, scheduler, and queue programs, but avoids the unauthenticated Supervisor
+HTTP endpoint.
+
+## Networking
+
+Discount Bandit has broader egress needs than a typical internal web app:
+
+- DNS for name resolution
+- HTTPS/HTTP egress to product stores for crawling
+- HTTPS egress to notification providers and exchange-rate API
+- MySQL egress to the same namespace or an external database
+
+`networkPolicy.enabled=false` by default so development installs work without tuning. Production examples enable NetworkPolicy
+and document the crawler egress tradeoff.
+
+## Storage
+
+The chart separates storage concerns:
+
+- MySQL data is owned by the MySQL subchart.
+- SQLite data uses `persistence.database` only in SQLite mode and is mounted at `/app/database/sqlite` so upstream
+  migrations and seeders under `/app/database` remain visible.
+- Application logs use `persistence.logs`, defaulting to `emptyDir` because Kubernetes-native log collection should read
+  container stdout/stderr first.
+
+## Security
+
+Defaults avoid mounting the Kubernetes API token:
+
+```yaml
+serviceAccount:
+  automountServiceAccountToken: false
+```
+
+The upstream image currently runs Supervisor and worker processes in a way that is not assumed to be non-root safe. For that
+reason the chart exposes `podSecurityContext` and `securityContext` but does not force a restrictive default that could break
+the application before K3D validation.
+
+## Production Checklist
+
+- Use `mysql.enabled=true` or `database.mode=external`.
+- Set `discountBandit.appUrl` and `discountBandit.assetUrl`.
+- Store `APP_KEY`, database password, and exchange-rate key in Secrets or External Secrets.
+- Enable Gateway API or Ingress with TLS.
+- Set resource requests and memory limits.
+- Validate crawler and notification egress before enabling restrictive NetworkPolicy.
+- Review pod logs after adding real product URLs because store-specific crawling may depend on Chromium behavior.

--- a/charts/discount-bandit/README.md
+++ b/charts/discount-bandit/README.md
@@ -1,96 +1,247 @@
 # Discount Bandit Helm Chart
 
-Deploy [Discount Bandit](https://github.com/Joffcom/discount-bandit) on Kubernetes using the official [joffcom/discount-bandit](https://hub.docker.com/r/joffcom/discount-bandit) container image. A self-hosted deal aggregator and price tracker for finding the best deals across multiple retailers.
+Deploy [Discount Bandit](https://github.com/Cybrarist/Discount-Bandit) on Kubernetes using the
+[cybrarist/discount-bandit](https://hub.docker.com/r/cybrarist/discount-bandit) container image.
+
+Discount Bandit is a self-hosted price tracker for products across multiple stores. It provides a web UI, scheduled crawling,
+price history, currency conversion, multi-user management, and notifications through services such as Ntfy, Telegram, and
+Gotify.
 
 ## Features
 
-- **Deal aggregation** — track prices and deals from multiple sources
-- **Web UI** — browser-based interface on port 3000
-- **SQLite storage** — no external database required, data persisted on PVC
-- **Ingress support** — TLS with cert-manager, supports traefik and nginx
+- MySQL primary deployment path through the `helmforge/mysql` subchart
+- SQLite development mode for small single-replica installs
+- External MySQL/MariaDB support
+- Gateway API `HTTPRoute` and classic Kubernetes Ingress
+- Service dual-stack fields (`ipFamilyPolicy`, `ipFamilies`)
+- External Secrets Operator v1 integration for `APP_KEY`, exchange-rate key, and external database password
+- Optional NetworkPolicy for HTTP ingress, crawler egress, notification egress, DNS, and database egress
+- Optional persistent logs volume mounted at `/logs`
+- Optional PodDisruptionBudget
+- Kubernetes-safe Supervisor base config that removes the upstream unauthenticated Supervisor HTTP endpoint
+- Production example with MySQL, Gateway API, NetworkPolicy, and resources
 
 ## Installation
-
-**HTTPS repository:**
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
 helm repo update
-helm install discount-bandit helmforge/discount-bandit -f values.yaml
+helm install discount-bandit helmforge/discount-bandit -n discount-bandit --create-namespace
 ```
 
-**OCI registry:**
+OCI registry:
 
 ```bash
-helm install discount-bandit oci://ghcr.io/helmforgedev/helm/discount-bandit -f values.yaml
+helm install discount-bandit oci://ghcr.io/helmforgedev/helm/discount-bandit -n discount-bandit --create-namespace
 ```
 
-## Basic Example
+Default values deploy Discount Bandit with the HelmForge MySQL subchart.
+
+Ready-to-use examples are available in `examples/production.yaml`, `examples/sqlite.yaml`,
+`examples/external-mysql.yaml`, `examples/external-secrets.yaml`, and `examples/gateway-api.yaml`.
+
+## Access
+
+```bash
+kubectl port-forward -n discount-bandit svc/discount-bandit 8080:80
+```
+
+Open `http://localhost:8080` and create the first admin account.
+
+## Production Example
 
 ```yaml
-# values.yaml — minimal install with defaults
+discountBandit:
+  appUrl: https://deals.example.com
+  assetUrl: https://deals.example.com
+  timezone: UTC
+  themeColor: Stone
+
+mysql:
+  enabled: true
+  standalone:
+    persistence:
+      enabled: true
+      size: 20Gi
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - deals.example.com
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+    allowSameNamespaceDatabase: true
+
+serviceAccount:
+  automountServiceAccountToken: false
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi
+```
+
+## Database Modes
+
+### MySQL Subchart
+
+MySQL is the primary default:
+
+```yaml
+mysql:
+  enabled: true
+  auth:
+    database: discount_bandit
+    username: discount_bandit
+```
+
+The application reads the generated MySQL user password from the subchart Secret.
+
+### External MySQL
+
+```yaml
+mysql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    type: mysql
+    host: mysql.example.com
+    port: 3306
+    name: discount_bandit
+    username: discount_bandit
+    existingSecret: discount-bandit-db
+    existingSecretPasswordKey: database-password
+```
+
+### SQLite Development Mode
+
+```yaml
+mysql:
+  enabled: false
+
+database:
+  mode: sqlite
+  sqlite:
+    enabled: true
+
 persistence:
-  enabled: true
-  size: 5Gi
+  database:
+    enabled: true
+    size: 5Gi
 ```
 
-After deploying:
+Keep `replicaCount=1` with SQLite.
 
-```bash
-# Port-forward to access the UI
-kubectl port-forward svc/<release>-discount-bandit 8080:80
-
-# Open http://localhost:8080 in your browser
-```
-
-## Ingress Example
+## External Secrets
 
 ```yaml
-ingress:
+mysql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: mysql.example.com
+    name: discount_bandit
+    username: discount_bandit
+
+externalSecrets:
   enabled: true
-  ingressClassName: traefik  # or nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-  hosts:
-    - host: deals.example.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - deals.example.com
-      secretName: discount-bandit-tls
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  app:
+    enabled: true
+    appKeyRemoteRef:
+      key: discount-bandit/app
+      property: app-key
+    exchangeRateApiKeyRemoteRef:
+      key: discount-bandit/app
+      property: exchange-rate-api-key
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: discount-bandit/mysql
+      property: password
+```
+
+The chart renders `external-secrets.io/v1` resources.
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - deals.example.com
+```
+
+Use Gateway API when the cluster has a Gateway controller. Use `ingress.enabled=true` for classic Ingress controllers.
+
+## NetworkPolicy
+
+Discount Bandit needs outbound network access for product crawling, exchange-rate API calls, and user-configured notification
+services. Start with `networkPolicy.enabled=false`, then enable egress rules once you understand the required destinations.
+
+```yaml
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+    allowSameNamespaceDatabase: true
 ```
 
 ## Key Values
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.repository` | `docker.io/joffcom/discount-bandit` | Container image |
-| `image.tag` | `""` (appVersion) | Image tag |
-| `discountBandit.extraEnv` | `[]` | Extra environment variables |
-| `persistence.enabled` | `true` | Enable persistence for SQLite |
-| `persistence.size` | `5Gi` | PVC size |
-| `service.type` | `ClusterIP` | Service type |
-| `service.port` | `80` | Service port |
-| `ingress.enabled` | `false` | Enable ingress |
-| `ingress.ingressClassName` | `traefik` | Ingress class (traefik, nginx) |
+| `mysql.enabled` | `true` | Deploy HelmForge MySQL as the primary database. |
+| `database.mode` | `auto` | Database mode: `auto`, `mysql`, `external`, or `sqlite`. |
+| `database.sqlite.enabled` | `false` | Enables explicit SQLite development mode. |
+| `discountBandit.appUrl` | `""` | Public application URL (`APP_URL`). |
+| `discountBandit.assetUrl` | `""` | Public asset URL (`ASSET_URL`). |
+| `discountBandit.cron` | `*/5 * * * *` | Product crawl schedule. |
+| `discountBandit.themeColor` | `Stone` | UI theme color. |
+| `discountBandit.exchangeRateApiKey` | `""` | ExchangeRate API key; prefer Secret/ExternalSecret. |
+| `service.ipFamilyPolicy` | `""` | Optional dual-stack Service policy. |
+| `service.ipFamilies` | `[]` | Optional Service IP families. |
+| `gatewayAPI.enabled` | `false` | Render Gateway API HTTPRoute. |
+| `externalSecrets.enabled` | `false` | Enable External Secrets Operator resources. |
+| `networkPolicy.enabled` | `false` | Render NetworkPolicy. |
+| `serviceAccount.automountServiceAccountToken` | `false` | Disable Kubernetes API token mount by default. |
+| `persistence.logs.enabled` | `false` | Persist `/logs` instead of using `emptyDir`. |
+| `supervisor.configMap.enabled` | `true` | Replace the upstream Supervisor base config with a Kubernetes-safe config. |
+| `pdb.enabled` | `false` | Render PodDisruptionBudget. |
 
-## Limitations
+## Operational Notes
 
-- **Single instance** — SQLite does not support concurrent writers
-- **No clustering** — designed as a single-node deployment with Recreate strategy
+- The upstream container runs FrankenPHP, Laravel scheduler, queue worker, and Chromium-based crawlers under Supervisor.
+- Some stores require Chromium headless; review pod logs when validating product crawling.
+- The chart waits for MySQL before starting the application container in MySQL and external database modes.
+- By default the chart mounts a sanitized Supervisor base config without the upstream unauthenticated `inet_http_server`.
+- SQLite is suitable for development and small personal installs only.
+- Production deployments should use the MySQL subchart or external MySQL/MariaDB.
+- Enable NetworkPolicy carefully because product crawling and notifications need outbound internet access.
 
 ## More Information
 
-- [Discount Bandit source](https://github.com/Joffcom/discount-bandit)
-- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/discount-bandit)
-
-<!-- @AI-METADATA
-type: chart-readme
-path: charts/discount-bandit/README.md
-date: 2026-04-03
-relations:
-  - charts/discount-bandit/values.yaml
-  - charts/discount-bandit/Chart.yaml
--->
+- [Discount Bandit source](https://github.com/Cybrarist/Discount-Bandit)
+- [Discount Bandit documentation](https://discount-bandit.cybrarist.com)
+- [HelmForge chart source](https://github.com/helmforgedev/charts/tree/main/charts/discount-bandit)

--- a/charts/discount-bandit/ci/default-values.yaml
+++ b/charts/discount-bandit/ci/default-values.yaml
@@ -1,1 +1,2 @@
-# CI: default values with SQLite persistence
+# SPDX-License-Identifier: Apache-2.0
+# CI: default values with MySQL subchart

--- a/charts/discount-bandit/ci/dual-stack-values.yaml
+++ b/charts/discount-bandit/ci/dual-stack-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: Service dual-stack fields
+service:
+  ipFamilyPolicy: PreferDualStack

--- a/charts/discount-bandit/ci/external-mysql-values.yaml
+++ b/charts/discount-bandit/ci/external-mysql-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: external MySQL with native Secret
+database:
+  mode: external
+  external:
+    type: mysql
+    host: mysql.example.com
+    port: 3306
+    name: discount_bandit
+    username: discount_bandit
+    password: change-me
+mysql:
+  enabled: false

--- a/charts/discount-bandit/ci/external-secrets-values.yaml
+++ b/charts/discount-bandit/ci/external-secrets-values.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: External Secrets for app and external database credentials
+database:
+  mode: external
+  external:
+    host: mysql.example.com
+    name: discount_bandit
+    username: discount_bandit
+mysql:
+  enabled: false
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+  app:
+    enabled: true
+    appKeyRemoteRef:
+      key: discount-bandit/app
+      property: app-key
+    exchangeRateApiKeyRemoteRef:
+      key: discount-bandit/app
+      property: exchange-rate-api-key
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: discount-bandit/mysql
+      property: password

--- a/charts/discount-bandit/ci/gateway-values.yaml
+++ b/charts/discount-bandit/ci/gateway-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: Gateway API HTTPRoute
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - deals.example.com
+discountBandit:
+  appUrl: https://deals.example.com

--- a/charts/discount-bandit/ci/ingress-values.yaml
+++ b/charts/discount-bandit/ci/ingress-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: ingress enabled
 ingress:
   enabled: true

--- a/charts/discount-bandit/ci/network-policy-values.yaml
+++ b/charts/discount-bandit/ci/network-policy-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: NetworkPolicy with crawler and database egress
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+    allowHTTP: true
+    allowSameNamespaceDatabase: true

--- a/charts/discount-bandit/ci/production-values.yaml
+++ b/charts/discount-bandit/ci/production-values.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: production-style deployment with MySQL, Gateway API, and NetworkPolicy
+replicaCount: 1
+discountBandit:
+  appUrl: https://deals.example.com
+  assetUrl: https://deals.example.com
+  timezone: UTC
+  themeColor: Stone
+mysql:
+  enabled: true
+  standalone:
+    persistence:
+      enabled: true
+      size: 20Gi
+serviceAccount:
+  automountServiceAccountToken: false
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - deals.example.com
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+    allowHTTP: false
+    allowSameNamespaceDatabase: true
+pdb:
+  enabled: true
+  minAvailable: 1
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi

--- a/charts/discount-bandit/ci/sqlite-values.yaml
+++ b/charts/discount-bandit/ci/sqlite-values.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: explicit SQLite development mode
+database:
+  mode: sqlite
+  sqlite:
+    enabled: true
+mysql:
+  enabled: false
+persistence:
+  database:
+    enabled: true
+    size: 1Gi

--- a/charts/discount-bandit/examples/external-mysql.yaml
+++ b/charts/discount-bandit/examples/external-mysql.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production example using an externally managed MySQL or MariaDB database.
+
+database:
+  mode: external
+  external:
+    type: mysql
+    host: mysql.example.internal
+    port: 3306
+    name: discount_bandit
+    username: discount_bandit
+    existingSecret: discount-bandit-db
+    existingSecretPasswordKey: database-password
+
+mysql:
+  enabled: false
+
+discountBandit:
+  appUrl: https://deals.example.com
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+    extraTo:
+      - ipBlock:
+          cidr: 10.20.30.40/32

--- a/charts/discount-bandit/examples/external-secrets.yaml
+++ b/charts/discount-bandit/examples/external-secrets.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# External Secrets Operator example. Requires external-secrets.io/v1 CRDs.
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: production-secrets
+    kind: ClusterSecretStore
+  app:
+    enabled: true
+    appKeyRemoteRef:
+      key: apps/discount-bandit
+      property: app-key
+    exchangeRateApiKeyRemoteRef:
+      key: apps/discount-bandit
+      property: exchange-rate-api-key
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: databases/discount-bandit
+      property: password
+
+discountBandit:
+  appUrl: https://deals.example.com
+
+database:
+  mode: external
+  external:
+    host: mysql.example.internal
+    name: discount_bandit
+    username: discount_bandit
+
+mysql:
+  enabled: false
+

--- a/charts/discount-bandit/examples/gateway-api.yaml
+++ b/charts/discount-bandit/examples/gateway-api.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Gateway API example. Requires Gateway API v1 CRDs and a Gateway controller.
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - deals.example.com
+
+discountBandit:
+  appUrl: https://deals.example.com
+
+service:
+  type: ClusterIP
+  port: 80
+

--- a/charts/discount-bandit/examples/production.yaml
+++ b/charts/discount-bandit/examples/production.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented example using the HelmForge MySQL subchart.
+
+discountBandit:
+  appUrl: https://deals.example.com
+  timezone: America/New_York
+  themeColor: Stone
+  cron: "*/10 * * * *"
+  existingSecret: discount-bandit-app
+
+mysql:
+  enabled: true
+  architecture: standalone
+  auth:
+    database: discount_bandit
+    username: discount_bandit
+    existingSecret: discount-bandit-mysql
+  standalone:
+    persistence:
+      enabled: true
+      size: 20Gi
+
+serviceAccount:
+  automountServiceAccountToken: false
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: deals.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: discount-bandit-tls
+      hosts:
+        - deals.example.com
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+    allowHTTP: false
+    allowSameNamespaceDatabase: true
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi

--- a/charts/discount-bandit/examples/sqlite.yaml
+++ b/charts/discount-bandit/examples/sqlite.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Development example using SQLite. Keep this mode to a single replica.
+
+database:
+  mode: sqlite
+  sqlite:
+    enabled: true
+
+mysql:
+  enabled: false
+
+persistence:
+  database:
+    enabled: true
+    size: 5Gi
+  logs:
+    enabled: false
+
+replicaCount: 1
+

--- a/charts/discount-bandit/templates/NOTES.txt
+++ b/charts/discount-bandit/templates/NOTES.txt
@@ -1,6 +1,5 @@
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Discount Bandit has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+Discount Bandit has been deployed.
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
@@ -8,53 +7,63 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Runtime
+  Database mode: {{ include "discount-bandit.databaseMode" . }}
+  ServiceAccount: {{ include "discount-bandit.serviceAccountName" . }}
+  ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
+  NetworkPolicy enabled: {{ .Values.networkPolicy.enabled }}
+  Gateway API enabled: {{ .Values.gatewayAPI.enabled }}
+  External Secrets enabled: {{ .Values.externalSecrets.enabled }}
+  Logs persistence enabled: {{ .Values.persistence.logs.enabled }}
+  Supervisor ConfigMap enabled: {{ .Values.supervisor.configMap.enabled }}
 
-{{- if .Values.ingress.enabled }}
+Access
+{{- if .Values.gatewayAPI.enabled }}
+{{- range .Values.gatewayAPI.hostnames }}
+  WEB UI: https://{{ . }}/
+{{- end }}
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  WEB UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else }}
-Port-forward to access Discount Bandit locally:
+  Port-forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "discount-bandit.fullname" . }} 8080:{{ .Values.service.port }}
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "discount-bandit.fullname" . }} 3000:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:3000/
+  WEB UI:
+    http://localhost:8080/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Health checks
+  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=300s
+  kubectl get pods -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --all-containers --tail=100
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  kubectl describe pod -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=discount-bandit -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
+Database
+{{- if eq (include "discount-bandit.databaseMode" .) "mysql" }}
+  The HelmForge MySQL subchart is enabled.
+  MySQL Service: {{ .Release.Name }}-mysql
+  Secret: {{ include "discount-bandit.databaseSecretName" . }}
+{{- else if eq (include "discount-bandit.databaseMode" .) "external" }}
+  External database host: {{ include "discount-bandit.databaseHost" . }}:{{ include "discount-bandit.databasePort" . }}
+  Secret: {{ include "discount-bandit.databaseSecretName" . }}
+{{- else }}
+  SQLite is enabled for development/small installs.
+  PVC: {{ include "discount-bandit.dataClaimName" . }}
+  Keep replicaCount=1 with SQLite.
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Troubleshooting
+  kubectl describe pod -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+  kubectl get deploy,svc,secret,pvc,networkpolicy,pdb -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
-Documentation:      https://helmforge.dev/docs/charts/discount-bandit
-Discount Bandit GH: https://github.com/PastaBolo/discount-bandit
+Production reminders
+  - Use mysql.enabled=true or database.mode=external for production.
+  - Set discountBandit.appUrl and discountBandit.assetUrl to the public URL.
+  - Store APP_KEY, database passwords, and exchange-rate keys in Kubernetes Secrets or External Secrets.
+  - Enable NetworkPolicy only after confirming crawler and notification egress destinations.
+  - Review crawler logs because some stores rely on Chromium headless.
 
-Happy Helmforging :)
+Documentation:
+  https://helmforge.dev/docs/charts/discount-bandit

--- a/charts/discount-bandit/templates/_helpers.tpl
+++ b/charts/discount-bandit/templates/_helpers.tpl
@@ -121,7 +121,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "discount-bandit.databaseSecretName" -}}
 {{- $mode := include "discount-bandit.databaseMode" . -}}
 {{- if eq $mode "mysql" -}}
+{{- if .Values.mysql.auth.existingSecret -}}
+{{- .Values.mysql.auth.existingSecret -}}
+{{- else -}}
 {{- printf "%s-mysql-auth" .Release.Name -}}
+{{- end -}}
 {{- else if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
 {{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}

--- a/charts/discount-bandit/templates/_helpers.tpl
+++ b/charts/discount-bandit/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "discount-bandit.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -42,11 +43,152 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
-{{/* Data PVC claim name */}}
-{{- define "discount-bandit.dataClaimName" -}}
-{{- if .Values.persistence.existingClaim -}}
-{{- .Values.persistence.existingClaim -}}
-{{- else -}}
-{{- printf "%s-data" (include "discount-bandit.fullname" .) -}}
+{{- define "discount-bandit.databaseMode" -}}
+{{- $mode := .Values.database.mode | default "auto" -}}
+{{- if not (has $mode (list "auto" "mysql" "external" "sqlite")) -}}
+{{- fail (printf "database.mode must be one of: auto, mysql, external, sqlite (got %s)" $mode) -}}
 {{- end -}}
+{{- $hasExternal := ne (.Values.database.external.host | default "") "" -}}
+{{- $hasMysql := .Values.mysql.enabled | default false -}}
+{{- $hasSqlite := .Values.database.sqlite.enabled | default false -}}
+{{- if eq $mode "auto" -}}
+  {{- if and $hasExternal $hasMysql -}}
+    {{- fail "discount-bandit database selection is ambiguous: configure only one of database.external.host or mysql.enabled" -}}
+  {{- end -}}
+  {{- if and (or $hasExternal $hasMysql) $hasSqlite -}}
+    {{- fail "discount-bandit database selection is ambiguous: sqlite mode cannot be combined with mysql or external database" -}}
+  {{- end -}}
+  {{- if $hasExternal -}}external
+  {{- else if $hasMysql -}}mysql
+  {{- else if $hasSqlite -}}sqlite
+  {{- else -}}{{- fail "discount-bandit requires a database: keep mysql.enabled=true, configure database.external.host, or set database.sqlite.enabled=true" -}}
+  {{- end -}}
+{{- else -}}
+  {{- if and (eq $mode "mysql") (not $hasMysql) -}}{{- fail "database.mode=mysql requires mysql.enabled=true" -}}{{- end -}}
+  {{- if and (eq $mode "mysql") (or $hasExternal $hasSqlite) -}}{{- fail "database.mode=mysql cannot be combined with database.external or database.sqlite.enabled" -}}{{- end -}}
+  {{- if and (eq $mode "external") (not $hasExternal) -}}{{- fail "database.mode=external requires database.external.host" -}}{{- end -}}
+  {{- if and (eq $mode "external") (or $hasMysql $hasSqlite) -}}{{- fail "database.mode=external cannot be combined with mysql.enabled or database.sqlite.enabled" -}}{{- end -}}
+  {{- if and (eq $mode "sqlite") (or $hasMysql $hasExternal) -}}{{- fail "database.mode=sqlite cannot be combined with mysql.enabled or database.external" -}}{{- end -}}
+  {{- if and (eq $mode "sqlite") (not $hasSqlite) -}}{{- fail "database.mode=sqlite requires database.sqlite.enabled=true" -}}{{- end -}}
+  {{- $mode -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.validateDatabase" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "external" -}}
+  {{- if and (not .Values.database.external.password) (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) -}}
+    {{- fail "database.mode=external requires database.external.password, database.external.existingSecret, or externalSecrets.database.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databaseConnection" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "sqlite" -}}sqlite{{- else if eq $mode "external" -}}{{ .Values.database.external.type | default "mysql" }}{{- else -}}mysql{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databaseHost" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "external" -}}{{ .Values.database.external.host }}{{- else -}}{{ printf "%s-mysql" .Release.Name }}{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databasePort" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "external" -}}{{ .Values.database.external.port | default 3306 | toString }}{{- else -}}3306{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databaseName" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "external" -}}{{ .Values.database.external.name }}{{- else -}}{{ .Values.mysql.auth.database }}{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databaseUsername" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "external" -}}{{ .Values.database.external.username }}{{- else -}}{{ .Values.mysql.auth.username }}{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.appSecretName" -}}
+{{- if .Values.discountBandit.existingSecret -}}
+{{- .Values.discountBandit.existingSecret -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled .Values.externalSecrets.app.targetName -}}
+{{- .Values.externalSecrets.app.targetName -}}
+{{- else -}}
+{{- printf "%s-app" (include "discount-bandit.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databaseSecretName" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "mysql" -}}
+{{- printf "%s-mysql-auth" .Release.Name -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}
+{{- .Values.externalSecrets.database.targetName -}}
+{{- else -}}
+{{- printf "%s-db" (include "discount-bandit.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.databaseSecretPasswordKey" -}}
+{{- $mode := include "discount-bandit.databaseMode" . -}}
+{{- if eq $mode "mysql" -}}
+{{- .Values.mysql.auth.existingSecretUserPasswordKey | default "mysql-user-password" -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "database-password" -}}
+{{- else -}}
+{{- "database-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.dataClaimName" -}}
+{{- if .Values.persistence.database.existingClaim -}}
+{{- .Values.persistence.database.existingClaim -}}
+{{- else -}}
+{{- printf "%s-database" (include "discount-bandit.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.logsClaimName" -}}
+{{- if .Values.persistence.logs.existingClaim -}}
+{{- .Values.persistence.logs.existingClaim -}}
+{{- else -}}
+{{- printf "%s-logs" (include "discount-bandit.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.validateExternalSecrets" -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if ne .Values.externalSecrets.apiVersion "external-secrets.io/v1" -}}
+    {{- fail "externalSecrets.apiVersion must be external-secrets.io/v1" -}}
+  {{- end -}}
+  {{- if not .Values.externalSecrets.secretStoreRef.name -}}
+    {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.app.enabled .Values.discountBandit.existingSecret -}}
+    {{- fail "externalSecrets.app.enabled cannot be combined with discountBandit.existingSecret" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.app.enabled (not .Values.externalSecrets.app.appKeyRemoteRef.key) -}}
+    {{- fail "externalSecrets.app.appKeyRemoteRef.key is required when externalSecrets.app.enabled=true" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.database.enabled (ne (include "discount-bandit.databaseMode" .) "external") -}}
+    {{- fail "externalSecrets.database.enabled requires database.mode=external" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.database.enabled .Values.database.external.existingSecret -}}
+    {{- fail "externalSecrets.database.enabled cannot be combined with database.external.existingSecret" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.database.enabled (not .Values.externalSecrets.database.passwordRemoteRef.key) -}}
+    {{- fail "externalSecrets.database.passwordRemoteRef.key is required when externalSecrets.database.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "discount-bandit.externalSecretDataItem" -}}
+- secretKey: {{ .secretKey | quote }}
+  remoteRef:
+    key: {{ required (printf "%s.key is required" .remoteRefName) .remoteRef.key | quote }}
+    {{- with .remoteRef.property }}
+    property: {{ . | quote }}
+    {{- end }}
 {{- end -}}

--- a/charts/discount-bandit/templates/configmap-supervisor.yaml
+++ b/charts/discount-bandit/templates/configmap-supervisor.yaml
@@ -1,0 +1,52 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.supervisor.configMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "discount-bandit.fullname" . }}-supervisor
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+data:
+  base_supervisord.conf: |
+    [supervisord]
+    user=root
+    nodaemon=true
+    logfile=/logs/supervisord_stdout.log
+    pidfile=/var/run/supervisord.pid
+
+    [supervisorctl]
+
+    [program:octane]
+    command=php artisan octane:frankenphp --host=$FRANKEN_HOST --port=80 --workers=4 --max-requests=1000 --admin-port=2019
+    user=root
+    autostart=true
+    autorestart=true
+    priority=2
+    stdout_events_enabled=true
+    stderr_events_enabled=true
+    stdout_logfile=/logs/octane_stdout.log
+    stderr_logfile=/logs/octane_stderr.log
+
+    [program:scheduler]
+    process_name=%(program_name)s_%(process_num)02d
+    user=root
+    command=php artisan schedule:work
+    autostart=true
+    autorestart=true
+    numprocs=1
+    redirect_stderr=true
+    stdout_logfile=/logs/scheduler.log
+
+    [program:default_queue]
+    process_name=%(program_name)s_%(process_num)02d
+    user=root
+    command=php artisan queue:work --max-time=300 --sleep=1 --tries=1
+    autostart=true
+    autorestart=true
+    stopasgroup=true
+    killasgroup=true
+    numprocs=1
+    redirect_stderr=true
+    stdout_logfile=/var/log/default_worker.log
+    stopwaitsecs=300
+{{- end }}

--- a/charts/discount-bandit/templates/deployment.yaml
+++ b/charts/discount-bandit/templates/deployment.yaml
@@ -1,20 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "discount-bandit.validateDatabase" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "discount-bandit.fullname" . }}
   labels:
     {{- include "discount-bandit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: discount-bandit
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "discount-bandit.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: discount-bandit
   template:
     metadata:
       labels:
         {{- include "discount-bandit.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: discount-bandit
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,6 +35,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "discount-bandit.serviceAccountName" . }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -38,25 +44,107 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or (ne (include "discount-bandit.databaseMode" .) "sqlite") .Values.extraInitContainers }}
+      initContainers:
+        {{- if ne (include "discount-bandit.databaseMode" .) "sqlite" }}
+        - name: wait-for-database
+          image: docker.io/library/busybox:1.37.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until nc -z "${DB_HOST}" "${DB_PORT}"; do
+                echo "waiting for database ${DB_HOST}:${DB_PORT}"
+                sleep 2
+              done
+          env:
+            - name: DB_HOST
+              value: {{ include "discount-bandit.databaseHost" . | quote }}
+            - name: DB_PORT
+              value: {{ include "discount-bandit.databasePort" . | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: discount-bandit
           image: {{ include "discount-bandit.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.persistence.logs.enabled }}
+          command:
+            - sh
+            - -ec
+          args:
+            - |
+              sed -i 's/\[ ! -f "\/logs" \]/[ ! -e "\/logs" ]/' docker/entrypoint.sh
+              exec docker/entrypoint.sh
+          {{- end }}
           ports:
             - name: http
               containerPort: 80
               protocol: TCP
           env:
             - name: DB_CONNECTION
-              value: sqlite
+              value: {{ include "discount-bandit.databaseConnection" . | quote }}
+            {{- if eq (include "discount-bandit.databaseMode" .) "sqlite" }}
+            - name: DB_DATABASE
+              value: /app/database/sqlite/database.sqlite
+            {{- end }}
+            {{- if ne (include "discount-bandit.databaseMode" .) "sqlite" }}
+            - name: DB_HOST
+              value: {{ include "discount-bandit.databaseHost" . | quote }}
+            - name: DB_PORT
+              value: {{ include "discount-bandit.databasePort" . | quote }}
+            - name: DB_DATABASE
+              value: {{ include "discount-bandit.databaseName" . | quote }}
+            - name: DB_USERNAME
+              value: {{ include "discount-bandit.databaseUsername" . | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "discount-bandit.databaseSecretName" . }}
+                  key: {{ include "discount-bandit.databaseSecretPasswordKey" . }}
+            {{- end }}
             - name: APP_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "discount-bandit.fullname" . }}-app
-                  key: app-key
+                  name: {{ include "discount-bandit.appSecretName" . }}
+                  key: {{ .Values.discountBandit.existingSecretAppKeyKey }}
+            - name: APP_TIMEZONE
+              value: {{ .Values.discountBandit.timezone | quote }}
+            - name: FRANKEN_HOST
+              value: "0.0.0.0"
+            - name: THEME_COLOR
+              value: {{ .Values.discountBandit.themeColor | quote }}
+            - name: CRON
+              value: {{ .Values.discountBandit.cron | quote }}
             {{- with .Values.discountBandit.appUrl }}
             - name: APP_URL
               value: {{ . | quote }}
+            {{- end }}
+            {{- if or .Values.discountBandit.assetUrl .Values.discountBandit.appUrl }}
+            - name: ASSET_URL
+              value: {{ default .Values.discountBandit.appUrl .Values.discountBandit.assetUrl | quote }}
+            {{- end }}
+            {{- if or .Values.discountBandit.exchangeRateApiKey .Values.discountBandit.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled .Values.externalSecrets.app.exchangeRateApiKeyRemoteRef.key) }}
+            - name: EXCHANGE_RATE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "discount-bandit.appSecretName" . }}
+                  key: {{ .Values.discountBandit.existingSecretExchangeRateApiKeyKey }}
+                  optional: true
             {{- end }}
             {{- with .Values.discountBandit.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -97,19 +185,46 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: data
-              mountPath: /app/database
+            {{- if eq (include "discount-bandit.databaseMode" .) "sqlite" }}
+            - name: database
+              mountPath: /app/database/sqlite
+            {{- end }}
+            {{- if .Values.persistence.logs.enabled }}
+            - name: logs
+              mountPath: /logs
+            {{- end }}
+            {{- if .Values.supervisor.configMap.enabled }}
+            - name: supervisor-config
+              mountPath: /app/docker/base_supervisord.conf
+              subPath: base_supervisord.conf
+              readOnly: true
+            {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
-        - name: data
-          {{- if .Values.persistence.enabled }}
+        {{- if eq (include "discount-bandit.databaseMode" .) "sqlite" }}
+        - name: database
+          {{- if .Values.persistence.database.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "discount-bandit.dataClaimName" . }}
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
+        {{- if .Values.persistence.logs.enabled }}
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ include "discount-bandit.logsClaimName" . }}
+        {{- end }}
+        {{- if .Values.supervisor.configMap.enabled }}
+        - name: supervisor-config
+          configMap:
+            name: {{ include "discount-bandit.fullname" . }}-supervisor
+        {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/discount-bandit/templates/externalsecret.yaml
+++ b/charts/discount-bandit/templates/externalsecret.yaml
@@ -1,0 +1,44 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- include "discount-bandit.validateExternalSecrets" . }}
+{{- if .Values.externalSecrets.app.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "discount-bandit.appSecretName" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "discount-bandit.appSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "discount-bandit.externalSecretDataItem" (dict "secretKey" .Values.discountBandit.existingSecretAppKeyKey "remoteRefName" "externalSecrets.app.appKeyRemoteRef" "remoteRef" .Values.externalSecrets.app.appKeyRemoteRef) | nindent 4 }}
+    {{- if .Values.externalSecrets.app.exchangeRateApiKeyRemoteRef.key }}
+    {{- include "discount-bandit.externalSecretDataItem" (dict "secretKey" .Values.discountBandit.existingSecretExchangeRateApiKeyKey "remoteRefName" "externalSecrets.app.exchangeRateApiKeyRemoteRef" "remoteRef" .Values.externalSecrets.app.exchangeRateApiKeyRemoteRef) | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- if .Values.externalSecrets.database.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "discount-bandit.databaseSecretName" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "discount-bandit.databaseSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "discount-bandit.externalSecretDataItem" (dict "secretKey" (include "discount-bandit.databaseSecretPasswordKey" .) "remoteRefName" "externalSecrets.database.passwordRemoteRef" "remoteRef" .Values.externalSecrets.database.passwordRemoteRef) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/discount-bandit/templates/gateway-httproute.yaml
+++ b/charts/discount-bandit/templates/gateway-httproute.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- if not .Values.gatewayAPI.parentRefs }}
+{{- fail "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "discount-bandit.fullname" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gatewayAPI.matches | nindent 8 }}
+      {{- with .Values.gatewayAPI.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "discount-bandit.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/discount-bandit/templates/networkpolicy.yaml
+++ b/charts/discount-bandit/templates/networkpolicy.yaml
@@ -1,0 +1,80 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "discount-bandit.fullname" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "discount-bandit.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: discount-bandit
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- else }}
+    []
+    {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowHTTP .Values.networkPolicy.egress.allowSameNamespaceDatabase .Values.networkPolicy.egress.extraTo }}
+  egress:
+    {{- if $allowEgress }}
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: "kube-system"
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSameNamespaceDatabase }}
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.databasePort }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTP }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- else }}
+    []
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/discount-bandit/templates/pdb.yaml
+++ b/charts/discount-bandit/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "discount-bandit.fullname" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+spec:
+  {{- if ne (toString .Values.pdb.maxUnavailable) "" }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "discount-bandit.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: discount-bandit
+{{- end }}

--- a/charts/discount-bandit/templates/pvc.yaml
+++ b/charts/discount-bandit/templates/pvc.yaml
@@ -1,17 +1,43 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and (eq (include "discount-bandit.databaseMode" .) "sqlite") .Values.persistence.database.enabled (not .Values.persistence.database.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "discount-bandit.dataClaimName" . }}
   labels:
     {{- include "discount-bandit.labels" . | nindent 4 }}
+  {{- with .Values.persistence.database.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
-    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
-  {{- with .Values.persistence.storageClass }}
+    {{- toYaml .Values.persistence.database.accessModes | nindent 4 }}
+  {{- with .Values.persistence.database.storageClass }}
   storageClassName: {{ . }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.persistence.database.size }}
+{{- end }}
+{{- if and .Values.persistence.logs.enabled (not .Values.persistence.logs.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "discount-bandit.logsClaimName" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+  {{- with .Values.persistence.logs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.logs.accessModes | nindent 4 }}
+  {{- with .Values.persistence.logs.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.logs.size }}
 {{- end }}

--- a/charts/discount-bandit/templates/pvc.yaml
+++ b/charts/discount-bandit/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and (eq (include "discount-bandit.databaseMode" .) "sqlite") .Values.persistence.database.enabled (not .Values.persistence.database.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/discount-bandit/templates/secret.yaml
+++ b/charts/discount-bandit/templates/secret.yaml
@@ -1,4 +1,7 @@
-{{- $secretName := printf "%s-app" (include "discount-bandit.fullname" .) -}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "discount-bandit.validateExternalSecrets" . }}
+{{- if and (not .Values.discountBandit.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled)) }}
+{{- $secretName := include "discount-bandit.appSecretName" . -}}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
 apiVersion: v1
 kind: Secret
@@ -11,7 +14,23 @@ metadata:
 type: Opaque
 stringData:
   {{- if $existingSecret }}
-  app-key: {{ index $existingSecret.data "app-key" | b64dec }}
+  {{ .Values.discountBandit.existingSecretAppKeyKey }}: {{ index $existingSecret.data .Values.discountBandit.existingSecretAppKeyKey | b64dec | quote }}
   {{- else }}
-  app-key: {{ printf "base64:%s" (randAlphaNum 32 | b64enc) }}
+  {{ .Values.discountBandit.existingSecretAppKeyKey }}: {{ printf "base64:%s" (randAlphaNum 32 | b64enc) | quote }}
   {{- end }}
+  {{- with .Values.discountBandit.exchangeRateApiKey }}
+  {{ $.Values.discountBandit.existingSecretExchangeRateApiKeyKey }}: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if and (eq (include "discount-bandit.databaseMode" .) "external") (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "discount-bandit.databaseSecretName" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ include "discount-bandit.databaseSecretPasswordKey" . }}: {{ .Values.database.external.password | quote }}
+{{- end }}

--- a/charts/discount-bandit/templates/service.yaml
+++ b/charts/discount-bandit/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/discount-bandit/templates/service.yaml
+++ b/charts/discount-bandit/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}
@@ -17,3 +24,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "discount-bandit.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: discount-bandit

--- a/charts/discount-bandit/templates/serviceaccount.yaml
+++ b/charts/discount-bandit/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "discount-bandit.serviceAccountName" . }}
+  labels:
+    {{- include "discount-bandit.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/discount-bandit/tests/configmap_supervisor_test.yaml
+++ b/charts/discount-bandit/tests/configmap_supervisor_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Supervisor ConfigMap
 templates:
   - templates/configmap-supervisor.yaml

--- a/charts/discount-bandit/tests/configmap_supervisor_test.yaml
+++ b/charts/discount-bandit/tests/configmap_supervisor_test.yaml
@@ -1,0 +1,25 @@
+suite: Supervisor ConfigMap
+templates:
+  - templates/configmap-supervisor.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render the Kubernetes-safe Supervisor base config by default
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["base_supervisord.conf"]
+          pattern: "\\[program:octane\\]"
+      - notMatchRegex:
+          path: data["base_supervisord.conf"]
+          pattern: "\\[inet_http_server\\]"
+
+  - it: should not render when disabled
+    set:
+      supervisor.configMap.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/charts/discount-bandit/tests/deployment_test.yaml
+++ b/charts/discount-bandit/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml

--- a/charts/discount-bandit/tests/deployment_test.yaml
+++ b/charts/discount-bandit/tests/deployment_test.yaml
@@ -60,6 +60,20 @@ tests:
             name: DB_HOST
             value: test-mysql
 
+  - it: should use the configured MySQL existingSecret
+    set:
+      mysql.auth.existingSecret: discount-bandit-mysql
+      mysql.auth.existingSecretUserPasswordKey: app-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: discount-bandit-mysql
+                key: app-password
+
   - it: should use PVC for SQLite data when persistence enabled
     set:
       database.mode: sqlite

--- a/charts/discount-bandit/tests/deployment_test.yaml
+++ b/charts/discount-bandit/tests/deployment_test.yaml
@@ -34,32 +34,62 @@ tests:
             containerPort: 80
             protocol: TCP
 
-  - it: should mount data volume at /app/database
+  - it: should mount data volume at /app/database/sqlite
+    set:
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
-            name: data
-            mountPath: /app/database
+            name: database
+            mountPath: /app/database/sqlite
 
-  - it: should use PVC for data when persistence enabled
+  - it: should use MySQL by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_CONNECTION
+            value: mysql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: test-mysql
+
+  - it: should use PVC for SQLite data when persistence enabled
+    set:
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
     asserts:
       - contains:
           path: spec.template.spec.volumes
           content:
-            name: data
+            name: database
             persistentVolumeClaim:
-              claimName: test-discount-bandit-data
+              claimName: test-discount-bandit-database
 
   - it: should use emptyDir when persistence disabled
     set:
-      persistence.enabled: false
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
+      persistence.database.enabled: false
     asserts:
       - contains:
           path: spec.template.spec.volumes
           content:
-            name: data
+            name: database
             emptyDir: {}
+
+  - it: should disable service account token automount
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
 
   - it: should use TCP probes
     asserts:

--- a/charts/discount-bandit/tests/externalsecret_test.yaml
+++ b/charts/discount-bandit/tests/externalsecret_test.yaml
@@ -1,0 +1,31 @@
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render app and database ExternalSecrets
+    set:
+      database.mode: external
+      database.external.host: mysql.example.com
+      mysql.enabled: false
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+      externalSecrets.app.enabled: true
+      externalSecrets.app.appKeyRemoteRef.key: discount-bandit/app
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef.key: discount-bandit/mysql
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1

--- a/charts/discount-bandit/tests/externalsecret_test.yaml
+++ b/charts/discount-bandit/tests/externalsecret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ExternalSecret
 templates:
   - templates/externalsecret.yaml

--- a/charts/discount-bandit/tests/gateway_test.yaml
+++ b/charts/discount-bandit/tests/gateway_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Gateway API
 templates:
   - templates/gateway-httproute.yaml

--- a/charts/discount-bandit/tests/gateway_test.yaml
+++ b/charts/discount-bandit/tests/gateway_test.yaml
@@ -1,0 +1,28 @@
+suite: Gateway API
+templates:
+  - templates/gateway-httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute when enabled
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public-gateway
+      gatewayAPI.hostnames:
+        - deals.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.hostnames[0]
+          value: deals.example.com

--- a/charts/discount-bandit/tests/networkpolicy_test.yaml
+++ b/charts/discount-bandit/tests/networkpolicy_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: NetworkPolicy
 templates:
   - templates/networkpolicy.yaml

--- a/charts/discount-bandit/tests/networkpolicy_test.yaml
+++ b/charts/discount-bandit/tests/networkpolicy_test.yaml
@@ -1,0 +1,25 @@
+suite: NetworkPolicy
+templates:
+  - templates/networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ingress and egress policy
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress

--- a/charts/discount-bandit/tests/pdb_test.yaml
+++ b/charts/discount-bandit/tests/pdb_test.yaml
@@ -1,0 +1,21 @@
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render when enabled
+    set:
+      pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1

--- a/charts/discount-bandit/tests/pdb_test.yaml
+++ b/charts/discount-bandit/tests/pdb_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: PodDisruptionBudget
 templates:
   - templates/pdb.yaml

--- a/charts/discount-bandit/tests/pvc_test.yaml
+++ b/charts/discount-bandit/tests/pvc_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: PVC
 templates:
   - templates/pvc.yaml

--- a/charts/discount-bandit/tests/pvc_test.yaml
+++ b/charts/discount-bandit/tests/pvc_test.yaml
@@ -6,28 +6,42 @@ release:
   namespace: default
 tests:
   - it: should render PVC by default
+    set:
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
     asserts:
       - isKind:
           of: PersistentVolumeClaim
       - equal:
           path: metadata.name
-          value: test-discount-bandit-data
+          value: test-discount-bandit-database
 
   - it: should not render when persistence disabled
     set:
-      persistence.enabled: false
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
+      persistence.database.enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
   - it: should not render when existingClaim is set
     set:
-      persistence.existingClaim: my-pvc
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
+      persistence.database.existingClaim: my-pvc
     asserts:
       - hasDocuments:
           count: 0
 
   - it: should set storage size
+    set:
+      database.mode: sqlite
+      database.sqlite.enabled: true
+      mysql.enabled: false
     asserts:
       - equal:
           path: spec.resources.requests.storage

--- a/charts/discount-bandit/tests/service_test.yaml
+++ b/charts/discount-bandit/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml

--- a/charts/discount-bandit/tests/service_test.yaml
+++ b/charts/discount-bandit/tests/service_test.yaml
@@ -28,3 +28,17 @@ tests:
       - equal:
           path: spec.type
           value: ClusterIP
+
+  - it: should render dual-stack fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4

--- a/charts/discount-bandit/tests/serviceaccount_test.yaml
+++ b/charts/discount-bandit/tests/serviceaccount_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ServiceAccount
 templates:
   - templates/serviceaccount.yaml

--- a/charts/discount-bandit/tests/serviceaccount_test.yaml
+++ b/charts/discount-bandit/tests/serviceaccount_test.yaml
@@ -1,0 +1,21 @@
+suite: ServiceAccount
+templates:
+  - templates/serviceaccount.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a ServiceAccount by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should not render when disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/discount-bandit/values.schema.json
+++ b/charts/discount-bandit/values.schema.json
@@ -1,80 +1,167 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Discount Bandit Helm Chart Values",
-  "description": "Values for the Discount Bandit Helm chart — deal aggregator and price tracker for self-hosted deal hunting",
+  "description": "Values for the Discount Bandit Helm chart",
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "nameOverride": { "type": "string", "default": "" },
-    "fullnameOverride": { "type": "string", "default": "" },
-    "commonLabels": { "type": "object" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object", "additionalProperties": true },
+    "replicaCount": { "type": "integer", "minimum": 1 },
     "image": {
       "type": "object",
+      "additionalProperties": true,
       "properties": {
-        "repository": { "type": "string", "default": "docker.io/joffcom/discount-bandit" },
-        "tag": { "type": "string", "default": "" },
-        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
       }
     },
     "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
     "discountBandit": {
       "type": "object",
-      "description": "Discount Bandit application configuration",
+      "additionalProperties": true,
       "properties": {
+        "appUrl": { "type": "string" },
+        "assetUrl": { "type": "string" },
+        "timezone": { "type": "string" },
+        "themeColor": { "type": "string" },
+        "cron": { "type": "string" },
+        "exchangeRateApiKey": { "type": "string" },
+        "existingSecret": { "type": "string" },
+        "existingSecretAppKeyKey": { "type": "string" },
+        "existingSecretExchangeRateApiKeyKey": { "type": "string" },
         "extraEnv": { "type": "array", "items": { "type": "object" } }
       }
     },
+    "database": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": { "type": "string", "enum": ["auto", "mysql", "external", "sqlite"] },
+        "sqlite": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "external": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": { "type": "string", "enum": ["mysql", "mariadb"] },
+            "host": { "type": "string" },
+            "port": { "type": "integer" },
+            "name": { "type": "string" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "mysql": { "type": "object", "additionalProperties": true },
     "persistence": {
       "type": "object",
-      "description": "Persistence for SQLite database",
+      "additionalProperties": true,
       "properties": {
-        "enabled": { "type": "boolean", "default": true },
-        "size": { "type": "string", "default": "5Gi" },
-        "storageClass": { "type": "string", "default": "" },
-        "accessModes": { "type": "array", "items": { "type": "string" } },
-        "existingClaim": { "type": "string", "default": "" }
+        "database": { "$ref": "#/definitions/persistenceBlock" },
+        "logs": { "$ref": "#/definitions/persistenceBlock" }
       }
     },
     "serviceAccount": {
       "type": "object",
+      "additionalProperties": true,
       "properties": {
-        "create": { "type": "boolean", "default": false },
-        "name": { "type": "string", "default": "" },
-        "annotations": { "type": "object" }
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": true },
+        "automountServiceAccountToken": { "type": "boolean" }
       }
     },
     "service": {
       "type": "object",
+      "additionalProperties": true,
       "properties": {
-        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
-        "port": { "type": "integer", "default": 80 },
-        "annotations": { "type": "object" }
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer" },
+        "annotations": { "type": "object", "additionalProperties": true },
+        "ipFamilyPolicy": { "type": "string" },
+        "ipFamilies": { "type": "array", "items": { "type": "string" } }
       }
     },
-    "ingress": {
+    "ingress": { "type": "object", "additionalProperties": true },
+    "gatewayAPI": {
       "type": "object",
+      "additionalProperties": true,
       "properties": {
-        "enabled": { "type": "boolean", "default": false },
-        "ingressClassName": { "type": "string", "default": "traefik" },
-        "annotations": { "type": "object" },
-        "hosts": { "type": "array", "items": { "type": "object" } },
-        "tls": { "type": "array", "items": { "type": "object" } }
+        "enabled": { "type": "boolean" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "annotations": { "type": "object", "additionalProperties": true },
+        "matches": { "type": "array", "items": { "type": "object" } },
+        "filters": { "type": "array", "items": { "type": "object" } }
       }
     },
-    "probes": { "type": "object" },
-    "resources": { "type": "object" },
-    "podSecurityContext": { "type": "object" },
-    "securityContext": { "type": "object" },
-    "nodeSelector": { "type": "object" },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string" }
+          }
+        },
+        "app": { "type": "object", "additionalProperties": true },
+        "database": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "probes": { "type": "object", "additionalProperties": true },
+    "supervisor": { "type": "object", "additionalProperties": true },
+    "resources": { "type": "object", "additionalProperties": true },
+    "podSecurityContext": { "type": "object", "additionalProperties": true },
+    "securityContext": { "type": "object", "additionalProperties": true },
+    "networkPolicy": { "type": "object", "additionalProperties": true },
+    "pdb": { "type": "object", "additionalProperties": true },
+    "nodeSelector": { "type": "object", "additionalProperties": true },
     "tolerations": { "type": "array", "items": { "type": "object" } },
-    "affinity": { "type": "object" },
+    "affinity": { "type": "object", "additionalProperties": true },
     "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
-    "priorityClassName": { "type": "string", "default": "" },
-    "terminationGracePeriodSeconds": { "type": "integer", "default": 30 },
-    "podLabels": { "type": "object" },
-    "podAnnotations": { "type": "object" },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer" },
+    "podLabels": { "type": "object", "additionalProperties": true },
+    "podAnnotations": { "type": "object", "additionalProperties": true },
     "extraVolumes": { "type": "array", "items": { "type": "object" } },
     "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraInitContainers": { "type": "array", "items": { "type": "object" } },
+    "extraContainers": { "type": "array", "items": { "type": "object" } },
     "extraManifests": { "type": "array", "items": { "type": "object" } }
+  },
+  "definitions": {
+    "persistenceBlock": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "existingClaim": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": true }
+      }
+    }
   }
 }

--- a/charts/discount-bandit/values.yaml
+++ b/charts/discount-bandit/values.yaml
@@ -1,11 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# Discount Bandit Helm Chart — Default Values
+# Discount Bandit Helm Chart - Default Values
 # =============================================================================
-# Focus: deal aggregator and price tracker for self-hosted deal hunting
+# Primary path: Discount Bandit + HelmForge MySQL subchart.
+# Dev/small path: SQLite with a single replica and ReadWriteOnce persistence.
 
 nameOverride: ""
 fullnameOverride: ""
 commonLabels: {}
+
+replicaCount: 1
 
 # =============================================================================
 # Image
@@ -25,28 +29,113 @@ imagePullSecrets: []
 # =============================================================================
 
 discountBandit:
-  # -- Public URL of the instance (e.g. https://deals.example.com)
+  # -- Public URL of the instance. If empty, derive from ingress or Gateway examples where possible.
   appUrl: ""
+  # -- Public asset URL. Defaults to appUrl when empty.
+  assetUrl: ""
+  # -- Application timezone (APP_TIMEZONE)
+  timezone: UTC
+  # -- UI theme color. Upstream supports Slate, Gray, Zinc, Neutral, Stone, Red, Orange, Amber, Yellow, Lime, Green, Emerald, Teal, Cyan, Sky, Blue, Indigo, Violet, Purple, Fuchsia, Pink, Rose.
+  themeColor: Stone
+  # -- Product crawl schedule used by Discount Bandit (CRON)
+  cron: "*/5 * * * *"
+  # -- ExchangeRate API key used for currency conversion. Prefer existingSecret or External Secrets for production.
+  exchangeRateApiKey: ""
+  # -- Existing secret with application secrets.
+  existingSecret: ""
+  # -- Secret key for APP_KEY.
+  existingSecretAppKeyKey: app-key
+  # -- Secret key for EXCHANGE_RATE_API_KEY.
+  existingSecretExchangeRateApiKeyKey: exchange-rate-api-key
   # -- Extra environment variables for the container
   # -- @default -- `[]`
   extraEnv: []
+
+# =============================================================================
+# Database
+# =============================================================================
+# Mode detection (when mode is auto):
+# 1. database.external.host -> external
+# 2. mysql.enabled -> mysql
+# 3. database.sqlite.enabled -> sqlite
+# 4. fail
+
+database:
+  # -- Database mode: auto | mysql | external | sqlite
+  mode: auto
+
+  sqlite:
+    # -- Enable SQLite fallback mode for development/small installs. MySQL remains the primary default.
+    enabled: false
+
+  external:
+    # -- External database type passed to DB_CONNECTION: mysql | mariadb
+    type: mysql
+    # -- External database hostname
+    host: ""
+    # -- External database port
+    port: 3306
+    # -- External database name
+    name: discount_bandit
+    # -- External database username
+    username: discount_bandit
+    # -- External database password. Prefer existingSecret or External Secrets for production.
+    password: ""
+    # -- Existing secret containing the external database password
+    existingSecret: ""
+    # -- Secret key containing the external database password
+    existingSecretPasswordKey: database-password
+
+# =============================================================================
+# MySQL Subchart
+# =============================================================================
+
+mysql:
+  # -- Deploy HelmForge MySQL as the primary database.
+  enabled: true
+  architecture: standalone
+  auth:
+    database: discount_bandit
+    username: discount_bandit
+    password: ""
+    rootPassword: ""
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi
+  serviceAccount:
+    automountServiceAccountToken: false
+  startupProbe:
+    initialDelaySeconds: 30
 
 # =============================================================================
 # Persistence
 # =============================================================================
 
 persistence:
-  # -- Enable persistence for SQLite database
-  enabled: true
-  # -- Storage size
-  size: 5Gi
-  # -- Storage class
-  storageClass: ""
-  # -- Access modes
-  accessModes:
-    - ReadWriteOnce
-  # -- Use an existing PVC
-  existingClaim: ""
+  database:
+    # -- Enable persistence for SQLite database storage. Used only when database mode is sqlite.
+    enabled: true
+    # -- Storage size for SQLite database
+    size: 5Gi
+    # -- Storage class for SQLite database PVC
+    storageClass: ""
+    # -- Access modes for SQLite database PVC
+    accessModes:
+      - ReadWriteOnce
+    # -- Use an existing PVC for SQLite database storage
+    existingClaim: ""
+    annotations: {}
+
+  logs:
+    # -- Persist /logs. EmptyDir is used when disabled.
+    enabled: false
+    size: 2Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
+    annotations: {}
 
 # =============================================================================
 # Service Account
@@ -54,11 +143,13 @@ persistence:
 
 serviceAccount:
   # -- Create a ServiceAccount
-  create: false
+  create: true
   # -- ServiceAccount name
   name: ""
   # -- Annotations for the ServiceAccount
   annotations: {}
+  # -- Mount Kubernetes API credentials into the application pod
+  automountServiceAccountToken: false
 
 # =============================================================================
 # Service
@@ -71,6 +162,10 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Ordered list of IP families for the Service: IPv4 | IPv6. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -96,13 +191,72 @@ ingress:
     #   secretName: discount-bandit-tls
 
 # =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Render Gateway API HTTPRoute resources
+  enabled: false
+  # -- HTTPRoute parentRefs
+  parentRefs: []
+    # - name: public-gateway
+    #   namespace: gateway-system
+  # -- Hostnames routed to Discount Bandit
+  hostnames: []
+    # - deals.example.com
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Path matches for the HTTPRoute
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # -- Optional filters for the HTTPRoute rule
+  filters: []
+
+# =============================================================================
+# External Secrets
+# =============================================================================
+
+externalSecrets:
+  # -- Enable External Secrets Operator resources (external-secrets.io/v1)
+  enabled: false
+  # -- ExternalSecret API version. Must remain external-secrets.io/v1.
+  apiVersion: external-secrets.io/v1
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ""
+    kind: ClusterSecretStore
+  target:
+    creationPolicy: Owner
+  app:
+    # -- Manage APP_KEY and optional exchange-rate key through External Secrets
+    enabled: false
+    # -- Optional target Secret name. Defaults to the application Secret name.
+    targetName: ""
+    appKeyRemoteRef:
+      key: ""
+      property: ""
+    exchangeRateApiKeyRemoteRef:
+      key: ""
+      property: ""
+  database:
+    # -- Manage external database password through External Secrets. Requires database.mode=external.
+    enabled: false
+    # -- Optional target Secret name. Defaults to the database Secret name.
+    targetName: ""
+    passwordRemoteRef:
+      key: ""
+      property: ""
+
+# =============================================================================
 # Probes
 # =============================================================================
 
 probes:
   startup:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 40
     periodSeconds: 5
     timeoutSeconds: 3
     failureThreshold: 30
@@ -120,6 +274,15 @@ probes:
     failureThreshold: 3
 
 # =============================================================================
+# Supervisor
+# =============================================================================
+
+supervisor:
+  # -- Mount a Kubernetes-safe Supervisor base config that disables the unauthenticated inet_http_server.
+  configMap:
+    enabled: true
+
+# =============================================================================
 # Resources and Security
 # =============================================================================
 
@@ -128,6 +291,44 @@ resources: {}
 podSecurityContext: {}
 
 securityContext: {}
+
+# =============================================================================
+# NetworkPolicy
+# =============================================================================
+
+networkPolicy:
+  # -- Enable NetworkPolicy resources
+  enabled: false
+  ingress:
+    # -- Allow HTTP ingress from pods in the same namespace
+    allowSameNamespace: true
+    # -- Additional NetworkPolicy ingress peers
+    extraFrom: []
+  egress:
+    # -- Enable egress policy rules
+    enabled: false
+    # -- Allow DNS egress to kube-system
+    allowDNS: true
+    # -- Allow HTTPS egress to public internet for crawling stores, notifications, and exchange-rate API
+    allowHTTPS: true
+    # -- Allow HTTP egress to public internet for stores that do not support HTTPS
+    allowHTTP: false
+    # -- Allow egress to same-namespace database pods
+    allowSameNamespaceDatabase: true
+    # -- Database port allowed when allowSameNamespaceDatabase=true
+    databasePort: 3306
+    # -- Additional NetworkPolicy egress peers
+    extraTo: []
+
+# =============================================================================
+# Disruption Budget
+# =============================================================================
+
+pdb:
+  # -- Create a PodDisruptionBudget. Most useful when using external MySQL and replicaCount > 1.
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
 
 # =============================================================================
 # Scheduling
@@ -149,6 +350,8 @@ podAnnotations: {}
 
 extraVolumes: []
 extraVolumeMounts: []
+extraInitContainers: []
+extraContainers: []
 
 # -- Extra manifests to deploy alongside the chart
 extraManifests: []


### PR DESCRIPTION
## Summary
- make HelmForge MySQL the primary default database path
- add external MySQL, SQLite dev mode, Gateway API, External Secrets, dual-stack Service fields, NetworkPolicy, PDB, service account token hardening, and Supervisor config hardening
- expand README, NOTES, DESIGN, examples, CI values, and unit coverage

Related to #117 (upstream Cybrarist/Discount-Bandit#117).

## Validation
- helm dependency build charts/discount-bandit (Chart.lock removed afterwards)
- helm lint charts/discount-bandit
- helm lint --strict charts/discount-bandit
- helm template default, all ci/*.yaml, and examples/*.yaml
- helm unittest charts/discount-bandit (10 suites, 33 tests)
- ah lint -p charts/discount-bandit
- kubeconform strict with CI schema locations for default and all ci/*.yaml
- K3D runtime installs with --timeout 90s: default MySQL, SQLite, external MySQL + NetworkPolicy, Gateway API, production-style, PreferDualStack Service
- ExternalSecret manifests validated with server-side dry-run because no real SecretStore backend is configured locally

BREAKING CHANGE: Default installs now deploy HelmForge MySQL as the primary database instead of using SQLite-only storage semantics.