### PR TITLE
fix(mongodb): fix mongodb url option for exporter pod

### DIFF
--- a/charts/mongodb/templates/_helpers.tpl
+++ b/charts/mongodb/templates/_helpers.tpl
@@ -207,6 +207,19 @@ mongosh --quiet --eval "db.adminCommand('ping')"
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+MongoDB exporter command.
+*/}}
+{{- define "mongodb.exporter.mongoUrl" -}}
+{{- if eq .Values.auth.enabled true -}}
+- "--mongodb.uri=mongodb://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@localhost:{{ .Values.port }}/admin"
+{{- else -}}
+- "--mongodb.uri=mongodb://localhost:{{ .Values.port }}/admin"
+{{- end -}}
+{{- end -}}
+
+
 {{/*
 Common mongod args.
 */}}
@@ -370,7 +383,7 @@ spec:
       image: "{{ .root.Values.metrics.image.repository }}:{{ .root.Values.metrics.image.tag }}"
       imagePullPolicy: {{ .root.Values.metrics.image.pullPolicy }}
       args:
-        - "--mongodb.uri=mongodb://$(MONGO_INITDB_ROOT_USERNAME):$(MONGO_INITDB_ROOT_PASSWORD)@localhost:{{ .root.Values.port }}/admin"
+        {{ include "mongodb.exporter.mongoUrl" .root  }}
         - "--web.listen-address=:{{ .root.Values.metrics.port }}"
         - "--collect-all"
         {{- with .root.Values.metrics.extraArgs }}


### PR DESCRIPTION
## Summary

When mongodb is deployed with auth disabled and with metrics are enabled, exporter still uses MONGO_INITDB_ROOT_USERNAME/MONGO_INITDB_ROOT_PASSWORD in mongoUrl parameter. Which causes exporter to fail at runtime.

-

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [ ] My commit message and PR title follow Conventional Commits
- [ ] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [ ] I updated `values.schema.json` for any values changes
- [ ] I updated chart docs for behavior or default changes

## Upstream Verification

- [ ] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [ ] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [ ] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [ ] `helm lint charts/<chart-name> --strict` passed
- [ ] `helm unittest charts/<chart-name>` passed
- [ ] All relevant `ci/*.yaml` scenarios rendered successfully
- [ ] I validated this change on a local `k3d` cluster when required
- [ ] I validated the default install
- [ ] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

-

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.
