### PR TITLE
chore(strava-statistics): update image to v4.7.10

### DIFF
--- a/charts/strava-statistics/.helmignore
+++ b/charts/strava-statistics/.helmignore
@@ -20,11 +20,15 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-# JS/Ruby/Python package lock files
+
+# Lock files
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
 Gemfile.lock
+Pipfile.lock
+poetry.lock
+
 # Logs
 *.log
 

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: strava-statistics
 description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
 type: application
 version: 1.1.8
-appVersion: "4.7.8"
+appVersion: "4.7.10"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade image to v4.7.8 (#202)"
+      description: "upgrade image to v4.7.10 (#256)"
     - kind: changed
       description: "add Phase 3-4 operational intelligence and cleanup (#142)"
   artifacthub.io/maintainers: |

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml
@@ -23,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/robiningelbrecht/strava-statistics:v4.7.8"
+          value: "docker.io/robiningelbrecht/strava-statistics:v4.7.10"
 
   - it: should allow custom image tag
     set:

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  ""
+                                                                    "default":  "v4.7.10"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Statistics for Strava container image
   repository: docker.io/robiningelbrecht/strava-statistics
   # -- Image tag
-  tag: "v4.7.8"
+  tag: "v4.7.10"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -88,6 +88,14 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- IP family policy. One of: SingleStack | PreferDualStack | RequireDualStack. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilyPolicy: PreferDualStack
+  # -- Ordered list of IP families for the Service. Each entry: IPv4 | IPv6. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
 
 # =============================================================================
 # Ingress


### PR DESCRIPTION
Closes #256

## Summary
- Update Statistics for Strava to `v4.7.10` and set chart `appVersion` to `4.7.10`.
- Sync the deployment unittest and values schema default with the new image tag.
- Refresh `.helmignore` and document service dual-stack stubs required by HelmForge guardrails.

## Upstream evidence
- `docker manifest inspect docker.io/robiningelbrecht/strava-statistics:4.7.10` and `docker pull ...:4.7.10` were checked and the tag does not exist.
- `docker manifest inspect docker.io/robiningelbrecht/strava-statistics:v4.7.10` passed.
- `docker pull docker.io/robiningelbrecht/strava-statistics:v4.7.10` passed with digest `sha256:455ee82a93347c8e2c5fd2ddeb3df9e954fa3c45867845a13b6986e91e85dd57`.
- Upstream release notes for `v4.7.10` were reviewed.

## Validation
- `helm dependency build charts/strava-statistics`
- `helm lint charts/strava-statistics`
- `helm lint --strict charts/strava-statistics`
- `helm unittest charts/strava-statistics`
- `helm template` default plus all `charts/strava-statistics/ci/*.yaml` scenarios
- `kubeconform -strict -ignore-missing-schemas -summary` for default plus all CI scenarios
- `ah lint charts/strava-statistics`
- `npx -y markdownlint-cli2 charts/strava-statistics/README.md`
- Kubescape `MITRE,NSA,SOC2` score: `75.757576`
- K3D smoke install on `k3d-charts-test`: pods Ready, image verified, HTTP 200, log scan clean, cleanup completed