### PR TITLE
chore(minecraft): update image to 2026.5.2

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.4.9
-appVersion: "2026.4.2"
+appVersion: "2026.5.2"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -25,6 +25,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 2026.5.2 (#252)"
     - kind: changed
       description: "upgrade to 2026.4.2 (#180)"
   artifacthub.io/maintainers: |

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -225,7 +225,7 @@ mods:
 |-----|---------|-------------|
 | `metrics.enabled` | `false` | Enable mc-monitor sidecar |
 | `metrics.image.repository` | `itzg/mc-monitor` | mc-monitor image |
-| `metrics.image.tag` | `latest` | mc-monitor tag |
+| `metrics.image.tag` | `0.16.1` | mc-monitor tag |
 | `metrics.port` | `8080` | Metrics port |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor |
 | `metrics.serviceMonitor.interval` | `30s` | Scrape interval |
@@ -245,6 +245,13 @@ mods:
 | `backup.s3.existingSecret` | `""` | Existing secret for S3 credentials |
 | `backup.s3.accessKey` | `""` | Inline access key |
 | `backup.s3.secretKey` | `""` | Inline secret key |
+
+## Upgrade Notes
+
+`docker.io/itzg/minecraft-server:2026.5.2` is an upstream image update from
+`2026.4.2`. Review the upstream release notes before upgrading production
+servers, take a world backup, and verify plugins, mods, datapacks, and pinned
+`server.version` values in a staging environment before reusing existing PVCs.
 
 ### Mods & Plugins
 

--- a/charts/minecraft/docs/backup.md
+++ b/charts/minecraft/docs/backup.md
@@ -14,7 +14,7 @@ Enable scheduled backups of your Minecraft server data to S3-compatible object s
 
 ## How It Works
 
-```
+```text
 CronJob triggers at schedule
   │
   ├─ Init: pre-backup
@@ -96,24 +96,50 @@ Customize exclusions with `backup.excludes`.
 Restore is a manual operational task:
 
 1. **Scale down the server**
+
    ```bash
    kubectl scale deployment <release>-minecraft --replicas=0
    ```
 
 2. **Download the backup**
+
    ```bash
    mc cp backup/<bucket>/<prefix>/minecraft-<timestamp>.tar.gz ./backup.tar.gz
    ```
 
 3. **Restore to the PVC** (via a temporary pod or `kubectl cp`)
+
    ```bash
+   RESTORE_POD="$(cat <<'JSON'
+   {
+     "spec": {
+       "containers": [
+         {
+           "name": "restore",
+           "image": "alpine:3",
+           "command": ["sh"],
+           "volumeMounts": [{"name": "data", "mountPath": "/data"}]
+         }
+       ],
+       "volumes": [
+         {
+           "name": "data",
+           "persistentVolumeClaim": {"claimName": "<release>-minecraft"}
+         }
+       ]
+     }
+   }
+   JSON
+   )"
+
    kubectl run restore --rm -it --restart=Never \
      --image=alpine:3 \
-     --overrides='{"spec":{"containers":[{"name":"restore","image":"alpine:3","command":["sh"],"volumeMounts":[{"name":"data","mountPath":"/data"}]}],"volumes":[{"name":"data","persistentVolumeClaim":{"claimName":"<release>-minecraft"}}]}}' \
+     --overrides="$RESTORE_POD" \
      -- sh -c "cd /data && rm -rf * && tar xzf /dev/stdin" < backup.tar.gz
    ```
 
 4. **Scale up the server**
+
    ```bash
    kubectl scale deployment <release>-minecraft --replicas=1
    ```

--- a/charts/minecraft/docs/crossplay.md
+++ b/charts/minecraft/docs/crossplay.md
@@ -13,14 +13,15 @@ Allow Bedrock Edition clients (mobile, console, Windows 10/11) to connect to a J
 
 ## How It Works
 
-```
+```text
 Java Client (TCP 25565) ──────────────────┐
                                           ├──> Paper Server
 Bedrock Client (UDP 19132) ──> GeyserMC ──┘
                                (plugin)
 ```
 
-GeyserMC runs as a Paper/Spigot plugin and translates Bedrock protocol packets into Java protocol packets. Floodgate allows Bedrock players to authenticate with their Xbox Live account without needing a separate Java account.
+GeyserMC runs as a Paper/Spigot plugin and translates Bedrock protocol packets into Java protocol packets. Floodgate allows Bedrock
+players to authenticate with their Xbox Live account without needing a separate Java account.
 
 ## Requirements
 

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -66,6 +66,12 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].name
           value: archive
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].image
+          value: docker.io/itzg/minecraft-server:2026.5.2
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[1].image
+          value: docker.io/itzg/minecraft-server:2026.5.2
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -83,6 +89,9 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].name
           value: post-backup
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[1].image
+          value: docker.io/itzg/minecraft-server:2026.5.2
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -26,6 +26,12 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should use the default upstream image tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/itzg/minecraft-server:2026.5.2
+
   - it: should set EULA to true
     asserts:
       - contains:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -31,8 +31,8 @@
         },
         "tag": {
           "type": "string",
-          "description": "Container image tag (defaults to appVersion; use java21 for LTS)",
-          "default": ""
+          "description": "Container image tag",
+          "default": "2026.5.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -634,12 +634,12 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.4.2"
+              "default": "docker.io/itzg/minecraft-server:2026.5.2"
             },
             "uploader": {
               "type": "string",
               "description": "Image used for S3 upload (MinIO client)",
-              "default": "docker.io/minio/mc:RELEASE.2025-04-08T15-18-23Z"
+              "default": "docker.io/helmforge/mc:1.0.0"
             }
           }
         },

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.4.2"
+  tag: "2026.5.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -382,7 +382,7 @@ backup:
   images:
     # -- Image used for RCON commands and tar archiving
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.4.2
+    worker: docker.io/itzg/minecraft-server:2026.5.2
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
Closes #252

## Summary
- update Minecraft `appVersion`, default image tag, schema defaults, and backup worker image to `docker.io/itzg/minecraft-server:2026.5.2`
- add unit test assertions for the default server image and backup worker containers
- document upgrade notes and fix markdownlint issues in Minecraft chart docs

Docs PR: helmforgedev/site#215

## Upstream Evidence
- confirmed official upstream release/tag `2026.5.2` for `itzg/minecraft-server`
- `docker manifest inspect docker.io/itzg/minecraft-server:2026.5.2`
- `docker pull docker.io/itzg/minecraft-server:2026.5.2` digest `sha256:5476619d049f4c0e2764532b345da1db4c154b4294bcc16d9c3b8d5f4b0d9923`

## Validation
- `helm dependency build charts/minecraft`
- `helm lint charts/minecraft`
- `helm lint --strict charts/minecraft`
- `helm unittest charts/minecraft` — 7 suites, 71 tests
- `helm template minecraft-test charts/minecraft | kubeconform -strict -ignore-missing-schemas -summary` — 4 valid
- CI values rendered and passed kubeconform strict: `backup-values.yaml`, `dual-stack.yaml`, `external-secrets.yaml`, `forge-values.yaml`, `geyser-values.yaml`, `paper-values.yaml`, `vanilla-values.yaml`
- `ah lint charts/minecraft`
- `npx -y markdownlint-cli2 charts/minecraft/README.md charts/minecraft/docs/*.md`
- Kubescape `MITRE,NSA,SOC2` on `charts/minecraft` — complianceScore `81.818184`
- K3D `k3d-charts-test` default install smoke: rollout ready, image `2026.5.2`, RCON `list` OK, logs clean
- K3D backup flow against local MinIO: backup job complete, logs clean, archive uploaded, `helmforge-backup-marker.txt` content verified
- Site docs: `npm run lint`, `npm run format:check -- src/pages/docs/charts/minecraft.mdx`, `npm run build`, internal link traversal check
- MCP Helmforge compliance: 46/47 pass, 0 blockers, 1 expected CI-managed chart version warning