### PR TITLE
chore(memcached): update image to 1.6.42

### DIFF
--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -4,7 +4,7 @@ name: memcached
 description: Memcached Helm Chart for standalone and distributed cache topologies
 type: application
 version: 1.0.0
-appVersion: "1.6.41"
+appVersion: "1.6.42"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,8 +24,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/memcached.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add HelmForge Memcached chart (#239)"
+    - kind: changed
+      description: "update image to 1.6.42 (#317)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -287,7 +287,7 @@ networkPolicy:
 | `architecture` | `standalone` | `standalone` or `distributed`. |
 | `replicaCount` | `1` | Number of Memcached pods. Must be `1` for standalone. |
 | `image.repository` | `docker.io/library/memcached` | Official Memcached image. |
-| `image.tag` | `1.6.41` | Pinned image tag. |
+| `image.tag` | `1.6.42` | Pinned image tag. |
 | `memcached.memoryLimitMB` | `64` | Memcached item memory limit passed to `-m`. |
 | `memcached.maxConnections` | `1024` | Maximum simultaneous connections. |
 | `memcached.threads` | `4` | Worker threads. |
@@ -309,6 +309,10 @@ networkPolicy:
 | `serviceAccount.automountServiceAccountToken` | `false` | Keeps Kubernetes API token disabled by default. |
 
 ## Operations
+
+Memcached `1.6.42` is an upstream security-focused release. Upgrading is
+strongly advised when Memcached is reachable by untrusted clients; validate
+connectivity with a `version` or `stats` command after rollout.
 
 Scale distributed mode:
 

--- a/charts/memcached/tests/statefulset_test.yaml
+++ b/charts/memcached/tests/statefulset_test.yaml
@@ -20,7 +20,7 @@ tests:
           value: false
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/memcached:1.6.41
+          value: docker.io/library/memcached:1.6.42
       - contains:
           path: spec.template.spec.containers[0].args
           content: -m

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -79,7 +79,7 @@
       "additionalProperties": true,
       "properties": {
         "repository": { "type": "string", "minLength": 1 },
-        "tag": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "minLength": 1, "default": "1.6.42" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
       }
     },

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/library/memcached
-  tag: 1.6.41
+  tag: 1.6.42
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Closes #317.

## Summary
- Update Memcached image/appVersion to `1.6.42`.
- Align README, values schema, and unit tests with the new image tag.
- Document the upstream security-focused upgrade note.

## Validation
- `helm dependency build charts/memcached` and `helm dependency list charts/memcached` (no dependencies, exit code 0)
- `helm lint charts/memcached`
- `helm lint --strict charts/memcached`
- `helm template memcached-test charts/memcached` and all Memcached CI values files
- `helm unittest charts/memcached`: 9 suites, 39 tests passed
- `kubeconform` strict on all Memcached CI values: 0 invalid, 0 errors
- `ah lint charts/memcached`: 65 packages, 0 errors
- Kubescape MITRE, NSA, SOC2: overall 82, Resource Summary 81.82%
- k3d runtime on `k3d-helmforge-tests-wsl`: pod Ready 1/1, `version` returned `VERSION 1.6.42`, set/get passed, no non-Normal events; release and namespace cleaned

## Upstream
- `docker.io/library/memcached:1.6.42` exists for linux/amd64 and linux/arm64.
- Official release notes reviewed: https://github.com/memcached/memcached/wiki/ReleaseNotes1642
- The release is security-focused and upstream strongly advises upgrading.

## Site sync
- `/docs/charts/memcached#values` is queued for the site repository update after the chart issue batch, per the requested cross-repo workflow.