### PR TITLE
feat(liwan): update to 1.5.0

### DIFF
--- a/charts/liwan/.helmignore
+++ b/charts/liwan/.helmignore
@@ -20,7 +20,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: liwan
 description: Liwan ultra-lightweight privacy-first web analytics with embedded DuckDB
 type: application
 version: 1.1.7
-appVersion: "1.4.0"
+appVersion: "1.5.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,6 +23,8 @@ sources:
   - https://github.com/explodingcamera/liwan
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to 1.5.0 (#250)"
     - kind: changed
       description: "prepare sandbox governance and Apache licensing (#124)"
   artifacthub.io/maintainers: |

--- a/charts/liwan/README.md
+++ b/charts/liwan/README.md
@@ -1,6 +1,10 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Liwan Helm Chart
 
-Deploy [Liwan](https://liwan.dev) on Kubernetes using the official [ghcr.io/explodingcamera/liwan](https://github.com/explodingcamera/liwan/pkgs/container/liwan) container image. Ultra-lightweight privacy-first web analytics written in Rust with embedded DuckDB — runs on minimal resources with zero external dependencies.
+Deploy [Liwan](https://liwan.dev) on Kubernetes using the official
+[ghcr.io/explodingcamera/liwan](https://github.com/explodingcamera/liwan/pkgs/container/liwan)
+container image. Ultra-lightweight privacy-first web analytics written in Rust with embedded DuckDB.
 
 ## Features
 
@@ -10,6 +14,8 @@ Deploy [Liwan](https://liwan.dev) on Kubernetes using the official [ghcr.io/expl
 - **Non-root** — runs as UID 1000 by default
 - **Persistent storage** — DuckDB database and GeoIP data on PVC
 - **Ingress support** — TLS with cert-manager
+- **Gateway API support** — optional HTTPRoute for native Kubernetes routing
+- **Dual-stack ready Service** — optional `ipFamilyPolicy` and `ipFamilies`
 
 ## Installation
 
@@ -30,7 +36,7 @@ helm install liwan oci://ghcr.io/helmforgedev/helm/liwan -f values.yaml
 ## Basic Example
 
 ```yaml
-# values.yaml — default values are sufficient
+# values.yaml - default values are sufficient
 # DuckDB embedded, no database needed
 ```
 
@@ -45,12 +51,46 @@ kubectl port-forward svc/<release>-liwan 9042:80
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `image.repository` | `ghcr.io/explodingcamera/liwan` | Liwan image repository |
+| `image.tag` | `"1.5.0"` | Liwan image tag |
 | `liwan.port` | `9042` | Application port |
 | `liwan.baseUrl` | `""` | Public base URL |
 | `persistence.enabled` | `true` | Enable persistence for /data |
 | `persistence.size` | `2Gi` | PVC size |
 | `ingress.enabled` | `false` | Enable ingress |
 | `service.port` | `80` | Service port |
+| `service.ipFamilyPolicy` | `null` | Service IP family policy |
+| `service.ipFamilies` | `[]` | Ordered Service IP families |
+| `gatewayAPI.enabled` | `false` | Render a Gateway API HTTPRoute |
+
+## Gateway API Example
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - analytics.example.com
+```
+
+## Dual-Stack Service Example
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## Upgrade Notes
+
+Liwan `1.5.0` is published in GHCR and includes the unreleased upstream changelog entries after `v1.4.0`,
+including additional trusted proxy/header options, new dimensions, DuckDB updates, and startup locking fixes.
+The chart keeps the single-replica `Recreate` strategy because DuckDB remains single-writer storage.
 
 ## Limitations
 

--- a/charts/liwan/ci/dual-stack.yaml
+++ b/charts/liwan/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/liwan/ci/gateway-api.yaml
+++ b/charts/liwan/ci/gateway-api.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - analytics.example.com

--- a/charts/liwan/templates/NOTES.txt
+++ b/charts/liwan/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Liwan has been successfully deployed!
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -23,6 +24,37 @@ Port-forward to access Liwan locally:
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "liwan.fullname" . }} 9042:{{ .Values.service.port }}
 
   WEB UI:   http://localhost:9042/
+{{- end }}
+{{- if .Values.gatewayAPI.enabled }}
+
+Gateway API HTTPRoute rendered.
+{{- with .Values.gatewayAPI.hostnames }}
+Hostnames:
+{{- range . }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Base URL:
+{{- if .Values.liwan.baseUrl }}
+  {{ .Values.liwan.baseUrl }}
+{{- else }}
+  Not configured. Set liwan.baseUrl to the public URL before enabling tracking scripts.
+{{- end }}
+Persistence:
+{{- if .Values.persistence.enabled }}
+  enabled, claim {{ include "liwan.dataClaimName" . }}
+{{- else }}
+  disabled, data is stored on an emptyDir volume and is lost on pod restart
+{{- end }}
+{{- with .Values.service.ipFamilyPolicy }}
+Service IP family policy:
+  {{ . }}
 {{- end }}
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/charts/liwan/templates/deployment.yaml
+++ b/charts/liwan/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/liwan/templates/httproute.yaml
+++ b/charts/liwan/templates/httproute.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "liwan.fullname" . }}
+  labels:
+    {{- include "liwan.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gatewayAPI.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.gatewayAPI.paths }}
+        - path:
+            type: {{ .type }}
+            value: {{ .value | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ include "liwan.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/liwan/templates/service.yaml
+++ b/charts/liwan/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,6 +11,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/liwan/tests/deployment_test.yaml
+++ b/charts/liwan/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml
@@ -23,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/explodingcamera/liwan:1.4.0"
+          value: "ghcr.io/explodingcamera/liwan:1.5.0"
 
   - it: should run as non-root UID 1000
     asserts:

--- a/charts/liwan/tests/httproute_test.yaml
+++ b/charts/liwan/tests/httproute_test.yaml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: HTTPRoute
+templates:
+  - templates/httproute.yaml
+tests:
+  - it: should not render HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute when Gateway API is enabled
+    set:
+      gatewayAPI:
+        enabled: true
+        parentRefs:
+          - name: shared-gateway
+            namespace: gateway-system
+            sectionName: https
+        hostnames:
+          - analytics.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: analytics.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80

--- a/charts/liwan/tests/service_test.yaml
+++ b/charts/liwan/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml
@@ -22,3 +23,27 @@ tests:
             port: 80
             targetPort: http
             protocol: TCP
+
+  - it: should not set IP family fields by default
+    asserts:
+      - isNull:
+          path: spec.ipFamilyPolicy
+      - isNull:
+          path: spec.ipFamilies
+
+  - it: should render dual-stack Service settings
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6

--- a/charts/liwan/values.schema.json
+++ b/charts/liwan/values.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Liwan Helm Chart Values",
-  "description": "Values for the Liwan Helm chart — ultra-lightweight privacy-first web analytics with embedded DuckDB",
+  "description": "Values for the Liwan Helm chart - ultra-lightweight privacy-first web analytics with embedded DuckDB",
   "type": "object",
   "additionalProperties": true,
   "properties": {
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/explodingcamera/liwan" },
-        "tag": { "type": "string", "default": "" },
+        "tag": { "type": "string", "default": "1.5.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -50,7 +50,17 @@
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
         "port": { "type": "integer", "default": 80 },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2,
+          "uniqueItems": true
+        }
       }
     },
     "ingress": {
@@ -61,6 +71,26 @@
         "annotations": { "type": "object" },
         "hosts": { "type": "array", "items": { "type": "object" } },
         "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"] },
+              "value": { "type": "string" }
+            },
+            "required": ["type", "value"]
+          }
+        },
+        "annotations": { "type": "object" }
       }
     },
     "probes": { "type": "object" },

--- a/charts/liwan/values.yaml
+++ b/charts/liwan/values.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# Liwan Helm Chart — Default Values
+# Liwan Helm Chart - Default Values
 # =============================================================================
 # Focus: ultra-lightweight privacy-first web analytics with embedded DuckDB
 
@@ -15,7 +16,7 @@ image:
   # -- Liwan container image
   repository: ghcr.io/explodingcamera/liwan
   # -- Image tag
-  tag: "1.4.0"
+  tag: "1.5.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -72,6 +73,32 @@ service:
   # -- HTTP service port
   port: 80
   # -- Annotations for the Service
+  annotations: {}
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute for Liwan HTTP (requires Gateway API CRDs)
+  enabled: false
+  # -- Parent Gateway references. Leave empty to attach through controller defaults.
+  parentRefs: []
+  #   - name: shared-gateway
+  #     namespace: gateway-system
+  #     sectionName: https
+  # -- HTTPRoute hostnames
+  hostnames: []
+  #   - analytics.example.com
+  # -- HTTPRoute path matches
+  paths:
+    - type: PathPrefix
+      value: /
+  # -- HTTPRoute annotations
   annotations: {}
 
 # =============================================================================


### PR DESCRIPTION
Closes #250

## Summary
- Update Liwan appVersion and image tag to 1.5.0.
- Add opt-in Service dual-stack values and Gateway API HTTPRoute support.
- Add CI scenarios, helm-unittest coverage, README, and NOTES.txt updates.
- External Secrets is not rendered because the Liwan chart has no chart-managed secret material.

## Upstream Evidence
- Official upstream registry verified: `docker manifest inspect ghcr.io/explodingcamera/liwan:1.5.0` passed.
- Official upstream registry pull verified: `docker pull ghcr.io/explodingcamera/liwan:1.5.0` passed.
- Official upstream source reviewed: https://github.com/explodingcamera/liwan.
- Upstream changelog reviewed: https://raw.githubusercontent.com/explodingcamera/liwan/main/CHANGELOG.md.
- Stable release selected: `1.5.0`; no alpha, beta, rc, dev, snapshot, or nightly tag was selected.
- AppVersion/image tag aligned: `Chart.yaml` appVersion `1.5.0` matches `values.yaml` image tag `1.5.0`.
- Image digest verified: `sha256:6fe612500ab04abacbba64a7870f2a916f8938e87c1b6974751b00f6a137cd08`.
- OCI labels reviewed: version `1.5.0`, source `https://github.com/explodingcamera/liwan`, revision `70404ed82c2923f49bb965d769aa68498acec92b`.

## Local Validation
- `helm dependency build charts/liwan`
- `helm lint charts/liwan`
- `helm lint --strict charts/liwan`
- `helm template liwan-test charts/liwan | kubeconform -strict -summary -schema-location default -schema-location <CRDs catalog> -exit-on-error` => 3 valid, 0 invalid.
- CI values kubeconform with CRDs catalog: `default-values.yaml` 3 valid, `dual-stack.yaml` 3 valid, `gateway-api.yaml` 4 valid, `ingress-values.yaml` 4 valid.
- `helm unittest charts/liwan` => 5 suites, 22 tests passed.
- `ah lint charts/liwan` => 65 packages found, 0 package errors.
- `npx -y markdownlint-cli2 charts/liwan/README.md` => 0 errors.
- `rg -n "[^\\x00-\\x7F]" charts/liwan/values.yaml` => no non-ASCII content.
- Kubescape `MITRE,NSA,SOC2` => score 79, above the required 50.
- `git diff --check` => passed.

## K3D Runtime Validation
- Context: `k3d-charts-test`.
- Command: `helm upgrade --install liwan-250-smoke charts/liwan --namespace liwan-250-smoke --create-namespace --kube-context k3d-charts-test --wait --timeout 15m --set service.ipFamilyPolicy=PreferDualStack`.
- Pod: `liwan-250-smoke-liwan-595445d5bd-wzhw5`, status `true 0`.
- Image: `ghcr.io/explodingcamera/liwan:1.5.0`.
- Service `ipFamilyPolicy`: `PreferDualStack`.
- In-cluster HTTP smoke: `/` returned `200`.
- Logs checked for every pod/container: `error_like_logs=0`.

## MCP Guardrails
- `mcp_health`: PASS.
- `validate_chart_lock`: PASS.
- `validate_chart`: WARN only for preserved release-please chart version management; 0 blockers.
- `validate_service_dualstack`: PASS.
- `validate_gateway_api`: PASS.
- `validate_externalsecrets`: SKIP, no secret material.
- `check_site_sync`: PASS.
- `validate_chart_ci_evidence`: PASS.
- `validate_chart_security_evidence`: PASS.
- `validate_upstream_update`: PASS.