### PR TITLE
fix(pihole): gravity-init no longer needs egress DNS

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
       {{- if .Values.gravity.enabled }}
       initContainers:
         - name: gravity-init
-          image: "{{ .Values.gravity.image.repository }}:{{ .Values.gravity.image.tag }}"
-          imagePullPolicy: {{ .Values.gravity.image.pullPolicy }}
+          image: {{ include "pihole.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/sh", "/scripts/init-gravity.sh"]
           {{- with .Values.gravity.resources }}
           resources:

--- a/charts/pihole/templates/gravity-init-configmap.yaml
+++ b/charts/pihole/templates/gravity-init-configmap.yaml
@@ -29,7 +29,7 @@ data:
       echo "Gravity database found. Ensuring Pi-hole v6 schema compatibility..."
     fi
 
-    sqlite3 "$DB" <<'SQL'
+    pihole-FTL sqlite3 "$DB" <<'SQL'
     PRAGMA foreign_keys=OFF;
     BEGIN TRANSACTION;
     CREATE TABLE IF NOT EXISTS "group" (id INTEGER PRIMARY KEY AUTOINCREMENT, enabled BOOLEAN NOT NULL DEFAULT 1, name TEXT UNIQUE NOT NULL, date_added INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), date_modified INTEGER NOT NULL DEFAULT (cast(strftime('%s', 'now') as int)), description TEXT);
@@ -48,12 +48,12 @@ data:
     COMMIT;
     SQL
 
-    if ! sqlite3 "$DB" "SELECT type FROM adlist LIMIT 1;" >/dev/null 2>&1; then
+    if ! pihole-FTL sqlite3 "$DB" "SELECT type FROM adlist LIMIT 1;" >/dev/null 2>&1; then
       echo "Adding missing Pi-hole v6 adlist.type column..."
-      sqlite3 "$DB" "ALTER TABLE adlist ADD COLUMN type INTEGER NOT NULL DEFAULT 0;"
+      pihole-FTL sqlite3 "$DB" "ALTER TABLE adlist ADD COLUMN type INTEGER NOT NULL DEFAULT 0;"
     fi
 
-    sqlite3 "$DB" <<'SQL'
+    pihole-FTL sqlite3 "$DB" <<'SQL'
     PRAGMA foreign_keys=ON;
     BEGIN TRANSACTION;
     INSERT OR IGNORE INTO adlist_by_group (adlist_id, group_id) SELECT id, 0 FROM adlist;
@@ -102,22 +102,22 @@ data:
 
     # Add adlists
     {{- range (include "pihole.adlists" . | mustFromJson) }}
-    sqlite3 "$DB" "INSERT OR IGNORE INTO adlist (address, type, enabled, comment) VALUES ('{{ . | replace "'" "''" }}', 0, 1, 'Added by Helm chart');"
+    pihole-FTL sqlite3 "$DB" "INSERT OR IGNORE INTO adlist (address, type, enabled, comment) VALUES ('{{ . | replace "'" "''" }}', 0, 1, 'Added by Helm chart');"
     {{- end }}
 
     # Add whitelist domains (type=0)
     {{- range (include "pihole.whitelist" . | mustFromJson) }}
-    sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (0, '{{ . | replace "'" "''" }}', 1, 'Added by Helm chart');"
+    pihole-FTL sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (0, '{{ . | replace "'" "''" }}', 1, 'Added by Helm chart');"
     {{- end }}
 
     # Add blacklist domains (type=1)
     {{- range .Values.dns.blacklist }}
-    sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (1, '{{ . | replace "'" "''" }}', 1, 'Added by Helm chart');"
+    pihole-FTL sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (1, '{{ . | replace "'" "''" }}', 1, 'Added by Helm chart');"
     {{- end }}
 
     # Add regex blacklist (type=3)
     {{- range .Values.dns.regex }}
-    sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (3, '{{ . | replace "'" "''" }}', 1, 'Added by Helm chart');"
+    pihole-FTL sqlite3 "$DB" "INSERT OR IGNORE INTO domainlist (type, domain, enabled, comment) VALUES (3, '{{ . | replace "'" "''" }}', 1, 'Added by Helm chart');"
     {{- end }}
 
     echo "Gravity database populated successfully."

--- a/charts/pihole/templates/gravity-init-configmap.yaml
+++ b/charts/pihole/templates/gravity-init-configmap.yaml
@@ -19,8 +19,7 @@ data:
       sleep 2
     done
 
-    echo "Volume mounted. Installing sqlite3..."
-    apk add --no-cache sqlite
+    echo "Volume mounted. Preparing gravity database..."
 
     DB="/etc/pihole/gravity.db"
 

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -344,25 +344,6 @@
           "description": "Run pihole -g after populating database",
           "default": true
         },
-        "image": {
-          "type": "object",
-          "description": "Init container image configuration",
-          "properties": {
-            "repository": {
-              "type": "string",
-              "default": "docker.io/library/alpine"
-            },
-            "tag": {
-              "type": "string",
-              "default": "3.23"
-            },
-            "pullPolicy": {
-              "type": "string",
-              "enum": ["Always", "IfNotPresent", "Never"],
-              "default": "IfNotPresent"
-            }
-          }
-        },
         "resources": {
           "type": "object",
           "description": "Resources for the init container"

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -205,14 +205,6 @@ gravity:
   # -- Run pihole -g after populating database (updates gravity)
   updateOnInit: true
 
-  image:
-    # -- Init container image repository
-    repository: docker.io/library/alpine
-    # -- Init container image tag
-    tag: "3.23"
-    # -- Init container pull policy
-    pullPolicy: IfNotPresent
-
   # -- Resources for the init container
   resources: {}
     # requests:


### PR DESCRIPTION
## Summary

- The pihole \`gravity-init\` init container used an Alpine image and ran \`apk add --no-cache sqlite\` at startup. That requires egress DNS to \`dl-cdn.alpinelinux.org\`, which fails whenever the pod's DNS path is not reachable at init time (common when Pi-hole itself is the cluster's DNS resolver, or any time the CoreDNS path is flaky). Setting \`gravity.enabled: false\` was the only workaround.
- Reuse the Pi-hole image for \`gravity-init\` (it already ships with \`sqlite3\`, exactly like the existing \`gravity-update\` init container does). This removes the runtime package install and the external DNS dependency entirely.
- Drops the now-unused \`gravity.image\` block from \`values.yaml\` and \`values.schema.json\`.

### Reported symptom

```
gravity-init === Pi-hole Gravity Init ===
gravity-init Waiting for /etc/pihole to be writable...
gravity-init Volume mounted. Installing sqlite3...
gravity-init WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.23/main/x86_64/APKINDEX.tar.gz: DNS: name does not exist
gravity-init WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.23/community/x86_64/APKINDEX.tar.gz: DNS: name does not exist
gravity-init ERROR: unable to select packages:
gravity-init   sqlite (no such package):
gravity-init     required by: world[sqlite]
```

After this change, \`gravity.enabled: true\` (the default) works without requiring egress DNS for the init container.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (\`Resolves #NNN\` or \`Related to #NNN\`)
- [ ] If this is a new chart PR, labels \`enhancement\` and \`type:feature\` are applied

## Checklist

- [x] I created this branch from updated \`main\`
- [x] My PR targets \`main\`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit \`version\` in \`Chart.yaml\` manually
- [x] I updated the root \`README.md\` if a new chart was added or public chart metadata changed (N/A)
- [x] I updated \`values.schema.json\` for any values changes
- [x] I updated chart docs for behavior or default changes (no public docs referenced \`gravity.image\`)

## Upstream Verification

- [x] I verified \`appVersion\` in \`Chart.yaml\` matches the real upstream release (unchanged)
- [x] I confirmed the image tag in \`values.yaml\` corresponds to a published, stable tag (unchanged)
- [x] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

- [x] N/A, this change does not affect public documentation

## Local Validation

- [x] I confirmed \`kubectl config current-context\` before local installs/upgrades/uninstalls
- [x] \`helm lint charts/pihole --strict\` passed
- [ ] \`helm unittest charts/pihole\` passed
- [x] All relevant \`ci/*.yaml\` scenarios rendered successfully (verified \`helm template\` renders \`gravity-init\` with the pihole image)
- [ ] I validated this change on a local \`k3d\` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO (N/A)