### PR TITLE
feat(valkey): add Valkey chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Browse the full catalog with descriptions, install commands, and playground conf
 
 Common categories include:
 
-- **Databases and data stores** — PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Kafka, RabbitMQ, Elasticsearch, and Druid.
+- **Databases and data stores** — PostgreSQL, MySQL, MariaDB, MongoDB, Redis, Valkey, Kafka, RabbitMQ, Elasticsearch, and Druid.
 - **Identity and access** — Keycloak, Authelia, and application charts with ingress/auth integration patterns.
 - **Automation and operations** — n8n, Cronicle, FastMCP Server, Cloudflared, Velero, DDNS Updater, and Envoy Gateway.
 - **Content and community apps** — WordPress, Ghost, Drupal, Gitea, Wallabag, Castopod, Komga, OpenWebUI, and more.

--- a/charts/valkey/.helmignore
+++ b/charts/valkey/.helmignore
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+
+# Lock files
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/valkey/.helmignore
+++ b/charts/valkey/.helmignore
@@ -25,8 +25,10 @@ Thumbs.db
 # Lock files
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 Pipfile.lock
 poetry.lock
+Gemfile.lock
 
 # Logs
 *.log

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: valkey
+description: Valkey Helm chart for standalone, replication, sentinel, and cluster topologies
+type: application
+version: 0.1.0
+appVersion: "9.1.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - valkey
+  - cache
+  - datastore
+  - sentinel
+  - cluster
+  - database
+  - key-value
+  - in-memory
+  - ha
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://hub.docker.com/r/valkey/valkey
+  - https://github.com/valkey-io/valkey
+icon: https://helmforge.dev/icons/charts/valkey.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: "add Valkey chart with standalone, replication, sentinel, and cluster support (#357)"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: database
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://valkey.io
+    - name: Source
+      url: https://github.com/valkey-io/valkey
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/valkey
+    - name: Chart Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/valkey
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/zookeeper
+    - url: https://artifacthub.io/packages/helm/helmforge/uptime-kuma

--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -1,0 +1,286 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Valkey Chart Design
+
+Status: implemented and maintained
+
+Date: 2026-05-05
+
+## Goal
+
+The Valkey chart provides explicit, production-oriented Valkey topologies without hiding operational tradeoffs behind generic StatefulSet defaults. The chart supports four runtime contracts:
+
+- `standalone`
+- `replication`
+- `sentinel`
+- `cluster`
+
+Each mode renders a different Kubernetes resource model because each mode has different client behavior, failover expectations, persistence patterns, and operational risk.
+
+## Design Principles
+
+- Make topology the first decision through `architecture`.
+- Keep Valkey data-plane resources separate from optional observability and extension resources.
+- Prefer stable DNS names for internal Valkey discovery instead of pod IPs.
+- Support custom Kubernetes cluster domains through `clusterDomain`.
+- Keep services dual-stack capable through `service.ipFamilyPolicy` and `service.ipFamilies`.
+- Keep authentication explicit and reusable through generated Secrets, `existingSecret`, or External Secrets Operator integration.
+- Use StatefulSets for Valkey data nodes to preserve stable identities and storage.
+- Use startup checks where Valkey role discovery depends on another component becoming reachable.
+- Make generated names predictable through shared helpers.
+- Keep chart validation representative by covering every supported topology in CI values and unit tests.
+
+## Topology Selection
+
+```yaml
+architecture: standalone | replication | sentinel | cluster
+```
+
+Use `standalone` for development, small environments, caches where downtime is acceptable, or single-node production scenarios with external recovery procedures.
+
+Use `replication` when applications can read from replicas or when operators want a primary/replica layout without Sentinel-managed failover.
+
+Use `sentinel` when applications expect a single writable primary and can integrate with Sentinel discovery/failover.
+
+Use `cluster` when applications are Valkey Cluster aware and need sharding at the Valkey protocol level.
+
+## Architecture Diagrams
+
+### Standalone
+
+```mermaid
+flowchart LR
+  Client[Client] --> Service[Valkey Service]
+  Service --> Pod[Valkey-standalone-0]
+  Pod --> PVC[(Valkey PVC)]
+  Pod --> Config[ConfigMap]
+  Pod --> Secret[Secret or existingSecret]
+```
+
+Standalone keeps the resource graph intentionally small. It is easy to operate, but it has no in-chart failover target.
+
+### Replication
+
+```mermaid
+flowchart LR
+  Client[Client] --> ClientSvc[Client Service]
+  ClientSvc --> Primary[Valkey-primary-0]
+  ReplicaSvc[Replica Headless Service] --> Replica0[Valkey-replica-0]
+  ReplicaSvc --> Replica1[Valkey-replica-1]
+  Replica0 --> Primary
+  Replica1 --> Primary
+  Primary --> PrimaryPVC[(Primary PVC)]
+  Replica0 --> ReplicaPVC0[(Replica PVC)]
+  Replica1 --> ReplicaPVC1[(Replica PVC)]
+```
+
+Replication separates primary and replica StatefulSets. This keeps role-specific configuration and persistence clear, and lets operators tune scheduling, resources, and storage per role.
+
+### Sentinel
+
+```mermaid
+flowchart LR
+  Client[Sentinel-aware Client] --> SentinelSvc[Sentinel Service]
+  SentinelSvc --> Sentinel0[sentinel-0]
+  SentinelSvc --> Sentinel1[sentinel-1]
+  SentinelSvc --> Sentinel2[sentinel-2]
+  Sentinel0 --> Primary[Valkey-primary-0]
+  Sentinel1 --> Primary
+  Sentinel2 --> Primary
+  Replica[Valkey-replica-0] --> Primary
+  Primary --> PrimaryPVC[(Primary PVC)]
+  Replica --> ReplicaPVC[(Replica PVC)]
+```
+
+Sentinel is a distinct architecture because it changes the client contract. Sentinel pods wait for the primary before startup and use hostname resolution so custom cluster domains work consistently.
+
+### Valkey Cluster
+
+```mermaid
+flowchart LR
+  Client[Cluster-aware Client] --> ClusterSvc[Cluster Client Service]
+  ClusterSvc --> Node0[Valkey-cluster-0]
+  ClusterSvc --> Node1[Valkey-cluster-1]
+  ClusterSvc --> Node2[Valkey-cluster-2]
+  Headless[Headless Service] --> Node0
+  Headless --> Node1
+  Headless --> Node2
+  Init[Cluster Init Job] --> Headless
+  Node0 --> PVC0[(PVC 0)]
+  Node1 --> PVC1[(PVC 1)]
+  Node2 --> PVC2[(PVC 2)]
+```
+
+Cluster mode uses stable pod FQDNs for `cluster-announce-hostname` and a bootstrap Job for initial cluster creation.
+It does not try to replace dedicated Valkey Cluster operational tooling for resharding or complex node replacement.
+
+## Kubernetes Resource Model
+
+### Shared Resources
+
+- `Secret` or references to `existingSecret`
+- optional `ExternalSecret`
+- `ConfigMap`
+- client and headless `Service` resources
+- optional `ServiceMonitor`
+- optional `PodDisruptionBudget`
+- optional `extraManifests`
+
+### Standalone Resources
+
+- one Valkey StatefulSet
+- one PVC per pod when persistence is enabled
+- one client Service
+
+### Replication Resources
+
+- primary StatefulSet
+- replica StatefulSet
+- primary and replica DNS helpers
+- role-specific persistence
+
+### Sentinel Resources
+
+- primary and replica Valkey resources
+- Sentinel StatefulSet
+- Sentinel service
+- Sentinel configuration with hostname resolution
+- startup wait loop for primary reachability
+
+### Cluster Resources
+
+- Valkey Cluster StatefulSet
+- headless service for stable pod DNS
+- client service for cluster-aware clients
+- bootstrap Job
+- per-node persistence
+
+## DNS And Cluster Domain
+
+Valkey internals must not hardcode `svc.cluster.local`. The chart centralizes FQDN generation in helper templates and uses:
+
+```yaml
+clusterDomain: cluster.local
+```
+
+Operators running clusters with a non-default domain can set `clusterDomain` once and have replication, Sentinel, Cluster announce names, bootstrap jobs, and NOTES output use the same domain.
+
+## Service Networking
+
+Services support single-stack and dual-stack clusters through Kubernetes service family fields:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Best practices:
+
+- Leave the defaults empty unless the cluster supports the requested families.
+- Use `PreferDualStack` for portable dual-stack behavior.
+- Use `RequireDualStack` only when both families are guaranteed.
+- Keep headless and client services aligned so DNS behavior is predictable.
+
+## Security Model
+
+- Authentication is enabled by default for production-oriented usage.
+- `existingSecret` avoids chart-owned credential rotation when an external secret manager is authoritative.
+- External Secrets Operator integration lets the chart reference externally managed credentials while still rendering Kubernetes-native Secret consumers.
+- Pods run with restricted security contexts by default where Valkey compatibility allows it.
+- The chart avoids privileged containers and host namespace access.
+- Sensitive values should not be embedded in examples, CI values, or NOTES.
+
+## Persistence
+
+Stateful Valkey nodes use PVCs because identity and data continuity matter for Valkey operations.
+
+Best practices:
+
+- Use persistence for production data-bearing nodes.
+- Keep storage class and size explicit in production values.
+- Disable persistence only for tests, ephemeral caches, or local k3d validation.
+- Treat backup/restore as an application-level operational procedure, not as an implicit chart side effect.
+
+## Scheduling And Availability
+
+HA topologies should spread pods across nodes and failure domains where the cluster has enough capacity.
+
+Recommended production controls:
+
+- pod anti-affinity for Valkey replicas and Sentinel pods
+- topology spread constraints across zones or hosts
+- PodDisruptionBudgets for HA modes
+- explicit resource requests and limits
+- node selectors or tolerations only when they reflect real platform policy
+
+## Observability
+
+Metrics are optional and should be enabled only when the Prometheus Operator or a compatible scraper is present.
+
+When enabled, exporter resources should follow the selected architecture and expose a stable ServiceMonitor target. The chart should not render CRDs owned by observability operators.
+
+## Extension Points
+
+The chart exposes extension points for advanced operators without making them required:
+
+- `extraEnv`
+- `extraVolumes`
+- `extraVolumeMounts`
+- `extraManifests`
+- pod annotations and labels
+- service annotations
+- topology-specific resource overrides
+
+Extension points are escape hatches. Common operational paths should remain first-class values with schema validation.
+
+## Validation Strategy
+
+Every change to the chart should keep the following checks passing:
+
+- `helm dependency build charts/valkey`
+- `helm lint charts/valkey --strict`
+- `helm unittest charts/valkey`
+- `helm template valkey charts/valkey`
+- `helm template valkey charts/valkey -f charts/valkey/ci/*.yaml`
+- strict Kubernetes schema validation for default and CI renders
+- documentation linting for changed Markdown files
+- runtime k3d validation for behavior-changing chart changes
+
+The CI values must cover standalone, replication, sentinel, cluster, metrics, existing secrets, and networking variants that affect rendered resources.
+
+## Non-Goals
+
+- Valkey Enterprise or active-active Valkey
+- arbitrary Valkey modules as first-class chart features
+- operator-grade resharding or node replacement automation
+- hiding Valkey Cluster complexity from non-cluster-aware clients
+- rendering third-party CRDs owned by other operators
+
+## Related Documents
+
+- [`README.md`](README.md)
+- [`values.yaml`](values.yaml)
+- [`values.schema.json`](values.schema.json)
+- [`templates/NOTES.txt`](templates/NOTES.txt)
+
+<!-- @AI-METADATA
+type: design
+title: Valkey Chart Design
+description: Architecture and operational design document for the Valkey Helm chart
+
+keywords: Valkey, design, architecture, standalone, replication, sentinel, cluster, dual-stack, clusterDomain
+
+purpose: Document Valkey chart architecture, resource model, diagrams, best practices, and validation expectations
+scope: Chart Design
+
+relations:
+  - charts/valkey/README.md
+  - charts/valkey/values.yaml
+  - charts/valkey/templates/NOTES.txt
+path: charts/valkey/DESIGN.md
+version: 2.0
+date: 2026-05-05
+-->

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -1,0 +1,311 @@
+# Valkey
+
+Valkey for Kubernetes with explicit support for `standalone`, `replication`, `sentinel`, and `cluster` topologies.
+
+## Install
+
+### HTTPS repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install valkey helmforge/valkey -f values.yaml
+```
+
+### OCI registry
+
+```bash
+helm install valkey oci://ghcr.io/helmforgedev/helm/valkey -f values.yaml
+```
+
+## What this chart covers
+
+- topology selection with `architecture`
+- password authentication through generated, inline, existing, or externally reconciled secrets
+- optional External Secrets Operator integration
+- persistence settings by topology
+- internal service DNS customization with `clusterDomain`
+- dual-stack service fields through `service.ipFamilyPolicy` and `service.ipFamilies`
+- optional TLS file wiring for Valkey server configuration
+- optional Valkey exporter sidecar and `ServiceMonitor`
+- optional `PodDisruptionBudget`
+- topology-specific Services, StatefulSets, and Valkey Cluster bootstrap Job
+- `extraEnv`, `extraVolumes`, `extraVolumeMounts`, and `extraManifests` extension points
+
+## Supported architectures
+
+| Architecture | Contract | Primary resources | Document |
+|-------------|----------|-------------------|----------|
+| `standalone` | One Valkey pod, lowest operational complexity, no HA contract | headless Service, client Service, StatefulSet | [docs/standalone.md](docs/standalone.md) |
+| `replication` | One fixed primary with read replicas, no automatic promotion | headless Service, primary Service, replica Service, primary and replica StatefulSets | [docs/replication.md](docs/replication.md) |
+| `sentinel` | Valkey replication plus Sentinel primary discovery and failover for compatible clients | replication resources, Sentinel Service, Sentinel StatefulSet | [docs/sentinel.md](docs/sentinel.md) |
+| `cluster` | Valkey Cluster sharding and HA for Valkey Cluster-compatible clients | headless Service, client Service, cluster StatefulSet, cluster init Job | [docs/cluster.md](docs/cluster.md) |
+
+## How to choose the architecture
+
+- Use `standalone` for development, simple workloads, and systems that do not need Valkey-level HA.
+- Use `replication` when applications can tolerate a fixed primary endpoint and only need read replicas.
+- Use `sentinel` when clients can query Sentinel and need automatic primary discovery after failover.
+- Use `cluster` when clients support Valkey Cluster and data must be sharded across nodes.
+
+Read the topology document before production use:
+
+- [Standalone](docs/standalone.md)
+- [Replication](docs/replication.md)
+- [Sentinel](docs/sentinel.md)
+- [Cluster](docs/cluster.md)
+
+## Quick start
+
+Minimal standalone deployment with an existing password Secret:
+
+```yaml
+architecture: standalone
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+standalone:
+  persistence:
+    enabled: true
+    size: 8Gi
+```
+
+Install:
+
+```bash
+helm install valkey helmforge/valkey -f valkey-values.yaml
+```
+
+## Authentication
+
+The chart supports four credential patterns:
+
+| Pattern | Values | Notes |
+|---------|--------|-------|
+| Generated password | `auth.enabled=true`, empty `auth.password`, empty `auth.existingSecret` | Useful for quick starts. The generated value is stored in the chart-managed Secret. |
+| Inline password | `auth.password` | Acceptable for local testing. Avoid committing real credentials. |
+| Existing Secret | `auth.existingSecret` and `auth.existingSecretPasswordKey` | Recommended for production when another process owns the Secret. |
+| ExternalSecret | `externalSecrets.enabled=true` and `auth.existingSecret` | Recommended when External Secrets Operator reconciles the Secret from an external provider. |
+
+When `externalSecrets.enabled=true`, set `auth.existingSecret` to the same target Secret name. This avoids drift between a chart-managed Secret and an externally reconciled Secret.
+
+Example:
+
+```yaml
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: valkey-password
+      remoteRef:
+        key: valkey/auth
+        property: password
+```
+
+## Networking
+
+The chart creates a headless Service for stable StatefulSet pod DNS and topology-specific client Services.
+
+| Mode | Client-facing service |
+|------|-----------------------|
+| `standalone` | `<release>-valkey-client` |
+| `replication` | `<release>-valkey-primary` for writes, `<release>-valkey-replicas` for reads |
+| `sentinel` | `<release>-valkey-sentinel` for Sentinel, plus replication services |
+| `cluster` | `<release>-valkey-client` |
+
+### Cluster domain
+
+Set `clusterDomain` when the Kubernetes cluster does not use `cluster.local`:
+
+```yaml
+clusterDomain: corp.internal
+```
+
+The value is used for internal FQDNs rendered into Valkey replication, Sentinel, Valkey Cluster announce hostnames, cluster bootstrap commands, and `NOTES.txt`.
+
+### Dual-stack services
+
+Service dual-stack fields are available through:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Leave these values empty to use the cluster defaults.
+
+## Persistence
+
+Persistence is configured under each topology:
+
+- `standalone.persistence`
+- `replication.primary.persistence`
+- `replication.replica.persistence`
+- `sentinel.persistence`
+- `cluster.persistence`
+
+Use persistent volumes for production stateful modes. Disable persistence only for ephemeral tests and short-lived environments.
+
+## Observability
+
+Enable the Valkey exporter sidecar with:
+
+```yaml
+metrics:
+  enabled: true
+```
+
+When Prometheus Operator is installed, enable a `ServiceMonitor`:
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      prometheus: monitoring
+```
+
+Monitor memory usage, connected clients, command latency, replication lag, Sentinel state, and Valkey Cluster health depending on the selected topology.
+
+## Scheduling and availability
+
+For HA-oriented modes, configure:
+
+- `pdb.enabled=true`
+- `affinity` or pod anti-affinity
+- `topologySpreadConstraints`
+- resource requests and limits
+- a storage class with the required availability profile
+
+The chart exposes scheduling knobs but does not enforce a single cluster layout. Match these values to your node topology and maintenance policy.
+
+## Extension points
+
+Use the generic extension values when platform-specific integration is needed:
+
+- `commonLabels`
+- `podLabels`
+- `podAnnotations`
+- `annotations`
+- `extraEnv`
+- `extraVolumes`
+- `extraVolumeMounts`
+- `extraManifests`
+
+`extraManifests` are rendered with `tpl`.
+
+## Main values
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `architecture` | Valkey topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
+| `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
+| `image.repository` | Valkey image repository | `docker.io/valkey/valkey` |
+| `image.tag` | Valkey image tag | `9.1.0` |
+| `auth.enabled` | Enable password authentication | `true` |
+| `auth.password` | Inline Valkey password | `""` |
+| `auth.existingSecret` | Existing Secret containing the Valkey password | `""` |
+| `auth.existingSecretPasswordKey` | Secret key used for the Valkey password | `valkey-password` |
+| `tls.enabled` | Enable Valkey TLS settings. Requires `tls.existingSecret`. | `false` |
+| `standalone.persistence.enabled` | Enable persistence for standalone mode | `true` |
+| `replication.replicaCount` | Number of replica pods in replication and sentinel modes | `2` |
+| `sentinel.replicaCount` | Number of Sentinel pods | `3` |
+| `sentinel.quorum` | Sentinel quorum | `2` |
+| `cluster.nodes` | Number of Valkey Cluster nodes | `6` |
+| `cluster.replicasPerMaster` | Valkey Cluster replicas per master | `1` |
+| `service.type` | Client Service type where applicable | `ClusterIP` |
+| `service.ipFamilyPolicy` | Service IP family policy for dual-stack clusters | `null` |
+| `service.ipFamilies` | Service IP families for dual-stack clusters | `[]` |
+| `metrics.enabled` | Enable redis_exporter sidecar | `false` |
+| `metrics.serviceMonitor.enabled` | Create ServiceMonitor | `false` |
+| `tests.enabled` | Render Helm test connection pod | `true` |
+| `tests.image.repository` | Helm test image repository | `docker.io/valkey/valkey` |
+| `tests.image.tag` | Helm test image tag | `9.1.0` |
+| `podSecurityContext.seccompProfile.type` | Pod seccomp profile | `RuntimeDefault` |
+| `securityContext.capabilities.drop` | Linux capabilities dropped by default | `["ALL"]` |
+| `pdb.enabled` | Create PodDisruptionBudget for HA modes | `false` |
+| `externalSecrets.enabled` | Render an ExternalSecret for the auth Secret | `false` |
+| `externalSecrets.secretStoreRef.name` | SecretStore or ClusterSecretStore name | `""` |
+| `extraManifests` | Extra Kubernetes manifests rendered with `tpl` | `[]` |
+
+## CI scenarios
+
+The `ci/` scenarios validate chart behavior across common configurations:
+
+- `standalone.yaml`
+- `replication.yaml`
+- `sentinel.yaml`
+- `cluster.yaml`
+- `existing-secret.yaml`
+- `external-secrets.yaml`
+- `metrics.yaml`
+- `dual-stack.yaml`
+
+Local validation should include:
+
+```bash
+helm dependency build charts/valkey
+helm lint charts/valkey --strict
+helm unittest charts/valkey
+helm template valkey charts/valkey
+helm test valkey -n <namespace>
+for f in charts/valkey/ci/*.yaml; do helm template valkey charts/valkey -f "$f" >/dev/null; done
+```
+
+## Examples
+
+See `examples/`:
+
+- `standalone-simple.yaml`
+- `replication-production.yaml`
+- `cluster.yaml`
+
+## Operational notes
+
+- `replication` and `sentinel` are different operational contracts.
+- `sentinel` requires Sentinel-compatible clients for automatic primary discovery.
+- `cluster` requires Valkey Cluster-compatible clients.
+- If `auth.password` is not set and `auth.existingSecret` is not used, the chart generates a password automatically.
+- If your cluster domain is not `cluster.local`, set `clusterDomain` before installing stateful topologies.
+- For production, verify storage, credentials, scheduling, network policy, monitoring, backup strategy, and client compatibility before exposing Valkey to applications.
+
+## Official product references
+
+- Valkey Sentinel: <https://valkey.io/docs/latest/operate/oss_and_stack/management/sentinel/>
+- Valkey Cluster: <https://valkey.io/docs/latest/operate/oss_and_stack/management/scaling/>
+- Valkey security: <https://valkey.io/docs/latest/operate/oss_and_stack/management/security/>
+
+<!-- @AI-METADATA
+type: chart-readme
+title: Valkey Helm Chart
+description: Valkey chart with standalone, replication, sentinel, and cluster architectures
+
+keywords: Valkey, cache, in-memory, replication, sentinel, cluster, dual-stack, external-secrets
+
+purpose: Usage guide for the Valkey Helm chart with authentication, networking, observability, and topology guidance
+scope: Chart
+
+relations:
+  - charts/valkey/DESIGN.md
+  - charts/valkey/docs/standalone.md
+  - charts/valkey/docs/replication.md
+  - charts/valkey/docs/sentinel.md
+  - charts/valkey/docs/cluster.md
+path: charts/valkey/README.md
+version: 1.1
+date: 2026-05-05
+-->

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -235,6 +235,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `tests.enabled` | Render Helm test connection pod | `true` |
 | `tests.image.repository` | Helm test image repository | `docker.io/valkey/valkey` |
 | `tests.image.tag` | Helm test image tag | `9.1.0` |
+| `automountServiceAccountToken` | Mount Kubernetes API service account token into pods | `false` |
 | `podSecurityContext.seccompProfile.type` | Pod seccomp profile | `RuntimeDefault` |
 | `securityContext.capabilities.drop` | Linux capabilities dropped by default | `["ALL"]` |
 | `pdb.enabled` | Create PodDisruptionBudget for HA modes | `false` |
@@ -254,6 +255,8 @@ The `ci/` scenarios validate chart behavior across common configurations:
 - `external-secrets.yaml`
 - `metrics.yaml`
 - `dual-stack.yaml`
+- `tls-replication.yaml`
+- `tls-cluster.yaml`
 
 Local validation should include:
 

--- a/charts/valkey/ci/cluster.yaml
+++ b/charts/valkey/ci/cluster.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: cluster
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+cluster:
+  nodes: 6
+  replicasPerMaster: 1
+  persistence:
+    enabled: true
+    size: 2Gi
+
+pdb:
+  enabled: true

--- a/charts/valkey/ci/dual-stack.yaml
+++ b/charts/valkey/ci/dual-stack.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack IPv6 for Valkey standalone (GR-058)
+architecture: standalone
+
+standalone:
+  persistence:
+    enabled: false
+
+service:
+  type: ClusterIP
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/valkey/ci/existing-secret.yaml
+++ b/charts/valkey/ci/existing-secret.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: replication
+
+auth:
+  enabled: true
+  existingSecret: external-valkey-auth
+  existingSecretPasswordKey: password
+
+replication:
+  replicaCount: 1

--- a/charts/valkey/ci/external-secrets.yaml
+++ b/charts/valkey/ci/external-secrets.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: ExternalSecrets with drift guard (GR-061).
+# auth.existingSecret is required when externalSecrets.enabled=true.
+architecture: standalone
+
+standalone:
+  persistence:
+    enabled: false
+
+auth:
+  enabled: true
+  existingSecret: my-valkey-auth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: my-store
+    kind: ClusterSecretStore
+  data:
+    - secretKey: valkey-password
+      remoteRef:
+        key: valkey/auth
+        property: password

--- a/charts/valkey/ci/metrics.yaml
+++ b/charts/valkey/ci/metrics.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: standalone
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus

--- a/charts/valkey/ci/replication.yaml
+++ b/charts/valkey/ci/replication.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: replication
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+replication:
+  replicaCount: 2
+  primary:
+    persistence:
+      enabled: true
+      size: 2Gi
+  replica:
+    persistence:
+      enabled: true
+      size: 2Gi
+
+pdb:
+  enabled: true
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: valkey

--- a/charts/valkey/ci/sentinel.yaml
+++ b/charts/valkey/ci/sentinel.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: sentinel
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+replication:
+  replicaCount: 2
+
+sentinel:
+  replicaCount: 3
+  quorum: 2
+
+pdb:
+  enabled: true

--- a/charts/valkey/ci/standalone.yaml
+++ b/charts/valkey/ci/standalone.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: standalone
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+standalone:
+  persistence:
+    enabled: true
+    size: 2Gi
+
+pdb:
+  enabled: false

--- a/charts/valkey/ci/tls-cluster.yaml
+++ b/charts/valkey/ci/tls-cluster.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: cluster
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+tls:
+  enabled: true
+  existingSecret: valkey-tls
+
+cluster:
+  nodes: 6
+  replicasPerMaster: 1
+  persistence:
+    enabled: false

--- a/charts/valkey/ci/tls-replication.yaml
+++ b/charts/valkey/ci/tls-replication.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: replication
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+tls:
+  enabled: true
+  existingSecret: valkey-tls
+
+replication:
+  primary:
+    persistence:
+      enabled: false
+  replica:
+    persistence:
+      enabled: false

--- a/charts/valkey/docs/cluster.md
+++ b/charts/valkey/docs/cluster.md
@@ -1,0 +1,110 @@
+# Valkey Cluster
+
+## When to use
+
+Use `cluster` when you need native sharding and the client supports Valkey Cluster.
+
+Common cases:
+
+- horizontally growing datasets
+- need for multiple masters
+- cluster-aware applications
+
+## What this architecture delivers
+
+- multiple Valkey nodes
+- cluster bootstrap through a `Job`
+- replicas per master
+- client service for access to the set of nodes
+
+## What it requires from the client
+
+- support for `MOVED` and `ASK` redirects
+- explicit Valkey Cluster compatibility
+
+## Environment requirements
+
+- node count aligned with `replicasPerMaster`
+- persistence on all nodes
+- stable DNS between pods
+- validated client and library support for Valkey Cluster
+
+## How to think about this topology
+
+`cluster` is a scale and availability choice, not just a redundancy choice. Data is partitioned across masters, and the client must understand redirects and slot mapping.
+
+## Common risks
+
+- using clients that are not Valkey Cluster compatible
+- choosing a node count incompatible with the replica strategy
+- ignoring future rebalance and expansion operations
+- treating cluster as a simple replacement for `sentinel`
+
+## Production best practices
+
+- start with 6 nodes for 3 masters and 3 replicas when the workload justifies it
+- use anti-affinity and zone distribution
+- keep PVCs on every node
+- enable `pdb.enabled=true`
+- monitor bootstrap, slots, failover, and memory usage per node
+- plan operational windows for cluster expansion or maintenance
+
+## Best practices
+
+- use node counts compatible with `replicasPerMaster`
+- validate application clients before adopting this mode
+- use persistent volumes on all nodes
+- enable anti-affinity and `pdb.enabled=true`
+- monitor bootstrap, rebalance, and overall cluster health
+
+## Most relevant values
+
+| Parameter | Description |
+|-----------|-------------|
+| `architecture` | Must be `cluster` |
+| `cluster.nodes` | Total number of nodes |
+| `cluster.replicasPerMaster` | Replicas per master |
+| `cluster.persistence.enabled` | PVC on each node |
+| `cluster.persistence.size` | Volume size per node |
+| `metrics.enabled` | Exporter for monitoring |
+
+## Example
+
+```yaml
+architecture: cluster
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+cluster:
+  nodes: 6
+  replicasPerMaster: 1
+  persistence:
+    enabled: true
+    size: 20Gi
+```
+
+## When not to use
+
+- when the application only needs one primary and read replicas
+- when the client does not understand Valkey Cluster
+- when the data volume still fits comfortably in a single instance
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Valkey - Cluster
+description: Cluster mode
+
+keywords: Valkey, cluster, sharding
+
+purpose: Valkey Cluster mode with sharding guide
+scope: Chart Architecture
+
+relations:
+  - charts/valkey/README.md
+path: charts/valkey/docs/cluster.md
+version: 1.0
+date: 2026-03-20
+-->

--- a/charts/valkey/docs/replication.md
+++ b/charts/valkey/docs/replication.md
@@ -1,0 +1,111 @@
+# Valkey Replication
+
+## When to use
+
+Use `replication` when you need one fixed primary for writes and replicas for reads.
+
+Common cases:
+
+- read-heavy applications
+- workloads that already handle primary unavailability outside the chart
+- environments that want read/write separation without Valkey Cluster
+
+## What this architecture delivers
+
+- one primary
+- multiple replicas
+- separate services for primary and replicas
+- persistence by role
+
+## What it does not deliver
+
+- automatic failover through Sentinel
+- automatic client reconfiguration
+
+## Environment requirements
+
+- separate PVCs for primary and replicas
+- stable networking between pods for replication
+- client strategy that understands where to send writes and where to send reads
+
+## How to think about this topology
+
+`replication` is useful when the application wants read scale but still accepts a stable, known primary.
+It is simpler than `sentinel`, but it pushes more failover responsibility to the application and the operating team.
+
+## Common risks
+
+- assuming replicas alone provide HA
+- sending writes to replicas by mistake
+- not separating CPU, memory, and IOPS sizing between primary and replicas
+- scheduling every pod onto the same node or zone
+
+## Production best practices
+
+- keep at least 2 replicas in critical environments
+- use anti-affinity and `topologySpreadConstraints`
+- enable `pdb.enabled=true`
+- treat the primary service as the write-only endpoint
+- monitor replication lag and pod restarts
+
+## Best practices
+
+- use `auth.existingSecret`
+- keep anti-affinity enabled at the cluster level
+- enable `pdb.enabled=true` in production
+- size storage and resources separately for primary and replicas
+
+## Most relevant values
+
+| Parameter | Description |
+|-----------|-------------|
+| `architecture` | Must be `replication` |
+| `replication.replicaCount` | Number of replicas |
+| `replication.primary.persistence.*` | Persistence for the primary |
+| `replication.replica.persistence.*` | Persistence for replicas |
+| `pdb.enabled` | Protection against planned disruption |
+| `metrics.enabled` | Exporter for monitoring |
+
+## Example
+
+```yaml
+architecture: replication
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+replication:
+  replicaCount: 2
+  primary:
+    persistence:
+      enabled: true
+      size: 50Gi
+  replica:
+    persistence:
+      enabled: true
+      size: 50Gi
+```
+
+## When to move to another mode
+
+- move to `sentinel` when automatic primary promotion becomes a requirement
+- move to `cluster` when the need shifts from read scaling to true shard-based scale
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Valkey - Replication
+description: Primary-replica replication
+
+keywords: Valkey, replication
+
+purpose: Valkey primary-replica replication setup guide
+scope: Chart Architecture
+
+relations:
+  - charts/valkey/README.md
+path: charts/valkey/docs/replication.md
+version: 1.0
+date: 2026-03-20
+-->

--- a/charts/valkey/docs/sentinel.md
+++ b/charts/valkey/docs/sentinel.md
@@ -1,0 +1,110 @@
+# Valkey Sentinel
+
+## When to use
+
+Use `sentinel` when the application or client can query Sentinel to discover the current primary.
+
+Common cases:
+
+- HA with primary discovery
+- Sentinel-compatible clients
+- need for failover without adopting Valkey Cluster
+
+## What this architecture delivers
+
+- primary and replica data topology
+- dedicated Sentinel pods
+- configurable quorum
+- primary discovery through the Sentinel service
+
+## What it requires from the client
+
+- the client must support Valkey Sentinel
+- the application must tolerate primary changes discovered through Sentinel
+
+## Environment requirements
+
+- at least 3 Sentinel instances for consistent quorum
+- enough replicas to fail over without losing service
+- distribution across nodes or zones to reduce correlated failure
+- validated client and library behavior before production rollout
+
+## How to think about this topology
+
+`sentinel` is the right option when you want automatic failover without moving to the Valkey Cluster contract.
+It keeps one active primary at a time and uses Sentinels for election, health observation, and replica promotion.
+
+## Common risks
+
+- choosing a quorum incompatible with the number of Sentinels
+- concentrating Sentinels and replicas on the same node
+- using clients that do not discover the primary correctly
+- treating Sentinel as a substitute for sharding
+
+## Production best practices
+
+- keep 3 Sentinels as the minimum baseline
+- use majority quorum
+- distribute Sentinels, primary, and replicas across failure domains
+- enable `pdb.enabled=true`
+- validate real failover and application reconnect timing
+- monitor primary changes, replication lag, and Sentinel health
+
+## Best practices
+
+- use at least 3 Sentinels
+- keep `quorum` aligned with the number of Sentinels
+- distribute Sentinels and replicas across distinct nodes
+- enable `pdb.enabled=true`
+- validate failover behavior in the real environment
+
+## Most relevant values
+
+| Parameter | Description |
+|-----------|-------------|
+| `architecture` | Must be `sentinel` |
+| `replication.replicaCount` | Number of Valkey replicas |
+| `sentinel.replicaCount` | Number of Sentinel pods |
+| `sentinel.quorum` | Quorum for failover decisions |
+| `pdb.enabled` | Protection against planned disruption |
+| `metrics.enabled` | Exporter for monitoring |
+
+## Example
+
+```yaml
+architecture: sentinel
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+replication:
+  replicaCount: 2
+
+sentinel:
+  replicaCount: 3
+  quorum: 2
+```
+
+## When to move to another mode
+
+- move back to `replication` if the application cannot operate with Sentinel
+- move to `cluster` when the primary need becomes shard-based scale rather than failover
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Valkey - Sentinel
+description: Sentinel HA with failover
+
+keywords: Valkey, sentinel, ha, failover
+
+purpose: Valkey Sentinel HA with automated failover guide
+scope: Chart Architecture
+
+relations:
+  - charts/valkey/README.md
+path: charts/valkey/docs/sentinel.md
+version: 1.0
+date: 2026-03-20
+-->

--- a/charts/valkey/docs/standalone.md
+++ b/charts/valkey/docs/standalone.md
@@ -1,0 +1,102 @@
+# Valkey Standalone
+
+## When to use
+
+Use `standalone` when you need a simple, predictable Valkey deployment with the lowest operational cost.
+
+Common cases:
+
+- development
+- testing
+- local application cache
+- small workloads without failover requirements
+
+## What this architecture delivers
+
+- a single Valkey node
+- optional persistence
+- password authentication
+- optional metrics
+
+## What it does not deliver
+
+- automatic failover
+- high availability
+- horizontal sharding
+
+## Environment requirements
+
+- PVC when data must survive pod recreation
+- a storage class aligned with write behavior
+- memory sized for the dataset and Valkey usage pattern
+
+## Recommended operational flow
+
+1. keep `auth.enabled=true`
+2. use `auth.existingSecret` in production
+3. enable persistence when Valkey stores non-disposable data
+4. enable metrics when the environment is monitored
+
+## Common risks
+
+- treating `standalone` as an HA solution
+- using ephemeral storage for important data
+- under-sizing memory and causing eviction or instability
+- exposing the service outside the cluster without proper controls
+
+## Best practices
+
+- keep `auth.enabled=true`
+- use persistent volumes when data cannot be lost
+- do not expose the service externally without a clear reason
+- enable metrics in monitored environments
+
+## Most relevant values
+
+| Parameter | Description |
+|-----------|-------------|
+| `architecture` | Must remain `standalone` |
+| `auth.enabled` | Enables password auth |
+| `auth.existingSecret` | Uses an existing secret for the password |
+| `standalone.persistence.enabled` | Enables PVC |
+| `standalone.persistence.size` | Volume size |
+| `metrics.enabled` | Enables exporter |
+
+## Example
+
+```yaml
+architecture: standalone
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+standalone:
+  persistence:
+    enabled: true
+    size: 10Gi
+```
+
+## When to move to another mode
+
+- move to `replication` when separating reads from writes becomes necessary
+- move to `sentinel` when automatic primary failover becomes a requirement
+- move to `cluster` when one node no longer fits the capacity or throughput needs
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Valkey - Standalone
+description: Standalone deployment
+
+keywords: Valkey, standalone
+
+purpose: Standalone Valkey deployment guide
+scope: Chart Architecture
+
+relations:
+  - charts/valkey/README.md
+path: charts/valkey/docs/standalone.md
+version: 1.0
+date: 2026-03-20
+-->

--- a/charts/valkey/examples/cluster.yaml
+++ b/charts/valkey/examples/cluster.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: cluster
 
 auth:

--- a/charts/valkey/examples/cluster.yaml
+++ b/charts/valkey/examples/cluster.yaml
@@ -1,0 +1,21 @@
+architecture: cluster
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+cluster:
+  nodes: 6
+  replicasPerMaster: 1
+  persistence:
+    enabled: true
+    size: 20Gi
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+pdb:
+  enabled: true

--- a/charts/valkey/examples/replication-production.yaml
+++ b/charts/valkey/examples/replication-production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: replication
 
 auth:

--- a/charts/valkey/examples/replication-production.yaml
+++ b/charts/valkey/examples/replication-production.yaml
@@ -1,0 +1,49 @@
+architecture: replication
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+replication:
+  replicaCount: 2
+  primary:
+    persistence:
+      enabled: true
+      size: 50Gi
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 4Gi
+  replica:
+    persistence:
+      enabled: true
+      size: 50Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 1Gi
+      limits:
+        cpu: "2"
+        memory: 4Gi
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+
+pdb:
+  enabled: true
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: valkey

--- a/charts/valkey/examples/standalone-simple.yaml
+++ b/charts/valkey/examples/standalone-simple.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: standalone
 
 auth:

--- a/charts/valkey/examples/standalone-simple.yaml
+++ b/charts/valkey/examples/standalone-simple.yaml
@@ -1,0 +1,11 @@
+architecture: standalone
+
+auth:
+  enabled: true
+  existingSecret: valkey-auth
+  existingSecretPasswordKey: valkey-password
+
+standalone:
+  persistence:
+    enabled: true
+    size: 10Gi

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -1,0 +1,190 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+Valkey has been installed.
+
+1. Installation summary
+=======================
+
+- Release: {{ .Release.Name }}
+- Namespace: {{ .Release.Namespace }}
+- Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+- App version: {{ .Chart.AppVersion }}
+- Architecture: {{ .Values.architecture }}
+- Image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+- Cluster domain: {{ include "valkey.clusterDomain" . }}
+- ServiceAccount: {{ include "valkey.serviceAccountName" . }}
+- Authentication enabled: {{ .Values.auth.enabled }}
+- Metrics enabled: {{ .Values.metrics.enabled }}
+- ServiceMonitor enabled: {{ and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+- PodDisruptionBudget enabled: {{ .Values.pdb.enabled }}
+- External Secrets enabled: {{ .Values.externalSecrets.enabled }}
+
+2. Access
+=========
+
+Headless service:
+- Name: {{ include "valkey.headlessServiceName" . }}
+- DNS: {{ include "valkey.headlessServiceFqdn" . }}
+- Port: {{ .Values.service.ports.valkey }}
+
+{{- if include "valkey.isStandalone" . }}
+Standalone client service:
+- Name: {{ include "valkey.clientServiceName" . }}
+- Type: {{ .Values.service.type }}
+- DNS: {{ include "valkey.clientServiceFqdn" . }}
+- Port: {{ .Values.service.ports.valkey }}
+{{- end }}
+
+{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+Primary service:
+- Name: {{ include "valkey.primaryServiceName" . }}
+- DNS: {{ include "valkey.primaryServiceFqdn" . }}
+- Port: {{ .Values.service.ports.valkey }}
+
+Replica service:
+- Name: {{ include "valkey.replicaServiceName" . }}
+- DNS: {{ include "valkey.replicaServiceFqdn" . }}
+- Port: {{ .Values.service.ports.valkey }}
+{{- end }}
+
+{{- if include "valkey.isSentinel" . }}
+Sentinel service:
+- Name: {{ include "valkey.sentinelServiceName" . }}
+- DNS: {{ include "valkey.sentinelServiceFqdn" . }}
+- Port: {{ .Values.service.ports.sentinel }}
+- Monitored primary: {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}
+{{- end }}
+
+{{- if include "valkey.isCluster" . }}
+Valkey Cluster client service:
+- Name: {{ include "valkey.clientServiceName" . }}
+- Type: ClusterIP
+- DNS: {{ include "valkey.clientServiceFqdn" . }}
+- Port: {{ .Values.service.ports.valkey }}
+- Nodes: {{ .Values.cluster.nodes }}
+- Replicas per master: {{ .Values.cluster.replicasPerMaster }}
+{{- end }}
+
+{{- if .Values.service.ipFamilyPolicy }}
+Service IP family policy: {{ .Values.service.ipFamilyPolicy }}
+{{- end }}
+{{- if .Values.service.ipFamilies }}
+Service IP families: {{ join ", " .Values.service.ipFamilies }}
+{{- end }}
+
+3. Credentials
+==============
+
+{{- if .Values.auth.enabled }}
+Valkey password:
+
+  kubectl get secret {{ include "valkey.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretPasswordKey }}}" | base64 -d
+
+Secret name: {{ include "valkey.secretName" . }}
+Secret key: {{ .Values.auth.existingSecretPasswordKey }}
+{{- else }}
+Authentication is disabled.
+{{- end }}
+
+{{- if .Values.externalSecrets.enabled }}
+ExternalSecret:
+- SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+- Target Secret: {{ include "valkey.secretName" . }}
+- Refresh interval: {{ .Values.externalSecrets.refreshInterval }}
+{{- end }}
+
+4. Getting started
+==================
+
+Wait for Valkey pods:
+
+  kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "valkey.name" . }} --timeout=10m
+
+Check release resources:
+
+  kubectl get sts,svc,secret,cm,pdb -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+{{- if include "valkey.isStandalone" . }}
+Check standalone connectivity:
+
+  kubectl run {{ include "valkey.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.image.repository }}:{{ .Values.image.tag }} -- valkey-cli -h {{ include "valkey.clientServiceName" . }} -p {{ .Values.service.ports.valkey }}{{ if .Values.auth.enabled }} -a "$(kubectl get secret {{ include "valkey.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.auth.existingSecretPasswordKey }}}' | base64 -d)"{{ end }} ping
+{{- end }}
+
+{{- if include "valkey.isReplication" . }}
+Use the primary service for writes and the replica service for read-only workloads:
+
+  {{ include "valkey.primaryServiceFqdn" . }}:{{ .Values.service.ports.valkey }}
+  {{ include "valkey.replicaServiceFqdn" . }}:{{ .Values.service.ports.valkey }}
+{{- end }}
+
+{{- if include "valkey.isSentinel" . }}
+Use the Sentinel service for Sentinel-aware clients:
+
+  {{ include "valkey.sentinelServiceFqdn" . }}:{{ .Values.service.ports.sentinel }}
+
+Verify Sentinel can see the primary:
+
+  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "valkey.sentinelStatefulSetName" . }} -- valkey-cli -p {{ .Values.service.ports.sentinel }} SENTINEL masters
+{{- end }}
+
+{{- if include "valkey.isCluster" . }}
+Use a Valkey Cluster-compatible client and connect through:
+
+  {{ include "valkey.clientServiceFqdn" . }}:{{ .Values.service.ports.valkey }}
+
+Check cluster state:
+
+  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "valkey.clusterStatefulSetName" . }} -- valkey-cli{{ if .Values.auth.enabled }} -a "$(kubectl get secret {{ include "valkey.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.auth.existingSecretPasswordKey }}}' | base64 -d)"{{ end }} cluster info
+{{- end }}
+
+5. Configuration summary
+========================
+
+Persistence:
+- Standalone persistence: {{ .Values.standalone.persistence.enabled }}
+- Primary persistence: {{ .Values.replication.primary.persistence.enabled }}
+- Replica persistence: {{ .Values.replication.replica.persistence.enabled }}
+- Sentinel persistence: {{ .Values.sentinel.persistence.enabled }}
+- Cluster persistence: {{ .Values.cluster.persistence.enabled }}
+
+Networking:
+- Service type: {{ .Values.service.type }}
+- Valkey port: {{ .Values.service.ports.valkey }}
+- Sentinel port: {{ .Values.service.ports.sentinel }}
+- Metrics port: {{ .Values.service.ports.metrics }}
+
+Scheduling:
+- PriorityClass: {{ default "(not configured)" .Values.priorityClassName }}
+- Termination grace period: {{ .Values.terminationGracePeriodSeconds }}s
+
+6. Troubleshooting
+==================
+
+Inspect pods and events:
+
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+  kubectl describe pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+Inspect logs:
+
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200
+
+Common checks:
+
+- If replicas cannot connect, verify headless Service DNS and `clusterDomain`.
+- If Sentinel does not start, verify the primary pod FQDN and auth Secret.
+- If Valkey Cluster bootstrap is stuck, inspect the cluster init Job logs.
+- If clients cannot authenticate, verify Secret name, key, and password content.
+- If dual-stack fields are rejected, verify the Kubernetes version and cluster network configuration.
+- If metrics are missing, verify `metrics.enabled`, Service ports, and ServiceMonitor labels.
+
+7. Resources
+============
+
+- HelmForge chart docs: https://helmforge.dev/docs/charts/valkey
+- Valkey docs: https://valkey.io/docs/latest/
+- Valkey Sentinel: https://valkey.io/docs/latest/operate/oss_and_stack/management/sentinel/
+- Valkey Cluster: https://valkey.io/docs/latest/operate/oss_and_stack/management/scaling/
+- HelmForge chart issues: https://github.com/helmforgedev/charts/issues
+
+Happy Helmforging :)

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -249,6 +249,9 @@ Common valkey.conf baseline.
 {{- define "valkey.commonConfig" -}}
 bind 0.0.0.0
 protected-mode no
+{{- if not .Values.tls.enabled }}
+port {{ .Values.service.ports.valkey }}
+{{- end }}
 dir /data
 appendonly yes
 save 900 1
@@ -273,7 +276,11 @@ Exporter environment.
 */}}
 {{- define "valkey.exporterEnv" -}}
 - name: REDIS_ADDR
-  value: redis://127.0.0.1:{{ .Values.service.ports.valkey }}
+  value: {{ ternary "rediss" "redis" .Values.tls.enabled }}://127.0.0.1:{{ .Values.service.ports.valkey }}
+{{- if .Values.tls.enabled }}
+- name: REDIS_EXPORTER_TLS_CA_CERT_FILE
+  value: /tls/{{ .Values.tls.caFilename }}
+{{- end }}
 {{- if .Values.auth.enabled }}
 - name: REDIS_USER
   value: default
@@ -282,6 +289,15 @@ Exporter environment.
     secretKeyRef:
       name: {{ include "valkey.secretName" . }}
       key: {{ .Values.auth.existingSecretPasswordKey }}
+{{- end }}
+{{- end -}}
+
+{{- define "valkey.metricsVolumeMounts" -}}
+{{- if .Values.tls.enabled }}
+volumeMounts:
+  - name: tls
+    mountPath: /tls
+    readOnly: true
 {{- end }}
 {{- end -}}
 

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -265,9 +265,9 @@ Probe command.
 */}}
 {{- define "valkey.probeCommand" -}}
 {{- if .Values.auth.enabled -}}
-valkey-cli {{ include "valkey.cliTlsArgs" . }} -a "$VALKEY_PASSWORD" --no-auth-warning ping
+valkey-cli {{ include "valkey.cliTlsArgs" . }} -p {{ .Values.service.ports.valkey }} -a "$VALKEY_PASSWORD" --no-auth-warning ping
 {{- else -}}
-valkey-cli {{ include "valkey.cliTlsArgs" . }} ping
+valkey-cli {{ include "valkey.cliTlsArgs" . }} -p {{ .Values.service.ports.valkey }} ping
 {{- end -}}
 {{- end -}}
 

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -280,6 +280,10 @@ Exporter environment.
 {{- if .Values.tls.enabled }}
 - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
   value: /tls/{{ .Values.tls.caFilename }}
+{{- if .Values.metrics.tlsSkipVerify }}
+- name: REDIS_EXPORTER_SKIP_TLS_VERIFICATION
+  value: "true"
+{{- end }}
 {{- end }}
 {{- if .Values.auth.enabled }}
 - name: REDIS_USER

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -1,0 +1,328 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "valkey.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "valkey.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "valkey.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "valkey.labels" -}}
+helm.sh/chart: {{ include "valkey.chart" . }}
+{{ include "valkey.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "valkey.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "valkey.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "valkey.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "valkey.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Architecture checks.
+*/}}
+{{- define "valkey.isStandalone" -}}
+{{- if eq .Values.architecture "standalone" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "valkey.isReplication" -}}
+{{- if eq .Values.architecture "replication" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "valkey.isSentinel" -}}
+{{- if eq .Values.architecture "sentinel" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "valkey.isCluster" -}}
+{{- if eq .Values.architecture "cluster" -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Common names.
+*/}}
+{{- define "valkey.secretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "valkey.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "valkey.headlessServiceName" -}}
+{{- printf "%s-headless" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.clientServiceName" -}}
+{{- printf "%s-client" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.primaryServiceName" -}}
+{{- printf "%s-primary" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.replicaServiceName" -}}
+{{- printf "%s-replicas" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.sentinelServiceName" -}}
+{{- printf "%s-sentinel" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.metricsServiceName" -}}
+{{- printf "%s-metrics" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.primaryStatefulSetName" -}}
+{{- printf "%s-primary" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.replicaStatefulSetName" -}}
+{{- printf "%s-replica" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.sentinelStatefulSetName" -}}
+{{- printf "%s-sentinel" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.clusterStatefulSetName" -}}
+{{- printf "%s-cluster" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.configMapName" -}}
+{{- printf "%s-config" (include "valkey.fullname" .) -}}
+{{- end -}}
+
+{{- define "valkey.clusterDomain" -}}
+{{- default "cluster.local" .Values.clusterDomain -}}
+{{- end -}}
+
+{{- define "valkey.serviceFqdn" -}}
+{{- printf "%s.%s.svc.%s" .name .root.Release.Namespace (include "valkey.clusterDomain" .root) -}}
+{{- end -}}
+
+{{- define "valkey.headlessServiceFqdn" -}}
+{{- include "valkey.serviceFqdn" (dict "root" . "name" (include "valkey.headlessServiceName" .)) -}}
+{{- end -}}
+
+{{- define "valkey.fullnameFqdn" -}}
+{{- include "valkey.serviceFqdn" (dict "root" . "name" (include "valkey.fullname" .)) -}}
+{{- end -}}
+
+{{- define "valkey.clientServiceFqdn" -}}
+{{- include "valkey.serviceFqdn" (dict "root" . "name" (include "valkey.clientServiceName" .)) -}}
+{{- end -}}
+
+{{- define "valkey.primaryServiceFqdn" -}}
+{{- include "valkey.serviceFqdn" (dict "root" . "name" (include "valkey.primaryServiceName" .)) -}}
+{{- end -}}
+
+{{- define "valkey.replicaServiceFqdn" -}}
+{{- include "valkey.serviceFqdn" (dict "root" . "name" (include "valkey.replicaServiceName" .)) -}}
+{{- end -}}
+
+{{- define "valkey.sentinelServiceFqdn" -}}
+{{- include "valkey.serviceFqdn" (dict "root" . "name" (include "valkey.sentinelServiceName" .)) -}}
+{{- end -}}
+
+{{- define "valkey.primaryPodFqdn" -}}
+{{- printf "%s-0.%s" (include "valkey.primaryStatefulSetName" .) (include "valkey.headlessServiceFqdn" .) -}}
+{{- end -}}
+
+{{- define "valkey.clusterPodFqdn" -}}
+{{- printf "%s.%s" .podName (include "valkey.headlessServiceFqdn" .root) -}}
+{{- end -}}
+
+{{/*
+Secret value helpers.
+*/}}
+{{- define "valkey.password" -}}
+{{- if .Values.auth.password -}}
+{{- .Values.auth.password -}}
+{{- else if .Values.auth.existingSecret -}}
+{{- "" -}}
+{{- else -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "valkey.secretName" .) -}}
+{{- if and $secret $secret.data (hasKey $secret.data .Values.auth.existingSecretPasswordKey) -}}
+{{- index $secret.data .Values.auth.existingSecretPasswordKey | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Port helper for Valkey when TLS is enabled.
+*/}}
+{{- define "valkey.serverArgs" -}}
+- /etc/valkey/valkey.conf
+{{- if .Values.auth.enabled }}
+- --requirepass
+- $(VALKEY_PASSWORD)
+{{- end }}
+{{- end -}}
+
+{{/*
+TLS block for valkey.conf.
+*/}}
+{{- define "valkey.tlsConfig" -}}
+{{- if .Values.tls.enabled }}
+port 0
+tls-port {{ .Values.service.ports.valkey }}
+tls-cert-file /tls/{{ .Values.tls.certFilename }}
+tls-key-file /tls/{{ .Values.tls.keyFilename }}
+tls-ca-cert-file /tls/{{ .Values.tls.caFilename }}
+tls-auth-clients no
+{{- end }}
+{{- end -}}
+
+{{/*
+Common valkey.conf baseline.
+*/}}
+{{- define "valkey.commonConfig" -}}
+bind 0.0.0.0
+protected-mode no
+dir /data
+appendonly yes
+save 900 1
+save 300 10
+save 60 10000
+{{ include "valkey.tlsConfig" . }}
+{{- end -}}
+
+{{/*
+Probe command.
+*/}}
+{{- define "valkey.probeCommand" -}}
+{{- if .Values.auth.enabled -}}
+valkey-cli -a "$VALKEY_PASSWORD" ping
+{{- else -}}
+valkey-cli ping
+{{- end -}}
+{{- end -}}
+
+{{/*
+Exporter environment.
+*/}}
+{{- define "valkey.exporterEnv" -}}
+- name: REDIS_ADDR
+  value: redis://127.0.0.1:{{ .Values.service.ports.valkey }}
+{{- if .Values.auth.enabled }}
+- name: REDIS_USER
+  value: default
+- name: REDIS_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "valkey.secretName" . }}
+      key: {{ .Values.auth.existingSecretPasswordKey }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pod labels with component and role.
+*/}}
+{{- define "valkey.componentLabels" -}}
+{{ include "valkey.selectorLabels" .root }}
+app.kubernetes.io/component: valkey
+app.kubernetes.io/part-of: valkey
+{{- if .role }}
+app.kubernetes.io/role: {{ .role }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Volume claim template.
+*/}}
+{{- define "valkey.volumeClaimTemplate" -}}
+- metadata:
+    name: data
+    labels:
+      {{- include "valkey.selectorLabels" .root | nindent 6 }}
+  spec:
+    accessModes:
+      {{- toYaml .persistence.accessModes | nindent 6 }}
+    {{- if .persistence.storageClass }}
+    storageClassName: {{ .persistence.storageClass | quote }}
+    {{- end }}
+    resources:
+      requests:
+        storage: {{ .persistence.size }}
+{{- end -}}
+
+{{/*
+Common pod spec fragments.
+*/}}
+{{- define "valkey.podSpecCommon" -}}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+{{- with .Values.priorityClassName }}
+priorityClassName: {{ . }}
+{{- end }}
+{{- with .Values.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -234,6 +234,20 @@ Secret value helpers.
 {{- end -}}
 
 {{/*
+Authentication checksum for pod rollouts.
+*/}}
+{{- define "valkey.authChecksum" -}}
+{{- $existingSecretData := "" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.auth.existingSecret -}}
+{{- if and $secret $secret.data (hasKey $secret.data .Values.auth.existingSecretPasswordKey) -}}
+{{- $existingSecretData = index $secret.data .Values.auth.existingSecretPasswordKey -}}
+{{- end -}}
+{{- end -}}
+{{- dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "existingSecretData" $existingSecretData "externalSecrets" .Values.externalSecrets | toJson | sha256sum -}}
+{{- end -}}
+
+{{/*
 Port helper for Valkey when TLS is enabled.
 */}}
 {{- define "valkey.serverArgs" -}}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -220,6 +220,30 @@ tls-auth-clients no
 {{- end -}}
 
 {{/*
+TLS block for sentinel.conf.
+*/}}
+{{- define "valkey.sentinelTlsConfig" -}}
+{{- if .Values.tls.enabled }}
+port 0
+tls-port {{ .Values.service.ports.sentinel }}
+tls-cert-file /tls/{{ .Values.tls.certFilename }}
+tls-key-file /tls/{{ .Values.tls.keyFilename }}
+tls-ca-cert-file /tls/{{ .Values.tls.caFilename }}
+tls-auth-clients no
+tls-replication yes
+{{- end }}
+{{- end -}}
+
+{{/*
+valkey-cli TLS flags.
+*/}}
+{{- define "valkey.cliTlsArgs" -}}
+{{- if .Values.tls.enabled -}}
+--tls --cacert /tls/{{ .Values.tls.caFilename }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common valkey.conf baseline.
 */}}
 {{- define "valkey.commonConfig" -}}
@@ -238,9 +262,9 @@ Probe command.
 */}}
 {{- define "valkey.probeCommand" -}}
 {{- if .Values.auth.enabled -}}
-valkey-cli -a "$VALKEY_PASSWORD" ping
+valkey-cli {{ include "valkey.cliTlsArgs" . }} -a "$VALKEY_PASSWORD" --no-auth-warning ping
 {{- else -}}
-valkey-cli ping
+valkey-cli {{ include "valkey.cliTlsArgs" . }} ping
 {{- end -}}
 {{- end -}}
 
@@ -301,6 +325,7 @@ imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -44,6 +44,27 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{/*
+Merge global annotations with resource-specific annotations.
+Resource-specific annotations win when keys overlap.
+*/}}
+{{- define "valkey.annotations" -}}
+{{- $global := default dict .root.Values.annotations -}}
+{{- $local := default dict .annotations -}}
+{{- $annotations := mergeOverwrite (deepCopy $global) $local -}}
+{{- with $annotations -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "valkey.renderAnnotations" -}}
+{{- $annotations := include "valkey.annotations" . -}}
+{{- if $annotations }}
+annotations:
+{{ $annotations | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Selector labels.
 */}}
 {{- define "valkey.selectorLabels" -}}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -282,6 +282,12 @@ valkey-cli TLS flags.
 {{- end -}}
 {{- end -}}
 
+{{- define "valkey.probeTlsArgs" -}}
+{{- if .Values.tls.enabled -}}
+--tls --cacert /tls/{{ .Values.tls.caFilename }} --insecure
+{{- end -}}
+{{- end -}}
+
 {{/*
 Common valkey.conf baseline.
 */}}
@@ -304,9 +310,9 @@ Probe command.
 */}}
 {{- define "valkey.probeCommand" -}}
 {{- if .Values.auth.enabled -}}
-valkey-cli {{ include "valkey.cliTlsArgs" . }} -p {{ .Values.service.ports.valkey }} -a "$VALKEY_PASSWORD" --no-auth-warning ping
+valkey-cli {{ include "valkey.probeTlsArgs" . }} -p {{ .Values.service.ports.valkey }} -a "$VALKEY_PASSWORD" --no-auth-warning ping
 {{- else -}}
-valkey-cli {{ include "valkey.cliTlsArgs" . }} -p {{ .Values.service.ports.valkey }} ping
+valkey-cli {{ include "valkey.probeTlsArgs" . }} -p {{ .Values.service.ports.valkey }} ping
 {{- end -}}
 {{- end -}}
 

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -64,6 +64,24 @@ annotations:
 {{- end -}}
 {{- end -}}
 
+{{- define "valkey.serviceAnnotations" -}}
+{{- $global := default dict .root.Values.annotations -}}
+{{- $service := default dict .root.Values.service.annotations -}}
+{{- $local := default dict .annotations -}}
+{{- $annotations := mergeOverwrite (deepCopy $global) $service $local -}}
+{{- with $annotations -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "valkey.renderServiceAnnotations" -}}
+{{- $annotations := include "valkey.serviceAnnotations" . -}}
+{{- if $annotations }}
+annotations:
+{{ $annotations | nindent 2 }}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Selector labels.
 */}}

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -19,6 +19,10 @@ spec:
         app.kubernetes.io/component: valkey-cluster-init
     spec:
       restartPolicy: OnFailure
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and (include "valkey.isCluster" .) .Values.cluster.initJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "valkey.fullname" . }}-cluster-init
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.cluster.initJob.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.cluster.initJob.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: valkey-cluster-init
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      containers:
+        - name: valkey-cli
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
+                until valkey-cli -h "{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }} ping; do
+                  echo "waiting for node $i"
+                  sleep 5
+                done
+              done
+              if valkey-cli -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }} cluster info | grep -q cluster_state:ok; then
+                echo "cluster already initialized"
+                exit 0
+              fi
+              yes yes | valkey-cli --cluster create \
+              {{- range $i, $_ := until (.Values.cluster.nodes | int) }}
+                {{ include "valkey.clusterStatefulSetName" $ }}-{{ $i }}.{{ include "valkey.headlessServiceFqdn" $ }}:{{ $.Values.service.ports.valkey }} \
+              {{- end }}
+              --cluster-replicas {{ .Values.cluster.replicasPerMaster }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+          env:
+            {{- if .Values.auth.enabled }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+{{- end }}

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -6,9 +6,7 @@ metadata:
   name: {{ include "valkey.fullname" . }}-cluster-init
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" (dict "helm.sh/hook" "post-install,post-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 2 }}
 spec:
   backoffLimit: {{ .Values.cluster.initJob.backoffLimit }}
   activeDeadlineSeconds: {{ .Values.cluster.initJob.activeDeadlineSeconds }}

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -29,12 +29,12 @@ spec:
           args:
             - |
               for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
-                until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping; do
+                until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping; do
                   echo "waiting for node $i"
                   sleep 5
                 done
               done
-              if valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster info | grep -q cluster_state:ok; then
+              if valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster info | grep -q cluster_state:ok; then
                 echo "cluster already initialized"
                 exit 0
               fi

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -93,7 +93,7 @@ spec:
                   done
                   [ "$missing_nodes" -eq 0 ] || { echo "cluster membership did not converge before rebalance"; exit 1; }
                 fi
-                valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster rebalance "$existing" --cluster-use-empty-primaries --cluster-threshold 1 --cluster-yes {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster rebalance "$existing" --cluster-use-empty-masters --cluster-threshold 1 --cluster-yes {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
                 echo "cluster already initialized"
                 exit 0
               fi

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -41,11 +41,21 @@ spec:
               if valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster info | grep -q cluster_state:ok; then
                 existing="{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}:{{ .Values.service.ports.valkey }}"
                 cluster_nodes="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster nodes)"
+                replicas_per_master={{ .Values.cluster.replicasPerMaster }}
+                desired_masters=$(({{ .Values.cluster.nodes }} / (replicas_per_master + 1)))
+                [ "$desired_masters" -lt 1 ] && desired_masters=1
+                existing_masters="$(printf '%s\n' "$cluster_nodes" | awk '$3 ~ /master/ && $3 !~ /fail/ {count++} END {print count+0}')"
                 for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
                   node="{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}:{{ .Values.service.ports.valkey }}"
                   if ! printf '%s\n' "$cluster_nodes" | grep -Fq "$node"; then
-                    echo "adding missing cluster node $node"
-                    yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                    if [ "$existing_masters" -lt "$desired_masters" ]; then
+                      echo "adding missing cluster master $node"
+                      yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                      existing_masters=$((existing_masters + 1))
+                    else
+                      echo "adding missing cluster replica $node"
+                      yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" --cluster-replica {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                    fi
                   fi
                 done
                 yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster rebalance "$existing" --cluster-use-empty-masters {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -44,6 +44,7 @@ spec:
                     yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
                   fi
                 done
+                yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster rebalance "$existing" --cluster-use-empty-masters {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
                 echo "cluster already initialized"
                 exit 0
               fi

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -20,6 +20,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       containers:
         - name: valkey-cli
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -28,16 +29,16 @@ spec:
           args:
             - |
               for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
-                until valkey-cli -h "{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }} ping; do
+                until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping; do
                   echo "waiting for node $i"
                   sleep 5
                 done
               done
-              if valkey-cli -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }} cluster info | grep -q cluster_state:ok; then
+              if valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster info | grep -q cluster_state:ok; then
                 echo "cluster already initialized"
                 exit 0
               fi
-              yes yes | valkey-cli --cluster create \
+              yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster create \
               {{- range $i, $_ := until (.Values.cluster.nodes | int) }}
                 {{ include "valkey.clusterStatefulSetName" $ }}-{{ $i }}.{{ include "valkey.headlessServiceFqdn" $ }}:{{ $.Values.service.ports.valkey }} \
               {{- end }}
@@ -50,4 +51,16 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
             {{- end }}
+          {{- if .Values.tls.enabled }}
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+          {{- end }}
+      {{- if .Values.tls.enabled }}
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
+      {{- end }}
 {{- end }}

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -35,6 +35,15 @@ spec:
                 done
               done
               if valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster info | grep -q cluster_state:ok; then
+                existing="{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}:{{ .Values.service.ports.valkey }}"
+                cluster_nodes="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster nodes)"
+                for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
+                  node="{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}:{{ .Values.service.ports.valkey }}"
+                  if ! printf '%s\n' "$cluster_nodes" | grep -Fq "$node"; then
+                    echo "adding missing cluster node $node"
+                    yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                  fi
+                done
                 echo "cluster already initialized"
                 exit 0
               fi

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -38,25 +38,62 @@ spec:
               done
               if valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster info | grep -q cluster_state:ok; then
                 existing="{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}:{{ .Values.service.ports.valkey }}"
-                cluster_nodes="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster nodes)"
+                refresh_cluster_nodes() {
+                  cluster_nodes="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "{{ include "valkey.clusterStatefulSetName" . }}-0.{{ include "valkey.headlessServiceFqdn" . }}" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} cluster nodes)"
+                }
+                refresh_cluster_nodes
+                node_address_exists() {
+                  node_host="$1"
+                  node_endpoint="${node_host}:{{ .Values.service.ports.valkey }}"
+                  printf '%s\n' "$cluster_nodes" | awk -v host="$node_host" -v endpoint="$node_endpoint" '
+                    {
+                      split($2, announced, ",")
+                      split(announced[1], bus, "@")
+                      if (bus[1] == endpoint || announced[2] == host || announced[2] == endpoint) {
+                        found = 1
+                      }
+                    }
+                    END { exit found ? 0 : 1 }
+                  '
+                }
                 replicas_per_master={{ .Values.cluster.replicasPerMaster }}
                 desired_masters=$(({{ .Values.cluster.nodes }} / (replicas_per_master + 1)))
                 [ "$desired_masters" -lt 1 ] && desired_masters=1
                 existing_masters="$(printf '%s\n' "$cluster_nodes" | awk '$3 ~ /master/ && $3 !~ /fail/ {count++} END {print count+0}')"
+                added_nodes=0
                 for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
-                  node="{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}:{{ .Values.service.ports.valkey }}"
-                  if ! printf '%s\n' "$cluster_nodes" | grep -Fq "$node"; then
+                  node_host="{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}"
+                  node="${node_host}:{{ .Values.service.ports.valkey }}"
+                  if ! node_address_exists "$node_host"; then
                     if [ "$existing_masters" -lt "$desired_masters" ]; then
                       echo "adding missing cluster master $node"
                       yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
                       existing_masters=$((existing_masters + 1))
+                      added_nodes=$((added_nodes + 1))
                     else
                       echo "adding missing cluster replica $node"
                       yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster add-node "$node" "$existing" --cluster-replica {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                      added_nodes=$((added_nodes + 1))
                     fi
                   fi
                 done
-                yes yes | valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster rebalance "$existing" --cluster-use-empty-masters {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
+                if [ "$added_nodes" -gt 0 ]; then
+                  for attempt in $(seq 1 30); do
+                    refresh_cluster_nodes
+                    missing_nodes=0
+                    for i in $(seq 0 $(({{ .Values.cluster.nodes }} - 1))); do
+                      node_host="{{ include "valkey.clusterStatefulSetName" . }}-${i}.{{ include "valkey.headlessServiceFqdn" . }}"
+                      if ! node_address_exists "$node_host"; then
+                        missing_nodes=$((missing_nodes + 1))
+                      fi
+                    done
+                    [ "$missing_nodes" -eq 0 ] && break
+                    echo "waiting for new cluster nodes to be visible before rebalance ($attempt/30)"
+                    sleep 2
+                  done
+                  [ "$missing_nodes" -eq 0 ] || { echo "cluster membership did not converge before rebalance"; exit 1; }
+                fi
+                valkey-cli {{ include "valkey.cliTlsArgs" . }} --cluster rebalance "$existing" --cluster-use-empty-primaries --cluster-threshold 1 --cluster-yes {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" {{- end }}
                 echo "cluster already initialized"
                 exit 0
               fi

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -59,6 +59,9 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             exec:
               command:
@@ -97,6 +100,9 @@ spec:
               mountPath: /tls
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -120,6 +126,9 @@ spec:
         - name: tls
           secret:
             secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
   {{- if .Values.cluster.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -22,6 +22,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.clusterStatefulSetName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   serviceName: {{ include "valkey.headlessServiceName" . }}
   replicas: {{ .Values.cluster.nodes }}

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -91,6 +91,11 @@ spec:
               subPath: valkey-cluster.conf
             - name: data
               mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -108,6 +113,11 @@ spec:
         {{- if not .Values.cluster.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
         {{- end }}
   {{- if .Values.cluster.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -105,6 +105,7 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -20,10 +20,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- include "valkey.podSpecCommon" . | nindent 6 }}
       containers:

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -24,7 +24,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.auth.enabled }}
-        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        checksum/auth-secret: {{ include "valkey.authChecksum" . }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -1,0 +1,116 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if include "valkey.isCluster" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.clusterStatefulSetName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "valkey.headlessServiceName" . }}
+  replicas: {{ .Values.cluster.nodes }}
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      {{- include "valkey.componentLabels" (dict "root" . "role" "cluster") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.componentLabels" (dict "root" . "role" "cluster") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      containers:
+        - name: valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["valkey-server"]
+          args:
+            - /etc/valkey/valkey.conf
+            {{- if .Values.auth.enabled }}
+            - --requirepass
+            - $(VALKEY_PASSWORD)
+            - --masterauth
+            - $(VALKEY_PASSWORD)
+            {{- end }}
+            - --cluster-announce-hostname
+            - $(POD_NAME).{{ include "valkey.headlessServiceFqdn" . }}
+          ports:
+            - name: valkey
+              containerPort: {{ .Values.service.ports.valkey }}
+            - name: bus
+              containerPort: 16379
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.auth.enabled }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.cluster.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey/valkey.conf
+              subPath: valkey-cluster.conf
+            - name: data
+              mountPath: /data
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          env:
+            {{- include "valkey.exporterEnv" . | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "valkey.configMapName" . }}
+        {{- if not .Values.cluster.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.cluster.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.cluster.persistence) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -116,6 +116,10 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
           {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -1,0 +1,44 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "valkey.configMapName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+data:
+  valkey-standalone.conf: |
+    {{- include "valkey.commonConfig" . | nindent 4 }}
+    {{- with .Values.config.valkey }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  valkey-primary.conf: |
+    {{- include "valkey.commonConfig" . | nindent 4 }}
+    {{- with .Values.config.valkey }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  valkey-replica.conf: |
+    {{- include "valkey.commonConfig" . | nindent 4 }}
+    replica-read-only yes
+    {{- with .Values.config.valkey }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  valkey-cluster.conf: |
+    {{- include "valkey.commonConfig" . | nindent 4 }}
+    cluster-enabled yes
+    cluster-config-file nodes.conf
+    cluster-node-timeout 5000
+    appendonly yes
+    {{- with .Values.config.valkey }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  sentinel.conf: |
+    port {{ .Values.service.ports.sentinel }}
+    dir /tmp
+    sentinel resolve-hostnames yes
+    sentinel monitor mymaster {{ include "valkey.primaryPodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}
+    sentinel down-after-milliseconds mymaster {{ .Values.sentinel.downAfterMilliseconds }}
+    sentinel failover-timeout mymaster {{ .Values.sentinel.failoverTimeout }}
+    sentinel parallel-syncs mymaster {{ .Values.sentinel.parallelSyncs }}
+    {{- with .Values.config.sentinel }}
+    {{ . | nindent 4 }}
+    {{- end }}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
     {{- end }}
   valkey-primary.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}
+    {{- if .Values.tls.enabled }}
+    tls-replication yes
+    {{- end }}
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
     {{- end }}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -46,6 +46,7 @@ data:
     {{ . | nindent 4 }}
     {{- end }}
   sentinel.conf: |
+    # HelmForge managed sentinel config begin
     {{- if .Values.tls.enabled }}
     {{- include "valkey.sentinelTlsConfig" . | nindent 4 }}
     {{- else }}
@@ -60,3 +61,4 @@ data:
     {{- with .Values.config.sentinel }}
     {{ . | nindent 4 }}
     {{- end }}
+    # HelmForge managed sentinel config end

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "valkey.configMapName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 data:
   valkey-standalone.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -1,4 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
+{{- fail "tls.enabled requires tls.existingSecret" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -18,6 +18,9 @@ data:
     {{- end }}
   valkey-replica.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}
+    {{- if .Values.tls.enabled }}
+    tls-replication yes
+    {{- end }}
     replica-read-only yes
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
@@ -27,12 +30,20 @@ data:
     cluster-enabled yes
     cluster-config-file nodes.conf
     cluster-node-timeout 5000
+    {{- if .Values.tls.enabled }}
+    tls-cluster yes
+    tls-replication yes
+    {{- end }}
     appendonly yes
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
     {{- end }}
   sentinel.conf: |
+    {{- if .Values.tls.enabled }}
+    {{- include "valkey.sentinelTlsConfig" . | nindent 4 }}
+    {{- else }}
     port {{ .Values.service.ports.sentinel }}
+    {{- end }}
     dir /tmp
     sentinel resolve-hostnames yes
     sentinel monitor mymaster {{ include "valkey.primaryPodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}

--- a/charts/valkey/templates/externalsecret.yaml
+++ b/charts/valkey/templates/externalsecret.yaml
@@ -18,6 +18,7 @@ metadata:
   name: {{ include "valkey.fullname" . }}-auth
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
   secretStoreRef:

--- a/charts/valkey/templates/externalsecret.yaml
+++ b/charts/valkey/templates/externalsecret.yaml
@@ -1,0 +1,31 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- /*
+  Guard: when externalSecrets.enabled=true the chart-managed auth Secret is still rendered
+  unless auth.existingSecret is set. Without this guard, both resources target the same
+  Secret name, creating credential drift between the chart-managed Valkey password and the
+  ExternalSecret. Require auth.existingSecret explicitly.
+*/}}
+{{- if not .Values.auth.existingSecret }}
+  {{- fail "externalSecrets.enabled requires auth.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "valkey.fullname" . }}-auth
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.auth.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/valkey/templates/extra-manifests.yaml
+++ b/charts/valkey/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests | default list }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/valkey/templates/extra-manifests.yaml
+++ b/charts/valkey/templates/extra-manifests.yaml
@@ -1,5 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- range .Values.extraManifests | default list }}
 ---
-{{ toYaml . }}
+{{ tpl (toYaml .) $ }}
 {{- end }}

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.pdb.enabled (or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) (include "valkey.isCluster" .)) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: valkey
+{{- end }}

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.fullname" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   maxUnavailable: 1
   selector:

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -14,3 +14,20 @@ spec:
       {{- include "valkey.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: valkey
 {{- end }}
+{{- if and .Values.pdb.enabled (include "valkey.isSentinel" .) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "valkey.sentinelStatefulSetName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
+spec:
+  minAvailable: {{ .Values.sentinel.quorum }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sentinel
+{{- end }}

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -34,14 +34,43 @@ spec:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if include "valkey.isSentinel" . }}
+          command: ["sh", "-ec"]
+          {{- else }}
           command: ["valkey-server"]
+          {{- end }}
           args:
+            {{- if include "valkey.isSentinel" . }}
+            - |
+              set -- /etc/valkey/valkey.conf
+              {{- if .Values.auth.enabled }}
+              set -- "$@" --requirepass "$VALKEY_PASSWORD" --masterauth "$VALKEY_PASSWORD"
+              {{- end }}
+              sentinel_master=""
+              for attempt in $(seq 1 30); do
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                [ -n "$sentinel_master" ] && break
+                echo "waiting for Sentinel master discovery ($attempt/30)"
+                sleep 2
+              done
+              self_fqdn="$(hostname -f)"
+              self_ip="$(hostname -i | awk '{ print $1 }')"
+              if [ -n "$sentinel_master" ] \
+                && [ "$sentinel_master" != "$self_fqdn" ] \
+                && [ "$sentinel_master" != "$self_ip" ] \
+                && [ "$sentinel_master" != {{ include "valkey.primaryPodFqdn" . | quote }} ]; then
+                echo "starting as replica of Sentinel master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
+                set -- "$@" --replicaof "$sentinel_master" {{ .Values.service.ports.valkey }}
+              fi
+              exec valkey-server "$@"
+            {{- else }}
             - /etc/valkey/valkey.conf
             {{- if .Values.auth.enabled }}
             - --requirepass
             - $(VALKEY_PASSWORD)
             - --masterauth
             - $(VALKEY_PASSWORD)
+            {{- end }}
             {{- end }}
           ports:
             - name: valkey

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             exec:
               command:
@@ -88,6 +91,9 @@ spec:
               mountPath: /tls
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -111,6 +117,9 @@ spec:
         - name: tls
           secret:
             secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
   {{- if .Values.replication.primary.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -107,6 +107,10 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
           {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.auth.enabled }}
-        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        checksum/auth-secret: {{ include "valkey.authChecksum" . }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -21,6 +21,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.primaryStatefulSetName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   serviceName: {{ include "valkey.headlessServiceName" . }}
   replicas: 1

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -1,0 +1,105 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.primaryStatefulSetName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "valkey.headlessServiceName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "valkey.componentLabels" (dict "root" . "role" "primary") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.componentLabels" (dict "root" . "role" "primary") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      containers:
+        - name: valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["valkey-server"]
+          args:
+            - /etc/valkey/valkey.conf
+            {{- if .Values.auth.enabled }}
+            - --requirepass
+            - $(VALKEY_PASSWORD)
+            {{- end }}
+          ports:
+            - name: valkey
+              containerPort: {{ .Values.service.ports.valkey }}
+          env:
+            {{- if .Values.auth.enabled }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.replication.primary.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey/valkey.conf
+              subPath: valkey-primary.conf
+            - name: data
+              mountPath: /data
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          env:
+            {{- include "valkey.exporterEnv" . | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "valkey.configMapName" . }}
+        {{- if not .Values.replication.primary.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.replication.primary.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.replication.primary.persistence) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -46,13 +46,20 @@ spec:
               {{- if .Values.auth.enabled }}
               set -- "$@" --requirepass "$VALKEY_PASSWORD" --masterauth "$VALKEY_PASSWORD"
               {{- end }}
+              bootstrap_marker="/data/.helmforge-sentinel-primary-bootstrapped"
               sentinel_master=""
-              for attempt in $(seq 1 30); do
-                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
-                [ -n "$sentinel_master" ] && break
-                echo "waiting for Sentinel master discovery ($attempt/30)"
-                sleep 2
-              done
+              if [ -f "$bootstrap_marker" ]; then
+                for attempt in $(seq 1 30); do
+                  sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                  [ -n "$sentinel_master" ] && break
+                  echo "waiting for Sentinel master discovery ($attempt/30)"
+                  sleep 2
+                done
+                if [ -z "$sentinel_master" ]; then
+                  echo "Sentinel master discovery failed for an already bootstrapped primary; refusing to start without role confirmation"
+                  exit 1
+                fi
+              fi
               self_fqdn="$(hostname -f)"
               self_ip="$(hostname -i | awk '{ print $1 }')"
               if [ -n "$sentinel_master" ] \
@@ -62,6 +69,7 @@ spec:
                 echo "starting as replica of Sentinel master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
                 set -- "$@" --replicaof "$sentinel_master" {{ .Values.service.ports.valkey }}
               fi
+              touch "$bootstrap_marker"
               exec valkey-server "$@"
             {{- else }}
             - /etc/valkey/valkey.conf

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -94,6 +94,7 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -35,6 +35,8 @@ spec:
             {{- if .Values.auth.enabled }}
             - --requirepass
             - $(VALKEY_PASSWORD)
+            - --masterauth
+            - $(VALKEY_PASSWORD)
             {{- end }}
           ports:
             - name: valkey

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -80,6 +80,11 @@ spec:
               subPath: valkey-primary.conf
             - name: data
               mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -97,6 +102,11 @@ spec:
         {{- if not .Values.replication.primary.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
         {{- end }}
   {{- if .Values.replication.primary.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -19,10 +19,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- include "valkey.podSpecCommon" . | nindent 6 }}
       containers:

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -123,6 +123,7 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -19,10 +19,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- include "valkey.podSpecCommon" . | nindent 6 }}
       initContainers:

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -36,6 +36,12 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
+              {{- if include "valkey.isSentinel" . }}
+              if [ -f /data/.helmforge-sentinel-replica-bootstrapped ]; then
+                echo "replica already bootstrapped; sentinel will preserve the current role"
+                exit 0
+              fi
+              {{- end }}
               until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.primaryPodFqdn" . | quote }} -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
                 echo "waiting for primary {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}"
                 sleep 5
@@ -63,12 +69,19 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
-              exec valkey-server /etc/valkey/valkey.conf \
-                --replicaof {{ include "valkey.primaryPodFqdn" . }} {{ .Values.service.ports.valkey }} \
-              {{- if .Values.auth.enabled }}
-                --masterauth "$VALKEY_PASSWORD" \
-                --requirepass "$VALKEY_PASSWORD"
+              set -- /etc/valkey/valkey.conf
+              {{- if include "valkey.isSentinel" . }}
+              if [ ! -f /data/.helmforge-sentinel-replica-bootstrapped ]; then
+                set -- "$@" --replicaof {{ include "valkey.primaryPodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
+                touch /data/.helmforge-sentinel-replica-bootstrapped
+              fi
+              {{- else }}
+              set -- "$@" --replicaof {{ include "valkey.primaryPodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
               {{- end }}
+              {{- if .Values.auth.enabled }}
+              set -- "$@" --masterauth "$VALKEY_PASSWORD" --requirepass "$VALKEY_PASSWORD"
+              {{- end }}
+              exec valkey-server "$@"
           ports:
             - name: valkey
               containerPort: {{ .Values.service.ports.valkey }}

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.auth.enabled }}
-        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        checksum/auth-secret: {{ include "valkey.authChecksum" . }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -21,6 +21,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -56,12 +56,14 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.tls.enabled }}
           volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
             - name: tls
               mountPath: /tls
               readOnly: true
-          {{- end }}
+            {{- end }}
       containers:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -134,6 +134,10 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
           {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
-              until valkey-cli -h {{ include "valkey.primaryPodFqdn" . | quote }} -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+              until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.primaryPodFqdn" . | quote }} -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
                 echo "waiting for primary {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}"
                 sleep 5
               done
@@ -46,6 +46,12 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.tls.enabled }}
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+          {{- end }}
       containers:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -103,6 +109,11 @@ spec:
               subPath: valkey-replica.conf
             - name: data
               mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -120,6 +131,11 @@ spec:
         {{- if not .Values.replication.replica.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
         {{- end }}
   {{- if .Values.replication.replica.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -38,8 +38,15 @@ spec:
           args:
             - |
               {{- if include "valkey.isSentinel" . }}
+              sentinel_master=""
+              for attempt in $(seq 1 30); do
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                [ -n "$sentinel_master" ] && exit 0
+                echo "waiting for Sentinel master discovery ($attempt/30)"
+                sleep 2
+              done
               if [ -f /data/.helmforge-sentinel-replica-bootstrapped ]; then
-                echo "replica already bootstrapped; sentinel will preserve the current role"
+                echo "Sentinel unavailable for already bootstrapped replica; main container will fail closed if the role cannot be confirmed"
                 exit 0
               fi
               {{- end }}
@@ -74,10 +81,31 @@ spec:
             - |
               set -- /etc/valkey/valkey.conf
               {{- if include "valkey.isSentinel" . }}
-              if [ ! -f /data/.helmforge-sentinel-replica-bootstrapped ]; then
+              bootstrap_marker="/data/.helmforge-sentinel-replica-bootstrapped"
+              sentinel_master=""
+              for attempt in $(seq 1 30); do
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                [ -n "$sentinel_master" ] && break
+                echo "waiting for Sentinel master discovery ($attempt/30)"
+                sleep 2
+              done
+              self_fqdn="$(hostname -f)"
+              self_ip="$(hostname -i | awk '{ print $1 }')"
+              if [ -n "$sentinel_master" ]; then
+                if [ "$sentinel_master" != "$self_fqdn" ] && [ "$sentinel_master" != "$self_ip" ]; then
+                  echo "starting as replica of Sentinel master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
+                  set -- "$@" --replicaof "$sentinel_master" {{ .Values.service.ports.valkey }}
+                else
+                  echo "Sentinel reports this pod as the current master; starting without replicaof"
+                fi
+              elif [ -f "$bootstrap_marker" ]; then
+                echo "Sentinel master discovery failed for an already bootstrapped replica; refusing to start as an unconfirmed master"
+                exit 1
+              else
+                echo "Sentinel unavailable during first replica bootstrap; seeding from initial primary {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}"
                 set -- "$@" --replicaof {{ include "valkey.primaryPodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
-                touch /data/.helmforge-sentinel-replica-bootstrapped
               fi
+              touch "$bootstrap_marker"
               {{- else }}
               set -- "$@" --replicaof {{ include "valkey.primaryPodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
               {{- end }}

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.replicaStatefulSetName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   serviceName: {{ include "valkey.headlessServiceName" . }}
   replicas: {{ .Values.replication.replicaCount }}

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -77,6 +77,9 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             exec:
               command:
@@ -115,6 +118,9 @@ spec:
               mountPath: /tls
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -138,6 +144,9 @@ spec:
         - name: tls
           secret:
             secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
   {{- if .Values.replication.replica.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -1,0 +1,128 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.replicaStatefulSetName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "valkey.headlessServiceName" . }}
+  replicas: {{ .Values.replication.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "valkey.componentLabels" (dict "root" . "role" "replica") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.componentLabels" (dict "root" . "role" "replica") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      initContainers:
+        - name: wait-for-primary
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              until valkey-cli -h {{ include "valkey.primaryPodFqdn" . | quote }} -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+                echo "waiting for primary {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}"
+                sleep 5
+              done
+          {{- if .Values.auth.enabled }}
+          env:
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              exec valkey-server /etc/valkey/valkey.conf \
+                --replicaof {{ include "valkey.primaryPodFqdn" . }} {{ .Values.service.ports.valkey }} \
+              {{- if .Values.auth.enabled }}
+                --masterauth "$VALKEY_PASSWORD" \
+                --requirepass "$VALKEY_PASSWORD"
+              {{- end }}
+          ports:
+            - name: valkey
+              containerPort: {{ .Values.service.ports.valkey }}
+          env:
+            {{- if .Values.auth.enabled }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.replication.replica.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey/valkey.conf
+              subPath: valkey-replica.conf
+            - name: data
+              mountPath: /data
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          env:
+            {{- include "valkey.exporterEnv" . | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "valkey.configMapName" . }}
+        {{- if not .Values.replication.replica.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.replication.replica.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.replication.replica.persistence) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/valkey/templates/secret.yaml
+++ b/charts/valkey/templates/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.secretName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 type: Opaque
 stringData:
   {{ .Values.auth.existingSecretPasswordKey }}: {{ include "valkey.password" . | quote }}

--- a/charts/valkey/templates/secret.yaml
+++ b/charts/valkey/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "valkey.secretName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.existingSecretPasswordKey }}: {{ include "valkey.password" . | quote }}
+{{- end }}

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -21,10 +21,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- include "valkey.podSpecCommon" . | nindent 6 }}
       containers:

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -45,6 +45,26 @@ spec:
                   sleep 5
                 done
                 cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
+              elif grep -q '^# HelmForge managed sentinel config begin$' /data/sentinel.conf; then
+                sed -i '/^# HelmForge managed sentinel config begin$/,/^# HelmForge managed sentinel config end$/d' /data/sentinel.conf
+                cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
+              else
+                sed -i \
+                  -e '/^port /d' \
+                  -e '/^tls-port /d' \
+                  -e '/^tls-cert-file /d' \
+                  -e '/^tls-key-file /d' \
+                  -e '/^tls-ca-cert-file /d' \
+                  -e '/^tls-auth-clients /d' \
+                  -e '/^tls-replication /d' \
+                  -e '/^dir /d' \
+                  -e '/^sentinel resolve-hostnames /d' \
+                  -e '/^sentinel monitor mymaster /d' \
+                  -e '/^sentinel down-after-milliseconds mymaster /d' \
+                  -e '/^sentinel failover-timeout mymaster /d' \
+                  -e '/^sentinel parallel-syncs mymaster /d' \
+                  /data/sentinel.conf
+                cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
               fi
               {{- if .Values.auth.enabled }}
               sed -i '/^sentinel auth-pass mymaster /d' /data/sentinel.conf

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.sentinelStatefulSetName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   serviceName: {{ include "valkey.sentinelServiceName" . }}
   replicas: {{ .Values.sentinel.replicaCount }}

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -39,11 +39,11 @@ spec:
                 echo "waiting for primary $VALKEY_PRIMARY_HOST:$VALKEY_PRIMARY_PORT"
                 sleep 5
               done
-              cp /etc/valkey-base/sentinel.conf /tmp/sentinel.conf
+              cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
               {{- if .Values.auth.enabled }}
-              echo "sentinel auth-pass mymaster ${VALKEY_PASSWORD}" >> /tmp/sentinel.conf
+              echo "sentinel auth-pass mymaster ${VALKEY_PASSWORD}" >> /data/sentinel.conf
               {{- end }}
-              exec valkey-sentinel /tmp/sentinel.conf
+              exec valkey-sentinel /data/sentinel.conf
           ports:
             - name: sentinel
               containerPort: {{ .Values.service.ports.sentinel }}
@@ -60,6 +60,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- else }}
           env:
             - name: VALKEY_PRIMARY_HOST
@@ -68,6 +71,9 @@ spec:
               value: {{ .Values.service.ports.valkey | quote }}
             - name: VALKEY_TLS_ARGS
               value: {{ ternary (printf "--tls --cacert /tls/%s" .Values.tls.caFilename) "" .Values.tls.enabled | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.sentinel.resources }}
           resources:
@@ -79,19 +85,31 @@ spec:
             - name: config
               mountPath: /etc/valkey-base/sentinel.conf
               subPath: sentinel.conf
+            - name: data
+              mountPath: /data
             {{- if .Values.tls.enabled }}
             - name: tls
               mountPath: /tls
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "valkey.configMapName" . }}
+        {{- if not .Values.sentinel.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: tls
           secret:
             secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
   {{- if .Values.sentinel.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -23,6 +23,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -39,8 +42,11 @@ spec:
                 echo "waiting for primary $VALKEY_PRIMARY_HOST:$VALKEY_PRIMARY_PORT"
                 sleep 5
               done
-              cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
+              if [ ! -f /data/sentinel.conf ]; then
+                cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
+              fi
               {{- if .Values.auth.enabled }}
+              sed -i '/^sentinel auth-pass mymaster /d' /data/sentinel.conf
               echo "sentinel auth-pass mymaster ${VALKEY_PASSWORD}" >> /data/sentinel.conf
               {{- end }}
               exec valkey-sentinel /data/sentinel.conf

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -45,26 +45,38 @@ spec:
                   sleep 5
                 done
                 cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
-              elif grep -q '^# HelmForge managed sentinel config begin$' /data/sentinel.conf; then
-                sed -i '/^# HelmForge managed sentinel config begin$/,/^# HelmForge managed sentinel config end$/d' /data/sentinel.conf
-                cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
               else
-                sed -i \
-                  -e '/^port /d' \
-                  -e '/^tls-port /d' \
-                  -e '/^tls-cert-file /d' \
-                  -e '/^tls-key-file /d' \
-                  -e '/^tls-ca-cert-file /d' \
-                  -e '/^tls-auth-clients /d' \
-                  -e '/^tls-replication /d' \
-                  -e '/^dir /d' \
-                  -e '/^sentinel resolve-hostnames /d' \
-                  -e '/^sentinel monitor mymaster /d' \
-                  -e '/^sentinel down-after-milliseconds mymaster /d' \
-                  -e '/^sentinel failover-timeout mymaster /d' \
-                  -e '/^sentinel parallel-syncs mymaster /d' \
-                  /data/sentinel.conf
-                cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
+                persisted_monitor="$(grep '^sentinel monitor mymaster ' /data/sentinel.conf | tail -n 1 || true)"
+                append_sentinel_base() {
+                  if [ -n "$persisted_monitor" ]; then
+                    awk -v monitor="$persisted_monitor" '
+                      /^sentinel monitor mymaster / { print monitor; next }
+                      { print }
+                    ' /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
+                  else
+                    cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
+                  fi
+                }
+                if grep -q '^# HelmForge managed sentinel config begin$' /data/sentinel.conf; then
+                  sed -i '/^# HelmForge managed sentinel config begin$/,/^# HelmForge managed sentinel config end$/d' /data/sentinel.conf
+                else
+                  sed -i \
+                    -e '/^port /d' \
+                    -e '/^tls-port /d' \
+                    -e '/^tls-cert-file /d' \
+                    -e '/^tls-key-file /d' \
+                    -e '/^tls-ca-cert-file /d' \
+                    -e '/^tls-auth-clients /d' \
+                    -e '/^tls-replication /d' \
+                    -e '/^dir /d' \
+                    -e '/^sentinel resolve-hostnames /d' \
+                    -e '/^sentinel monitor mymaster /d' \
+                    -e '/^sentinel down-after-milliseconds mymaster /d' \
+                    -e '/^sentinel failover-timeout mymaster /d' \
+                    -e '/^sentinel parallel-syncs mymaster /d' \
+                    /data/sentinel.conf
+                fi
+                append_sentinel_base
               fi
               {{- if .Values.auth.enabled }}
               sed -i '/^sentinel auth-pass mymaster /d' /data/sentinel.conf

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.auth.enabled }}
-        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        checksum/auth-secret: {{ include "valkey.authChecksum" . }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -1,0 +1,85 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if include "valkey.isSentinel" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.sentinelStatefulSetName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "valkey.sentinelServiceName" . }}
+  replicas: {{ .Values.sentinel.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sentinel
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: sentinel
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      containers:
+        - name: sentinel
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              until valkey-cli -h "$VALKEY_PRIMARY_HOST" -p "$VALKEY_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+                echo "waiting for primary $VALKEY_PRIMARY_HOST:$VALKEY_PRIMARY_PORT"
+                sleep 5
+              done
+              cp /etc/valkey-base/sentinel.conf /tmp/sentinel.conf
+              {{- if .Values.auth.enabled }}
+              echo "sentinel auth-pass mymaster ${VALKEY_PASSWORD}" >> /tmp/sentinel.conf
+              {{- end }}
+              exec valkey-sentinel /tmp/sentinel.conf
+          ports:
+            - name: sentinel
+              containerPort: {{ .Values.service.ports.sentinel }}
+          {{- if .Values.auth.enabled }}
+          env:
+            - name: VALKEY_PRIMARY_HOST
+              value: {{ include "valkey.primaryPodFqdn" . | quote }}
+            - name: VALKEY_PRIMARY_PORT
+              value: {{ .Values.service.ports.valkey | quote }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+          {{- else }}
+          env:
+            - name: VALKEY_PRIMARY_HOST
+              value: {{ include "valkey.primaryPodFqdn" . | quote }}
+            - name: VALKEY_PRIMARY_PORT
+              value: {{ .Values.service.ports.valkey | quote }}
+          {{- end }}
+          {{- with .Values.sentinel.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey-base/sentinel.conf
+              subPath: sentinel.conf
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "valkey.configMapName" . }}
+  {{- if .Values.sentinel.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.sentinel.persistence) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
-              until valkey-cli -h "$VALKEY_PRIMARY_HOST" -p "$VALKEY_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+              until valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_PRIMARY_HOST" -p "$VALKEY_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
                 echo "waiting for primary $VALKEY_PRIMARY_HOST:$VALKEY_PRIMARY_PORT"
                 sleep 5
               done
@@ -52,6 +52,8 @@ spec:
               value: {{ include "valkey.primaryPodFqdn" . | quote }}
             - name: VALKEY_PRIMARY_PORT
               value: {{ .Values.service.ports.valkey | quote }}
+            - name: VALKEY_TLS_ARGS
+              value: {{ ternary (printf "--tls --cacert /tls/%s" .Values.tls.caFilename) "" .Values.tls.enabled | quote }}
             - name: VALKEY_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -63,6 +65,8 @@ spec:
               value: {{ include "valkey.primaryPodFqdn" . | quote }}
             - name: VALKEY_PRIMARY_PORT
               value: {{ .Values.service.ports.valkey | quote }}
+            - name: VALKEY_TLS_ARGS
+              value: {{ ternary (printf "--tls --cacert /tls/%s" .Values.tls.caFilename) "" .Values.tls.enabled | quote }}
           {{- end }}
           {{- with .Values.sentinel.resources }}
           resources:
@@ -74,10 +78,20 @@ spec:
             - name: config
               mountPath: /etc/valkey-base/sentinel.conf
               subPath: sentinel.conf
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "valkey.configMapName" . }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
   {{- if .Values.sentinel.persistence.enabled }}
   volumeClaimTemplates:
     {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.sentinel.persistence) | nindent 4 }}

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -38,11 +38,11 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
-              until valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_PRIMARY_HOST" -p "$VALKEY_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
-                echo "waiting for primary $VALKEY_PRIMARY_HOST:$VALKEY_PRIMARY_PORT"
-                sleep 5
-              done
               if [ ! -f /data/sentinel.conf ]; then
+                until valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_PRIMARY_HOST" -p "$VALKEY_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+                  echo "waiting for primary $VALKEY_PRIMARY_HOST:$VALKEY_PRIMARY_PORT"
+                  sleep 5
+                done
                 cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
               fi
               {{- if .Values.auth.enabled }}

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "valkey.headlessServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -41,7 +41,7 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
-  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -68,7 +68,7 @@ metadata:
   name: {{ include "valkey.clientServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.clientAnnotations) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" . "annotations" .Values.service.clientAnnotations) | nindent 2 }}
 spec:
   type: {{ .Values.service.type }}
   {{- with .Values.service.ipFamilyPolicy }}
@@ -101,7 +101,7 @@ metadata:
   name: {{ include "valkey.primaryServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.primaryAnnotations) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" . "annotations" .Values.service.primaryAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -131,7 +131,7 @@ metadata:
   name: {{ include "valkey.replicaServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.replicaAnnotations) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" . "annotations" .Values.service.replicaAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -164,7 +164,7 @@ metadata:
   name: {{ include "valkey.sentinelServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.sentinelAnnotations) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" . "annotations" .Values.service.sentinelAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -191,7 +191,7 @@ metadata:
   name: {{ include "valkey.clientServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.clusterAnnotations) | nindent 2 }}
+  {{- include "valkey.renderServiceAnnotations" (dict "root" . "annotations" .Values.service.clusterAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -193,7 +193,7 @@ metadata:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- include "valkey.renderServiceAnnotations" (dict "root" . "annotations" .Values.service.clusterAnnotations) | nindent 2 }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   {{- with .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -1,0 +1,196 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or (include "valkey.isStandalone" .) (include "valkey.isReplication" .) (include "valkey.isSentinel" .) (include "valkey.isCluster" .) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.headlessServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: valkey
+      port: {{ .Values.service.ports.valkey }}
+      targetPort: valkey
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+{{- end }}
+
+{{- if include "valkey.isStandalone" . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.clientServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.service.clientAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: valkey
+      port: {{ .Values.service.ports.valkey }}
+      targetPort: valkey
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/role: standalone
+{{- end }}
+
+{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.primaryServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.service.primaryAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: valkey
+      port: {{ .Values.service.ports.valkey }}
+      targetPort: valkey
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/role: primary
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.replicaServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.service.replicaAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: valkey
+      port: {{ .Values.service.ports.valkey }}
+      targetPort: valkey
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/role: replica
+{{- end }}
+
+{{- if include "valkey.isSentinel" . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.sentinelServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.service.sentinelAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: sentinel
+      port: {{ .Values.service.ports.sentinel }}
+      targetPort: sentinel
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+{{- end }}
+
+{{- if include "valkey.isCluster" . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.clientServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.service.clusterAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: valkey
+      port: {{ .Values.service.ports.valkey }}
+      targetPort: valkey
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+    app.kubernetes.io/role: cluster
+{{- end }}

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: valkey
       port: {{ .Values.service.ports.valkey }}

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -31,6 +31,33 @@ spec:
     app.kubernetes.io/component: valkey
 {{- end }}
 
+{{- if and .Values.metrics.enabled (or (include "valkey.isStandalone" .) (include "valkey.isReplication" .) (include "valkey.isSentinel" .) (include "valkey.isCluster" .)) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.metricsServiceName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+{{- end }}
+
 {{- if include "valkey.isStandalone" . }}
 ---
 apiVersion: v1

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "valkey.headlessServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -40,6 +41,7 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -66,10 +68,7 @@ metadata:
   name: {{ include "valkey.clientServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- with .Values.service.clientAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.clientAnnotations) | nindent 2 }}
 spec:
   type: {{ .Values.service.type }}
   {{- with .Values.service.ipFamilyPolicy }}
@@ -102,10 +101,7 @@ metadata:
   name: {{ include "valkey.primaryServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- with .Values.service.primaryAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.primaryAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -135,10 +131,7 @@ metadata:
   name: {{ include "valkey.replicaServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- with .Values.service.replicaAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.replicaAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -171,10 +164,7 @@ metadata:
   name: {{ include "valkey.sentinelServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- with .Values.service.sentinelAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.sentinelAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -201,10 +191,7 @@ metadata:
   name: {{ include "valkey.clientServiceName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- with .Values.service.clusterAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.service.clusterAnnotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}

--- a/charts/valkey/templates/serviceaccount.yaml
+++ b/charts/valkey/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "valkey.serviceAccountName" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/valkey/templates/serviceaccount.yaml
+++ b/charts/valkey/templates/serviceaccount.yaml
@@ -6,8 +6,5 @@ metadata:
   name: {{ include "valkey.serviceAccountName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" .Values.serviceAccount.annotations) | nindent 2 }}
 {{- end }}

--- a/charts/valkey/templates/servicemonitor.yaml
+++ b/charts/valkey/templates/servicemonitor.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- with .Values.metrics.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   endpoints:
     - port: metrics

--- a/charts/valkey/templates/servicemonitor.yaml
+++ b/charts/valkey/templates/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "valkey.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/valkey/templates/servicemonitor.yaml
+++ b/charts/valkey/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -96,6 +96,7 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- include "valkey.metricsVolumeMounts" . | nindent 10 }}
           {{- with .Values.metrics.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.auth.enabled }}
-        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        checksum/auth-secret: {{ include "valkey.authChecksum" . }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -21,6 +21,9 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -1,0 +1,128 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if include "valkey.isStandalone" . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "valkey.headlessServiceName" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "valkey.componentLabels" (dict "root" . "role" "standalone") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "valkey.componentLabels" (dict "root" . "role" "standalone") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      containers:
+        - name: valkey
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["valkey-server"]
+          args:
+            {{- include "valkey.serverArgs" . | nindent 12 }}
+          ports:
+            - name: valkey
+              containerPort: {{ .Values.service.ports.valkey }}
+          env:
+            {{- if .Values.auth.enabled }}
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "valkey.probeCommand" . | quote }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.standalone.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/valkey/valkey.conf
+              subPath: valkey-standalone.conf
+            - name: data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          env:
+            {{- include "valkey.exporterEnv" . | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "valkey.configMapName" . }}
+        {{- if not .Values.standalone.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if .Values.standalone.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.standalone.persistence) | nindent 4 }}
+  {{- else }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Delete
+  {{- end }}
+{{- end }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.fullname" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+  {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   serviceName: {{ include "valkey.headlessServiceName" . }}
   replicas: 1

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -19,10 +19,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- include "valkey.podSpecCommon" . | nindent 6 }}
       containers:

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -13,6 +13,7 @@ metadata:
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+  automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
   {{- with .Values.podSecurityContext }}
   securityContext:
     {{- toYaml . | nindent 4 }}
@@ -25,11 +26,11 @@ spec:
       args:
         - |
           {{- if include "valkey.isCluster" . }}
-          valkey-cli -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'
+          valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'
           {{- else }}
-          valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS ping | grep -q PONG
-          valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS set helmforge:health ok | grep -q OK
-          test "$(valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS get helmforge:health)" = "ok"
+          valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS ping | grep -q PONG
+          valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS set helmforge:health ok | grep -q OK
+          test "$(valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS get helmforge:health)" = "ok"
           {{- end }}
       env:
         - name: VALKEY_HOST
@@ -40,6 +41,8 @@ spec:
           {{- end }}
         - name: VALKEY_PORT
           value: {{ .Values.service.ports.valkey | quote }}
+        - name: VALKEY_TLS_ARGS
+          value: {{ ternary (printf "--tls --cacert /tls/%s" .Values.tls.caFilename) "" .Values.tls.enabled | quote }}
         {{- if .Values.auth.enabled }}
         - name: VALKEY_PASSWORD
           valueFrom:
@@ -54,4 +57,16 @@ spec:
         {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- if .Values.tls.enabled }}
+      volumeMounts:
+        - name: tls
+          mountPath: /tls
+          readOnly: true
+      {{- end }}
+  {{- if .Values.tls.enabled }}
+  volumes:
+    - name: tls
+      secret:
+        secretName: {{ .Values.tls.existingSecret }}
+  {{- end }}
 {{- end }}

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -7,9 +7,7 @@ metadata:
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- include "valkey.renderAnnotations" (dict "root" . "annotations" (dict "helm.sh/hook" "test" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 2 }}
 spec:
   restartPolicy: Never
   serviceAccountName: {{ include "valkey.serviceAccountName" . }}

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -1,0 +1,57 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "valkey.fullname" . }}-test-connection
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+  {{- with .Values.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: valkey-cli
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      command: ["sh", "-ec"]
+      args:
+        - |
+          {{- if include "valkey.isCluster" . }}
+          valkey-cli -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'
+          {{- else }}
+          valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS ping | grep -q PONG
+          valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS set helmforge:health ok | grep -q OK
+          test "$(valkey-cli -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS get helmforge:health)" = "ok"
+          {{- end }}
+      env:
+        - name: VALKEY_HOST
+          {{- if or (include "valkey.isStandalone" .) (include "valkey.isCluster" .) }}
+          value: {{ include "valkey.clientServiceName" . | quote }}
+          {{- else }}
+          value: {{ include "valkey.primaryServiceName" . | quote }}
+          {{- end }}
+        - name: VALKEY_PORT
+          value: {{ .Values.service.ports.valkey | quote }}
+        {{- if .Values.auth.enabled }}
+        - name: VALKEY_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "valkey.secretName" . }}
+              key: {{ .Values.auth.existingSecretPasswordKey }}
+        - name: VALKEY_AUTH_ARGS
+          value: --no-auth-warning -a $(VALKEY_PASSWORD)
+        {{- else }}
+        - name: VALKEY_AUTH_ARGS
+          value: ""
+        {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+{{- end }}

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -24,7 +24,15 @@ spec:
       args:
         - |
           {{- if include "valkey.isCluster" . }}
-          valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'
+          for i in $(seq 1 30); do
+            if valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'; then
+              exit 0
+            fi
+            echo "waiting for Valkey Cluster to report cluster_state:ok ($i/30)"
+            sleep 2
+          done
+          valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info
+          exit 1
           {{- else }}
           valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS ping | grep -q PONG
           valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS set helmforge:health ok | grep -q OK

--- a/charts/valkey/tests/cluster_domain_test.yaml
+++ b/charts/valkey/tests/cluster_domain_test.yaml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Cluster Domain
+templates:
+  - configmap.yaml
+  - replication-replica-statefulset.yaml
+  - sentinel-statefulset.yaml
+  - cluster-statefulset.yaml
+  - cluster-init-job.yaml
+release:
+  name: test
+  namespace: custom-ns
+tests:
+  - it: should use custom cluster domain in sentinel configuration
+    template: configmap.yaml
+    set:
+      architecture: sentinel
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel monitor mymaster test-valkey-primary-0\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel resolve-hostnames yes"
+      - notMatchRegex:
+          path: data["sentinel.conf"]
+          pattern: "svc\\.cluster\\.local"
+
+  - it: should use custom cluster domain in replication replica args
+    template: replication-replica-statefulset.yaml
+    set:
+      architecture: replication
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--replicaof test-valkey-primary-0\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal 6379"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "svc\\.cluster\\.local"
+
+  - it: should wait for custom primary FQDN before starting sentinel
+    template: sentinel-statefulset.yaml
+    set:
+      architecture: sentinel
+      clusterDomain: corp.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VALKEY_PRIMARY_HOST
+            value: test-valkey-primary-0.test-valkey-headless.custom-ns.svc.corp.internal
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "until valkey-cli -h \"\\$VALKEY_PRIMARY_HOST\""
+
+  - it: should use custom cluster domain in cluster announce hostname
+    template: cluster-statefulset.yaml
+    set:
+      architecture: cluster
+      clusterDomain: corp.internal
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "$(POD_NAME).test-valkey-headless.custom-ns.svc.corp.internal"
+
+  - it: should use custom cluster domain in cluster init job
+    template: cluster-init-job.yaml
+    set:
+      architecture: cluster
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "test-valkey-cluster-\\$\\{i\\}\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "svc\\.cluster\\.local"

--- a/charts/valkey/tests/cluster_domain_test.yaml
+++ b/charts/valkey/tests/cluster_domain_test.yaml
@@ -52,7 +52,7 @@ tests:
             value: test-valkey-primary-0.test-valkey-headless.custom-ns.svc.corp.internal
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "until valkey-cli -h \"\\$VALKEY_PRIMARY_HOST\""
+          pattern: "until valkey-cli \\$VALKEY_TLS_ARGS -h \"\\$VALKEY_PRIMARY_HOST\""
 
   - it: should use custom cluster domain in cluster announce hostname
     template: cluster-statefulset.yaml

--- a/charts/valkey/tests/cluster_domain_test.yaml
+++ b/charts/valkey/tests/cluster_domain_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "--replicaof test-valkey-primary-0\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal 6379"
+          pattern: '--replicaof "test-valkey-primary-0\.test-valkey-headless\.custom-ns\.svc\.corp\.internal" 6379'
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "svc\\.cluster\\.local"

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -17,6 +17,24 @@ tests:
           pattern: "cluster nodes"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
+          pattern: "node_address_exists\\(\\)"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "refresh_cluster_nodes\\(\\)"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "split\\(\\$2, announced, \",\"\\)"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "announced\\[2\\] == host"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "waiting for new cluster nodes to be visible before rebalance"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "grep -Fq \"\\$node\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
           pattern: "--cluster add-node"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
@@ -29,7 +47,13 @@ tests:
           pattern: "--cluster rebalance"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "--cluster-use-empty-masters"
+          pattern: "--cluster-use-empty-primaries"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster-threshold 1"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster-yes"
 
   - it: should render image pull secrets on cluster init job
     set:

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Cluster Init
+templates:
+  - cluster-init-job.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should add missing nodes during cluster scale-up
+    set:
+      architecture: cluster
+    asserts:
+      - isKind:
+          of: Job
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "cluster nodes"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster add-node"

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -40,3 +40,16 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: private-registry
+
+  - it: should merge global annotations with hook annotations
+    set:
+      architecture: cluster
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -24,3 +24,13 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "--cluster-use-empty-masters"
+
+  - it: should render image pull secrets on cluster init job
+    set:
+      architecture: cluster
+      imagePullSecrets:
+        - name: private-registry
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: private-registry

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -47,6 +47,9 @@ tests:
           pattern: "--cluster rebalance"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster-use-empty-masters"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
           pattern: "--cluster-use-empty-primaries"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -20,6 +20,12 @@ tests:
           pattern: "--cluster add-node"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
+          pattern: "desired_masters=\\$\\(\\(6 / \\(replicas_per_master \\+ 1\\)\\)\\)"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster-replica"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
           pattern: "--cluster rebalance"
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -18,3 +18,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "--cluster add-node"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster rebalance"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "--cluster-use-empty-masters"

--- a/charts/valkey/tests/config_rollout_test.yaml
+++ b/charts/valkey/tests/config_rollout_test.yaml
@@ -17,6 +17,9 @@ tests:
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: "^[a-f0-9]{64}$"
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
 
   - it: should checksum config in replication pod templates
     set:
@@ -28,6 +31,14 @@ tests:
         template: replication-primary-statefulset.yaml
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
           pattern: "^[a-f0-9]{64}$"
         template: replication-replica-statefulset.yaml
 
@@ -47,6 +58,10 @@ tests:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: "^[a-f0-9]{64}$"
         template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: sentinel-statefulset.yaml
 
   - it: should checksum config in cluster pod template
     set:
@@ -56,6 +71,28 @@ tests:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: "^[a-f0-9]{64}$"
         template: cluster-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: cluster-statefulset.yaml
+
+  - it: should checksum auth secret references for existing auth secrets
+    set:
+      auth.existingSecret: valkey-auth
+      auth.existingSecretPasswordKey: password
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: standalone-statefulset.yaml
+
+  - it: should omit auth checksum when auth is disabled
+    set:
+      auth.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+        template: standalone-statefulset.yaml
 
   - it: should preserve user pod annotations with checksum
     set:

--- a/charts/valkey/tests/config_rollout_test.yaml
+++ b/charts/valkey/tests/config_rollout_test.yaml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Config Rollout
+templates:
+  - standalone-statefulset.yaml
+  - replication-primary-statefulset.yaml
+  - replication-replica-statefulset.yaml
+  - sentinel-statefulset.yaml
+  - cluster-statefulset.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should checksum config in standalone pod template
+    template: standalone-statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+
+  - it: should checksum config in replication pod templates
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-replica-statefulset.yaml
+
+  - it: should checksum config in sentinel pod templates
+    set:
+      architecture: sentinel
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: sentinel-statefulset.yaml
+
+  - it: should checksum config in cluster pod template
+    set:
+      architecture: cluster
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: cluster-statefulset.yaml
+
+  - it: should preserve user pod annotations with checksum
+    set:
+      podAnnotations:
+        example.com/restarted-by: platform
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
+        template: standalone-statefulset.yaml
+      - equal:
+          path: spec.template.metadata.annotations["example.com/restarted-by"]
+          value: platform
+        template: standalone-statefulset.yaml

--- a/charts/valkey/tests/config_rollout_test.yaml
+++ b/charts/valkey/tests/config_rollout_test.yaml
@@ -86,6 +86,51 @@ tests:
           pattern: "^[a-f0-9]{64}$"
         template: standalone-statefulset.yaml
 
+  - it: should checksum existing auth secret references for replication pods
+    set:
+      architecture: replication
+      auth.existingSecret: valkey-auth
+      auth.existingSecretPasswordKey: password
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-replica-statefulset.yaml
+
+  - it: should checksum existing auth secret references for sentinel pods
+    set:
+      architecture: sentinel
+      auth.existingSecret: valkey-auth
+      auth.existingSecretPasswordKey: password
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: sentinel-statefulset.yaml
+
+  - it: should checksum existing auth secret references for cluster pods
+    set:
+      architecture: cluster
+      auth.existingSecret: valkey-auth
+      auth.existingSecretPasswordKey: password
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: cluster-statefulset.yaml
+
   - it: should omit auth checksum when auth is disabled
     set:
       auth.enabled: false

--- a/charts/valkey/tests/extra_manifests_test.yaml
+++ b/charts/valkey/tests/extra_manifests_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Extra manifests
+templates:
+  - extra-manifests.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render extra manifests through tpl
+    set:
+      extraManifests:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: "{{ .Release.Name }}-extra"
+            namespace: "{{ .Release.Namespace }}"
+          data:
+            release: "{{ .Release.Name }}"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: test-extra
+      - equal:
+          path: metadata.namespace
+          value: default
+      - equal:
+          path: data.release
+          value: test

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: HA Extension Points
+templates:
+  - replication-primary-statefulset.yaml
+  - replication-replica-statefulset.yaml
+  - sentinel-statefulset.yaml
+  - cluster-statefulset.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render extra env and volumes in replication pods
+    set:
+      architecture: replication
+      extraEnv:
+        - name: EXTRA_SETTING
+          value: enabled
+      extraVolumes:
+        - name: extra-config
+          configMap:
+            name: extra-config
+      extraVolumeMounts:
+        - name: extra-config
+          mountPath: /extra
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_SETTING
+            value: enabled
+        template: replication-primary-statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config
+            mountPath: /extra
+        template: replication-replica-statefulset.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config
+            configMap:
+              name: extra-config
+        template: replication-primary-statefulset.yaml
+
+  - it: should render extra env and volumes in sentinel pods
+    set:
+      architecture: sentinel
+      extraEnv:
+        - name: EXTRA_SETTING
+          value: enabled
+      extraVolumes:
+        - name: extra-config
+          configMap:
+            name: extra-config
+      extraVolumeMounts:
+        - name: extra-config
+          mountPath: /extra
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_SETTING
+            value: enabled
+        template: sentinel-statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config
+            mountPath: /extra
+        template: sentinel-statefulset.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config
+            configMap:
+              name: extra-config
+        template: sentinel-statefulset.yaml
+
+  - it: should persist sentinel runtime state when enabled
+    set:
+      architecture: sentinel
+      sentinel.persistence.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "exec valkey-sentinel /data/sentinel.conf"
+        template: sentinel-statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+        template: sentinel-statefulset.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+        template: sentinel-statefulset.yaml
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
+        template: sentinel-statefulset.yaml
+
+  - it: should render extra env and volumes in cluster pods
+    set:
+      architecture: cluster
+      extraEnv:
+        - name: EXTRA_SETTING
+          value: enabled
+      extraVolumes:
+        - name: extra-config
+          configMap:
+            name: extra-config
+      extraVolumeMounts:
+        - name: extra-config
+          mountPath: /extra
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_SETTING
+            value: enabled
+        template: cluster-statefulset.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config
+            mountPath: /extra
+        template: cluster-statefulset.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config
+            configMap:
+              name: extra-config
+        template: cluster-statefulset.yaml

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -145,3 +145,59 @@ tests:
             configMap:
               name: extra-config
         template: cluster-statefulset.yaml
+
+  - it: should render metrics resources in replication pods
+    set:
+      architecture: replication
+      metrics.enabled: true
+      metrics.resources:
+        requests:
+          cpu: 20m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 20m
+        template: replication-primary-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.memory
+          value: 128Mi
+        template: replication-replica-statefulset.yaml
+
+  - it: should render metrics resources in sentinel valkey pods
+    set:
+      architecture: sentinel
+      metrics.enabled: true
+      metrics.resources:
+        requests:
+          cpu: 20m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.memory
+          value: 64Mi
+        template: replication-primary-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.memory
+          value: 128Mi
+        template: replication-replica-statefulset.yaml
+
+  - it: should render metrics resources in cluster pods
+    set:
+      architecture: cluster
+      metrics.enabled: true
+      metrics.resources:
+        requests:
+          cpu: 20m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 20m
+        template: cluster-statefulset.yaml

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -109,7 +109,19 @@ tests:
         template: sentinel-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf"
+          pattern: "persisted_monitor=\"\\$\\(grep '\\^sentinel monitor mymaster ' /data/sentinel.conf"
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "append_sentinel_base\\(\\)"
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "awk -v monitor=\"\\$persisted_monitor\""
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "\\^sentinel monitor mymaster / \\{ print monitor; next \\}"
         template: sentinel-statefulset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -179,21 +179,33 @@ tests:
           pattern: "# HelmForge managed sentinel config end"
         template: configmap.yaml
 
-  - it: should preserve sentinel failover role on replica restarts
+  - it: should reseed sentinel replicas from the current sentinel master on restarts
     set:
       architecture: sentinel
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: "replica already bootstrapped; sentinel will preserve the current role"
+          pattern: "sentinel get-master-addr-by-name mymaster"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "main container will fail closed if the role cannot be confirmed"
         template: replication-replica-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "if \\[ ! -f /data/\\.helmforge-sentinel-replica-bootstrapped \\]; then"
+          pattern: "sentinel get-master-addr-by-name mymaster"
         template: replication-replica-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "set -- \"\\$@\" --replicaof"
+          pattern: "set -- \"\\$@\" --replicaof \"\\$sentinel_master\""
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "refusing to start as an unconfirmed master"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "Sentinel reports this pod as the current master; starting without replicaof"
         template: replication-replica-statefulset.yaml
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
@@ -223,6 +235,14 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "set -- \"\\$@\" --replicaof \"\\$sentinel_master\""
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "helmforge-sentinel-primary-bootstrapped"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "refusing to start without role confirmation"
         template: replication-primary-statefulset.yaml
 
   - it: should keep fixed replicaof in replication mode

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -112,6 +112,36 @@ tests:
           value: data
         template: sentinel-statefulset.yaml
 
+  - it: should preserve sentinel failover role on replica restarts
+    set:
+      architecture: sentinel
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "replica already bootstrapped; sentinel will preserve the current role"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "if \\[ ! -f /data/\\.helmforge-sentinel-replica-bootstrapped \\]; then"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "set -- \"\\$@\" --replicaof"
+        template: replication-replica-statefulset.yaml
+
+  - it: should keep fixed replicaof in replication mode
+    set:
+      architecture: replication
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "helmforge-sentinel-replica-bootstrapped"
+        template: replication-replica-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "set -- \"\\$@\" --replicaof"
+        template: replication-replica-statefulset.yaml
+
   - it: should render extra env and volumes in cluster pods
     set:
       architecture: cluster

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -87,6 +87,14 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "exec valkey-sentinel /data/sentinel.conf"
         template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "if \\[ ! -f /data/sentinel.conf \\]; then"
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "sed -i '/\\^sentinel auth-pass mymaster /d' /data/sentinel.conf"
+        template: sentinel-statefulset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -99,6 +99,18 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "sed -i '/\\^sentinel auth-pass mymaster /d' /data/sentinel.conf"
         template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "HelmForge managed sentinel config begin"
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "sentinel down-after-milliseconds mymaster /d"
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "cat /etc/valkey-base/sentinel.conf >> /data/sentinel.conf"
+        template: sentinel-statefulset.yaml
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -115,6 +127,45 @@ tests:
           path: spec.volumeClaimTemplates[0].metadata.name
           value: data
         template: sentinel-statefulset.yaml
+
+  - it: should mark sentinel config as a replaceable managed block
+    set:
+      architecture: sentinel
+      sentinel.quorum: 3
+      sentinel.downAfterMilliseconds: 45000
+      sentinel.failoverTimeout: 240000
+      sentinel.parallelSyncs: 2
+      config.sentinel: |
+        sentinel announce-hostnames yes
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "# HelmForge managed sentinel config begin"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel monitor mymaster test-valkey-primary-0\\.test-valkey-headless\\.default\\.svc\\.cluster\\.local 6379 3"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel down-after-milliseconds mymaster 45000"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel failover-timeout mymaster 240000"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel parallel-syncs mymaster 2"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel announce-hostnames yes"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "# HelmForge managed sentinel config end"
+        template: configmap.yaml
 
   - it: should preserve sentinel failover role on replica restarts
     set:

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -132,6 +132,12 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "set -- \"\\$@\" --replicaof"
         template: replication-replica-statefulset.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+        template: replication-replica-statefulset.yaml
 
   - it: should keep fixed replicaof in replication mode
     set:

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -202,10 +202,38 @@ tests:
             mountPath: /data
         template: replication-replica-statefulset.yaml
 
+  - it: should start old sentinel primary as a replica of the current sentinel master
+    set:
+      architecture: sentinel
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - sh
+            - -ec
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "sentinel get-master-addr-by-name mymaster"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "self_ip=\"\\$\\(hostname -i"
+        template: replication-primary-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "set -- \"\\$@\" --replicaof \"\\$sentinel_master\""
+        template: replication-primary-statefulset.yaml
+
   - it: should keep fixed replicaof in replication mode
     set:
       architecture: replication
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - valkey-server
+        template: replication-primary-statefulset.yaml
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "helmforge-sentinel-replica-bootstrapped"

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -93,6 +93,10 @@ tests:
         template: sentinel-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
+          pattern: "if \\[ ! -f /data/sentinel.conf \\]; then\\n.*until valkey-cli"
+        template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
           pattern: "sed -i '/\\^sentinel auth-pass mymaster /d' /data/sentinel.conf"
         template: sentinel-statefulset.yaml
       - contains:

--- a/charts/valkey/tests/pdb_test.yaml
+++ b/charts/valkey/tests/pdb_test.yaml
@@ -30,3 +30,39 @@ tests:
           value: 1
       - notExists:
           path: spec.minAvailable
+
+  - it: should protect data and sentinel pods in sentinel mode
+    set:
+      architecture: sentinel
+      pdb.enabled: true
+      sentinel.quorum: 2
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-valkey
+        documentIndex: 0
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: valkey
+        documentIndex: 0
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-valkey-sentinel
+        documentIndex: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: sentinel
+        documentIndex: 1
+      - equal:
+          path: spec.minAvailable
+          value: 2
+        documentIndex: 1
+      - notExists:
+          path: spec.maxUnavailable
+        documentIndex: 1

--- a/charts/valkey/tests/pdb_test.yaml
+++ b/charts/valkey/tests/pdb_test.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: PodDisruptionBudget
+templates:
+  - pdb.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not create PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create PDB in standalone even when enabled
+    set:
+      pdb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create PDB in replication mode when enabled
+    set:
+      architecture: replication
+      pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget

--- a/charts/valkey/tests/pdb_test.yaml
+++ b/charts/valkey/tests/pdb_test.yaml
@@ -25,3 +25,8 @@ tests:
     asserts:
       - isKind:
           of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable

--- a/charts/valkey/tests/secret_test.yaml
+++ b/charts/valkey/tests/secret_test.yaml
@@ -23,6 +23,15 @@ tests:
           path: type
           value: Opaque
 
+  - it: should apply global annotations
+    set:
+      annotations:
+        reloader.stakater.com/auto: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+
   - it: should contain password key in stringData
     asserts:
       - isNotNull:

--- a/charts/valkey/tests/secret_test.yaml
+++ b/charts/valkey/tests/secret_test.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Secret
+templates:
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should be a Secret
+    asserts:
+      - isKind:
+          of: Secret
+
+  - it: should have correct name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-valkey-auth
+
+  - it: should be Opaque type
+    asserts:
+      - equal:
+          path: type
+          value: Opaque
+
+  - it: should contain password key in stringData
+    asserts:
+      - isNotNull:
+          path: stringData["valkey-password"]
+
+  - it: should not be created when existingSecret is set
+    set:
+      auth.existingSecret: my-external-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -45,6 +45,28 @@ tests:
             port: 6379
             targetPort: valkey
 
+  - it: should render a single dedicated metrics service
+    set:
+      metrics.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: test-valkey-metrics
+        documentIndex: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: metrics
+        documentIndex: 1
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+            port: 9121
+            targetPort: metrics
+        documentIndex: 1
+
   - it: should apply dual-stack settings to headless and client services
     set:
       service.ipFamilyPolicy: PreferDualStack

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -45,6 +45,18 @@ tests:
             port: 6379
             targetPort: valkey
 
+  - it: should honor service type for standalone client service
+    documentIndex: 1
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-valkey-client
+      - equal:
+          path: spec.type
+          value: NodePort
+
   - it: should apply global and service annotations with per-service overrides
     set:
       annotations:
@@ -136,3 +148,16 @@ tests:
             - IPv4
             - IPv6
         documentIndex: 1
+
+  - it: should honor service type for cluster client service
+    documentIndex: 1
+    set:
+      architecture: cluster
+      service.type: LoadBalancer
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-valkey-client
+      - equal:
+          path: spec.type
+          value: LoadBalancer

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -45,30 +45,41 @@ tests:
             port: 6379
             targetPort: valkey
 
-  - it: should apply global annotations and allow service-specific overrides
+  - it: should apply global and service annotations with per-service overrides
     set:
       annotations:
         argocd.argoproj.io/sync-wave: "1"
         example.com/global: "true"
       service:
-        clientAnnotations:
+        annotations:
           argocd.argoproj.io/sync-wave: "2"
+          example.com/service: "true"
+        clientAnnotations:
+          argocd.argoproj.io/sync-wave: "3"
           example.com/client: "true"
     asserts:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
-          value: "1"
+          value: "2"
         documentIndex: 0
       - equal:
           path: metadata.annotations["example.com/global"]
           value: "true"
         documentIndex: 0
       - equal:
+          path: metadata.annotations["example.com/service"]
+          value: "true"
+        documentIndex: 0
+      - equal:
           path: metadata.annotations["argocd.argoproj.io/sync-wave"]
-          value: "2"
+          value: "3"
         documentIndex: 1
       - equal:
           path: metadata.annotations["example.com/global"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["example.com/service"]
           value: "true"
         documentIndex: 1
       - equal:

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render headless and client services
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should have headless service
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-valkey-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+
+  - it: should have client service
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-valkey-client
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should expose port 6379
+    documentIndex: 1
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: valkey
+            port: 6379
+            targetPort: valkey

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -44,3 +44,31 @@ tests:
             name: valkey
             port: 6379
             targetPort: valkey
+
+  - it: should apply dual-stack settings to headless and client services
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+        documentIndex: 1

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -45,6 +45,37 @@ tests:
             port: 6379
             targetPort: valkey
 
+  - it: should apply global annotations and allow service-specific overrides
+    set:
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+        example.com/global: "true"
+      service:
+        clientAnnotations:
+          argocd.argoproj.io/sync-wave: "2"
+          example.com/client: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["example.com/global"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "2"
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["example.com/global"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["example.com/client"]
+          value: "true"
+        documentIndex: 1
+
   - it: should render a single dedicated metrics service
     set:
       metrics.enabled: true

--- a/charts/valkey/tests/servicemonitor_test.yaml
+++ b/charts/valkey/tests/servicemonitor_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ServiceMonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should select only the dedicated metrics service
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: metrics
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics

--- a/charts/valkey/tests/standalone_statefulset_test.yaml
+++ b/charts/valkey/tests/standalone_statefulset_test.yaml
@@ -20,6 +20,16 @@ tests:
           path: metadata.name
           value: test-valkey
 
+  - it: should apply global annotations to statefulset metadata
+    template: standalone-statefulset.yaml
+    set:
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"
+
   - it: should not render in replication mode
     template: standalone-statefulset.yaml
     set:

--- a/charts/valkey/tests/standalone_statefulset_test.yaml
+++ b/charts/valkey/tests/standalone_statefulset_test.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Standalone StatefulSet
+templates:
+  - standalone-statefulset.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should be a StatefulSet in standalone mode
+    template: standalone-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+
+  - it: should have correct name
+    template: standalone-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-valkey
+
+  - it: should not render in replication mode
+    template: standalone-statefulset.yaml
+    set:
+      architecture: replication
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use the correct image
+    template: standalone-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/valkey/valkey:9.1.0"
+
+  - it: should have 1 replica
+    template: standalone-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should expose Valkey port
+    template: standalone-statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: valkey
+            containerPort: 6379
+
+  - it: should set security context
+    template: standalone-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 999
+
+  - it: should have probes
+    template: standalone-statefulset.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should create VolumeClaimTemplate with default 8Gi
+    template: standalone-statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
+          value: 8Gi

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -55,3 +55,9 @@ tests:
       - equal:
           path: spec.containers[0].env[0].value
           value: test-valkey-client
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "for i in \\$\\(seq 1 30\\)"
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "waiting for Valkey Cluster to report cluster_state:ok"

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Helm test connection
+templates:
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a helm test pod by default
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: test-valkey-test-connection
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: spec.containers[0].env[0].value
+          value: test-valkey-client
+
+  - it: should target the primary service for replication
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.containers[0].env[0].value
+          value: test-valkey-primary
+
+  - it: should target the primary service for sentinel
+    set:
+      architecture: sentinel
+    asserts:
+      - equal:
+          path: spec.containers[0].env[0].value
+          value: test-valkey-primary
+
+  - it: should target the client service for cluster
+    set:
+      architecture: cluster
+    asserts:
+      - equal:
+          path: spec.containers[0].env[0].value
+          value: test-valkey-client

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -20,6 +20,18 @@ tests:
           path: spec.containers[0].env[0].value
           value: test-valkey-client
 
+  - it: should merge global annotations with helm test annotations
+    set:
+      annotations:
+        argocd.argoproj.io/sync-wave: "1"
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+
   - it: should target the primary service for replication
     set:
       architecture: replication

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -83,11 +83,30 @@ tests:
             name: REDIS_EXPORTER_TLS_CA_CERT_FILE
             value: /tls/ca.crt
       - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_EXPORTER_SKIP_TLS_VERIFICATION
+            value: "true"
+      - contains:
           path: spec.template.spec.containers[1].volumeMounts
           content:
             name: tls
             mountPath: /tls
             readOnly: true
+
+  - it: should allow TLS metrics verification when explicitly requested
+    template: standalone-statefulset.yaml
+    set:
+      metrics.enabled: true
+      metrics.tlsSkipVerify: false
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_EXPORTER_SKIP_TLS_VERIFICATION
+            value: "true"
 
   - it: should mount TLS certificates on replication primary
     template: replication-primary-statefulset.yaml

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -29,7 +29,7 @@ tests:
             readOnly: true
 
   - it: should require a TLS secret when TLS is enabled
-    template: configmap.yaml
+    template: standalone-statefulset.yaml
     set:
       tls.enabled: true
     asserts:

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
-          pattern: "valkey-cli --tls --cacert /tls/ca.crt .* ping"
+          pattern: "valkey-cli --tls --cacert /tls/ca.crt --insecure .* ping"
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: TLS support
+templates:
+  - configmap.yaml
+  - standalone-statefulset.yaml
+  - replication-primary-statefulset.yaml
+  - replication-replica-statefulset.yaml
+  - cluster-statefulset.yaml
+  - cluster-init-job.yaml
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should make standalone probes use valkey-cli TLS flags
+    template: standalone-statefulset.yaml
+    set:
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          pattern: "valkey-cli --tls --cacert /tls/ca.crt .* ping"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+
+  - it: should mount TLS certificates on replication primary
+    template: replication-primary-statefulset.yaml
+    set:
+      architecture: replication
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: valkey-tls
+
+  - it: should wait for primary over TLS before starting replicas
+    template: replication-replica-statefulset.yaml
+    set:
+      architecture: replication
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "valkey-cli --tls --cacert /tls/ca.crt"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+
+  - it: should enable replication and cluster TLS directives
+    template: configmap.yaml
+    set:
+      architecture: cluster
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: data["valkey-replica.conf"]
+          pattern: "tls-replication yes"
+      - matchRegex:
+          path: data["valkey-cluster.conf"]
+          pattern: "tls-cluster yes"
+      - matchRegex:
+          path: data["valkey-cluster.conf"]
+          pattern: "tls-replication yes"
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "tls-port 26379"
+
+  - it: should mount TLS certificates on cluster nodes and init job
+    template: cluster-statefulset.yaml
+    set:
+      architecture: cluster
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls
+            secret:
+              secretName: valkey-tls
+
+  - it: should use TLS in cluster init commands
+    template: cluster-init-job.yaml
+    set:
+      architecture: cluster
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "valkey-cli --tls --cacert /tls/ca.crt"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+
+  - it: should mount TLS certificates and use TLS in helm test
+    template: templates/tests/test-connection.yaml
+    set:
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: VALKEY_TLS_ARGS
+            value: --tls --cacert /tls/ca.crt
+      - contains:
+          path: spec.containers[0].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -140,6 +140,9 @@ tests:
       tls.existingSecret: valkey-tls
     asserts:
       - matchRegex:
+          path: data["valkey-primary.conf"]
+          pattern: "tls-replication yes"
+      - matchRegex:
           path: data["valkey-replica.conf"]
           pattern: "tls-replication yes"
       - matchRegex:
@@ -182,6 +185,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "valkey-cli --tls --cacert /tls/ca.crt"
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "-p 6379"
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -45,6 +45,26 @@ tests:
           path: data["valkey-standalone.conf"]
           pattern: "port 6380"
 
+  - it: should pass custom port to health probes
+    template: standalone-statefulset.yaml
+    set:
+      service.ports.valkey: 6380
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          pattern: "valkey-cli .* -p 6380 .*ping"
+
+  - it: should configure masterauth on authenticated primary
+    template: replication-primary-statefulset.yaml
+    set:
+      architecture: replication
+      auth.enabled: true
+      auth.password: secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --masterauth
+
   - it: should configure metrics exporter for TLS
     template: standalone-statefulset.yaml
     set:

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -28,6 +28,47 @@ tests:
             mountPath: /tls
             readOnly: true
 
+  - it: should require a TLS secret when TLS is enabled
+    template: configmap.yaml
+    set:
+      tls.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "tls.enabled requires tls.existingSecret"
+
+  - it: should render custom plaintext port in Valkey config
+    template: configmap.yaml
+    set:
+      service.ports.valkey: 6380
+    asserts:
+      - matchRegex:
+          path: data["valkey-standalone.conf"]
+          pattern: "port 6380"
+
+  - it: should configure metrics exporter for TLS
+    template: standalone-statefulset.yaml
+    set:
+      metrics.enabled: true
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_ADDR
+            value: rediss://127.0.0.1:6379
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_EXPORTER_TLS_CA_CERT_FILE
+            value: /tls/ca.crt
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: tls
+            mountPath: /tls
+            readOnly: true
+
   - it: should mount TLS certificates on replication primary
     template: replication-primary-statefulset.yaml
     set:

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -1,0 +1,591 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "valkey Helm Chart Values",
+  "description": "Default values for the Valkey Helm chart. Supports standalone, replication, sentinel, and cluster architectures.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "architecture": {
+      "type": "string",
+      "description": "valkey topology to deploy: standalone | replication | sentinel | cluster",
+      "enum": ["standalone", "replication", "sentinel", "cluster"]
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override chart name"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override full release name"
+    },
+    "clusterDomain": {
+      "type": "string",
+      "description": "Kubernetes cluster DNS domain used for internal service FQDNs",
+      "default": "cluster.local"
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Extra labels applied to all resources"
+    },
+    "image": {
+      "type": "object",
+      "description": "valkey container image settings",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "valkey image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "valkey image tag"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "description": "Image pull policy",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "Image pull secrets for private registries",
+      "items": {
+        "type": "object"
+      }
+    },
+    "auth": {
+      "type": "object",
+      "description": "valkey authentication settings",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable password authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "valkey password. Auto-generated if empty and auth.enabled=true"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing secret with the Valkey password"
+        },
+        "existingSecretPasswordKey": {
+          "type": "string",
+          "description": "Secret key name for the password in auth.existingSecret"
+        }
+      }
+    },
+    "tls": {
+      "type": "object",
+      "description": "TLS configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable TLS. Requires tls.existingSecret."
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing secret with tls.crt, tls.key and ca.crt"
+        },
+        "certFilename": {
+          "type": "string",
+          "description": "TLS certificate filename"
+        },
+        "keyFilename": {
+          "type": "string",
+          "description": "TLS private key filename"
+        },
+        "caFilename": {
+          "type": "string",
+          "description": "TLS CA certificate filename"
+        }
+      }
+    },
+    "standalone": {
+      "type": "object",
+      "description": "Standalone architecture settings",
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "description": "Persistence settings for standalone mode",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable persistence"
+            },
+            "storageClass": {
+              "type": "string",
+              "description": "Storage class for the PVC"
+            },
+            "accessModes": {
+              "type": "array",
+              "description": "Access modes for the PVC",
+              "items": {
+                "type": "string"
+              }
+            },
+            "size": {
+              "type": "string",
+              "description": "PVC size"
+            }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits"
+        }
+      }
+    },
+    "replication": {
+      "type": "object",
+      "description": "Replication architecture settings",
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of replica nodes"
+        },
+        "primary": {
+          "type": "object",
+          "description": "Primary node settings",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "description": "Persistence settings for the primary node",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "storageClass": { "type": "string" },
+                "accessModes": { "type": "array", "items": { "type": "string" } },
+                "size": { "type": "string" }
+              }
+            },
+            "resources": {
+              "type": "object",
+              "description": "Resource requests and limits for the primary node"
+            }
+          }
+        },
+        "replica": {
+          "type": "object",
+          "description": "Replica node settings",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "description": "Persistence settings for replica nodes",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "storageClass": { "type": "string" },
+                "accessModes": { "type": "array", "items": { "type": "string" } },
+                "size": { "type": "string" }
+              }
+            },
+            "resources": {
+              "type": "object",
+              "description": "Resource requests and limits for replica nodes"
+            }
+          }
+        }
+      }
+    },
+    "sentinel": {
+      "type": "object",
+      "description": "Sentinel architecture settings",
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of sentinel replicas"
+        },
+        "quorum": {
+          "type": "integer",
+          "description": "Quorum for sentinel failover"
+        },
+        "downAfterMilliseconds": {
+          "type": "integer",
+          "description": "Milliseconds before marking a node as down"
+        },
+        "failoverTimeout": {
+          "type": "integer",
+          "description": "Failover timeout in milliseconds"
+        },
+        "parallelSyncs": {
+          "type": "integer",
+          "description": "Number of parallel syncs during failover"
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Persistence settings for sentinel",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for sentinel"
+        }
+      }
+    },
+    "cluster": {
+      "type": "object",
+      "description": "Cluster architecture settings",
+      "properties": {
+        "nodes": {
+          "type": "integer",
+          "description": "Total number of cluster nodes"
+        },
+        "replicasPerMaster": {
+          "type": "integer",
+          "description": "Number of replicas per master node"
+        },
+        "initJob": {
+          "type": "object",
+          "description": "Cluster initialization job settings",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable the cluster init job"
+            },
+            "backoffLimit": {
+              "type": "integer",
+              "description": "Job backoff limit"
+            },
+            "activeDeadlineSeconds": {
+              "type": "integer",
+              "description": "Job active deadline in seconds"
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Persistence settings for cluster nodes",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for cluster nodes"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "description": "Extra Valkey and Sentinel configuration",
+      "properties": {
+        "valkey": {
+          "type": "string",
+          "description": "Extra Valkey configuration appended to the generated valkey.conf"
+        },
+        "sentinel": {
+          "type": "string",
+          "description": "Extra Sentinel configuration appended to the generated sentinel.conf"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "description": "Service configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Service type",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations applied to the service"
+        },
+        "clientAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to the client service"
+        },
+        "primaryAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to the primary service"
+        },
+        "replicaAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to the replica service"
+        },
+        "sentinelAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to the sentinel service"
+        },
+        "clusterAnnotations": {
+          "type": "object",
+          "description": "Annotations applied to the cluster service"
+        },
+        "ports": {
+          "type": "object",
+          "description": "Service port configuration",
+          "properties": {
+            "valkey": {
+              "type": "integer",
+              "description": "valkey port"
+            },
+            "sentinel": {
+              "type": "integer",
+              "description": "Sentinel port"
+            },
+            "metrics": {
+              "type": "integer",
+              "description": "Metrics exporter port"
+            }
+          }
+        },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "description": "Dual-stack ipFamilyPolicy (GR-058)",
+          "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Dual-stack ipFamilies (GR-058)",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "description": "ServiceAccount configuration",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create a ServiceAccount"
+        },
+        "name": {
+          "type": "string",
+          "description": "Existing ServiceAccount name"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations added to the ServiceAccount"
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Liveness probe configuration",
+      "properties": {
+        "initialDelaySeconds": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" },
+        "failureThreshold": { "type": "integer" }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe configuration",
+      "properties": {
+        "initialDelaySeconds": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" },
+        "failureThreshold": { "type": "integer" }
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "description": "Startup probe configuration",
+      "properties": {
+        "initialDelaySeconds": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" },
+        "failureThreshold": { "type": "integer" }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Prometheus metrics configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Prometheus metrics exporter"
+        },
+        "image": {
+          "type": "object",
+          "description": "Metrics exporter image settings",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for the metrics exporter"
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "description": "ServiceMonitor configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create a ServiceMonitor resource"
+            },
+            "interval": {
+              "type": "string",
+              "description": "Scrape interval"
+            },
+            "labels": {
+              "type": "object",
+              "description": "Extra labels for the ServiceMonitor"
+            }
+          }
+        }
+      }
+    },
+    "tests": {
+      "type": "object",
+      "description": "Helm test settings",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Render the Helm test connection pod"
+        },
+        "image": {
+          "type": "object",
+          "description": "Image used by Helm tests",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod-level security context",
+      "properties": {
+        "fsGroup": { "type": "integer" },
+        "seccompProfile": {
+          "type": "object",
+          "description": "Seccomp profile applied at pod level",
+          "properties": {
+            "type": { "type": "string" }
+          }
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Container-level security context",
+      "properties": {
+        "runAsUser": { "type": "integer" },
+        "runAsGroup": { "type": "integer" },
+        "runAsNonRoot": { "type": "boolean" },
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "readOnlyRootFilesystem": { "type": "boolean" },
+        "capabilities": { "type": "object" }
+      }
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Extra labels for pods"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Extra annotations for pods"
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Extra annotations for all resources"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling"
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling",
+      "items": {
+        "type": "object"
+      }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Topology spread constraints for pod scheduling",
+      "items": {
+        "type": "object"
+      }
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "Priority class name for pods"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "description": "Termination grace period in seconds"
+    },
+    "pdb": {
+      "type": "object",
+      "description": "PodDisruptionBudget configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable PodDisruptionBudget"
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "description": "Extra environment variables",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Extra volumes",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Extra volume mounts",
+      "items": {
+        "type": "object"
+      }
+    },
+    "extraManifests": {
+      "type": "array",
+      "description": "Extra manifests rendered with tpl",
+      "items": {
+        "type": "object"
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator configuration.",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  }
+}

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -368,6 +368,10 @@
         }
       }
     },
+    "automountServiceAccountToken": {
+      "type": "boolean",
+      "description": "Mount Kubernetes API service account token into pods"
+    },
     "livenessProbe": {
       "type": "object",
       "description": "Liveness probe configuration",

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -27,10 +27,14 @@ commonLabels: {}
 # =============================================================================
 
 image:
+  # -- Container image repository
   repository: docker.io/valkey/valkey
+  # -- Container image tag
   tag: "9.1.0"
+  # -- Image pull policy
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets for private registries
 imagePullSecrets: []
 
 # =============================================================================
@@ -56,8 +60,11 @@ tls:
   enabled: false
   # -- Existing secret with tls.crt, tls.key and ca.crt
   existingSecret: ""
+  # -- Certificate filename mounted from tls.existingSecret
   certFilename: tls.crt
+  # -- Private key filename mounted from tls.existingSecret
   keyFilename: tls.key
+  # -- CA certificate filename mounted from tls.existingSecret
   caFilename: ca.crt
 
 # =============================================================================
@@ -66,11 +73,16 @@ tls:
 
 standalone:
   persistence:
+    # -- Enable persistent storage for standalone mode
     enabled: true
+    # -- StorageClass for the standalone PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for the standalone PVC
     accessModes:
       - ReadWriteOnce
+    # -- Size of the standalone PVC
     size: 8Gi
+  # -- Resource requests and limits for the standalone Valkey container
   resources: {}
 
 # =============================================================================
@@ -78,22 +90,33 @@ standalone:
 # =============================================================================
 
 replication:
+  # -- Number of replica nodes in replication mode
   replicaCount: 2
   primary:
     persistence:
+      # -- Enable persistent storage for the primary node
       enabled: true
+      # -- StorageClass for the primary PVC. Empty uses the cluster default.
       storageClass: ""
+      # -- Access modes for the primary PVC
       accessModes:
         - ReadWriteOnce
+      # -- Size of the primary PVC
       size: 8Gi
+    # -- Resource requests and limits for the primary Valkey container
     resources: {}
   replica:
     persistence:
+      # -- Enable persistent storage for replica nodes
       enabled: true
+      # -- StorageClass for replica PVCs. Empty uses the cluster default.
       storageClass: ""
+      # -- Access modes for replica PVCs
       accessModes:
         - ReadWriteOnce
+      # -- Size of each replica PVC
       size: 8Gi
+    # -- Resource requests and limits for replica Valkey containers
     resources: {}
 
 # =============================================================================
@@ -101,17 +124,27 @@ replication:
 # =============================================================================
 
 sentinel:
+  # -- Number of Sentinel pods
   replicaCount: 3
+  # -- Sentinel quorum required for failover decisions
   quorum: 2
+  # -- Milliseconds before Sentinel marks the primary as subjectively down
   downAfterMilliseconds: 60000
+  # -- Sentinel failover timeout in milliseconds
   failoverTimeout: 180000
+  # -- Number of replicas that can reconfigure in parallel during failover
   parallelSyncs: 1
   persistence:
+    # -- Enable persistent storage for Sentinel pods
     enabled: false
+    # -- StorageClass for Sentinel PVCs. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for Sentinel PVCs
     accessModes:
       - ReadWriteOnce
+    # -- Size of each Sentinel PVC
     size: 1Gi
+  # -- Resource requests and limits for Sentinel containers
   resources: {}
 
 # =============================================================================
@@ -119,18 +152,28 @@ sentinel:
 # =============================================================================
 
 cluster:
+  # -- Total number of Valkey Cluster nodes
   nodes: 6
+  # -- Number of replicas assigned to each cluster master
   replicasPerMaster: 1
   initJob:
+    # -- Run a post-install Job that creates the Valkey Cluster topology
     enabled: true
+    # -- Backoff limit for the cluster initialization Job
     backoffLimit: 4
+    # -- Active deadline for the cluster initialization Job
     activeDeadlineSeconds: 900
   persistence:
+    # -- Enable persistent storage for cluster nodes
     enabled: true
+    # -- StorageClass for cluster PVCs. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for cluster PVCs
     accessModes:
       - ReadWriteOnce
+    # -- Size of each cluster PVC
     size: 8Gi
+  # -- Resource requests and limits for cluster Valkey containers
   resources: {}
 
 # =============================================================================
@@ -148,16 +191,26 @@ config:
 # =============================================================================
 
 service:
+  # -- Client Service type used by standalone and cluster modes
   type: ClusterIP
+  # -- Annotations applied to all Valkey Services
   annotations: {}
+  # -- Annotations applied to the client Service
   clientAnnotations: {}
+  # -- Annotations applied to the primary Service in replication and sentinel modes
   primaryAnnotations: {}
+  # -- Annotations applied to the replica Service in replication and sentinel modes
   replicaAnnotations: {}
+  # -- Annotations applied to the Sentinel Service
   sentinelAnnotations: {}
+  # -- Annotations applied to the cluster client Service
   clusterAnnotations: {}
   ports:
+    # -- Valkey service port
     valkey: 6379
+    # -- Sentinel service port
     sentinel: 26379
+    # -- Metrics service port
     metrics: 9121
   # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ~
@@ -165,8 +218,11 @@ service:
   ipFamilies: []
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount
   create: false
+  # -- Existing ServiceAccount name when serviceAccount.create=false
   name: ""
+  # -- Annotations added to the ServiceAccount
   annotations: {}
 
 # -- Mount Kubernetes API service account token into pods.
@@ -177,21 +233,33 @@ automountServiceAccountToken: false
 # =============================================================================
 
 livenessProbe:
+  # -- Initial delay before liveness probes begin
   initialDelaySeconds: 20
+  # -- Liveness probe interval
   periodSeconds: 15
+  # -- Liveness probe timeout
   timeoutSeconds: 5
+  # -- Liveness probe failure threshold
   failureThreshold: 6
 
 readinessProbe:
+  # -- Initial delay before readiness probes begin
   initialDelaySeconds: 10
+  # -- Readiness probe interval
   periodSeconds: 10
+  # -- Readiness probe timeout
   timeoutSeconds: 5
+  # -- Readiness probe failure threshold
   failureThreshold: 3
 
 startupProbe:
+  # -- Initial delay before startup probes begin
   initialDelaySeconds: 5
+  # -- Startup probe interval
   periodSeconds: 10
+  # -- Startup probe timeout
   timeoutSeconds: 5
+  # -- Startup probe failure threshold
   failureThreshold: 30
 
 # =============================================================================
@@ -199,16 +267,25 @@ startupProbe:
 # =============================================================================
 
 metrics:
+  # -- Enable Prometheus metrics exporter sidecar
   enabled: false
+  # -- Skip TLS verification for exporter connections to Valkey when TLS is enabled
   tlsSkipVerify: true
   image:
+    # -- Metrics exporter image repository
     repository: docker.io/oliver006/redis_exporter
+    # -- Metrics exporter image tag
     tag: v1.69.0
+    # -- Metrics exporter image pull policy
     pullPolicy: IfNotPresent
+  # -- Resource requests and limits for the metrics exporter
   resources: {}
   serviceMonitor:
+    # -- Render a Prometheus Operator ServiceMonitor
     enabled: false
+    # -- ServiceMonitor scrape interval
     interval: 30s
+    # -- Extra labels added to the ServiceMonitor
     labels: {}
 
 # =============================================================================
@@ -216,10 +293,14 @@ metrics:
 # =============================================================================
 
 tests:
+  # -- Render Helm test resources
   enabled: true
   image:
+    # -- Helm test image repository
     repository: docker.io/valkey/valkey
+    # -- Helm test image tag
     tag: "9.1.0"
+    # -- Helm test image pull policy
     pullPolicy: IfNotPresent
 
 # =============================================================================
@@ -227,41 +308,63 @@ tests:
 # =============================================================================
 
 podSecurityContext:
+  # -- Filesystem group used by Valkey writable volumes
   fsGroup: 999
   seccompProfile:
+    # -- Pod-level seccomp profile type
     type: RuntimeDefault
 
 securityContext:
+  # -- User ID used by Valkey containers
   runAsUser: 999
+  # -- Group ID used by Valkey containers
   runAsGroup: 999
+  # -- Require containers to run as a non-root user
   runAsNonRoot: true
+  # -- Prevent privilege escalation
   allowPrivilegeEscalation: false
+  # -- Run root filesystem as read-only when supported by the deployment mode
   readOnlyRootFilesystem: false
   capabilities:
+    # -- Linux capabilities dropped from containers
     drop:
       - ALL
 
+# -- Extra labels added to pods
 podLabels: {}
+# -- Extra annotations added to pods
 podAnnotations: {}
+# -- Extra annotations added to all resources
 annotations: {}
 
+# -- Node selector for pod scheduling
 nodeSelector: {}
+# -- Tolerations for pod scheduling
 tolerations: []
+# -- Affinity rules for pod scheduling
 affinity: {}
+# -- Topology spread constraints for pod scheduling
 topologySpreadConstraints: []
+# -- PriorityClass name for pods
 priorityClassName: ""
+# -- Termination grace period in seconds
 terminationGracePeriodSeconds: 60
 
 pdb:
+  # -- Render PodDisruptionBudget resources for supported topologies
   enabled: false
 
 # =============================================================================
 # Extra
 # =============================================================================
 
+# -- Extra environment variables added to Valkey containers
 extraEnv: []
+# -- Extra volumes added to Valkey pods
 extraVolumes: []
+# -- Extra volume mounts added to Valkey containers
 extraVolumeMounts: []
+# -- Extra Kubernetes manifests rendered with tpl
 extraManifests: []
 
 # =============================================================================
@@ -273,12 +376,17 @@ externalSecrets:
   # Requires auth.existingSecret to be set to prevent credential drift between
   # the chart-managed auth Secret and the ExternalSecret.
   enabled: false
+  # -- ExternalSecret API version
   apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval
   refreshInterval: "0"
   secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name
     name: ""
+    # -- Secret store kind: SecretStore or ClusterSecretStore
     kind: SecretStore
   target:
+    # -- ExternalSecret target creation policy
     creationPolicy: Owner
   # -- Data entries mapping remote keys to the Valkey password key.
   data: []

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -200,6 +200,7 @@ startupProbe:
 
 metrics:
   enabled: false
+  tlsSkipVerify: true
   image:
     repository: docker.io/oliver006/redis_exporter
     tag: v1.69.0

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Valkey Helm Chart - Default Values
+# =============================================================================
+# Supported architectures:
+# - standalone
+# - replication
+# - sentinel
+# - cluster
+
+# -- Valkey topology to deploy: standalone | replication | sentinel | cluster
+architecture: standalone
+
+# -- Override chart name
+nameOverride: ""
+# -- Override full release name
+fullnameOverride: ""
+
+# -- Kubernetes cluster DNS domain used for internal service FQDNs
+clusterDomain: cluster.local
+
+# -- Extra labels applied to all resources
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  repository: docker.io/valkey/valkey
+  tag: "9.1.0"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+auth:
+  # -- Enable password authentication
+  enabled: true
+  # -- Valkey password. Auto-generated if empty and auth.enabled=true
+  password: ""
+  # -- Existing secret with the Valkey password
+  existingSecret: ""
+  # -- Secret key name for the password in auth.existingSecret
+  existingSecretPasswordKey: valkey-password
+
+# =============================================================================
+# TLS
+# =============================================================================
+
+tls:
+  # -- Enable TLS. Requires tls.existingSecret.
+  enabled: false
+  # -- Existing secret with tls.crt, tls.key and ca.crt
+  existingSecret: ""
+  certFilename: tls.crt
+  keyFilename: tls.key
+  caFilename: ca.crt
+
+# =============================================================================
+# Standalone
+# =============================================================================
+
+standalone:
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+  resources: {}
+
+# =============================================================================
+# Replication
+# =============================================================================
+
+replication:
+  replicaCount: 2
+  primary:
+    persistence:
+      enabled: true
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+    resources: {}
+  replica:
+    persistence:
+      enabled: true
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+    resources: {}
+
+# =============================================================================
+# Sentinel
+# =============================================================================
+
+sentinel:
+  replicaCount: 3
+  quorum: 2
+  downAfterMilliseconds: 60000
+  failoverTimeout: 180000
+  parallelSyncs: 1
+  persistence:
+    enabled: false
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+  resources: {}
+
+# =============================================================================
+# Cluster
+# =============================================================================
+
+cluster:
+  nodes: 6
+  replicasPerMaster: 1
+  initJob:
+    enabled: true
+    backoffLimit: 4
+    activeDeadlineSeconds: 900
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+  resources: {}
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+config:
+  # -- Extra Valkey configuration appended to the generated valkey.conf
+  valkey: ""
+  # -- Extra Sentinel configuration appended to the generated sentinel.conf
+  sentinel: ""
+
+# =============================================================================
+# Networking
+# =============================================================================
+
+service:
+  type: ClusterIP
+  annotations: {}
+  clientAnnotations: {}
+  primaryAnnotations: {}
+  replicaAnnotations: {}
+  sentinelAnnotations: {}
+  clusterAnnotations: {}
+  ports:
+    valkey: 6379
+    sentinel: 26379
+    metrics: 9121
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+livenessProbe:
+  initialDelaySeconds: 20
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+# =============================================================================
+# Metrics
+# =============================================================================
+
+metrics:
+  enabled: false
+  image:
+    repository: docker.io/oliver006/redis_exporter
+    tag: v1.69.0
+    pullPolicy: IfNotPresent
+  resources: {}
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}
+
+# =============================================================================
+# Helm Tests
+# =============================================================================
+
+tests:
+  enabled: true
+  image:
+    repository: docker.io/valkey/valkey
+    tag: "9.1.0"
+    pullPolicy: IfNotPresent
+
+# =============================================================================
+# Scheduling and Security
+# =============================================================================
+
+podSecurityContext:
+  fsGroup: 999
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 999
+  runAsGroup: 999
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+podLabels: {}
+podAnnotations: {}
+annotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 60
+
+pdb:
+  enabled: false
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+extraManifests: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for the Valkey auth Secret.
+  # Requires auth.existingSecret to be set to prevent credential drift between
+  # the chart-managed auth Secret and the ExternalSecret.
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "0"
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  # -- Data entries mapping remote keys to the Valkey password key.
+  data: []
+  #   - secretKey: valkey-password
+  #     remoteRef:
+  #       key: valkey/auth
+  #       property: password

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -169,6 +169,9 @@ serviceAccount:
   name: ""
   annotations: {}
 
+# -- Mount Kubernetes API service account token into pods.
+automountServiceAccountToken: false
+
 # =============================================================================
 # Probes
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds the HelmForge `valkey` chart as a stable chart using the official `docker.io/valkey/valkey:9.1.0` image.

Closes #357.

## Scope

- supports `standalone`, `replication`, `sentinel`, and `cluster` architectures in one chart
- includes auth, existing Secret, External Secrets, TLS file wiring, persistence, PDB, dual-stack service fields, metrics exporter, ServiceMonitor, schema, examples, and topology docs
- adds Helm test hook for connection and topology health checks
- adds startup guard for replicas so they wait for the primary before starting replication
- hardens pod defaults with non-root execution, `RuntimeDefault` seccomp, privilege escalation disabled, and dropped capabilities
- aligns client Service exposure so `service.type` is honored by both standalone and cluster client Services

## Validation

Latest local validation after review fixes:

- `helm dependency build charts/valkey` and `helm dependency list charts/valkey` - no dependencies
- `helm lint charts/valkey --strict`
- `helm unittest charts/valkey` - 11 suites, 71 tests passed
- `npx --yes markdownlint-cli2 "charts/valkey/**/*.md"` - 6 files, 0 errors
- strict kubeconform for default render - 6 valid, 0 invalid
- strict kubeconform for all `charts/valkey/ci/*.yaml` scenarios: cluster, dual-stack, existing-secret, external-secrets, metrics, replication, sentinel, standalone, tls-cluster, tls-replication
- strict kubeconform for `architecture=cluster, service.type=LoadBalancer` and `service.type=NodePort`
- `ah lint charts/valkey` - Valkey package lint succeeded; repository scan 66 packages, 0 errors
- Kubescape NSA on `ci/cluster.yaml`: score 72.50, threshold 70, no critical findings
- MCP HelmForge: CI evidence PASS, security evidence PASS

## k3d validation

Validated on local cluster `k3d-helmforge-tests-wsl` after review fixes:

- namespace `hf-valkey-cluster`
- `helm install valkey-test charts/valkey -f charts/valkey/ci/cluster.yaml --wait --timeout 10m`
- `helm test valkey-test` succeeded
- `cluster_state:ok`
- `cluster_slots_assigned:16384` and `cluster_slots_ok:16384`
- 6 known nodes, 3 masters, replicas connected
- SET/GET through `valkey-test-client` succeeded
- all Valkey pods Ready with zero restarts
- no Warning events in the namespace
- logs scanned for `error|fatal|panic|exception|back-off|failed`; no matches
- namespace `hf-valkey-cluster` deleted after validation

Historical validation on earlier commits also covered standalone, replication, sentinel, metrics, TLS replication, and TLS cluster scenarios.