### PR TITLE
chore(elasticsearch): update image to 9.4.1

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.0.5
-appVersion: "9.4.0"
+appVersion: "9.4.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev
@@ -27,7 +27,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 9.4.0 (#267)"
+      description: "update Elasticsearch and Kibana images to 9.4.1 (#276)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -160,7 +160,7 @@ dataTiers:
 | `clusterProfile` | Cluster preset: `dev`, `staging`, `production-ha` | `dev` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.4.0` |
+| `image.tag` | Image tag | `9.4.1` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -261,7 +261,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.0` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.1` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -290,8 +290,8 @@ dataTiers:
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.0` is an upstream image update from
-`9.3.4`. Review the upstream Elasticsearch release notes before upgrading
+`docker.io/library/elasticsearch:9.4.1` is an upstream image update from
+`9.4.0`. Review the upstream Elasticsearch release notes before upgrading
 production clusters, take a snapshot backup, and verify Kibana compatibility,
 plugins, ILM policies, and index templates in a staging environment before
 reusing existing PVCs.

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.4.0
+          value: docker.io/library/kibana:9.4.1
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.4.0
+          value: docker.io/library/elasticsearch:9.4.1
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.4.0"
+          "default": "9.4.1"
         },
         "pullPolicy": {
           "type": "string",
@@ -242,7 +242,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.4.0"
+              "default": "9.4.1"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -48,7 +48,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.4.0"
+  tag: "9.4.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -321,7 +321,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.4.0"
+    tag: "9.4.1"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
Closes #276

## Summary
- update Elasticsearch image tag/appVersion from 9.4.0 to 9.4.1
- keep Kibana aligned at 9.4.1 because the chart documents Kibana as matching the Elasticsearch version
- refresh schema defaults, README upgrade notes, and unit-test image assertions

## Upstream verification
- Docker pull: docker.io/library/elasticsearch:9.4.1, digest sha256:12aec8d2b01e0447c61303fc04a66dfbb7bfbb6a1332faf32707c3a2b54787d8
- Docker pull: docker.io/library/kibana:9.4.1, digest sha256:9264958e159335dd6564da7315bf39eb29f63704b69d5d108e41d29cb80a43eb
- Reviewed upstream Elasticsearch 9.4.1 release notes: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.4.1-release-notes

## Validation
- helm dependency build charts/elasticsearch
- helm lint --strict charts/elasticsearch
- helm template elasticsearch-test charts/elasticsearch
- helm template elasticsearch-test charts/elasticsearch -f each charts/elasticsearch/ci/*.yaml
- helm unittest charts/elasticsearch: 91 tests passed
- ah lint charts/elasticsearch: package lint passed
- helm template elasticsearch-test charts/elasticsearch | kubeconform -strict -summary: 4 valid, 0 invalid
- K3D runtime on dedicated cluster k3d-helmforge-tests-wsl: pod 1/1 Running, 0 restarts, Elasticsearch cluster health green, no Warning events

## Notes
- The original Docker Desktop-backed k3d cluster had only about 1.9GiB total memory and could not schedule the chart defaults requesting 2Gi memory. Runtime validation was completed on the dedicated WSL K3D cluster with explicit test-only resource and persistence overrides to fit this host.
- HelmForge MCP validators were invoked, but the MCP endpoint returned HTTP transport errors during this run.