### PR TITLE
chore(mongodb): update image to 8.3.1

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -4,7 +4,7 @@ name: mongodb
 description: MongoDB Helm Chart - standalone, replica set, or sharded cluster using the official MongoDB image
 type: application
 version: 1.7.11
-appVersion: "8.2.7"
+appVersion: "8.3.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,6 +22,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 8.3.1 (#253)"
     - kind: fixed
       description: "fix mongodb url option for exporter pod (#257)"
   artifacthub.io/maintainers: |

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -124,7 +124,7 @@ sharded:
 |-----------|-------------|---------|
 | `architecture` | `standalone`, `replicaset`, or `sharded` | `standalone` |
 | `image.repository` | MongoDB image | `mongo` |
-| `image.tag` | Image tag | `8.2.6` |
+| `image.tag` | Image tag | `8.3.1` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -241,6 +241,16 @@ See the [`examples/`](examples/) directory:
 - [`docs/replicaset.md`](docs/replicaset.md) — when to use replica set topology and what it requires operationally
 - [`docs/sharded.md`](docs/sharded.md) — when to use sharding, mongos, config servers, and multiple shards
 - [`docs/backup-restore.md`](docs/backup-restore.md) — S3 backup strategy and restore guidance
+
+## Upgrade Notes
+
+MongoDB `8.3.1` is an upstream minor release update from `8.2.7`.
+Review the MongoDB 8.3 release notes before upgrading production clusters,
+take a backup, and verify the data files are compatible with the target
+`mongod` version before reusing existing PVCs. Keep replica set keyFiles and
+root credentials stable across `helm upgrade`; those values are initialized by
+MongoDB and should be rotated with MongoDB administrative commands instead of
+changing chart values.
 
 ## Connection Strings
 

--- a/charts/mongodb/docs/replicaset.md
+++ b/charts/mongodb/docs/replicaset.md
@@ -34,7 +34,10 @@ Common cases:
 
 ## Operational guidance
 
-`replicaset` is usually the right default for production MongoDB when you need HA but do not need sharding. This chart bootstraps the replica set automatically, but the operational contract remains MongoDB's standard behavior: one primary, secondaries replicating from it, and elections on failure.
+`replicaset` is usually the right default for production MongoDB when you need HA
+but do not need sharding. This chart bootstraps the replica set automatically,
+but the operational contract remains MongoDB's standard behavior: one primary,
+secondaries replicating from it, and elections on failure.
 
 ## Common risks
 

--- a/charts/mongodb/docs/sharded.md
+++ b/charts/mongodb/docs/sharded.md
@@ -34,7 +34,10 @@ Common cases:
 
 ## Operational guidance
 
-`sharded` is the most capable and the most operationally demanding architecture in this chart. It should be chosen because the workload needs sharding, not because sharding sounds more robust. The right question is whether the workload truly needs data distribution, not only failover.
+`sharded` is the most capable and the most operationally demanding architecture
+in this chart. It should be chosen because the workload needs sharding, not
+because sharding sounds more robust. The right question is whether the workload
+truly needs data distribution, not only failover.
 
 ## Common risks
 

--- a/charts/mongodb/docs/standalone.md
+++ b/charts/mongodb/docs/standalone.md
@@ -35,7 +35,9 @@ Common cases:
 
 ## Operational guidance
 
-`standalone` is the simplest mode in this chart. It is appropriate when simplicity is more important than high availability. If the workload becomes operationally important, the next step is usually `replicaset`, not `sharded`.
+`standalone` is the simplest mode in this chart. It is appropriate when
+simplicity is more important than high availability. If the workload becomes
+operationally important, the next step is usually `replicaset`, not `sharded`.
 
 ## Common risks
 

--- a/charts/mongodb/examples/replicaset-production.yaml
+++ b/charts/mongodb/examples/replicaset-production.yaml
@@ -5,7 +5,7 @@
 architecture: replicaset
 
 image:
-  tag: "8.2.6"
+  tag: "8.3.1"
 
 auth:
   enabled: true

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mongo:8.2.7"
+          value: "docker.io/library/mongo:8.3.1"
 
   - it: should have 1 replica in standalone mode
     template: statefulset.yaml

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -39,7 +39,7 @@
         "tag": {
           "type": "string",
           "description": "MongoDB image tag",
-          "default": "8.2.6"
+          "default": "8.3.1"
         },
         "pullPolicy": {
           "type": "string",
@@ -650,7 +650,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "8.2.7"
+                  "default": "8.3.1"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/mongo
-  tag: "8.2.7"
+  tag: "8.3.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -295,7 +295,7 @@ backup:
       pullPolicy: IfNotPresent
     mongodb:
       repository: docker.io/library/mongo
-      tag: "8.2.7"
+      tag: "8.3.1"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com
@@ -377,4 +377,3 @@ externalSecrets:
   #     remoteRef:
   #       key: mongodb/credentials
   #       property: root-password
-


### PR DESCRIPTION
## Summary

- Update MongoDB image/appVersion from `8.2.7` to `8.3.1`.
- Keep the backup `mongodump` image tag aligned to the primary MongoDB image.
- Sync chart schema, README, examples, tests, chart docs, and site docs.

Closes #253

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [x] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

- [x] I updated the corresponding page in `site/` repository: helmforgedev/site#214
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/mongodb --strict` passed
- [x] `helm unittest charts/mongodb` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO

## Local Validation Evidence

- [x] `helm dependency build charts/mongodb`
- [x] `helm lint charts/mongodb`
- [x] `helm lint --strict charts/mongodb`
- [x] `helm unittest charts/mongodb` (4 suites, 23 tests)
- [x] default render and all 8 CI values rendered and passed strict kubeconform
- [x] `ah lint charts/mongodb` (65 packages, 0 errors)
- [x] `npx -y markdownlint-cli2 charts/mongodb/README.md charts/mongodb/docs/*.md`
- [x] Kubescape MITRE/NSA/SOC2 scan completed: overall compliance score 76 / JSON complianceScore 75.76
- [x] K3D default smoke: StatefulSet rollout complete, image `docker.io/library/mongo:8.3.1`, authenticated `ping=1`, logs clean
- [x] K3D backup validation against local MinIO: manual CronJob execution, `backupcheck.items` dumped, archive uploaded/downloaded, restored into disposable MongoDB, restored document verified, logs clean
- [x] Site validation: `npm run lint`, `npm run format:check -- src/pages/docs/charts/mongodb.mdx`, `npm run build`, and local internal link check over `dist/**/*.html`

## Upstream Evidence

- `docker manifest inspect docker.io/library/mongo:8.3.1` passed.
- `docker pull docker.io/library/mongo:8.3.1` passed with digest `sha256:707dc009433c311caa978246b1792fca4358882fafe310e6d540eb60017604ec`.
- MongoDB 8.3 release notes reviewed; MongoDB 8.3.1 patch release dated May 4, 2026.
- Docker Hub official `mongo` tag availability reviewed.

## Notes

- `Chart.yaml.version` was intentionally left unchanged because chart versioning is CI-managed.
