### PR TITLE
chore(n8n): update image to 2.21.3

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: postgresql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.10.0
+- name: mysql
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.9.1
+- name: redis
+  repository: oci://ghcr.io/helmforgedev/helm
+  version: 1.6.14
+digest: sha256:852ff29cf4d73be30758e358ff79a1bb9f2af105b8a5fcde43d2d3f02844ff5c
+generated: "2026-05-20T03:33:34.1471973-03:00"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.5.7
-appVersion: "2.20.6"
+appVersion: "2.21.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 2.20.6 (#264)"
+      description: "update image to 2.21.3 (#283)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -139,7 +139,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.20.6` | n8n container image tag |
+| `image.tag` | `2.21.3` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -170,7 +170,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.20.6` is an upstream stable bugfix release. Review the upstream release
+n8n `2.21.3` is an upstream stable bugfix release. Review the upstream release
 notes before upgrading, back up the database, and keep the encryption key
 stable before upgrading live deployments. When using the bundled PostgreSQL
 subchart on a fresh data directory, the chart bootstraps the `uuid-ossp`

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.20.6"
+          value: "docker.io/n8nio/n8n:2.21.3"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.20.6"
+  tag: "2.21.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -303,8 +303,8 @@ livenessProbe:
 readinessProbe:
   # -- Enable readiness probe
   enabled: true
-  # -- Path for HTTP GET probe
-  path: /healthz
+  # -- Path for HTTP GET probe. /healthz/readiness checks database connectivity and migrations.
+  path: /healthz/readiness
   initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
## Summary
- Update n8n image/appVersion from `2.20.6` to `2.21.3`.
- Refresh README and helm-unittest expected image.
- Add `Chart.lock` for the existing optional PostgreSQL/MySQL/Redis dependencies.
- Set default readiness probe path to `/healthz/readiness`, matching n8n docs for database and migration readiness.

Closes #283.

## Validation
- `docker pull docker.io/n8nio/n8n:2.21.3` -> `sha256:23005738b8539e34c13986f8d2c76c2ac540a89a318cbc5481aae89265a28c93`
- `helm dependency build charts/n8n`
- `helm lint --strict charts/n8n`
- `helm unittest charts/n8n` -> 50 tests passed
- `helm template n8n-test charts/n8n | kubeconform -strict -summary -ignore-missing-schemas` -> 4 valid
- rendered 10 files under `charts/n8n/ci/*.yaml`
- `ah lint charts/n8n` -> 65 packages found, 0 errors
- K3D `k3d-helmforge-tests-wsl`: pod `1/1 Running`, `0` restarts; `/healthz` and `/healthz/readiness` returned `{"status":"ok"}`; no Warning events; no problem log lines

## K3D test overrides
- `persistence.enabled=false`
- disabled diagnostics/version notifications and secure cookie for local HTTP
- set task runners to external mode for the constrained validation pod to avoid n8n attempting the internal Python runner without Python in the base image

## Notes
- HelmForge MCP was invoked for planning/guardrail checks, but the endpoint returned HTTP transport errors during this run; local CI-parity and K3D validation were completed directly.