### PR TITLE
chore(envoy-gateway): update image to v1.7.3

### DIFF
--- a/charts/envoy-gateway/Chart.lock
+++ b/charts/envoy-gateway/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.6.9
-digest: sha256:07e0ff02211d6b0a794659081ac8e6403967942c477e57b64f64e7866f2dd7ba
-generated: "2026-04-29T09:22:32.5849021-03:00"

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 1.5.4
-appVersion: "v1.7.2"
+appVersion: "v1.7.3"
 kubeVersion: ">=1.24.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
@@ -29,6 +29,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to v1.7.3 (#246)"
     - kind: changed
       description: "upgrade to 1.7.2 (#193)"
   artifacthub.io/maintainers: |

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,6 +1,8 @@
 # Envoy Gateway
 
-A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/) v1.7.1 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages Envoy proxy pods automatically in response to Gateway API resources.
+A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
+v1.7.3 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
+Envoy proxy pods automatically in response to Gateway API resources.
 
 ## Installation
 
@@ -147,6 +149,8 @@ highAvailability:
 | `nameOverride` | `""` | Override chart name |
 | `fullnameOverride` | `""` | Override full name |
 | `imagePullSecrets` | `[]` | Image pull secrets |
+| `service.ipFamilyPolicy` | `null` | Dual-stack ipFamilyPolicy for controller Services |
+| `service.ipFamilies` | `[]` | Dual-stack ipFamilies for controller Services |
 
 ### Controller
 
@@ -154,7 +158,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.7.1` | Controller image tag |
+| `controller.image.tag` | `v1.7.3` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -172,7 +176,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.7.1` | Certgen image tag |
+| `certgen.image.tag` | `v1.7.3` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -184,6 +188,7 @@ highAvailability:
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `proxy.ipFamily` | `""` | EnvoyProxy IP family (`IPv4`, `IPv6`, or `DualStack`) |
 | `proxy.kind` | `Deployment` | Proxy workload kind: `Deployment` or `DaemonSet` |
 | `proxy.replicaCount` | `1` | Number of proxy replicas (Deployment mode only, overridden by profile) |
 | `proxy.image.repository` | `docker.io/envoyproxy/envoy` | Proxy image repository |
@@ -381,23 +386,34 @@ helm upgrade envoy-gateway helmforge/envoy-gateway --set profile=production-ha -
 
 ## Migration Guide
 
-### Version 1.3.0 (EG v1.7.1)
+### Version 1.3.0 (EG v1.7.3)
 
 Major architectural redesign to align with the EG operator model.
 
 **Breaking Changes**:
+
 - `proxy.mode` renamed to `proxy.kind`
 - `certificates.certManager` section removed — use external cert-manager and reference Secrets in Gateway listeners
 - `profile: staging` removed — use `profile: custom` with explicit values
 - Proxy Deployment/DaemonSet/Service/HPA are no longer managed by this chart (EG operator manages them via EnvoyProxy CRD)
 
 **New Features**:
+
 - `certgen` job for automatic controller TLS cert generation
 - `gateway.create` for optional default Gateway provisioning
 - `SecurityPolicy` CRD: JWT, OIDC, API Key, CORS
 - `BackendTrafficPolicy` CRD: retries, circuit breaking, timeouts
 - `ClientTrafficPolicy` CRD: connection limits, HTTP/2 settings
-- Updated to EG v1.7.1 and Redis 8.0.2-alpine
+- Updated to EG v1.7.3 and Redis 8.0.2-alpine
+
+## Upgrade Notes
+
+`docker.io/envoyproxy/gateway:v1.7.3` is the upstream patch update from
+`v1.7.2`. The automatically generated issue referenced `1.7.3`, but Docker Hub
+publishes the canonical Envoy Gateway image tag with the `v` prefix. Review the
+upstream Envoy Gateway `v1.7.3` release notes, verify Gateway API/Envoy Gateway
+CRDs in staging, and test existing Gateway, HTTPRoute, EnvoyProxy, and policy
+resources before upgrading production controllers.
 
 ### Version 1.0.0
 
@@ -414,7 +430,7 @@ This chart intentionally does not support:
 <!-- @AI-METADATA
 type: chart-readme
 title: Envoy Gateway Helm Chart
-description: Deploy Envoy Gateway v1.7.1 on Kubernetes with operator architecture, SecurityPolicy, rate limiting, and comprehensive observability
+description: Deploy Envoy Gateway v1.7.3 on Kubernetes with operator architecture, SecurityPolicy, rate limiting, and comprehensive observability
 keywords: envoy, gateway, gateway-api, helm, kubernetes, rate-limiting, prometheus, grafana, redis, networking, securitypolicy, backendtrafficpolicy, clienttrafficpolicy
 purpose: Installation guide, configuration reference, and operational documentation for the Envoy Gateway Helm chart
 scope: Chart

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -192,7 +192,7 @@ highAvailability:
 | `proxy.kind` | `Deployment` | Proxy workload kind: `Deployment` or `DaemonSet` |
 | `proxy.replicaCount` | `1` | Number of proxy replicas (Deployment mode only, overridden by profile) |
 | `proxy.image.repository` | `docker.io/envoyproxy/envoy` | Proxy image repository |
-| `proxy.image.tag` | `distroless-v1.33.0` | Proxy image tag |
+| `proxy.image.tag` | `distroless-v1.37.0` | Proxy image tag |
 | `proxy.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `proxy.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `proxy.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -1,12 +1,14 @@
 # TLS Certificates
 
-This chart handles two distinct certificate concerns: internal TLS for the controller (managed automatically by a certgen job) and application TLS for HTTPS Gateway listeners (managed externally by the user).
+This chart handles two distinct certificate concerns: internal TLS for the
+controller (managed automatically by a certgen job) and application TLS for
+HTTPS Gateway listeners (managed externally by the user).
 
 ## Internal Certificates (Certgen Job)
 
 ### Architecture
 
-```
+```text
 Helm install/upgrade
       │
       ▼
@@ -19,7 +21,9 @@ Secret: <release>-certs
       └→ xDS server TLS (controller ↔ proxy communication)
 ```
 
-The chart runs a `certgen` Kubernetes Job as a Helm pre-install and pre-upgrade hook. This job generates self-signed TLS certificates for:
+The chart runs a `certgen` Kubernetes Job as a Helm pre-install and pre-upgrade
+hook. This job generates self-signed TLS certificates for:
+
 - The EG controller webhook (required by the Kubernetes API server)
 - The xDS gRPC server used for controller-to-proxy communication
 
@@ -30,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.7.1
+    tag: v1.7.3
   resources:
     requests:
       cpu: 10m
@@ -57,7 +61,9 @@ kubectl get secret <release>-certs
 
 ## Application TLS (HTTPS Gateway Listeners)
 
-For HTTPS listeners on your Gateway, you must supply a TLS Secret separately. This chart does **not** create Certificate resources or integrate with cert-manager directly — you manage application certificates externally.
+For HTTPS listeners on your Gateway, you must supply a TLS Secret separately.
+This chart does **not** create Certificate resources or integrate with
+cert-manager directly — you manage application certificates externally.
 
 ### Using cert-manager (External, Not Chart-Integrated)
 
@@ -195,7 +201,10 @@ openssl s_client -connect app.example.com:443 -servername app.example.com
 
 ## Monitoring Certificate Expiration
 
-Since application certificates are managed externally, set up your own monitoring. If using cert-manager, it exposes the `certmanager_certificate_expiration_timestamp_seconds` metric that Prometheus can scrape:
+Since application certificates are managed externally, set up your own
+monitoring. If using cert-manager, it exposes the
+`certmanager_certificate_expiration_timestamp_seconds` metric that Prometheus can
+scrape:
 
 ```yaml
 # Example manual PrometheusRule for cert-manager certificates

--- a/charts/envoy-gateway/templates/NOTES.txt
+++ b/charts/envoy-gateway/templates/NOTES.txt
@@ -265,3 +265,5 @@ Gateway API:   https://gateway-api.sigs.k8s.io/
 Envoy Gateway: https://gateway.envoyproxy.io/
 
 ================================================================================
+
+Happy Helmforging :)

--- a/charts/envoy-gateway/templates/envoyproxy-config.yaml
+++ b/charts/envoy-gateway/templates/envoyproxy-config.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:
+  {{- with .Values.proxy.ipFamily }}
+  ipFamily: {{ . }}
+  {{- end }}
   provider:
     type: Kubernetes
     kubernetes:

--- a/charts/envoy-gateway/templates/service-controller.yaml
+++ b/charts/envoy-gateway/templates/service-controller.yaml
@@ -7,6 +7,13 @@ metadata:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
   - name: http
     port: 8080
@@ -31,6 +38,13 @@ metadata:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
   - name: xds
     port: 18000

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -65,7 +65,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "envoyproxy/gateway:v1.7.2"
+          pattern: "envoyproxy/gateway:v1.7.3"
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
+++ b/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
@@ -30,6 +30,12 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment.replicas
           value: 1
 
+  - it: should use the Envoy data-plane image compatible with Envoy Gateway v1.7
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.container.image
+          value: docker.io/envoyproxy/envoy:distroless-v1.37.0
+
   - it: should configure DaemonSet mode when kind is DaemonSet
     set:
       proxy:

--- a/charts/envoy-gateway/tests/services_test.yaml
+++ b/charts/envoy-gateway/tests/services_test.yaml
@@ -58,6 +58,39 @@ tests:
         template: service-controller.yaml
         documentIndex: 1
 
+  - it: should apply dual-stack settings to controller services
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        template: service-controller.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+        template: service-controller.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        template: service-controller.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+        template: service-controller.yaml
+        documentIndex: 1
+
   - it: should configure proxy service type LoadBalancer by default in EnvoyProxy CRD
     asserts:
       - equal:
@@ -86,6 +119,16 @@ tests:
       - equal:
           path: spec.provider.kubernetes.envoyService.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
           value: nlb
+        template: envoyproxy-config.yaml
+
+  - it: should configure proxy EnvoyProxy ipFamily for dual-stack
+    set:
+      proxy:
+        ipFamily: DualStack
+    asserts:
+      - equal:
+          path: spec.ipFamily
+          value: DualStack
         template: envoyproxy-config.yaml
 
   - it: should configure HPA in EnvoyProxy CRD when autoscaling enabled

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -208,7 +208,7 @@
             "tag": {
               "type": "string",
               "description": "Proxy image tag",
-              "default": "v1.29.0"
+              "default": "distroless-v1.37.0"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -33,6 +33,26 @@
         }
       }
     },
+    "service": {
+      "type": "object",
+      "description": "Controller Service configuration",
+      "properties": {
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "description": "Dual-stack ipFamilyPolicy for controller Services",
+          "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Dual-stack ipFamilies for controller Services",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          },
+          "maxItems": 2
+        }
+      }
+    },
     "podAnnotations": {
       "type": "object",
       "description": "Annotations to add to all pods"
@@ -63,7 +83,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.0.0"
+              "default": "v1.7.3"
             },
             "pullPolicy": {
               "type": "string",
@@ -109,6 +129,26 @@
             }
           }
         },
+        "service": {
+          "type": "object",
+          "description": "Controller Service configuration",
+          "properties": {
+            "ipFamilyPolicy": {
+              "type": ["string", "null"],
+              "description": "Dual-stack ipFamilyPolicy for controller Services",
+              "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"]
+            },
+            "ipFamilies": {
+              "type": "array",
+              "description": "Dual-stack ipFamilies for controller Services",
+              "items": {
+                "type": "string",
+                "enum": ["IPv4", "IPv6"]
+              },
+              "maxItems": 2
+            }
+          }
+        },
         "nodeSelector": {
           "type": "object",
           "description": "Node selector for controller pods"
@@ -138,6 +178,12 @@
       "type": "object",
       "description": "Proxy configuration",
       "properties": {
+        "ipFamily": {
+          "type": "string",
+          "description": "EnvoyProxy IP family",
+          "enum": ["", "IPv4", "IPv6", "DualStack"],
+          "default": ""
+        },
         "mode": {
           "type": "string",
           "description": "Deployment mode: Deployment or DaemonSet",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -83,8 +83,8 @@ proxy:
     repository: docker.io/envoyproxy/envoy
     # -- Proxy image pull policy
     pullPolicy: IfNotPresent
-    # -- Envoy image tag for EG v1.7.3 (distroless)
-    tag: "distroless-v1.33.0"
+    # -- Envoy image tag for EG v1.7 (distroless)
+    tag: "distroless-v1.37.0"
 
   # -- Resources for proxy pods (overridden by profile)
   resources:

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -7,6 +7,13 @@
 # Options: dev, production-ha, custom
 profile: custom
 
+## Controller Service configuration
+service:
+  # -- Set the ipFamilyPolicy for controller Services (dual-stack)
+  ipFamilyPolicy: ~
+  # -- Set the ipFamilies for controller Services
+  ipFamilies: []
+
 ## Controller (EG operator pod)
 controller:
   # -- Number of controller replicas (overridden by profile)
@@ -18,7 +25,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.7.2"
+    tag: "v1.7.3"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -60,10 +67,12 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.7.2"
+    tag: "v1.7.3"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:
+  # -- EnvoyProxy IP family. Use DualStack for dual-stack data plane Services.
+  ipFamily: ""
   # -- Proxy provisioning mode: Deployment or DaemonSet
   kind: Deployment
   # -- Number of proxy replicas (only for Deployment kind)
@@ -74,7 +83,7 @@ proxy:
     repository: docker.io/envoyproxy/envoy
     # -- Proxy image pull policy
     pullPolicy: IfNotPresent
-    # -- Envoy image tag for EG v1.7.1 (distroless)
+    # -- Envoy image tag for EG v1.7.3 (distroless)
     tag: "distroless-v1.33.0"
 
   # -- Resources for proxy pods (overridden by profile)
@@ -402,4 +411,3 @@ externalSecrets:
   target:
     creationPolicy: Owner
   data: []
-


### PR DESCRIPTION
## Summary

Closes #246.

- Update Envoy Gateway controller and certgen image defaults from v1.7.2 to v1.7.3.
- Document that Docker Hub publishes the canonical v-prefixed tag; the issue's unprefixed 1.7.3 tag was checked and does not exist.
- Add service dual-stack controls (`service.ipFamilyPolicy`, `service.ipFamilies`) and EnvoyProxy `proxy.ipFamily` support.
- Remove `Chart.lock` to satisfy HelmForge GR-062.
- Update chart README, certificate docs, NOTES.txt and site docs.

Docs PR: helmforgedev/site#217

## Upstream Evidence

- Tavily release note search reviewed Envoy Gateway v1.7.3 upstream release evidence.
- Context7 Envoy Gateway docs reviewed for Helm/image configuration and EnvoyProxy `ipFamily` behavior.
- `docker manifest inspect docker.io/envoyproxy/gateway:v1.7.3`
- `docker pull docker.io/envoyproxy/gateway:v1.7.3`
- Pulled digest: `sha256:2d9492627dde5786d8b3738e1be560fb99b63333f370c4fc23c137c474f246ef`
- `docker manifest inspect docker.io/envoyproxy/gateway:1.7.3` failed as expected because the unprefixed tag is not published.

## Validation

- `helm dependency build charts/envoy-gateway`
- `helm lint --strict charts/envoy-gateway`
- `helm unittest charts/envoy-gateway` - 14 suites, 97 tests
- `helm template envoy-gateway-test charts/envoy-gateway | kubeconform -strict -ignore-missing-schemas -summary`
- CI values render + kubeconform: default, dev, staging, production-ha, monitoring, rate-limiting, security, dual-stack, external-secrets
- `ah lint charts/envoy-gateway`
- `npx -y markdownlint-cli2 charts/envoy-gateway/README.md charts/envoy-gateway/docs/certificates.md`
- `git diff --check`
- Kubescape framework scan (`MITRE,NSA,SOC2`) completed, score `75.25`
- K3D smoke on `k3d-charts-test`: controller Ready with `docker.io/envoyproxy/gateway:v1.7.3`, GatewayClass accepted, Gateway Programmed, Envoy proxy pods Ready, HTTPRoute example returned HTTP 200 through Envoy, controller/proxy logs clean, namespace cleaned up.
- Site validation in helmforgedev/site#217: lint, format check, build, internal link/assets traversal.
- HelmForge MCP: `check_site_sync` PASS, service dual-stack PASS, ExternalSecrets PASS, Chart.lock policy PASS, chart CI evidence PASS, upstream update evidence PASS, security evidence PASS, consolidated compliance 46/47 PASS with only the expected CI-managed chart-version warning.

## HelmForge Guardrail Notes

- `Chart.lock` is intentionally not restored. HelmForge MCP `validate_chart_lock` reports any committed chart-level `Chart.lock` as a GR-062 BLOCKER: chart directories must validate dependencies without committing lock files.
- `Chart.yaml.version` remains CI/release-pipeline managed per GR-003.