### PR TITLE
chore(elasticsearch): update image to 9.4.0

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.0.4
-appVersion: "9.3.4"
+appVersion: "9.4.0"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev
@@ -26,6 +26,8 @@ sources:
   - https://hub.docker.com/_/elasticsearch
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 9.4.0 (#245)"
     - kind: changed
       description: "upgrade to 9.3.4 (#227)"
   artifacthub.io/maintainers: |

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -160,7 +160,7 @@ dataTiers:
 | `clusterProfile` | Cluster preset: `dev`, `staging`, `production-ha` | `dev` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.3.4` |
+| `image.tag` | Image tag | `9.4.0` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -261,7 +261,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.3.4` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.0` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -287,6 +287,14 @@ dataTiers:
 | `nodeSelector` | Global node selector | `{}` |
 | `tolerations` | Global tolerations | `[]` |
 | `priorityClassName` | Priority class | `""` |
+
+## Upgrade Notes
+
+`docker.io/library/elasticsearch:9.4.0` is an upstream image update from
+`9.3.4`. Review the upstream Elasticsearch release notes before upgrading
+production clusters, take a snapshot backup, and verify Kibana compatibility,
+plugins, ILM policies, and index templates in a staging environment before
+reusing existing PVCs.
 
 ## Resources Generated
 

--- a/charts/elasticsearch/docs/profile-dev.md
+++ b/charts/elasticsearch/docs/profile-dev.md
@@ -36,7 +36,10 @@ Common cases:
 
 ## Operational guidance
 
-The dev profile is the simplest configuration. It is appropriate when data loss is acceptable and speed of startup is more important than durability. If the workload becomes operationally important, migrate to `staging` or `production-ha` and take an Elasticsearch snapshot before switching.
+The dev profile is the simplest configuration. It is appropriate when data loss
+is acceptable and speed of startup is more important than durability. If the
+workload becomes operationally important, migrate to `staging` or
+`production-ha` and take an Elasticsearch snapshot before switching.
 
 ## Common risks
 

--- a/charts/elasticsearch/docs/security.md
+++ b/charts/elasticsearch/docs/security.md
@@ -42,6 +42,7 @@ security:
 ```
 
 This creates:
+
 - `Issuer` — self-signed, in the same namespace
 - `Certificate` — multi-SAN covering all headless service DNS entries
 
@@ -105,7 +106,9 @@ curl --cacert /path/to/ca.crt \
 
 ## Internode transport TLS
 
-Transport TLS (port 9300) is always configured when `security.enabled=true`. Nodes authenticate each other using the same certificate that covers all headless service names. This prevents rogue nodes from joining the cluster.
+Transport TLS (port 9300) is always configured when `security.enabled=true`.
+Nodes authenticate each other using the same certificate that covers all
+headless service names. This prevents rogue nodes from joining the cluster.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/elasticsearch/templates/NOTES.txt
+++ b/charts/elasticsearch/templates/NOTES.txt
@@ -133,6 +133,15 @@ KIBANA
     Open: http://localhost:5601
 {{- end }}
 
+CONFIGURATION
+-------------------------------------------
+  View the applied values:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+
+  Upgrade the release with a values file:
+    helm upgrade {{ .Release.Name }} helmforge/elasticsearch \
+      -n {{ $namespace }} -f values.yaml
+
 GETTING STARTED
 -------------------------------------------
   1. Wait for cluster to form:
@@ -169,6 +178,14 @@ TROUBLESHOOTING
   Check full chart docs:
     https://helmforge.dev/docs/charts/elasticsearch
 
+RESOURCES
+-------------------------------------------
+  Chart source:
+    https://github.com/helmforgedev/charts/tree/main/charts/elasticsearch
+
+  Elasticsearch documentation:
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+
 {{- if eq $profile "dev" }}
 -------------------------------------------
 --  Running in DEV profile (single node, no HA)
@@ -176,3 +193,5 @@ TROUBLESHOOTING
     helm upgrade {{ .Release.Name }} helmforge/elasticsearch \
       --set clusterProfile=production-ha
 {{- end }}
+
+Happy Helmforging :)

--- a/charts/elasticsearch/templates/cronjob-backup.yaml
+++ b/charts/elasticsearch/templates/cronjob-backup.yaml
@@ -40,7 +40,7 @@ data:
     echo "=== Snapshot created: ${SNAPSHOT_NAME} ==="
     if [ "${RETENTION_DAYS}" -gt "0" ]; then
       echo "=== Pruning snapshots older than ${RETENTION_DAYS} days ==="
-      CUTOFF=$(date -d "${RETENTION_DAYS} days ago" +%s 2>/dev/null || date -v-${RETENTION_DAYS}d +%s)
+      CUTOFF=$(($(date -u +%s) - (RETENTION_DAYS * 86400)))
       SNAPSHOTS=$(curl -sf ${SSL_FLAGS} ${AUTH_FLAGS} "${BASE_URL}/_snapshot/${REPO_NAME}/_all" | grep -o '"snapshot":"[^"]*"' | sed 's/"snapshot":"//;s/"//')
       for s in ${SNAPSHOTS}; do
         SNAP_INFO=$(curl -sf ${SSL_FLAGS} ${AUTH_FLAGS} "${BASE_URL}/_snapshot/${REPO_NAME}/${s}")

--- a/charts/elasticsearch/templates/statefulset-coordinating.yaml
+++ b/charts/elasticsearch/templates/statefulset-coordinating.yaml
@@ -43,6 +43,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
       {{- end }}
       containers:
         - name: elasticsearch

--- a/charts/elasticsearch/templates/statefulset-data-hot.yaml
+++ b/charts/elasticsearch/templates/statefulset-data-hot.yaml
@@ -43,6 +43,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
       {{- end }}
       containers:
         - name: elasticsearch

--- a/charts/elasticsearch/templates/statefulset-data-warm.yaml
+++ b/charts/elasticsearch/templates/statefulset-data-warm.yaml
@@ -43,6 +43,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
       {{- end }}
       containers:
         - name: elasticsearch

--- a/charts/elasticsearch/templates/statefulset-data.yaml
+++ b/charts/elasticsearch/templates/statefulset-data.yaml
@@ -43,6 +43,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
       {{- end }}
       containers:
         - name: elasticsearch

--- a/charts/elasticsearch/templates/statefulset-master.yaml
+++ b/charts/elasticsearch/templates/statefulset-master.yaml
@@ -45,6 +45,7 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+            runAsNonRoot: false
         {{- end }}
         {{- if eq (include "elasticsearch.backupEnabled" .) "true" }}
         # Copies config dir to emptyDir and adds S3 credentials to ES keystore

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -51,6 +51,16 @@ tests:
             value: "http://RELEASE-NAME-elasticsearch.NAMESPACE.svc.cluster.local:9200"
         documentIndex: 0
 
+  - it: kibana uses the default image tag aligned with Elasticsearch
+    set:
+      kibana:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/library/kibana:9.4.0
+        documentIndex: 0
+
   - it: kibana with security uses https url
     set:
       kibana:

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -47,6 +47,29 @@ tests:
             name: node.roles
             value: "master,data,ingest"
 
+  - it: dev profile master should use the default upstream image tag
+    set:
+      clusterProfile: dev
+    template: templates/statefulset-master.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/library/elasticsearch:9.4.0
+
+  - it: sysctl init should explicitly opt out of pod-level non-root policy
+    set:
+      clusterProfile: dev
+      sysctlInit:
+        enabled: true
+    template: templates/statefulset-master.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: false
+
   - it: production-ha master should have node.roles=master (dedicated master)
     set:
       clusterProfile: production-ha

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -31,7 +31,8 @@
         },
         "tag": {
           "type": "string",
-          "description": "Elasticsearch image tag (must not be latest)"
+          "description": "Elasticsearch image tag (must not be latest)",
+          "default": "9.4.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -240,7 +241,8 @@
             },
             "tag": {
               "type": "string",
-              "description": "Kibana image tag. Keep aligned with Elasticsearch."
+              "description": "Kibana image tag. Keep aligned with Elasticsearch.",
+              "default": "9.4.0"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -48,7 +48,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.3.4"
+  tag: "9.4.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -321,7 +321,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.3.4"
+    tag: "9.4.0"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
## Summary

Closes #245.

- Update Elasticsearch and Kibana defaults from 9.3.4 to 9.4.0.
- Add upstream upgrade notes to chart README and site docs.
- Add image-tag unit assertions for Elasticsearch and Kibana.
- Fix the sysctl init container security context so it can run as root when the pod-level context enforces non-root containers.
- Fix backup retention cutoff calculation for BusyBox `date` in `curlimages/curl`.
- Improve `NOTES.txt` with configuration/resources sections and the standard HelmForge closing phrase.

Docs PR: helmforgedev/site#216

## Upstream Evidence

- Tavily search reviewed Elastic release notes, Docker Hub, and Elastic registry sources.
- Context7 checked Elasticsearch documentation for Docker/Kubernetes configuration expectations.
- `docker manifest inspect docker.io/library/elasticsearch:9.4.0`
- `docker pull docker.io/library/elasticsearch:9.4.0`
- Pulled digest: `sha256:8aad7ee59774021886ffd26ffbcee623aa13a377ea734f73454307df7e340705`

## Validation

- `helm dependency build charts/elasticsearch`
- `helm lint charts/elasticsearch`
- `helm lint --strict charts/elasticsearch`
- `helm unittest charts/elasticsearch` - 12 suites, 91 tests
- `helm template elasticsearch-test charts/elasticsearch | kubeconform -strict -ignore-missing-schemas -summary`
- CI values render + strict kubeconform: `dev`, `staging`, `production-ha`, `data-tiers`, `dual-stack`, `gateway-api`, `external-secrets`
- `ah lint charts/elasticsearch`
- `npx -y markdownlint-cli2 charts/elasticsearch/README.md charts/elasticsearch/docs/*.md`
- `git diff --check`
- Kubescape framework scan (`MITRE,NSA,SOC2`) compliance score: `89.393936`
- K3D smoke on `k3d-charts-test`: dev profile installed successfully, pod Ready, Elasticsearch 9.4.0 reported by the root endpoint, cluster health `green`, logs clean after filtering non-error template names.
- K3D backup validation with local MinIO: marker index created, manual backup job completed, snapshot metadata included `helmforge_backup_marker`, repository objects verified in the MinIO bucket, backup job logs clean.
- Site validation in helmforgedev/site#216: lint, format check, build, internal link/assets traversal.
- HelmForge MCP: `check_site_sync` PASS, chart CI evidence PASS, security evidence PASS, upstream update evidence PASS, consolidated compliance 46/47 PASS with only the expected CI-managed chart-version warning.