### PR TITLE
chore(adguard-home): update image to 0.107.76

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -4,7 +4,7 @@ name: adguard-home
 description: AdGuard Home network-wide ad and tracker blocking DNS server with sync and S3 backup
 type: application
 version: 1.4.9
-appVersion: "0.107.74"
+appVersion: "0.107.76"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/adguard-home.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 0.107.74 (#184)"
+      description: "Update AdGuard Home image to 0.107.76 (#306)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -249,9 +249,9 @@ backup:
 | `initPermissions.securityContext.capabilities.add` | `[CHOWN]` | Minimal capability required to assign PVC ownership when non-root runtime security contexts are configured |
 | `initPermissions.resources` | `{}` | Init permissions resource requests/limits |
 
-When `securityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with `config.adGuardHome` or
-`config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch; pre-seeded mode runs successfully
-with non-root UID and `podSecurityContext.fsGroup`.
+When `securityContext.runAsUser` or `podSecurityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with
+`config.adGuardHome` or `config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch;
+pre-seeded mode runs successfully with non-root UID and `podSecurityContext.fsGroup`.
 
 ### Sync (adguardhome-sync)
 

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -33,6 +33,12 @@ kubectl port-forward svc/adguard-home-web 3000:80
 
 To skip the wizard and deploy a pre-configured instance, provide `config.adGuardHome` with your desired configuration. See the [preconfigured example](examples/preconfigured.yaml).
 
+## Upstream Version Notes
+
+AdGuard Home `0.107.76` is an upstream hotfix release for cache behavior after the previous update.
+The release notes also state that YAML duration values now support `d` day units. If you roll back to
+a version below `v0.107.76`, convert any `d` duration values in `config.adGuardHome` back to hours first.
+
 ## Features
 
 - **Network-Wide Ad Blocking** - DNS-level filtering for all devices on the network
@@ -46,6 +52,7 @@ To skip the wizard and deploy a pre-configured instance, provide `config.adGuard
 - **ExternalSecrets** - opt-in `ExternalSecret` to source `AdGuardHome.yaml` from an external secrets store
 - **Ingress Support** - configurable ingress with TLS for the web admin interface
 - **Config Seeding** - initial configuration is preserved across upgrades (only seeded on first run)
+- **Volume Permission Guard** - optional init container normalizes mounted volume permissions before startup
 
 ## Configuration
 
@@ -175,8 +182,8 @@ backup:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.repository` | `adguard/adguardhome` | Container image |
-| `image.tag` | `""` (appVersion) | Image tag (auto-prefixed with `v`) |
+| `image.repository` | `docker.io/adguard/adguardhome` | Container image |
+| `image.tag` | `v0.107.76` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### General Configuration
@@ -229,6 +236,17 @@ backup:
 | `probes.startup.enabled` | `true` | Enable startup probe |
 | `probes.liveness.enabled` | `true` | Enable liveness probe |
 | `probes.readiness.enabled` | `true` | Enable readiness probe |
+
+### Security
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `podSecurityContext` | `{}` | Pod-level security context |
+| `securityContext` | `{}` | Main container security context |
+| `initPermissions.enabled` | `true` | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` permissions before startup |
+| `initPermissions.image.repository` | `docker.io/library/busybox` | Init permissions container image |
+| `initPermissions.image.tag` | `1.37` | Init permissions image tag |
+| `initPermissions.resources` | `{}` | Init permissions resource requests/limits |
 
 ### Sync (adguardhome-sync)
 

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -246,7 +246,7 @@ backup:
 | `initPermissions.enabled` | `true` | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` permissions before startup |
 | `initPermissions.image.repository` | `docker.io/library/busybox` | Init permissions container image |
 | `initPermissions.image.tag` | `1.37` | Init permissions image tag |
-| `initPermissions.securityContext.capabilities.add` | `[CHOWN]` | Minimal capability required to assign PVC ownership when non-root runtime security contexts are configured |
+| `initPermissions.securityContext.capabilities.add` | `[CHOWN, DAC_READ_SEARCH, FOWNER]` | Minimal capabilities for PVC ownership, recursive traversal, and directory mode updates |
 | `initPermissions.resources` | `{}` | Init permissions resource requests/limits |
 
 When `securityContext.runAsUser` or `podSecurityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -246,7 +246,12 @@ backup:
 | `initPermissions.enabled` | `true` | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` permissions before startup |
 | `initPermissions.image.repository` | `docker.io/library/busybox` | Init permissions container image |
 | `initPermissions.image.tag` | `1.37` | Init permissions image tag |
+| `initPermissions.securityContext.capabilities.add` | `[CHOWN]` | Minimal capability required to assign PVC ownership when non-root runtime security contexts are configured |
 | `initPermissions.resources` | `{}` | Init permissions resource requests/limits |
+
+When `securityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with `config.adGuardHome` or
+`config.existingSecret`. The interactive setup wizard requires administrator privileges on first launch; pre-seeded mode runs successfully
+with non-root UID and `podSecurityContext.fsGroup`.
 
 ### Sync (adguardhome-sync)
 

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -246,7 +246,7 @@ backup:
 | `initPermissions.enabled` | `true` | Normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` permissions before startup |
 | `initPermissions.image.repository` | `docker.io/library/busybox` | Init permissions container image |
 | `initPermissions.image.tag` | `1.37` | Init permissions image tag |
-| `initPermissions.securityContext.capabilities.add` | `[CHOWN, DAC_READ_SEARCH, FOWNER]` | Minimal capabilities for PVC ownership, recursive traversal, and directory mode updates |
+| `initPermissions.securityContext.capabilities.add` | `[CHOWN, DAC_OVERRIDE, FOWNER]` | Baseline-compatible capabilities for PVC ownership, recursive traversal, and directory mode updates |
 | `initPermissions.resources` | `{}` | Init permissions resource requests/limits |
 
 When `securityContext.runAsUser` or `podSecurityContext.runAsUser` is configured for a non-root runtime, pre-seed `AdGuardHome.yaml` with

--- a/charts/adguard-home/templates/NOTES.txt
+++ b/charts/adguard-home/templates/NOTES.txt
@@ -61,6 +61,7 @@ DNS Service:
 Deployment:
   Image:              {{ include "adguard-home.image" . }}
   Strategy:           Recreate (single-instance, no rolling update)
+  Init Permissions:   {{ .Values.initPermissions.enabled }}
   Persistence (conf): {{ .Values.persistence.conf.enabled }} ({{ .Values.persistence.conf.size }})
   Persistence (work): {{ .Values.persistence.work.enabled }} ({{ .Values.persistence.work.size }})
 
@@ -139,6 +140,12 @@ Describe pod (events and errors):
 View application logs:
   kubectl logs -l app.kubernetes.io/name=adguard-home \
     -n {{ .Release.Namespace }} --all-containers --tail=100
+
+{{- if .Values.initPermissions.enabled }}
+View init container (volume permissions) logs:
+  kubectl logs -l app.kubernetes.io/name=adguard-home \
+    -n {{ .Release.Namespace }} -c init-permissions
+{{- end }}
 
 {{- if (include "adguard-home.hasConfig" .) }}
 View init container (config seeder) logs:

--- a/charts/adguard-home/templates/NOTES.txt
+++ b/charts/adguard-home/templates/NOTES.txt
@@ -223,7 +223,7 @@ Enable for production:
     --set persistence.work.enabled=true --reuse-values
 {{- end }}
 
-{{- if and (hasKey .Values.securityContext "runAsUser") (not (include "adguard-home.hasConfig" .)) }}
+{{- if and (or (hasKey .Values.securityContext "runAsUser") (hasKey .Values.podSecurityContext "runAsUser")) (not (include "adguard-home.hasConfig" .)) }}
 
 WARNING: A non-root runAsUser is configured while AdGuard Home is in setup wizard mode.
 AdGuard Home requires administrator privileges for the first launch wizard.

--- a/charts/adguard-home/templates/NOTES.txt
+++ b/charts/adguard-home/templates/NOTES.txt
@@ -223,6 +223,13 @@ Enable for production:
     --set persistence.work.enabled=true --reuse-values
 {{- end }}
 
+{{- if and (hasKey .Values.securityContext "runAsUser") (not (include "adguard-home.hasConfig" .)) }}
+
+WARNING: A non-root runAsUser is configured while AdGuard Home is in setup wizard mode.
+AdGuard Home requires administrator privileges for the first launch wizard.
+Use config.adGuardHome or config.existingSecret to pre-seed AdGuardHome.yaml before running as non-root.
+{{- end }}
+
 --------------------------------------------------------------------
   ADDITIONAL RESOURCES
 --------------------------------------------------------------------

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -44,8 +44,33 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- if (include "adguard-home.hasConfig" .) }}
+      {{- if or .Values.initPermissions.enabled (include "adguard-home.hasConfig" .) }}
       initContainers:
+        {{- if .Values.initPermissions.enabled }}
+        - name: init-permissions
+          image: {{ .Values.initPermissions.image.repository }}:{{ .Values.initPermissions.image.tag }}
+          imagePullPolicy: {{ .Values.initPermissions.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
+              chmod 700 /opt/adguardhome/conf /opt/adguardhome/work
+          {{- with .Values.initPermissions.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.initPermissions.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: conf
+              mountPath: /opt/adguardhome/conf
+            - name: work
+              mountPath: /opt/adguardhome/work
+        {{- end }}
+        {{- if (include "adguard-home.hasConfig" .) }}
         - name: copy-config
           image: docker.io/library/busybox:1.37
           command:
@@ -64,6 +89,7 @@ spec:
             - name: config-seed
               mountPath: /config-seed
               readOnly: true
+        {{- end }}
       {{- end }}
       containers:
         - name: adguard-home

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -108,6 +108,10 @@ spec:
               else
                 echo "Configuration already exists, skipping seed."
               fi
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: conf
               mountPath: /opt/adguardhome/conf

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -47,6 +47,22 @@ spec:
       {{- if or .Values.initPermissions.enabled (include "adguard-home.hasConfig" .) }}
       initContainers:
         {{- if .Values.initPermissions.enabled }}
+        {{- $volumeMode := "700" }}
+        {{- if hasKey .Values.podSecurityContext "fsGroup" }}
+        {{- $volumeMode = "770" }}
+        {{- end }}
+        {{- $volumeUser := "0" }}
+        {{- if hasKey .Values.securityContext "runAsUser" }}
+        {{- $volumeUser = toString .Values.securityContext.runAsUser }}
+        {{- end }}
+        {{- $volumeGroup := "0" }}
+        {{- if hasKey .Values.podSecurityContext "fsGroup" }}
+        {{- $volumeGroup = toString .Values.podSecurityContext.fsGroup }}
+        {{- end }}
+        {{- if hasKey .Values.securityContext "runAsGroup" }}
+        {{- $volumeGroup = toString .Values.securityContext.runAsGroup }}
+        {{- end }}
+        {{- $needsOwnership := or (hasKey .Values.securityContext "runAsUser") (hasKey .Values.securityContext "runAsGroup") (hasKey .Values.podSecurityContext "fsGroup") }}
         - name: init-permissions
           image: {{ .Values.initPermissions.image.repository }}:{{ .Values.initPermissions.image.tag }}
           imagePullPolicy: {{ .Values.initPermissions.image.pullPolicy }}
@@ -55,7 +71,10 @@ spec:
             - -c
             - |
               mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
-              chmod 700 /opt/adguardhome/conf /opt/adguardhome/work
+              chmod {{ $volumeMode }} /opt/adguardhome/conf /opt/adguardhome/work
+              {{- if $needsOwnership }}
+              chown {{ $volumeUser }}:{{ $volumeGroup }} /opt/adguardhome/conf /opt/adguardhome/work
+              {{- end }}
           {{- with .Values.initPermissions.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -52,17 +52,23 @@ spec:
         {{- $volumeMode = "770" }}
         {{- end }}
         {{- $volumeUser := "0" }}
+        {{- if hasKey .Values.podSecurityContext "runAsUser" }}
+        {{- $volumeUser = toString .Values.podSecurityContext.runAsUser }}
+        {{- end }}
         {{- if hasKey .Values.securityContext "runAsUser" }}
         {{- $volumeUser = toString .Values.securityContext.runAsUser }}
         {{- end }}
         {{- $volumeGroup := "0" }}
+        {{- if hasKey .Values.podSecurityContext "runAsGroup" }}
+        {{- $volumeGroup = toString .Values.podSecurityContext.runAsGroup }}
+        {{- end }}
         {{- if hasKey .Values.podSecurityContext "fsGroup" }}
         {{- $volumeGroup = toString .Values.podSecurityContext.fsGroup }}
         {{- end }}
         {{- if hasKey .Values.securityContext "runAsGroup" }}
         {{- $volumeGroup = toString .Values.securityContext.runAsGroup }}
         {{- end }}
-        {{- $needsOwnership := or (hasKey .Values.securityContext "runAsUser") (hasKey .Values.securityContext "runAsGroup") (hasKey .Values.podSecurityContext "fsGroup") }}
+        {{- $needsOwnership := or (hasKey .Values.securityContext "runAsUser") (hasKey .Values.securityContext "runAsGroup") (hasKey .Values.podSecurityContext "runAsUser") (hasKey .Values.podSecurityContext "runAsGroup") (hasKey .Values.podSecurityContext "fsGroup") }}
         - name: init-permissions
           image: {{ .Values.initPermissions.image.repository }}:{{ .Values.initPermissions.image.tag }}
           imagePullPolicy: {{ .Values.initPermissions.image.pullPolicy }}

--- a/charts/adguard-home/templates/deployment.yaml
+++ b/charts/adguard-home/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
               mkdir -p /opt/adguardhome/conf /opt/adguardhome/work
               chmod {{ $volumeMode }} /opt/adguardhome/conf /opt/adguardhome/work
               {{- if $needsOwnership }}
-              chown {{ $volumeUser }}:{{ $volumeGroup }} /opt/adguardhome/conf /opt/adguardhome/work
+              chown -R {{ $volumeUser }}:{{ $volumeGroup }} /opt/adguardhome/conf /opt/adguardhome/work
               {{- end }}
           {{- with .Values.initPermissions.securityContext }}
           securityContext:

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -156,6 +156,22 @@ tests:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "chmod 770 /opt/adguardhome/conf /opt/adguardhome/work"
 
+  - it: should assign pod-level user ownership when configured
+    template: templates/deployment.yaml
+    set:
+      podSecurityContext.runAsUser: 1000
+      podSecurityContext.runAsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 1000:1000 /opt/adguardhome/conf /opt/adguardhome/work"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 700 /opt/adguardhome/conf /opt/adguardhome/work"
+
   - it: should allow disabling permission normalization
     template: templates/deployment.yaml
     set:

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -196,6 +196,29 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: copy-config
 
+  - it: should run copy-config with the configured container security context
+    template: templates/deployment.yaml
+    set:
+      securityContext.runAsUser: 1000
+      securityContext.runAsGroup: 1000
+      securityContext.runAsNonRoot: true
+      config.adGuardHome:
+        http:
+          address: "0.0.0.0:80"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: copy-config
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.runAsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.initContainers[1].securityContext.runAsNonRoot
+          value: true
+
   - it: should use PVC for conf and work by default
     template: templates/deployment.yaml
     asserts:

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -119,7 +119,7 @@ tests:
           value: init-permissions
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "chown 0:2000 /opt/adguardhome/conf /opt/adguardhome/work"
+          pattern: "chown -R 0:2000 /opt/adguardhome/conf /opt/adguardhome/work"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "chmod 770 /opt/adguardhome/conf /opt/adguardhome/work"
@@ -135,7 +135,7 @@ tests:
           value: init-permissions
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "chown 1000:1000 /opt/adguardhome/conf /opt/adguardhome/work"
+          pattern: "chown -R 1000:1000 /opt/adguardhome/conf /opt/adguardhome/work"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "chmod 700 /opt/adguardhome/conf /opt/adguardhome/work"
@@ -151,7 +151,7 @@ tests:
           value: init-permissions
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "chown 1000:2000 /opt/adguardhome/conf /opt/adguardhome/work"
+          pattern: "chown -R 1000:2000 /opt/adguardhome/conf /opt/adguardhome/work"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "chmod 770 /opt/adguardhome/conf /opt/adguardhome/work"
@@ -167,7 +167,7 @@ tests:
           value: init-permissions
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "chown 1000:1000 /opt/adguardhome/conf /opt/adguardhome/work"
+          pattern: "chown -R 1000:1000 /opt/adguardhome/conf /opt/adguardhome/work"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "chmod 700 /opt/adguardhome/conf /opt/adguardhome/work"

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -96,6 +96,12 @@ tests:
           path: spec.template.spec.initContainers[0].securityContext.capabilities.add
           content: CHOWN
       - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: DAC_READ_SEARCH
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: FOWNER
+      - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: conf

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/adguard/adguardhome:v0.107.74"
+          value: "docker.io/adguard/adguardhome:v0.107.76"
 
   - it: should expose setup wizard port 3000 by default (no config)
     template: templates/deployment.yaml
@@ -83,8 +83,30 @@ tests:
             name: work
             mountPath: /opt/adguardhome/work
 
-  - it: should not have init container when no config
+  - it: should normalize volume permissions by default
     template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/busybox:1.37
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: conf
+            mountPath: /opt/adguardhome/conf
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: work
+            mountPath: /opt/adguardhome/work
+
+  - it: should allow disabling permission normalization
+    template: templates/deployment.yaml
+    set:
+      initPermissions.enabled: false
     asserts:
       - isNull:
           path: spec.template.spec.initContainers
@@ -100,6 +122,9 @@ tests:
           path: spec.template.spec.initContainers
       - equal:
           path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - equal:
+          path: spec.template.spec.initContainers[1].name
           value: copy-config
 
   - it: should use PVC for conf and work by default

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -93,6 +93,9 @@ tests:
           path: spec.template.spec.initContainers[0].image
           value: docker.io/library/busybox:1.37
       - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add
+          content: CHOWN
+      - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: conf
@@ -102,6 +105,56 @@ tests:
           content:
             name: work
             mountPath: /opt/adguardhome/work
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 700 /opt/adguardhome/conf /opt/adguardhome/work"
+
+  - it: should preserve group volume access when fsGroup is configured
+    template: templates/deployment.yaml
+    set:
+      podSecurityContext.fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 0:2000 /opt/adguardhome/conf /opt/adguardhome/work"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 770 /opt/adguardhome/conf /opt/adguardhome/work"
+
+  - it: should assign volume ownership when container user and group are configured
+    template: templates/deployment.yaml
+    set:
+      securityContext.runAsUser: 1000
+      securityContext.runAsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 1000:1000 /opt/adguardhome/conf /opt/adguardhome/work"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 700 /opt/adguardhome/conf /opt/adguardhome/work"
+
+  - it: should assign user ownership and preserve fsGroup access together
+    template: templates/deployment.yaml
+    set:
+      securityContext.runAsUser: 1000
+      podSecurityContext.fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-permissions
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 1000:2000 /opt/adguardhome/conf /opt/adguardhome/work"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 770 /opt/adguardhome/conf /opt/adguardhome/work"
 
   - it: should allow disabling permission normalization
     template: templates/deployment.yaml

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -97,7 +97,7 @@ tests:
           content: CHOWN
       - contains:
           path: spec.template.spec.initContainers[0].securityContext.capabilities.add
-          content: DAC_READ_SEARCH
+          content: DAC_OVERRIDE
       - contains:
           path: spec.template.spec.initContainers[0].securityContext.capabilities.add
           content: FOWNER

--- a/charts/adguard-home/values.schema.json
+++ b/charts/adguard-home/values.schema.json
@@ -424,6 +424,46 @@
       "type": "object",
       "description": "Container-level security context"
     },
+    "initPermissions": {
+      "type": "object",
+      "description": "Init container that normalizes AdGuard Home volume permissions before startup",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run the init-permissions container",
+          "default": true
+        },
+        "image": {
+          "type": "object",
+          "description": "Init permissions container image",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "docker.io/library/busybox"
+            },
+            "tag": {
+              "type": "string",
+              "default": "1.37"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for the init-permissions container"
+        },
+        "resources": {
+          "type": "object",
+          "description": "CPU and memory requests/limits for the init-permissions container"
+        }
+      }
+    },
     "nodeSelector": {
       "type": "object",
       "description": "Node selector for pod scheduling"

--- a/charts/adguard-home/values.schema.json
+++ b/charts/adguard-home/values.schema.json
@@ -456,7 +456,50 @@
         },
         "securityContext": {
           "type": "object",
-          "description": "Security context for the init-permissions container"
+          "description": "Security context for the init-permissions container",
+          "additionalProperties": true,
+          "properties": {
+            "runAsUser": {
+              "type": "integer",
+              "default": 0
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "default": 0
+            },
+            "runAsNonRoot": {
+              "type": "boolean",
+              "default": false
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "default": false
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean",
+              "default": true
+            },
+            "capabilities": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "add": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": ["CHOWN", "DAC_OVERRIDE", "FOWNER"]
+                },
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": ["ALL"]
+                }
+              }
+            }
+          }
         },
         "resources": {
           "type": "object",

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -222,6 +222,8 @@ initPermissions:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     capabilities:
+      add:
+        - CHOWN
       drop:
         - ALL
   resources: {}

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- AdGuard Home container image
   repository: docker.io/adguard/adguardhome
   # -- Image tag
-  tag: "v0.107.74"
+  tag: "v0.107.76"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -207,6 +207,24 @@ resources: {}
 podSecurityContext: {}
 
 securityContext: {}
+
+initPermissions:
+  # -- Run an init container that normalizes AdGuard Home volume permissions before startup.
+  enabled: true
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+  resources: {}
 
 # =============================================================================
 # Scheduling

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -224,7 +224,7 @@ initPermissions:
     capabilities:
       add:
         - CHOWN
-        - DAC_READ_SEARCH
+        - DAC_OVERRIDE
         - FOWNER
       drop:
         - ALL

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -224,6 +224,8 @@ initPermissions:
     capabilities:
       add:
         - CHOWN
+        - DAC_READ_SEARCH
+        - FOWNER
       drop:
         - ALL
   resources: {}


### PR DESCRIPTION
## Summary
- Closes #306.
- Updates AdGuard Home appVersion, default image tag, and unit test expectation to `v0.107.76`.
- Documents the upstream hotfix and rollback note for YAML duration `d` units.
- Adds configurable `initPermissions` to normalize `/opt/adguardhome/conf` and `/opt/adguardhome/work` permissions before startup after k3d log review found a runtime permission warning.
- Updates `NOTES.txt` and the README values reference for the new runtime behavior.

## Local Validation Evidence
- [x] `helm dependency build charts/adguard-home`
- [x] `helm dependency list charts/adguard-home` (no dependencies; no `Chart.lock` generated)
- [x] `helm lint charts/adguard-home`
- [x] `helm lint --strict charts/adguard-home`
- [x] `helm template adguard-home-test charts/adguard-home`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/backup-values.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/dual-stack.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/external-secrets.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/full-values.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/gateway-api.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/preconfigured-values.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/sync-values.yaml`
- [x] `helm template adguard-home-test charts/adguard-home -f charts/adguard-home/ci/wizard-values.yaml`
- [x] `helm unittest charts/adguard-home` (8 suites, 42 tests)
- [x] `ah lint charts/adguard-home`
- [x] strict `kubeconform` for default and all CI renders using the Kubernetes default schema plus datreeio CRD catalog
- [x] `npx -y markdownlint-cli2 charts/adguard-home/README.md charts/adguard-home/docs/*.md`
- [x] `git diff --check`
- [x] SPDX header check for changed YAML/TPL/SH files

## k3d Runtime Evidence
- [x] Context: `k3d-helmforge-tests-wsl`
- [x] Installed with persistence enabled and `service.dns.type=ClusterIP`
- [x] Pod Ready `1/1`, restarts `0`
- [x] PVCs Bound for conf and work
- [x] Effective image: `docker.io/adguard/adguardhome:v0.107.76`
- [x] App logs show `AdGuard Home, version v0.107.76`
- [x] App logs inspected after `initPermissions`; previous `/opt/adguardhome/work` permission warning is gone
- [x] Events inspected; only Normal events observed
- [x] HTTP service smoke test returned `302` wizard redirect
- [x] Release and namespace cleaned after validation

## Security Evidence
- [x] Kubescape installed/verified: `v4.0.8`
- [x] `kubescape scan framework nsa,mitre` on default render: NSA `65.00`, MITRE `100.00`, overall `77`
- [x] `kubescape scan framework soc2` on default render: overall `80`

## Upstream Evidence
- [x] Docker manifest verified for `docker.io/adguard/adguardhome:v0.107.76` with linux/amd64, linux/arm64, linux/386, linux/arm, linux/ppc64le
- [x] `docker run --rm docker.io/adguard/adguardhome:v0.107.76 --version` returned `AdGuard Home, version v0.107.76`
- [x] Upstream release notes reviewed: v0.107.76 is a hotfix for cache behavior and includes YAML duration `d` unit notes

## Site Sync
- [ ] Site values documentation update is required after chart PRs are complete, per HelmForge site sync matrix.
