### PR TITLE
chore(homarr): update to 1.61.0

### DIFF
--- a/charts/homarr/.helmignore
+++ b/charts/homarr/.helmignore
@@ -9,7 +9,6 @@ Thumbs.db
 
 # Helm
 .helmignore
-Chart.lock
 
 # Editors / IDE
 .vscode/

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,8 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.10
-appVersion: "1.60.0"
+appVersion: "1.61.0"
+kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
 keywords:
@@ -21,6 +22,8 @@ sources:
   - https://github.com/homarr-labs/homarr
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 1.61.0 (#248)"
     - kind: changed
       description: "upgrade to 1.60.0 (#226)"
   artifacthub.io/maintainers: |

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.60.0`.
+Current application version: `v1.61.0`.
 
 ## Features
 
@@ -18,6 +18,9 @@ Current application version: `v1.60.0`.
 - **Persistent storage** application data in `/appdata`
 - **S3-compatible backup** database-aware CronJob (SQLite tar, pg_dump, mysqldump)
 - **Ingress support** configurable ingress with TLS
+- **Gateway API support** optional HTTPRoute for modern Kubernetes ingress controllers
+- **Dual-stack ready Service** optional `ipFamilyPolicy` and `ipFamilies`
+- **External Secrets Operator** optional projection for the Homarr encryption/auth Secret
 - **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
 
 ## Installation
@@ -63,6 +66,45 @@ ingress:
     - secretName: homarr-tls
       hosts:
         - dash.example.com
+```
+
+### Gateway API HTTPRoute
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - dash.example.com
+  paths:
+    - type: PathPrefix
+      value: /
+```
+
+### External Secrets Operator
+
+```yaml
+encryption:
+  existingSecret: homarr-encryption
+  existingSecretKey: secret-encryption-key
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: secret-encryption-key
+      remoteRef:
+        key: homarr/credentials
+        property: secret-encryption-key
+    - secretKey: auth-secret
+      remoteRef:
+        key: homarr/credentials
+        property: auth-secret
 ```
 
 ### PostgreSQL with Kubernetes Integration
@@ -132,7 +174,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.60.0"` | Homarr image tag |
+| `image.tag` | `"v1.61.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -162,8 +204,15 @@ backup:
 | `persistence.size` | `1Gi` | Volume size |
 | `service.type` | `ClusterIP` | Service type |
 | `service.port` | `7575` | Service port |
+| `service.ipFamilyPolicy` | `null` | Service IP family policy |
+| `service.ipFamilies` | `[]` | Ordered service IP families |
 | `ingress.enabled` | `false` | Enable ingress |
 | `ingress.ingressClassName` | `""` | Ingress class |
+| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `gatewayAPI.parentRefs` | `[]` | Parent Gateway references |
+| `gatewayAPI.hostnames` | `[]` | HTTPRoute hostnames |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret for the Homarr encryption/auth Secret |
+| `externalSecrets.secretStoreRef.name` | `""` | SecretStore or ClusterSecretStore name |
 | `backup.enabled` | `false` | Enable S3 backup CronJob |
 | `backup.schedule` | `"0 3 * * *"` | Backup cron schedule |
 | `backup.s3.endpoint` | `""` | S3-compatible endpoint URL |
@@ -188,10 +237,29 @@ openssl rand -hex 32
 
 Then pass it via `encryption.key` or an existing secret.
 
+## Gateway API
+
+The chart can render a native Kubernetes Gateway API `HTTPRoute` alongside or instead of Ingress. Set
+`gatewayAPI.enabled=true` and reference an existing shared Gateway with `gatewayAPI.parentRefs`. Gateway API CRDs and a
+controller such as Envoy Gateway, Cilium, Istio, Traefik, or NGINX Gateway Fabric must be installed separately.
+
+## Dual-Stack Networking
+
+The Service supports Kubernetes dual-stack networking through `service.ipFamilyPolicy` and `service.ipFamilies`. Defaults
+omit both fields so existing installs keep the cluster default behavior. Set `service.ipFamilyPolicy=PreferDualStack` for a
+portable dual-stack opt-in, or include explicit `ipFamilies` only on clusters that advertise those families.
+
+## External Secrets
+
+Set `externalSecrets.enabled=true` with `encryption.existingSecret` to let External Secrets Operator populate Homarr's
+`SECRET_ENCRYPTION_KEY` and `AUTH_SECRET`. The `externalSecrets.data` entries must include `secret-encryption-key` (or the
+configured `encryption.existingSecretKey`) and `auth-secret`. The External Secrets Operator and SecretStore are managed
+outside this chart.
+
 ## Upgrade Notes
 
-This update moves the default image from `v1.57.1` to `v1.60.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.60.0` includes scheduler, OpenAPI documentation and icon updater fixes, with no breaking changes
+This update moves the default image from `v1.60.0` to `v1.61.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.61.0` includes feature, bug fix and revert updates, with no breaking changes
 identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of

--- a/charts/homarr/ci/dual-stack.yaml
+++ b/charts/homarr/ci/dual-stack.yaml
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack

--- a/charts/homarr/ci/dual-stack.yaml
+++ b/charts/homarr/ci/dual-stack.yaml
@@ -1,0 +1,2 @@
+service:
+  ipFamilyPolicy: PreferDualStack

--- a/charts/homarr/ci/external-secrets.yaml
+++ b/charts/homarr/ci/external-secrets.yaml
@@ -1,0 +1,17 @@
+encryption:
+  existingSecret: homarr-encryption
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: secret-encryption-key
+      remoteRef:
+        key: homarr/credentials
+        property: secret-encryption-key
+    - secretKey: auth-secret
+      remoteRef:
+        key: homarr/credentials
+        property: auth-secret

--- a/charts/homarr/ci/external-secrets.yaml
+++ b/charts/homarr/ci/external-secrets.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 encryption:
   existingSecret: homarr-encryption
 

--- a/charts/homarr/ci/gateway-api.yaml
+++ b/charts/homarr/ci/gateway-api.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 gatewayAPI:
   enabled: true
   hostnames:

--- a/charts/homarr/ci/gateway-api.yaml
+++ b/charts/homarr/ci/gateway-api.yaml
@@ -1,0 +1,7 @@
+gatewayAPI:
+  enabled: true
+  hostnames:
+    - dash.example.local
+  paths:
+    - type: PathPrefix
+      value: /

--- a/charts/homarr/templates/NOTES.txt
+++ b/charts/homarr/templates/NOTES.txt
@@ -16,6 +16,11 @@ Namespace:  {{ .Release.Namespace }}
 {{- range $host := .Values.ingress.hosts }}
 DASHBOARD:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
+{{- else if .Values.gatewayAPI.enabled }}
+Gateway API HTTPRoute has been rendered for Homarr.
+{{- with .Values.gatewayAPI.hostnames }}
+DASHBOARD:  http://{{ index . 0 }}/
+{{- end }}
 {{- else }}
 Port-forward to access Homarr locally:
 
@@ -35,6 +40,11 @@ Port-forward to access Homarr locally:
 
 Database mode:
   {{ include "homarr.databaseMode" . }}
+
+{{- with .Values.service.ipFamilyPolicy }}
+Service IP family policy:
+  {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
+{{- end }}
 
 {{- if .Values.backup.enabled }}
 S3 backup schedule:

--- a/charts/homarr/templates/externalsecret.yaml
+++ b/charts/homarr/templates/externalsecret.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- /*
+  Guard: when externalSecrets.enabled=true the chart-managed encryption Secret is
+  still rendered unless encryption.existingSecret is set. Require the existing
+  Secret path so ExternalSecret is the only writer for Homarr credentials.
+*/}}
+{{- if not .Values.encryption.existingSecret }}
+  {{- fail "externalSecrets.enabled requires encryption.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+{{- $encKey := .Values.encryption.existingSecretKey | default "secret-encryption-key" }}
+{{- $hasEncryptionKey := false }}
+{{- $hasAuthSecret := false }}
+{{- range .Values.externalSecrets.data }}
+  {{- if eq .secretKey $encKey }}
+    {{- $hasEncryptionKey = true }}
+  {{- end }}
+  {{- if eq .secretKey "auth-secret" }}
+    {{- $hasAuthSecret = true }}
+  {{- end }}
+{{- end }}
+{{- if not $hasEncryptionKey }}
+  {{- fail (printf "externalSecrets.data must contain an entry with secretKey '%s' when externalSecrets.enabled=true to populate SECRET_ENCRYPTION_KEY." $encKey) }}
+{{- end }}
+{{- if not $hasAuthSecret }}
+  {{- fail "externalSecrets.data must contain an entry with secretKey 'auth-secret' when externalSecrets.enabled=true to populate AUTH_SECRET." }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "homarr.fullname" . }}-encryption
+  labels:
+    {{- include "homarr.labels" . | nindent 4 }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.encryption.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/homarr/templates/httproute.yaml
+++ b/charts/homarr/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "homarr.fullname" . }}
+  labels:
+    {{- include "homarr.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gatewayAPI.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.gatewayAPI.paths }}
+        - path:
+            type: {{ .type }}
+            value: {{ .value | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ include "homarr.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/homarr/templates/service.yaml
+++ b/charts/homarr/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/homarr/templates/service.yaml
+++ b/charts/homarr/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.60.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.61.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/tests/externalsecret_test.yaml
+++ b/charts/homarr/tests/externalsecret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: externalsecret
 templates:
   - templates/externalsecret.yaml

--- a/charts/homarr/tests/externalsecret_test.yaml
+++ b/charts/homarr/tests/externalsecret_test.yaml
@@ -1,0 +1,84 @@
+suite: externalsecret
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: should not render ExternalSecret by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret for encryption secret
+    set:
+      encryption:
+        existingSecret: homarr-encryption
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        data:
+          - secretKey: secret-encryption-key
+            remoteRef:
+              key: homarr/credentials
+              property: secret-encryption-key
+          - secretKey: auth-secret
+            remoteRef:
+              key: homarr/credentials
+              property: auth-secret
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+      - equal:
+          path: spec.target.name
+          value: homarr-encryption
+      - equal:
+          path: spec.data[0].secretKey
+          value: secret-encryption-key
+      - equal:
+          path: spec.data[1].secretKey
+          value: auth-secret
+
+  - it: should fail when enabled without existing encryption secret
+    set:
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+        data:
+          - secretKey: secret-encryption-key
+            remoteRef:
+              key: homarr/credentials
+              property: secret-encryption-key
+          - secretKey: auth-secret
+            remoteRef:
+              key: homarr/credentials
+              property: auth-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled requires encryption.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."
+
+  - it: should fail when auth-secret is missing
+    set:
+      encryption:
+        existingSecret: homarr-encryption
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+        data:
+          - secretKey: secret-encryption-key
+            remoteRef:
+              key: homarr/credentials
+              property: secret-encryption-key
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data must contain an entry with secretKey 'auth-secret' when externalSecrets.enabled=true to populate AUTH_SECRET."

--- a/charts/homarr/tests/httproute_test.yaml
+++ b/charts/homarr/tests/httproute_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: httproute
 templates:
   - templates/httproute.yaml

--- a/charts/homarr/tests/httproute_test.yaml
+++ b/charts/homarr/tests/httproute_test.yaml
@@ -1,0 +1,46 @@
+suite: httproute
+templates:
+  - templates/httproute.yaml
+tests:
+  - it: should not render HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute when Gateway API is enabled
+    set:
+      gatewayAPI:
+        enabled: true
+        parentRefs:
+          - name: shared-gateway
+            namespace: gateway-system
+            sectionName: https
+        hostnames:
+          - dash.example.com
+        paths:
+          - type: PathPrefix
+            value: /
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: dash.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-homarr
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 7575

--- a/charts/homarr/tests/service_test.yaml
+++ b/charts/homarr/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: service
 templates:
   - templates/service.yaml

--- a/charts/homarr/tests/service_test.yaml
+++ b/charts/homarr/tests/service_test.yaml
@@ -9,3 +9,40 @@ tests:
       - equal:
           path: spec.ports[0].port
           value: 7575
+      - notExists:
+          path: spec.ipFamilyPolicy
+      - notExists:
+          path: spec.ipFamilies
+
+  - it: should render dual-stack settings when configured
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv6
+          - IPv4
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv6
+            - IPv4
+
+  - it: should render SingleStack policy when configured
+    set:
+      service.ipFamilyPolicy: SingleStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+
+  - it: should render RequireDualStack policy when configured
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: RequireDualStack

--- a/charts/homarr/values.schema.json
+++ b/charts/homarr/values.schema.json
@@ -124,7 +124,17 @@
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
         "port": { "type": "integer" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2,
+          "uniqueItems": true
+        }
       }
     },
     "ingress": {
@@ -135,6 +145,26 @@
         "annotations": { "type": "object" },
         "hosts": { "type": "array" },
         "tls": { "type": "array" }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"] },
+              "value": { "type": "string" }
+            },
+            "required": ["type", "value"]
+          }
+        },
+        "annotations": { "type": "object" }
       }
     },
     "serviceAccount": {
@@ -152,6 +182,29 @@
         "schedule": { "type": "string" },
         "s3": { "type": "object" },
         "database": { "type": "object" }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } },
+        "annotations": { "type": "object" }
       }
     },
     "nodeSelector": { "type": "object" },

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.60.0"
+  tag: "v1.61.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets
@@ -301,6 +301,12 @@ service:
   # -- Annotations for the service
   annotations: {}
 
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
 # =============================================================================
 # Ingress
 # =============================================================================
@@ -332,6 +338,32 @@ ingress:
   #     hosts:
   #       - dash.example.com
   tls: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute for Homarr HTTP (requires Gateway API CRDs)
+  enabled: false
+
+  # -- Parent Gateway references. Leave empty to attach through controller defaults.
+  parentRefs: []
+  #   - name: shared-gateway
+  #     namespace: gateway-system
+  #     sectionName: https
+
+  # -- HTTPRoute hostnames
+  hostnames: []
+  #   - dash.example.com
+
+  # -- HTTPRoute path matches
+  paths:
+    - type: PathPrefix
+      value: /
+
+  # -- HTTPRoute annotations
+  annotations: {}
 
 # =============================================================================
 # Service Account
@@ -440,6 +472,46 @@ backup:
     postgresDumpArgs: ""
     # -- Extra arguments for mysqldump
     mysqlDumpArgs: "--single-transaction --quick --skip-lock-tables --no-tablespaces"
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for the Homarr encryption/auth secret.
+  # Requires encryption.existingSecret to be set to prevent credential drift
+  # between the chart-managed Secret and the ExternalSecret.
+  enabled: false
+
+  # -- ExternalSecret apiVersion
+  apiVersion: external-secrets.io/v1
+
+  # -- Refresh interval
+  refreshInterval: "0"
+
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name
+    name: ""
+    # -- SecretStore or ClusterSecretStore
+    kind: SecretStore
+
+  target:
+    # -- ExternalSecret target Secret creation policy
+    creationPolicy: Owner
+
+  # -- ExternalSecret data entries mapping remote keys to Homarr encryption Secret keys.
+  data: []
+  #   - secretKey: secret-encryption-key
+  #     remoteRef:
+  #       key: homarr/credentials
+  #       property: secret-encryption-key
+  #   - secretKey: auth-secret
+  #     remoteRef:
+  #       key: homarr/credentials
+  #       property: auth-secret
+
+  # -- ExternalSecret annotations
+  annotations: {}
 
 # =============================================================================
 # Scheduling


### PR DESCRIPTION
## Summary

Closes #248.

- Update Homarr from `v1.60.0` to `v1.61.0` and align `Chart.yaml.appVersion`.
- Add `kubeVersion`, Service dual-stack opt-in, Gateway API `HTTPRoute`, and External Secrets Operator support for the Homarr encryption/auth Secret.
- Update chart README, NOTES, schema, CI scenarios, and unit tests.

## Upstream evidence

- Release notes reviewed: https://github.com/homarr-labs/homarr/releases/tag/v1.61.0
- Official GHCR image verified with `docker pull ghcr.io/homarr-labs/homarr:v1.61.0`.
- Digest: `sha256:6a726c72b37d56a7ce271d35498712f90bfd05ee203bc81e069d718489c35b06`.
- `appVersion` `1.61.0` aligns with image tag `v1.61.0`.
- Context7 checked Homarr deployment/env docs (`/homarr-labs/documentation`).

## Validation

- `helm dependency build charts/homarr` and removed generated `Chart.lock` per GR-062.
- `helm lint charts/homarr`.
- `helm lint --strict charts/homarr`.
- `helm unittest charts/homarr`: 9 suites, 47 tests.
- `helm template homarr-test charts/homarr | kubeconform -strict -ignore-missing-schemas -summary`.
- All `charts/homarr/ci/*.yaml` rendered through strict kubeconform: backup, default, dual-stack, external-db, external-secrets, gateway-api, kubernetes-integration, mysql, postgresql.
- `ah lint charts/homarr`: 65 packages, 0 errors.
- `npx -y markdownlint-cli2 charts/homarr/README.md`.
- Kubescape `MITRE,NSA,SOC2` score: 84.
- K3D runtime on `k3d-charts-test`: installed Homarr with `service.ipFamilyPolicy=PreferDualStack` and `NO_EXTERNAL_CONNECTION=true`, pod ready, image `ghcr.io/homarr-labs/homarr:v1.61.0`, Service policy `PreferDualStack`, HTTP check returned 200, logs had 0 error-like lines.
- MCP HelmForge: chart lock, chart standards, service dual-stack, Gateway API, ExternalSecrets, site sync, chart CI evidence, security evidence, and upstream update evidence passed.

## Docs

- helmforgedev/site#219