### PR TITLE
chore(generic): update nginx to 1.31.0

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 maintainers:
   - name: helmforgedev
   - name: mberlofa
-version: 2.0.4
+version: 2.0.3
 appVersion: "1.31.0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -6,14 +6,14 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 version: 2.0.3
-appVersion: "1.30.0"
+appVersion: "1.31.0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade nginx to 1.30.0 (#201)"
+      description: "upgrade nginx to 1.31.0 (#278)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: generic
 description: Generic Helm Chart for Kubernetes workloads
@@ -5,7 +6,7 @@ type: application
 maintainers:
   - name: helmforgedev
   - name: mberlofa
-version: 2.0.3
+version: 2.0.4
 appVersion: "1.31.0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -14,5 +14,5 @@ tests:
           of: DaemonSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/nginx:1.30.0
+          value: docker.io/library/nginx:1.31.0
 

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: DaemonSet
 templates:
   - daemonset.yaml
@@ -15,4 +16,3 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: docker.io/library/nginx:1.31.0
-

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - deployment.yaml

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -55,7 +55,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/nginx:1.30.0"
+          value: "docker.io/library/nginx:1.31.0"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -87,7 +87,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/nginx:1.30.0"
+          value: "registry.example.com/nginx:1.31.0"
 
   - it: should apply global registry to namespaced unqualified repositories
     set:
@@ -96,7 +96,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/team/app:1.30.0"
+          value: "registry.example.com/team/app:1.31.0"
 
   - it: should not apply global registry to fully qualified repositories
     set:
@@ -105,7 +105,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/team/app:1.30.0"
+          value: "ghcr.io/team/app:1.31.0"
 
   - it: should allow per-container image digest override
     set:

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -81,7 +81,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "1.30.0"
+          "default": "1.31.0"
         },
         "digest": {
           "type": "string",

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -52,7 +52,7 @@ global:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.30.0"
+  tag: "1.31.0"
   digest: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #278

## Summary
- update generic chart default nginx image/appVersion from 1.30.0 to 1.31.0
- refresh values schema defaults and unit-test image expectations
- add SPDX license headers requested by automation

## Upstream verification
- Docker pull: docker.io/library/nginx:1.31.0, digest sha256:206a753092e3db9fc0c5c1f295fee35f0c298c23bd015032db5faa23910318bf
- Checked upstream/Docker Hub references. The tag is present in the official nginx image registry.

## Validation
- helm dependency build charts/generic
- helm lint charts/generic
- helm lint --strict charts/generic
- helm template generic-test charts/generic
- helm template generic-test charts/generic -f each charts/generic/ci/*.yaml
- helm unittest charts/generic: 60 tests passed
- ah lint charts/generic: package lint passed
- helm template generic-test charts/generic | kubeconform -strict -summary -ignore-missing-schemas: 2 valid, 0 invalid
- K3D runtime on k3d-helmforge-tests-wsl: pod 1/1 Running, 0 restarts, HTTP 200 OK from nginx/1.31.0, no Warning events, no error/fatal/panic/emerg/crit log lines
- GitHub Actions: all checks passed after c05890b
- HelmForge MCP: available again; PR governance validation passed (GR-064)