### PR TITLE
chore(envoy-gateway): update image to v1.8.0

### DIFF
--- a/charts/envoy-gateway/Chart.lock
+++ b/charts/envoy-gateway/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.6.9
+digest: sha256:07e0ff02211d6b0a794659081ac8e6403967942c477e57b64f64e7866f2dd7ba
+generated: "2026-05-20T00:27:43.7397816-03:00"

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 1.5.5
-appVersion: "v1.7.3"
+appVersion: "v1.8.0"
 kubeVersion: ">=1.24.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
@@ -30,7 +30,7 @@ icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v1.7.3 (#268)"
+      description: "update image to v1.8.0 (#277)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,7 +1,7 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.7.3 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
+v1.8.0 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
 Envoy proxy pods automatically in response to Gateway API resources.
 
 ## Installation
@@ -158,7 +158,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.7.3` | Controller image tag |
+| `controller.image.tag` | `v1.8.0` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -176,7 +176,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.7.3` | Certgen image tag |
+| `certgen.image.tag` | `v1.8.0` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -386,7 +386,7 @@ helm upgrade envoy-gateway helmforge/envoy-gateway --set profile=production-ha -
 
 ## Migration Guide
 
-### Version 1.3.0 (EG v1.7.3)
+### Version 1.3.0 (EG v1.8.0)
 
 Major architectural redesign to align with the EG operator model.
 
@@ -404,14 +404,14 @@ Major architectural redesign to align with the EG operator model.
 - `SecurityPolicy` CRD: JWT, OIDC, API Key, CORS
 - `BackendTrafficPolicy` CRD: retries, circuit breaking, timeouts
 - `ClientTrafficPolicy` CRD: connection limits, HTTP/2 settings
-- Updated to EG v1.7.3 and Redis 8.0.2-alpine
+- Updated to EG v1.8.0 and Redis 8.0.2-alpine
 
 ## Upgrade Notes
 
-`docker.io/envoyproxy/gateway:v1.7.3` is the upstream patch update from
-`v1.7.2`. The automatically generated issue referenced `1.7.3`, but Docker Hub
+`docker.io/envoyproxy/gateway:v1.8.0` is the upstream minor update from
+`v1.7.3`. The automatically generated issue referenced `1.8.0`, but Docker Hub
 publishes the canonical Envoy Gateway image tag with the `v` prefix. Review the
-upstream Envoy Gateway `v1.7.3` release notes, verify Gateway API/Envoy Gateway
+upstream Envoy Gateway `v1.8.0` release notes, verify Gateway API/Envoy Gateway
 CRDs in staging, and test existing Gateway, HTTPRoute, EnvoyProxy, and policy
 resources before upgrading production controllers.
 
@@ -430,7 +430,7 @@ This chart intentionally does not support:
 <!-- @AI-METADATA
 type: chart-readme
 title: Envoy Gateway Helm Chart
-description: Deploy Envoy Gateway v1.7.3 on Kubernetes with operator architecture, SecurityPolicy, rate limiting, and comprehensive observability
+description: Deploy Envoy Gateway v1.8.0 on Kubernetes with operator architecture, SecurityPolicy, rate limiting, and comprehensive observability
 keywords: envoy, gateway, gateway-api, helm, kubernetes, rate-limiting, prometheus, grafana, redis, networking, securitypolicy, backendtrafficpolicy, clienttrafficpolicy
 purpose: Installation guide, configuration reference, and operational documentation for the Envoy Gateway Helm chart
 scope: Chart

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -34,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.7.3
+    tag: v1.8.0
   resources:
     requests:
       cpu: 10m

--- a/charts/envoy-gateway/templates/rbac.yaml
+++ b/charts/envoy-gateway/templates/rbac.yaml
@@ -129,6 +129,7 @@ rules:
   - tcproutes
   - udproutes
   - grpcroutes
+  - listenersets
   - backendtlspolicies
   verbs:
   - get
@@ -148,6 +149,7 @@ rules:
   - tcproutes/status
   - udproutes/status
   - grpcroutes/status
+  - listenersets/status
   - backendtlspolicies/status
   verbs:
   - get

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -65,7 +65,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "envoyproxy/gateway:v1.7.3"
+          pattern: "envoyproxy/gateway:v1.8.0"
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/rbac_test.yaml
+++ b/charts/envoy-gateway/tests/rbac_test.yaml
@@ -85,6 +85,7 @@ tests:
               - tcproutes
               - udproutes
               - grpcroutes
+              - listenersets
               - backendtlspolicies
             verbs:
               - get

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -83,7 +83,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.7.3"
+              "default": "v1.8.0"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -25,7 +25,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.7.3"
+    tag: "v1.8.0"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -67,7 +67,7 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.7.3"
+    tag: "v1.8.0"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:


### PR DESCRIPTION
Closes #277

## Summary
- update Envoy Gateway controller/certgen image and appVersion from v1.7.3 to v1.8.0
- refresh README, docs, schema defaults, and image unit-test expectations
- add `listenersets` and `listenersets/status` to Gateway API RBAC; v1.8.0 watches this resource and the controller stays unready without it
- add the generated Chart.lock for the existing Redis dependency

## Upstream verification
- Docker pull: docker.io/envoyproxy/gateway:v1.8.0, digest sha256:a9b4c4d8a402e8c007b74f2796587a6fb33d8baba46094f17c8a6f233e46d609
- Reviewed upstream Envoy Gateway v1.8.0 release notes: https://gateway.envoyproxy.io/news/releases/notes/v1.8.0

## Validation
- helm dependency build charts/envoy-gateway
- helm lint --strict charts/envoy-gateway
- helm template envoy-gateway-test charts/envoy-gateway
- helm template envoy-gateway-test charts/envoy-gateway -f each charts/envoy-gateway/ci/*.yaml
- helm unittest charts/envoy-gateway: 98 tests passed
- ah lint charts/envoy-gateway: package lint passed
- helm template envoy-gateway-test charts/envoy-gateway | kubeconform -strict -summary -ignore-missing-schemas: 15 valid, 0 invalid, 5 skipped custom resources
- K3D runtime on k3d-helmforge-tests-wsl with Envoy/Gateway CRDs v1.8.0 and test-only resource/example overrides: controller 1/1 Running, 0 restarts, no Warning events, no error/forbidden/fatal/panic log lines after the RBAC fix

## Notes
- The upstream issue listed `1.8.0`, but Docker publishes the canonical Envoy Gateway image tag with the `v` prefix, so this PR uses `v1.8.0` consistently.
- HelmForge MCP validators were invoked, but the MCP endpoint returned HTTP transport errors during this run.