### PR TITLE
feat(gophish): add Gateway API routes

### DIFF
--- a/charts/gophish/.helmignore
+++ b/charts/gophish/.helmignore
@@ -20,7 +20,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/gophish/Chart.lock
+++ b/charts/gophish/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.7
-digest: sha256:2c00ec27fea778833ed8db0ca5e5bb877615488e5013ef34862daab0b3eba112
-generated: "2026-04-28T17:30:46.962085073Z"

--- a/charts/gophish/README.md
+++ b/charts/gophish/README.md
@@ -1,6 +1,8 @@
 # Gophish
 
-Gophish is an open-source phishing awareness platform for authorized security training. This chart deploys Gophish with separate admin and phishing traffic, safe SQLite defaults, optional HelmForge MySQL, optional external MySQL, NetworkPolicy, and SQLite backup support.
+Gophish is an open-source phishing awareness platform for authorized security training.
+This chart deploys Gophish with separate admin and phishing traffic, safe SQLite defaults, optional HelmForge MySQL,
+optional external MySQL, NetworkPolicy, and SQLite backup support.
 
 ## Install
 
@@ -88,16 +90,43 @@ phishIngress:
           pathType: Prefix
 ```
 
-## Dual-Stack Services
+## Gateway API
 
-Admin and phishing Services can opt into Kubernetes dual-stack fields independently. Leave these values omitted to inherit cluster defaults.
+Gateway API HTTPRoutes are available as an opt-in alongside Ingress. The chart keeps admin and phishing routes separate so operators can attach them to different Gateway listeners.
 
 ```yaml
-adminService:
+gateway:
+  enabled: true
+  admin:
+    enabled: true
+    parentRefs:
+      - name: internal-gateway
+        namespace: gateway-system
+    hostnames:
+      - gophish-admin.example.com
+  phish:
+    enabled: true
+    parentRefs:
+      - name: public-gateway
+        namespace: gateway-system
+    hostnames:
+      - training.example.com
+```
+
+The Gateway API resources target `gateway.networking.k8s.io/v1` and require the Gateway API CRDs and a Gateway controller installed in the cluster.
+
+## Dual-Stack Services
+
+Admin and phishing Services can opt into Kubernetes dual-stack fields independently, or inherit shared defaults from `service`. Leave these values omitted to inherit cluster defaults.
+
+```yaml
+service:
   ipFamilyPolicy: PreferDualStack
 
 phishService:
-  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
 ```
 
 Explicit `ipFamilies` should be used only on clusters that advertise those families.

--- a/charts/gophish/ci/dual-stack-values.yaml
+++ b/charts/gophish/ci/dual-stack-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI scenario: dual-stack networking via Service ipFamilyPolicy.
 #
 # Uses PreferDualStack policy without explicit ipFamilies so this scenario
@@ -6,17 +7,10 @@
 # so explicit families should be tested only on a dual-stack cluster.
 #
 # To test explicit families on a dual-stack cluster, also set:
-#   adminService:
-#     ipFamilies:
-#       - IPv4
-#       - IPv6
-#   phishService:
+#   service:
 #     ipFamilies:
 #       - IPv4
 #       - IPv6
 
-adminService:
-  ipFamilyPolicy: PreferDualStack
-
-phishService:
+service:
   ipFamilyPolicy: PreferDualStack

--- a/charts/gophish/ci/gateway-values.yaml
+++ b/charts/gophish/ci/gateway-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: Gateway API HTTPRoutes for separated admin and phishing traffic.
+
+gateway:
+  enabled: true
+  admin:
+    enabled: true
+    parentRefs:
+      - name: internal-gateway
+        namespace: gateway-system
+    hostnames:
+      - gophish-admin.example.com
+  phish:
+    enabled: true
+    parentRefs:
+      - name: public-gateway
+        namespace: gateway-system
+    hostnames:
+      - training.example.com

--- a/charts/gophish/docs/architecture.md
+++ b/charts/gophish/docs/architecture.md
@@ -12,11 +12,11 @@ Gophish is an open-source phishing toolkit for security awareness training, phis
 
 Primary upstream references:
 
-- Official site: https://getgophish.com
-- Source repository: https://github.com/gophish/gophish
-- Release `v0.12.1`: https://github.com/gophish/gophish/releases/tag/v0.12.1
-- Official Docker image: https://hub.docker.com/r/gophish/gophish
-- User guide installation and configuration: https://github.com/gophish/user-guide/blob/master/installation.md
+- Official site: <https://getgophish.com>
+- Source repository: <https://github.com/gophish/gophish>
+- Release `v0.12.1`: <https://github.com/gophish/gophish/releases/tag/v0.12.1>
+- Official Docker image: <https://hub.docker.com/r/gophish/gophish>
+- User guide installation and configuration: <https://github.com/gophish/user-guide/blob/master/installation.md>
 
 ## Version Decision
 
@@ -76,7 +76,9 @@ Supported upstream image environment overrides include:
 - `CONTACT_ADDRESS`
 - `DB_FILE_PATH`
 
-The image does not expose environment overrides for all database modes. In particular, MySQL configuration requires `db_name` and `db_path`, so the chart should render a full `config.json` when database mode is not default SQLite.
+The image does not expose environment overrides for all database modes.
+In particular, MySQL configuration requires `db_name` and `db_path`, so the chart should render a full `config.json`
+when database mode is not default SQLite.
 
 Chart decision:
 
@@ -190,27 +192,9 @@ These are Phase 10 deliverables, but they are recorded here because architecture
 
 ## References
 
-- Gophish release `v0.12.1`: https://github.com/gophish/gophish/releases/tag/v0.12.1
-- Gophish Dockerfile at `v0.12.1`: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/Dockerfile
-- Gophish default config at `v0.12.1`: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/config.json
-- Gophish Docker entrypoint at `v0.12.1`: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/docker/run.sh
-- Gophish installation guide: https://github.com/gophish/user-guide/blob/master/installation.md
-- Docker Hub tag API: https://hub.docker.com/v2/repositories/gophish/gophish/tags/0.12.1
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Gophish - Architecture Research
-description: Phase 1 architecture research for the Gophish HelmForge chart
-
-keywords: gophish, architecture, helm, kubernetes, phishing-awareness
-
-purpose: Capture upstream runtime facts and HelmForge chart architecture decisions
-scope: Chart Research
-
-relations:
-  - charts/gophish/docs/database.md
-  - charts/gophish/docs/security.md
-path: charts/gophish/docs/architecture.md
-version: 1.0
-date: 2026-04-28
--->
+- Gophish release `v0.12.1`: <https://github.com/gophish/gophish/releases/tag/v0.12.1>
+- Gophish Dockerfile at `v0.12.1`: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/Dockerfile>
+- Gophish default config at `v0.12.1`: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/config.json>
+- Gophish Docker entrypoint at `v0.12.1`: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/docker/run.sh>
+- Gophish installation guide: <https://github.com/gophish/user-guide/blob/master/installation.md>
+- Docker Hub tag API: <https://hub.docker.com/v2/repositories/gophish/gophish/tags/0.12.1>

--- a/charts/gophish/docs/database.md
+++ b/charts/gophish/docs/database.md
@@ -188,26 +188,8 @@ The chart should not silently migrate database modes during a normal upgrade.
 
 ## References
 
-- Gophish default config: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/config.json
-- Gophish installation guide: https://github.com/gophish/user-guide/blob/master/installation.md
-- Gophish Docker entrypoint: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/docker/run.sh
+- Gophish default config: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/config.json>
+- Gophish installation guide: <https://github.com/gophish/user-guide/blob/master/installation.md>
+- Gophish Docker entrypoint: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/docker/run.sh>
 - HelmForge backup patterns MCP resource
 - HelmForge dependency policy MCP resource
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Gophish - Database Research
-description: Database mode research and decisions for the Gophish HelmForge chart
-
-keywords: gophish, sqlite, mysql, database, helm
-
-purpose: Define database modes, config rendering, and backup boundaries
-scope: Chart Research
-
-relations:
-  - charts/gophish/docs/architecture.md
-  - charts/gophish/docs/security.md
-path: charts/gophish/docs/database.md
-version: 1.0
-date: 2026-04-28
--->

--- a/charts/gophish/docs/security.md
+++ b/charts/gophish/docs/security.md
@@ -64,7 +64,9 @@ Chart decisions:
 - Avoid ConfigMap for generated config.
 - Avoid printing rendered config in NOTES or examples when credentials are present.
 
-The official Docker entrypoint prints runtime configuration before starting the app. If the chart renders MySQL credentials into `config.json`, runtime validation must confirm whether the entrypoint logs the DSN. If it does, Phase 3 should either:
+The official Docker entrypoint prints runtime configuration before starting the app.
+If the chart renders MySQL credentials into `config.json`, runtime validation must confirm whether the entrypoint logs
+the DSN. If it does, Phase 3 should either:
 
 - bypass the mutating entrypoint with a safer command, or
 - avoid putting sensitive DSNs into files that the entrypoint prints, if technically feasible.
@@ -135,7 +137,7 @@ Chart implication:
 
 Reference:
 
-- https://github.com/advisories/GHSA-rv83-h68q-c4wq
+- <https://github.com/advisories/GHSA-rv83-h68q-c4wq>
 
 ## Existing Chart Gap Analysis
 
@@ -159,28 +161,10 @@ Security gaps HelmForge should address:
 
 ## References
 
-- Gophish release `v0.12.1`: https://github.com/gophish/gophish/releases/tag/v0.12.1
-- Gophish default config: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/config.json
-- Gophish Dockerfile: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/Dockerfile
-- Gophish Docker entrypoint: https://raw.githubusercontent.com/gophish/gophish/v0.12.1/docker/run.sh
-- Gophish installation guide: https://github.com/gophish/user-guide/blob/master/installation.md
-- GitHub advisory: https://github.com/advisories/GHSA-rv83-h68q-c4wq
+- Gophish release `v0.12.1`: <https://github.com/gophish/gophish/releases/tag/v0.12.1>
+- Gophish default config: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/config.json>
+- Gophish Dockerfile: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/Dockerfile>
+- Gophish Docker entrypoint: <https://raw.githubusercontent.com/gophish/gophish/v0.12.1/docker/run.sh>
+- Gophish installation guide: <https://github.com/gophish/user-guide/blob/master/installation.md>
+- GitHub advisory: <https://github.com/advisories/GHSA-rv83-h68q-c4wq>
 - HelmForge security baseline MCP resource
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Gophish - Security Research
-description: Security posture and hardening research for the Gophish HelmForge chart
-
-keywords: gophish, security, admin, networkpolicy, tls, kubernetes
-
-purpose: Define security defaults and risks for the Gophish chart
-scope: Chart Research
-
-relations:
-  - charts/gophish/docs/architecture.md
-  - charts/gophish/docs/database.md
-path: charts/gophish/docs/security.md
-version: 1.0
-date: 2026-04-28
--->

--- a/charts/gophish/templates/NOTES.txt
+++ b/charts/gophish/templates/NOTES.txt
@@ -29,6 +29,21 @@ Phishing service:
 - http://127.0.0.1:8080
 {{- end }}
 
+{{- if and .Values.gateway.enabled (or .Values.gateway.admin.enabled .Values.gateway.phish.enabled) }}
+
+Gateway API routes:
+{{- if .Values.gateway.admin.enabled }}
+{{- range .Values.gateway.admin.hostnames }}
+- admin: http://{{ . }}
+{{- end }}
+{{- end }}
+{{- if .Values.gateway.phish.enabled }}
+{{- range .Values.gateway.phish.hostnames }}
+- phishing: http://{{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 Operational notes:
 - database mode selected for this release: {{ include "gophish.effectiveDatabaseMode" . | trim }}
 - keep admin ingress separate from phishing campaign ingress

--- a/charts/gophish/templates/gateway-admin-httproute.yaml
+++ b/charts/gophish/templates/gateway-admin-httproute.yaml
@@ -1,0 +1,35 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "gophish.validateAll" . }}
+{{- if and .Values.gateway.enabled .Values.gateway.admin.enabled }}
+{{- if not .Values.gateway.admin.parentRefs }}
+{{- fail "gateway.admin.parentRefs is required when gateway.enabled=true and gateway.admin.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "gophish.fullname" . }}-admin
+  labels:
+    {{- include "gophish.labels" . | nindent 4 }}
+    app.kubernetes.io/component: admin
+  {{- with .Values.gateway.admin.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.admin.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.admin.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gateway.admin.matches | nindent 8 }}
+      {{- with .Values.gateway.admin.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "gophish.fullname" . }}-admin
+          port: {{ .Values.adminService.port }}
+{{- end }}

--- a/charts/gophish/templates/gateway-phish-httproute.yaml
+++ b/charts/gophish/templates/gateway-phish-httproute.yaml
@@ -1,0 +1,35 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "gophish.validateAll" . }}
+{{- if and .Values.gateway.enabled .Values.gateway.phish.enabled }}
+{{- if not .Values.gateway.phish.parentRefs }}
+{{- fail "gateway.phish.parentRefs is required when gateway.enabled=true and gateway.phish.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "gophish.fullname" . }}-phish
+  labels:
+    {{- include "gophish.labels" . | nindent 4 }}
+    app.kubernetes.io/component: phish
+  {{- with .Values.gateway.phish.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.phish.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.phish.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gateway.phish.matches | nindent 8 }}
+      {{- with .Values.gateway.phish.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "gophish.fullname" . }}-phish
+          port: {{ .Values.phishService.port }}
+{{- end }}

--- a/charts/gophish/templates/service-admin.yaml
+++ b/charts/gophish/templates/service-admin.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- include "gophish.validateAll" . }}
 apiVersion: v1
 kind: Service
@@ -12,10 +13,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.adminService.type }}
-  {{- with .Values.adminService.ipFamilyPolicy }}
+  {{- $ipFamilyPolicy := coalesce .Values.adminService.ipFamilyPolicy .Values.service.ipFamilyPolicy }}
+  {{- with $ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}
-  {{- with .Values.adminService.ipFamilies }}
+  {{- $ipFamilies := default .Values.service.ipFamilies .Values.adminService.ipFamilies }}
+  {{- with $ipFamilies }}
   ipFamilies:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/gophish/templates/service-phish.yaml
+++ b/charts/gophish/templates/service-phish.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- include "gophish.validateAll" . }}
 apiVersion: v1
 kind: Service
@@ -12,10 +13,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.phishService.type }}
-  {{- with .Values.phishService.ipFamilyPolicy }}
+  {{- $ipFamilyPolicy := coalesce .Values.phishService.ipFamilyPolicy .Values.service.ipFamilyPolicy }}
+  {{- with $ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}
-  {{- with .Values.phishService.ipFamilies }}
+  {{- $ipFamilies := default .Values.service.ipFamilies .Values.phishService.ipFamilies }}
+  {{- with $ipFamilies }}
   ipFamilies:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/gophish/tests/gateway_test.yaml
+++ b/charts/gophish/tests/gateway_test.yaml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - templates/gateway-admin-httproute.yaml
+  - templates/gateway-phish-httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render HTTPRoutes by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render admin HTTPRoute when enabled
+    template: templates/gateway-admin-httproute.yaml
+    set:
+      gateway:
+        enabled: true
+        admin:
+          enabled: true
+          parentRefs:
+            - name: internal-gateway
+              namespace: gateway-system
+          hostnames:
+            - gophish-admin.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test-gophish-admin
+      - equal:
+          path: spec.parentRefs[0].name
+          value: internal-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: gophish-admin.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-gophish-admin
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3333
+
+  - it: should render phishing HTTPRoute when enabled
+    template: templates/gateway-phish-httproute.yaml
+    set:
+      gateway:
+        enabled: true
+        phish:
+          enabled: true
+          parentRefs:
+            - name: public-gateway
+              namespace: gateway-system
+          hostnames:
+            - training.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test-gophish-phish
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: training.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-gophish-phish
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should fail admin route without parentRefs
+    template: templates/gateway-admin-httproute.yaml
+    set:
+      gateway.enabled: true
+      gateway.admin.enabled: true
+      gateway.admin.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.admin.parentRefs is required when gateway.enabled=true and gateway.admin.enabled=true"
+
+  - it: should fail phishing route without parentRefs
+    template: templates/gateway-phish-httproute.yaml
+    set:
+      gateway.enabled: true
+      gateway.phish.enabled: true
+      gateway.phish.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.phish.parentRefs is required when gateway.enabled=true and gateway.phish.enabled=true"

--- a/charts/gophish/tests/service_test.yaml
+++ b/charts/gophish/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Services
 templates:
   - templates/service-admin.yaml
@@ -81,6 +82,25 @@ tests:
           path: spec.ipFamilies[1]
           value: IPv6
 
+  - it: should use shared dual-stack defaults for the admin Service
+    template: templates/service-admin.yaml
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
   - it: should set phishing Service dual-stack fields when configured
     template: templates/service-phish.yaml
     set:
@@ -99,6 +119,26 @@ tests:
       - equal:
           path: spec.ipFamilies[1]
           value: IPv4
+
+  - it: should allow phishing Service dual-stack values to override shared defaults
+    template: templates/service-phish.yaml
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+      phishService:
+        ipFamilyPolicy: SingleStack
+        ipFamilies:
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: SingleStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6
 
   - it: should support SingleStack IPv6 on the admin Service
     template: templates/service-admin.yaml

--- a/charts/gophish/values.schema.json
+++ b/charts/gophish/values.schema.json
@@ -124,8 +124,10 @@
     },
     "adminService": { "$ref": "#/definitions/service" },
     "phishService": { "$ref": "#/definitions/service" },
+    "service": { "$ref": "#/definitions/serviceDefaults" },
     "adminIngress": { "$ref": "#/definitions/ingress" },
     "phishIngress": { "$ref": "#/definitions/ingress" },
+    "gateway": { "$ref": "#/definitions/gateway" },
     "networkPolicy": {
       "type": "object",
       "additionalProperties": false,
@@ -281,6 +283,27 @@
         }
       }
     },
+    "serviceDefaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "description": "Shared Service IP family policy. One of SingleStack, PreferDualStack, RequireDualStack. Omit for cluster default.",
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Shared ordered list of IP families for Services. Each entry is IPv4 or IPv6. Omit for cluster default.",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          },
+          "maxItems": 2,
+          "uniqueItems": true
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "additionalProperties": false,
@@ -314,6 +337,54 @@
       "properties": {
         "secretName": { "type": "string" },
         "hosts": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Gateway API HTTPRoute rendering",
+          "default": false
+        },
+        "admin": { "$ref": "#/definitions/gatewayRoute" },
+        "phish": { "$ref": "#/definitions/gatewayRoute" }
+      }
+    },
+    "gatewayRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Render this HTTPRoute",
+          "default": false
+        },
+        "parentRefs": {
+          "type": "array",
+          "description": "HTTPRoute parentRefs for existing Gateway listeners",
+          "items": { "type": "object" }
+        },
+        "hostnames": {
+          "type": "array",
+          "description": "HTTPRoute hostnames",
+          "items": { "type": "string" }
+        },
+        "annotations": {
+          "type": "object",
+          "description": "HTTPRoute annotations"
+        },
+        "matches": {
+          "type": "array",
+          "description": "HTTPRoute path/header matches",
+          "items": { "type": "object" }
+        },
+        "filters": {
+          "type": "array",
+          "description": "HTTPRoute filters",
+          "items": { "type": "object" }
+        }
       }
     },
     "networkPolicyIngressSurface": {

--- a/charts/gophish/values.yaml
+++ b/charts/gophish/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Gophish Helm Chart - Default Values
 # =============================================================================
@@ -213,6 +214,15 @@ phishService:
   #   - IPv4
   #   - IPv6
 
+# -- Shared Service defaults applied when a surface-specific Service value is omitted
+service:
+  # -- Shared Service IP family policy. One of SingleStack, PreferDualStack, RequireDualStack. Omit for cluster default.
+  # @default -- omitted
+  ipFamilyPolicy: null
+  # -- Shared ordered list of IP families for Services. Each entry: IPv4 | IPv6. Omit for cluster default.
+  # @default -- omitted
+  ipFamilies: []
+
 # =============================================================================
 # Ingress
 # =============================================================================
@@ -240,6 +250,52 @@ phishIngress:
   hosts: []
   # -- Ingress TLS configuration
   tls: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  # -- Enable Gateway API HTTPRoute rendering. Routes remain disabled until their per-surface enabled flag is true.
+  enabled: false
+  admin:
+    # -- Render an HTTPRoute for the admin UI
+    enabled: false
+    # -- HTTPRoute parentRefs for existing Gateway listeners
+    parentRefs: []
+      # - name: internal-gateway
+      #   namespace: gateway-system
+    # -- Admin hostnames attached to the HTTPRoute
+    hostnames: []
+      # - gophish-admin.example.com
+    # -- Additional HTTPRoute annotations
+    annotations: {}
+    # -- Path matches for the admin HTTPRoute
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Optional HTTPRoute filters
+    filters: []
+  phish:
+    # -- Render an HTTPRoute for the phishing listener
+    enabled: false
+    # -- HTTPRoute parentRefs for existing Gateway listeners
+    parentRefs: []
+      # - name: public-gateway
+      #   namespace: gateway-system
+    # -- Phishing hostnames attached to the HTTPRoute
+    hostnames: []
+      # - training.example.com
+    # -- Additional HTTPRoute annotations
+    annotations: {}
+    # -- Path matches for the phishing HTTPRoute
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # -- Optional HTTPRoute filters
+    filters: []
 
 # =============================================================================
 # Network Policy


### PR DESCRIPTION
## Summary  - Add opt-in Gateway API HTTPRoutes for the separated Gophish admin and phishing surfaces. - Add shared `service.*` dual-stack defaults while preserving `adminService.*` and `phishService.*` overrides. - Remove the chart lock artifact and clean internal metadata blocks from chart docs.  Related to #126 Related to #125  ## Local Validation Evidence  - [x] `helm dependency build charts/gophish` - [x] `helm dependency list charts/gophish` - [x] `helm lint charts/gophish` - [x] `helm lint --strict charts/gophish` - [x] `helm template gophish charts/gophish` default render - [x] Rendered every `charts/gophish/ci/*.yaml` scenario, including `gateway-values.yaml` - [x] `helm unittest charts/gophish` - 12 suites, 86 tests - [x] `ah lint -p charts/gophish` - [x] strict `kubeconform` for default and all CI renders with CRDs catalog - [x] Kubescape MITRE/NSA/SOC2 score: 90.90909 - [x] MCP HelmForge validators: Gateway API, service dual-stack, values quality, security evidence, CI evidence  ## k3d Runtime Validation  Context: `k3d-helmforge-tests-wsl`  - [x] Default SQLite install: deployment ready, PVC bound, admin UI smoke returned 200 after login redirect, phishing service returned expected 404 for empty campaign root. - [x] Dual-stack install: both Services accepted `PreferDualStack`, deployment ready, service smoke passed. - [x] Gateway API install: temporarily installed Gateway API standard CRDs, HTTPRoutes were accepted by the local API, backendRefs/hostnames verified, service smoke passed. - [x] Pod logs inspected for every scenario. No error logs; Gophish emits the existing configurable `contact_address` startup warning when unset. - [x] Namespace events inspected for every scenario. Only `Normal` events observed. - [x] Cleanup completed: all `hf-gophish-*` namespaces and temporary Gateway API CRDs removed.  ## Site Sync  - [x] Site documentation update tracked in helmforgedev/site#228, per the requested workflow.

Closes #386
