### PR TITLE
feat(openhab): harden namespace and networking support

### DIFF
--- a/charts/openhab/README.md
+++ b/charts/openhab/README.md
@@ -83,7 +83,9 @@ helm install my-openhab helmforge/openhab -f values.yaml
 - Correct security context (`fsGroup: 9001`; `runAsUser`/`runAsGroup` intentionally unset — entrypoint manages privilege drop via gosu)
 - Startup/liveness/readiness probes via `/rest/uuid` (returns 200, no auth required)
 - Optional Ingress with websocket annotation guidance for `/rest/events`
+- Optional Gateway API HTTPRoute for shared Gateway deployments
 - Optional Karaf SSH admin console (port 8101)
+- Namespace override support for pre-created operational namespaces
 - Optional admin credentials Secret
 - Prometheus metrics via `/rest/metrics/prometheus` (pod annotations + ServiceMonitor)
 - Automated S3 backup via CronJob (tar + MinIO client)
@@ -100,18 +102,32 @@ Use feature flags instead to enable optional components.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.tag` | openHAB image tag | `4.2.2` |
+| `image.tag` | openHAB image tag | `5.1.4` |
 | `image.repository` | Image repository | `docker.io/openhab/openhab` |
 | `replicaCount` | Must be 1 — no clustering support | `1` |
+| `namespaceOverride` | Namespace for chart-managed resources | `""` |
+| `serviceAccount.automountServiceAccountToken` | Mount Kubernetes API token into the pod | `false` |
 | `podSecurityContext.fsGroup` | fsGroup for PVC ownership after privilege drop | `9001` |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | HTTP port | `8080` |
+| `service.ipFamilyPolicy` | HTTP Service dual-stack policy | `""` |
+| `service.ipFamilies` | HTTP Service IP families | `[]` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.ingressClassName` | Ingress class name | `""` |
 | `env.TZ` | Timezone | `UTC` |
 | `env.EXTRA_JAVA_OPTS` | Extra JVM options | `""` |
 | `karaf.enabled` | Enable Karaf SSH console | `false` |
+| `karaf.service.ipFamilyPolicy` | Karaf Service dual-stack policy | `""` |
+| `karaf.service.ipFamilies` | Karaf Service IP families | `[]` |
 | `admin.secretEnabled` | Create admin credentials Secret | `false` |
+
+### Gateway API Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `gateway.enabled` | Enable HTTPRoute creation | `false` |
+| `gateway.hostnames` | HTTPRoute hostnames | `[openhab.local]` |
+| `gateway.parentRefs` | Parent Gateway references | `[]` |
 
 ### Persistence Parameters
 

--- a/charts/openhab/ci/namespace-override.yaml
+++ b/charts/openhab/ci/namespace-override.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: render all chart-managed namespaced resources into a dedicated namespace.
+
+namespaceOverride: openhab-system
+
+ingress:
+  enabled: true
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+karaf:
+  enabled: true
+  service:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv4
+      - IPv6

--- a/charts/openhab/docs/backup.md
+++ b/charts/openhab/docs/backup.md
@@ -1,6 +1,7 @@
 # Automated Backup
 
-The openHAB chart includes an optional automated backup system that uses a Kubernetes CronJob to create compressed archives of your openHAB data directories and upload them to any S3-compatible object storage.
+The openHAB chart includes an optional automated backup system that uses a Kubernetes CronJob to create compressed
+archives of your openHAB data directories and upload them to any S3-compatible object storage.
 
 ## How It Works
 
@@ -94,7 +95,7 @@ The uploader uses the MinIO client (`mc`), which is compatible with any S3-compa
 
 Archives follow this pattern:
 
-```
+```text
 <archivePrefix>-backup-<YYYY-MM-DD-HHmmss>.tar.gz
 ```
 
@@ -156,19 +157,48 @@ To restore from a backup:
 kubectl scale statefulset openhab -n openhab --replicas=0
 ```
 
-3. Extract the archive into the PVC via a temporary pod:
+1. Extract the archive into the PVC via a temporary pod:
 
 ```bash
+cat > restore-overrides.json <<'EOF'
+{
+  "spec": {
+    "volumes": [
+      {
+        "name": "userdata",
+        "persistentVolumeClaim": {
+          "claimName": "openhab-userdata"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "restore",
+        "image": "alpine",
+        "command": ["sh"],
+        "stdin": true,
+        "tty": true,
+        "volumeMounts": [
+          {
+            "name": "userdata",
+            "mountPath": "/openhab/userdata"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
 kubectl run restore --rm -it --image=alpine --restart=Never \
-  --overrides='{"spec":{"volumes":[{"name":"userdata","persistentVolumeClaim":{"claimName":"openhab-userdata"}}],"containers":[{"name":"restore","image":"alpine","command":["sh"],"stdin":true,"tty":true,"volumeMounts":[{"name":"userdata","mountPath":"/openhab/userdata"}]}]}}' \
-  -- sh
+  --overrides="$(cat restore-overrides.json)" -- sh
 
 # Inside the pod:
 tar -xzf /path/to/openhab-backup-<timestamp>.tar.gz -C /
 exit
 ```
 
-4. Scale openHAB back to 1:
+1. Scale openHAB back to 1:
 
 ```bash
 kubectl scale statefulset openhab -n openhab --replicas=1

--- a/charts/openhab/docs/configmaps-live-reload.md
+++ b/charts/openhab/docs/configmaps-live-reload.md
@@ -8,7 +8,7 @@ openHAB configuration declaratively via Helm values or GitOps pipelines.
 
 ## How It Works
 
-```
+```text
 Helm values.yaml
     └─> ConfigMap (K8s)
             └─> Volume mount (subPath) → /openhab/conf/<dir>/<file>
@@ -77,11 +77,13 @@ helm upgrade my-openhab helmforge/openhab -f values.yaml
 ### File not being reloaded
 
 Check if the file exists on the pod:
+
 ```bash
 kubectl exec -n <namespace> <pod> -- ls /openhab/conf/sitemaps/
 ```
 
 Check openHAB logs for errors:
+
 ```bash
 kubectl exec -n <namespace> <pod> -- tail -f /openhab/userdata/logs/openhab.log
 ```

--- a/charts/openhab/docs/metrics.md
+++ b/charts/openhab/docs/metrics.md
@@ -6,7 +6,7 @@ for Prometheus Operator.
 
 ## Architecture
 
-```
+```text
 openHAB (port 8080)
   └─> GET /rest/metrics/prometheus
         └─> Prometheus scraper (annotation-based or ServiceMonitor)

--- a/charts/openhab/docs/security.md
+++ b/charts/openhab/docs/security.md
@@ -22,6 +22,7 @@ securityContext:
 ### Why readOnlyRootFilesystem is false
 
 openHAB (OSGi/Karaf) writes to several directories at runtime:
+
 - `/openhab/runtime/` — OSGi framework state
 - `/openhab/userdata/tmp/` — Temporary files
 - `/openhab/userdata/cache/` — Bundle cache

--- a/charts/openhab/templates/NOTES.txt
+++ b/charts/openhab/templates/NOTES.txt
@@ -4,7 +4,7 @@ openHAB {{ .Chart.AppVersion }} - Home Automation Platform
 ================================================================================
 
 Release   : {{ .Release.Name }}
-Namespace : {{ .Release.Namespace }}
+Namespace : {{ include "openhab.namespace" . }}
 Version   : {{ .Chart.Version }}
 App       : {{ .Chart.AppVersion }}
 
@@ -17,17 +17,17 @@ App       : {{ .Chart.AppVersion }}
   openHAB Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
 {{- end }}
 {{- else if eq .Values.service.type "NodePort" }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openhab.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "openhab.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openhab.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "openhab.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "openHAB Web UI: http://$NODE_IP:$NODE_PORT"
 {{- else if eq .Values.service.type "LoadBalancer" }}
   NOTE: It may take a few minutes for the LoadBalancer IP to be assigned.
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "openhab.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "openhab.namespace" . }} {{ include "openhab.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo "openHAB Web UI: http://$SERVICE_IP:{{ .Values.service.port }}"
 {{- else }}
   Port-forward to access the web UI:
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "openhab.fullname" . }} 8080:{{ .Values.service.port }}
+  kubectl port-forward --namespace {{ include "openhab.namespace" . }} svc/{{ include "openhab.fullname" . }} 8080:{{ .Values.service.port }}
 
   openHAB Web UI: http://127.0.0.1:8080
 {{- end }}
@@ -48,11 +48,11 @@ App       : {{ .Chart.AppVersion }}
   Admin credentials are stored in Secret '{{ include "openhab.adminSecretName" . }}' for reference:
 
   Username:
-    kubectl get secret --namespace {{ .Release.Namespace }} {{ include "openhab.adminSecretName" . }} \
+    kubectl get secret --namespace {{ include "openhab.namespace" . }} {{ include "openhab.adminSecretName" . }} \
       -o jsonpath="{.data.username}" | base64 --decode
 
   Password:
-    kubectl get secret --namespace {{ .Release.Namespace }} {{ include "openhab.adminSecretName" . }} \
+    kubectl get secret --namespace {{ include "openhab.namespace" . }} {{ include "openhab.adminSecretName" . }} \
       -o jsonpath="{.data.password}" | base64 --decode
 {{- end }}
 
@@ -65,7 +65,7 @@ App       : {{ .Chart.AppVersion }}
 
   Wait for the pod to be READY before accessing the web UI:
 
-  kubectl wait --namespace {{ .Release.Namespace }} \
+  kubectl wait --namespace {{ include "openhab.namespace" . }} \
     pod -l app.kubernetes.io/name={{ include "openhab.name" . }} \
     --for=condition=Ready --timeout=300s
 
@@ -126,12 +126,12 @@ App       : {{ .Chart.AppVersion }}
   openHAB will pick up the change automatically.
 {{- else }}
   No ConfigMaps configured. Manage configuration files directly via:
-    kubectl exec --namespace {{ .Release.Namespace }} \
-      deploy/{{ include "openhab.fullname" . }} -- ls /openhab/conf/
+    kubectl exec --namespace {{ include "openhab.namespace" . }} \
+      statefulset/{{ include "openhab.fullname" . }} -- ls /openhab/conf/
 
   Or copy files to the pod:
     kubectl cp ./myfile.items \
-      {{ .Release.Namespace }}/$(kubectl get pod -n {{ .Release.Namespace }} \
+      {{ include "openhab.namespace" . }}/$(kubectl get pod -n {{ include "openhab.namespace" . }} \
       -l app.kubernetes.io/name={{ include "openhab.name" . }} -o name | head -1 | cut -d/ -f2):/openhab/conf/items/
 {{- end }}
 
@@ -143,7 +143,7 @@ App       : {{ .Chart.AppVersion }}
   Karaf admin console is enabled on port {{ .Values.karaf.service.port }}.
 
   Port-forward and connect:
-    kubectl port-forward --namespace {{ .Release.Namespace }} \
+    kubectl port-forward --namespace {{ include "openhab.namespace" . }} \
       svc/{{ include "openhab.fullname" . }}-karaf {{ .Values.karaf.service.port }}:{{ .Values.karaf.service.port }}
 
     ssh -p {{ .Values.karaf.service.port }} openhab@127.0.0.1
@@ -165,25 +165,25 @@ App       : {{ .Chart.AppVersion }}
 ================================================================================
 
   Check pod status:
-    kubectl get pods --namespace {{ .Release.Namespace }} \
+    kubectl get pods --namespace {{ include "openhab.namespace" . }} \
       -l app.kubernetes.io/name={{ include "openhab.name" . }}
 
   View logs (live):
-    kubectl logs --namespace {{ .Release.Namespace }} \
+    kubectl logs --namespace {{ include "openhab.namespace" . }} \
       -l app.kubernetes.io/name={{ include "openhab.name" . }} -f
 
   View openHAB application log:
-    kubectl exec --namespace {{ .Release.Namespace }} \
-      $(kubectl get pod -n {{ .Release.Namespace }} \
+    kubectl exec --namespace {{ include "openhab.namespace" . }} \
+      $(kubectl get pod -n {{ include "openhab.namespace" . }} \
       -l app.kubernetes.io/name={{ include "openhab.name" . }} -o name | head -1) -- \
       tail -f /openhab/userdata/logs/openhab.log
 
   Describe pod (for events/errors):
-    kubectl describe pod --namespace {{ .Release.Namespace }} \
+    kubectl describe pod --namespace {{ include "openhab.namespace" . }} \
       -l app.kubernetes.io/name={{ include "openhab.name" . }}
 
   Check startup probe:
-    kubectl get pod --namespace {{ .Release.Namespace }} \
+    kubectl get pod --namespace {{ include "openhab.namespace" . }} \
       -l app.kubernetes.io/name={{ include "openhab.name" . }} \
       -o jsonpath='{.items[0].status.containerStatuses[0].started}'
 
@@ -203,3 +203,4 @@ App       : {{ .Chart.AppVersion }}
   Chart issues:       https://github.com/helmforgedev/charts/issues
 
 ================================================================================
+Happy Helmforging :)

--- a/charts/openhab/templates/_helpers.tpl
+++ b/charts/openhab/templates/_helpers.tpl
@@ -44,6 +44,13 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Namespace for chart-managed namespaced resources.
+*/}}
+{{- define "openhab.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace }}
+{{- end }}
+
+{{/*
 Selector labels
 */}}
 {{- define "openhab.selectorLabels" -}}

--- a/charts/openhab/templates/backup-configmap.yaml
+++ b/charts/openhab/templates/backup-configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "openhab.fullname" . }}-backup-scripts
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
     app.kubernetes.io/component: backup
@@ -75,6 +75,8 @@ data:
 
     echo ""
     echo "Configuring MinIO client..."
+    export MC_CONFIG_DIR="${MC_CONFIG_DIR:-/tmp/.mc}"
+    mkdir -p "${MC_CONFIG_DIR}"
     mc alias set s3 "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}" --quiet
 
     echo "Uploading..."

--- a/charts/openhab/templates/backup-cronjob.yaml
+++ b/charts/openhab/templates/backup-cronjob.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "openhab.fullname" . }}-backup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
     app.kubernetes.io/component: backup

--- a/charts/openhab/templates/backup-secret.yaml
+++ b/charts/openhab/templates/backup-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "openhab.fullname" . }}-backup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
     app.kubernetes.io/component: backup

--- a/charts/openhab/templates/configmap.yaml
+++ b/charts/openhab/templates/configmap.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "openhab.fullname" . }}-sitemaps
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
   annotations:
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "openhab.fullname" . }}-things
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
   annotations:
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "openhab.fullname" . }}-items
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
   annotations:

--- a/charts/openhab/templates/externalsecret.yaml
+++ b/charts/openhab/templates/externalsecret.yaml
@@ -11,6 +11,7 @@ apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
   name: {{ include "openhab.fullname" . }}-credentials
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:

--- a/charts/openhab/templates/httproute.yaml
+++ b/charts/openhab/templates/httproute.yaml
@@ -7,6 +7,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "openhab.fullname" . }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:

--- a/charts/openhab/templates/ingress.yaml
+++ b/charts/openhab/templates/ingress.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "openhab.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/openhab/templates/pvc.yaml
+++ b/charts/openhab/templates/pvc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "openhab.fullname" . }}-userdata
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "openhab.fullname" . }}-conf
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:
@@ -42,7 +42,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "openhab.fullname" . }}-addons
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:

--- a/charts/openhab/templates/secret.yaml
+++ b/charts/openhab/templates/secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "openhab.fullname" . }}-admin
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
   annotations:

--- a/charts/openhab/templates/service.yaml
+++ b/charts/openhab/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "openhab.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:
@@ -28,11 +28,20 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "openhab.fullname" . }}-karaf
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.karaf.service.type }}
+  {{- $karafIpFamilyPolicy := .Values.karaf.service.ipFamilyPolicy | default .Values.service.ipFamilyPolicy }}
+  {{- with $karafIpFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- $karafIpFamilies := .Values.karaf.service.ipFamilies | default .Values.service.ipFamilies }}
+  {{- with $karafIpFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.karaf.service.port }}
       targetPort: karaf

--- a/charts/openhab/templates/serviceaccount.yaml
+++ b/charts/openhab/templates/serviceaccount.yaml
@@ -4,11 +4,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "openhab.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/openhab/templates/servicemonitor.yaml
+++ b/charts/openhab/templates/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "openhab.fullname" . }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default (include "openhab.namespace" .) }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.additionalLabels }}
@@ -29,5 +29,5 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "openhab.namespace" . }}
 {{- end }}

--- a/charts/openhab/templates/statefulset.yaml
+++ b/charts/openhab/templates/statefulset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "openhab.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "openhab.namespace" . }}
   labels:
     {{- include "openhab.labels" . | nindent 4 }}
 spec:
@@ -37,6 +37,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "openhab.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/openhab/tests/backup_test.yaml
+++ b/charts/openhab/tests/backup_test.yaml
@@ -262,6 +262,17 @@ tests:
           path: data["upload.sh"]
           pattern: "myhab-backup-"
 
+  - it: should configure mc in writable temporary storage
+    set:
+      backup.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["upload.sh"]
+          pattern: "MC_CONFIG_DIR"
+      - matchRegex:
+          path: data["upload.sh"]
+          pattern: "/tmp/.mc"
+
 ---
 suite: Backup Secret
 templates:

--- a/charts/openhab/tests/namespace_test.yaml
+++ b/charts/openhab/tests/namespace_test.yaml
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Namespace Override
+templates:
+  - statefulset.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - pvc.yaml
+  - ingress.yaml
+  - httproute.yaml
+  - externalsecret.yaml
+  - servicemonitor.yaml
+  - configmap.yaml
+  - backup-cronjob.yaml
+  - backup-configmap.yaml
+  - backup-secret.yaml
+  - secret.yaml
+tests:
+  - it: should render core resources in namespaceOverride
+    set:
+      namespaceOverride: openhab-system
+      serviceAccount.create: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: statefulset.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: service.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: serviceaccount.yaml
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+        template: serviceaccount.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: pvc.yaml
+        documentIndex: 0
+
+  - it: should render optional exposure resources in namespaceOverride
+    set:
+      namespaceOverride: openhab-system
+      ingress.enabled: true
+      gateway:
+        enabled: true
+        parentRefs:
+          - name: shared-gateway
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: ingress.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: httproute.yaml
+
+  - it: should render config and secret resources in namespaceOverride
+    set:
+      namespaceOverride: openhab-system
+      admin:
+        secretEnabled: true
+        password: changeme
+      configMaps:
+        items:
+          enabled: true
+          files:
+            lights.items: "Switch Light_GF"
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: cluster-store
+        data:
+          - secretKey: password
+            remoteRef:
+              key: openhab/admin
+      admin.existingSecret: openhab-admin
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: configmap.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: externalsecret.yaml
+
+  - it: should render monitoring namespace selectors against namespaceOverride
+    set:
+      namespaceOverride: openhab-system
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: servicemonitor.yaml
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: openhab-system
+        template: servicemonitor.yaml
+
+  - it: should render backup resources in namespaceOverride
+    set:
+      namespaceOverride: openhab-system
+      backup:
+        enabled: true
+        s3:
+          endpoint: http://minio.minio.svc:9000
+          bucket: openhab
+          accessKey: minio
+          secretKey: minio123
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: backup-cronjob.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: backup-configmap.yaml
+      - equal:
+          path: metadata.namespace
+          value: openhab-system
+        template: backup-secret.yaml

--- a/charts/openhab/tests/service_test.yaml
+++ b/charts/openhab/tests/service_test.yaml
@@ -48,6 +48,24 @@ tests:
           path: spec.ports[0].port
           value: 9090
 
+  - it: should apply dual-stack settings to HTTP service
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
   - it: should not create karaf service when disabled
     set:
       karaf.enabled: false
@@ -61,3 +79,49 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
+
+  - it: should apply dual-stack settings to Karaf service when enabled
+    set:
+      karaf:
+        enabled: true
+        service:
+          ipFamilyPolicy: PreferDualStack
+          ipFamilies:
+            - IPv4
+            - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+        documentIndex: 1
+
+  - it: should inherit dual-stack settings for Karaf service from HTTP service
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+      karaf:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+        documentIndex: 1

--- a/charts/openhab/tests/statefulset_test.yaml
+++ b/charts/openhab/tests/statefulset_test.yaml
@@ -39,6 +39,12 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 9001
 
+  - it: should not automount the Kubernetes API token by default
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
   - it: should not drop ALL capabilities (entrypoint needs CAP_SETUID, CAP_SETGID, CAP_CHOWN)
     asserts:
       - notExists:
@@ -126,6 +132,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
           value: /rest/uuid
+
+  - it: should delay startup probe to avoid first-boot warning events
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 60
 
   - it: should have liveness probe on /rest/uuid
     asserts:

--- a/charts/openhab/values.schema.json
+++ b/charts/openhab/values.schema.json
@@ -48,6 +48,11 @@
       "type": "string",
       "description": "Override the full release name"
     },
+    "namespaceOverride": {
+      "type": "string",
+      "description": "Override the namespace used by chart-managed namespaced resources",
+      "default": ""
+    },
     "serviceAccount": {
       "type": "object",
       "description": "ServiceAccount configuration",
@@ -56,6 +61,11 @@
           "type": "boolean",
           "description": "Create a ServiceAccount",
           "default": true
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Mount the Kubernetes API token into the pod",
+          "default": false
         },
         "annotations": {
           "type": "object",
@@ -369,6 +379,15 @@
               "minimum": 1,
               "maximum": 65535,
               "default": 8101
+            },
+            "ipFamilyPolicy": {
+              "type": "string",
+              "description": "Dual-stack ipFamilyPolicy for the Karaf SSH Service"
+            },
+            "ipFamilies": {
+              "type": "array",
+              "description": "Dual-stack ipFamilies for the Karaf SSH Service",
+              "items": { "type": "string" }
             }
           }
         }

--- a/charts/openhab/values.yaml
+++ b/charts/openhab/values.yaml
@@ -20,11 +20,15 @@ replicaCount: 1
 nameOverride: ""
 # -- Override the full release name
 fullnameOverride: ""
+# -- Override the namespace used by chart-managed namespaced resources. The target namespace must already exist.
+namespaceOverride: ""
 
 # -- ServiceAccount configuration
 serviceAccount:
   # -- Create a ServiceAccount
   create: true
+  # -- Mount the Kubernetes API token into the pod
+  automountServiceAccountToken: false
   # -- Annotations to add to the ServiceAccount
   annotations: {}
   # -- Name of the ServiceAccount (defaults to release name)
@@ -208,6 +212,10 @@ karaf:
     type: ClusterIP
     # -- Karaf SSH port
     port: 8101
+    # -- Set the ipFamilyPolicy for Karaf SSH Service (dual-stack)
+    ipFamilyPolicy: ''
+    # -- Set the ipFamilies for Karaf SSH Service
+    ipFamilies: []
 
 # -- Resource requests and limits
 resources:
@@ -227,6 +235,8 @@ startupProbe:
   httpGet:
     path: /rest/uuid
     port: http
+  # Avoid noisy first-boot probe warning events while OSGi starts.
+  initialDelaySeconds: 60
   # 60 attempts x 10s = 10 minutes maximum startup window.
   # Keep this generous: openHAB's OSGi bundle loading depends heavily on hardware.
   failureThreshold: 60
@@ -402,4 +412,3 @@ externalSecrets:
   target:
     creationPolicy: Owner
   data: []
-


### PR DESCRIPTION
Related to #347  ## Summary - add namespaceOverride support across namespaced openHAB resources and NOTES output - harden ServiceAccount token mounting defaults and tune startup probe timing - add Karaf dual-stack inheritance/overrides plus namespaceOverride CI and unit coverage - fix backup uploader mc config path for non-root backup jobs  ## Validation - helm lint charts/openhab - helm lint --strict charts/openhab - helm unittest charts/openhab (13 suites, 113 tests) - npx -y markdownlint-cli2 charts/openhab/README.md charts/openhab/docs/*.md - ah lint -p charts/openhab - helm dependency build/list charts/openhab (no dependencies, no Chart.lock) - helm template default and all charts/openhab/ci files - kubeconform -strict -ignore-missing-schemas for default and all CI renders - Kubescape MITRE 100, NSA 75, SOC2 80 - k3d-helmforge-tests-wsl default install: HTTP 200 /rest/uuid, no error logs, no non-Normal events - k3d-helmforge-tests-wsl namespaceOverride install: resources in target namespace, HTTP 200 /rest/uuid, no error logs, no non-Normal events - k3d-helmforge-tests-wsl backup-to-MinIO: backup Job completed, object uploaded, downloaded tar contains openhab/userdata and openhab/conf  ## Notes - The official openhab/openhab entrypoint emits non-error adduser home-directory warnings before Java starts; no chart-level setting suppresses those without replacing upstream entrypoint behavior. - The local k3d cluster is single-stack, so dual-stack was validated through render/kubeconform/unit coverage; runtime namespaceOverride used IPv4-compatible values.  

Closes #384
