### PR TITLE
chore(metabase): update image to v0.61.1

### DIFF
--- a/charts/metabase/Chart.lock
+++ b/charts/metabase/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.9.11
+digest: sha256:cfb9c45d371da28d8ce053b68ce12dc4a6132a7e2eb5cfc2d67292372b9919a9
+generated: "2026-05-20T01:38:20.3396262-03:00"

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.11
-appVersion: "v0.60.4"
+appVersion: "v0.61.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update to v0.60.4 (#273)"
+      description: "update to v0.61.1 (#281)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.60.4"
+          value: "docker.io/metabase/metabase:v0.61.1"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -13,7 +13,7 @@
       "description": "Container image configuration",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/metabase/metabase" },
-        "tag": { "type": "string", "description": "Image tag", "default": "v0.60.4" },
+        "tag": { "type": "string", "description": "Image tag", "default": "v0.61.1" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.60.4"
+  tag: "v0.61.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Update Metabase image/appVersion from `v0.60.4` to `v0.61.1`.
- Refresh the expected deployment image in helm-unittest coverage.
- Add `Chart.lock` for the existing PostgreSQL dependency.

Closes #281.

## Notes
- The issue checklist mentions `docker.io/metabase/metabase:0.61.1`, but Docker Hub does not publish that tag. The existing chart uses `v`-prefixed Metabase tags, and `docker.io/metabase/metabase:v0.61.1` pulls successfully.
- HelmForge MCP was invoked for planning/guardrail checks, but the MCP endpoint returned HTTP transport errors during this run; local CI-parity and K3D validation were completed directly.

## Validation
- `docker pull docker.io/metabase/metabase:v0.61.1` -> `sha256:95228c25b23f014c0fbc4f86d69a66ad5f14ff74fd8e6b8223bf82e58ee416ea`
- `helm dependency build charts/metabase`
- `helm lint --strict charts/metabase`
- `helm unittest charts/metabase` -> 33 tests passed
- `helm template metabase-test charts/metabase | kubeconform -strict -summary -ignore-missing-schemas` -> 9 valid
- `ah lint charts/metabase` -> 65 packages found, 0 errors
- K3D `k3d-helmforge-tests-wsl`: Metabase and PostgreSQL pods `1/1 Running`, `0` restarts, `/api/health` returned `{"status":"ok"}`, no Warning events, no `ERROR/FATAL/PANIC` log-level lines

## K3D test overrides
- `postgresql.standalone.persistence.enabled=false`
- `metabase.javaOpts=-Xms128m -Xmx384m`
- `metabase.extraEnv`: `MB_LOAD_SAMPLE_CONTENT=false`, `MB_INSTALL_ANALYTICS_DATABASE=false`
- probes disabled for this constrained local K3D run to avoid Metabase logging transient `/api/health` 503 responses during first initialization