### PR TITLE
chore(ghost): update image to 6.37.1

### DIFF
--- a/charts/ghost/Chart.lock
+++ b/charts/ghost/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:43ea75f43a616dbac5ea9837826a9cb806646d5c2c3c7029008fa5b3a0ad22c3
-generated: "2026-04-29T04:40:01.1735447-03:00"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.10
-appVersion: "6.35.0"
+appVersion: "6.37.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,6 +24,8 @@ sources:
   - https://github.com/TryGhost/Ghost
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 6.37.1 (#247)"
     - kind: changed
       description: "upgrade to 6.35.0 (#190)"
   artifacthub.io/maintainers: |

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,6 +1,8 @@
 # Ghost Helm Chart
 
-Deploy [Ghost](https://ghost.org) on Kubernetes using the official [ghost](https://hub.docker.com/_/ghost) container image. A modern publishing platform for building blogs, newsletters, and membership-based content with built-in monetization.
+Deploy [Ghost](https://ghost.org) on Kubernetes using the official
+[ghost](https://hub.docker.com/_/ghost) container image. A modern publishing platform
+for building blogs, newsletters, and membership-based content with built-in monetization.
 
 ## Features
 

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.35.0"
+          value: "docker.io/library/ghost:6.37.1"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  ""
+                                                                    "default":  "6.37.1"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.35.0"
+  tag: "6.37.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -279,4 +279,3 @@ externalSecrets:
   #     remoteRef:
   #       key: ghost/db
   #       property: password
-


### PR DESCRIPTION
## Summary
- Updates Ghost image/appVersion from 6.35.0 to 6.37.1 for #247.
- Updates schema default, ArtifactHub changelog, README formatting, and image unit test.
- Removes `charts/ghost/Chart.lock` per HelmForge GR-062; dependency tarball remains vendored and `helm dependency build` was validated without committing the lock file.

Fixes #247

## Related
- Docs PR: helmforgedev/site#218

## Upstream Evidence
- Tavily/GitHub release evidence found TryGhost/Ghost `v6.37.1`.
- `docker manifest inspect docker.io/library/ghost:6.37.1` passed.
- `docker pull docker.io/library/ghost:6.37.1` passed with digest `sha256:b9bb8898a04041632e3233de2f3a7bf4a0d8758fa7e6e2452fe0c8b139a59741`.

## Local Validation
- `helm dependency build charts/ghost`
- `helm lint charts/ghost`
- `helm lint --strict charts/ghost`
- `helm unittest charts/ghost` (4 suites, 17 tests)
- `helm template ghost-test charts/ghost | kubeconform -strict -ignore-missing-schemas -summary`
- All 6 `charts/ghost/ci/*.yaml` renders with strict kubeconform
- `ah lint charts/ghost` (65 packages, 0 errors)
- `npx -y markdownlint-cli2 charts/ghost/README.md`
- `git diff --check`
- Kubescape MITRE/NSA/SOC2 score: 82
- K3D smoke on `k3d-charts-test`: default install with MySQL, Ghost pod ready on `docker.io/library/ghost:6.37.1`, HTTP 200 from `/ghost/api/admin/site/`, pod logs clean.

## HelmForge Guardrails
- Site sync: helmforgedev/site#218.
- GR-058 dual-stack Service: pass.
- GR-060 Gateway API: existing chart uses opt-in HTTPRoute via `gateway.enabled`; MCP emitted a naming warning expecting `gatewayAPI.enabled`, no blocker.
- GR-061 ExternalSecrets: pass.
- GR-062 Chart.lock: pass after removal.