### PR TITLE
chore(cloudflared): update image to 2026.5.0

### DIFF
--- a/charts/cloudflared/.helmignore
+++ b/charts/cloudflared/.helmignore
@@ -20,7 +20,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -3,7 +3,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.3
-appVersion: "2026.3.0"
+appVersion: "2026.5.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "prepare sandbox governance and Apache licensing (#124)"
+      description: "update cloudflared image to 2026.5.0 (#275)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.3.0"
+  tag: "2026.5.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -1,5 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
-# Cloudflare Tunnel (cloudflared) Helm Chart — Default Values
+# Cloudflare Tunnel (cloudflared) Helm Chart - Default Values
 # =============================================================================
 # Focus: secure outbound tunnel to Cloudflare's network
 


### PR DESCRIPTION
## Summary

- Closes #275
- Updates cloudflared from `2026.3.0` to `2026.5.0`
- Updates Artifact Hub change metadata
- Removes stale `*.lock` from the chart `.helmignore` for GR-062 Chart.lock policy

## Upstream Verification

- Verified image tag with `docker pull docker.io/cloudflare/cloudflared:2026.5.0`
- Reviewed upstream release: https://github.com/cloudflare/cloudflared/releases/tag/2026.5.0
- Tavily search also found the upstream GitHub release page for `cloudflared`.

## Local Validation

- `helm dependency build charts/cloudflared`
- `helm lint --strict charts/cloudflared`
- `helm template cloudflared-test charts/cloudflared --set tunnel.token=test-token`
- `helm template` for all `charts/cloudflared/ci/*.yaml` scenarios
- `helm unittest charts/cloudflared` - 32 tests passed
- `ah lint charts/cloudflared` - package lint passed
- `helm template cloudflared-test charts/cloudflared --set tunnel.token=test-token | kubeconform -strict -summary` - 4 valid resources

## K3D Runtime Validation

Validated on `k3d-helmforge-tests` with a synthetic tunnel token:

- release submitted successfully in namespace `hf-issue-275-cloudflared`
- rendered pod used `docker.io/cloudflare/cloudflared:2026.5.0`
- container started and failed only because the synthetic token is not valid:

```text
Provided Tunnel token is not valid.
See 'cloudflared tunnel run --help'.
```

A full Ready-state tunnel validation requires a real Cloudflare Tunnel token, so this PR validates chart rendering, Kubernetes resource validity, image pullability, and process startup up to the expected external-credential boundary.

## Notes

The HelmForge MCP validator intermittently returned an HTTP transport error during this run. I applied the known guardrail checks locally and kept the validation evidence aligned with the HelmForge chart CI contract.