### PR TITLE
chore(redis): update image to 8.6.3

### DIFF
--- a/charts/redis/.helmignore
+++ b/charts/redis/.helmignore
@@ -21,7 +21,12 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
+
+# Lock files
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock
 
 # Logs
 *.log

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -4,7 +4,7 @@ name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 1.6.14
-appVersion: "8.6.2"
+appVersion: "8.6.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,6 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 8.6.3 (#255)"
     - kind: changed
       description: "refresh design architecture guide (#219)"
   artifacthub.io/maintainers: |

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -215,7 +215,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Redis topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Redis image repository | `docker.io/library/redis` |
-| `image.tag` | Redis image tag | `8.6.2` |
+| `image.tag` | Redis image tag | `8.6.3` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Redis password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Redis password | `""` |

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/redis:8.6.2"
+          value: "docker.io/library/redis:8.6.3"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -28,7 +28,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/redis
-  tag: "8.6.2"
+  tag: "8.6.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Closes #255

## Summary
- Update Redis `appVersion` and default image tag to `8.6.3`.
- Refresh README values and unit test image expectation.
- Replace the forbidden bare `*.lock` chart ignore pattern with explicit lock-file names for GR-062.

## Upstream Evidence
- `docker manifest inspect docker.io/library/redis:8.6.3` passed.
- `docker pull docker.io/library/redis:8.6.3` passed with digest `sha256:0c341492924cad6f5483f9133e43bd6c51ecdecbcadfac5b51657393b6a7936c`.
- Redis 8.6.3 release/advisory evidence reviewed; 8.6.3 is the published fixed OSS/CE release.

## Local Validation Evidence
- `helm dependency build charts/redis`
- `helm dependency list charts/redis`
- `helm lint charts/redis`
- `helm lint --strict charts/redis`
- `helm unittest charts/redis` (5 suites, 26 tests)
- `helm template redis-test charts/redis | kubeconform -strict -ignore-missing-schemas -summary` (5 valid)
- CI values rendered through strict kubeconform: `cluster`, `dual-stack`, `existing-secret`, `external-secrets`, `metrics`, `replication`, `sentinel`, `standalone`
- `ah lint charts/redis`
- `npx -y markdownlint-cli2 charts/redis/README.md`
- Kubescape MITRE/NSA/SOC2 score: `83.33`
- K3D runtime on `k3d-charts-test`: install with `standalone.persistence.enabled=false`, pod ready, image `docker.io/library/redis:8.6.3`, `redis-cli PING` returned `PONG`, events normal, logs had no error/exception/fatal/panic
- `git diff --check`

## Site Sync
- Site docs updated in companion PR: helmforgedev/site#212
- `npm run format:check -- src/pages/docs/charts/redis.mdx`
- `npm run build`