### PR TITLE
chore(archivebox): update image to 0.7.4

### DIFF
--- a/charts/archivebox/.helmignore
+++ b/charts/archivebox/.helmignore
@@ -20,7 +20,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: archivebox
 description: ArchiveBox self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage

--- a/charts/archivebox/Chart.yaml
+++ b/charts/archivebox/Chart.yaml
@@ -3,7 +3,7 @@ name: archivebox
 description: ArchiveBox self-hosted web archiving with Chromium headless, multi-format capture, and persistent storage
 type: application
 version: 1.1.8
-appVersion: "0.7.3"
+appVersion: "0.7.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "prepare sandbox governance and Apache licensing (#124)"
+      description: "update ArchiveBox image to 0.7.4 (#274)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/archivebox/tests/deployment_test.yaml
+++ b/charts/archivebox/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml

--- a/charts/archivebox/tests/deployment_test.yaml
+++ b/charts/archivebox/tests/deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/archivebox/archivebox:0.7.3"
+          value: "docker.io/archivebox/archivebox:0.7.4"
 
   - it: should set server command
     asserts:

--- a/charts/archivebox/values.yaml
+++ b/charts/archivebox/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- ArchiveBox container image
   repository: docker.io/archivebox/archivebox
   # -- Image tag
-  tag: "0.7.3"
+  tag: "0.7.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/archivebox/values.yaml
+++ b/charts/archivebox/values.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# ArchiveBox Helm Chart — Default Values
+# ArchiveBox Helm Chart - Default Values
 # =============================================================================
 # Focus: self-hosted web archiving with Chromium headless and multi-format capture
 


### PR DESCRIPTION
## Summary

- Closes #274
- Updates ArchiveBox from `0.7.3` to `0.7.4`
- Updates the rendered image unit test expectation
- Removes stale `*.lock` from the chart `.helmignore` for GR-062 Chart.lock policy

## Upstream Verification

- Verified image tag with `docker pull docker.io/archivebox/archivebox:0.7.4`
- Reviewed upstream release: https://github.com/ArchiveBox/ArchiveBox/releases/tag/v0.7.4
- Upstream notes describe Docker/container dependency updates for Chromium, Playwright, Node.js, gosu, yt-dlp, single-file and related dependencies.

## Local Validation

- `helm dependency build charts/archivebox`
- `helm lint --strict charts/archivebox`
- `helm template archivebox-test charts/archivebox`
- `helm template archivebox-test charts/archivebox -f charts/archivebox/ci/backup-values.yaml`
- `helm template archivebox-test charts/archivebox -f charts/archivebox/ci/default-values.yaml`
- `helm template archivebox-test charts/archivebox -f charts/archivebox/ci/ingress-values.yaml`
- `helm unittest charts/archivebox` - 33 tests passed
- `ah lint charts/archivebox` - package lint passed
- `helm template archivebox-test charts/archivebox | kubeconform -strict -summary` - 4 valid resources
- K3D runtime validation on `k3d-helmforge-tests`:
  - release `archivebox-274` installed in namespace `hf-issue-274-archivebox`
  - pod reached `1/1 Running`
  - `kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=archivebox-274` passed
  - no Warning events
  - logs checked with no fatal/error runtime failures

## Notes

The HelmForge MCP validator was invoked but returned an HTTP transport error during this run. I applied the known guardrail checks locally and kept the validation evidence above aligned with the HelmForge chart CI contract.