### PR TITLE
feat(envoy-gateway): support namespace override

### DIFF
--- a/charts/envoy-gateway/Chart.lock
+++ b/charts/envoy-gateway/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.6.9
-digest: sha256:07e0ff02211d6b0a794659081ac8e6403967942c477e57b64f64e7866f2dd7ba
-generated: "2026-05-20T00:27:43.7397816-03:00"

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -146,6 +146,7 @@ highAvailability:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `profile` | `custom` | Profile preset (dev, production-ha, custom) |
+| `namespaceOverride` | `""` | Namespace for chart-managed resources; target namespace must already exist |
 | `nameOverride` | `""` | Override chart name |
 | `fullnameOverride` | `""` | Override full name |
 | `imagePullSecrets` | `[]` | Image pull secrets |
@@ -259,8 +260,9 @@ highAvailability:
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `gatewayAPI.enabled` | `true` | Enable chart-managed Gateway API helper resources |
 | `gatewayAPI.examples.enabled` | `true` | Create example Gateway, HTTPRoute, and backend |
-| `gatewayAPI.examples.namespace` | `""` | Namespace for examples (defaults to Release.Namespace) |
+| `gatewayAPI.examples.namespace` | `""` | Namespace for examples (defaults to `namespaceOverride` or release namespace) |
 
 ### Rate Limiting
 
@@ -426,22 +428,3 @@ This chart intentionally does not support:
 - **Multiple gateway classes** — Deploy separate releases for multiple GatewayClasses
 - **Built-in cert-manager integration** — Manage application TLS externally; chart only runs certgen for controller certs
 - **Legacy Ingress API** — Use Gateway API for modern routing capabilities
-
-<!-- @AI-METADATA
-type: chart-readme
-title: Envoy Gateway Helm Chart
-description: Deploy Envoy Gateway v1.8.0 on Kubernetes with operator architecture, SecurityPolicy, rate limiting, and comprehensive observability
-keywords: envoy, gateway, gateway-api, helm, kubernetes, rate-limiting, prometheus, grafana, redis, networking, securitypolicy, backendtrafficpolicy, clienttrafficpolicy
-purpose: Installation guide, configuration reference, and operational documentation for the Envoy Gateway Helm chart
-scope: Chart
-relations:
-  - charts/envoy-gateway/docs/architecture.md
-  - charts/envoy-gateway/docs/rate-limiting.md
-  - charts/envoy-gateway/docs/certificates.md
-  - charts/envoy-gateway/docs/observability.md
-  - charts/envoy-gateway/docs/security-policies.md
-  - charts/envoy-gateway/values.yaml
-path: charts/envoy-gateway/README.md
-version: 1.3.0
-date: 2026-04-10
--->

--- a/charts/envoy-gateway/ci/namespace-override-values.yaml
+++ b/charts/envoy-gateway/ci/namespace-override-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: chart-managed resources rendered into a dedicated controller namespace.
+
+namespaceOverride: envoy-gateway-system
+
+gatewayAPI:
+  examples:
+    enabled: true

--- a/charts/envoy-gateway/docs/architecture.md
+++ b/charts/envoy-gateway/docs/architecture.md
@@ -7,38 +7,44 @@ Envoy Gateway (EG) is a Kubernetes operator built on the Gateway API. This chart
 ## Components
 
 ### Controller (managed by this chart)
+
 - Watches Gateway API resources (GatewayClass, Gateway, HTTPRoute, etc.)
 - Watches EG-specific CRDs (SecurityPolicy, BackendTrafficPolicy, etc.)
 - Provisions and configures Envoy proxy pods automatically
 
 ### Certgen Job (managed by this chart)
+
 - Runs as a pre-install/pre-upgrade Helm hook
 - Generates TLS certificates for the controller webhook and xDS server
 - Stores certs in Secrets: `<release>-certs`
 
 ### GatewayClass (managed by this chart)
+
 - Registers the controller with the Gateway API
 - References the EnvoyProxy CRD for proxy shape configuration
 
 ### EnvoyProxy CRD (managed by this chart)
+
 - Configures how EG provisions proxy pods:
   - `proxy.kind: Deployment|DaemonSet`
   - Replicas, resources, service type
   - HPA configuration
 
 ### Gateway (managed by this chart, optional)
+
 - Creates a default `Gateway` resource when `gateway.create: true`
 - The `Gateway` resource triggers EG to provision Envoy proxy pods
 - Users create `HTTPRoute`, `TCPRoute`, `GRPCRoute` etc. that attach to this Gateway
 
 ### Envoy Proxy Pods (managed by EG operator, NOT by this chart)
+
 - Created automatically when a `Gateway` resource exists
 - Named `envoy-<namespace>-<gateway-name>-<uid>`
 - Service is also created automatically with the same naming convention
 
 ## Request Flow
 
-```
+```text
 Client
   │
   ▼
@@ -46,13 +52,13 @@ Envoy Proxy Pod (EG-managed)
   │  ← routes configured by HTTPRoute resources
   ▼
 Backend Service
-```
+```text
 
 ## Policy Hierarchy
 
 Policies attach to Gateway API resources via `targetRef`:
 
-```
+```text
 GatewayClass ← EnvoyProxy (proxy shape)
      │
 Gateway ← SecurityPolicy (auth)
@@ -71,20 +77,3 @@ Backend Service
 2. `gateway.create: true` → Gateway resource created → EG provisions proxy pods + service
 3. Create HTTPRoutes that reference the Gateway
 4. (Optional) Create SecurityPolicy, BackendTrafficPolicy, ClientTrafficPolicy for advanced config
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Architecture Overview
-description: Architectural overview of the Envoy Gateway Helm chart and EG operator model
-keywords: architecture, operator, gateway-api, envoy-gateway, envoyproxy, gatewayclass, certgen
-purpose: Overview of how EG works as a Kubernetes operator and how chart components interact
-scope: Chart
-relations:
-  - charts/envoy-gateway/README.md
-  - charts/envoy-gateway/values.yaml
-  - charts/envoy-gateway/docs/security-policies.md
-  - charts/envoy-gateway/docs/observability.md
-path: charts/envoy-gateway/docs/architecture.md
-version: 1.0
-date: 2026-04-10
--->

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -222,19 +222,3 @@ scrape:
 3. **Use Let's Encrypt staging for testing** — Avoid rate limits during development
 4. **Wildcard certificates** — Use DNS-01 challenge with cert-manager for `*.example.com`
 5. **Ensure Secret exists before Gateway** — The Gateway will not accept an HTTPS listener if the referenced Secret is missing
-
-<!-- @AI-METADATA
-type: chart-docs
-title: TLS Certificates Guide
-description: Internal certgen job and external application TLS configuration for Envoy Gateway
-keywords: tls, certificates, certgen, letsencrypt, acme, ssl, https, envoy-gateway, gateway-listener
-purpose: Guide for internal cert generation and configuring HTTPS on Gateway listeners
-scope: Chart
-relations:
-  - charts/envoy-gateway/README.md
-  - charts/envoy-gateway/values.yaml
-  - charts/envoy-gateway/examples/production.yaml
-path: charts/envoy-gateway/docs/certificates.md
-version: 2.0
-date: 2026-04-10
--->

--- a/charts/envoy-gateway/docs/observability.md
+++ b/charts/envoy-gateway/docs/observability.md
@@ -4,15 +4,17 @@ Envoy Gateway provides comprehensive observability through Prometheus metrics, G
 
 ## Architecture
 
-```
+```text
 EG-managed Proxy Pods → Metrics (dynamic) ─┐
                                             ├→ Prometheus → Grafana
 Controller → Metrics (8081) ───────────────┘
 
 EG-managed Proxy Pods → Access Logs → stdout
-```
+```text
 
-Proxy pods are created dynamically by the EG operator when a `Gateway` resource exists. They are named `envoy-<namespace>-<gateway-name>-<uid>` and do not have a fixed service name, so proxy scraping must use pod-level service discovery.
+Proxy pods are created dynamically by the EG operator when a `Gateway` resource exists.
+They are named `envoy-<namespace>-<gateway-name>-<uid>` and do not have a fixed service name,
+so proxy scraping must use pod-level service discovery.
 
 ## Components
 
@@ -46,6 +48,7 @@ monitoring:
 ```
 
 Includes 6 production-ready alerts:
+
 - **ProxyHighMemoryUsage** — Proxy memory > 80%
 - **ProxyHighCPUUsage** — Proxy CPU > 80%
 - **ControllerHighMemoryUsage** — Controller memory > 80%
@@ -90,7 +93,10 @@ kubectl get servicemonitor -l app.kubernetes.io/name=envoy-gateway
 
 ### Without Prometheus Operator
 
-Manually configure Prometheus scrape jobs. Because proxy pods are provisioned dynamically by the EG operator (named `envoy-<namespace>-<gateway-name>-<uid>`), only the controller can be scraped via a fixed service name. Proxy metrics should be discovered via pod labels:
+Manually configure Prometheus scrape jobs.
+Because proxy pods are provisioned dynamically by the EG operator,
+only the controller can be scraped via a fixed service name.
+Proxy metrics should be discovered via pod labels:
 
 ```yaml
 scrape_configs:
@@ -107,7 +113,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_endpoint_port_name]
     action: keep
     regex: metrics
-```
+```text
 
 ## Metrics
 
@@ -116,6 +122,7 @@ scrape_configs:
 **Endpoint**: `http://envoy-gateway-controller:8081/metrics`
 
 Key metrics:
+
 - `controller_runtime_reconcile_total` — Total reconciliation attempts
 - `controller_runtime_reconcile_errors_total` — Reconciliation failures
 - `workqueue_depth` — Work queue depth
@@ -140,12 +147,14 @@ histogram_quantile(0.99, rate(rest_client_request_duration_seconds_bucket[5m]))
 **Endpoint**: Proxy pods are created dynamically by the EG operator with names like `envoy-<namespace>-<gateway-name>-<uid>`. Access metrics via port-forward to a specific pod on port 9090.
 
 Example:
+
 ```bash
 kubectl port-forward pod/<envoy-pod-name> 9090:9090
 curl http://localhost:9090/stats/prometheus
 ```
 
 Key metrics:
+
 - `envoy_http_downstream_rq_total` — Total requests
 - `envoy_http_downstream_rq_xx` — Requests by status code (2xx, 4xx, 5xx)
 - `envoy_http_downstream_rq_time_bucket` — Request latency histogram
@@ -281,6 +290,7 @@ monitoring:
 ```
 
 The chart creates ConfigMaps with official Envoy Gateway dashboards:
+
 - **Envoy Proxy Dashboard** — Traffic, latency, errors, connections
 - **Envoy Gateway Controller Dashboard** — Reconciliation, API calls, queue depth
 
@@ -289,11 +299,12 @@ The chart creates ConfigMaps with official Envoy Gateway dashboards:
 If not using ConfigMap provisioning:
 
 1. **Export dashboard ConfigMap**:
+
 ```bash
 kubectl get configmap envoy-gateway-grafana-dashboard -o jsonpath='{.data.dashboard\.json}' > dashboard.json
 ```
 
-2. **Import to Grafana**:
+1. **Import to Grafana**:
    - Open Grafana UI
    - Go to Dashboards → Import
    - Upload `dashboard.json`
@@ -301,6 +312,7 @@ kubectl get configmap envoy-gateway-grafana-dashboard -o jsonpath='{.data.dashbo
 ### Dashboard Panels
 
 **Envoy Proxy Dashboard**:
+
 - Request rate (RPS)
 - Error rate (%)
 - P50/P95/P99 latency
@@ -310,6 +322,7 @@ kubectl get configmap envoy-gateway-grafana-dashboard -o jsonpath='{.data.dashbo
 - Rate limit rejections
 
 **Controller Dashboard**:
+
 - Reconciliation rate
 - Reconciliation errors
 - Work queue depth
@@ -364,6 +377,7 @@ Example log entry:
 ```
 
 **Benefits**:
+
 - Structured for log aggregation (Loki, Elasticsearch)
 - Easy to parse and query
 - Machine-readable
@@ -379,7 +393,7 @@ monitoring:
 
 Example log entry:
 
-```
+```text
 [2026-04-09T10:15:30.123Z] "GET /api/users HTTP/1.1" 200 - 0 1234 45 42 "203.0.113.42" "Mozilla/5.0" "abc123" "api.example.com" "10.42.0.15:8080"
 ```
 
@@ -429,6 +443,7 @@ kubectl logs <envoy-pod-name> -c envoy | jq 'select(.path | startswith("/api"))'
 ```
 
 Query examples:
+
 ```logql
 # 5xx errors
 {app="envoy-gateway"} | json | response_code >= 500
@@ -481,8 +496,8 @@ spec:
 3. **Set up Grafana dashboards** — Visual monitoring is essential
 4. **Configure alert notifications** — Integrate with PagerDuty, Slack, etc.
 5. **Track error rates** — Set up SLIs/SLOs for availability
-7. **Use distributed tracing** — Debug complex request flows
-8. **Aggregate logs centrally** — Don't rely on kubectl logs for production
+6. **Use distributed tracing** — Debug complex request flows
+7. **Aggregate logs centrally** — Don't rely on kubectl logs for production
 
 ## Troubleshooting
 
@@ -510,6 +525,7 @@ curl http://localhost:9090/stats/prometheus
 ```
 
 **Common Causes**:
+
 1. ServiceMonitor namespace doesn't match Prometheus Operator config
 2. Prometheus RBAC doesn't allow scraping
 3. Metrics ports not exposed
@@ -532,6 +548,7 @@ kubectl get prometheusrule envoy-gateway-alerts
 ```
 
 **Common Causes**:
+
 1. PrometheusRule not created (`prometheusRule: false`)
 2. Alert expression syntax error
 3. Metrics not available
@@ -556,24 +573,7 @@ kubectl logs deployment/envoy-gateway-controller
 ```
 
 **Common Causes**:
+
 1. Access logs disabled (`enabled: false`)
 2. No traffic to proxy
 3. Wrong container name (use `-c envoy`)
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Observability Guide
-description: Comprehensive monitoring with Prometheus, Grafana, alerts, and access logs for Envoy Gateway
-keywords: observability, prometheus, grafana, metrics, alerts, access-logs, monitoring, tracing, envoy-gateway
-purpose: Guide for configuring monitoring, metrics, alerts, dashboards, and logging
-scope: Chart
-relations:
-  - charts/envoy-gateway/README.md
-  - charts/envoy-gateway/values.yaml
-  - charts/envoy-gateway/examples/production.yaml
-  - charts/envoy-gateway/examples/staging.yaml
-  - charts/envoy-gateway/examples/monitoring-values.yaml
-path: charts/envoy-gateway/docs/observability.md
-version: 1.0
-date: 2026-04-09
--->

--- a/charts/envoy-gateway/docs/rate-limiting.md
+++ b/charts/envoy-gateway/docs/rate-limiting.md
@@ -4,7 +4,7 @@ Envoy Gateway supports distributed rate limiting with Redis backend for API prot
 
 ## Architecture
 
-```
+```text
 Client → Gateway (EG Operator provisions Envoy) → Rate Limit Service → Redis
                     ↓
                Backend Service
@@ -39,6 +39,7 @@ rateLimiting:
 ```
 
 The chart automatically:
+
 - Creates Redis StatefulSet with PVC
 - Configures rate limit service to use Redis
 - Sets up headless service for Redis
@@ -81,6 +82,7 @@ rateLimiting:
 ```
 
 Creates `BackendTrafficPolicy` with a `targetRef.kind: Gateway` targeting the active Gateway resource:
+
 - **Limit**: 100 requests per minute
 - **Scope**: Per client IP (x-real-ip header)
 - **Type**: Global (distributed across all proxy instances)
@@ -114,6 +116,7 @@ rateLimiting:
 ```
 
 Creates `BackendTrafficPolicy` with:
+
 - **Limit**: 10 requests per minute
 - **Scope**: Per client IP
 - **Type**: Global
@@ -184,6 +187,7 @@ rateLimiting:
 ```
 
 **Guidelines**:
+
 - **Low traffic** (<1000 req/s): 100m CPU, 128Mi memory
 - **Medium traffic** (1000-10000 req/s): 200m CPU, 256Mi memory
 - **High traffic** (>10000 req/s): 500m CPU, 512Mi memory
@@ -214,6 +218,7 @@ curl http://localhost:8081/metrics | grep ratelimit
 ```
 
 Key metrics:
+
 - `envoy_cluster_ratelimit_over_limit` — requests rejected by rate limiter
 - `envoy_cluster_ratelimit_ok` — requests allowed by rate limiter
 - `envoy_cluster_ratelimit_error` — rate limiter errors
@@ -238,6 +243,7 @@ kubectl get httproute <route-name> -o yaml | grep -A 10 filters
 ```
 
 **Common Causes**:
+
 1. Redis pod not running
 2. Rate limit policy not attached to HTTPRoute
 3. Wrong header selector (x-real-ip vs x-forwarded-for)
@@ -276,19 +282,3 @@ rateLimiting:
 3. **Size Redis appropriately** — Allocate memory based on expected traffic
 4. **Use different limits for different routes** — Apply stricter limits to expensive operations
 5. **Test rate limits** — Validate limits work before production deployment
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Rate Limiting Guide
-description: Distributed rate limiting with Redis backend for Envoy Gateway
-keywords: rate-limiting, redis, api-protection, distributed, envoy-gateway, backendtrafficpolicy
-purpose: Architecture guide and configuration reference for rate limiting with Envoy Gateway
-scope: Chart
-relations:
-  - charts/envoy-gateway/README.md
-  - charts/envoy-gateway/values.yaml
-  - charts/envoy-gateway/examples/rate-limiting.yaml
-path: charts/envoy-gateway/docs/rate-limiting.md
-version: 1.0
-date: 2026-04-09
--->

--- a/charts/envoy-gateway/docs/security-policies.md
+++ b/charts/envoy-gateway/docs/security-policies.md
@@ -32,7 +32,7 @@ securityPolicy:
 
 JWT validation verifies bearer tokens against a remote JWKS endpoint before forwarding the request to the backend.
 
-### Values Configuration
+### JWT Values Configuration
 
 ```yaml
 securityPolicy:
@@ -51,7 +51,7 @@ securityPolicy:
             header: x-user-email
 ```
 
-### Raw CRD Example
+### JWT Raw CRD Example
 
 ```yaml
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -95,7 +95,7 @@ spec:
 
 OIDC enables OAuth2 Authorization Code Flow — the proxy handles the redirect to the identity provider and token exchange. Ideal for browser-based access to protected services.
 
-### Values Configuration
+### OIDC Values Configuration
 
 ```yaml
 securityPolicy:
@@ -122,7 +122,7 @@ kubectl create secret generic oidc-client-secret \
   --from-literal=client-secret=<your-oidc-client-secret>
 ```
 
-### Raw CRD Example
+### OIDC Raw CRD Example
 
 ```yaml
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -152,7 +152,7 @@ spec:
 
 API Key auth validates a key provided in a request header or query parameter against a set of pre-shared secrets.
 
-### Values Configuration
+### API Key Values Configuration
 
 ```yaml
 securityPolicy:
@@ -174,7 +174,7 @@ kubectl create secret generic api-keys \
   --from-literal=keys=$'key-abc123\nkey-xyz789'
 ```
 
-### Raw CRD Example
+### API Key Raw CRD Example
 
 ```yaml
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -199,7 +199,7 @@ spec:
 
 CORS configuration is applied at the Gateway or HTTPRoute level. It controls which origins, methods, and headers are permitted for cross-origin requests.
 
-### Values Configuration
+### CORS Values Configuration
 
 ```yaml
 securityPolicy:
@@ -224,7 +224,7 @@ securityPolicy:
     maxAge: 86400
 ```
 
-### Raw CRD Example
+### CORS Raw CRD Example
 
 ```yaml
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -288,6 +288,7 @@ kubectl logs deployment/envoy-gateway-controller | grep security
 ```
 
 Common causes:
+
 - JWKS URI unreachable from proxy pods
 - Token audience mismatch
 - Clock skew between issuer and proxy
@@ -295,22 +296,7 @@ Common causes:
 ### OIDC Redirect Loop
 
 Verify that:
+
 1. `redirectURL` matches the redirect URI configured in your identity provider
 2. The Gateway has an HTTPS listener (OIDC requires HTTPS)
 3. The client secret exists in the same namespace as the SecurityPolicy
-
-<!-- @AI-METADATA
-type: chart-docs
-title: Security Policies Guide
-description: JWT, OIDC, API Key, and CORS authentication with SecurityPolicy CRD for Envoy Gateway
-keywords: security, jwt, oidc, oauth2, api-key, cors, mtls, authentication, authorization, securitypolicy, envoy-gateway
-purpose: Guide for configuring authentication and security policies with the SecurityPolicy CRD
-scope: Chart
-relations:
-  - charts/envoy-gateway/README.md
-  - charts/envoy-gateway/values.yaml
-  - charts/envoy-gateway/docs/architecture.md
-path: charts/envoy-gateway/docs/security-policies.md
-version: 1.0
-date: 2026-04-10
--->

--- a/charts/envoy-gateway/templates/NOTES.txt
+++ b/charts/envoy-gateway/templates/NOTES.txt
@@ -4,7 +4,7 @@
 ================================================================================
 
 Release Name: {{ .Release.Name }}
-Namespace:    {{ .Release.Namespace }}
+  Namespace:    {{ include "envoy-gateway.namespace" . }}
 Profile:      {{ .Values.profile | default "custom" }}
 
 --------------------------------------------------------------------------------
@@ -29,7 +29,7 @@ NOTE: Proxy pods are provisioned automatically by the EG operator when a
       Gateway resource is accepted. They are NOT created directly by this chart.
 
 Check deployment status:
-  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get pods -n {{ include "envoy-gateway.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 --------------------------------------------------------------------------------
 2. GATEWAY API RESOURCES
@@ -45,14 +45,14 @@ Verify GatewayClass:
 Default Gateway deployed: {{ include "envoy-gateway.gateway.name" . }}
 
 View Gateway status:
-  kubectl get gateway {{ include "envoy-gateway.gateway.name" . }} -n {{ .Release.Namespace }}
+  kubectl get gateway {{ include "envoy-gateway.gateway.name" . }} -n {{ include "envoy-gateway.namespace" . }}
 
 Wait for Gateway to be programmed:
   kubectl wait --for=condition=Programmed gateway/{{ include "envoy-gateway.gateway.name" . }} \
-    -n {{ .Release.Namespace }} --timeout=300s
+    -n {{ include "envoy-gateway.namespace" . }} --timeout=300s
 
 After the Gateway is programmed, get the external IP:
-  kubectl get gateway {{ include "envoy-gateway.gateway.name" . }} -n {{ .Release.Namespace }} \
+  kubectl get gateway {{ include "envoy-gateway.gateway.name" . }} -n {{ include "envoy-gateway.namespace" . }} \
     -o jsonpath='{.status.addresses[0].value}'
 
 {{- else }}
@@ -64,7 +64,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: my-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
 spec:
   gatewayClassName: {{ .Values.gatewayClass.name }}
   listeners:
@@ -94,10 +94,10 @@ View example resources:
 A pre-install Job (certgen) generates TLS certificates for the EG controller.
 
 Check certgen status:
-  kubectl get job {{ include "envoy-gateway.fullname" . }}-certgen -n {{ .Release.Namespace }}
+  kubectl get job {{ include "envoy-gateway.fullname" . }}-certgen -n {{ include "envoy-gateway.namespace" . }}
 
 Verify certs secret was created:
-  kubectl get secret {{ include "envoy-gateway.fullname" . }}-certs -n {{ .Release.Namespace }}
+  kubectl get secret {{ include "envoy-gateway.fullname" . }}-certs -n {{ include "envoy-gateway.namespace" . }}
 
 --------------------------------------------------------------------------------
 4. MONITORING AND OBSERVABILITY
@@ -111,7 +111,7 @@ Monitoring: Enabled
 Prometheus ServiceMonitor created for controller metrics (port 8081, path /metrics).
 
 View controller metrics:
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "envoy-gateway.fullname" . }}-controller 8081:8081
+  kubectl port-forward -n {{ include "envoy-gateway.namespace" . }} svc/{{ include "envoy-gateway.fullname" . }}-controller 8081:8081
   curl http://localhost:8081/metrics
 {{- end }}
 
@@ -119,7 +119,7 @@ View controller metrics:
 Access Logs: Enabled (format: {{ .Values.monitoring.accessLogs.format }})
 
 View proxy access logs:
-  kubectl logs -n {{ .Release.Namespace }} -l gateway.envoyproxy.io/owning-gateway-name={{ include "envoy-gateway.gateway.name" . }} -f
+  kubectl logs -n {{ include "envoy-gateway.namespace" . }} -l gateway.envoyproxy.io/owning-gateway-name={{ include "envoy-gateway.gateway.name" . }} -f
 {{- end }}
 
 {{- if .Values.monitoring.prometheus.prometheusRule }}
@@ -134,7 +134,7 @@ PrometheusRule created with 6 alerts:
   - Rate limit exceeded
 
 View alerts:
-  kubectl get prometheusrule {{ include "envoy-gateway.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl get prometheusrule {{ include "envoy-gateway.fullname" . }} -n {{ include "envoy-gateway.namespace" . }}
 {{- end }}
 
 {{- if .Values.monitoring.grafana.dashboards }}
@@ -244,13 +244,13 @@ NetworkPolicies: Disabled
 --------------------------------------------------------------------------------
 
 Check controller logs:
-  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/component=controller -f
+  kubectl logs -n {{ include "envoy-gateway.namespace" . }} -l app.kubernetes.io/component=controller -f
 
 Check Gateway status:
-  kubectl describe gateway {{ include "envoy-gateway.gateway.name" . }} -n {{ .Release.Namespace }}
+  kubectl describe gateway {{ include "envoy-gateway.gateway.name" . }} -n {{ include "envoy-gateway.namespace" . }}
 
 Check EnvoyProxy config:
-  kubectl describe envoyproxy {{ include "envoy-gateway.fullname" . }}-proxy-config -n {{ .Release.Namespace }}
+  kubectl describe envoyproxy {{ include "envoy-gateway.fullname" . }}-proxy-config -n {{ include "envoy-gateway.namespace" . }}
 
 View all EG-managed proxy pods:
   kubectl get pods -A -l gateway.envoyproxy.io/owning-gateway-name={{ include "envoy-gateway.gateway.name" . }}

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -42,6 +42,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Namespace for chart-managed namespaced resources.
+*/}}
+{{- define "envoy-gateway.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "envoy-gateway.selectorLabels" -}}
@@ -180,7 +187,7 @@ Controller image
 Gateway API examples namespace
 */}}
 {{- define "envoy-gateway.examples.namespace" -}}
-{{- .Values.gatewayAPI.examples.namespace | default .Release.Namespace }}
+{{- .Values.gatewayAPI.examples.namespace | default (include "envoy-gateway.namespace" .) }}
 {{- end }}
 
 {{/*

--- a/charts/envoy-gateway/templates/backendtrafficpolicy.yaml
+++ b/charts/envoy-gateway/templates/backendtrafficpolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-backend
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/certgen-job.yaml
+++ b/charts/envoy-gateway/templates/certgen-job.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $fullName }}-certgen
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
   annotations:
@@ -49,13 +49,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ $fullName }}-certgen
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $fullName }}-certgen
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
   annotations:

--- a/charts/envoy-gateway/templates/clienttrafficpolicy.yaml
+++ b/charts/envoy-gateway/templates/clienttrafficpolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-client
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/configmap.yaml
+++ b/charts/envoy-gateway/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-config
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 data:

--- a/charts/envoy-gateway/templates/deployment-controller.yaml
+++ b/charts/envoy-gateway/templates/deployment-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-controller
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/envoyproxy-config.yaml
+++ b/charts/envoy-gateway/templates/envoyproxy-config.yaml
@@ -4,7 +4,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-proxy-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/examples/gateway.yaml
+++ b/charts/envoy-gateway/templates/examples/gateway.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gatewayAPI.examples.enabled -}}
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.examples.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/charts/envoy-gateway/templates/examples/gateway.yaml
+++ b/charts/envoy-gateway/templates/examples/gateway.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.examples.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/charts/envoy-gateway/templates/examples/httproute.yaml
+++ b/charts/envoy-gateway/templates/examples/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gatewayAPI.examples.enabled -}}
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.examples.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/envoy-gateway/templates/examples/httproute.yaml
+++ b/charts/envoy-gateway/templates/examples/httproute.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.examples.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/envoy-gateway/templates/externalsecret.yaml
+++ b/charts/envoy-gateway/templates/externalsecret.yaml
@@ -11,6 +11,7 @@ apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-redis
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/gateway.yaml
+++ b/charts/envoy-gateway/templates/gateway.yaml
@@ -4,7 +4,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: {{ include "envoy-gateway.gateway.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/gatewayclass.yaml
+++ b/charts/envoy-gateway/templates/gatewayclass.yaml
@@ -12,5 +12,5 @@ spec:
     group: gateway.envoyproxy.io
     kind: EnvoyProxy
     name: {{ include "envoy-gateway.fullname" . }}-proxy-config
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "envoy-gateway.namespace" . }}
 {{- end }}

--- a/charts/envoy-gateway/templates/grafana-dashboard.yaml
+++ b/charts/envoy-gateway/templates/grafana-dashboard.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-grafana-dashboard
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
     grafana_dashboard: "1"

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -95,7 +95,10 @@ spec:
   egress:
   {{- if .Values.rateLimiting.redis.enabled }}
   - to:
-    - podSelector:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+      podSelector:
         matchLabels:
           {{- include "envoy-gateway.selectorLabels" . | nindent 10 }}
           app.kubernetes.io/component: redis

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -48,6 +48,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-redis
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis
@@ -73,6 +74,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-ratelimit
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
     app.kubernetes.io/component: ratelimit

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -5,6 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-controller
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/pdb-controller.yaml
+++ b/charts/envoy-gateway/templates/pdb-controller.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-controller
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/prometheusrule.yaml
+++ b/charts/envoy-gateway/templates/prometheusrule.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/ratelimit-policies.yaml
+++ b/charts/envoy-gateway/templates/ratelimit-policies.yaml
@@ -30,6 +30,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-ratelimit-api
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:
@@ -55,6 +56,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: BackendTrafficPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-ratelimit-strict
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/ratelimit-policies.yaml
+++ b/charts/envoy-gateway/templates/ratelimit-policies.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-ratelimit-config
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 data:

--- a/charts/envoy-gateway/templates/rbac.yaml
+++ b/charts/envoy-gateway/templates/rbac.yaml
@@ -216,13 +216,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "envoy-gateway.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-leader-election
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 rules:
@@ -262,7 +262,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-leader-election
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 roleRef:
@@ -272,5 +272,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "envoy-gateway.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
 {{- end }}

--- a/charts/envoy-gateway/templates/securitypolicy.yaml
+++ b/charts/envoy-gateway/templates/securitypolicy.yaml
@@ -5,7 +5,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-security
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/service-controller.yaml
+++ b/charts/envoy-gateway/templates/service-controller.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-controller
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:
@@ -33,7 +34,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: envoy-gateway
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/templates/serviceaccount.yaml
+++ b/charts/envoy-gateway/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "envoy-gateway.serviceAccountName" . }}
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/envoy-gateway/templates/servicemonitor.yaml
+++ b/charts/envoy-gateway/templates/servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "envoy-gateway.fullname" . }}-controller
+  namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
 spec:

--- a/charts/envoy-gateway/tests/gateway-api-examples_test.yaml
+++ b/charts/envoy-gateway/tests/gateway-api-examples_test.yaml
@@ -39,6 +39,20 @@ tests:
           count: 0
         template: examples/httproute.yaml
 
+  - it: should not create examples when Gateway API helpers are globally disabled
+    set:
+      gatewayAPI:
+        enabled: false
+        examples:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: examples/gateway.yaml
+      - hasDocuments:
+          count: 0
+        template: examples/httproute.yaml
+
   - it: should create HTTPRoute with example backend
     set:
       gatewayAPI:
@@ -83,5 +97,22 @@ tests:
       - equal:
           path: metadata.namespace
           value: custom-ns
+        template: examples/httproute.yaml
+        documentIndex: 0
+
+  - it: should default examples to namespaceOverride
+    set:
+      namespaceOverride: envoy-system
+      gatewayAPI:
+        examples:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: examples/gateway.yaml
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
         template: examples/httproute.yaml
         documentIndex: 0

--- a/charts/envoy-gateway/tests/gateway_test.yaml
+++ b/charts/envoy-gateway/tests/gateway_test.yaml
@@ -40,6 +40,14 @@ tests:
           path: metadata.name
           value: my-gateway
 
+  - it: should render Gateway in namespaceOverride
+    set:
+      namespaceOverride: envoy-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+
   - it: should default to release name when name not set
     asserts:
       - equal:

--- a/charts/envoy-gateway/tests/rate-limiting_test.yaml
+++ b/charts/envoy-gateway/tests/rate-limiting_test.yaml
@@ -112,3 +112,30 @@ tests:
       - hasDocuments:
           count: 3
         template: ratelimit-policies.yaml
+
+  - it: should render all rate limit resources in namespaceOverride
+    set:
+      namespaceOverride: envoy-system
+      rateLimiting:
+        enabled: true
+        presets:
+          api: true
+          strict: true
+      redis:
+        enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: ratelimit-policies.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: ratelimit-policies.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: ratelimit-policies.yaml
+        documentIndex: 2

--- a/charts/envoy-gateway/tests/rbac_test.yaml
+++ b/charts/envoy-gateway/tests/rbac_test.yaml
@@ -34,6 +34,30 @@ tests:
           value: custom-sa
         template: serviceaccount.yaml
 
+  - it: should render namespace-scoped RBAC references in namespaceOverride
+    set:
+      namespaceOverride: envoy-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: serviceaccount.yaml
+      - equal:
+          path: subjects[0].namespace
+          value: envoy-system
+        template: rbac.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: rbac.yaml
+        documentIndex: 2
+      - equal:
+          path: subjects[0].namespace
+          value: envoy-system
+        template: rbac.yaml
+        documentIndex: 3
+
   - it: should create RBAC resources by default
     asserts:
       - hasDocuments:
@@ -158,4 +182,13 @@ tests:
       - equal:
           path: metadata.name
           value: custom-gateway-class
+        template: gatewayclass.yaml
+
+  - it: should point GatewayClass parametersRef at namespaceOverride
+    set:
+      namespaceOverride: envoy-system
+    asserts:
+      - equal:
+          path: spec.parametersRef.namespace
+          value: envoy-system
         template: gatewayclass.yaml

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -30,6 +30,7 @@ tests:
 
   - it: should create NetworkPolicies for Redis and ratelimit when rate limiting enabled
     set:
+      namespaceOverride: envoy-system
       security:
         networkPolicies: true
       rateLimiting:
@@ -46,8 +47,18 @@ tests:
         template: networkpolicy.yaml
         documentIndex: 1
       - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
           path: metadata.name
           value: RELEASE-NAME-envoy-gateway-ratelimit
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
         template: networkpolicy.yaml
         documentIndex: 2
 

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -61,6 +61,11 @@ tests:
           value: envoy-system
         template: networkpolicy.yaml
         documentIndex: 2
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: NAMESPACE
+        template: networkpolicy.yaml
+        documentIndex: 2
 
   - it: should create PrometheusRule when enabled
     set:

--- a/charts/envoy-gateway/tests/services_test.yaml
+++ b/charts/envoy-gateway/tests/services_test.yaml
@@ -91,6 +91,21 @@ tests:
         template: service-controller.yaml
         documentIndex: 1
 
+  - it: should render controller services in namespaceOverride
+    set:
+      namespaceOverride: envoy-system
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: service-controller.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: envoy-system
+        template: service-controller.yaml
+        documentIndex: 1
+
   - it: should configure proxy service type LoadBalancer by default in EnvoyProxy CRD
     asserts:
       - equal:

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -11,6 +11,11 @@
       "enum": ["dev", "staging", "production-ha", "custom"],
       "default": "custom"
     },
+    "namespaceOverride": {
+      "type": "string",
+      "description": "Override the namespace used by chart-managed namespaced resources",
+      "default": ""
+    },
     "nameOverride": {
       "type": "string",
       "description": "Override the chart name",
@@ -339,6 +344,11 @@
       "type": "object",
       "description": "Gateway API example resources configuration",
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable chart-managed Gateway API helper resources",
+          "default": true
+        },
         "examples": {
           "type": "object",
           "description": "Example Gateway and HTTPRoute resources",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -7,6 +7,9 @@
 # Options: dev, production-ha, custom
 profile: custom
 
+# -- Override the namespace used by chart-managed namespaced resources. The target namespace must already exist.
+namespaceOverride: ""
+
 ## Controller Service configuration
 service:
   # -- Set the ipFamilyPolicy for controller Services (dual-stack)
@@ -83,7 +86,7 @@ proxy:
     repository: docker.io/envoyproxy/envoy
     # -- Proxy image pull policy
     pullPolicy: IfNotPresent
-    # -- Envoy image tag for EG v1.7 (distroless)
+    # -- Envoy image tag for EG v1.8 (distroless)
     tag: "distroless-v1.37.0"
 
   # -- Resources for proxy pods (overridden by profile)
@@ -364,10 +367,12 @@ highAvailability:
 
 ## Gateway API Examples
 gatewayAPI:
+  # -- Enable chart-managed Gateway API helper resources
+  enabled: true
   examples:
     # -- Create example Gateway and HTTPRoute resources
     enabled: true
-    # -- Namespace for example resources (defaults to Release.Namespace)
+    # -- Namespace for example resources (defaults to namespaceOverride or Release.Namespace)
     namespace: ""
 
 ## ServiceAccount


### PR DESCRIPTION
## Summary - add `namespaceOverride` support for chart-managed namespaced resources and GatewayClass parametersRef - add a global `gatewayAPI.enabled` gate for helper Gateway API examples - remove the generated `Chart.lock` and stale metadata blocks, and refresh chart docs/tests  ## Validation - [x] `helm dependency build charts/envoy-gateway` - [x] `helm dependency list charts/envoy-gateway` - [x] `helm lint charts/envoy-gateway` - [x] `helm lint --strict charts/envoy-gateway` - [x] `helm unittest charts/envoy-gateway` (14 suites, 104 tests) - [x] `ah lint -p charts/envoy-gateway` - [x] `helm template` default and all `ci/*-values.yaml` scenarios - [x] `kubeconform -strict` default and all CI scenarios: 0 invalid, 0 errors - [x] `markdownlint-cli2` README and docs: 0 errors - [x] Kubescape NSA score: 75.30303 - [x] K3D `k3d-helmforge-tests-wsl`: default Gateway API route/proxy smoke and namespaceOverride placement scenarios passed; every pod/container log and non-Normal event checked clean; resources cleaned - [x] K3D `production-ha`: controller reached 2/2 Ready, PDB ready with one allowed disruption, resources cleaned  ## Notes - In K3D, the Gateway parent condition stayed `Programmed=False` because the LoadBalancer external address remains pending; listener status was programmed and in-cluster HTTPRoute smoke returned HTTP 200 through the managed proxy ClusterIP. - The `production-ha` runtime check showed an upstream Envoy Gateway v1.8 leader-election conflict log during simultaneous replica startup. It did not affect readiness, PDB behavior, or rollout completion; this PR does not change autoscaling/HA semantics.  Related to #277 

Closes #385
