### PR TITLE
chore(pihole): update images to 2026.05.0 and exporter v1.2.0

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: pihole
 type: application
 version: 2.0.7
-appVersion: "2026.04.1"
+appVersion: "2026.05.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Pi-hole DNS sinkhole on Kubernetes
 maintainers:

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -125,7 +125,7 @@ metrics:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/pihole/pihole` | Pi-hole container image repository |
-| `image.tag` | `2026.04.1` | Pi-hole container image tag (Core v6.4.2, Web v6.5, FTL v6.6.1) |
+| `image.tag` | `2026.05.0` | Pi-hole container image tag (Core v6.4.2, Web v6.5, FTL v6.6.2) |
 | `image.pullPolicy` | `IfNotPresent` | Pi-hole image pull policy |
 | `pihole.timezone` | `UTC` | Timezone for logs and scheduled tasks |
 | `pihole.upstreamDns` | `8.8.8.8;8.8.4.4` | Upstream DNS servers (semicolon-delimited) |
@@ -201,7 +201,7 @@ metrics:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `metrics.enabled` | `false` | Enable pihole-exporter sidecar |
-| `metrics.image.tag` | `v0.4.0` | pihole-exporter version |
+| `metrics.image.tag` | `v1.2.0` | pihole-exporter version |
 | `metrics.port` | `9617` | Metrics port |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor |
 | `metrics.serviceMonitor.interval` | `30s` | Scrape interval |
@@ -259,9 +259,10 @@ metrics:
 
 ## Upgrade Notes
 
-Pi-hole `2026.04.1` includes FTL `v6.6.1` and Core `v6.4.2` fixes,
-including security advisories and concurrency fixes for API access. Back up
-`/etc/pihole` and `/etc/dnsmasq.d` before upgrading live deployments.
+Pi-hole `2026.05.0` ships FTL `v6.6.2`, which imports six upstream `dnsmasq`
+security fixes covering the publicly disclosed CVEs against the dnsmasq
+2.92/2.93 line. Back up `/etc/pihole` and `/etc/dnsmasq.d` before upgrading
+live deployments.
 
 ## Connection
 

--- a/charts/pihole/tests/deployment_test.yaml
+++ b/charts/pihole/tests/deployment_test.yaml
@@ -374,7 +374,7 @@ tests:
           value: exporter
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/ekofr/pihole-exporter:v0.4.0"
+          value: "docker.io/ekofr/pihole-exporter:v1.2.0"
 
   - it: should not render metrics sidecar by default
     template: templates/deployment.yaml
@@ -439,7 +439,7 @@ tests:
           value: gravity-update
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "docker.io/pihole/pihole:2026.04.1"
+          value: "docker.io/pihole/pihole:2026.05.0"
       - matchRegex:
           path: spec.template.spec.initContainers[1].command[2]
           pattern: "pihole -g"

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.04.1"
+          "default": "2026.05.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -354,7 +354,7 @@
             },
             "tag": {
               "type": "string",
-              "default": "3.22"
+              "default": "3.23"
             },
             "pullPolicy": {
               "type": "string",
@@ -736,7 +736,7 @@
             "tag": {
               "type": "string",
               "description": "pihole-exporter image tag",
-              "default": "v0.4.0"
+              "default": "v1.2.0"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/pihole/pihole
   # -- Container image tag
-  tag: "2026.04.1"
+  tag: "2026.05.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -209,7 +209,7 @@ gravity:
     # -- Init container image repository
     repository: docker.io/library/alpine
     # -- Init container image tag
-    tag: "3.22"
+    tag: "3.23"
     # -- Init container pull policy
     pullPolicy: IfNotPresent
 
@@ -267,7 +267,7 @@ backup:
     # -- Backup utility image (tar + gzip)
     utility:
       repository: docker.io/library/alpine
-      tag: "3.22"
+      tag: "3.23"
       pullPolicy: IfNotPresent
     # -- S3 uploader image (MinIO client)
     uploader:
@@ -472,7 +472,7 @@ metrics:
     # -- pihole-exporter image repository
     repository: docker.io/ekofr/pihole-exporter
     # -- pihole-exporter image tag
-    tag: v0.4.0
+    tag: v1.2.0
     # -- pihole-exporter pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- Bump `pihole/pihole` from `2026.04.1` to `2026.05.0`. FTL `v6.6.2`
  imports six upstream `dnsmasq` security fixes covering the publicly
  disclosed CVEs against the dnsmasq 2.92/2.93 line.
- Bump `ekofr/pihole-exporter` from `v0.4.0` to `v1.2.0` (the supported
  release line for Pi-hole v6).
- Bump alpine gravity-init and backup-utility image tags from `3.22`
  to `3.23`.
- `mvance/unbound:1.22.0` and `helmforge/mc:1.0.0` are already at the
  latest published stable tags; no change.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced [upstream GitHub Releases](https://github.com/pi-hole/docker-pi-hole/releases/tag/2026.05.0) and [Docker Hub tags](https://hub.docker.com/r/pihole/pihole/tags)

## Site Sync (GR-007)

- [ ] I updated the corresponding page in `site/` repository
- [x] N/A , this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/pihole --strict` passed
- [x] `helm unittest charts/pihole` passed (10 suites, 104 tests, via `helmunittest/helm-unittest:latest` Docker image)
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [ ] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

- pihole-exporter jumps from `v0.4.0` (March 2023) to `v1.2.0`. v0.4.0
  predates the Pi-hole v6 API rewrite that the chart already targets,
  so this upgrade is required for metrics to work against the current
  Pi-hole image.
- Alpine `3.22` is still maintained; the bump to `3.23` follows the
  latest-stable convention.
- `Chart.yaml.version` is intentionally unchanged per GR-003 (chart
  version is owned by the release pipeline).
