### PR TITLE
chore(ghost): update image to 6.39.0

### DIFF
--- a/charts/ghost/Chart.lock
+++ b/charts/ghost/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mysql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.8.5
+digest: sha256:43ea75f43a616dbac5ea9837826a9cb806646d5c2c3c7029008fa5b3a0ad22c3
+generated: "2026-05-20T00:46:13.5184904-03:00"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.11
-appVersion: "6.37.1"
+appVersion: "6.39.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 6.37.1 (#269)"
+      description: "update image to 6.39.0 (#279)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.37.1"
+          value: "docker.io/library/ghost:6.39.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.37.1"
+                                                                    "default":  "6.39.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.37.1"
+  tag: "6.39.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Closes #279
- Update the Ghost chart default image from `docker.io/library/ghost:6.37.1` to `docker.io/library/ghost:6.39.0`.
- Add the generated `Chart.lock` for the existing MySQL dependency.
- Update deployment unit-test expectations and Artifact Hub change metadata.

## Validation
- `docker pull docker.io/library/ghost:6.39.0` -> `sha256:876880a26b770631949d9bf2aa4b62d169e2a2f1dad56e9b065ac5d6f1c346e1`
- `helm dependency build charts/ghost`
- `helm lint --strict charts/ghost`
- `helm unittest charts/ghost` -> 17 tests passed
- `helm template ghost-test charts/ghost`
- `helm template ghost-test charts/ghost -f charts/ghost/ci/*.yaml`
- `helm template ghost-test charts/ghost | kubeconform -strict -summary -ignore-missing-schemas` -> 9 valid, 0 invalid
- `ah lint charts/ghost` -> 65 packages found, 0 package errors
- K3D runtime on dedicated WSL cluster `helmforge-tests-wsl`:
  - `ghost-279-ghost` and `ghost-279-mysql` both `1/1 Running`
  - 0 restarts
  - no Warning events
  - no `error|fatal|panic|emerg|crit` lines in Ghost or MySQL logs

## Notes
- Helmforge MCP was invoked for health, validation planning, values validation, and change-set analysis, but the remote MCP endpoint returned an HTTP transport error during this run. I used the local Helmforge-equivalent gate set above and validated the chart in K3D before opening this PR.