### PR TITLE
chore(changedetection): update image to 0.55.5

### DIFF
--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -4,7 +4,7 @@ name: changedetection
 description: changedetection.io website change detection and monitoring with optional Playwright browser
 type: application
 version: 1.1.8
-appVersion: "0.55.3"
+appVersion: "0.55.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 0.55.3 (#232)"
+      description: "Update changedetection.io image to 0.55.5 (#307)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/changedetection/README.md
+++ b/charts/changedetection/README.md
@@ -116,6 +116,7 @@ changedetection:
   fetchWorkers: 10
   minimumSecondsRecheckTime: "180"
   timezone: "America/Sao_Paulo"
+  locale: C
   extraEnv:
     - name: LOGGER_LEVEL
       value: INFO
@@ -165,13 +166,14 @@ probes:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/dgtlmoon/changedetection.io` | changedetection.io image repository |
-| `image.tag` | Chart appVersion | changedetection.io image tag |
+| `image.tag` | `0.55.5` | changedetection.io image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `changedetection.port` | `5000` | Application port |
 | `changedetection.baseUrl` | `""` | Public base URL |
 | `changedetection.fetchWorkers` | `10` | Concurrent fetch workers |
 | `changedetection.minimumSecondsRecheckTime` | `""` | Minimum seconds between checks |
 | `changedetection.timezone` | `""` | Container timezone via `TZ` |
+| `changedetection.locale` | `C` | Locale assigned to `LANG` and `LC_ALL` |
 | `changedetection.extraEnv` | `[]` | Extra environment variables |
 | `browser.enabled` | `false` | Enable Playwright browser sidecar |
 | `browser.image.repository` | `ghcr.io/browserless/chromium` | Browser sidecar image repository |
@@ -193,9 +195,12 @@ probes:
 
 ## Upgrade Notes
 
-For this release the application image is updated to `0.55.3`. Review the
-upstream changelog before production rollout and test restores from the
-`/datastore` backup when upgrading long-lived instances.
+For this release the application image is updated to `0.55.5`. The upstream
+`0.55.4` and `0.55.5` releases include API, notification, LLM, localization,
+and security-related fixes, including an SSRF guard for the LLM `api_base`
+setting and a shared diff access fix. Review the upstream changelog before
+production rollout and test restores from the `/datastore` backup when upgrading
+long-lived instances.
 
 ## Limitations
 

--- a/charts/changedetection/templates/deployment.yaml
+++ b/charts/changedetection/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,6 +60,10 @@ spec:
             - name: MINIMUM_SECONDS_RECHECK_TIME
               value: {{ . | quote }}
             {{- end }}
+            - name: LANG
+              value: {{ .Values.changedetection.locale | quote }}
+            - name: LC_ALL
+              value: {{ .Values.changedetection.locale | quote }}
             {{- with .Values.changedetection.timezone }}
             - name: TZ
               value: {{ . | quote }}

--- a/charts/changedetection/tests/deployment_test.yaml
+++ b/charts/changedetection/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.3"
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.5"
 
   - it: should expose port 5000
     asserts:
@@ -62,6 +62,19 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
           content: ALL
+
+  - it: should set a locale supported by the container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANG
+            value: C
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LC_ALL
+            value: C
 
   - it: should use PVC for data when persistence enabled
     asserts:

--- a/charts/changedetection/values.schema.json
+++ b/charts/changedetection/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/dgtlmoon/changedetection.io" },
-        "tag": { "type": "string", "default": "0.55.3" },
+        "tag": { "type": "string", "default": "0.55.5" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -26,6 +26,7 @@
         "fetchWorkers": { "type": "integer", "default": 10 },
         "minimumSecondsRecheckTime": { "type": "string", "default": "" },
         "timezone": { "type": "string", "default": "" },
+        "locale": { "type": "string", "default": "C" },
         "extraEnv": { "type": "array", "items": { "type": "object" } }
       }
     },

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- changedetection.io container image
   repository: ghcr.io/dgtlmoon/changedetection.io
   # -- Image tag
-  tag: "0.55.3"
+  tag: "0.55.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -36,6 +36,8 @@ changedetection:
   minimumSecondsRecheckTime: ""
   # -- Timezone
   timezone: ""
+  # -- Container locale used for LANG and LC_ALL
+  locale: C
   # -- Extra environment variables for the container
   # -- @default -- `[]`
   extraEnv: []


### PR DESCRIPTION
## Summary
- Closes #307.
- Updates changedetection.io appVersion, default image tag, schema default, and unit test expectation to `0.55.5`.
- Documents upstream `0.55.4` and `0.55.5` release notes, including security-related fixes.
- Sets `LANG`/`LC_ALL` through `changedetection.locale` with a default of `C` to avoid the upstream container missing-locale warning observed during k3d runtime validation.

## Local Validation Evidence
- [x] `helm dependency build charts/changedetection`
- [x] `helm dependency list charts/changedetection` (no dependencies; no `Chart.lock` generated)
- [x] `helm lint charts/changedetection`
- [x] `helm lint --strict charts/changedetection`
- [x] `helm template changedetection-test charts/changedetection`
- [x] `helm template changedetection-test charts/changedetection -f charts/changedetection/ci/default-values.yaml`
- [x] `helm template changedetection-test charts/changedetection -f charts/changedetection/ci/ingress-values.yaml`
- [x] `helm unittest charts/changedetection` (4 suites, 21 tests)
- [x] `ah lint charts/changedetection`
- [x] strict `kubeconform` for default and CI renders using the Kubernetes default schema plus datreeio CRD catalog
- [x] `npx -y markdownlint-cli2 charts/changedetection/README.md`
- [x] `git diff --check`
- [x] SPDX header check for changed YAML/TPL/SH files

## k3d Runtime Evidence
- [x] Context: `k3d-helmforge-tests-wsl`
- [x] Installed with default persistence
- [x] Pod Ready `1/1`, restarts `0`
- [x] PVC Bound
- [x] Effective image: `ghcr.io/dgtlmoon/changedetection.io:0.55.5`
- [x] App logs show `changedetection.io version 0.55.5 starting.`
- [x] Locale warning from `LC_ALL=en_US.UTF-8` was fixed by defaulting `changedetection.locale` to `C`
- [x] Events inspected; only Normal events observed
- [x] HTTP service smoke test returned `200`
- [x] Release and namespace cleaned after validation
- [x] Remaining upstream warnings reviewed: fresh datastore creation on empty PVC, official container Werkzeug warning, and sample URL charset/mimetype fallback during default watch bootstrap

## Security Evidence
- [x] Kubescape installed/verified: `v4.0.8`
- [x] `kubescape scan framework nsa,mitre` on default render: NSA `75.00`, MITRE `100.00`, overall `83`
- [x] `kubescape scan framework soc2` on default render: overall `80`

## Upstream Evidence
- [x] Docker manifest verified for `ghcr.io/dgtlmoon/changedetection.io:0.55.5` with linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v8
- [x] OCI image label verified: `org.opencontainers.image.version=0.55.5`
- [x] Upstream release notes reviewed for `0.55.4` and `0.55.5`

## Site Sync
- [ ] Site values documentation update is required after chart PRs are complete, per HelmForge site sync matrix.
