### PR TITLE
chore(strava-statistics): update image to v4.7.12

### DIFF
--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -4,7 +4,7 @@ name: strava-statistics
 description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
 type: application
 version: 1.1.9
-appVersion: "4.7.10"
+appVersion: "4.7.12"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v4.7.10 (#262)"
+      description: "update image to v4.7.12 (#287)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -65,6 +65,7 @@ strava:
 | `strava.refreshToken` | `""` | Strava Refresh Token |
 | `strava.existingSecret` | `""` | Use existing secret for credentials |
 | `strava.timezone` | `UTC` | Timezone |
+| `strava.config` | See `values.yaml` | Application `config.yaml` content mounted at `/var/www/config/app/config.yaml` |
 | `persistence.enabled` | `true` | Enable persistence for /data |
 | `persistence.size` | `2Gi` | PVC size |
 | `ingress.enabled` | `false` | Enable ingress |

--- a/charts/strava-statistics/templates/_helpers.tpl
+++ b/charts/strava-statistics/templates/_helpers.tpl
@@ -43,6 +43,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "strava-statistics.configData" -}}
+config.yaml: |
+{{ .Values.strava.config | indent 2 }}
+{{- end -}}
+
 {{/* Strava secret name */}}
 {{- define "strava-statistics.secretName" -}}
 {{- if .Values.strava.existingSecret -}}

--- a/charts/strava-statistics/templates/configmap.yaml
+++ b/charts/strava-statistics/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "strava-statistics.fullname" . }}
+  labels:
+    {{- include "strava-statistics.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{ .Values.strava.config | indent 4 }}

--- a/charts/strava-statistics/templates/configmap.yaml
+++ b/charts/strava-statistics/templates/configmap.yaml
@@ -6,5 +6,4 @@ metadata:
   labels:
     {{- include "strava-statistics.labels" . | nindent 4 }}
 data:
-  config.yaml: |
-{{ .Values.strava.config | indent 4 }}
+{{ include "strava-statistics.configData" . | nindent 2 }}

--- a/charts/strava-statistics/templates/deployment.yaml
+++ b/charts/strava-statistics/templates/deployment.yaml
@@ -19,10 +19,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include "strava-statistics.configData" . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/strava-statistics/templates/deployment.yaml
+++ b/charts/strava-statistics/templates/deployment.yaml
@@ -104,12 +104,19 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: config
+              mountPath: /var/www/config/app/config.yaml
+              subPath: config.yaml
+              readOnly: true
             - name: data
               mountPath: /data
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
+        - name: config
+          configMap:
+            name: {{ include "strava-statistics.fullname" . }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/strava-statistics/tests/configmap_test.yaml
+++ b/charts/strava-statistics/tests/configmap_test.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ConfigMap
+templates:
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render application config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-strava-statistics
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "appUrl: \"http://localhost:8080/\""
+
+  - it: should allow overriding application config
+    set:
+      strava.config: |
+        general:
+          appUrl: "https://strava.example.com/"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "https://strava.example.com/"

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/robiningelbrecht/strava-statistics:v4.7.10"
+          value: "docker.io/robiningelbrecht/strava-statistics:v4.7.12"
 
   - it: should allow custom image tag
     set:
@@ -98,13 +98,20 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
+            name: config
+            mountPath: /var/www/config/app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
             name: data
             mountPath: /data
 
   - it: should use PVC for data when persistence enabled
     asserts:
       - equal:
-          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
           value: test-strava-statistics-data
 
   - it: should use emptyDir when persistence disabled
@@ -112,7 +119,7 @@ tests:
       persistence.enabled: false
     asserts:
       - equal:
-          path: spec.template.spec.volumes[0].emptyDir
+          path: spec.template.spec.volumes[1].emptyDir
           value: {}
 
   - it: should use TCP probes

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -108,6 +108,22 @@ tests:
             name: data
             mountPath: /data
 
+  - it: should roll pods when config changes
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: should preserve custom pod annotations
+    set:
+      podAnnotations:
+        example.com/custom: "true"
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - equal:
+          path: spec.template.metadata.annotations["example.com/custom"]
+          value: "true"
+
   - it: should use PVC for data when persistence enabled
     asserts:
       - equal:

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "v4.7.10"
+                                                                    "default":  "v4.7.12"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",
@@ -90,6 +90,10 @@
                                                                           "description":  "Timezone",
                                                                           "default":  "UTC"
                                                                       },
+                                                         "config":  {
+                                                                        "type":  "string",
+                                                                        "description":  "Application config.yaml content"
+                                                                    },
                                                          "extraEnv":  {
                                                                           "type":  "array",
                                                                           "items":  {

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Statistics for Strava container image
   repository: docker.io/robiningelbrecht/strava-statistics
   # -- Image tag
-  tag: "v4.7.10"
+  tag: "v4.7.12"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -44,6 +44,119 @@ strava:
   existingSecretRefreshTokenKey: refresh-token
   # -- Timezone
   timezone: UTC
+  # -- Application config mounted at /var/www/config/app/config.yaml
+  config: |
+    general:
+      appUrl: "http://localhost:8080/"
+      appSubTitle: null
+      profilePictureUrl: null
+      athlete:
+        birthday: "1990-01-01"
+        maxHeartRateFormula: fox
+        restingHeartRateFormula: heuristicAgeBased
+        heartRateZones:
+          mode: relative
+          default:
+            zone1:
+              from: 50
+              to: 60
+            zone2:
+              from: 61
+              to: 70
+            zone3:
+              from: 71
+              to: 80
+            zone4:
+              from: 81
+              to: 90
+            zone5:
+              from: 91
+              to: null
+        weightHistory:
+          "2024-01-01": 75
+        ftpHistory:
+          cycling: []
+          running: []
+    appearance:
+      locale: "en_US"
+      unitSystem: metric
+      timeFormat: 24
+      dateFormat:
+        short: "d-m-y"
+        normal: "d-m-Y"
+      dashboard:
+        layout: null
+      heatmap:
+        polylineColor: "#fc6719"
+        tileLayerUrl: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+        enableGreyScale: true
+        initialCenter: null
+        initialZoom: null
+      photos:
+        hidePhotosForSportTypes: []
+        defaultEnabledFilters:
+          sportTypes: []
+          countryCode: null
+      sportTypesSortingOrder: []
+    import:
+      numberOfNewActivitiesToProcessPerImport: 250
+      sportTypesToImport: []
+      activityVisibilitiesToImport: []
+      skipActivitiesRecordedBefore: null
+      activitiesToSkipDuringImport: []
+      optInToSegmentDetailImport: false
+    metrics:
+      excludeActivitiesFromPeakPowerOutputs: []
+      eddington:
+        - label: Ride
+          showInNavBar: true
+          showInDashboardWidget: true
+          sportTypesToInclude:
+            - Ride
+            - MountainBikeRide
+            - GravelRide
+            - VirtualRide
+        - label: Run
+          showInNavBar: true
+          showInDashboardWidget: true
+          sportTypesToInclude:
+            - Run
+            - TrailRun
+            - VirtualRun
+        - label: Walk
+          showInNavBar: false
+          showInDashboardWidget: false
+          sportTypesToInclude:
+            - Walk
+            - Hike
+    gear:
+      stravaGear: []
+      recordingDevices: []
+      customGear: []
+    zwift:
+      level: null
+      racingScore: null
+    integrations:
+      notifications:
+        services: []
+      ai:
+        enabled: false
+        enableUI: false
+        provider: openAI
+        configuration:
+          key: ""
+          model: ""
+    daemon:
+      cron:
+        - action: importDataAndBuildApp
+          expression: "0 14 * * *"
+          enabled: false
+        - action: gearMaintenanceNotification
+          expression: "0 14 * * *"
+          enabled: false
+        - action: appUpdateAvailableNotification
+          expression: "0 14 * * *"
+          enabled: false
   # -- Extra environment variables for the container
   # -- @default -- `[]`
   extraEnv: []


### PR DESCRIPTION
## Summary
- Update `strava-statistics` to `docker.io/robiningelbrecht/strava-statistics:v4.7.12`.
- Add the required application `config.yaml` ConfigMap mount for `/var/www/config/app/config.yaml`; without it, the new image starts but the web app fails at runtime.
- Document `strava.config` and cover the new ConfigMap with helm-unittest.

## Notes
- Issue #287 requested `4.7.12`; the upstream image is published as `v4.7.12`, while the non-v tag is not published.
- Pulled image digest: `sha256:167c06a3002d3ce5672987982a538ec237368a100ffa22f799d3112c1eb820de`.
- HelmForge MCP tools were invoked (`validate_action`, `plan_chart_validation`, `validate_chart_ci_evidence`), but the MCP endpoint returned a transport HTTP request failure for `https://helmforge.mcp.berlofa.com.br/v1`. Local guardrails and CI parity checks were run directly.

## Validation
- `docker pull docker.io/robiningelbrecht/strava-statistics:v4.7.12`
- `helm lint --strict charts/strava-statistics`
- `helm unittest charts/strava-statistics` - 6 suites, 25 tests
- `helm template strava-test charts/strava-statistics | kubeconform -strict -summary -ignore-missing-schemas` - 5 valid resources
- rendered all 5 chart CI values files
- `ah lint charts/strava-statistics` - 65 packages found, 0 errors
- K3D `helmforge-tests-wsl` clean install in namespace `hf-issue-287-strava` with `persistence.enabled=false` and dummy Strava credentials:
  - pod `1/1 Running`, 0 restarts
  - `/` returned `302 Found` to `/strava-oauth`, then `200 OK`
  - `/strava-oauth` returned `200 OK` and rendered `Statistics for Strava`
  - no Kubernetes Warning events
  - no error/fatal/panic/critical/exception/failed/problem log lines
- Cleaned release and namespace after validation.

Closes #287