### PR TITLE
chore(homarr): update image to v1.62.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .dist/
 .tmp/
 charts/*/charts/*.tgz
+charts/*/Chart.lock
 .claude/
 .tmp/
 new-charts-requests/

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.11
-appVersion: "1.61.0"
+appVersion: "1.62.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update to 1.61.0 (#270)"
+      description: "Update Homarr image to v1.62.0 (#314)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.61.0`.
+Current application version: `v1.62.0`.
 
 ## Features
 
@@ -174,7 +174,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.61.0"` | Homarr image tag |
+| `image.tag` | `"v1.62.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -258,9 +258,9 @@ outside this chart.
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.60.0` to `v1.61.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.61.0` includes feature, bug fix and revert updates, with no breaking changes
-identified in the upstream release metadata.
+This update moves the default image from `v1.61.0` to `v1.62.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.62.0` includes feature, bug fix, and performance updates; no breaking changes were identified in
+the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/templates/NOTES.txt
+++ b/charts/homarr/templates/NOTES.txt
@@ -95,4 +95,9 @@ NOTE: Ingress is not enabled. Access via port-forward (see above).
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 Documentation:  https://helmforge.dev/docs/charts/homarr
+Chart Source:   https://github.com/helmforgedev/charts/tree/main/charts/homarr
+Report Issues:  https://github.com/helmforgedev/charts/issues
+Discussions:    https://github.com/helmforgedev/charts/discussions
 Homarr:         https://homarr.dev | https://github.com/homarr-labs/homarr
+
+Happy Helmforging :)

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.61.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.62.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.61.0"
+  tag: "v1.62.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
Closes #314.

## Summary
- Update Homarr image tag to `v1.62.0` and appVersion to `1.62.0`.
- Align README, NOTES.txt, and unit tests with the new image tag and HelmForge notes standard.
- Keep generated chart lock files ignored locally while leaving dependency resolution to validation/packaging.

## Validation
- `helm dependency build charts/homarr` and `helm dependency list charts/homarr`: postgresql 1.10.0 ok, mysql 1.9.1 ok
- `helm lint charts/homarr`
- `helm lint --strict charts/homarr`
- `helm template homarr-test charts/homarr` and all 9 Homarr CI values files
- `helm unittest charts/homarr`: 9 suites, 47 tests passed
- `kubeconform` strict on default plus all 9 Homarr CI values files: 0 invalid, 0 errors
- `ah lint charts/homarr`: 65 packages, 0 errors
- `markdownlint-cli2 charts/homarr/README.md`: 0 errors
- `helm install homarr-notes-test charts/homarr --dry-run --debug`: NOTES.txt renders and ends with `Happy Helmforging :)`
- Kubescape MITRE, NSA, SOC2: overall 84, Resource Summary 83.55%
- k3d runtime on `k3d-helmforge-tests-wsl`: pod Ready 1/1, PVC Bound, HTTP 307 to `/init` then 200 OK, logs showed migrations/Redis/Next.js/WebSocket startup, no non-Normal events; release and namespace cleaned

## Upstream
- `ghcr.io/homarr-labs/homarr:v1.62.0` exists for linux/amd64 and linux/arm64.
- `ghcr.io/homarr-labs/homarr:1.62.0` does not exist, so the chart keeps the upstream `v`-prefixed tag style used by Homarr.
- Official release metadata reviewed: `v1.62.0` / `1.62.0` published 2026-05-22 with feature, bug fix, and performance updates.

## Site sync
- `/docs/charts/homarr#values` is queued for the site repository update after the chart issue batch, per the requested cross-repo workflow.
