### PR TITLE
chore(metabase): update to v0.60.4

### DIFF
--- a/charts/metabase/Chart.lock
+++ b/charts/metabase/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-digest: sha256:cfb9c45d371da28d8ce053b68ce12dc4a6132a7e2eb5cfc2d67292372b9919a9
-generated: "2026-04-29T02:34:24.5583271-03:00"

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.10
-appVersion: "v0.60.3"
+appVersion: "v0.60.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,6 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "upgrade to v0.60.4 (#251)"
     - kind: changed
       description: "upgrade to v0.60.3 (#179)"
   artifacthub.io/maintainers: |

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -89,7 +89,7 @@ service:
 Requires Gateway API CRDs and a compatible controller (e.g. Envoy Gateway).
 
 ```yaml
-gateway:
+gatewayAPI:
   enabled: true
   gatewayName: envoy-gateway
   gatewayNamespace: envoy-gateway-system
@@ -97,7 +97,8 @@ gateway:
     - metabase.example.com
 ```
 
-> **Note:** `gateway.gatewayName` is required when `gateway.enabled=true`.
+> **Note:** `gatewayAPI.gatewayName` is required when `gatewayAPI.enabled=true`. The older `gateway` block remains
+> supported as a compatibility alias.
 
 ## External Secrets Operator (ESO)
 
@@ -127,6 +128,7 @@ externalSecrets:
 | `metabase.port` | `3000` | Application port |
 | `metabase.encryptionSecretKey` | `""` | Encryption key (auto-generated) |
 | `metabase.siteUrl` | `""` | Public site URL |
+| `metabase.aiFeaturesEnabled` | `false` | Enable Metabase AI features after configuring a supported provider |
 | `metabase.javaTimezone` | `UTC` | Java timezone |
 | `metabase.javaOpts` | `""` | JVM memory options |
 | `postgresql.enabled` | `true` | Deploy PostgreSQL subchart |
@@ -134,10 +136,12 @@ externalSecrets:
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
 | `service.ipFamilies` | `[]` | IP families override (`IPv4`, `IPv6`) |
-| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
-| `gateway.gatewayName` | `""` | Gateway name (required when `gateway.enabled=true`) |
-| `gateway.gatewayNamespace` | `""` | Gateway namespace |
-| `gateway.hostnames` | `[]` | HTTPRoute hostnames |
+| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `gatewayAPI.gatewayName` | `""` | Gateway name (required when `gatewayAPI.enabled=true`) |
+| `gatewayAPI.gatewayNamespace` | `""` | Gateway namespace |
+| `gatewayAPI.hostnames` | `[]` | HTTPRoute hostnames |
+| `gatewayAPI.path` | `/` | HTTPRoute path match value |
+| `gatewayAPI.pathType` | `PathPrefix` | HTTPRoute path match type |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret resource |
 | `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
 | `externalSecrets.refreshInterval` | `"0"` | Refresh interval (`"0"` = one-time sync) |

--- a/charts/metabase/ci/gateway-api.yaml
+++ b/charts/metabase/ci/gateway-api.yaml
@@ -10,7 +10,7 @@ database:
     username: metabase
     password: "testpassword"
 
-gateway:
+gatewayAPI:
   enabled: true
   gatewayName: my-gateway
   gatewayNamespace: default

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -35,6 +35,18 @@ Port-forward to access Metabase locally:
 4. Open the UI and complete the initial setup wizard
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CONFIGURATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Metabase AI features are disabled by default to avoid background AI jobs
+without a configured provider:
+
+  metabase.aiFeaturesEnabled={{ .Values.metabase.aiFeaturesEnabled }}
+
+To use Gateway API, prefer gatewayAPI.* values. The legacy gateway.* block
+is still accepted as a compatibility alias.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   TROUBLESHOOTING
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -54,11 +66,15 @@ Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
   WARNINGS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-{{- if .Values.gateway.enabled }}
+{{- $gateway := .Values.gatewayAPI }}
+{{- if and (not .Values.gatewayAPI.enabled) .Values.gateway.enabled }}
+  {{- $gateway = .Values.gateway }}
+{{- end }}
+{{- if or .Values.gatewayAPI.enabled .Values.gateway.enabled }}
 
 NOTE: Gateway API HTTPRoute {{ include "metabase.fullname" . }} is active.
-  Gateway: {{ .Values.gateway.gatewayName }}{{ with .Values.gateway.gatewayNamespace }}.{{ . }}{{ end }}
-  {{- with .Values.gateway.hostnames }}
+  Gateway: {{ $gateway.gatewayName }}{{ with $gateway.gatewayNamespace }}.{{ . }}{{ end }}
+  {{- with $gateway.hostnames }}
   Hostnames: {{ join ", " . }}
   {{- end }}
 {{- else if not .Values.ingress.enabled }}

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -78,6 +78,8 @@ spec:
                   key: {{ include "metabase.dbSecretPasswordKey" . }}
             - name: MB_JETTY_PORT
               value: {{ .Values.metabase.port | quote }}
+            - name: MB_AI_FEATURES_ENABLED
+              value: {{ .Values.metabase.aiFeaturesEnabled | quote }}
             - name: MB_ENCRYPTION_SECRET_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/metabase/templates/httproute.yaml
+++ b/charts/metabase/templates/httproute.yaml
@@ -1,7 +1,11 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.gateway.enabled }}
-{{- if not .Values.gateway.gatewayName }}
-  {{- fail "gateway.gatewayName is required when gateway.enabled=true" }}
+{{- $gateway := .Values.gatewayAPI }}
+{{- if and (not .Values.gatewayAPI.enabled) .Values.gateway.enabled }}
+  {{- $gateway = .Values.gateway }}
+{{- end }}
+{{- if or .Values.gatewayAPI.enabled .Values.gateway.enabled }}
+{{- if not $gateway.gatewayName }}
+  {{- fail "gatewayAPI.gatewayName is required when gatewayAPI.enabled=true" }}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -11,19 +15,19 @@ metadata:
     {{- include "metabase.labels" . | nindent 4 }}
 spec:
   parentRefs:
-    - name: {{ .Values.gateway.gatewayName }}
-      {{- with .Values.gateway.gatewayNamespace }}
+    - name: {{ $gateway.gatewayName }}
+      {{- with $gateway.gatewayNamespace }}
       namespace: {{ . }}
       {{- end }}
-  {{- with .Values.gateway.hostnames }}
+  {{- with $gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ .Values.gateway.pathType }}
-            value: {{ .Values.gateway.path }}
+            type: {{ $gateway.pathType }}
+            value: {{ $gateway.path }}
       backendRefs:
         - name: {{ include "metabase.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.60.3"
+          value: "docker.io/metabase/metabase:v0.60.4"
 
   - it: should set custom image tag
     set:
@@ -51,6 +51,21 @@ tests:
           content:
             name: MB_DB_DBNAME
             value: metabase
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_AI_FEATURES_ENABLED
+            value: "false"
+
+  - it: should allow enabling AI features explicitly
+    set:
+      metabase.aiFeaturesEnabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_AI_FEATURES_ENABLED
+            value: "true"
 
   - it: should reference postgresql subchart secret for DB password
     asserts:

--- a/charts/metabase/tests/gatewayapi_test.yaml
+++ b/charts/metabase/tests/gatewayapi_test.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute with gatewayAPI values
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gatewayName: shared-gateway
+      gatewayAPI.gatewayNamespace: gateway-system
+      gatewayAPI.hostnames:
+        - metabase.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: metabase.example.com
+
+  - it: should keep legacy gateway values working
+    set:
+      gateway.enabled: true
+      gateway.gatewayName: legacy-gateway
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -13,7 +13,7 @@
       "description": "Container image configuration",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/metabase/metabase" },
-        "tag": { "type": "string", "description": "Image tag (defaults to v{appVersion})", "default": "" },
+        "tag": { "type": "string", "description": "Image tag", "default": "v0.60.4" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -27,6 +27,11 @@
         "existingSecret": { "type": "string", "description": "Existing secret containing the encryption key", "default": "" },
         "existingSecretKey": { "type": "string", "default": "encryption-secret-key" },
         "siteUrl": { "type": "string", "description": "Public site URL", "default": "" },
+        "aiFeaturesEnabled": {
+          "type": "boolean",
+          "description": "Enable Metabase AI features",
+          "default": false
+        },
         "javaTimezone": { "type": "string", "description": "Java timezone", "default": "UTC" },
         "javaOpts": { "type": "string", "description": "JVM options for memory tuning", "default": "" },
         "extraEnv": { "type": "array", "items": { "type": "object" } }
@@ -68,9 +73,21 @@
         "ipFamilies": { "type": "array", "description": "Dual-stack ipFamilies (GR-058)", "items": { "type": "string", "enum": ["IPv4", "IPv6"] }, "maxItems": 2 }
       }
     },
-    "gateway": {
+    "gatewayAPI": {
       "type": "object",
       "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "gatewayName": { "type": "string", "default": "" },
+        "gatewayNamespace": { "type": "string", "default": "" },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "path": { "type": "string", "default": "/" },
+        "pathType": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"], "default": "PathPrefix" }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Deprecated compatibility alias for gatewayAPI",
       "properties": {
         "enabled": { "type": "boolean", "default": false },
         "gatewayName": { "type": "string", "default": "" },

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.60.3"
+  tag: "v0.60.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -36,6 +36,8 @@ metabase:
   existingSecretKey: encryption-secret-key
   # -- Public site URL
   siteUrl: ""
+  # -- Enable Metabase AI features. Keep disabled by default to avoid background AI jobs without a configured provider.
+  aiFeaturesEnabled: false
   # -- Java timezone
   javaTimezone: UTC
   # -- JVM options for memory tuning
@@ -118,6 +120,22 @@ ingress:
 # Gateway API
 # =============================================================================
 
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
+  enabled: false
+  # -- Gateway name to attach the HTTPRoute to
+  gatewayName: ""
+  # -- Namespace of the gateway
+  gatewayNamespace: ""
+  # -- Hostnames the HTTPRoute matches
+  hostnames: []
+    # - metabase.example.com
+  # -- Path prefix for the HTTPRoute
+  path: /
+  # -- Path match type
+  pathType: PathPrefix
+
+# Deprecated compatibility alias for gatewayAPI. Prefer gatewayAPI for new values.
 gateway:
   # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
   enabled: false


### PR DESCRIPTION
## Summary
- Update Metabase image and appVersion from `v0.60.3` to `v0.60.4`.
- Add `metabase.aiFeaturesEnabled=false` by default so clean installs do not run AI background jobs without a configured provider.
- Adopt canonical `gatewayAPI.*` values while keeping `gateway.*` as a compatibility alias, add Gateway API unit tests, update docs/NOTES, and remove `Chart.lock` per GR-062.

Closes #251

## Upstream Evidence
- Official upstream registry verified: `docker manifest inspect docker.io/metabase/metabase:v0.60.4` passed.
- `docker pull docker.io/metabase/metabase:v0.60.4` passed; digest `sha256:a2161a720b6f3f774bdf3fb72bda272dae84011bfe76da32f36ea2eb3d3289ce`.
- `docker.io/metabase/metabase:0.60.4` was checked and does not exist; preserved existing `v` tag family.
- Upstream release notes/changelog reviewed: https://github.com/metabase/metabase/releases/tag/v0.60.4 and https://www.metabase.com/releases/metabase-60.
- AppVersion/image tag aligned: `v0.60.4`.

## Local Validation Evidence
- [x] `helm dependency build charts/metabase`
- [x] `helm lint charts/metabase`
- [x] `helm lint --strict charts/metabase`
- [x] `helm template metabase charts/metabase`
- [x] `helm template metabase charts/metabase -f charts/metabase/ci/backup-values.yaml`
- [x] `helm template metabase charts/metabase -f charts/metabase/ci/dual-stack.yaml`
- [x] `helm template metabase charts/metabase -f charts/metabase/ci/external-db-values.yaml`
- [x] `helm template metabase charts/metabase -f charts/metabase/ci/external-secrets.yaml`
- [x] `helm template metabase charts/metabase -f charts/metabase/ci/gateway-api.yaml`
- [x] `helm template metabase charts/metabase -f charts/metabase/ci/ingress-values.yaml`
- [x] strict `kubeconform` for default and all CI renders
- [x] `helm unittest charts/metabase` (7 suites, 33 tests)
- [x] `ah lint charts/metabase` (65 packages, 0 errors)
- [x] `npx -y markdownlint-cli2 charts/metabase/README.md`
- [x] local k3d install on `k3d-charts-test`
- [x] logs inspected for every pod/container; `error_like_logs=0`
- [x] Kubescape MITRE/NSA/SOC2 score 82, 0 Critical, 0 Action Required

## K3D Evidence
- Release/namespace: `metabase-251-smoke`
- Pod ready/restarts: `true 0`
- Image: `docker.io/metabase/metabase:v0.60.4`
- `MB_AI_FEATURES_ENABLED=false`
- Service `ipFamilyPolicy=PreferDualStack`
- `/api/health` returned HTTP 200

## HelmForge Guardrail Notes
- `Chart.yaml.version` is intentionally unchanged in this PR. HelmForge MCP `validate_action(edit_chart_version)` blocks manual chart-version edits under GR-003 because chart versioning is owned by the CI/release pipeline.
- `Chart.lock` is intentionally absent per GR-062; dependency validation was performed locally without committing the generated lock file.