### PR TITLE
chore(postgresql): update image to 18.4-trixie

### DIFF
--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ name: postgresql
 description: PostgreSQL for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.0.1
-appVersion: "18.3"
+appVersion: "18.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,8 +21,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "allow disabling default initdb bootstrap (#259)"
+    - kind: changed
+      description: "update image to 18.4-trixie (#286)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -325,7 +325,7 @@ Operational documents:
 |-----------|-------------|---------|
 | `architecture` | `standalone` or `replication` | `standalone` |
 | `image.repository` | PostgreSQL image repository | `postgres` |
-| `image.tag` | PostgreSQL image tag | `18.3-trixie` |
+| `image.tag` | PostgreSQL image tag | `18.4-trixie` |
 | `auth.database` | App database created at bootstrap | `app` |
 | `auth.username` | App user created at bootstrap | `app` |
 | `auth.existingSecret` | Existing secret for passwords | `""` |

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/postgres:18.3-trixie"
+          value: "docker.io/library/postgres:18.4-trixie"
 
   - it: should have selector labels matching template labels
     template: statefulset-primary.yaml

--- a/charts/postgresql/values.schema.json
+++ b/charts/postgresql/values.schema.json
@@ -44,7 +44,7 @@
         "tag": {
           "type": "string",
           "description": "PostgreSQL image tag",
-          "default": "18.3-trixie"
+          "default": "18.4-trixie"
         },
         "pullPolicy": {
           "type": "string",
@@ -961,7 +961,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "18.3-trixie"
+                  "default": "18.4-trixie"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- PostgreSQL image repository
   repository: docker.io/library/postgres
   # -- PostgreSQL image tag
-  tag: "18.3-trixie"
+  tag: "18.4-trixie"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -374,7 +374,7 @@ backup:
       pullPolicy: IfNotPresent
     postgresql:
       repository: docker.io/library/postgres
-      tag: "18.3-trixie"
+      tag: "18.4-trixie"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary
- Update PostgreSQL image tag from `18.3-trixie` to `18.4-trixie` and appVersion from `18.3` to `18.4`.
- Refresh schema, README, backup image tag, and helm-unittest expected image.

Closes #286.

## Validation
- `docker pull docker.io/library/postgres:18.4-trixie` -> `sha256:7a329cef0fd5f39a1db2fc4b3f31ab21033d7971f0246832d8a671286791eca4`
- `helm lint --strict charts/postgresql`
- `helm unittest charts/postgresql` -> 92 tests passed
- `helm template postgresql-test charts/postgresql | kubeconform -strict -summary -ignore-missing-schemas` -> 6 valid
- rendered 20 files under `charts/postgresql/ci/*.yaml`
- `ah lint charts/postgresql` -> 65 packages found, 0 errors
- K3D `k3d-helmforge-tests-wsl`: `standalone.persistence.enabled=false`; pod `1/1 Running`, `0` restarts; `SELECT 1` succeeded; no Warning events; no PostgreSQL error log lines

## Notes
- HelmForge MCP was invoked for planning/guardrail checks, but the endpoint returned HTTP transport errors during this run; local CI-parity and K3D validation were completed directly.