### PR TITLE
feat(umami)!: modernize production chart

### DIFF
--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: umami
-description: Umami privacy-first web analytics with PostgreSQL backend
+description: Umami privacy-first web analytics with PostgreSQL, Gateway API, External Secrets, backups, and production controls
 type: application
 version: 1.2.10
 appVersion: "3.1.0"
@@ -15,6 +15,10 @@ keywords:
   - privacy
   - umami
   - self-hosted
+  - postgresql
+  - gateway-api
+  - external-secrets
+  - session-replay
 home: https://helmforge.dev
 sources:
   - https://github.com/helmforgedev/charts
@@ -22,6 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "modernize production deployment controls for Umami"
     - kind: changed
       description: "upgrade to 3.1.0 (#222)"
     - kind: changed
@@ -50,6 +56,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/umami/DESIGN.md
+++ b/charts/umami/DESIGN.md
@@ -1,0 +1,186 @@
+# Umami Chart Design
+
+This chart packages Umami as a single web Deployment backed by PostgreSQL. The chart keeps the default install small for local use while exposing the controls needed for production deployments.
+
+## Goals
+
+- Keep a working default install for development and demos.
+- Support production deployments without raw template overrides.
+- Prefer structured values for common Umami runtime settings.
+- Support both bundled and external PostgreSQL.
+- Allow platform-owned secrets through External Secrets Operator.
+- Support modern Kubernetes exposure through Gateway API while keeping Ingress.
+- Make network, availability, and backup controls explicit.
+
+## Default Architecture
+
+```text
+┌──────────────┐       ┌──────────────────────┐
+│ kubectl port │       │ Service ClusterIP    │
+│ forward      ├──────►│ <release>-umami:80   │
+└──────────────┘       └──────────┬───────────┘
+                                  │
+                         ┌────────▼─────────┐
+                         │ Umami Deployment │
+                         │ 1 replica        │
+                         └────────┬─────────┘
+                                  │ DATABASE_URL
+                         ┌────────▼─────────┐
+                         │ PostgreSQL       │
+                         │ HelmForge chart  │
+                         └──────────────────┘
+```
+
+Default installs generate the application and database secrets and do not expose Umami publicly.
+
+## Production Architecture
+
+```text
+┌───────────────┐
+│ Internet      │
+└───────┬───────┘
+        │ HTTPS
+┌───────▼────────┐       ┌───────────────────────┐
+│ Gateway        │       │ HTTPRoute             │
+│ or Ingress     ├──────►│ analytics.example.com │
+└────────────────┘       └───────────┬───────────┘
+                                      │
+                             ┌────────▼─────────┐
+                             │ Service          │
+                             │ ClusterIP/dual   │
+                             └────────┬─────────┘
+                                      │
+                       ┌──────────────▼──────────────┐
+                       │ Umami Deployment             │
+                       │ 2+ replicas, PDB, resources  │
+                       └──────────────┬──────────────┘
+                                      │
+                    ┌─────────────────▼─────────────────┐
+                    │ Managed PostgreSQL / DB operator   │
+                    └───────────────────────────────────┘
+```
+
+Recommended production values use a stable APP_SECRET, external PostgreSQL, explicit resource requests, Gateway API or Ingress TLS, a PDB, and egress-aware NetworkPolicy.
+
+## External Database Preparation
+
+Umami's first migration creates `pgcrypto`. Some PostgreSQL services allow the application owner to create extensions,
+while others require an administrative user. The chart supports an optional `prepare-external-db` init container for the
+second case.
+
+```text
+┌──────────────────────┐
+│ Admin Secret          │
+│ postgres-password     │
+└──────────┬───────────┘
+           │ valueFrom
+┌──────────▼───────────┐       CREATE EXTENSION       ┌──────────────────┐
+│ prepare-external-db  ├─────────────────────────────►│ External Postgres │
+│ postgres client      │                              │ umami database    │
+└──────────┬───────────┘                              └──────────────────┘
+           │ success
+┌──────────▼───────────┐
+│ wait-for-db          │
+└──────────┬───────────┘
+           │
+┌──────────▼───────────┐
+│ Umami container      │
+└──────────────────────┘
+```
+
+This is opt-in and only active when `postgresql.enabled=false`. It lets operators keep the runtime Umami user least-privileged while still preparing required extensions during installation.
+
+## External Secrets Architecture
+
+```text
+┌────────────────────┐      sync       ┌──────────────────────┐
+│ Secret backend     ├────────────────►│ ExternalSecret       │
+│ Vault / AWS / GCP  │                 │ external-secrets.io  │
+└────────────────────┘                 └──────────┬───────────┘
+                                                   │ creates
+                                      ┌────────────▼────────────┐
+                                      │ Kubernetes Secret        │
+                                      │ app, db, backup creds    │
+                                      └────────────┬────────────┘
+                                                   │ envFrom/valueFrom
+                                      ┌────────────▼────────────┐
+                                      │ Umami / backup CronJob   │
+                                      └─────────────────────────┘
+```
+
+The chart renders `external-secrets.io/v1` resources only when enabled. It never requires External Secrets Operator for default installs.
+
+## Backup Architecture
+
+```text
+┌────────────────────┐       pg_dump       ┌──────────────────┐
+│ Backup CronJob     ├────────────────────►│ PostgreSQL       │
+│ postgres tools     │                     │ bundled/external │
+└──────────┬─────────┘                     └──────────────────┘
+           │ upload
+┌──────────▼─────────┐
+│ S3-compatible      │
+│ object storage     │
+└────────────────────┘
+```
+
+The backup job is optional and designed for smaller self-hosted installations.
+Production teams should still validate restores and may prefer database-native backups from their PostgreSQL operator
+or managed database service.
+
+## Runtime Configuration
+
+The chart maps common Umami environment variables to structured values. This makes production values easier to review than large `extraEnv` blocks:
+
+- `APP_SECRET` from generated, existing, or external-managed Secret.
+- `DATABASE_URL` composed by chart helpers.
+- `DISABLE_TELEMETRY` and `DISABLE_UPDATES` default to true.
+- `FORCE_SSL`, `CLIENT_IP_HEADER`, `COLLECT_API_ENDPOINT`, `TRACKER_SCRIPT_NAME`, `ALLOWED_FRAME_URLS`, and related settings are optional structured values.
+
+`extraEnv` remains available for upstream settings that are not modeled yet.
+`BASE_PATH` is intentionally not modeled because Umami v3 treats it as a build-time setting for the stock image.
+
+## Security Posture
+
+- The service account token is not mounted by default.
+- Secrets can be user-provided or managed by External Secrets Operator.
+- The container runs with the chart-defined security context.
+- NetworkPolicy is opt-in because clusters and CNIs vary.
+- Public exposure is opt-in through Ingress or Gateway API.
+- Production examples avoid embedding secret values in Helm values.
+
+## Availability
+
+Umami is stateless at the pod layer. Horizontal scaling depends on a shared PostgreSQL database and a stable APP_SECRET. Enable:
+
+- `replicaCount: 2` or higher
+- `pdb.enabled: true`
+- production resources
+- external PostgreSQL or a highly available PostgreSQL operator
+- `database.external.init.enabled` when the application user cannot create required extensions
+
+## Dual Stack
+
+The Service supports `ipFamilyPolicy` and `ipFamilies`. The chart does not force dual-stack by default because the Kubernetes cluster and CNI must provide IPv6 support.
+
+## Gateway API
+
+Gateway API support renders an `HTTPRoute` using `gateway.networking.k8s.io/v1`.
+The chart expects the cluster to already provide Gateway API CRDs and a Gateway implementation.
+Ingress remains available for clusters that have not adopted Gateway API.
+
+## Validation Strategy
+
+Chart changes should be validated with:
+
+- `helm lint`
+- `helm lint --strict`
+- `helm unittest`
+- render of every `ci/*.yaml`
+- `kubeconform -strict`
+- `ah lint`
+- K3D install with bundled PostgreSQL
+- K3D install with external PostgreSQL
+- pod logs and namespace events inspection
+
+Generated dependency artifacts such as `Chart.lock` and `charts/` are not committed in this repository workflow.

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -1,50 +1,95 @@
 # Umami Helm Chart
 
-Deploy [Umami](https://umami.is) on Kubernetes using the official
-[ghcr.io/umami-software/umami](https://github.com/umami-software/umami/pkgs/container/umami) container image.
-Privacy-first web analytics — no cookies, GDPR-compliant, lightweight alternative to Google Analytics.
+Deploy [Umami](https://umami.is), a privacy-first web analytics platform, on Kubernetes using the official
+`ghcr.io/umami-software/umami` image and HelmForge production patterns.
+
+The chart supports a fast development install with bundled PostgreSQL and a production path with external
+PostgreSQL, managed secrets, ingress or Gateway API, NetworkPolicy, PodDisruptionBudget, S3-compatible database
+backups, and explicit Umami runtime options.
 
 ## Features
 
-- **Privacy-first** — no cookies, no personal data collection, GDPR/CCPA compliant
-- **Lightweight** — single Node.js container, minimal resource usage
-- **PostgreSQL backend** — bundled subchart or external database
-- **Auto-generated secrets** — APP_SECRET created automatically
-- **Custom tracker** — configurable tracker script name for ad-blocker bypass
-- **Ingress support** — TLS with cert-manager
+- Privacy-first analytics with no cookies by default.
+- Official Umami image and configurable image pull policy.
+- Bundled `helmforge/postgresql` subchart for quick starts.
+- External PostgreSQL support for managed or operator-owned databases.
+- Structured Umami settings for telemetry, updates, bot checks, SSL forwarding, base paths, tracker names, CORS, and frame allowlists.
+- Optional `external-secrets.io/v1` resources for APP_SECRET, database password, and S3 backup credentials.
+- Ingress and Kubernetes Gateway API `HTTPRoute` exposure options.
+- Dual-stack service controls through `ipFamilyPolicy` and `ipFamilies`.
+- Optional NetworkPolicy with ingress and egress controls.
+- Optional PodDisruptionBudget for multi-replica deployments.
+- S3-compatible PostgreSQL backup CronJob.
+- Focused Helm unit tests and CI values for default, external DB, backup, ingress, Gateway API, dual-stack, External Secrets, NetworkPolicy, and production examples.
 
-## Installation
-
-**HTTPS repository:**
+## Install
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
 helm repo update
-helm install umami helmforge/umami -f values.yaml
+helm install umami helmforge/umami --namespace umami --create-namespace
 ```
 
-**OCI registry:**
+OCI registry:
 
 ```bash
-helm install umami oci://ghcr.io/helmforgedev/helm/umami -f values.yaml
+helm install umami oci://ghcr.io/helmforgedev/helm/umami --namespace umami --create-namespace
 ```
 
-## Basic Example
-
-```yaml
-# values.yaml - default values deploy with bundled PostgreSQL
-# No configuration needed for a basic setup
-```
-
-After deploying, access Umami:
+Access a default install:
 
 ```bash
-kubectl port-forward svc/<release>-umami 3000:80
-# Open http://localhost:3000
-# Default login: admin / umami
+kubectl port-forward -n umami svc/umami-umami 3000:80
 ```
 
-## External Database
+Open `http://localhost:3000` and sign in with Umami's initial credentials:
+
+- Username: `admin`
+- Password: `umami`
+
+Change the password immediately after first login.
+
+## Development Defaults
+
+The default values are intentionally simple:
+
+- `postgresql.enabled=true`
+- one Umami replica
+- generated APP_SECRET and database password
+- ClusterIP service
+- no public ingress
+- no NetworkPolicy
+- no PDB
+- telemetry and update checks disabled
+
+This is useful for local clusters, demos, and CI smoke tests. It is not a production-ready posture by itself.
+
+## Production Path
+
+For production, prefer:
+
+- external or operator-managed PostgreSQL
+- a stable APP_SECRET stored in Kubernetes Secret or External Secrets Operator
+- TLS termination through Gateway API or ingress
+- `FORCE_SSL=true` when the proxy terminates HTTPS
+- `CLIENT_IP_HEADER` aligned with your ingress controller or gateway
+- multiple replicas with PDB
+- explicit resource requests and memory limits
+- NetworkPolicy ingress and egress controls
+- backup CronJob or a database-native backup solution
+
+Start from:
+
+```bash
+helm install umami helmforge/umami \
+  --namespace umami \
+  --create-namespace \
+  -f charts/umami/examples/production.yaml
+```
+
+## External PostgreSQL
+
+Disable the bundled database and point Umami at a managed PostgreSQL endpoint:
 
 ```yaml
 postgresql:
@@ -52,52 +97,208 @@ postgresql:
 
 database:
   external:
-    host: postgres.example.com
+    host: postgres-primary.database.svc.cluster.local
+    port: 5432
     name: umami
     username: umami
-    existingSecret: umami-db-credentials
+    existingSecret: umami-db
+    existingSecretPasswordKey: database-password
+    init:
+      enabled: true
+      adminUsername: postgres
+      adminExistingSecret: postgres-admin
 ```
+
+Create the secret:
+
+```bash
+kubectl create secret generic umami-db \
+  --from-literal=database-password='replace-me'
+```
+
+Umami creates the `pgcrypto` extension during its first migration. Many managed databases require an owner or
+administrative account to create extensions. When the application user cannot do that, enable
+`database.external.init.enabled` and provide an admin Secret. The init container runs before Umami starts and only
+executes the SQL configured in `database.external.init.sql`.
+
+## External Secrets
+
+Use External Secrets Operator when credentials are stored in Vault, AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, or another supported backend.
+
+```yaml
+postgresql:
+  enabled: false
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  app:
+    enabled: true
+    targetName: umami-app
+    appSecretRemoteRef:
+      key: prod/umami/app
+      property: appSecret
+  database:
+    enabled: true
+    targetName: umami-db
+    passwordRemoteRef:
+      key: prod/umami/database
+      property: password
+```
+
+The chart renders `external-secrets.io/v1` resources and consumes the generated Kubernetes Secrets.
+
+## Gateway API
+
+Gateway API is available through `gatewayAPI.enabled=true`:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - analytics.example.com
+```
+
+Use ingress instead when your cluster standardizes on `networking.k8s.io/v1` Ingress.
+
+## Service Dual Stack
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Dual-stack requires a cluster and CNI configured for IPv4/IPv6.
+
+## NetworkPolicy
+
+NetworkPolicy is opt-in:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: true
+    allowHTTPS: true
+```
+
+Some local CNIs enforce traffic through pod CIDRs differently when testing through Services. In those clusters, add an
+explicit ingress peer:
+
+```yaml
+networkPolicy:
+  ingress:
+    allowSameNamespace: false
+    extraFrom:
+      - ipBlock:
+          cidr: 10.42.0.0/16
+```
+
+## Umami Runtime Settings
+
+Common structured settings:
+
+| Value | Umami env var | Default | Purpose |
+| --- | --- | --- | --- |
+| `umami.disableTelemetry` | `DISABLE_TELEMETRY` | `true` | Disable Umami telemetry. |
+| `umami.disableUpdates` | `DISABLE_UPDATES` | `true` | Disable update checks. |
+| `umami.disableBotCheck` | `DISABLE_BOT_CHECK` | `false` | Disable built-in bot filtering when needed. |
+| `umami.forceSSL` | `FORCE_SSL` | `false` | Trust proxy HTTPS and generate secure URLs. |
+| `umami.clientIpHeader` | `CLIENT_IP_HEADER` | `""` | Header used to detect client IP behind a proxy. |
+| `umami.collectApiEndpoint` | `COLLECT_API_ENDPOINT` | `""` | Custom collect endpoint. |
+| `umami.trackerScriptName` | `TRACKER_SCRIPT_NAME` | `""` | Custom tracker script file name. |
+| `umami.allowedFrameUrls` | `ALLOWED_FRAME_URLS` | `""` | Allow specific frame embed URLs. |
+| `umami.corsMaxAge` | `CORS_MAX_AGE` | `""` | CORS preflight cache duration. |
+
+Use `extraEnv` for Umami settings not yet modeled by the chart.
+
+Sub-path hosting requires a custom Umami image built with the upstream `BASE_PATH` build-time variable.
+The chart does not set `BASE_PATH` as a runtime environment variable for the stock image.
+
+## Backup
+
+The chart can create a PostgreSQL dump CronJob and upload it to S3-compatible storage:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  s3:
+    endpoint: https://s3.example.com
+    bucket: umami-backups
+    existingSecret: umami-backup
+```
+
+The referenced secret must contain the keys configured by `backup.s3.existingSecretAccessKeyKey` and
+`backup.s3.existingSecretSecretKeyKey`.
+
+For production, test restore procedures outside Helm. Backups without restore validation are only partial protection.
 
 ## Key Values
 
 | Key | Default | Description |
-|-----|---------|-------------|
-| `image.repository` | `ghcr.io/umami-software/umami` | Umami container image repository |
-| `image.tag` | `3.1.0` | Umami container image tag |
-| `umami.port` | `3000` | Application port |
-| `umami.appSecret` | `""` | Hash secret (auto-generated) |
-| `umami.disableTelemetry` | `true` | Disable telemetry |
-| `umami.trackerScriptName` | `""` | Custom tracker script name |
-| `postgresql.enabled` | `true` | Deploy PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) |
-| `ingress.enabled` | `false` | Enable ingress |
-| `service.port` | `80` | Service port |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of Umami pods. |
+| `image.repository` | `ghcr.io/umami-software/umami` | Umami image repository. |
+| `image.tag` | `3.1.0` | Umami image tag. |
+| `service.type` | `ClusterIP` | Kubernetes service type. |
+| `service.ipFamilyPolicy` | `""` | Optional service IP family policy. |
+| `service.ipFamilies` | `[]` | Optional service IP families. |
+| `ingress.enabled` | `false` | Enable Ingress. |
+| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute. |
+| `postgresql.enabled` | `true` | Deploy bundled HelmForge PostgreSQL. |
+| `database.external.host` | `""` | External PostgreSQL host when bundled PostgreSQL is disabled. |
+| `database.external.init.enabled` | `false` | Run optional external database preparation SQL before Umami starts. |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resources. |
+| `networkPolicy.enabled` | `false` | Render NetworkPolicy. |
+| `pdb.enabled` | `false` | Render PodDisruptionBudget. |
+| `backup.enabled` | `false` | Enable S3-compatible backup CronJob. |
+| `serviceAccount.automountServiceAccountToken` | `false` | Control service account token mounting. |
+
+## Examples
+
+- `examples/production.yaml` - production-oriented values with external PostgreSQL, Gateway API, NetworkPolicy, and PDB.
+- `examples/external-postgresql.yaml` - managed database setup.
+- `examples/external-secrets.yaml` - External Secrets Operator integration.
+- `examples/gateway-api.yaml` - Gateway API HTTPRoute exposure.
 
 ## Upgrade Notes
 
-Umami `3.1.0` is a major upstream release that adds Boards, Session Replay,
-Web Vitals tracking, share page improvements, and security fixes. It includes
-database schema migrations for Boards, Shares, Session Replay, and duplicate
-board keys. Back up PostgreSQL before upgrading live deployments and review the
-upstream v3 release notes if migrating from an older Umami v2 installation.
+Umami 3.x includes database migrations for newer analytics features such as Boards, Shares, Session Replay, and Web Vitals.
+Back up PostgreSQL before upgrading live deployments, especially when migrating from Umami 2.x.
 
 ## More Information
 
 - [Umami documentation](https://umami.is/docs)
-- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/umami)
+- [Umami environment variables](https://umami.is/docs/environment-variables)
+- [HelmForge chart source](https://github.com/helmforgedev/charts/tree/main/charts/umami)
 
 <!-- @AI-METADATA
 type: chart-readme
 title: Umami Helm Chart
 description: README for the Umami privacy-first web analytics Helm chart
 
-keywords: umami, analytics, privacy, web-analytics, postgresql
+keywords: umami, analytics, privacy, web-analytics, postgresql, gateway-api, external-secrets
 
 purpose: Chart installation, configuration, and usage documentation
 scope: Chart
 
 relations:
   - charts/umami/values.yaml
+  - charts/umami/DESIGN.md
 path: charts/umami/README.md
-version: 1.0
-date: 2026-04-01
+version: 2.0
+date: 2026-05-07
 -->

--- a/charts/umami/ci/dual-stack-values.yaml
+++ b/charts/umami/ci/dual-stack-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/umami/ci/external-db-values.yaml
+++ b/charts/umami/ci/external-db-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: external PostgreSQL database
 postgresql:
   enabled: false
@@ -9,3 +10,6 @@ database:
     name: umami
     username: umami_user
     password: "ci-password"
+    init:
+      enabled: true
+      adminExistingSecret: postgres-admin

--- a/charts/umami/ci/external-secrets-values.yaml
+++ b/charts/umami/ci/external-secrets-values.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.internal
+    name: umami
+    username: umami
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  app:
+    enabled: true
+    appSecretRemoteRef:
+      key: prod/umami
+      property: app-secret
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/umami
+      property: database-password
+  backup:
+    enabled: true
+    accessKeyRemoteRef:
+      key: prod/umami/s3
+      property: access-key
+    secretKeyRemoteRef:
+      key: prod/umami/s3
+      property: secret-key
+
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.example.com
+    bucket: umami-backups

--- a/charts/umami/ci/gateway-values.yaml
+++ b/charts/umami/ci/gateway-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - analytics.example.com

--- a/charts/umami/ci/network-policy-values.yaml
+++ b/charts/umami/ci/network-policy-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: true
+    allowHTTPS: true

--- a/charts/umami/ci/production-values.yaml
+++ b/charts/umami/ci/production-values.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+umami:
+  existingSecret: umami-app
+  clientIpHeader: X-Forwarded-For
+  collectApiEndpoint: /collect
+  trackerScriptName: metrics.js
+  forceSSL: true
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres-primary.database.svc.cluster.local
+    name: umami
+    username: umami
+    existingSecret: umami-db
+    existingSecretPasswordKey: database-password
+    init:
+      enabled: true
+      adminExistingSecret: postgres-admin
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - analytics.example.com
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: false
+    allowHTTPS: true
+    extraTo:
+      - ipBlock:
+          cidr: 10.42.0.0/16
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi

--- a/charts/umami/examples/external-postgresql.yaml
+++ b/charts/umami/examples/external-postgresql.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# Create the password Secret before installing:
+# kubectl create secret generic umami-db --from-literal=database-password="..."
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres-primary.database.svc.cluster.local
+    port: 5432
+    name: umami
+    username: umami
+    existingSecret: umami-db
+    existingSecretPasswordKey: database-password
+    # Enable when the external database user cannot create extensions.
+    # The admin secret should contain a temporary/admin password that can run CREATE EXTENSION.
+    init:
+      enabled: true
+      adminUsername: postgres
+      adminExistingSecret: postgres-admin
+      adminExistingSecretPasswordKey: postgres-password
+      sql: |
+        CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/charts/umami/examples/external-secrets.yaml
+++ b/charts/umami/examples/external-secrets.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# External Secrets Operator example. The chart renders ExternalSecret resources,
+# but it does not install ESO or create SecretStore/ClusterSecretStore objects.
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres-primary.database.svc.cluster.local
+    name: umami
+    username: umami
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  app:
+    enabled: true
+    appSecretRemoteRef:
+      key: prod/umami
+      property: app-secret
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: prod/umami
+      property: database-password

--- a/charts/umami/examples/gateway-api.yaml
+++ b/charts/umami/examples/gateway-api.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - analytics.example.com
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system

--- a/charts/umami/examples/production.yaml
+++ b/charts/umami/examples/production.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented Umami example with external PostgreSQL, Gateway API, NetworkPolicy, and PDB.
+# Create the referenced Secrets before installing:
+# kubectl create secret generic umami-app --from-literal=app-secret="$(openssl rand -hex 32)"
+# kubectl create secret generic umami-db --from-literal=database-password="..."
+
+replicaCount: 2
+
+umami:
+  existingSecret: umami-app
+  clientIpHeader: X-Forwarded-For
+  collectApiEndpoint: /collect
+  trackerScriptName: metrics.js
+  forceSSL: true
+  disableTelemetry: true
+  disableUpdates: true
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres-primary.database.svc.cluster.local
+    port: 5432
+    name: umami
+    username: umami
+    existingSecret: umami-db
+    existingSecretPasswordKey: database-password
+    init:
+      enabled: true
+      adminUsername: postgres
+      adminExistingSecret: postgres-admin
+      adminExistingSecretPasswordKey: postgres-password
+      sql: |
+        CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - analytics.example.com
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespaceDatabase: false
+    allowHTTPS: true
+    extraTo:
+      - ipBlock:
+          cidr: 10.42.0.0/16
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    memory: 1Gi

--- a/charts/umami/templates/NOTES.txt
+++ b/charts/umami/templates/NOTES.txt
@@ -1,79 +1,77 @@
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Umami has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Umami {{ .Chart.AppVersion }} was deployed.
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart:     {{ .Chart.Name }} {{ .Chart.Version }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-{{- if .Values.ingress.enabled }}
+Access:
+{{- if .Values.gatewayAPI.enabled }}
+  Gateway API HTTPRoute is enabled.
+  Hosts:
+{{- range .Values.gatewayAPI.hostnames }}
+    - https://{{ . }}/
+{{- else }}
+    - Check the attached Gateway listener hostnames.
+{{- end }}
+{{- else if .Values.ingress.enabled }}
+  Ingress is enabled.
 {{- range $host := .Values.ingress.hosts }}
-DASHBOARD:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-TRACKER:     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/script.js
+    - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else }}
-Port-forward to access Umami locally:
+  Port-forward locally:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "umami.fullname" . }} 3000:{{ .Values.service.port }}
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "umami.fullname" . }} 3000:{{ .Values.service.port | default 3000 }}
-
-  DASHBOARD:  http://localhost:3000/
+  Open:
+    http://localhost:3000/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  CREDENTIALS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Default admin credentials (change after first login!):
+Initial Umami credentials:
   Username: admin
   Password: umami
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Change the password after first login.
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-4. Log in and add your first website to track
+Runtime:
+  Service:     {{ include "umami.fullname" . }}:{{ .Values.service.port }}
+  Database:    {{ include "umami.dbHost" . }}:{{ include "umami.dbPort" . }}/{{ include "umami.dbName" . }}
+  PostgreSQL:  {{ ternary "bundled HelmForge subchart" "external database" .Values.postgresql.enabled }}
+  APP_SECRET:  {{ include "umami.appSecretName" . }}/{{ include "umami.appSecretKey" . }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  kubectl describe pod -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=umami -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-
-{{- if .Values.postgresql.enabled }}
-View PostgreSQL logs:
-  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+{{- if .Values.database.external.init.enabled }}
+External database preparation:
+  The prepare-external-db init container ran before Umami startup.
+  It uses {{ .Values.database.external.init.adminExistingSecret }}/{{ .Values.database.external.init.adminExistingSecretPasswordKey }} only during pod initialization.
 {{- end }}
 
-Upgrade reminder:
-  Umami {{ .Chart.AppVersion }} can run database schema migrations on startup.
-  Back up PostgreSQL before upgrading production releases.
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
-The tracking script requires a public URL to collect analytics data.
+{{- if .Values.externalSecrets.enabled }}
+External Secrets:
+  external-secrets.io/v1 resources were rendered.
+  Confirm reconciliation before troubleshooting application startup:
+    kubectl get externalsecret -n {{ .Release.Namespace }}
+    kubectl describe externalsecret -n {{ .Release.Namespace }}
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{- if .Values.networkPolicy.enabled }}
+NetworkPolicy:
+  NetworkPolicy is enabled. If Umami cannot reach PostgreSQL or external endpoints,
+  inspect egress rules and CNI enforcement.
+{{- end }}
 
-Documentation:  https://helmforge.dev/docs/charts/umami
-Umami:          https://umami.is | https://github.com/umami-software/umami
+{{- if .Values.backup.enabled }}
+Backup:
+  S3-compatible backup CronJob is enabled.
+  Check jobs:
+    kubectl get cronjob,job -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+{{- end }}
 
-Happy Helmforging :)
+Health checks:
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "umami.name" . }}
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "umami.name" . }} --all-containers --tail=100
+  kubectl get events -n {{ .Release.Namespace }} --sort-by='.lastTimestamp'
+
+Upgrade note:
+  Umami can run database migrations on startup. Back up PostgreSQL before upgrading production releases.
+
+Documentation:
+  https://helmforge.dev/docs/charts/umami

--- a/charts/umami/templates/_helpers.tpl
+++ b/charts/umami/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- define "umami.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -36,6 +37,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- else -}}
 {{- default "default" .Values.serviceAccount.name -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "umami.componentLabels" -}}
+{{ include "umami.selectorLabels" . }}
+app.kubernetes.io/component: umami
 {{- end -}}
 
 {{- define "umami.image" -}}
@@ -81,7 +87,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Database secret name for password */}}
 {{- define "umami.dbSecretName" -}}
 {{- if .Values.postgresql.enabled -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- else -}}
 {{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}
+{{- .Values.externalSecrets.database.targetName -}}
 {{- else if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
 {{- else -}}
@@ -92,8 +104,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Database secret password key */}}
 {{- define "umami.dbSecretPasswordKey" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- "user-password" -}}
-{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecretUserPasswordKey | default "user-password" -}}
+{{- else if or .Values.database.external.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled) -}}
 {{- .Values.database.external.existingSecretPasswordKey | default "password" -}}
 {{- else -}}
 {{- "password" -}}
@@ -107,7 +119,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* App secret name */}}
 {{- define "umami.appSecretName" -}}
-{{- if .Values.umami.existingSecret -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled .Values.externalSecrets.app.targetName -}}
+{{- .Values.externalSecrets.app.targetName -}}
+{{- else if .Values.umami.existingSecret -}}
 {{- .Values.umami.existingSecret -}}
 {{- else -}}
 {{- printf "%s-app" (include "umami.fullname" .) -}}
@@ -116,7 +130,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* App secret key */}}
 {{- define "umami.appSecretKey" -}}
-{{- if .Values.umami.existingSecret -}}
+{{- if or .Values.umami.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled) -}}
 {{- .Values.umami.existingSecretKey | default "app-secret" -}}
 {{- else -}}
 {{- "app-secret" -}}
@@ -125,7 +139,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Backup — S3 secret name */}}
 {{- define "umami.backupSecretName" -}}
-{{- if .Values.backup.s3.existingSecret -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.backup.enabled .Values.externalSecrets.backup.targetName -}}
+{{- .Values.externalSecrets.backup.targetName -}}
+{{- else if .Values.backup.s3.existingSecret -}}
 {{- .Values.backup.s3.existingSecret -}}
 {{- else -}}
 {{- printf "%s-backup" (include "umami.fullname" .) -}}
@@ -141,10 +157,47 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if not .Values.backup.s3.bucket -}}
     {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
   {{- end -}}
-  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.backup.enabled)) -}}
     {{- fail "backup.s3.accessKey or backup.s3.existingSecret is required when backup.enabled is true" -}}
   {{- end -}}
 true
+{{- end -}}
+{{- end -}}
+
+{{/* ExternalSecret data entry helper */}}
+{{- define "umami.externalSecretDataItem" -}}
+{{- if not .remoteRef.key -}}
+{{- fail (printf "%s.key is required when the related ExternalSecret is enabled" .remoteRefName) -}}
+{{- end -}}
+- secretKey: {{ .secretKey | quote }}
+  remoteRef:
+    key: {{ .remoteRef.key | quote }}
+    {{- with .remoteRef.property }}
+    property: {{ . | quote }}
+    {{- end }}
+{{- end -}}
+
+{{/* Validate External Secrets Operator values */}}
+{{- define "umami.validateExternalSecrets" -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if not .Values.externalSecrets.secretStoreRef.name -}}
+    {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+  {{- end -}}
+  {{- if and .Values.externalSecrets.database.enabled .Values.postgresql.enabled -}}
+    {{- fail "externalSecrets.database.enabled requires postgresql.enabled=false" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate external database preparation values */}}
+{{- define "umami.validateExternalDbInit" -}}
+{{- if .Values.database.external.init.enabled -}}
+  {{- if .Values.postgresql.enabled -}}
+    {{- fail "database.external.init.enabled requires postgresql.enabled=false" -}}
+  {{- end -}}
+  {{- if not .Values.database.external.init.adminExistingSecret -}}
+    {{- fail "database.external.init.adminExistingSecret is required when database.external.init.enabled=true" -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/umami/templates/backup-cronjob.yaml
+++ b/charts/umami/templates/backup-cronjob.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if include "umami.backupEnabled" . }}
 apiVersion: batch/v1
 kind: CronJob
@@ -20,6 +21,10 @@ spec:
             {{- include "umami.selectorLabels" . | nindent 12 }}
         spec:
           restartPolicy: Never
+          {{- if .Values.serviceAccount.create }}
+          serviceAccountName: {{ include "umami.serviceAccountName" . }}
+          {{- end }}
+          automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}

--- a/charts/umami/templates/deployment.yaml
+++ b/charts/umami/templates/deployment.yaml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- include "umami.validateExternalDbInit" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,7 +7,7 @@ metadata:
   labels:
     {{- include "umami.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   strategy:
     type: RollingUpdate
   selector:
@@ -14,7 +16,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "umami.selectorLabels" . | nindent 8 }}
+        {{- include "umami.componentLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,6 +32,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "umami.serviceAccountName" . }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
@@ -39,6 +42,37 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
+        {{- if .Values.database.external.init.enabled }}
+        - name: prepare-external-db
+          image: {{ .Values.database.external.init.image | quote }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.external.init.adminExistingSecret }}
+                  key: {{ .Values.database.external.init.adminExistingSecretPasswordKey }}
+            - name: DATABASE_INIT_SQL
+              value: |
+{{ .Values.database.external.init.sql | indent 16 }}
+          command:
+            - sh
+            - -ec
+          args:
+            - |
+              echo "Preparing external PostgreSQL database {{ include "umami.dbName" . }} at {{ include "umami.dbHost" . }}:{{ include "umami.dbPort" . }}..."
+              printf '%s\n' "${DATABASE_INIT_SQL}" | PGPASSWORD="${DATABASE_ADMIN_PASSWORD}" psql \
+                -h {{ include "umami.dbHost" . | quote }} \
+                -p {{ include "umami.dbPort" . | quote }} \
+                -U {{ .Values.database.external.init.adminUsername | quote }} \
+                -d {{ include "umami.dbName" . | quote }} \
+                -v ON_ERROR_STOP=1
+              echo "External PostgreSQL database is prepared."
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
         - name: wait-for-db
           image: docker.io/library/busybox:1.37
           command:
@@ -51,6 +85,10 @@ spec:
                 sleep 2
               done
               echo "Database is ready."
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: umami
           image: {{ include "umami.image" . | quote }}
@@ -77,6 +115,42 @@ spec:
             {{- if .Values.umami.disableTelemetry }}
             - name: DISABLE_TELEMETRY
               value: "1"
+            {{- end }}
+            {{- if .Values.umami.disableUpdates }}
+            - name: DISABLE_UPDATES
+              value: "1"
+            {{- end }}
+            {{- if .Values.umami.disableBotCheck }}
+            - name: DISABLE_BOT_CHECK
+              value: "1"
+            {{- end }}
+            {{- if .Values.umami.cloudMode }}
+            - name: CLOUD_MODE
+              value: "1"
+            {{- end }}
+            {{- if .Values.umami.forceSSL }}
+            - name: FORCE_SSL
+              value: "1"
+            {{- end }}
+            {{- with .Values.umami.clientIpHeader }}
+            - name: CLIENT_IP_HEADER
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.umami.collectApiEndpoint }}
+            - name: COLLECT_API_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.umami.corsMaxAge }}
+            - name: CORS_MAX_AGE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.umami.allowedFrameUrls }}
+            - name: ALLOWED_FRAME_URLS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.umami.debug }}
+            - name: DEBUG
+              value: {{ . | quote }}
             {{- end }}
             {{- with .Values.umami.trackerScriptName }}
             - name: TRACKER_SCRIPT_NAME

--- a/charts/umami/templates/externalsecret.yaml
+++ b/charts/umami/templates/externalsecret.yaml
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- include "umami.validateExternalSecrets" . }}
+{{- if .Values.externalSecrets.app.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "umami.appSecretName" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "umami.appSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "umami.externalSecretDataItem" (dict "secretKey" (include "umami.appSecretKey" .) "remoteRefName" "externalSecrets.app.appSecretRemoteRef" "remoteRef" .Values.externalSecrets.app.appSecretRemoteRef) | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.database.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "umami.dbSecretName" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "umami.dbSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "umami.externalSecretDataItem" (dict "secretKey" (include "umami.dbSecretPasswordKey" .) "remoteRefName" "externalSecrets.database.passwordRemoteRef" "remoteRef" .Values.externalSecrets.database.passwordRemoteRef) | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.backup.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "umami.backupSecretName" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "umami.backupSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "umami.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretAccessKeyKey "remoteRefName" "externalSecrets.backup.accessKeyRemoteRef" "remoteRef" .Values.externalSecrets.backup.accessKeyRemoteRef) | nindent 4 }}
+    {{- include "umami.externalSecretDataItem" (dict "secretKey" .Values.backup.s3.existingSecretSecretKeyKey "remoteRefName" "externalSecrets.backup.secretKeyRemoteRef" "remoteRef" .Values.externalSecrets.backup.secretKeyRemoteRef) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/umami/templates/gateway-httproute.yaml
+++ b/charts/umami/templates/gateway-httproute.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- if not .Values.gatewayAPI.parentRefs }}
+{{- fail "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "umami.fullname" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gatewayAPI.matches | nindent 8 }}
+      {{- with .Values.gatewayAPI.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "umami.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/umami/templates/networkpolicy.yaml
+++ b/charts/umami/templates/networkpolicy.yaml
@@ -1,0 +1,89 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "umami.fullname" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "umami.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.umami.port }}
+    {{- else }}
+    []
+    {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespaceDatabase .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowHTTP .Values.networkPolicy.egress.extraTo }}
+  egress:
+    {{- if $allowEgress }}
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: "kube-system"
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSameNamespaceDatabase }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.databasePort }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTP }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- else }}
+    []
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/umami/templates/pdb.yaml
+++ b/charts/umami/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "umami.fullname" . }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  {{- if ne (toString .Values.pdb.maxUnavailable) "" }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "umami.componentLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/umami/templates/secret.yaml
+++ b/charts/umami/templates/secret.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.umami.existingSecret }}
+# SPDX-License-Identifier: Apache-2.0
+{{- if and (not .Values.umami.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,7 +11,7 @@ stringData:
   app-secret: {{ .Values.umami.appSecret | default (randAlphaNum 32) | quote }}
 {{- end }}
 ---
-{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) .Values.database.external.password }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) .Values.database.external.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,7 +23,7 @@ stringData:
   password: {{ .Values.database.external.password | quote }}
 {{- end }}
 ---
-{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.backup.enabled)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/umami/templates/service.yaml
+++ b/charts/umami/templates/service.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/umami/templates/serviceaccount.yaml
+++ b/charts/umami/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 {{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -26,6 +26,14 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should set custom replica count
+    set:
+      replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
   - it: should set the correct image
     asserts:
       - equal:
@@ -51,6 +59,11 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DISABLE_TELEMETRY
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_UPDATES
             value: "1"
 
   - it: should set DATABASE_URL with subchart host
@@ -89,6 +102,31 @@ tests:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-db
 
+  - it: should prepare external database when enabled
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.init.enabled: true
+      database.external.init.adminExistingSecret: postgres-admin
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-external-db
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/postgres:18-alpine
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DATABASE_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: postgres-admin
+                key: postgres-password
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-db
+
   - it: should set external database host when subchart is disabled
     set:
       postgresql.enabled: false
@@ -118,6 +156,20 @@ tests:
               secretKeyRef:
                 name: my-db-secret
                 key: db-pass
+
+  - it: should use configured PostgreSQL existingSecret
+    set:
+      postgresql.auth.existingSecret: umami-postgres
+      postgresql.auth.existingSecretUserPasswordKey: app-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: umami-postgres
+                key: app-password
 
   - it: should set probes on heartbeat path
     asserts:
@@ -153,6 +205,58 @@ tests:
             name: TRACKER_SCRIPT_NAME
             value: "custom.js"
 
+  - it: should set structured Umami runtime options
+    set:
+      umami.clientIpHeader: X-Forwarded-For
+      umami.collectApiEndpoint: /collect
+      umami.corsMaxAge: "3600"
+      umami.allowedFrameUrls: "https://portal.example.com"
+      umami.debug: "umami:prisma"
+      umami.forceSSL: true
+      umami.disableBotCheck: true
+      umami.cloudMode: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLIENT_IP_HEADER
+            value: X-Forwarded-For
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COLLECT_API_ENDPOINT
+            value: /collect
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CORS_MAX_AGE
+            value: "3600"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOWED_FRAME_URLS
+            value: "https://portal.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEBUG
+            value: "umami:prisma"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FORCE_SSL
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_BOT_CHECK
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLOUD_MODE
+            value: "1"
+
   - it: should not set telemetry env when disabled
     set:
       umami.disableTelemetry: false
@@ -173,3 +277,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 100m
+
+  - it: should disable service account token automount by default
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false

--- a/charts/umami/tests/externalsecret_test.yaml
+++ b/charts/umami/tests/externalsecret_test.yaml
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render app ExternalSecret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.app.enabled: true
+      externalSecrets.app.appSecretRemoteRef:
+        key: prod/umami
+        property: app-secret
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.data[0].secretKey
+          value: app-secret
+
+  - it: should render database ExternalSecret for external database
+    set:
+      postgresql.enabled: false
+      database.external.host: postgres.example.com
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef:
+        key: prod/umami
+        property: database-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.data[0].secretKey
+          value: password
+
+  - it: should fail database ExternalSecret with bundled PostgreSQL
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef:
+        key: prod/umami
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.database.enabled requires postgresql.enabled=false"
+
+  - it: should fail without secret store name
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.app.enabled: true
+      externalSecrets.app.appSecretRemoteRef:
+        key: prod/umami
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true"

--- a/charts/umami/tests/gateway_test.yaml
+++ b/charts/umami/tests/gateway_test.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - templates/gateway-httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute when enabled
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public-gateway
+          namespace: gateway-system
+      gatewayAPI.hostnames:
+        - analytics.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: analytics.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-umami
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should fail when parentRefs are missing
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true"

--- a/charts/umami/tests/networkpolicy_test.yaml
+++ b/charts/umami/tests/networkpolicy_test.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: NetworkPolicy
+templates:
+  - templates/networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ingress-only policy by default when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.policyTypes[0]
+          value: Ingress
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 3000
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: umami
+      - isNull:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+      - equal:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: default
+
+  - it: should render egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 5432
+      - equal:
+          path: spec.egress[1].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: default
+      - equal:
+          path: spec.egress[2].to[1].ipBlock.cidr
+          value: "::/0"
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 443
+
+  - it: should include extra ingress peers
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.extraFrom:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+    asserts:
+      - equal:
+          path: spec.ingress[0].from[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: gateway-system

--- a/charts/umami/tests/pdb_test.yaml
+++ b/charts/umami/tests/pdb_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: PodDisruptionBudget
+templates:
+  - templates/pdb.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render with minAvailable
+    set:
+      pdb.enabled: true
+      pdb.minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should prefer maxUnavailable when set
+    set:
+      pdb.enabled: true
+      pdb.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1

--- a/charts/umami/tests/service_test.yaml
+++ b/charts/umami/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml
@@ -45,3 +46,20 @@ tests:
       - equal:
           path: metadata.annotations.my-annotation
           value: my-value
+
+  - it: should set dual-stack service fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/umami/tests/serviceaccount_test.yaml
+++ b/charts/umami/tests/serviceaccount_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ServiceAccount
 templates:
   - templates/serviceaccount.yaml
@@ -19,6 +20,9 @@ tests:
       - equal:
           path: metadata.name
           value: test-umami
+      - equal:
+          path: automountServiceAccountToken
+          value: false
 
   - it: should set custom name
     set:
@@ -38,3 +42,12 @@ tests:
       - equal:
           path: metadata.annotations["iam.gke.io/gcp-service-account"]
           value: test@project.iam.gserviceaccount.com
+
+  - it: should set automountServiceAccountToken when enabled
+    set:
+      serviceAccount.create: true
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -19,6 +19,12 @@
       "type": "object",
       "description": "Labels added to every resource created by this chart"
     },
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of Umami application replicas",
+      "minimum": 1,
+      "default": 1
+    },
     "image": {
       "type": "object",
       "description": "Container image configuration",
@@ -79,6 +85,51 @@
           "description": "Disable telemetry",
           "default": true
         },
+        "disableUpdates": {
+          "type": "boolean",
+          "description": "Disable upstream update checks",
+          "default": true
+        },
+        "disableBotCheck": {
+          "type": "boolean",
+          "description": "Disable bot detection",
+          "default": false
+        },
+        "cloudMode": {
+          "type": "boolean",
+          "description": "Disable users, teams, and websites settings pages",
+          "default": false
+        },
+        "forceSSL": {
+          "type": "boolean",
+          "description": "Enable Umami FORCE_SSL",
+          "default": false
+        },
+        "clientIpHeader": {
+          "type": "string",
+          "description": "HTTP header used to determine client IP behind reverse proxies",
+          "default": ""
+        },
+        "collectApiEndpoint": {
+          "type": "string",
+          "description": "Custom collection endpoint",
+          "default": ""
+        },
+        "corsMaxAge": {
+          "type": ["string", "integer"],
+          "description": "CORS preflight max age in seconds",
+          "default": ""
+        },
+        "allowedFrameUrls": {
+          "type": "string",
+          "description": "Space-delimited URLs allowed to frame Umami",
+          "default": ""
+        },
+        "debug": {
+          "type": "string",
+          "description": "Debug namespaces",
+          "default": ""
+        },
         "trackerScriptName": {
           "type": "string",
           "description": "Custom tracker script name (for ad-blocker bypass)",
@@ -136,6 +187,43 @@
               "type": "string",
               "description": "Key in the existing secret containing the password",
               "default": "password"
+            },
+            "init": {
+              "type": "object",
+              "description": "Optional external PostgreSQL preparation before Umami starts",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Prepare an external PostgreSQL database before Umami starts",
+                  "default": false
+                },
+                "image": {
+                  "type": "string",
+                  "description": "PostgreSQL client image used by the init container",
+                  "default": "docker.io/library/postgres:18-alpine"
+                },
+                "adminUsername": {
+                  "type": "string",
+                  "description": "Administrative database user used by the init container",
+                  "default": "postgres"
+                },
+                "adminExistingSecret": {
+                  "type": "string",
+                  "description": "Existing secret containing the administrative database password",
+                  "default": ""
+                },
+                "adminExistingSecretPasswordKey": {
+                  "type": "string",
+                  "description": "Key in the admin secret containing the administrative database password",
+                  "default": "postgres-password"
+                },
+                "sql": {
+                  "type": "string",
+                  "description": "SQL executed before Umami starts",
+                  "default": "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
+                }
+              }
             }
           }
         }
@@ -159,6 +247,11 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the ServiceAccount"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Mount Kubernetes API credentials into pods",
+          "default": false
         }
       }
     },
@@ -181,6 +274,16 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the Service"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Service IP family policy",
+          "default": ""
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Ordered Service IP families",
+          "items": { "type": "string" }
         }
       }
     },
@@ -236,6 +339,34 @@
         }
       }
     },
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "annotations": { "type": "object" },
+        "matches": { "type": "array", "items": { "type": "object" } },
+        "filters": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator resources",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": { "type": "object", "additionalProperties": true },
+        "target": { "type": "object", "additionalProperties": true },
+        "app": { "type": "object", "additionalProperties": true },
+        "database": { "type": "object", "additionalProperties": true },
+        "backup": { "type": "object", "additionalProperties": true }
+      }
+    },
     "probes": {
       "type": "object",
       "description": "Health probe configuration",
@@ -247,7 +378,7 @@
           "properties": {
             "enabled": { "type": "boolean", "default": true },
             "path": { "type": "string", "default": "/api/heartbeat" },
-            "initialDelaySeconds": { "type": "integer" },
+            "initialDelaySeconds": { "type": "integer", "default": 30 },
             "periodSeconds": { "type": "integer" },
             "timeoutSeconds": { "type": "integer" },
             "failureThreshold": { "type": "integer" }
@@ -290,6 +421,26 @@
     "securityContext": {
       "type": "object",
       "description": "Container-level security context"
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy configuration",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingress": { "type": "object", "additionalProperties": true },
+        "egress": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "description": "PodDisruptionBudget configuration",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "minAvailable": { "type": ["integer", "string"], "default": 1 },
+        "maxUnavailable": { "type": ["integer", "string"], "default": "" }
+      }
     },
     "nodeSelector": {
       "type": "object",

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -8,6 +8,9 @@ nameOverride: ""
 fullnameOverride: ""
 commonLabels: {}
 
+# -- Number of Umami application replicas. Use external PostgreSQL before scaling above one.
+replicaCount: 1
+
 # =============================================================================
 # Image
 # =============================================================================
@@ -36,6 +39,24 @@ umami:
   existingSecretKey: app-secret
   # -- Disable telemetry
   disableTelemetry: true
+  # -- Disable upstream update checks
+  disableUpdates: true
+  # -- Disable bot detection. Leave false for normal analytics accuracy.
+  disableBotCheck: false
+  # -- Disable users, teams, and websites settings pages for managed/cloud-style deployments
+  cloudMode: false
+  # -- Force Strict-Transport-Security responses from Umami. Enable only when public access is HTTPS.
+  forceSSL: false
+  # -- HTTP header used to determine client IP behind reverse proxies
+  clientIpHeader: ""
+  # -- Custom collection endpoint to avoid ad blockers. Defaults to Umami upstream behavior when empty.
+  collectApiEndpoint: ""
+  # -- CORS preflight max age in seconds. Empty uses upstream default.
+  corsMaxAge: ""
+  # -- Space-delimited URLs allowed to frame Umami. Prefer explicit origins.
+  allowedFrameUrls: ""
+  # -- Debug namespaces, for example umami:prisma or umami:middleware
+  debug: ""
   # -- Custom tracker script name (for ad-blocker bypass)
   trackerScriptName: ""
   # -- Extra environment variables for the container
@@ -60,6 +81,20 @@ database:
     existingSecret: ""
     # -- Key in the existing secret containing the password
     existingSecretPasswordKey: password
+    init:
+      # -- Prepare an external PostgreSQL database before Umami starts. Useful when the app user cannot create extensions.
+      enabled: false
+      # -- PostgreSQL client image used by the init container.
+      image: docker.io/library/postgres:18-alpine
+      # -- Administrative database user used only by the init container.
+      adminUsername: postgres
+      # -- Existing secret containing the administrative database password.
+      adminExistingSecret: ""
+      # -- Key in adminExistingSecret containing the administrative database password.
+      adminExistingSecretPasswordKey: postgres-password
+      # -- SQL executed against database.external.name before Umami starts.
+      sql: |
+        CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 # =============================================================================
 # Service Account
@@ -72,6 +107,8 @@ serviceAccount:
   name: ""
   # -- Annotations for the ServiceAccount
   annotations: {}
+  # -- Mount Kubernetes API credentials into Umami and backup pods
+  automountServiceAccountToken: false
 
 # =============================================================================
 # Service
@@ -84,6 +121,10 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ""
+  # -- Ordered Service IP families: IPv4 | IPv6. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -109,6 +150,77 @@ ingress:
     #   secretName: umami-tls
 
 # =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Render Gateway API HTTPRoute resources
+  enabled: false
+  # -- HTTPRoute parentRefs
+  parentRefs: []
+    # - name: public-gateway
+    #   namespace: gateway-system
+  # -- Hostnames routed to Umami
+  hostnames: []
+    # - analytics.example.com
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Path matches for the HTTPRoute
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # -- Optional HTTPRoute filters
+  filters: []
+
+# =============================================================================
+# External Secrets
+# =============================================================================
+
+externalSecrets:
+  # -- Enable External Secrets Operator resources (external-secrets.io/v1)
+  enabled: false
+  # -- ExternalSecret API version. Must remain external-secrets.io/v1.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval used by rendered ExternalSecrets
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name
+    name: ""
+    # -- SecretStore kind: SecretStore | ClusterSecretStore
+    kind: SecretStore
+  target:
+    # -- ExternalSecret target creation policy
+    creationPolicy: Owner
+  app:
+    # -- Manage APP_SECRET through External Secrets
+    enabled: false
+    # -- Optional target Secret name. Defaults to the application Secret name.
+    targetName: ""
+    appSecretRemoteRef:
+      key: ""
+      property: ""
+  database:
+    # -- Manage external database password through External Secrets. Requires postgresql.enabled=false.
+    enabled: false
+    # -- Optional target Secret name. Defaults to the database Secret name.
+    targetName: ""
+    passwordRemoteRef:
+      key: ""
+      property: ""
+  backup:
+    # -- Manage S3 backup credentials through External Secrets
+    enabled: false
+    # -- Optional target Secret name. Defaults to the backup Secret name.
+    targetName: ""
+    accessKeyRemoteRef:
+      key: ""
+      property: ""
+    secretKeyRemoteRef:
+      key: ""
+      property: ""
+
+# =============================================================================
 # Probes
 # =============================================================================
 
@@ -116,7 +228,7 @@ probes:
   startup:
     enabled: true
     path: /api/heartbeat
-    initialDelaySeconds: 10
+    initialDelaySeconds: 30
     periodSeconds: 5
     timeoutSeconds: 3
     failureThreshold: 30
@@ -144,6 +256,44 @@ resources: {}
 podSecurityContext: {}
 
 securityContext: {}
+
+# =============================================================================
+# NetworkPolicy
+# =============================================================================
+
+networkPolicy:
+  # -- Enable NetworkPolicy resources
+  enabled: false
+  ingress:
+    # -- Allow HTTP ingress from pods in the same namespace
+    allowSameNamespace: true
+    # -- Additional NetworkPolicy ingress peers for HTTP traffic, for example Gateway controller namespaces
+    extraFrom: []
+  egress:
+    # -- Enable egress policy rules. Disabled by default to avoid blocking unknown database, OIDC, or backup endpoints.
+    enabled: false
+    # -- Allow DNS egress to kube-system
+    allowDNS: true
+    # -- Allow egress to same-namespace PostgreSQL pods
+    allowSameNamespaceDatabase: true
+    # -- Database port allowed when allowSameNamespaceDatabase=true
+    databasePort: 5432
+    # -- Allow HTTPS egress to public internet for integrations, update checks when enabled, and S3 HTTPS endpoints
+    allowHTTPS: true
+    # -- Allow HTTP egress to public internet for non-TLS S3 endpoints or internal integrations
+    allowHTTP: false
+    # -- Additional NetworkPolicy egress peers
+    extraTo: []
+
+# =============================================================================
+# Disruption Budget
+# =============================================================================
+
+pdb:
+  # -- Create a PodDisruptionBudget. Useful when replicaCount is increased with an external PostgreSQL backend.
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
 
 # =============================================================================
 # S3 Backup
@@ -259,6 +409,8 @@ postgresql:
     username: umami
     # -- PostgreSQL password (auto-generated if empty)
     password: ""
+  serviceAccount:
+    automountServiceAccountToken: false
   initdb:
     scripts:
       02-extensions.sql: |


### PR DESCRIPTION
Related to #4239

## Summary
- Add production-grade controls to the Umami chart: Gateway API HTTPRoute, External Secrets Operator v1, service dual-stack, NetworkPolicy, PDB, and service account automount controls.
- Add optional external PostgreSQL preparation for required Umami extensions, so runtime database users can stay least-privileged.
- Update HelmForge PostgreSQL dependency to 2.0.0 without manually bumping chart version.
- Expand README, NOTES, DESIGN, examples, CI values, schema, and unit tests.

## Breaking Change
The bundled PostgreSQL dependency is updated to `helmforge/postgresql` `2.0.0`. Existing users should review PostgreSQL values before upgrading.

## Local Validation Evidence
- [x] `helm dependency build charts/umami`
- [x] `helm lint charts/umami`
- [x] `helm lint --strict charts/umami`
- [x] `helm template umami-test charts/umami`
- [x] `helm template umami-test charts/umami -f charts/umami/ci/*.yaml`
- [x] `helm unittest charts/umami` - 11 suites, 66 tests
- [x] `ah lint charts/umami` - 65 packages found, 0 package errors
- [x] strict `kubeconform` for default and CI renders (`-ignore-missing-schemas` only for Gateway API/ExternalSecret CRDs)
- [x] `helm dependency list charts/umami` - PostgreSQL 2.0.0 OK
- [x] Kubescape NSA scan with v4.0.6 - score 73

## K3D Runtime Validation
- [x] Default install with bundled PostgreSQL on `k3d-charts-test`, `--wait --timeout 90s`
- [x] Default heartbeat from in-cluster curl returned `{"ok":true}`
- [x] Default pod logs inspected for all containers, no application errors, no non-normal events
- [x] Production-style install with external PostgreSQL, external DB init, Gateway API, PDB, and NetworkPolicy on `k3d-charts-test`, `--wait --timeout 90s`
- [x] Production heartbeat from in-cluster curl returned `{"ok":true}` with NetworkPolicy active using explicit K3D Pod CIDR ingress peer
- [x] Production pod logs inspected for all containers, no application errors, no non-normal events

## Notes
`Chart.lock` is intentionally not committed, following the repository workflow requested by the maintainer in this workstream, although MCP GR-062 still flags missing Chart.lock for dependency charts.
