### PR TITLE
fix(mariadb): repair mysqld exporter authentication

### DIFF
--- a/charts/mariadb/templates/NOTES.txt
+++ b/charts/mariadb/templates/NOTES.txt
@@ -4,9 +4,16 @@ MariaDB has been installed.
 Useful Services:
 
 - Client Service: {{ include "mariadb.clientServiceName" . }}
+{{- if .Values.metrics.enabled }}
+- Metrics Service: {{ include "mariadb.metricsServiceName" . }}
+{{- end }}
 {{- if eq .Values.architecture "replication" }}
 - Source Service: {{ include "mariadb.sourceServiceName" . }}
 - Replicas Service: {{ include "mariadb.replicasServiceName" . }}
+{{- if .Values.metrics.enabled }}
+- Source Metrics Service: {{ include "mariadb.sourceMetricsServiceName" . }}
+- Replicas Metrics Service: {{ include "mariadb.replicasMetricsServiceName" . }}
+{{- end }}
 {{- end }}
 
 Root password:
@@ -37,8 +44,14 @@ Initial troubleshooting:
 
   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
   kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0
+{{- if .Values.metrics.enabled }}
+  kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0 -c mysqld-exporter
+{{- end }}
 {{- if eq .Values.architecture "replication" }}
   kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.replicaStatefulSetName" . }}-0
+{{- if .Values.metrics.enabled }}
+  kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.replicaStatefulSetName" . }}-0 -c mysqld-exporter
+{{- end }}
 {{- end }}
 
 {{- if .Values.externalSecrets.enabled }}
@@ -54,3 +67,6 @@ Important:
 
 - replication mode provides one fixed source and asynchronous read replicas
 - the chart does not implement automatic source promotion or operator-style HA
+- default values are suitable for development; production installs should provide external credentials, persistence, TLS, NetworkPolicy, resources, backups, and operational runbooks
+
+Happy Helmforging :)

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -197,13 +197,55 @@ MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb -h 127.0.0.1 -P {{ .Values.service.
 {{- end -}}
 
 {{- define "mariadb.metricsEnv" -}}
-- name: DATA_SOURCE_NAME
-  value: root:$(MARIADB_ROOT_PASSWORD)@(127.0.0.1:{{ .Values.service.port }})/{{ if or .Values.tls.client.enabled .Values.tls.requireSecureTransport }}?tls=skip-verify{{ end }}
 - name: MARIADB_ROOT_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "mariadb.secretName" . }}
       key: {{ .Values.auth.existingSecretRootPasswordKey }}
+{{- end -}}
+
+{{- define "mariadb.metricsConfigInitContainer" -}}
+- name: mysqld-exporter-config
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  command:
+    - sh
+    - -ec
+    - |
+      umask 077
+      cat > /metrics/.my.cnf <<EOF
+      [client]
+      user=root
+      password=${MARIADB_ROOT_PASSWORD}
+      host=127.0.0.1
+      port={{ .Values.service.port }}
+      {{- if include "mariadb.tlsClientEnabled" . }}
+      ssl-ca=/tls/{{ .Values.tls.caFilename }}
+      {{- end }}
+      EOF
+  env:
+    {{- include "mariadb.metricsEnv" . | nindent 4 }}
+  securityContext:
+    {{- toYaml .Values.securityContext | nindent 4 }}
+  volumeMounts:
+    - name: mysqld-exporter-config
+      mountPath: /metrics
+    {{- if .Values.tls.enabled }}
+    - name: tls
+      mountPath: /tls
+      readOnly: true
+    {{- end }}
+{{- end -}}
+
+{{- define "mariadb.metricsVolumeMounts" -}}
+- name: mysqld-exporter-config
+  mountPath: /etc/mysqld-exporter
+  readOnly: true
+{{- if .Values.tls.enabled }}
+- name: tls
+  mountPath: /tls
+  readOnly: true
+{{- end }}
 {{- end -}}
 
 {{- define "mariadb.tlsClientEnabled" -}}

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -121,6 +121,9 @@ spec:
               mountPath: /tls
               readOnly: true
             {{- end }}
+        {{- if .Values.metrics.enabled }}
+        {{- include "mariadb.metricsConfigInitContainer" . | nindent 8 }}
+        {{- end }}
       containers:
         - name: mariadb
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -218,11 +221,10 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           args:
             - --web.listen-address=:{{ .Values.service.metricsPort }}
+            - --config.my-cnf=/etc/mysqld-exporter/.my.cnf
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
-          env:
-            {{- include "mariadb.metricsEnv" . | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
@@ -231,10 +233,16 @@ spec:
             {{- else }}
             {{- include "mariadb.metricsResourcesPreset" . | nindent 12 }}
             {{- end }}
+          volumeMounts:
+            {{- include "mariadb.metricsVolumeMounts" . | nindent 12 }}
         {{- end }}
       volumes:
         - name: mariadb-conf
           emptyDir: {}
+        {{- if .Values.metrics.enabled }}
+        - name: mysqld-exporter-config
+          emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "mariadb.configMapName" . }}

--- a/charts/mariadb/templates/statefulset-source.yaml
+++ b/charts/mariadb/templates/statefulset-source.yaml
@@ -25,6 +25,10 @@ spec:
         {{- end }}
     spec:
       {{- include "mariadb.podSpecCommon" . | nindent 6 }}
+      {{- if .Values.metrics.enabled }}
+      initContainers:
+        {{- include "mariadb.metricsConfigInitContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: mariadb
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -152,11 +156,10 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           args:
             - --web.listen-address=:{{ .Values.service.metricsPort }}
+            - --config.my-cnf=/etc/mysqld-exporter/.my.cnf
           ports:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
-          env:
-            {{- include "mariadb.metricsEnv" . | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
@@ -165,10 +168,16 @@ spec:
             {{- else }}
             {{- include "mariadb.metricsResourcesPreset" . | nindent 12 }}
             {{- end }}
+          volumeMounts:
+            {{- include "mariadb.metricsVolumeMounts" . | nindent 12 }}
         {{- end }}
       volumes:
         - name: mariadb-conf
           emptyDir: {}
+        {{- if .Values.metrics.enabled }}
+        - name: mysqld-exporter-config
+          emptyDir: {}
+        {{- end }}
         - name: config
           configMap:
             name: {{ include "mariadb.configMapName" . }}

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -83,3 +83,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].name
           value: mysqld-exporter
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --config.my-cnf=/etc/mysqld-exporter/.my.cnf
+      - isNull:
+          path: spec.template.spec.containers[1].env
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: mysqld-exporter-config
+            mountPath: /etc/mysqld-exporter
+            readOnly: true
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: mysqld-exporter-config
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: MARIADB_ROOT_PASSWORD
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mysqld-exporter-config
+            emptyDir: {}


### PR DESCRIPTION
Fixes #324.

## Summary
- Replaces the removed mysqld_exporter DATA_SOURCE_NAME configuration with a generated .my.cnf file.
- Mounts the generated config into standalone/source and replica metrics sidecars.
- Keeps credentials sourced from the chart auth Secret, including auth.existingSecret, without exposing the password in container args.
- Adds unit coverage for the new exporter config path and volume mount.
- Updates NOTES.txt with metrics services, exporter log commands, and the standard closing phrase.

## Local Validation Evidence
- [x] `helm dependency build charts/mariadb`
- [x] `helm lint charts/mariadb`
- [x] `helm lint --strict charts/mariadb`
- [x] `helm template mariadb-test charts/mariadb`
- [x] `helm template mariadb-test charts/mariadb -f charts/mariadb/ci/*.yaml` for all 13 CI values files
- [x] `helm unittest charts/mariadb` (6 suites, 22 tests)
- [x] `ah lint charts/mariadb` (65 packages, 0 errors)
- [x] strict `kubeconform` for default and all CI renders
- [x] Kubescape MITRE/NSA/SOC2 score: 86.87 overall (MITRE 100.00, NSA 80.00, SOC2 93.33)
- [x] NOTES.txt rendered and reviewed; final non-empty line is `Happy Helmforging :)`

## k3d Runtime Evidence
- Context: `k3d-helmforge-tests-wsl`
- Release/namespace: `mariadb-issue-324` / `hf-issue-324`
- Scenario: `metrics.enabled=true`, `metrics.resourcesPreset=small`, `metrics.serviceMonitor.enabled=false`, `standalone.persistence.enabled=false`
- Wait command: `helm install mariadb-issue-324 charts/mariadb --namespace hf-issue-324 --set metrics.enabled=true --set metrics.resourcesPreset=small --set metrics.serviceMonitor.enabled=false --set standalone.persistence.enabled=false --wait --timeout 8m`
- Smoke test: `/metrics` returned `mysql_up 1` and successful collector metrics
- Logs checked for every pod/container: `mariadb-issue-324-mariadb-0` containers `mariadb` and `mysqld-exporter`
- Log/event result: no Warning events; no exporter config/auth errors; MariaDB reached ready-for-connections
- Cleanup: namespace `hf-issue-324` deleted

## Site Follow-up
- MCP site sync marks `/docs/charts/mariadb#architecture` for the later consolidated site PR.