### PR TITLE
chore(mongodb): update image to 8.3.2

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -4,7 +4,7 @@ name: mongodb
 description: MongoDB Helm Chart - standalone, replica set, or sharded cluster using the official MongoDB image
 type: application
 version: 1.7.12
-appVersion: "8.3.1"
+appVersion: "8.3.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 8.3.1 (#265)"
+      description: "update image to 8.3.2 (#282)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -124,7 +124,7 @@ sharded:
 |-----------|-------------|---------|
 | `architecture` | `standalone`, `replicaset`, or `sharded` | `standalone` |
 | `image.repository` | MongoDB image | `mongo` |
-| `image.tag` | Image tag | `8.3.1` |
+| `image.tag` | Image tag | `8.3.2` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -244,7 +244,7 @@ See the [`examples/`](examples/) directory:
 
 ## Upgrade Notes
 
-MongoDB `8.3.1` is an upstream minor release update from `8.2.7`.
+MongoDB `8.3.2` is an upstream minor release update from `8.2.7`.
 Review the MongoDB 8.3 release notes before upgrading production clusters,
 take a backup, and verify the data files are compatible with the target
 `mongod` version before reusing existing PVCs. Keep replica set keyFiles and

--- a/charts/mongodb/examples/replicaset-production.yaml
+++ b/charts/mongodb/examples/replicaset-production.yaml
@@ -5,7 +5,7 @@
 architecture: replicaset
 
 image:
-  tag: "8.3.1"
+  tag: "8.3.2"
 
 auth:
   enabled: true

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mongo:8.3.1"
+          value: "docker.io/library/mongo:8.3.2"
 
   - it: should have 1 replica in standalone mode
     template: statefulset.yaml

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -39,7 +39,7 @@
         "tag": {
           "type": "string",
           "description": "MongoDB image tag",
-          "default": "8.3.1"
+          "default": "8.3.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -650,7 +650,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "8.3.1"
+                  "default": "8.3.2"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/mongo
-  tag: "8.3.1"
+  tag: "8.3.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -213,9 +213,14 @@ serviceAccount:
 livenessProbe:
   exec:
     command:
-      - mongosh
-      - --eval
-      - "db.adminCommand('ping')"
+      - sh
+      - -ec
+      - |
+        if [ -n "${MONGO_INITDB_ROOT_USERNAME:-}" ]; then
+          mongosh --quiet --eval "db.adminCommand('ping')" -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin
+        else
+          mongosh --quiet --eval "db.adminCommand('ping')"
+        fi
   initialDelaySeconds: 30
   periodSeconds: 20
   timeoutSeconds: 10
@@ -224,9 +229,14 @@ livenessProbe:
 readinessProbe:
   exec:
     command:
-      - mongosh
-      - --eval
-      - "db.adminCommand('ping')"
+      - sh
+      - -ec
+      - |
+        if [ -n "${MONGO_INITDB_ROOT_USERNAME:-}" ]; then
+          mongosh --quiet --eval "db.adminCommand('ping')" -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin
+        else
+          mongosh --quiet --eval "db.adminCommand('ping')"
+        fi
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
@@ -235,9 +245,14 @@ readinessProbe:
 startupProbe:
   exec:
     command:
-      - mongosh
-      - --eval
-      - "db.adminCommand('ping')"
+      - sh
+      - -ec
+      - |
+        if [ -n "${MONGO_INITDB_ROOT_USERNAME:-}" ]; then
+          mongosh --quiet --eval "db.adminCommand('ping')" -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin
+        else
+          mongosh --quiet --eval "db.adminCommand('ping')"
+        fi
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5
@@ -295,7 +310,7 @@ backup:
       pullPolicy: IfNotPresent
     mongodb:
       repository: docker.io/library/mongo
-      tag: "8.3.1"
+      tag: "8.3.2"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary
- Update MongoDB image/appVersion from `8.3.1` to `8.3.2`.
- Refresh schema, README, example values, and helm-unittest expected image.
- Make default MongoDB probes auth-aware so the default `auth.enabled=true` deployment becomes ready correctly.

Closes #282.

## Validation
- `docker pull docker.io/library/mongo:8.3.2` -> `sha256:94b405c5aa83d5160e6dd97383c4687d471f8a6bd247ed3ff6463c092ebf7a8c`
- `helm lint --strict charts/mongodb`
- `helm unittest charts/mongodb` -> 23 tests passed
- `helm template mongodb-test charts/mongodb | kubeconform -strict -summary -ignore-missing-schemas` -> 4 valid
- rendered 8 files under `charts/mongodb/ci/*.yaml`
- `ah lint charts/mongodb` -> 65 packages found, 0 errors
- K3D `k3d-helmforge-tests-wsl`: default auth enabled, `persistence.enabled=false`; pod `1/1 Running`, `0` restarts; authenticated `mongosh` ping returned `{ ok: 1 }`; no Warning events; no MongoDB log-level `E/F` lines

## Notes
- HelmForge MCP was invoked for planning/guardrail checks, but the endpoint returned HTTP transport errors during this run; local CI-parity and K3D validation were completed directly.