### PR TITLE
chore(hoppscotch): update image to 2026.4.1

### DIFF
--- a/charts/hoppscotch/.helmignore
+++ b/charts/hoppscotch/.helmignore
@@ -9,7 +9,6 @@ Thumbs.db
 
 # Helm
 .helmignore
-Chart.lock
 
 # Editors / IDE
 .vscode/

--- a/charts/hoppscotch/Chart.lock
+++ b/charts/hoppscotch/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.10.0
-digest: sha256:cd48e755b9270946ee86c4f590f795af7680215b1d156b5f7777aff750b6237a
-generated: "2026-05-20T01:14:37.1478376-03:00"

--- a/charts/hoppscotch/Chart.lock
+++ b/charts/hoppscotch/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.10.0
+digest: sha256:cd48e755b9270946ee86c4f590f795af7680215b1d156b5f7777aff750b6237a
+generated: "2026-05-20T01:14:37.1478376-03:00"

--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
 version: 1.0.1
-appVersion: "2026.4.0"
+appVersion: "2026.4.1"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -30,7 +30,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 2026.4.0 (#225)"
+      description: "upgrade to 2026.4.1 (#280)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -72,7 +72,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.4.0` |
+| `image.tag` | Hoppscotch image tag | `2026.4.1` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.host` | Primary hostname (auto-derives all URLs) | `""` |
@@ -93,7 +93,8 @@ All traffic goes through a single Ingress/Service on port 80.
 
 ## Upgrade Notes
 
-Hoppscotch `2026.4.0` adds collection-level pre-request and test scripts,
+Hoppscotch `2026.4.1` includes the latest upstream Hoppscotch fixes after
+the `2026.4.0` release, which added collection-level pre-request and test scripts,
 API documentation publishing refinements, self-hosted SMTP OAuth2 support,
 desktop settings improvements, security patches, and bug fixes. Back up the
 PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -62,6 +62,27 @@ spec:
             {{- include "hoppscotch.databaseEnv" . | nindent 12 }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
+        - name: bootstrap-infra-config
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [sh, -c, "node /dist/backend/dist/src/main.js"]
+          envFrom:
+            - configMapRef:
+                name: {{ include "hoppscotch.fullname" . }}
+          env:
+            {{- include "hoppscotch.databaseEnv" . | nindent 12 }}
+            - name: DATA_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hoppscotch.encryptionSecretName" . }}
+                  key: {{ include "hoppscotch.encryptionSecretKey" . }}
+            - name: WEBAPP_SERVER_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hoppscotch.signingSecretName" . }}
+                  key: {{ include "hoppscotch.signingSecretKey" . }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
         - name: prepare-runtime-files
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -111,6 +132,12 @@ spec:
             {{- end }}
           env:
             {{- include "hoppscotch.databaseEnv" . | nindent 12 }}
+            - name: HOME
+              value: /tmp
+            - name: XDG_DATA_HOME
+              value: /tmp/.local/share
+            - name: XDG_CONFIG_HOME
+              value: /tmp/.config
             - name: DATA_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -81,6 +81,18 @@ spec:
               } = require('./dist/src/infra-config/helper');
               const { encrypt } = require('./dist/src/utils');
 
+              async function runSettledOrThrow(operations, description) {
+                const results = await Promise.allSettled(operations);
+                const failures = results.filter((result) => result.status === 'rejected');
+
+                if (failures.length > 0) {
+                  const reasons = failures
+                    .map((result) => (result.reason instanceof Error ? result.reason.message : String(result.reason)))
+                    .join('; ');
+                  throw new Error(`${description} failed for ${failures.length} operation(s): ${reasons}`);
+                }
+              }
+
               async function main() {
                 const prisma = new PrismaService();
                 try {
@@ -93,7 +105,7 @@ spec:
                   }
 
                   const encryptionRequiredEntries = await getEncryptionRequiredInfraConfigEntries(defaultInfraConfigs);
-                  await Promise.allSettled(
+                  await runSettledOrThrow(
                     encryptionRequiredEntries.map((dbConfig) =>
                       prisma.infraConfig.update({
                         where: { name: dbConfig.name },
@@ -102,17 +114,19 @@ spec:
                           isEncrypted: true,
                         },
                       })
-                    )
+                    ),
+                    'Encrypting infra config entries'
                   );
 
                   const derivedEnv = await buildDerivedEnv();
-                  await Promise.allSettled(
+                  await runSettledOrThrow(
                     Object.entries(derivedEnv).map(([name, value]) =>
                       prisma.infraConfig.update({
                         where: { name },
                         data: { value },
                       })
-                    )
+                    ),
+                    'Updating derived infra config entries'
                   );
 
                   console.log('Hoppscotch infra config bootstrap completed.');

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - sh
             - -c
             - |
-              until nc -z -w2 {{ include "hoppscotch.databaseHost" . }} {{ include "hoppscotch.databasePort" . }}; do
+              until nc -z -w2 {{ include "hoppscotch.databaseHost" . }} {{ include "hoppscotch.databasePort" . }} >/dev/null 2>&1; do
                 echo "waiting for database..."; sleep 2;
               done
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
@@ -65,7 +65,68 @@ spec:
         - name: bootstrap-infra-config
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [sh, -c, "node /dist/backend/dist/src/main.js"]
+          command:
+            - sh
+            - -ec
+            - |
+              cd /dist/backend
+              node <<'NODE'
+              const { PrismaService } = require('./dist/src/prisma/prisma.service');
+              const {
+                buildDerivedEnv,
+                disconnectSharedPrismaInstance,
+                getDefaultInfraConfigs,
+                getEncryptionRequiredInfraConfigEntries,
+                getMissingInfraConfigEntries,
+              } = require('./dist/src/infra-config/helper');
+              const { encrypt } = require('./dist/src/utils');
+
+              async function main() {
+                const prisma = new PrismaService();
+                try {
+                  await prisma.onModuleInit();
+
+                  const defaultInfraConfigs = await getDefaultInfraConfigs();
+                  const propsToInsert = await getMissingInfraConfigEntries(defaultInfraConfigs);
+                  if (propsToInsert.length > 0) {
+                    await prisma.infraConfig.createMany({ data: propsToInsert });
+                  }
+
+                  const encryptionRequiredEntries = await getEncryptionRequiredInfraConfigEntries(defaultInfraConfigs);
+                  await Promise.allSettled(
+                    encryptionRequiredEntries.map((dbConfig) =>
+                      prisma.infraConfig.update({
+                        where: { name: dbConfig.name },
+                        data: {
+                          value: dbConfig.value === null ? null : encrypt(dbConfig.value),
+                          isEncrypted: true,
+                        },
+                      })
+                    )
+                  );
+
+                  const derivedEnv = await buildDerivedEnv();
+                  await Promise.allSettled(
+                    Object.entries(derivedEnv).map(([name, value]) =>
+                      prisma.infraConfig.update({
+                        where: { name },
+                        data: { value },
+                      })
+                    )
+                  );
+
+                  console.log('Hoppscotch infra config bootstrap completed.');
+                } finally {
+                  await disconnectSharedPrismaInstance();
+                  await prisma.onModuleDestroy();
+                }
+              }
+
+              main().catch((error) => {
+                console.error(error);
+                process.exit(1);
+              });
+              NODE
           envFrom:
             - configMapRef:
                 name: {{ include "hoppscotch.fullname" . }}
@@ -102,11 +163,11 @@ spec:
             runAsUser: 1000
           resources:
             requests:
-              cpu: 10m
-              memory: 16Mi
+              cpu: 50m
+              memory: 128Mi
             limits:
-              cpu: 100m
-              memory: 32Mi
+              cpu: 500m
+              memory: 512Mi
           volumeMounts:
             - name: backend-runtime
               mountPath: /runtime-backend
@@ -227,6 +288,7 @@ spec:
             httpGet:
               path: /backend/health
               port: http
+            initialDelaySeconds: 20
             failureThreshold: 30
             periodSeconds: 10
           resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -40,6 +40,10 @@ tests:
           path: spec.template.spec.initContainers[0].image
           value: docker.io/library/busybox:1.37
         template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: ">/dev/null 2>&1"
+        template: deployment.yaml
 
   - it: should have migrate init container
     asserts:
@@ -57,6 +61,10 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[3].name
           value: prepare-runtime-files
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[3].resources.limits.memory
+          value: 512Mi
         template: deployment.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -80,6 +88,22 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[2].image
           pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[2].command[0]
+          value: sh
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[2].command[1]
+          value: -ec
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[2].command[2]
+          pattern: "Hoppscotch infra config bootstrap completed"
+        template: deployment.yaml
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[2].command[2]
+          pattern: "dist/src/main\\.js"
         template: deployment.yaml
       - contains:
           path: spec.template.spec.initContainers[2].env
@@ -157,6 +181,10 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /backend/health
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 20
         template: deployment.yaml
 
   - it: should run as non-root

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.0"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -49,13 +49,13 @@ tests:
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[1].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.0"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
     asserts:
       - equal:
-          path: spec.template.spec.initContainers[2].name
+          path: spec.template.spec.initContainers[3].name
           value: prepare-runtime-files
         template: deployment.yaml
       - contains:
@@ -69,6 +69,26 @@ tests:
           content:
             name: site-runtime
             mountPath: /site
+        template: deployment.yaml
+
+  - it: should bootstrap infra config before starting the main container
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[2].name
+          value: bootstrap-infra-config
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[2].image
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[2].env
+          content:
+            name: WEBAPP_SERVER_SIGNING_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-hoppscotch
+                key: webapp-server-signing-key
         template: deployment.yaml
 
   - it: should build DATABASE_URL from bundled PostgreSQL user password secret
@@ -87,6 +107,21 @@ tests:
           content:
             name: DATABASE_URL
             value: postgresql://hoppscotch:$(DB_PASSWORD)@RELEASE-NAME-postgresql:5432/hoppscotch
+        template: deployment.yaml
+
+  - it: should use writable XDG directories for Caddy storage
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: XDG_DATA_HOME
+            value: /tmp/.local/share
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: XDG_CONFIG_HOME
+            value: /tmp/.config
         template: deployment.yaml
 
   - it: should expose stable webapp server signing key

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -101,6 +101,14 @@ tests:
           path: spec.template.spec.initContainers[2].command[2]
           pattern: "Hoppscotch infra config bootstrap completed"
         template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[2].command[2]
+          pattern: "runSettledOrThrow"
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[2].command[2]
+          pattern: "failed for"
+        template: deployment.yaml
       - notMatchRegex:
           path: spec.template.spec.initContainers[2].command[2]
           pattern: "dist/src/main\\.js"

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.4.0"
+  tag: "2026.4.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Closes #280
- Update Hoppscotch from `2026.4.0` to `2026.4.1`.
- Fix first-install runtime behavior with a one-shot infra config bootstrap init container, so the init phase exits and the main app container can start.
- Fail the bootstrap init container if any settled infra-config update promise is rejected, preventing partially applied infra config from being treated as a successful bootstrap.
- Keep `wait-for-db` logs clean while DNS/PostgreSQL are still becoming available.
- Increase `prepare-runtime-files` init resources so copying Hoppscotch runtime files does not OOM.
- Add startup probe delay to avoid transient 502 startup warnings while the backend comes up behind Caddy.
- Normalize generated dependency artifacts per HelmForge `GR-062`: `Chart.lock` is not committed and `.helmignore` no longer carries a `Chart.lock` pattern.

## Validation
- Helmforge MCP: PASS (`GR-027`, `GR-062`, `GR-063`, `GR-064`, `GR-065`, `GR-066`, `GR-067`, `GR-068`)
- `docker pull docker.io/hoppscotch/hoppscotch:2026.4.1` -> `sha256:ac8eeda2e9a8347816412e707ae504a5cc02dc5ea83e974b00100516831cfb9a`
- `helm dependency build --skip-refresh charts/hoppscotch`
- `helm dependency list charts/hoppscotch` -> `postgresql 1.10.0 ... ok`
- `helm lint charts/hoppscotch`
- `helm lint --strict charts/hoppscotch`
- `helm unittest charts/hoppscotch` -> 8 suites, 56 tests passed
- `helm template hoppscotch-test charts/hoppscotch`
- Rendered all `charts/hoppscotch/ci/*.yaml`: `dual-stack`, `external-db`, `external-secrets`, `gateway-api`, `minimal`, `oauth`, `production`, `smtp`
- Strict kubeconform for default render and every `charts/hoppscotch/ci/*.yaml` render:
  - default: 12 valid, 0 invalid, 0 errors
  - `dual-stack`: 12 valid, 0 invalid, 0 errors
  - `external-db`: 6 valid, 0 invalid, 0 errors
  - `external-secrets`: 12 valid, 0 invalid, 0 errors, 1 skipped CRD
  - `gateway-api`: 12 valid, 0 invalid, 0 errors, 1 skipped CRD
  - `minimal`: 12 valid, 0 invalid, 0 errors
  - `oauth`: 13 valid, 0 invalid, 0 errors
  - `production`: 13 valid, 0 invalid, 0 errors
  - `smtp`: 12 valid, 0 invalid, 0 errors
- `ah lint charts/hoppscotch` -> 65 packages found, 0 package errors
- `kubescape scan framework "MITRE,NSA,SOC2" charts/hoppscotch` -> 86.36363
- Values Quality local checks: ASCII PASS, floating tags PASS, schema present PASS
- NOTES.txt reviewed; no update required for this review fix because validation commands and troubleshooting already cover init container logs and upgrade guidance.
- K3D runtime on dedicated local cluster `k3d-helmforge-tests-wsl`, namespace `hf-pr-297-hoppscotch-final`, release `hoppscotch-297-final`:
  - `helm upgrade --install hoppscotch-297-final charts/hoppscotch --namespace hf-pr-297-hoppscotch-final --set postgresql.primary.persistence.enabled=false --wait --timeout 5m`
  - Hoppscotch and PostgreSQL pods both `1/1 Running`
  - 0 app/container/init restarts
  - no namespace `Warning` events
  - no `error|fatal|exception|stack trace|oom|killed` markers in `wait-for-db`, `migrate`, `bootstrap-infra-config`, `prepare-runtime-files`, `hoppscotch`, or `postgresql` logs
  - `/backend/health` returned `{"status":"ok","info":{"database":{"status":"up"}}...}`

## Notes
- The local K3D cluster is the dedicated lightweight profile `k3d-helmforge-tests-wsl` with `traefik`, `servicelb`, and `metrics-server` disabled because they are not required for chart runtime validation.