### PR TITLE
chore(drupal): update image to 11.3.9

### DIFF
--- a/charts/drupal/Chart.lock
+++ b/charts/drupal/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:43ea75f43a616dbac5ea9837826a9cb806646d5c2c3c7029008fa5b3a0ad22c3
-generated: "2026-04-23T16:42:51.7134208-03:00"

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.0
-appVersion: "11.3.8"
+appVersion: "11.3.9"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +24,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add dual-stack ipFamilyPolicy/ipFamilies support (#129)"
+    - kind: changed
+      description: "upgrade to 11.3.9 (#244)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official image explicitly to `11.3.8-php8.5-apache-bookworm`, which includes PHP 8.5 and the Drupal-required database extensions.
+- HelmForge pins the Docker Official image explicitly to `11.3.9-php8.5-apache-bookworm`, which includes PHP 8.5 and the Drupal-required database extensions.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.3.8-php8.5-apache-bookworm`, which matches current Drupal 11.3 support for PHP 8.5 and keeps the Debian base explicit
+- **Pinned production image** — uses `drupal:11.3.9-php8.5-apache-bookworm`, which matches current Drupal 11.3 support for PHP 8.5 and keeps the Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -137,7 +137,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.3.8-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.3.9-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml
@@ -51,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.3.8-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.3.9-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -61,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.3.8-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.3.9-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Drupal Helm Chart
 # =============================================================================
@@ -26,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.3.8-php8.5-apache-bookworm"
+  tag: "11.3.9-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #244

## Summary
- Update Drupal `appVersion` and Docker Official Image tag to `11.3.9-php8.5-apache-bookworm`.
- Update chart README and deployment unittest expectations for the new image tag.
- Remove generated `Chart.lock` per HelmForge GR-062.

## Upstream evidence
- `docker manifest inspect docker.io/library/drupal:11.3.9-php8.5-apache-bookworm` passed.
- `docker pull docker.io/library/drupal:11.3.9-php8.5-apache-bookworm` passed with digest `sha256:2e3bef45cef5eeb9e55d01157a0dcfe78759d77e4e320f13c2460eccc1e99f1e`.
- Drupal.org lists `11.3.9` as a production-ready patch release.
- `docker-library/drupal` metadata lists `11.3.9` with PHP 8.5 and `apache-bookworm`.

## Validation
- `helm dependency build charts/drupal`
- `helm dependency list charts/drupal`
- `helm lint charts/drupal`
- `helm lint --strict charts/drupal`
- `helm unittest charts/drupal`
- `helm template` default plus all `charts/drupal/ci/*.yaml` scenarios
- `kubeconform -strict -summary` for default plus all CI scenarios
- `ah lint charts/drupal`
- `npx -y markdownlint-cli2 charts/drupal/README.md`
- `git diff --check`
- K3D smoke install on `k3d-charts-test`: pods Ready, image verified, Drupal version `11.3.9` verified, HTTP check passed, log scan clean, release/namespace cleaned up