### PR TITLE
chore(metabase): update image to v0.61.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .dist/
 .tmp/
 charts/*/charts/*.tgz
+charts/*/Chart.lock
 .claude/
 .tmp/
 new-charts-requests/

--- a/charts/metabase/Chart.lock
+++ b/charts/metabase/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-digest: sha256:cfb9c45d371da28d8ce053b68ce12dc4a6132a7e2eb5cfc2d67292372b9919a9
-generated: "2026-05-20T01:38:20.3396262-03:00"

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.12
-appVersion: "v0.61.1"
+appVersion: "v0.61.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v0.61.1 (#298)"
+      description: "update image to v0.61.2 (#318)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -125,6 +125,8 @@ externalSecrets:
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
+| `image.tag` | `v0.61.2` | Metabase container image tag |
 | `metabase.port` | `3000` | Application port |
 | `metabase.encryptionSecretKey` | `""` | Encryption key (auto-generated) |
 | `metabase.siteUrl` | `""` | Public site URL |
@@ -148,6 +150,12 @@ externalSecrets:
 | `externalSecrets.secretStoreRef.name` | `""` | SecretStore name (required when enabled) |
 | `externalSecrets.secretStoreRef.kind` | `SecretStore` | SecretStore kind |
 | `externalSecrets.data` | `[]` | Remote key mappings (must include encryption key entry) |
+
+## Upgrade Notes
+
+Metabase `v0.61.2` is a stable upstream maintenance release. Back up the Metabase
+application database before upgrading and validate the `/api/health` endpoint
+after rollout.
 
 ## More Information
 

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.61.1"
+          value: "docker.io/metabase/metabase:v0.61.2"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -13,7 +13,7 @@
       "description": "Container image configuration",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/metabase/metabase" },
-        "tag": { "type": "string", "description": "Image tag", "default": "v0.61.1" },
+        "tag": { "type": "string", "description": "Image tag", "default": "v0.61.2" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.61.1"
+  tag: "v0.61.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Closes #318.

## Summary
- Update Metabase image/appVersion to `v0.61.2`.
- Align README and values schema with the new default image tag.
- Remove the tracked Metabase `Chart.lock` and ignore chart lock files per HelmForge GR-062.

## Validation
- `helm dependency build charts/metabase`
- `helm dependency list charts/metabase`
- `helm lint charts/metabase`
- `helm lint --strict charts/metabase`
- `helm template metabase-test charts/metabase` and all Metabase CI values files
- `helm unittest charts/metabase`: 7 suites, 33 tests passed
- `kubeconform` strict on all Metabase CI values: 0 invalid, 0 errors
- `ah lint charts/metabase`: 65 packages, 0 errors
- Kubescape MITRE, NSA, SOC2: overall 82, Resource Summary 81.82%
- k3d runtime on `k3d-helmforge-tests-wsl`: Metabase and PostgreSQL Ready 1/1, PVC Bound, `/api/health` 200, UI 200, no non-Normal events; release and namespace cleaned

## Upstream
- `docker.io/metabase/metabase:v0.61.2` exists for linux/amd64 and linux/arm64.
- `docker.io/metabase/metabase:0.61.2` does not exist, so this PR keeps the existing v-prefixed upstream tag style.
- GitHub release `v0.61.2` was published on 2026-05-19 and is not marked prerelease.
- Official changelog reviewed: https://www.metabase.com/changelog/61#metabase-612

## Site sync
- `/docs/charts/metabase#values` is queued for the site repository update after the chart issue batch, per the requested cross-repo workflow.