### PR TITLE
fix(postgresql): allow disabling default initdb bootstrap

### DIFF
--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -272,6 +272,7 @@ the referenced `SecretStore` or `ClusterSecretStore` must already exist.
 
 - use `initdb.scripts` for deterministic first-boot SQL or shell customization
 - use `initdb.existingConfigMap` when scripts are already managed elsewhere
+- set `initdb.runDefaultScript=false` when you want only custom or externally managed first-boot scripts
 - remember that `docker-entrypoint-initdb.d` runs only during first initialization of a fresh data directory
 - the chart keeps internal maintenance traffic on PostgreSQL's standard `postgres` database
 - when an older reused PVC is missing `postgres`, the primary pod repairs that database during startup before probes and internal clients depend on it
@@ -336,6 +337,7 @@ Operational documents:
 | `standalone.resourcesPreset` | Resource preset for standalone mode | `none` |
 | `replication.primary.resourcesPreset` | Resource preset for the primary pod | `none` |
 | `replication.readReplicas.resourcesPreset` | Resource preset for replica pods | `none` |
+| `initdb.runDefaultScript` | Run the chart-generated first-boot app/replication user script | `true` |
 | `initdb.existingConfigMap` | External ConfigMap for extra init scripts | `""` |
 | `tls.enabled` | Enable PostgreSQL TLS | `false` |
 | `tls.existingSecret` | Existing secret with TLS material | `""` |
@@ -387,6 +389,7 @@ The `ci/` scenarios validate the main chart behaviors:
 - `standalone.yaml`
 - `replication.yaml`
 - `initdb.yaml`
+- `initdb-custom-only.yaml`
 - `existing-secret.yaml`
 - `external-secrets.yaml`
 - `metrics.yaml`

--- a/charts/postgresql/ci/initdb-custom-only.yaml
+++ b/charts/postgresql/ci/initdb-custom-only.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 initdb:
   runDefaultScript: false
   scripts:

--- a/charts/postgresql/ci/initdb-custom-only.yaml
+++ b/charts/postgresql/ci/initdb-custom-only.yaml
@@ -1,0 +1,9 @@
+initdb:
+  runDefaultScript: false
+  scripts:
+    10-custom.sql: |
+      CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+standalone:
+  persistence:
+    enabled: false

--- a/charts/postgresql/docs/standalone.md
+++ b/charts/postgresql/docs/standalone.md
@@ -15,7 +15,7 @@ Typical use cases:
 - one PostgreSQL pod
 - one persistent volume when persistence is enabled
 - one client Service
-- bootstrap of the app database and app user on first initialization
+- bootstrap of the app database and app user on first initialization, unless `initdb.runDefaultScript=false`
 - optional custom init scripts
 - optional `postgres_exporter`
 

--- a/charts/postgresql/templates/NOTES.txt
+++ b/charts/postgresql/templates/NOTES.txt
@@ -10,7 +10,11 @@ Primary Service:    {{ include "postgresql.primaryServiceName" . }}
 Port:               {{ .Values.service.port }}
 Maintenance DB:     postgres
 Application DB:     {{ .Values.auth.database }}
+{{- if .Values.initdb.runDefaultScript }}
 Application User:   {{ .Values.auth.username }}
+{{- else }}
+Application User:   not created by chart (initdb.runDefaultScript=false)
+{{- end }}
 {{- if eq .Values.architecture "replication" }}
 Replicas Service:   {{ include "postgresql.replicasServiceName" . }}
 Replica Count:      {{ .Values.replication.readReplicas.replicaCount }}
@@ -27,9 +31,13 @@ Connect with psql to the default PostgreSQL maintenance database:
   PGPASSWORD="$(kubectl get secret {{ include "postgresql.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretPostgresPasswordKey }}}" | base64 -d)" \
   psql -h 127.0.0.1 -p 5432 -U postgres -d postgres
 
+{{ if .Values.initdb.runDefaultScript }}
 Connect to the application database:
   PGPASSWORD="$(kubectl get secret {{ include "postgresql.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretUserPasswordKey }}}" | base64 -d)" \
   psql -h 127.0.0.1 -p 5432 -U {{ .Values.auth.username }} -d {{ .Values.auth.database }}
+{{- else }}
+The chart-generated application user bootstrap is disabled. Connect with users created by your custom init scripts or external provisioning.
+{{- end }}
 
 {{- if eq .Values.architecture "replication" }}
 Read-only clients should use:
@@ -45,7 +53,11 @@ Writable clients should use:
 
 - The chart keeps internal probes, metrics, and backup workflows on the standard `postgres` database.
 - If a reused data directory is missing `postgres`, the primary pod repairs it automatically during startup before normal readiness checks rely on it.
+{{- if .Values.initdb.runDefaultScript }}
 - The application bootstrap database remains `{{ .Values.auth.database }}` and is created only on first initialization of a fresh data directory.
+{{- else }}
+- The chart-generated application and replication user bootstrap script is disabled; only custom or externally managed init scripts are mounted.
+{{- end }}
 - `docker-entrypoint-initdb.d` scripts do not run again on reused PVCs.
 {{- if .Values.tls.enabled }}
 - TLS is enabled for server and internal clients with sslmode `{{ .Values.tls.sslMode }}`.

--- a/charts/postgresql/templates/NOTES.txt
+++ b/charts/postgresql/templates/NOTES.txt
@@ -9,10 +9,11 @@ Client Service:     {{ include "postgresql.clientServiceName" . }}
 Primary Service:    {{ include "postgresql.primaryServiceName" . }}
 Port:               {{ .Values.service.port }}
 Maintenance DB:     postgres
-Application DB:     {{ .Values.auth.database }}
 {{- if .Values.initdb.runDefaultScript }}
+Application DB:     {{ .Values.auth.database }}
 Application User:   {{ .Values.auth.username }}
 {{- else }}
+Application DB:     not created by chart (auth.database={{ .Values.auth.database }})
 Application User:   not created by chart (initdb.runDefaultScript=false)
 {{- end }}
 {{- if eq .Values.architecture "replication" }}
@@ -132,7 +133,7 @@ Reference production example:
 2. List the chart resources:
    kubectl get all -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
-3. Confirm the `postgres` and application databases exist:
+3. List initialized databases:
    kubectl exec -n {{ .Release.Namespace }} {{ include "postgresql.primaryStatefulSetName" . }}-0 -- \
      psql -U postgres -d postgres -tAc "SELECT datname FROM pg_database ORDER BY datname;"
 

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -74,6 +74,14 @@ app.kubernetes.io/role: {{ .role }}
 {{- if or (include "postgresql.generatedInitdbEnabled" .) .Values.initdb.existingConfigMap -}}true{{- end -}}
 {{- end -}}
 
+{{- define "postgresql.postgresDbEnv" -}}
+{{- if .Values.initdb.runDefaultScript -}}
+{{- .Values.auth.database -}}
+{{- else -}}
+{{- include "postgresql.maintenanceDatabase" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "postgresql.tlsSecretName" -}}
 {{- if .Values.tls.enabled -}}
 {{- if .Values.tls.existingSecret -}}

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -66,6 +66,14 @@ app.kubernetes.io/role: {{ .role }}
 {{- printf "%s-initdb" (include "postgresql.fullname" .) -}}
 {{- end -}}
 
+{{- define "postgresql.generatedInitdbEnabled" -}}
+{{- if or .Values.initdb.runDefaultScript .Values.initdb.scripts -}}true{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.initdbVolumeEnabled" -}}
+{{- if or (include "postgresql.generatedInitdbEnabled" .) .Values.initdb.existingConfigMap -}}true{{- end -}}
+{{- end -}}
+
 {{- define "postgresql.tlsSecretName" -}}
 {{- if .Values.tls.enabled -}}
 {{- if .Values.tls.existingSecret -}}

--- a/charts/postgresql/templates/configmap.yaml
+++ b/charts/postgresql/templates/configmap.yaml
@@ -62,7 +62,8 @@ data:
     {{- end }}
     {{- with .Values.config.pgHba }}
     {{ . | nindent 4 }}
-    {{- end }}
+{{- end }}
+{{- if include "postgresql.generatedInitdbEnabled" . }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -71,6 +72,7 @@ metadata:
   labels:
     {{- include "postgresql.labels" . | nindent 4 }}
 data:
+  {{- if .Values.initdb.runDefaultScript }}
   01-init-users.sh: |
     #!/bin/bash
     set -euo pipefail
@@ -103,7 +105,9 @@ data:
       psql --username "${POSTGRES_USER}" --dbname "${APP_DATABASE}" \
         -c "GRANT ALL ON SCHEMA public TO \"${APP_USERNAME}\";"
     fi
+  {{- end }}
 {{- range $name, $content := .Values.initdb.scripts }}
   {{ $name }}: |
 {{ $content | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/postgresql/templates/statefulset-primary.yaml
+++ b/charts/postgresql/templates/statefulset-primary.yaml
@@ -137,8 +137,10 @@ spec:
               mountPath: /var/lib/postgresql/data
             - name: config
               mountPath: /etc/postgresql/generated
+            {{- if include "postgresql.initdbVolumeEnabled" . }}
             - name: initdb
               mountPath: /docker-entrypoint-initdb.d
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: {{ include "postgresql.tlsVolumeMountName" . }}
               mountPath: /tls
@@ -180,16 +182,20 @@ spec:
         - name: config
           configMap:
             name: {{ include "postgresql.configMapName" . }}
+        {{- if include "postgresql.initdbVolumeEnabled" . }}
         - name: initdb
           projected:
             defaultMode: 0755
             sources:
+              {{- if include "postgresql.generatedInitdbEnabled" . }}
               - configMap:
                   name: {{ include "postgresql.initdbConfigMapName" . }}
+              {{- end }}
               {{- if .Values.initdb.existingConfigMap }}
               - configMap:
                   name: {{ .Values.initdb.existingConfigMap }}
               {{- end }}
+        {{- end }}
         {{- include "postgresql.tlsVolume" . | nindent 8 }}
         {{- if not (ternary .Values.replication.primary.persistence.enabled .Values.standalone.persistence.enabled (eq .Values.architecture "replication")) }}
         - name: data

--- a/charts/postgresql/templates/statefulset-primary.yaml
+++ b/charts/postgresql/templates/statefulset-primary.yaml
@@ -47,7 +47,7 @@ spec:
             - name: POSTGRES_USER
               value: postgres
             - name: POSTGRES_DB
-              value: {{ .Values.auth.database | quote }}
+              value: {{ include "postgresql.postgresDbEnv" . | quote }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/postgresql/tests/configmap_test.yaml
+++ b/charts/postgresql/tests/configmap_test.yaml
@@ -14,6 +14,29 @@ tests:
           path: data["01-init-users.sh"]
           pattern: 'psql --username "\$\{POSTGRES_USER\}" --dbname postgres'
 
+  - it: should skip generated init script when disabled and no custom scripts are set
+    template: configmap.yaml
+    set:
+      initdb.runDefaultScript: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render only custom init scripts when default init script is disabled
+    template: configmap.yaml
+    documentIndex: 1
+    set:
+      initdb.runDefaultScript: false
+      initdb.scripts:
+        10-custom.sql: |
+          CREATE EXTENSION IF NOT EXISTS pgcrypto;
+    asserts:
+      - notExists:
+          path: data["01-init-users.sh"]
+      - matchRegex:
+          path: data["10-custom.sql"]
+          pattern: 'CREATE EXTENSION IF NOT EXISTS pgcrypto;'
+
   - it: should require SCRAM for local socket connections by default
     template: configmap.yaml
     documentIndex: 0

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -160,6 +160,31 @@ tests:
             name: PGDATA
             value: /var/lib/postgresql/data/pgdata
 
+  - it: should let the image create the app database when default init script is enabled
+    template: statefulset-primary.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DB
+            value: app
+
+  - it: should stop the image from creating the app database when default init script is disabled
+    template: statefulset-primary.yaml
+    set:
+      initdb.runDefaultScript: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_DB
+            value: postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: APP_DATABASE
+            value: app
+
   - it: should use default port 5432
     template: statefulset-primary.yaml
     asserts:

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -85,6 +85,72 @@ tests:
             name: data
             mountPath: /var/lib/postgresql/data
 
+  - it: should mount generated initdb volume by default
+    template: statefulset-primary.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: initdb
+            mountPath: /docker-entrypoint-initdb.d
+      - contains:
+          path: spec.template.spec.volumes[1].projected.sources
+          content:
+            configMap:
+              name: test-postgresql-initdb
+
+  - it: should not mount initdb volume when default init script is disabled without custom scripts
+    template: statefulset-primary.yaml
+    set:
+      initdb.runDefaultScript: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: initdb
+            mountPath: /docker-entrypoint-initdb.d
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: initdb
+
+  - it: should mount custom initdb scripts without generated default script
+    template: statefulset-primary.yaml
+    set:
+      initdb.runDefaultScript: false
+      initdb.scripts:
+        10-custom.sql: |
+          CREATE EXTENSION IF NOT EXISTS pgcrypto;
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: initdb
+            mountPath: /docker-entrypoint-initdb.d
+      - contains:
+          path: spec.template.spec.volumes[1].projected.sources
+          content:
+            configMap:
+              name: test-postgresql-initdb
+
+  - it: should mount only external initdb ConfigMap when default script is disabled
+    template: statefulset-primary.yaml
+    set:
+      initdb.runDefaultScript: false
+      initdb.existingConfigMap: external-initdb
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: initdb
+            mountPath: /docker-entrypoint-initdb.d
+      - equal:
+          path: spec.template.spec.volumes[1].projected.sources[0].configMap.name
+          value: external-initdb
+      - lengthEqual:
+          path: spec.template.spec.volumes[1].projected.sources
+          count: 1
+
   - it: should set PGDATA env var
     template: statefulset-primary.yaml
     asserts:

--- a/charts/postgresql/values.schema.json
+++ b/charts/postgresql/values.schema.json
@@ -451,6 +451,11 @@
       "description": "Database initialization configuration",
       "additionalProperties": false,
       "properties": {
+        "runDefaultScript": {
+          "type": "boolean",
+          "description": "Run the chart-generated first-boot script that creates the application database, application user, and replication user",
+          "default": true
+        },
         "scripts": {
           "type": "object",
           "description": "Additional init scripts written into docker-entrypoint-initdb.d",

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -194,6 +194,8 @@ externalSecrets:
 # =============================================================================
 
 initdb:
+  # -- Run the chart-generated first-boot script that creates the application database, application user, and replication user
+  runDefaultScript: true
   # -- Additional init scripts written into docker-entrypoint-initdb.d
   scripts: {}
     # 10-extra.sql: |


### PR DESCRIPTION
## Summary
- Fixes #95 by adding `initdb.runDefaultScript=true` by default.
- Allows users to disable only the chart-generated application and replication bootstrap while still using `initdb.scripts` or `initdb.existingConfigMap`.
- Stops the official postgres image from pre-creating `auth.database` when the default init script is disabled by setting `POSTGRES_DB=postgres` in that mode.
- Updates chart docs, schema, unit tests, and CI scenario coverage.

## Local validation
- `helm lint --strict charts/postgresql`: PASS
- `helm unittest charts/postgresql`: PASS, 11 suites and 92 tests
- `helm template postgresql-test charts/postgresql -f charts/postgresql/ci/initdb-custom-only.yaml`: PASS
- k3d local runtime validation on `k3d-helmforge-pg-259-review`: PASS for `ci/initdb-custom-only.yaml`, pod logs reviewed, `app_db_count=0`, `pgcrypto_in_postgres=1`, `restarts=0`

## Prior full local validation on this PR
- `helm dependency build charts/postgresql`: PASS
- `helm lint charts/postgresql`: PASS
- `helm template` default and all `charts/postgresql/ci/*.yaml` scenarios: PASS
- `ah lint -p charts/postgresql`: PASS
- strict `kubeconform` for default and all CI scenarios with CRD catalog: PASS
- `kubescape scan framework MITRE,NSA,SOC2 charts/postgresql`: PASS, score `86.86869`

## Runtime log notes
- Official postgres image emits an initdb trust-auth warning during first cluster creation; runtime `pg_hba.conf` is chart-managed after startup.
- `kubectl exec` previously emitted a websocket `Unknown stream id` client warning after successful output; pod logs were reviewed and PostgreSQL reached ready state.

## Companion docs
- Site docs PR: helmforgedev/site#208