### PR TITLE
feat(mosquitto): add toggle to disable websocket listener

### DIFF
--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mosquitto
 type: application
-version: 1.2.7
+version: 1.2.6
 appVersion: "2.0.22"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Eclipse Mosquitto with WebSocket support and optional MQTTX Web

--- a/charts/mosquitto/Chart.yaml
+++ b/charts/mosquitto/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mosquitto
 type: application
-version: 1.2.6
+version: 1.2.7
 appVersion: "2.0.22"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Eclipse Mosquitto with WebSocket support and optional MQTTX Web

--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -156,6 +156,7 @@ broker:
 | `architecture.mode` | `standalone` | Broker topology: standalone or federated |
 | `broker.replicaCount` | `1` | Number of broker replicas |
 | `broker.listeners.mqtt` | `1883` | MQTT TCP listener port |
+| `broker.listeners.websocketEnabled` | bool | `true` | Enable MQTT over WebSocket listener |
 | `broker.listeners.websocket` | `9001` | MQTT over WebSocket listener port |
 | `broker.tls.enabled` | `false` | Enable broker MQTT TLS listener and disable plain MQTT `1883` |
 | `broker.tls.certSecretName` | `""` | Secret containing `tls.crt` and `tls.key` |

--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -156,7 +156,7 @@ broker:
 | `architecture.mode` | `standalone` | Broker topology: standalone or federated |
 | `broker.replicaCount` | `1` | Number of broker replicas |
 | `broker.listeners.mqtt` | `1883` | MQTT TCP listener port |
-| `broker.listeners.websocketEnabled` | bool | `true` | Enable MQTT over WebSocket listener |
+| `broker.listeners.websocketEnabled` | `true` | Enable MQTT over WebSocket listener |
 | `broker.listeners.websocket` | `9001` | MQTT over WebSocket listener port |
 | `broker.tls.enabled` | `false` | Enable broker MQTT TLS listener and disable plain MQTT `1883` |
 | `broker.tls.certSecretName` | `""` | Secret containing `tls.crt` and `tls.key` |

--- a/charts/mosquitto/templates/configmap.yaml
+++ b/charts/mosquitto/templates/configmap.yaml
@@ -17,8 +17,10 @@ data:
     protocol mqtt
     {{- end }}
 
+    {{- if .Values.broker.listeners.websocketEnabled }}
     listener {{ .Values.broker.listeners.websocket }} 0.0.0.0
     protocol websockets
+    {{- end }}
 
     {{- if .Values.broker.tls.enabled }}
     listener {{ .Values.broker.tls.port }} 0.0.0.0

--- a/charts/mosquitto/templates/service.yaml
+++ b/charts/mosquitto/templates/service.yaml
@@ -31,6 +31,7 @@ spec:
       nodePort: {{ .Values.service.mqttNodePort }}
       {{- end }}
     {{- end }}
+    {{- if .Values.broker.listeners.websocketEnabled }}
     - name: websocket
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket
@@ -38,6 +39,7 @@ spec:
       {{- if ne (int .Values.service.websocketNodePort) 0 }}
       nodePort: {{ .Values.service.websocketNodePort }}
       {{- end }}
+    {{- end }}
     {{- if .Values.broker.tls.enabled }}
     - name: mqtts
       port: {{ .Values.service.mqttsPort }}
@@ -71,10 +73,12 @@ spec:
       targetPort: mqtt
       protocol: TCP
     {{- end }}
+    {{- if .Values.broker.listeners.websocketEnabled }}
     - name: websocket
       port: {{ .Values.service.websocketPort }}
       targetPort: websocket
       protocol: TCP
+    {{- end }}
     {{- if .Values.broker.tls.enabled }}
     - name: mqtts
       port: {{ .Values.service.mqttsPort }}

--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -6,7 +6,10 @@ metadata:
     {{- include "mosquitto.labels" . | nindent 4 }}
     app.kubernetes.io/component: broker
 spec:
-  {{- $probePort := ternary "websocket" "mqtt" .Values.broker.tls.enabled }}
+  {{- $probePort := "mqtt" -}}
+  {{- if .Values.broker.tls.enabled }}
+    {{- $probePort = ternary "websocket" "mqtts" .Values.broker.listeners.websocketEnabled -}}
+  {{- end }}
   serviceName: {{ include "mosquitto.headlessServiceName" . }}
   replicas: {{ .Values.broker.replicaCount }}
   podManagementPolicy: Parallel

--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -126,9 +126,11 @@ spec:
               containerPort: {{ .Values.broker.listeners.mqtt }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.broker.listeners.websocketEnabled }}
             - name: websocket
               containerPort: {{ .Values.broker.listeners.websocket }}
               protocol: TCP
+            {{- end }}
             {{- if .Values.broker.tls.enabled }}
             - name: mqtts
               containerPort: {{ .Values.broker.tls.port }}

--- a/charts/mosquitto/tests/statefulset_test.yaml
+++ b/charts/mosquitto/tests/statefulset_test.yaml
@@ -151,3 +151,24 @@ tests:
             name: tls
             secret:
               secretName: mosquitto-tls
+
+  - it: should use mqtts for probes when tls is enabled and websocket is disabled
+    template: templates/statefulset.yaml
+    set:
+      broker.tls.enabled: true
+      broker.listeners.websocketEnabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: websocket
+
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: mqtts
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: mqtts
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: mqtts

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -112,6 +112,10 @@
               "type": "integer",
               "description": "MQTT TCP listener port (used only when broker.tls.enabled=false)"
             },
+            "websocketEnabled": {
+              "type": "boolean",
+              "description": "Enable MQTT over WebSocket listener"
+            },
             "websocket": {
               "type": "integer",
               "description": "MQTT over WebSocket listener port"

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -50,6 +50,8 @@ broker:
   listeners:
     # -- MQTT TCP listener port (used only when broker.tls.enabled=false)
     mqtt: 1883
+    # -- Enable MQTT over WebSocket listener
+    websocketEnabled: true
     # -- MQTT over WebSocket listener port
     websocket: 9001
 


### PR DESCRIPTION
## Summary

- When exposing Mosquitto via Cloud Load Balancers (specifically AWS Network Load Balancers using the AWS Load Balancer Controller), the controller automatically creates a listener for every port defined in the Kubernetes Service. This forces users to expose port 9001 to the network, even if they are strictly using MQTT/mTLS on port 8883.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (Resolves #NNN or Related to #NNN)

Fixes #305 - [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [ ] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [ ] All relevant `ci/*.yaml` scenarios rendered successfully
- [ ] I validated this change on a local `k3d` cluster when required
- [ ] I validated the default install
- [ ] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

- Added the `broker.listeners.websocketEnabled` (defaulting to true for backward compatibility). When set to false, it cleanly removes the WebSocket port from the Mosquitto config, the Pod spec, and the Service, allowing for strict, single-port Load Balancer deployments.

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.