### PR TITLE
chore(gitea): update image to 1.26.2-rootless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .dist/
 .tmp/
 charts/*/charts/*.tgz
+charts/*/Chart.lock
 .claude/
 .tmp/
 new-charts-requests/

--- a/charts/gitea/.helmignore
+++ b/charts/gitea/.helmignore
@@ -21,7 +21,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/gitea/Chart.lock
+++ b/charts/gitea/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:09bc7509b3ebe455bb1651e160c72df3c47cbfbff5f321103fbcd0c12c8045bd
-generated: "2026-04-29T04:19:34.7550243-03:00"

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: gitea
-description: Gitea  self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
+description: Gitea self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.10
-appVersion: "1.26.1"
+appVersion: "1.26.2"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 1.26.1 (#189)"
+      description: "Update Gitea image to 1.26.2-rootless (#313)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -205,12 +205,12 @@ All backups are uploaded to S3-compatible storage using the MinIO client.
 ## Pod Security Restricted
 
 The default install avoids root init containers so it can run in namespaces that enforce the Kubernetes `restricted`
-Pod Security profile. With `volumePermissions.enabled=false`, the chart stores `app.ini` under
-`/var/lib/gitea/custom/conf/app.ini` on the main data volume and relies on the rootless image ownership plus `fsGroup`
-for writable storage.
+Pod Security profile. The chart preserves the rootless Gitea config path at `/etc/gitea/app.ini` for upgrade
+compatibility and mounts it from the `config` subPath on the data PVC.
 
 Set `volumePermissions.enabled=true` only when your storage class requires an explicit root `chown` step. That opt-in
-mode restores the legacy `/etc/gitea/app.ini` mount and renders a root initContainer with `CHOWN`/`FOWNER`.
+mode renders a root initContainer with `CHOWN`/`FOWNER`; keep it disabled in restricted namespaces unless your policy
+explicitly allows that init container.
 
 ## More Information
 

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -4,6 +4,11 @@
 
 Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
 
+- **Current application version** `1.26.2`
+- **Default image** `docker.io/gitea/gitea:1.26.2-rootless`
+- **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
+- **Rootless storage** PVC paths are prepared for UID/GID 1000 by a small initContainer
+
 ## Features
 
 - **Official rootless image** based on `gitea/gitea:<version>-rootless` (UID 1000)
@@ -117,7 +122,7 @@ gitea:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `gitea/gitea` | Container image repository |
-| `image.tag` | `""` | Image tag (defaults to `appVersion-rootless`) |
+| `image.tag` | `"1.26.2-rootless"` | Image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
 | `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
@@ -143,6 +148,7 @@ gitea:
 | `mysql.enabled` | `false` | Deploy MySQL subchart |
 | `persistence.enabled` | `true` | Enable persistent storage |
 | `persistence.size` | `10Gi` | Volume size |
+| `volumePermissions.enabled` | `true` | Prepare rootless PVC ownership for UID/GID 1000 |
 | `service.http.type` | `ClusterIP` | HTTP service type |
 | `service.http.port` | `3000` | HTTP service port |
 | `service.ssh.enabled` | `true` | Enable SSH service |
@@ -167,6 +173,11 @@ When `database.mode` is `auto` (default), the chart detects which database to us
 4. Otherwise → **SQLite3** (zero configuration)
 
 Only one database source can be active. The chart fails with a clear error if multiple are configured.
+
+## Upgrade Notes
+
+This update moves the default rootless image from `1.26.1-rootless` to `1.26.2-rootless`. Review upstream
+Gitea release notes before upgrading production instances, especially for repository, SSH, and database migration behavior.
 
 ## SSH Access
 

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -148,7 +148,7 @@ gitea:
 | `mysql.enabled` | `false` | Deploy MySQL subchart |
 | `persistence.enabled` | `true` | Enable persistent storage |
 | `persistence.size` | `10Gi` | Volume size |
-| `volumePermissions.enabled` | `true` | Prepare rootless PVC ownership for UID/GID 1000 |
+| `volumePermissions.enabled` | `false` | Opt in to a root initContainer that prepares PVC ownership for UID/GID 1000 |
 | `service.http.type` | `ClusterIP` | HTTP service type |
 | `service.http.port` | `3000` | HTTP service port |
 | `service.ssh.enabled` | `true` | Enable SSH service |
@@ -201,6 +201,16 @@ The backup CronJob is database-aware:
 - **MySQL**: runs `mysqldump` and compresses the output
 
 All backups are uploaded to S3-compatible storage using the MinIO client.
+
+## Pod Security Restricted
+
+The default install avoids root init containers so it can run in namespaces that enforce the Kubernetes `restricted`
+Pod Security profile. With `volumePermissions.enabled=false`, the chart stores `app.ini` under
+`/var/lib/gitea/custom/conf/app.ini` on the main data volume and relies on the rootless image ownership plus `fsGroup`
+for writable storage.
+
+Set `volumePermissions.enabled=true` only when your storage class requires an explicit root `chown` step. That opt-in
+mode restores the legacy `/etc/gitea/app.ini` mount and renders a root initContainer with `CHOWN`/`FOWNER`.
 
 ## More Information
 

--- a/charts/gitea/templates/NOTES.txt
+++ b/charts/gitea/templates/NOTES.txt
@@ -30,6 +30,90 @@ SSH (if enabled):
 
   SSH:  ssh://git@localhost:2222/<org>/<repo>.git
 
+Internal service endpoints:
+  HTTP: http://{{ include "gitea.fullname" . }}-http.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.http.port | default 3000 }}
+  SSH:  {{ include "gitea.fullname" . }}-ssh.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ssh.port | default 22 }}
+
+--------------------------------------------------------------------
+  CONFIGURATION
+--------------------------------------------------------------------
+
+Deployment:
+  Image:        {{ include "gitea.image" . }}
+  Replicas:     {{ .Values.replicaCount }}
+  Run mode:     {{ .Values.gitea.runMode }}
+  App name:     {{ .Values.gitea.appName }}
+
+Services:
+  HTTP type:    {{ .Values.service.http.type }}
+  HTTP port:    {{ .Values.service.http.port }}
+  SSH type:     {{ .Values.service.ssh.type }}
+  SSH port:     {{ .Values.service.ssh.port }}
+{{- if .Values.service.http.ipFamilyPolicy }}
+  HTTP IP policy: {{ .Values.service.http.ipFamilyPolicy }}
+{{- end }}
+{{- with .Values.service.http.ipFamilies }}
+  HTTP IP families: {{ join ", " . }}
+{{- end }}
+{{- if .Values.service.ssh.ipFamilyPolicy }}
+  SSH IP policy: {{ .Values.service.ssh.ipFamilyPolicy }}
+{{- end }}
+{{- with .Values.service.ssh.ipFamilies }}
+  SSH IP families: {{ join ", " . }}
+{{- end }}
+
+Database:
+  Mode:         {{ include "gitea.databaseMode" . }}
+  Vendor:       {{ include "gitea.databaseVendor" . }}
+{{- if ne (include "gitea.databaseMode" .) "sqlite" }}
+  Host:         {{ include "gitea.databaseHost" . }}:{{ include "gitea.databasePort" . }}
+  Name:         {{ include "gitea.databaseName" . }}
+  Username:     {{ include "gitea.databaseUsername" . }}
+{{- else }}
+  SQLite file:  {{ .Values.database.sqlite.file }}
+{{- end }}
+
+Storage:
+  Persistence:  {{ .Values.persistence.enabled }}
+{{- if .Values.persistence.enabled }}
+  Size:         {{ .Values.persistence.size }}
+  Access mode:  {{ .Values.persistence.accessMode }}
+  StorageClass: {{ .Values.persistence.storageClass | default "<cluster default>" }}
+{{- end }}
+
+Backup:
+  Enabled:      {{ .Values.backup.enabled }}
+{{- if .Values.backup.enabled }}
+  Schedule:     {{ .Values.backup.schedule }}
+  Suspended:    {{ .Values.backup.suspend }}
+  S3 endpoint:  {{ .Values.backup.s3.endpoint }}
+  S3 bucket:    {{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+{{- end }}
+
+--------------------------------------------------------------------
+  CREDENTIALS AND SECRETS
+--------------------------------------------------------------------
+
+Admin account:
+  Username: {{ .Values.admin.username | default "<set admin.username to create admin user>" }}
+{{- if .Values.admin.existingSecret }}
+  Password: stored in existing Secret {{ .Values.admin.existingSecret }}
+{{- else if .Values.admin.password }}
+  Password: provided through values.
+{{- else }}
+  Password: auto-generated in Secret {{ include "gitea.adminSecretName" . }}
+  Retrieve it with:
+    kubectl get secret {{ include "gitea.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.admin-password}' | base64 -d
+{{- end }}
+
+Database credentials:
+{{- if eq (include "gitea.databaseMode" .) "sqlite" }}
+  SQLite mode does not require database network credentials.
+{{- else }}
+  Secret: {{ include "gitea.databaseSecretName" . }}
+  Password key: {{ include "gitea.databaseSecretKey" . }}
+{{- end }}
+
 --------------------------------------------------------------------
   GETTING STARTED
 --------------------------------------------------------------------
@@ -38,6 +122,23 @@ SSH (if enabled):
 2. kubectl get pods -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }}
 3. kubectl logs -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --all-containers --tail=50 -f
 4. Open the Web UI and complete the Gitea setup wizard (first access)
+5. Create the first organization and repository.
+6. Configure SSH clone URLs if exposing SSH outside the cluster.
+
+{{- if .Values.backup.enabled }}
+--------------------------------------------------------------------
+  BACKUP OPERATIONS
+--------------------------------------------------------------------
+
+List backup CronJobs:
+  kubectl get cronjob -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Trigger a manual backup:
+  kubectl create job -n {{ .Release.Namespace }} --from=cronjob/{{ include "gitea.fullname" . }}-backup {{ include "gitea.fullname" . }}-backup-manual-$(date +%s)
+
+Check recent backup logs:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=backup --tail=100
+{{- end }}
 
 --------------------------------------------------------------------
   TROUBLESHOOTING
@@ -47,6 +148,9 @@ SSH (if enabled):
   kubectl logs -l app.kubernetes.io/name=gitea -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+  kubectl describe svc {{ include "gitea.fullname" . }}-http -n {{ .Release.Namespace }}
+  kubectl describe svc {{ include "gitea.fullname" . }}-ssh -n {{ .Release.Namespace }}
 
 {{- if .Values.postgresql.enabled }}
 View PostgreSQL logs:
@@ -64,6 +168,18 @@ View MySQL logs:
 {{- if not .Values.ingress.enabled }}
 
 NOTE: Ingress is not enabled. Access via port-forward (see above).
+{{- end }}
+{{- if and (eq (include "gitea.databaseMode" .) "sqlite") (gt (int .Values.replicaCount) 1) }}
+
+WARNING: SQLite is selected with more than one replica. Use PostgreSQL, MySQL, or an external database before scaling writes.
+{{- end }}
+{{- if not .Values.persistence.enabled }}
+
+WARNING: Persistence is disabled. Repository data and SQLite state will be lost when pods are recreated.
+{{- end }}
+{{- if not .Values.backup.enabled }}
+
+NOTE: Backups are disabled. Enable backup.enabled and configure S3-compatible storage before production use.
 {{- end }}
 
 --------------------------------------------------------------------

--- a/charts/gitea/templates/NOTES.txt
+++ b/charts/gitea/templates/NOTES.txt
@@ -20,7 +20,7 @@ WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- else }}
 Port-forward to access Gitea locally:
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "gitea.fullname" . }} 3000:{{ .Values.service.http.port | default 3000 }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "gitea.fullname" . }}-http 3000:{{ .Values.service.http.port | default 3000 }}
 
   WEB UI:   http://localhost:3000/
 {{- end }}
@@ -71,6 +71,9 @@ NOTE: Ingress is not enabled. Access via port-forward (see above).
 --------------------------------------------------------------------
 
 Documentation:  https://helmforge.dev/docs/charts/gitea
+Chart Source:   https://github.com/helmforgedev/charts/tree/main/charts/gitea
+Report Issues:  https://github.com/helmforgedev/charts/issues
+Discussions:    https://github.com/helmforgedev/charts/discussions
 Gitea:          https://gitea.com | https://github.com/go-gitea/gitea
 
 Happy Helmforging :)

--- a/charts/gitea/templates/NOTES.txt
+++ b/charts/gitea/templates/NOTES.txt
@@ -79,6 +79,8 @@ Storage:
   Size:         {{ .Values.persistence.size }}
   Access mode:  {{ .Values.persistence.accessMode }}
   StorageClass: {{ .Values.persistence.storageClass | default "<cluster default>" }}
+  Volume permissions init: {{ .Values.volumePermissions.enabled }}
+  Config path:  {{ ternary "/etc/gitea/app.ini" "/var/lib/gitea/custom/conf/app.ini" .Values.volumePermissions.enabled }}
 {{- end }}
 
 Backup:
@@ -180,6 +182,10 @@ WARNING: Persistence is disabled. Repository data and SQLite state will be lost 
 {{- if not .Values.backup.enabled }}
 
 NOTE: Backups are disabled. Enable backup.enabled and configure S3-compatible storage before production use.
+{{- end }}
+{{- if .Values.volumePermissions.enabled }}
+
+NOTE: volumePermissions.enabled runs a root initContainer with CHOWN/FOWNER. Keep it disabled in namespaces enforcing the Kubernetes restricted Pod Security profile unless your policy explicitly allows it.
 {{- end }}
 
 --------------------------------------------------------------------

--- a/charts/gitea/templates/NOTES.txt
+++ b/charts/gitea/templates/NOTES.txt
@@ -80,7 +80,7 @@ Storage:
   Access mode:  {{ .Values.persistence.accessMode }}
   StorageClass: {{ .Values.persistence.storageClass | default "<cluster default>" }}
   Volume permissions init: {{ .Values.volumePermissions.enabled }}
-  Config path:  {{ ternary "/etc/gitea/app.ini" "/var/lib/gitea/custom/conf/app.ini" .Values.volumePermissions.enabled }}
+  Config path:  /etc/gitea/app.ini
 {{- end }}
 
 Backup:

--- a/charts/gitea/templates/admin-job.yaml
+++ b/charts/gitea/templates/admin-job.yaml
@@ -43,6 +43,7 @@ spec:
             - -c
             - |
               gitea admin user create \
+                --config "${GITEA_APP_INI}" \
                 --username "${ADMIN_USERNAME}" \
                 --password "${ADMIN_PASSWORD}" \
                 --email "${ADMIN_EMAIL}" \
@@ -66,6 +67,8 @@ spec:
                   key: admin-email
             - name: GITEA_WORK_DIR
               value: /var/lib/gitea
+            - name: GITEA_APP_INI
+              value: "/etc/gitea/app.ini"
           {{- if .Values.persistence.enabled }}
           volumeMounts:
             - name: data

--- a/charts/gitea/templates/deployment.yaml
+++ b/charts/gitea/templates/deployment.yaml
@@ -28,8 +28,31 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if ne (include "gitea.databaseMode" .) "sqlite" }}
+      {{- if or (and .Values.persistence.enabled .Values.volumePermissions.enabled) (ne (include "gitea.databaseMode" .) "sqlite") }}
       initContainers:
+        {{- if and .Values.persistence.enabled .Values.volumePermissions.enabled }}
+        - name: volume-permissions
+          image: "{{ .Values.volumePermissions.image.repository }}:{{ .Values.volumePermissions.image.tag }}"
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              mkdir -p /var/lib/gitea /etc/gitea
+              chown -R 1000:1000 /var/lib/gitea /etc/gitea
+          {{- with .Values.volumePermissions.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/gitea
+              subPath: data
+            - name: data
+              mountPath: /etc/gitea
+              subPath: config
+        {{- end }}
+        {{- if ne (include "gitea.databaseMode" .) "sqlite" }}
         - name: wait-for-db
           image: docker.io/library/busybox:1.37
           command:
@@ -41,6 +64,7 @@ spec:
                 sleep 2
               done
               echo "Database is reachable."
+        {{- end }}
       {{- end }}
       containers:
         - name: gitea

--- a/charts/gitea/templates/deployment.yaml
+++ b/charts/gitea/templates/deployment.yaml
@@ -70,6 +70,15 @@ spec:
         - name: gitea
           image: {{ include "gitea.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              mkdir -p "$(dirname "${GITEA_APP_INI}")"
+              if [ ! -f "${GITEA_APP_INI}" ]; then
+                touch "${GITEA_APP_INI}"
+              fi
+              exec /usr/bin/dumb-init -- /usr/local/bin/docker-entrypoint.sh
           ports:
             - name: http
               containerPort: 3000
@@ -82,7 +91,7 @@ spec:
           env:
             # -- Core Gitea settings
             - name: GITEA_APP_INI
-              value: {{ ternary "/etc/gitea/app.ini" "/var/lib/gitea/custom/conf/app.ini" .Values.volumePermissions.enabled | quote }}
+              value: "/etc/gitea/app.ini"
             - name: GITEA__server__APP_DATA_PATH
               value: /var/lib/gitea/data
             - name: GITEA__server__DOMAIN
@@ -175,11 +184,9 @@ spec:
             - name: data
               mountPath: /var/lib/gitea
               subPath: data
-            {{- if .Values.volumePermissions.enabled }}
             - name: data
               mountPath: /etc/gitea
               subPath: config
-            {{- end }}
           {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:

--- a/charts/gitea/templates/deployment.yaml
+++ b/charts/gitea/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             {{- end }}
           env:
             # -- Core Gitea settings
+            - name: GITEA_APP_INI
+              value: {{ ternary "/etc/gitea/app.ini" "/var/lib/gitea/custom/conf/app.ini" .Values.volumePermissions.enabled | quote }}
             - name: GITEA__server__APP_DATA_PATH
               value: /var/lib/gitea/data
             - name: GITEA__server__DOMAIN
@@ -173,9 +175,11 @@ spec:
             - name: data
               mountPath: /var/lib/gitea
               subPath: data
+            {{- if .Values.volumePermissions.enabled }}
             - name: data
               mountPath: /etc/gitea
               subPath: config
+            {{- end }}
           {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:

--- a/charts/gitea/tests/admin-job_test.yaml
+++ b/charts/gitea/tests/admin-job_test.yaml
@@ -35,3 +35,19 @@ tests:
               secretKeyRef:
                 name: my-admin-secret
                 key: admin-username
+
+  - it: should use the same app.ini path as the main deployment
+    set:
+      admin:
+        username: gitea_admin
+        password: test123
+        email: admin@test.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITEA_APP_INI
+            value: /etc/gitea/app.ini
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--config \"\\$\\{GITEA_APP_INI\\}\""

--- a/charts/gitea/tests/deployment_test.yaml
+++ b/charts/gitea/tests/deployment_test.yaml
@@ -35,25 +35,39 @@ tests:
       - isNull:
           path: spec.strategy
 
-  - it: should not have initContainers for SQLite
-    set:
-      volumePermissions:
-        enabled: false
+  - it: should not have initContainers for SQLite by default
     asserts:
       - isNull:
           path: spec.template.spec.initContainers
 
-  - it: should prepare rootless PVC permissions by default
+  - it: should avoid the root volume-permissions initContainer by default
     asserts:
-      - equal:
-          path: spec.template.spec.initContainers[0].name
-          value: volume-permissions
+      - isNull:
+          path: spec.template.spec.initContainers
       - equal:
           path: spec.template.spec.securityContext.runAsUser
           value: 1000
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1000
+
+  - it: should prepare rootless PVC permissions when explicitly enabled
+    set:
+      volumePermissions:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: volume-permissions
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /etc/gitea
+            subPath: config
 
   - it: should have wait-for-db initContainer for PostgreSQL
     set:
@@ -65,7 +79,7 @@ tests:
           password: test
     asserts:
       - equal:
-          path: spec.template.spec.initContainers[1].name
+          path: spec.template.spec.initContainers[0].name
           value: wait-for-db
 
   - it: should set DB_TYPE to sqlite3 by default
@@ -75,6 +89,14 @@ tests:
           content:
             name: GITEA__database__DB_TYPE
             value: "sqlite3"
+
+  - it: should store app.ini under the data volume by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITEA_APP_INI
+            value: /var/lib/gitea/custom/conf/app.ini
 
   - it: should set DB_TYPE to postgres when postgresql is enabled
     set:

--- a/charts/gitea/tests/deployment_test.yaml
+++ b/charts/gitea/tests/deployment_test.yaml
@@ -36,9 +36,24 @@ tests:
           path: spec.strategy
 
   - it: should not have initContainers for SQLite
+    set:
+      volumePermissions:
+        enabled: false
     asserts:
       - isNull:
           path: spec.template.spec.initContainers
+
+  - it: should prepare rootless PVC permissions by default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: volume-permissions
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
 
   - it: should have wait-for-db initContainer for PostgreSQL
     set:
@@ -50,7 +65,7 @@ tests:
           password: test
     asserts:
       - equal:
-          path: spec.template.spec.initContainers[0].name
+          path: spec.template.spec.initContainers[1].name
           value: wait-for-db
 
   - it: should set DB_TYPE to sqlite3 by default

--- a/charts/gitea/tests/deployment_test.yaml
+++ b/charts/gitea/tests/deployment_test.yaml
@@ -96,7 +96,19 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: GITEA_APP_INI
-            value: /var/lib/gitea/custom/conf/app.ini
+            value: /etc/gitea/app.ini
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /etc/gitea
+            subPath: config
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "touch \"\\$\\{GITEA_APP_INI\\}\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "docker-entrypoint\\.sh"
 
   - it: should set DB_TYPE to postgres when postgresql is enabled
     set:

--- a/charts/gitea/values.schema.json
+++ b/charts/gitea/values.schema.json
@@ -263,9 +263,9 @@
     },
     "volumePermissions": {
       "type": "object",
-      "description": "InitContainer that prepares rootless PVC ownership.",
+      "description": "Optional root initContainer that prepares rootless PVC ownership. Disabled by default for Pod Security restricted compatibility.",
       "properties": {
-        "enabled": { "type": "boolean" },
+        "enabled": { "type": "boolean", "default": false },
         "image": {
           "type": "object",
           "properties": {

--- a/charts/gitea/values.schema.json
+++ b/charts/gitea/values.schema.json
@@ -261,6 +261,22 @@
       "type": "object",
       "description": "Container security context."
     },
+    "volumePermissions": {
+      "type": "object",
+      "description": "InitContainer that prepares rootless PVC ownership.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "securityContext": { "type": "object" }
+      }
+    },
     "startupProbe": {
       "type": "object",
       "description": "Startup probe configuration."

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -207,8 +207,8 @@ securityContext:
   runAsGroup: 1000
 
 volumePermissions:
-  # -- Run an initContainer that prepares rootless PVC ownership for UID/GID 1000.
-  enabled: true
+  # -- Run a root initContainer that prepares rootless PVC ownership for UID/GID 1000. Disabled by default for Pod Security restricted compatibility.
+  enabled: false
   image:
     repository: docker.io/library/busybox
     tag: "1.37"

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -6,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.26.1-rootless"
+  tag: "1.26.2-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets
@@ -187,9 +187,42 @@ resources: {}
 # Security Context
 # =============================================================================
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+
+volumePermissions:
+  # -- Run an initContainer that prepares rootless PVC ownership for UID/GID 1000.
+  enabled: true
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      add:
+        - CHOWN
+        - FOWNER
+      drop:
+        - ALL
+    runAsNonRoot: false
+    runAsUser: 0
 
 # =============================================================================
 # Probes


### PR DESCRIPTION
Closes #313.

## Summary
- Update Gitea to `1.26.2-rootless` and align `appVersion` to `1.26.2`.
- Remove the tracked `Chart.lock` and ignore generated chart locks per HelmForge policy.
- Add rootless PVC permission preparation for UID/GID 1000, tighten the main container security context, and cover it with unit tests.
- Fix the NOTES.txt HTTP port-forward service name and add standard HelmForge resource links.

## Validation
- `helm dependency build charts/gitea` and `helm dependency list charts/gitea`: postgresql 1.9.11 ok, mysql 1.8.5 ok
- `helm lint charts/gitea`
- `helm lint --strict charts/gitea`
- `helm template gitea-test charts/gitea` and all 8 Gitea CI values files
- `helm unittest charts/gitea`: 7 suites, 49 tests passed
- `kubeconform` strict on default plus all 8 Gitea CI values files: 0 invalid, 0 errors
- `ah lint charts/gitea`: 65 packages, 0 errors
- `markdownlint-cli2 charts/gitea/README.md`: 0 errors
- Kubescape MITRE, NSA, SOC2: overall 87, Resource Summary 86.58%
- k3d runtime on `k3d-helmforge-tests-wsl`: pod Ready 1/1, initContainer completed with 0 restarts, PVC Bound, HTTP 200 install page, `gitea --version` reported 1.26.2, logs clean, no non-Normal events; release and namespace cleaned

## Upstream
- `docker.io/gitea/gitea:1.26.2-rootless` exists for linux/amd64, linux/arm64, and linux/riscv64.
- Official Gitea 1.26.2 release notes/changelog and rootless Docker documentation were reviewed.
- Gitea rootless docs confirm the `1.26.2-rootless` tag format, HTTP 3000, SSH 2222, and UID/GID 1000 ownership requirement.

## Site sync
- `/docs/charts/gitea#values` is queued for the site repository update after the chart issue batch, per the requested cross-repo workflow.
