### PR TITLE
chore(n8n): update image to 2.20.6

### DIFF
--- a/charts/n8n/.helmignore
+++ b/charts/n8n/.helmignore
@@ -10,7 +10,6 @@ Thumbs.db
 
 # Helm
 .helmignore
-Chart.lock
 
 # Editors / IDE
 .vscode/
@@ -22,6 +21,8 @@ Chart.lock
 *.rej
 *.swp
 *.tmp
+
+# Lock files
 package-lock.json
 yarn.lock
 pnpm-lock.yaml

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.5.6
-appVersion: "2.19.2"
+appVersion: "2.20.6"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,6 +22,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 2.20.6 (#254)"
     - kind: changed
       description: "upgrade to 2.19.2 (#224)"
   artifacthub.io/maintainers: |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -139,7 +139,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.19.2` | n8n container image tag |
+| `image.tag` | `2.20.6` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -170,12 +170,11 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.19.2` is an upstream bugfix release. It fixes execution context
-persistence before database writes, global admin favorite listing, peer project
-discovery in share dropdowns, and editor focus panel clipping. Back up the
-database and keep the encryption key stable before upgrading live deployments.
-When using the bundled PostgreSQL subchart on a fresh data directory, the chart
-bootstraps the `uuid-ossp` extension before n8n migrations run.
+n8n `2.20.6` is an upstream stable bugfix release. Review the upstream release
+notes before upgrading, back up the database, and keep the encryption key
+stable before upgrading live deployments. When using the bundled PostgreSQL
+subchart on a fresh data directory, the chart bootstraps the `uuid-ossp`
+extension before n8n migrations run.
 
 Self-hosted n8n `2.x` starts an internal JavaScript task runner by default. The
 base `n8nio/n8n` image may also log a Python runner warning when Python is not

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.19.2"
+          value: "docker.io/n8nio/n8n:2.20.6"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.19.2"
+  tag: "2.20.6"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #254

## Summary
- Update n8n `appVersion` and default image tag to `2.20.6`.
- Refresh README and unittest image expectation.
- Remove the stale `Chart.lock` ignore entry from the n8n chart `.helmignore` for GR-062 compliance.

## Upstream Evidence
- `docker manifest inspect docker.io/n8nio/n8n:2.20.6` passed.
- `docker pull docker.io/n8nio/n8n:2.20.6` passed with digest `sha256:d8b7ace22609c8297f02b2103543b2babdfa3880d5bcfb14e4e0d9d8ec11671c`.
- n8n release notes reviewed; docs list `2.20.6` as the current stable release, and GitHub releases list `2.20.6` dated 2026-05-08 with bug fixes.

## Local Validation Evidence
- `helm dependency build charts/n8n`
- `helm dependency list charts/n8n`
- `helm lint charts/n8n`
- `helm lint --strict charts/n8n`
- `helm unittest charts/n8n` (8 suites, 50 tests)
- `helm template n8n-test charts/n8n | kubeconform -strict -ignore-missing-schemas -summary` (4 valid)
- CI values rendered through strict kubeconform: `backup-values`, `default-values`, `dual-stack`, `external-db-values`, `external-secrets`, `gateway-api`, `ingress-values`, `mysql-values`, `postgresql-values`, `queue-values`
- `ah lint charts/n8n`
- `npx -y markdownlint-cli2 charts/n8n/README.md`
- Kubescape MITRE/NSA/SOC2 score: `83.50`
- K3D runtime on `k3d-charts-test`: install with `persistence.enabled=false`, pod ready, image `docker.io/n8nio/n8n:2.20.6`, `/healthz` returned `{"status":"ok"}`, events normal, n8n logs had no error/exception/fatal/panic
- `git diff --check`

## Site Sync
- Site docs updated in companion PR: helmforgedev/site#213
- `npm run lint`
- `npm run format:check -- src/pages/docs/charts/n8n.mdx`
- `npm run build`