### PR TITLE
chore(karakeep): update to 0.32.0

### DIFF
--- a/charts/karakeep/.helmignore
+++ b/charts/karakeep/.helmignore
@@ -20,7 +20,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -1,10 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: karakeep
 description: AI-powered bookmark manager with full-text search and web archiving
 icon: https://helmforge.dev/icons/charts/karakeep.png
 type: application
 version: 1.2.4
-appVersion: "0.31.0"
+appVersion: "0.32.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,6 +23,8 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
+      description: "upgrade to 0.32.0 (#249)"
+    - kind: changed
       description: "prepare sandbox governance and Apache licensing (#124)"
   artifacthub.io/maintainers: |
     - name: HelmForge
@@ -29,6 +32,7 @@ annotations:
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
   helmforge.dev/maturity: stable
+  helmforge.dev/repository: https://repo.helmforge.dev
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/karakeep/README.md
+++ b/charts/karakeep/README.md
@@ -1,6 +1,10 @@
 # Karakeep Helm Chart
 
-Deploy [Karakeep](https://karakeep.app) (formerly Hoarder) on Kubernetes using the official [karakeep-app/karakeep](https://github.com/karakeep-app/karakeep) container image. An AI-powered bookmark manager with full-text search, web archiving, and automatic tagging.
+Deploy [Karakeep](https://karakeep.app) (formerly Hoarder) on Kubernetes using the official
+[karakeep-app/karakeep](https://github.com/karakeep-app/karakeep) container image. An AI-powered bookmark manager with
+full-text search, web archiving, and automatic tagging.
+
+Current application version: `0.32.0`.
 
 ## Features
 
@@ -10,6 +14,9 @@ Deploy [Karakeep](https://karakeep.app) (formerly Hoarder) on Kubernetes using t
 - **SQLite storage** — no external database required, data stored on PVC
 - **Auto-generated secrets** — NEXTAUTH_SECRET and MEILI_MASTER_KEY are generated automatically and preserved across upgrades
 - **Ingress support** — TLS with cert-manager, supports traefik and nginx
+- **Gateway API support** — optional HTTPRoute for native Kubernetes routing
+- **Dual-stack ready Service** — optional `ipFamilyPolicy` and `ipFamilies`
+- **External Secrets Operator** — optional projection for NEXTAUTH_SECRET and MEILI_MASTER_KEY
 
 ## Installation
 
@@ -55,7 +62,7 @@ meilisearch:
   enabled: true  # default
   image:
     repository: docker.io/getmeili/meilisearch
-    tag: "v1.13.3"
+    tag: "v1.41.0"
   resources:
     requests:
       memory: 256Mi
@@ -77,7 +84,7 @@ chromium:
   enabled: true  # default
   image:
     repository: ghcr.io/browserless/chromium
-    tag: "v2.18.0"
+    tag: "v2.46.0"
   resources:
     requests:
       memory: 512Mi
@@ -94,14 +101,23 @@ chromium:
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `image.repository` | `ghcr.io/karakeep-app/karakeep` | Main Karakeep image |
+| `image.tag` | `"0.32.0"` | Main Karakeep image tag |
 | `karakeep.nextAuthUrl` | `""` | Public URL of the Karakeep instance |
+| `karakeep.browserConnectOnDemand` | `true` | Connect to Chromium only when crawling needs it |
+| `karakeep.existingSecret` | `""` | Existing secret with `nextauth-secret` and `meili-master-key` |
 | `meilisearch.enabled` | `true` | Enable Meilisearch sidecar for full-text search |
 | `chromium.enabled` | `true` | Enable Chromium sidecar for web page screenshots |
+| `chromium.port` | `9222` | Internal Chromium sidecar HTTP port |
 | `persistence.enabled` | `true` | Enable persistence for application data |
 | `persistence.size` | `10Gi` | PVC size |
 | `ingress.enabled` | `false` | Enable ingress |
 | `ingress.ingressClassName` | `traefik` | Ingress class (traefik, nginx, etc.) |
 | `service.port` | `80` | Service port |
+| `service.ipFamilyPolicy` | `null` | Service IP family policy |
+| `service.ipFamilies` | `[]` | Ordered Service IP families |
+| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret for app secrets |
 
 ## Ingress Example
 
@@ -124,6 +140,61 @@ ingress:
         - karakeep.example.com
       secretName: karakeep-tls
 ```
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - karakeep.example.com
+  paths:
+    - type: PathPrefix
+      value: /
+```
+
+## Dual-Stack Networking
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+```
+
+Set `service.ipFamilies` only when the target cluster advertises the requested IP families.
+
+## External Secrets
+
+```yaml
+karakeep:
+  existingSecret: karakeep-app-secret
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: nextauth-secret
+      remoteRef:
+        key: karakeep/credentials
+        property: nextauth-secret
+    - secretKey: meili-master-key
+      remoteRef:
+        key: karakeep/credentials
+        property: meili-master-key
+```
+
+The External Secrets Operator and SecretStore are managed outside this chart. `externalSecrets.data` must populate both
+`nextauth-secret` and `meili-master-key`, or the chart fails during template rendering.
+
+## Upgrade Notes
+
+This update moves the default Karakeep image from `0.31.0` to `0.32.0`. Upstream release notes describe mobile app design
+work and application fixes; no breaking chart value changes were identified.
 
 ## Persistence
 

--- a/charts/karakeep/ci/dual-stack.yaml
+++ b/charts/karakeep/ci/dual-stack.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack

--- a/charts/karakeep/ci/external-secrets.yaml
+++ b/charts/karakeep/ci/external-secrets.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+karakeep:
+  existingSecret: karakeep-app-secret
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: nextauth-secret
+      remoteRef:
+        key: karakeep/credentials
+        property: nextauth-secret
+    - secretKey: meili-master-key
+      remoteRef:
+        key: karakeep/credentials
+        property: meili-master-key

--- a/charts/karakeep/ci/gateway-api.yaml
+++ b/charts/karakeep/ci/gateway-api.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  hostnames:
+    - karakeep.example.local
+  paths:
+    - type: PathPrefix
+      value: /

--- a/charts/karakeep/templates/NOTES.txt
+++ b/charts/karakeep/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Karakeep has been successfully deployed!
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -16,6 +17,11 @@ Namespace:  {{ .Release.Namespace }}
 {{- range $host := .Values.ingress.hosts }}
 WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
+{{- else if .Values.gatewayAPI.enabled }}
+Gateway API HTTPRoute has been rendered for Karakeep.
+{{- with .Values.gatewayAPI.hostnames }}
+WEB UI:   http://{{ index . 0 }}/
+{{- end }}
 {{- else }}
 Port-forward to access Karakeep locally:
 
@@ -31,6 +37,11 @@ Port-forward to access Karakeep locally:
 1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --timeout=300s
 2. kubectl get pods -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
 3. kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+{{- with .Values.service.ipFamilyPolicy }}
+Service IP family policy:
+  {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
+{{- end }}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   TROUBLESHOOTING

--- a/charts/karakeep/templates/_helpers.tpl
+++ b/charts/karakeep/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "karakeep.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -53,7 +54,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Secret name */}}
 {{- define "karakeep.secretName" -}}
+{{- if .Values.karakeep.existingSecret -}}
+{{- .Values.karakeep.existingSecret -}}
+{{- else -}}
 {{- printf "%s-secret" (include "karakeep.fullname" .) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -61,9 +66,10 @@ Generate NEXTAUTH_SECRET: lookup existing secret or generate a new one.
 This ensures the value is preserved across upgrades.
 */}}
 {{- define "karakeep.nextAuthSecret" -}}
+{{- $key := .Values.karakeep.existingSecretNextAuthKey | default "nextauth-secret" -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "karakeep.secretName" .) -}}
-{{- if and $existing $existing.data (index $existing.data "nextauth-secret") -}}
-{{- index $existing.data "nextauth-secret" | b64dec -}}
+{{- if and $existing $existing.data (index $existing.data $key) -}}
+{{- index $existing.data $key | b64dec -}}
 {{- else -}}
 {{- randAlphaNum 32 -}}
 {{- end -}}
@@ -73,9 +79,10 @@ This ensures the value is preserved across upgrades.
 Generate MEILI_MASTER_KEY: lookup existing secret or generate a new one.
 */}}
 {{- define "karakeep.meiliMasterKey" -}}
+{{- $key := .Values.karakeep.existingSecretMeiliMasterKey | default "meili-master-key" -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "karakeep.secretName" .) -}}
-{{- if and $existing $existing.data (index $existing.data "meili-master-key") -}}
-{{- index $existing.data "meili-master-key" | b64dec -}}
+{{- if and $existing $existing.data (index $existing.data $key) -}}
+{{- index $existing.data $key | b64dec -}}
 {{- else -}}
 {{- randAlphaNum 32 -}}
 {{- end -}}

--- a/charts/karakeep/templates/deployment.yaml
+++ b/charts/karakeep/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,7 +55,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "karakeep.secretName" . }}
-                  key: nextauth-secret
+                  key: {{ .Values.karakeep.existingSecretNextAuthKey }}
             {{- with .Values.karakeep.nextAuthUrl }}
             - name: NEXTAUTH_URL
               value: {{ . | quote }}
@@ -66,11 +67,13 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "karakeep.secretName" . }}
-                  key: meili-master-key
+                  key: {{ .Values.karakeep.existingSecretMeiliMasterKey }}
             {{- end }}
             {{- if .Values.chromium.enabled }}
             - name: BROWSER_WEB_URL
-              value: "http://localhost:9222"
+              value: "http://localhost:{{ .Values.chromium.port }}"
+            - name: BROWSER_CONNECT_ONDEMAND
+              value: {{ .Values.karakeep.browserConnectOnDemand | quote }}
             {{- end }}
             {{- with .Values.karakeep.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -129,7 +132,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "karakeep.secretName" . }}
-                  key: meili-master-key
+                  key: {{ .Values.karakeep.existingSecretMeiliMasterKey }}
             - name: MEILI_NO_ANALYTICS
               value: "true"
           {{- with .Values.meilisearch.resources }}
@@ -147,8 +150,11 @@ spec:
           imagePullPolicy: {{ .Values.chromium.image.pullPolicy }}
           ports:
             - name: chrome
-              containerPort: 9222
+              containerPort: {{ .Values.chromium.port }}
               protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.chromium.port | quote }}
           {{- with .Values.chromium.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/karakeep/templates/externalsecret.yaml
+++ b/charts/karakeep/templates/externalsecret.yaml
@@ -1,0 +1,49 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- /*
+  Guard: when externalSecrets.enabled=true the chart-managed Secret is still
+  rendered unless karakeep.existingSecret is set. Require the existing Secret
+  path so ExternalSecret is the only writer for Karakeep credentials.
+*/}}
+{{- if not .Values.karakeep.existingSecret }}
+  {{- fail "externalSecrets.enabled requires karakeep.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+{{- $nextAuthKey := .Values.karakeep.existingSecretNextAuthKey | default "nextauth-secret" }}
+{{- $meiliKey := .Values.karakeep.existingSecretMeiliMasterKey | default "meili-master-key" }}
+{{- $hasNextAuthSecret := false }}
+{{- $hasMeiliMasterKey := false }}
+{{- range .Values.externalSecrets.data }}
+  {{- if eq .secretKey $nextAuthKey }}
+    {{- $hasNextAuthSecret = true }}
+  {{- end }}
+  {{- if eq .secretKey $meiliKey }}
+    {{- $hasMeiliMasterKey = true }}
+  {{- end }}
+{{- end }}
+{{- if not $hasNextAuthSecret }}
+  {{- fail (printf "externalSecrets.data must contain an entry with secretKey '%s' when externalSecrets.enabled=true to populate NEXTAUTH_SECRET." $nextAuthKey) }}
+{{- end }}
+{{- if not $hasMeiliMasterKey }}
+  {{- fail (printf "externalSecrets.data must contain an entry with secretKey '%s' when externalSecrets.enabled=true to populate MEILI_MASTER_KEY." $meiliKey) }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "karakeep.fullname" . }}-secret
+  labels:
+    {{- include "karakeep.labels" . | nindent 4 }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.karakeep.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/karakeep/templates/externalsecret.yaml
+++ b/charts/karakeep/templates/externalsecret.yaml
@@ -23,7 +23,7 @@
 {{- if not $hasNextAuthSecret }}
   {{- fail (printf "externalSecrets.data must contain an entry with secretKey '%s' when externalSecrets.enabled=true to populate NEXTAUTH_SECRET." $nextAuthKey) }}
 {{- end }}
-{{- if not $hasMeiliMasterKey }}
+{{- if and .Values.meilisearch.enabled (not $hasMeiliMasterKey) }}
   {{- fail (printf "externalSecrets.data must contain an entry with secretKey '%s' when externalSecrets.enabled=true to populate MEILI_MASTER_KEY." $meiliKey) }}
 {{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}

--- a/charts/karakeep/templates/httproute.yaml
+++ b/charts/karakeep/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "karakeep.fullname" . }}
+  labels:
+    {{- include "karakeep.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gatewayAPI.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.gatewayAPI.paths }}
+        - path:
+            type: {{ .type }}
+            value: {{ .value | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ include "karakeep.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/karakeep/templates/secret.yaml
+++ b/charts/karakeep/templates/secret.yaml
@@ -1,3 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if not .Values.karakeep.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +8,6 @@ metadata:
     {{- include "karakeep.labels" . | nindent 4 }}
 type: Opaque
 data:
-  nextauth-secret: {{ include "karakeep.nextAuthSecret" . | b64enc | quote }}
-  meili-master-key: {{ include "karakeep.meiliMasterKey" . | b64enc | quote }}
+  {{ .Values.karakeep.existingSecretNextAuthKey | quote }}: {{ include "karakeep.nextAuthSecret" . | b64enc | quote }}
+  {{ .Values.karakeep.existingSecretMeiliMasterKey | quote }}: {{ include "karakeep.meiliMasterKey" . | b64enc | quote }}
+{{- end }}

--- a/charts/karakeep/templates/service.yaml
+++ b/charts/karakeep/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/karakeep/tests/deployment_test.yaml
+++ b/charts/karakeep/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml
@@ -26,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/karakeep-app/karakeep:0.31.0"
+          value: "ghcr.io/karakeep-app/karakeep:0.32.0"
 
   - it: should set DATA_DIR env
     template: templates/deployment.yaml
@@ -82,6 +83,16 @@ tests:
           content:
             name: BROWSER_WEB_URL
             value: "http://localhost:9222"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BROWSER_CONNECT_ONDEMAND
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[2].env
+          content:
+            name: PORT
+            value: "9222"
 
   - it: should not set BROWSER_WEB_URL when chromium disabled
     template: templates/deployment.yaml
@@ -154,3 +165,30 @@ tests:
           content:
             name: NEXTAUTH_URL
             value: "https://karakeep.example.com"
+
+  - it: should use existing secret keys when configured
+    template: templates/deployment.yaml
+    set:
+      karakeep:
+        existingSecret: karakeep-app-secret
+        existingSecretNextAuthKey: nextauth
+        existingSecretMeiliMasterKey: meili
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: karakeep-app-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: nextauth
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.name
+          value: karakeep-app-secret
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.key
+          value: meili
+      - equal:
+          path: spec.template.spec.containers[1].env[0].valueFrom.secretKeyRef.name
+          value: karakeep-app-secret
+      - equal:
+          path: spec.template.spec.containers[1].env[0].valueFrom.secretKeyRef.key
+          value: meili

--- a/charts/karakeep/tests/externalsecret_test.yaml
+++ b/charts/karakeep/tests/externalsecret_test.yaml
@@ -83,3 +83,25 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "externalSecrets.data must contain an entry with secretKey 'meili-master-key' when externalSecrets.enabled=true to populate MEILI_MASTER_KEY."
+
+  - it: should allow ExternalSecret without meili key when meilisearch is disabled
+    set:
+      meilisearch:
+        enabled: false
+      karakeep:
+        existingSecret: karakeep-app-secret
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+        data:
+          - secretKey: nextauth-secret
+            remoteRef:
+              key: karakeep/credentials
+              property: nextauth-secret
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - lengthEqual:
+          path: spec.data
+          count: 1

--- a/charts/karakeep/tests/externalsecret_test.yaml
+++ b/charts/karakeep/tests/externalsecret_test.yaml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: externalsecret
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: should not render ExternalSecret by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret for app secret
+    set:
+      karakeep:
+        existingSecret: karakeep-app-secret
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        data:
+          - secretKey: nextauth-secret
+            remoteRef:
+              key: karakeep/credentials
+              property: nextauth-secret
+          - secretKey: meili-master-key
+            remoteRef:
+              key: karakeep/credentials
+              property: meili-master-key
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.secretStoreRef.kind
+          value: ClusterSecretStore
+      - equal:
+          path: spec.target.name
+          value: karakeep-app-secret
+      - equal:
+          path: spec.data[0].secretKey
+          value: nextauth-secret
+      - equal:
+          path: spec.data[1].secretKey
+          value: meili-master-key
+
+  - it: should fail when enabled without existing secret
+    set:
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+        data:
+          - secretKey: nextauth-secret
+            remoteRef:
+              key: karakeep/credentials
+              property: nextauth-secret
+          - secretKey: meili-master-key
+            remoteRef:
+              key: karakeep/credentials
+              property: meili-master-key
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled requires karakeep.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."
+
+  - it: should fail when meili-master-key is missing
+    set:
+      karakeep:
+        existingSecret: karakeep-app-secret
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+        data:
+          - secretKey: nextauth-secret
+            remoteRef:
+              key: karakeep/credentials
+              property: nextauth-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data must contain an entry with secretKey 'meili-master-key' when externalSecrets.enabled=true to populate MEILI_MASTER_KEY."

--- a/charts/karakeep/tests/httproute_test.yaml
+++ b/charts/karakeep/tests/httproute_test.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: httproute
+templates:
+  - templates/httproute.yaml
+tests:
+  - it: should not render HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute when Gateway API is enabled
+    set:
+      gatewayAPI:
+        enabled: true
+        parentRefs:
+          - name: shared-gateway
+            namespace: gateway-system
+            sectionName: https
+        hostnames:
+          - karakeep.example.com
+        paths:
+          - type: PathPrefix
+            value: /
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: karakeep.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-karakeep
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80

--- a/charts/karakeep/tests/secret_test.yaml
+++ b/charts/karakeep/tests/secret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Secret
 templates:
   - templates/secret.yaml
@@ -22,3 +23,25 @@ tests:
           path: data["nextauth-secret"]
       - isNotNull:
           path: data["meili-master-key"]
+
+  - it: should render custom secret keys
+    set:
+      karakeep:
+        existingSecretNextAuthKey: nextauth
+        existingSecretMeiliMasterKey: meili
+    asserts:
+      - isNotNull:
+          path: data["nextauth"]
+      - isNotNull:
+          path: data["meili"]
+      - isNull:
+          path: data["nextauth-secret"]
+      - isNull:
+          path: data["meili-master-key"]
+
+  - it: should not render Secret when existing secret is configured
+    set:
+      karakeep.existingSecret: karakeep-app-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/karakeep/tests/service_test.yaml
+++ b/charts/karakeep/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml
@@ -12,6 +13,10 @@ tests:
       - equal:
           path: metadata.name
           value: test-karakeep
+      - notExists:
+          path: spec.ipFamilyPolicy
+      - notExists:
+          path: spec.ipFamilies
 
   - it: should use port 80
     asserts:
@@ -34,3 +39,36 @@ tests:
             port: 8080
             targetPort: http
             protocol: TCP
+
+  - it: should render dual-stack settings when configured
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv6
+          - IPv4
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv6
+            - IPv4
+
+  - it: should render SingleStack policy when configured
+    set:
+      service.ipFamilyPolicy: SingleStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+
+  - it: should render RequireDualStack policy when configured
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: RequireDualStack

--- a/charts/karakeep/values.schema.json
+++ b/charts/karakeep/values.schema.json
@@ -22,6 +22,10 @@
       "description": "Karakeep application configuration",
       "properties": {
         "nextAuthUrl": { "type": "string", "description": "Public URL of the Karakeep instance", "default": "" },
+        "browserConnectOnDemand": { "type": "boolean", "default": true },
+        "existingSecret": { "type": "string", "description": "Existing secret containing nextauth-secret and meili-master-key", "default": "" },
+        "existingSecretNextAuthKey": { "type": "string", "default": "nextauth-secret" },
+        "existingSecretMeiliMasterKey": { "type": "string", "default": "meili-master-key" },
         "extraEnv": { "type": "array", "items": { "type": "object" } }
       }
     },
@@ -34,7 +38,7 @@
           "type": "object",
           "properties": {
             "repository": { "type": "string", "default": "docker.io/getmeili/meilisearch" },
-            "tag": { "type": "string", "default": "v1.13.3" },
+            "tag": { "type": "string", "default": "v1.41.0" },
             "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
           }
         },
@@ -46,11 +50,12 @@
       "description": "Chromium sidecar for web page screenshots",
       "properties": {
         "enabled": { "type": "boolean", "default": true },
+        "port": { "type": "integer", "default": 9222, "minimum": 1, "maximum": 65535 },
         "image": {
           "type": "object",
           "properties": {
             "repository": { "type": "string", "default": "ghcr.io/browserless/chromium" },
-            "tag": { "type": "string", "default": "v2.18.0" },
+            "tag": { "type": "string", "default": "v2.46.0" },
             "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
           }
         },
@@ -81,7 +86,17 @@
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
         "port": { "type": "integer", "default": 80 },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2,
+          "uniqueItems": true
+        }
       }
     },
     "ingress": {
@@ -92,6 +107,26 @@
         "annotations": { "type": "object" },
         "hosts": { "type": "array", "items": { "type": "object" } },
         "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"] },
+              "value": { "type": "string" }
+            },
+            "required": ["type", "value"]
+          }
+        },
+        "annotations": { "type": "object" }
       }
     },
     "probes": { "type": "object" },
@@ -108,6 +143,29 @@
     "podAnnotations": { "type": "object" },
     "extraVolumes": { "type": "array", "items": { "type": "object" } },
     "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
-    "extraManifests": { "type": "array", "items": { "type": "object" } }
+    "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "0" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "default": "" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"], "default": "SecretStore" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "default": "Owner" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } },
+        "annotations": { "type": "object" }
+      }
+    }
   }
 }

--- a/charts/karakeep/values.yaml
+++ b/charts/karakeep/values.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# Karakeep Helm Chart — Default Values
+# Karakeep Helm Chart - Default Values
 # =============================================================================
 # Focus: AI-powered bookmark manager with optional Meilisearch and Chromium sidecars
 

--- a/charts/karakeep/values.yaml
+++ b/charts/karakeep/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Karakeep Helm Chart — Default Values
 # =============================================================================
@@ -15,7 +16,7 @@ image:
   # -- Karakeep container image
   repository: ghcr.io/karakeep-app/karakeep
   # -- Image tag
-  tag: "0.31.0"
+  tag: "0.32.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -27,6 +28,14 @@ imagePullSecrets: []
 karakeep:
   # -- Public URL of the Karakeep instance (e.g. https://karakeep.example.com)
   nextAuthUrl: ""
+  # -- Connect to the browser service only when crawling needs it
+  browserConnectOnDemand: true
+  # -- Existing secret containing nextauth-secret and meili-master-key
+  existingSecret: ""
+  # -- Key in the existing secret for NEXTAUTH_SECRET
+  existingSecretNextAuthKey: nextauth-secret
+  # -- Key in the existing secret for MEILI_MASTER_KEY
+  existingSecretMeiliMasterKey: meili-master-key
   # -- Extra environment variables for the main container
   # -- @default -- `[]`
   extraEnv: []
@@ -54,6 +63,8 @@ meilisearch:
 chromium:
   # -- Enable Chromium sidecar for web page screenshots
   enabled: true
+  # -- Internal Chromium sidecar HTTP port
+  port: 9222
   image:
     # -- Chromium container image
     repository: ghcr.io/browserless/chromium
@@ -103,6 +114,10 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -126,6 +141,28 @@ ingress:
     # - hosts:
     #     - karakeep.example.com
     #   secretName: karakeep-tls
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute for Karakeep HTTP (requires Gateway API CRDs)
+  enabled: false
+  # -- Parent Gateway references. Leave empty to attach through controller defaults.
+  parentRefs: []
+  #   - name: shared-gateway
+  #     namespace: gateway-system
+  #     sectionName: https
+  # -- HTTPRoute hostnames
+  hostnames: []
+  #   - karakeep.example.com
+  # -- HTTPRoute path matches
+  paths:
+    - type: PathPrefix
+      value: /
+  # -- HTTPRoute annotations
+  annotations: {}
 
 # =============================================================================
 # Probes
@@ -184,3 +221,37 @@ extraVolumeMounts: []
 
 # -- Extra manifests to deploy alongside the chart
 extraManifests: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for the Karakeep auth/search secret.
+  # Requires karakeep.existingSecret to be set to prevent credential drift
+  # between the chart-managed Secret and the ExternalSecret.
+  enabled: false
+  # -- ExternalSecret apiVersion
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval
+  refreshInterval: "0"
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name
+    name: ""
+    # -- SecretStore or ClusterSecretStore
+    kind: SecretStore
+  target:
+    # -- ExternalSecret target Secret creation policy
+    creationPolicy: Owner
+  # -- ExternalSecret data entries mapping remote keys to Karakeep Secret keys.
+  data: []
+  #   - secretKey: nextauth-secret
+  #     remoteRef:
+  #       key: karakeep/credentials
+  #       property: nextauth-secret
+  #   - secretKey: meili-master-key
+  #     remoteRef:
+  #       key: karakeep/credentials
+  #       property: meili-master-key
+  # -- ExternalSecret annotations
+  annotations: {}


### PR DESCRIPTION
Closes #249

## Summary
- Update Karakeep to 0.32.0 and align `Chart.yaml` appVersion with the image tag.
- Add Service dual-stack values/schema/template support, native Gateway API `HTTPRoute`, and External Secrets integration.
- Fix Chromium sidecar runtime by setting Browserless `PORT=9222` and Karakeep `BROWSER_CONNECT_ONDEMAND=true`, so the default K3D deployment starts without browser timeout errors.
- Document new values in the chart README and paired site PR.

## Upstream Evidence
- Upstream release notes reviewed: https://github.com/karakeep-app/karakeep/releases/tag/v0.32.0
- Official registry tag exists: `ghcr.io/karakeep-app/karakeep:0.32.0`
- Stable release selected: `0.32.0`
- App version aligned: `Chart.yaml` appVersion `0.32.0` matches image tag `0.32.0`
- Image digest verified: `sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31`

## Validation
- `helm dependency build charts/karakeep`
- `helm lint charts/karakeep`
- `helm lint --strict charts/karakeep`
- `helm unittest charts/karakeep`: 7 suites, 40 tests
- `helm template` default + `kubeconform -strict`
- `helm template` for all `ci/*.yaml` + `kubeconform -strict -ignore-missing-schemas`
- `npx -y markdownlint-cli2 charts/karakeep/README.md`
- `ah lint charts/karakeep`: 65 packages, 0 errors
- Kubescape MITRE/NSA/SOC2 score: 76
- K3D `k3d-charts-test` smoke: 3/3 Ready, 0 restarts, HTTP 200, `PreferDualStack`, logs clean across all containers

## MCP Guardrails
- `validate_chart_lock`: PASS
- `validate_service_dualstack`: PASS
- `validate_gateway_api`: PASS
- `validate_externalsecrets`: PASS
- `check_site_sync`: PASS
- `validate_chart_security_evidence`: PASS
- `validate_chart_ci_evidence`: PASS
- `validate_upstream_update`: PASS
- `validate_chart`: 0 blockers, warning only for CI-managed chart version
- `validate_pr_governance`: PASS

Site PR: https://github.com/helmforgedev/site/pull/220