### PR TITLE
fix(discount-bandit): preserve sqlite pvc and mysql overrides

### DIFF
--- a/charts/discount-bandit/templates/NOTES.txt
+++ b/charts/discount-bandit/templates/NOTES.txt
@@ -42,7 +42,7 @@ Health checks
 Database
 {{- if eq (include "discount-bandit.databaseMode" .) "mysql" }}
   The HelmForge MySQL subchart is enabled.
-  MySQL Service: {{ .Release.Name }}-mysql
+  MySQL Service: {{ include "discount-bandit.mysqlFullname" . }}
   Secret: {{ include "discount-bandit.databaseSecretName" . }}
 {{- else if eq (include "discount-bandit.databaseMode" .) "external" }}
   External database host: {{ include "discount-bandit.databaseHost" . }}:{{ include "discount-bandit.databasePort" . }}

--- a/charts/discount-bandit/templates/_helpers.tpl
+++ b/charts/discount-bandit/templates/_helpers.tpl
@@ -43,6 +43,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "discount-bandit.mysqlName" -}}
+{{- default "mysql" .Values.mysql.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "discount-bandit.mysqlFullname" -}}
+{{- if .Values.mysql.fullnameOverride -}}
+{{- .Values.mysql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "discount-bandit.mysqlName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "discount-bandit.databaseMode" -}}
 {{- $mode := .Values.database.mode | default "auto" -}}
 {{- if not (has $mode (list "auto" "mysql" "external" "sqlite")) -}}
@@ -90,7 +102,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "discount-bandit.databaseHost" -}}
 {{- $mode := include "discount-bandit.databaseMode" . -}}
-{{- if eq $mode "external" -}}{{ .Values.database.external.host }}{{- else -}}{{ printf "%s-mysql" .Release.Name }}{{- end -}}
+{{- if eq $mode "external" -}}{{ .Values.database.external.host }}{{- else -}}{{ include "discount-bandit.mysqlFullname" . }}{{- end -}}
 {{- end -}}
 
 {{- define "discount-bandit.databasePort" -}}
@@ -124,7 +136,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.mysql.auth.existingSecret -}}
 {{- .Values.mysql.auth.existingSecret -}}
 {{- else -}}
-{{- printf "%s-mysql-auth" .Release.Name -}}
+{{- printf "%s-auth" (include "discount-bandit.mysqlFullname" .) -}}
 {{- end -}}
 {{- else if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
@@ -150,7 +162,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.persistence.database.existingClaim -}}
 {{- .Values.persistence.database.existingClaim -}}
 {{- else -}}
-{{- printf "%s-database" (include "discount-bandit.fullname" .) -}}
+{{- printf "%s-data" (include "discount-bandit.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/discount-bandit/tests/deployment_test.yaml
+++ b/charts/discount-bandit/tests/deployment_test.yaml
@@ -74,6 +74,52 @@ tests:
                 name: discount-bandit-mysql
                 key: app-password
 
+  - it: should honor MySQL fullnameOverride
+    set:
+      mysql.fullnameOverride: platform-mysql
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: platform-mysql
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: platform-mysql
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: platform-mysql-auth
+                key: mysql-user-password
+
+  - it: should honor MySQL nameOverride
+    set:
+      mysql.nameOverride: mysql-primary
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_HOST
+            value: test-mysql-primary
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DB_HOST
+            value: test-mysql-primary
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-mysql-primary-auth
+                key: mysql-user-password
+
   - it: should use PVC for SQLite data when persistence enabled
     set:
       database.mode: sqlite
@@ -85,7 +131,7 @@ tests:
           content:
             name: database
             persistentVolumeClaim:
-              claimName: test-discount-bandit-database
+              claimName: test-discount-bandit-data
 
   - it: should use emptyDir when persistence disabled
     set:

--- a/charts/discount-bandit/tests/pvc_test.yaml
+++ b/charts/discount-bandit/tests/pvc_test.yaml
@@ -16,7 +16,7 @@ tests:
           of: PersistentVolumeClaim
       - equal:
           path: metadata.name
-          value: test-discount-bandit-database
+          value: test-discount-bandit-data
 
   - it: should not render when persistence disabled
     set:


### PR DESCRIPTION
Fixes post-merge review comments from #240.

## Changes
- Preserve the existing default SQLite PVC name as `<fullname>-data` for upgrade compatibility.
- Derive MySQL host and generated auth Secret names from the MySQL subchart `nameOverride` / `fullnameOverride` values.
- Update NOTES output and Helm unit tests for both compatibility paths.

## Validation
- `helm dependency build charts/discount-bandit`
- `helm dependency list charts/discount-bandit`
- `helm lint charts/discount-bandit`
- `helm lint --strict charts/discount-bandit`
- `helm template discount-bandit-test charts/discount-bandit`
- `helm template discount-bandit-test charts/discount-bandit -f charts/discount-bandit/ci/*.yaml` for all CI values files
- `helm unittest charts/discount-bandit` - 10 suites, 36 tests passed
- `ah lint charts/discount-bandit` - 0 package errors
- `helm template ... | kubeconform -strict -summary` for default and all CI values
- Kubescape NSA score: 73
- K3D `k3d-charts-test`: MySQL `fullnameOverride=platform-mysql`, `--wait --timeout 90s`, pods ready, logs/events inspected
- K3D `k3d-charts-test`: SQLite mode, `--wait --timeout 90s`, PVC `<fullname>-data` bound, pod ready, logs/events inspected

No `Chart.lock` or vendored `charts/` directory is committed.