### PR TITLE
chore(generic): update nginx to 1.31.1

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,14 +7,14 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 version: 2.0.4
-appVersion: "1.31.0"
+appVersion: "1.31.1"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update nginx to 1.31.0 (#295)"
+      description: "Update default NGINX image to 1.31.1 (#312)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -1,6 +1,7 @@
 # Generic Helm Chart
 
-A single chart that handles **Deployments**, **StatefulSets**, **DaemonSets**, **Jobs**, and **CronJobs** with a unified values interface. Designed for teams that deploy many services and want one chart to rule them all.
+A single chart that handles **Deployments**, **StatefulSets**, **DaemonSets**, **Jobs**, and **CronJobs** with a unified values
+interface. Designed for teams that deploy many services and want one chart to rule them all.
 
 ## Install
 
@@ -71,6 +72,7 @@ ingress:
         - app.example.com
       secretName: app-tls
 ```
+
 </details>
 
 ## How to choose the right mode
@@ -80,7 +82,9 @@ ingress:
 - use `DaemonSet` when exactly one pod per node is the intended operating model
 - use Jobs or CronJobs when the release is batch-oriented and should not keep a long-running workload alive
 
-The generic chart is most useful when your team wants one operational contract for many internal services. It is not the right choice when a product has its own topology, bootstrap flow, or domain-specific configuration model that deserves a dedicated chart.
+The generic chart is most useful when your team wants one operational contract for many internal services. It is not the
+right choice when a product has its own topology, bootstrap flow, or domain-specific configuration model that deserves a
+dedicated chart.
 
 <details>
 <summary><b>StatefulSet</b></summary>
@@ -100,6 +104,7 @@ workload:
           requests:
             storage: 10Gi
 ```
+
 </details>
 
 <details>
@@ -117,6 +122,7 @@ workload:
 tolerations:
   - operator: Exists
 ```
+
 </details>
 
 <details>
@@ -136,6 +142,7 @@ cronjobs:
     schedule: "0 2 * * *"
     command: ["npm", "run", "cleanup"]
 ```
+
 </details>
 
 ## Key Features
@@ -247,11 +254,15 @@ rollout:
 
 The chart now includes opt-in primitives for common platform needs:
 
-- `secrets[]`, `externalSecrets`, and `sealedSecrets` for secret integration. ExternalSecret, SealedSecret, ServiceMonitor, PodMonitor, PrometheusRule, KEDA, VPA, and Gateway API resources require their CRDs to exist before enabling them.
+- `secrets[]`, `externalSecrets`, and `sealedSecrets` for secret integration. ExternalSecret, SealedSecret,
+  ServiceMonitor, PodMonitor, PrometheusRule, KEDA, VPA, and Gateway API resources require their CRDs to exist before
+  enabling them.
 - `rbac.create` and `networkPolicy.enabled` for least-privilege identity and traffic policy.
 - `securityPreset: baseline` or `restricted` for opt-in security contexts when explicit contexts are not set.
-- `services[]`, `service.headless`, `service.nameOverride`, per-port `appProtocol`, and custom Ingress backends for richer networking. When `service.enabled=false`, Ingress paths must set `backend` and HTTPRoute rules must set `backendRefs`.
-- `podMonitor`, `prometheusRule`, advanced HPA metrics, and optional KEDA ScaledObject/ScaledJob support. KEDA ScaledObjects target the chart workload and require `workload.enabled=true`; use ScaledJobs for batch-only releases.
+- `services[]`, `service.headless`, `service.nameOverride`, per-port `appProtocol`, and custom Ingress backends for richer
+  networking. When `service.enabled=false`, Ingress paths must set `backend` and HTTPRoute rules must set `backendRefs`.
+- `podMonitor`, `prometheusRule`, advanced HPA metrics, and optional KEDA ScaledObject/ScaledJob support. KEDA
+  ScaledObjects target the chart workload and require `workload.enabled=true`; use ScaledJobs for batch-only releases.
 - `persistence.persistentVolumeClaims[]` and explicit opt-in `persistence.persistentVolumes[]` for clearer storage ownership.
 
 ### Breaking-change migration notes

--- a/charts/generic/docs/observability.md
+++ b/charts/generic/docs/observability.md
@@ -30,9 +30,13 @@ KEDA ScaledObjects target the chart-managed Deployment or StatefulSet and requir
 
 ## Autoscaling and HA safety
 
-Deployment and StatefulSet HPA resources are supported by the Kubernetes `autoscaling/v2` API. Validate StatefulSet scaling with the application owner before enabling it in production, because ordered identity, storage semantics, and application clustering behavior remain workload-specific.
+Deployment and StatefulSet HPA resources are supported by the Kubernetes `autoscaling/v2` API. Validate StatefulSet scaling
+with the application owner before enabling it in production, because ordered identity, storage semantics, and application
+clustering behavior remain workload-specific.
 
-KEDA, VPA, PodMonitor, and PrometheusRule resources require their operators and CRDs to exist before enabling those features. The generic chart keeps them disabled by default and validates only their manifests unless the target cluster has the matching CRDs installed.
+KEDA, VPA, PodMonitor, and PrometheusRule resources require their operators and CRDs to exist before enabling those
+features. The generic chart keeps them disabled by default and validates only their manifests unless the target cluster
+has the matching CRDs installed.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -1,10 +1,27 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- range .Values.externalSecrets.items | default list }}
-{{- if not (dig "secretStoreRef" "name" "" (.spec | default dict)) }}
-{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" }}
+{{- $spec := .spec | default dict }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
 {{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
 {{- $secretStoreName := required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .spec.secretStoreRef.name }}
+{{- end }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -1,6 +1,10 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- range .Values.externalSecrets.items | default list }}
+{{- if not (dig "secretStoreRef" "name" "" (.spec | default dict)) }}
+{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- $secretStoreName := required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .spec.secretStoreRef.name }}
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/charts/generic/templates/service.yaml
+++ b/charts/generic/templates/service.yaml
@@ -96,12 +96,21 @@ spec:
   {{- with .clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
-  {{- with (.ipFamilyPolicy | default $.Values.service.ipFamilyPolicy) }}
+  {{- if .ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .ipFamilyPolicy }}
+  {{- else }}
+  {{- with $.Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}
-  {{- with (.ipFamilies | default $.Values.service.ipFamilies) }}
+  {{- end }}
+  {{- if .ipFamilies }}
+  ipFamilies:
+    {{- toYaml .ipFamilies | nindent 4 }}
+  {{- else if not .ipFamilyPolicy }}
+  {{- with $.Values.service.ipFamilies }}
   ipFamilies:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   ports:
     {{- toYaml .ports | nindent 4 }}

--- a/charts/generic/templates/service.yaml
+++ b/charts/generic/templates/service.yaml
@@ -96,6 +96,13 @@ spec:
   {{- with .clusterIP }}
   clusterIP: {{ . }}
   {{- end }}
+  {{- with (.ipFamilyPolicy | default $.Values.service.ipFamilyPolicy) }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with (.ipFamilies | default $.Values.service.ipFamilies) }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     {{- toYaml .ports | nindent 4 }}
   selector:

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -15,4 +15,4 @@ tests:
           of: DaemonSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/nginx:1.31.0
+          value: docker.io/library/nginx:1.31.1

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -56,7 +56,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/nginx:1.31.0"
+          value: "docker.io/library/nginx:1.31.1"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -88,7 +88,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/nginx:1.31.0"
+          value: "registry.example.com/nginx:1.31.1"
 
   - it: should apply global registry to namespaced unqualified repositories
     set:
@@ -97,7 +97,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/team/app:1.31.0"
+          value: "registry.example.com/team/app:1.31.1"
 
   - it: should not apply global registry to fully qualified repositories
     set:
@@ -106,7 +106,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/team/app:1.31.0"
+          value: "ghcr.io/team/app:1.31.1"
 
   - it: should allow per-container image digest override
     set:

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: ExternalSecret
 templates:
   - external-secret.yaml

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -1,0 +1,51 @@
+suite: ExternalSecret
+templates:
+  - external-secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render ExternalSecret by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret item
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: app
+            spec:
+              refreshInterval: 1h
+              target:
+                name: app-secret
+              secretStoreRef:
+                name: vault
+                kind: ClusterSecretStore
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: app/password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: test-app
+      - equal:
+          path: spec.secretStoreRef.name
+          value: vault
+
+  - it: should fail when ExternalSecret item has no secretStoreRef name
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: app
+            spec:
+              target:
+                name: app-secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true"

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -38,7 +38,32 @@ tests:
           path: spec.secretStoreRef.name
           value: vault
 
-  - it: should fail when ExternalSecret item has no secretStoreRef name
+  - it: should render ExternalSecret item with per-entry sourceRef storeRef
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: app
+            spec:
+              refreshInterval: 1h
+              target:
+                name: app-secret
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: app/password
+                  sourceRef:
+                    storeRef:
+                      name: vault
+                      kind: ClusterSecretStore
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.data[0].sourceRef.storeRef.name
+          value: vault
+
+  - it: should fail when ExternalSecret item has no default or per-entry store reference
     set:
       externalSecrets:
         enabled: true
@@ -49,4 +74,4 @@ tests:
                 name: app-secret
     asserts:
       - failedTemplate:
-          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true"
+          errorMessage: "externalSecrets.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"

--- a/charts/generic/tests/service_test.yaml
+++ b/charts/generic/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - service.yaml

--- a/charts/generic/tests/service_test.yaml
+++ b/charts/generic/tests/service_test.yaml
@@ -80,3 +80,25 @@ tests:
           value:
             - IPv4
             - IPv6
+
+  - it: should not inherit ipFamilies when an additional service overrides only ipFamilyPolicy
+    documentIndex: 1
+    set:
+      service:
+        ipFamilyPolicy: RequireDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+      services:
+        - name: metrics
+          ipFamilyPolicy: SingleStack
+          ports:
+            - name: metrics
+              port: 9090
+              targetPort: 9090
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+      - notExists:
+          path: spec.ipFamilies

--- a/charts/generic/tests/service_test.yaml
+++ b/charts/generic/tests/service_test.yaml
@@ -57,6 +57,10 @@ tests:
     set:
       services:
         - name: metrics
+          ipFamilyPolicy: PreferDualStack
+          ipFamilies:
+            - IPv4
+            - IPv6
           ports:
             - name: metrics
               port: 9090
@@ -67,3 +71,11 @@ tests:
       - equal:
           path: metadata.name
           value: test-metrics
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -81,7 +81,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "1.31.0"
+          "default": "1.31.1"
         },
         "digest": {
           "type": "string",

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -52,7 +52,7 @@ global:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.0"
+  tag: "1.31.1"
   digest: ""
   pullPolicy: IfNotPresent
 
@@ -190,6 +190,11 @@ service:
 services: []
   # - name: metrics
   #   type: ClusterIP
+  #   # Defaults to service.ipFamilyPolicy / service.ipFamilies when omitted.
+  #   ipFamilyPolicy: PreferDualStack
+  #   ipFamilies:
+  #     - IPv4
+  #     - IPv6
   #   ports:
   #     - name: metrics
   #       port: 9090


### PR DESCRIPTION
Closes #312

## Summary
- Update the generic chart default NGINX image and appVersion from 1.31.0 to 1.31.1.
- Align values schema and image-related unit test expectations with the new tag.
- Improve platform guardrails by allowing additional services in services[] to inherit global dual-stack settings, while still supporting per-service overrides.
- Add fail-fast ExternalSecret validation for missing spec.secretStoreRef.name and cover it with unit tests.
- Clean up generic README/docs markdownlint findings found during local validation.

## Upstream evidence
- docker manifest inspect docker.io/library/nginx:1.31.1 succeeded and includes linux/amd64 and linux/arm64 variants.
- docker run --rm docker.io/library/nginx:1.31.1 nginx -v returned nginx/1.31.1.
- Context7 official nginx Docker docs confirm versioned tags, HTTP port 80 usage, and stdout/stderr logging behavior.
- Tavily reviewed https://nginx.org/en/CHANGES and nginx/docker-nginx release context; the public CHANGES page extraction still showed nginx 1.31.0 as the latest visible entry, so registry and runtime verification were used for the issue-requested 1.31.1 tag.

## Validation
- helm dependency build charts/generic and helm dependency list charts/generic
- helm lint charts/generic and helm lint --strict charts/generic
- helm unittest charts/generic: 18 suites, 63 tests passed
- helm template default plus all 8 charts/generic/ci values files
- kubeconform strict on default plus all 8 CI values files: 0 invalid, 0 errors
- ah lint charts/generic: 65 packages, 0 errors
- markdownlint-cli2 charts/generic/README.md charts/generic/docs/*.md: 0 errors
- Kubescape MITRE, NSA, SOC2: overall 76, resource score 75.76, 0 critical
- k3d runtime on k3d-helmforge-tests-wsl: pod Ready 1/1, image docker.io/library/nginx:1.31.1, HTTP 200 from service, logs reviewed, no non-Normal events, namespace cleaned

## Site sync
- Deferred until the chart PR sequence is complete: /docs/charts/generic#values