### PR TITLE
chore(ntfy): update image to v2.23.0

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -4,7 +4,7 @@ name: ntfy
 description: ntfy self-hosted push notification service with HTTP-based pub-sub
 type: application
 version: 1.1.8
-appVersion: "v2.22.0"
+appVersion: "v2.23.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to v2.22.0 (#182)"
+      description: "upgrade to v2.23.0 (#284)"
     - kind: changed
       description: "add Phase 3-4 operational intelligence and cleanup (#142)"
   artifacthub.io/maintainers: |

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/binwiederhier/ntfy:v2.22.0"
+          value: "docker.io/binwiederhier/ntfy:v2.23.0"
 
   - it: should pass serve argument
     template: templates/deployment.yaml

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
   # -- Image tag
-  tag: "v2.22.0"
+  tag: "v2.23.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Update ntfy image/appVersion from `v2.22.0` to `v2.23.0`.
- Refresh helm-unittest expected image.

Closes #284.

## Notes
- The issue checklist mentions `docker.io/binwiederhier/ntfy:2.23.0`, but that tag is not published. The existing chart uses `v`-prefixed ntfy tags, and `docker.io/binwiederhier/ntfy:v2.23.0` pulls successfully.
- HelmForge MCP was invoked for planning/guardrail checks, but the endpoint returned HTTP transport errors during this run; local CI-parity and K3D validation were completed directly.

## Validation
- `docker pull docker.io/binwiederhier/ntfy:v2.23.0` -> `sha256:b32b4221a64ec2e7c000f0782b2feef24022e1a09a24e531640f4cbba6cfa1e6`
- `helm lint --strict charts/ntfy`
- `helm unittest charts/ntfy` -> 22 tests passed
- `helm template ntfy-test charts/ntfy | kubeconform -strict -summary -ignore-missing-schemas` -> 4 valid
- rendered 4 files under `charts/ntfy/ci/*.yaml`
- `ah lint charts/ntfy` -> 65 packages found, 0 errors
- K3D `k3d-helmforge-tests-wsl`: `persistence.enabled=false`; pod `1/1 Running`, `0` restarts; `/v1/health` returned `{"healthy":true}`; no Warning events; no problem log lines