### PR TITLE
feat(tomcat): add Apache Tomcat chart

### DIFF
--- a/charts/tomcat/.helmignore
+++ b/charts/tomcat/.helmignore
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+.git/
+.github/
+.DS_Store
+*.swp
+*.tmp
+*.bak
+*.tgz
+charts/

--- a/charts/tomcat/.helmignore
+++ b/charts/tomcat/.helmignore
@@ -1,9 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
-.git/
-.github/
+# OS
 .DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
 *.swp
 *.tmp
+
+# Lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Pipfile.lock
+poetry.lock
+Gemfile.lock
+
+# Logs
+*.log
+
+# CI / misc
 *.bak
-*.tgz
-charts/

--- a/charts/tomcat/Chart.yaml
+++ b/charts/tomcat/Chart.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: tomcat
+description: Apache Tomcat Helm chart with official image, Gateway API, JMX, and production controls
+type: application
+version: 0.1.0
+appVersion: "11.0.22"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - tomcat
+  - apache
+  - java
+  - jakarta-ee
+  - servlet
+  - jsp
+  - webserver
+  - application-server
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://hub.docker.com/_/tomcat
+  - https://github.com/apache/tomcat
+icon: https://helmforge.dev/icons/charts/tomcat.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add Apache Tomcat chart with official image and production controls (#359)"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://tomcat.apache.org
+    - name: Source
+      url: https://github.com/apache/tomcat
+    - name: Official Image
+      url: https://hub.docker.com/_/tomcat
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/tomcat
+    - name: Chart Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/tomcat
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/valkey
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql

--- a/charts/tomcat/DESIGN.md
+++ b/charts/tomcat/DESIGN.md
@@ -1,0 +1,33 @@
+# Apache Tomcat Chart Design
+
+## Goals
+
+- Package Apache Tomcat with the official Docker image.
+- Keep default installs functional in k3d without requiring a user WAR file.
+- Provide production controls that are usually missing from minimal Tomcat charts: Gateway API, dual-stack Service, NetworkPolicy, JMX, HPA, PDB, non-root runtime, and explicit writable runtime volumes.
+
+## Runtime Model
+
+The official image stores Tomcat under `/usr/local/tomcat` and listens on port `8080`.
+The chart runs the container as UID/GID `1001`, mounts writable volumes for directories Tomcat mutates, and keeps Kubernetes API token mounting disabled by default.
+
+The default ROOT app exists only to make health checks deterministic.
+Operators deploying a real app can disable it and point probes at their own endpoint, or use TCP probes while an application warms up.
+
+## Exposure
+
+The chart supports classic Ingress and Gateway API.
+Gateway API requires existing CRDs and an existing parent Gateway.
+The chart intentionally renders only `HTTPRoute`, leaving Gateway ownership to platform teams.
+
+## Monitoring
+
+JMX remote flags are opt-in.
+Authentication and TLS are intentionally left to mounted files plus `jmx.extraOpts`.
+JMX security is environment-specific and unsafe defaults would expose a management interface.
+
+## Persistence
+
+`webapps` persistence is optional for mutable deployments.
+Immutable app images or versioned init-container downloads are preferred for production because they make rollback and audit easier.
+Logs persistence is optional; clusters with centralized logging should leave it disabled.

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -1,0 +1,108 @@
+# Apache Tomcat
+
+Apache Tomcat chart for Kubernetes using the official `docker.io/library/tomcat` image.
+
+## Highlights
+
+- Official Tomcat image, pinned by default to `11.0.22-jdk17-temurin-noble`.
+- Stable default install with an optional ROOT health webapp for deterministic probes and Helm tests.
+- Non-root runtime with writable `webapps`, `logs`, `temp`, and `work` volumes.
+- Ingress and Gateway API `HTTPRoute` exposure.
+- Optional JMX remote port for platform monitoring integrations.
+- Dual-stack Service fields, NetworkPolicy, HPA, PDB, persistent webapps/logs, and extra init/sidecar hooks.
+
+## Install
+
+```bash
+helm install tomcat oci://repo.helmforge.dev/charts/tomcat
+```
+
+## Deploying Applications
+
+The official Tomcat image starts without a production application. This chart enables a small default ROOT app so `/health.jsp` works immediately.
+For real workloads, mount WAR files or exploded applications through `extraInitContainers`, `extraVolumes`, and `extraVolumeMounts`, or enable `webapps.persistence`.
+
+For production applications that do not expose `/health.jsp`, switch probes to TCP or set probe paths to an application endpoint:
+
+```yaml
+webapps:
+  defaultRoot:
+    enabled: false
+
+startupProbe:
+  mode: tcp
+livenessProbe:
+  mode: tcp
+readinessProbe:
+  mode: tcp
+```
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - tomcat.example.com
+```
+
+## JMX
+
+JMX is opt-in because remote JMX should normally be restricted to trusted networks.
+
+```yaml
+jmx:
+  enabled: true
+  hostname: tomcat.example.local
+```
+
+For authenticated or TLS-secured JMX, mount the required files with `extraVolumes`/`extraVolumeMounts` and append JVM flags through `jmx.extraOpts`.
+
+## Production Notes
+
+- Keep `serviceAccount.automountServiceAccountToken=false` unless your app needs Kubernetes API access.
+- Enable `networkPolicy.enabled` and explicitly allow ingress from your gateway or ingress controller namespace.
+- Use persistent `webapps` storage only when applications are installed or mutated at runtime.
+- Prefer immutable app images or init containers that fetch versioned WAR artifacts.
+- Configure `tomcat.serverXml` or `tomcat.existingServerXmlConfigMap` when you need proxy connector attributes such as `proxyName`, `proxyPort`, or `scheme`.
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of Tomcat pods when HPA is disabled. |
+| `image.repository` | `docker.io/library/tomcat` | Tomcat image repository. |
+| `image.tag` | `11.0.22-jdk17-temurin-noble` | Tomcat image tag. |
+| `service.type` | `ClusterIP` | Kubernetes Service type. |
+| `service.ipFamilyPolicy` | `null` | Optional Service dual-stack policy. |
+| `service.ipFamilies` | `[]` | Optional Service IP family ordering. |
+| `webapps.defaultRoot.enabled` | `true` | Render a minimal ROOT app for health checks. |
+| `webapps.persistence.enabled` | `false` | Persist `/usr/local/tomcat/webapps`. |
+| `logs.persistence.enabled` | `false` | Persist `/usr/local/tomcat/logs`. |
+| `tomcat.serverXml` | `""` | Inline `server.xml` override. |
+| `tomcat.existingServerXmlConfigMap` | `""` | Existing ConfigMap containing `server.xml`. |
+| `jmx.enabled` | `false` | Expose JMX remote options and service port. |
+| `ingress.enabled` | `false` | Render Ingress. |
+| `gatewayAPI.enabled` | `false` | Render Gateway API HTTPRoute. |
+| `networkPolicy.enabled` | `false` | Render NetworkPolicy. |
+| `autoscaling.enabled` | `false` | Render HPA. |
+| `pdb.enabled` | `false` | Render PodDisruptionBudget. |
+
+## CI Scenarios
+
+- `ci/standalone.yaml`
+- `ci/ingress.yaml`
+- `ci/gateway-api.yaml`
+- `ci/dual-stack.yaml`
+- `ci/jmx.yaml`
+- `ci/hardening.yaml`
+
+## Artifact Hub
+
+```yaml
+artifacthub.io/category: integration-delivery
+keywords: tomcat, apache, java, jakarta-ee, servlet, jsp, gateway-api
+```

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -63,6 +63,8 @@ jmx:
 ```
 
 For authenticated or TLS-secured JMX, mount the required files with `extraVolumes`/`extraVolumeMounts` and append JVM flags through `jmx.extraOpts`.
+When `jmx.rmiPort` differs from `jmx.port`, the chart exposes the RMI endpoint
+through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique.
 
 ## Production Notes
 

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -6,6 +6,7 @@ Apache Tomcat chart for Kubernetes using the official `docker.io/library/tomcat`
 
 - Official Tomcat image, pinned by default to `11.0.22-jdk17-temurin-noble`.
 - Stable default install with an optional ROOT health webapp for deterministic probes and Helm tests.
+- Preserves WARs or exploded applications baked into immutable Tomcat images before mounting the writable webapps volume.
 - Non-root runtime with writable `webapps`, `logs`, `temp`, and `work` volumes.
 - Ingress and Gateway API `HTTPRoute` exposure.
 - Optional JMX remote port for platform monitoring integrations.
@@ -21,6 +22,8 @@ helm install tomcat oci://repo.helmforge.dev/charts/tomcat
 
 The official Tomcat image starts without a production application. This chart enables a small default ROOT app so `/health.jsp` works immediately.
 For real workloads, mount WAR files or exploded applications through `extraInitContainers`, `extraVolumes`, and `extraVolumeMounts`, or enable `webapps.persistence`.
+If you build an immutable Tomcat image with applications under `/usr/local/tomcat/webapps`, keep `webapps.copyImageContent.enabled=true`.
+The chart copies those image contents into the writable webapps volume when it is empty.
 
 For production applications that do not expose `/health.jsp`, switch probes to TCP or set probe paths to an application endpoint:
 
@@ -80,6 +83,7 @@ For authenticated or TLS-secured JMX, mount the required files with `extraVolume
 | `service.ipFamilyPolicy` | `null` | Optional Service dual-stack policy. |
 | `service.ipFamilies` | `[]` | Optional Service IP family ordering. |
 | `webapps.defaultRoot.enabled` | `true` | Render a minimal ROOT app for health checks. |
+| `webapps.copyImageContent.enabled` | `true` | Copy image-baked webapps into the mounted webapps volume when empty. |
 | `webapps.persistence.enabled` | `false` | Persist `/usr/local/tomcat/webapps`. |
 | `logs.persistence.enabled` | `false` | Persist `/usr/local/tomcat/logs`. |
 | `tomcat.serverXml` | `""` | Inline `server.xml` override. |

--- a/charts/tomcat/ci/dual-stack.yaml
+++ b/charts/tomcat/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/tomcat/ci/gateway-api.yaml
+++ b/charts/tomcat/ci/gateway-api.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - tomcat.example.local

--- a/charts/tomcat/ci/hardening.yaml
+++ b/charts/tomcat/ci/hardening.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+pdb:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true

--- a/charts/tomcat/ci/ingress.yaml
+++ b/charts/tomcat/ci/ingress.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: tomcat.example.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/tomcat/ci/jmx.yaml
+++ b/charts/tomcat/ci/jmx.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+jmx:
+  enabled: true
+  hostname: tomcat.local

--- a/charts/tomcat/ci/standalone.yaml
+++ b/charts/tomcat/ci/standalone.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+
+webapps:
+  persistence:
+    enabled: false
+
+logs:
+  persistence:
+    enabled: false

--- a/charts/tomcat/docs/production.md
+++ b/charts/tomcat/docs/production.md
@@ -1,0 +1,31 @@
+# Production Guidance
+
+Use a pinned application artifact, explicit resources, NetworkPolicy, and either Ingress or Gateway API.
+
+```yaml
+replicaCount: 2
+
+webapps:
+  defaultRoot:
+    enabled: false
+
+startupProbe:
+  mode: tcp
+livenessProbe:
+  mode: tcp
+readinessProbe:
+  mode: tcp
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+
+pdb:
+  enabled: true
+```
+
+When Tomcat is behind a reverse proxy, use `tomcat.serverXml` or an existing ConfigMap to configure connector proxy attributes so applications see the correct external scheme, host, and port.

--- a/charts/tomcat/docs/production.md
+++ b/charts/tomcat/docs/production.md
@@ -8,6 +8,8 @@ replicaCount: 2
 webapps:
   defaultRoot:
     enabled: false
+  copyImageContent:
+    enabled: true
 
 startupProbe:
   mode: tcp
@@ -29,3 +31,7 @@ pdb:
 ```
 
 When Tomcat is behind a reverse proxy, use `tomcat.serverXml` or an existing ConfigMap to configure connector proxy attributes so applications see the correct external scheme, host, and port.
+
+For immutable Tomcat application images, keep `webapps.copyImageContent.enabled=true`.
+The chart copies applications already present under `/usr/local/tomcat/webapps` into the writable webapps volume only when that volume is empty.
+This preserves image-baked WARs while still supporting PVC-backed mutable deployments.

--- a/charts/tomcat/examples/jmx.yaml
+++ b/charts/tomcat/examples/jmx.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+jmx:
+  enabled: true
+  hostname: tomcat.example.local
+  extraOpts: "-Dcom.sun.management.jmxremote.local.only=false"
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring

--- a/charts/tomcat/examples/persistent-webapps.yaml
+++ b/charts/tomcat/examples/persistent-webapps.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+webapps:
+  persistence:
+    enabled: true
+    size: 20Gi
+
+logs:
+  persistence:
+    enabled: true
+    size: 10Gi

--- a/charts/tomcat/examples/production.yaml
+++ b/charts/tomcat/examples/production.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+webapps:
+  defaultRoot:
+    enabled: false
+
+startupProbe:
+  mode: tcp
+livenessProbe:
+  mode: tcp
+readinessProbe:
+  mode: tcp
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - tomcat.example.com
+
+networkPolicy:
+  enabled: true
+  ingress:
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    allowDNS: true
+    allowHTTPS: true
+
+pdb:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5

--- a/charts/tomcat/examples/production.yaml
+++ b/charts/tomcat/examples/production.yaml
@@ -4,6 +4,8 @@ replicaCount: 2
 webapps:
   defaultRoot:
     enabled: false
+  copyImageContent:
+    enabled: true
 
 startupProbe:
   mode: tcp

--- a/charts/tomcat/templates/NOTES.txt
+++ b/charts/tomcat/templates/NOTES.txt
@@ -14,10 +14,10 @@ Pods:
   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "tomcat.name" . }}
 
 Health:
-{{- if and .Values.readinessProbe.enabled (eq .Values.readinessProbe.mode "tcp") }}
-  kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- nc -z {{ include "tomcat.fullname" . }} {{ .Values.service.ports.http }}
-{{- else }}
+{{- if and .Values.readinessProbe.enabled (eq .Values.readinessProbe.mode "http") }}
   kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- wget -qO- http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}{{ .Values.readinessProbe.path }}
+{{- else }}
+  kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- nc -z {{ include "tomcat.fullname" . }} {{ .Values.service.ports.http }}
 {{- end }}
 
 {{- if .Values.jmx.enabled }}

--- a/charts/tomcat/templates/NOTES.txt
+++ b/charts/tomcat/templates/NOTES.txt
@@ -1,0 +1,19 @@
+Apache Tomcat has been installed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+App version: {{ .Chart.AppVersion }}
+Image: {{ include "tomcat.image" . }}
+
+Service:
+  kubectl get svc {{ include "tomcat.fullname" . }} -n {{ .Release.Namespace }}
+
+Pods:
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "tomcat.name" . }}
+
+Health check:
+  kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- wget -qO- http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}/health.jsp
+
+Documentation:
+  https://helmforge.dev/docs/charts/tomcat

--- a/charts/tomcat/templates/NOTES.txt
+++ b/charts/tomcat/templates/NOTES.txt
@@ -24,6 +24,7 @@ Health:
 JMX:
   service port: {{ .Values.service.ports.jmx }}
   registry target port: {{ .Values.jmx.port }}
+  rmi service port: {{ .Values.service.ports.jmxRmi }}
   rmi target port: {{ .Values.jmx.rmiPort }}
 {{- end }}
 

--- a/charts/tomcat/templates/NOTES.txt
+++ b/charts/tomcat/templates/NOTES.txt
@@ -1,19 +1,31 @@
-Apache Tomcat has been installed.
+Apache Tomcat has been deployed.
 
-Release: {{ .Release.Name }}
-Namespace: {{ .Release.Namespace }}
-Chart: {{ .Chart.Name }} {{ .Chart.Version }}
-App version: {{ .Chart.AppVersion }}
-Image: {{ include "tomcat.image" . }}
+Release:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  chart: {{ .Chart.Name }} {{ .Chart.Version }}
+  appVersion: {{ .Chart.AppVersion }}
+  image: {{ include "tomcat.image" . }}
 
 Service:
-  kubectl get svc {{ include "tomcat.fullname" . }} -n {{ .Release.Namespace }}
+  http://{{ include "tomcat.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ports.http }}
 
 Pods:
   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "tomcat.name" . }}
 
-Health check:
-  kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- wget -qO- http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}/health.jsp
+Health:
+{{- if and .Values.readinessProbe.enabled (eq .Values.readinessProbe.mode "tcp") }}
+  kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- nc -z {{ include "tomcat.fullname" . }} {{ .Values.service.ports.http }}
+{{- else }}
+  kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- wget -qO- http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}{{ .Values.readinessProbe.path }}
+{{- end }}
+
+{{- if .Values.jmx.enabled }}
+JMX:
+  service port: {{ .Values.service.ports.jmx }}
+  registry target port: {{ .Values.jmx.port }}
+  rmi target port: {{ .Values.jmx.rmiPort }}
+{{- end }}
 
 Documentation:
   https://helmforge.dev/docs/charts/tomcat

--- a/charts/tomcat/templates/_helpers.tpl
+++ b/charts/tomcat/templates/_helpers.tpl
@@ -92,4 +92,7 @@ failureThreshold: {{ $probe.failureThreshold }}
 {{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
 {{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
 {{- end -}}
+{{- if and .Values.jmx.enabled (ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int)) (eq (.Values.service.ports.jmxRmi | int) (.Values.service.ports.jmx | int)) -}}
+{{- fail "service.ports.jmxRmi must differ from service.ports.jmx when jmx.rmiPort differs from jmx.port" -}}
+{{- end -}}
 {{- end }}

--- a/charts/tomcat/templates/_helpers.tpl
+++ b/charts/tomcat/templates/_helpers.tpl
@@ -68,7 +68,7 @@ app.kubernetes.io/part-of: tomcat
 
 {{- define "tomcat.jmxOpts" -}}
 {{- if .Values.jmx.enabled -}}
--Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.rmi.port={{ .Values.jmx.rmiPort }} -Dcom.sun.management.jmxremote.authenticate={{ .Values.jmx.authenticate }} -Dcom.sun.management.jmxremote.ssl={{ .Values.jmx.ssl }} -Djava.rmi.server.hostname={{ .Values.jmx.hostname }}{{ with .Values.jmx.extraOpts }} {{ . }}{{ end }}
+-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.rmi.port={{ .Values.jmx.rmiPort }} -Dcom.sun.management.jmxremote.authenticate={{ .Values.jmx.authenticate }} -Dcom.sun.management.jmxremote.ssl={{ .Values.jmx.ssl }} -Djava.rmi.server.hostname={{ default "$(POD_IP)" .Values.jmx.hostname }}{{ with .Values.jmx.extraOpts }} {{ . }}{{ end }}
 {{- end -}}
 {{- end }}
 

--- a/charts/tomcat/templates/_helpers.tpl
+++ b/charts/tomcat/templates/_helpers.tpl
@@ -1,0 +1,104 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "tomcat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tomcat.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "tomcat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "tomcat.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tomcat.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "tomcat.labels" -}}
+helm.sh/chart: {{ include "tomcat.chart" . }}
+{{ include "tomcat.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: tomcat
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "tomcat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tomcat.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "tomcat.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+{{- end }}
+
+{{- define "tomcat.configMapName" -}}
+{{- printf "%s-config" (include "tomcat.fullname" .) }}
+{{- end }}
+
+{{- define "tomcat.defaultRootConfigMapName" -}}
+{{- printf "%s-root-webapp" (include "tomcat.fullname" .) }}
+{{- end }}
+
+{{- define "tomcat.webappsPvcName" -}}
+{{- default (printf "%s-webapps" (include "tomcat.fullname" .)) .Values.webapps.persistence.existingClaim }}
+{{- end }}
+
+{{- define "tomcat.logsPvcName" -}}
+{{- default (printf "%s-logs" (include "tomcat.fullname" .)) .Values.logs.persistence.existingClaim }}
+{{- end }}
+
+{{- define "tomcat.jmxOpts" -}}
+{{- if .Values.jmx.enabled -}}
+-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.rmi.port={{ .Values.jmx.rmiPort }} -Dcom.sun.management.jmxremote.authenticate={{ .Values.jmx.authenticate }} -Dcom.sun.management.jmxremote.ssl={{ .Values.jmx.ssl }} -Djava.rmi.server.hostname={{ .Values.jmx.hostname }}{{ with .Values.jmx.extraOpts }} {{ . }}{{ end }}
+{{- end -}}
+{{- end }}
+
+{{- define "tomcat.probe" -}}
+{{- $probe := .probe -}}
+{{- if eq $probe.mode "tcp" }}
+tcpSocket:
+  port: http
+{{- else }}
+httpGet:
+  path: {{ $probe.path }}
+  port: http
+{{- end }}
+initialDelaySeconds: {{ $probe.initialDelaySeconds }}
+periodSeconds: {{ $probe.periodSeconds }}
+timeoutSeconds: {{ $probe.timeoutSeconds }}
+failureThreshold: {{ $probe.failureThreshold }}
+{{- end }}
+
+{{- define "tomcat.validate" -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
+{{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- if and (not .Values.webapps.defaultRoot.enabled) (eq .Values.startupProbe.mode "http") -}}
+{{- fail "startupProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at startupProbe.path" -}}
+{{- end -}}
+{{- if and (not .Values.webapps.defaultRoot.enabled) (eq .Values.livenessProbe.mode "http") -}}
+{{- fail "livenessProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at livenessProbe.path" -}}
+{{- end -}}
+{{- if and (not .Values.webapps.defaultRoot.enabled) (eq .Values.readinessProbe.mode "http") -}}
+{{- fail "readinessProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at readinessProbe.path" -}}
+{{- end -}}
+{{- end }}

--- a/charts/tomcat/templates/_helpers.tpl
+++ b/charts/tomcat/templates/_helpers.tpl
@@ -92,13 +92,4 @@ failureThreshold: {{ $probe.failureThreshold }}
 {{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
 {{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
 {{- end -}}
-{{- if and (not .Values.webapps.defaultRoot.enabled) (eq .Values.startupProbe.mode "http") -}}
-{{- fail "startupProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at startupProbe.path" -}}
-{{- end -}}
-{{- if and (not .Values.webapps.defaultRoot.enabled) (eq .Values.livenessProbe.mode "http") -}}
-{{- fail "livenessProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at livenessProbe.path" -}}
-{{- end -}}
-{{- if and (not .Values.webapps.defaultRoot.enabled) (eq .Values.readinessProbe.mode "http") -}}
-{{- fail "readinessProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at readinessProbe.path" -}}
-{{- end -}}
 {{- end }}

--- a/charts/tomcat/templates/configmap.yaml
+++ b/charts/tomcat/templates/configmap.yaml
@@ -1,0 +1,30 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or .Values.tomcat.serverXml .Values.webapps.defaultRoot.enabled }}
+{{- if .Values.tomcat.serverXml }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tomcat.configMapName" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+data:
+  server.xml: |
+    {{- .Values.tomcat.serverXml | nindent 4 }}
+{{- end }}
+{{- if .Values.webapps.defaultRoot.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tomcat.defaultRootConfigMapName" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+data:
+  index.jsp: |
+    {{- .Values.webapps.defaultRoot.index | nindent 4 }}
+  health.jsp: |
+    {{- .Values.webapps.defaultRoot.health | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -46,8 +46,8 @@ spec:
       initContainers:
         {{- if .Values.webapps.defaultRoot.enabled }}
         - name: seed-default-root
-          image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
-          imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+          image: "{{ .Values.webapps.defaultRoot.initImage.repository }}:{{ .Values.webapps.defaultRoot.initImage.tag }}"
+          imagePullPolicy: {{ .Values.webapps.defaultRoot.initImage.pullPolicy }}
           command: ["sh", "-ec"]
           args:
             - |

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -42,8 +42,26 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- if or .Values.webapps.defaultRoot.enabled .Values.extraInitContainers }}
+      {{- if or .Values.webapps.copyImageContent.enabled .Values.webapps.defaultRoot.enabled .Values.extraInitContainers }}
       initContainers:
+        {{- if .Values.webapps.copyImageContent.enabled }}
+        - name: copy-image-webapps
+          image: {{ include "tomcat.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              if [ -d "{{ .Values.webapps.mountPath }}" ] && [ -z "$(find /webapps -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+                cp -R "{{ .Values.webapps.mountPath }}/." /webapps/
+              fi
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: webapps
+              mountPath: /webapps
+        {{- end }}
         {{- if .Values.webapps.defaultRoot.enabled }}
         - name: seed-default-root
           image: "{{ .Values.webapps.defaultRoot.initImage.repository }}:{{ .Values.webapps.defaultRoot.initImage.tag }}"

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -77,6 +77,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            {{- if and .Values.jmx.enabled (not .Values.jmx.hostname) }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- end }}
             - name: CATALINA_OPTS
               value: {{ printf "%s %s" .Values.tomcat.catalinaOpts (include "tomcat.jmxOpts" .) | trim | quote }}
             - name: JAVA_OPTS

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
               protocol: TCP
             {{- if .Values.jmx.enabled }}
             - name: jmx
-              containerPort: {{ .Values.containerPorts.jmx }}
+              containerPort: {{ .Values.jmx.port }}
               protocol: TCP
             {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}
             - name: jmx-rmi

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -51,8 +51,9 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
-              if [ -d "{{ .Values.webapps.mountPath }}" ] && [ -z "$(find /webapps -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+              if [ -d "{{ .Values.webapps.mountPath }}" ] && [ ! -f /webapps/.helmforge-image-webapps-seeded ] && [ -z "$(find /webapps -mindepth 1 -maxdepth 1 ! -name lost+found ! -name .helmforge-image-webapps-seeded -print -quit)" ]; then
                 cp -R "{{ .Values.webapps.mountPath }}/." /webapps/
+                touch /webapps/.helmforge-image-webapps-seeded
               fi
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -1,0 +1,199 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "tomcat.validate" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "tomcat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tomcat
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "tomcat.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: tomcat
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "tomcat.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or .Values.webapps.defaultRoot.enabled .Values.extraInitContainers }}
+      initContainers:
+        {{- if .Values.webapps.defaultRoot.enabled }}
+        - name: seed-default-root
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+          imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              mkdir -p /webapps/ROOT
+              cp /default-root/* /webapps/ROOT/
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.tests.resources | nindent 12 }}
+          volumeMounts:
+            - name: webapps
+              mountPath: /webapps
+            - name: default-root
+              mountPath: /default-root
+              readOnly: true
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      containers:
+        - name: tomcat
+          image: {{ include "tomcat.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: CATALINA_OPTS
+              value: {{ printf "%s %s" .Values.tomcat.catalinaOpts (include "tomcat.jmxOpts" .) | trim | quote }}
+            - name: JAVA_OPTS
+              value: {{ .Values.tomcat.javaOpts | quote }}
+            {{- with .Values.tomcat.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.tomcat.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+              protocol: TCP
+            {{- if .Values.jmx.enabled }}
+            - name: jmx
+              containerPort: {{ .Values.containerPorts.jmx }}
+              protocol: TCP
+            {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            {{- include "tomcat.probe" (dict "probe" .Values.startupProbe) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- include "tomcat.probe" (dict "probe" .Values.livenessProbe) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- include "tomcat.probe" (dict "probe" .Values.readinessProbe) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: webapps
+              mountPath: {{ .Values.webapps.mountPath }}
+            - name: logs
+              mountPath: /usr/local/tomcat/logs
+            - name: temp
+              mountPath: /usr/local/tomcat/temp
+            - name: work
+              mountPath: /usr/local/tomcat/work
+            - name: conf-localhost
+              mountPath: /usr/local/tomcat/conf/Catalina/localhost
+            {{- if or .Values.tomcat.serverXml .Values.tomcat.existingServerXmlConfigMap }}
+            - name: server-xml
+              mountPath: /usr/local/tomcat/conf/server.xml
+              subPath: server.xml
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: webapps
+          {{- if .Values.webapps.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "tomcat.webappsPvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: logs
+          {{- if .Values.logs.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "tomcat.logsPvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: temp
+          emptyDir: {}
+        - name: work
+          emptyDir: {}
+        - name: conf-localhost
+          emptyDir: {}
+        {{- if or .Values.tomcat.serverXml .Values.tomcat.existingServerXmlConfigMap }}
+        - name: server-xml
+          configMap:
+            name: {{ default (include "tomcat.configMapName" .) .Values.tomcat.existingServerXmlConfigMap }}
+            items:
+              - key: server.xml
+                path: server.xml
+        {{- end }}
+        {{- if .Values.webapps.defaultRoot.enabled }}
+        - name: default-root
+          configMap:
+            name: {{ include "tomcat.defaultRootConfigMapName" . }}
+            items:
+              - key: index.jsp
+                path: index.jsp
+              - key: health.jsp
+                path: health.jsp
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
-            {{- toYaml .Values.tests.resources | nindent 12 }}
+            {{- toYaml .Values.webapps.defaultRoot.resources | nindent 12 }}
           volumeMounts:
             - name: webapps
               mountPath: /webapps

--- a/charts/tomcat/templates/deployment.yaml
+++ b/charts/tomcat/templates/deployment.yaml
@@ -96,6 +96,11 @@ spec:
             - name: jmx
               containerPort: {{ .Values.containerPorts.jmx }}
               protocol: TCP
+            {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}
+            - name: jmx-rmi
+              containerPort: {{ .Values.jmx.rmiPort }}
+              protocol: TCP
+            {{- end }}
             {{- end }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:

--- a/charts/tomcat/templates/hpa.yaml
+++ b/charts/tomcat/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "tomcat.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/tomcat/templates/httproute.yaml
+++ b/charts/tomcat/templates/httproute.yaml
@@ -1,0 +1,31 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "tomcat.validate" . }}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: {{ .Values.gatewayAPI.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gatewayAPI.matches | nindent 8 }}
+      {{- with .Values.gatewayAPI.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "tomcat.fullname" . }}
+          port: {{ .Values.service.ports.http }}
+{{- end }}

--- a/charts/tomcat/templates/ingress.yaml
+++ b/charts/tomcat/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "tomcat.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/tomcat/templates/networkpolicy.yaml
+++ b/charts/tomcat/templates/networkpolicy.yaml
@@ -63,7 +63,8 @@ spec:
           port: 80
     {{- end }}
     {{- with .Values.networkPolicy.egress.extraTo }}
-    {{- toYaml . | nindent 4 }}
+    - to:
+        {{- toYaml . | nindent 8 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tomcat/templates/networkpolicy.yaml
+++ b/charts/tomcat/templates/networkpolicy.yaml
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tomcat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tomcat
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+        {{- if .Values.jmx.enabled }}
+        - protocol: TCP
+          port: jmx
+        {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTP }}
+    - ports:
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/tomcat/templates/networkpolicy.yaml
+++ b/charts/tomcat/templates/networkpolicy.yaml
@@ -17,6 +17,7 @@ spec:
     - Egress
     {{- end }}
   ingress:
+    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
     - from:
         {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
         - podSelector: {}
@@ -30,7 +31,14 @@ spec:
         {{- if .Values.jmx.enabled }}
         - protocol: TCP
           port: jmx
+          {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}
+        - protocol: TCP
+          port: jmx-rmi
+          {{- end }}
         {{- end }}
+    {{- else }}
+    []
+    {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
     {{- if .Values.networkPolicy.egress.allowDNS }}

--- a/charts/tomcat/templates/pdb.yaml
+++ b/charts/tomcat/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "tomcat.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tomcat
+{{- end }}

--- a/charts/tomcat/templates/pvc.yaml
+++ b/charts/tomcat/templates/pvc.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.webapps.persistence.enabled (not .Values.webapps.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "tomcat.webappsPvcName" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+spec:
+  accessModes:
+    {{- toYaml .Values.webapps.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.webapps.persistence.size }}
+  {{- with .Values.webapps.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.logs.persistence.enabled (not .Values.logs.persistence.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "tomcat.logsPvcName" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+spec:
+  accessModes:
+    {{- toYaml .Values.logs.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.logs.persistence.size }}
+  {{- with .Values.logs.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/tomcat/templates/service.yaml
+++ b/charts/tomcat/templates/service.yaml
@@ -29,7 +29,7 @@ spec:
       protocol: TCP
     {{- if .Values.jmx.enabled }}
     - name: jmx
-      port: {{ .Values.service.ports.jmx }}
+      port: {{ .Values.jmx.port }}
       targetPort: jmx
       protocol: TCP
     {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}

--- a/charts/tomcat/templates/service.yaml
+++ b/charts/tomcat/templates/service.yaml
@@ -32,4 +32,10 @@ spec:
       port: {{ .Values.service.ports.jmx }}
       targetPort: jmx
       protocol: TCP
+    {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}
+    - name: jmx-rmi
+      port: {{ .Values.jmx.rmiPort }}
+      targetPort: jmx-rmi
+      protocol: TCP
+    {{- end }}
     {{- end }}

--- a/charts/tomcat/templates/service.yaml
+++ b/charts/tomcat/templates/service.yaml
@@ -34,7 +34,7 @@ spec:
       protocol: TCP
     {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}
     - name: jmx-rmi
-      port: {{ .Values.jmx.rmiPort }}
+      port: {{ .Values.service.ports.jmxRmi }}
       targetPort: jmx-rmi
       protocol: TCP
     {{- end }}

--- a/charts/tomcat/templates/service.yaml
+++ b/charts/tomcat/templates/service.yaml
@@ -1,0 +1,35 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tomcat.fullname" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    {{- include "tomcat.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: tomcat
+  ports:
+    - name: http
+      port: {{ .Values.service.ports.http }}
+      targetPort: http
+      protocol: TCP
+    {{- if .Values.jmx.enabled }}
+    - name: jmx
+      port: {{ .Values.service.ports.jmx }}
+      targetPort: jmx
+      protocol: TCP
+    {{- end }}

--- a/charts/tomcat/templates/service.yaml
+++ b/charts/tomcat/templates/service.yaml
@@ -29,7 +29,7 @@ spec:
       protocol: TCP
     {{- if .Values.jmx.enabled }}
     - name: jmx
-      port: {{ .Values.jmx.port }}
+      port: {{ .Values.service.ports.jmx }}
       targetPort: jmx
       protocol: TCP
     {{- if ne (.Values.jmx.rmiPort | int) (.Values.jmx.port | int) }}

--- a/charts/tomcat/templates/serviceaccount.yaml
+++ b/charts/tomcat/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tomcat.serviceAccountName" . }}
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/tomcat/templates/tests/test-connection.yaml
+++ b/charts/tomcat/templates/tests/test-connection.yaml
@@ -25,7 +25,11 @@ spec:
       command: ["sh", "-ec"]
       args:
         - |
-          wget -qO- "http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}/health.jsp" | grep -q OK
+          {{- if eq .Values.readinessProbe.mode "http" }}
+          wget -qO- "http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}{{ .Values.readinessProbe.path }}" >/dev/null
+          {{- else }}
+          nc -z -w5 "{{ include "tomcat.fullname" . }}" {{ .Values.service.ports.http }}
+          {{- end }}
       resources:
         {{- toYaml .Values.tests.resources | nindent 8 }}
       securityContext:

--- a/charts/tomcat/templates/tests/test-connection.yaml
+++ b/charts/tomcat/templates/tests/test-connection.yaml
@@ -25,7 +25,7 @@ spec:
       command: ["sh", "-ec"]
       args:
         - |
-          {{- if eq .Values.readinessProbe.mode "http" }}
+          {{- if and .Values.readinessProbe.enabled (eq .Values.readinessProbe.mode "http") }}
           wget -qO- "http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}{{ .Values.readinessProbe.path }}" >/dev/null
           {{- else }}
           nc -z -w5 "{{ include "tomcat.fullname" . }}" {{ .Values.service.ports.http }}

--- a/charts/tomcat/templates/tests/test-connection.yaml
+++ b/charts/tomcat/templates/tests/test-connection.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "tomcat.fullname" . }}-test-connection
+  labels:
+    {{- include "tomcat.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "tomcat.serviceAccountName" . }}
+  automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+  {{- with .Values.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: wget
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      command: ["sh", "-ec"]
+      args:
+        - |
+          wget -qO- "http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}/health.jsp" | grep -q OK
+      resources:
+        {{- toYaml .Values.tests.resources | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+{{- end }}

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render deployment with official image and non-root security
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/library/tomcat:11.0.22-jdk17-temurin-noble
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: should mount writable runtime directories
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: webapps
+            mountPath: /usr/local/tomcat/webapps
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: logs
+            mountPath: /usr/local/tomcat/logs
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: temp
+            mountPath: /usr/local/tomcat/temp
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: work
+            mountPath: /usr/local/tomcat/work
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: conf-localhost
+            mountPath: /usr/local/tomcat/conf/Catalina/localhost
+
+  - it: should render default root health webapp
+    template: configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data["health.jsp"]
+          value: |
+            <%@ page contentType="text/plain; charset=UTF-8" %>
+            OK
+
+  - it: should fail http probes when default root is disabled
+    template: deployment.yaml
+    set:
+      webapps.defaultRoot.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "startupProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at startupProbe.path"
+
+  - it: should allow tcp probes without default root
+    template: deployment.yaml
+    set:
+      webapps.defaultRoot.enabled: false
+      startupProbe.mode: tcp
+      livenessProbe.mode: tcp
+      readinessProbe.mode: tcp
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: http

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -69,12 +69,17 @@ tests:
     template: deployment.yaml
     set:
       tests.image.repository: registry.example.com/private/test-only
+      tests.resources.requests.cpu: 900m
       webapps.defaultRoot.initImage.repository: docker.io/library/busybox
       webapps.defaultRoot.initImage.tag: "1.37"
+      webapps.defaultRoot.resources.requests.cpu: 25m
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: docker.io/library/busybox:1.37
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 25m
 
   - it: should allow user-provided HTTP probes when default root is disabled
     template: deployment.yaml

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -97,6 +97,12 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: "cp -R .*/webapps/\\.\" /webapps/"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "! -name lost\\+found"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: ".helmforge-image-webapps-seeded"
 
   - it: should allow disabling image webapps copy
     template: deployment.yaml

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -118,3 +118,36 @@ tests:
             name: jmx-rmi
             containerPort: 9011
             protocol: TCP
+
+  - it: should advertise pod IP for JMX by default
+    template: deployment.yaml
+    set:
+      jmx.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[1].value
+          pattern: "-Djava\\.rmi\\.server\\.hostname=\\$\\(POD_IP\\)"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[1].value
+          pattern: "-Djava\\.rmi\\.server\\.hostname=127\\.0\\.0\\.1"
+
+  - it: should honor explicit JMX hostname
+    template: deployment.yaml
+    set:
+      jmx.enabled: true
+      jmx.hostname: tomcat-jmx.example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_IP
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: "-Djava\\.rmi\\.server\\.hostname=tomcat-jmx\\.example\\.com"

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -75,11 +75,37 @@ tests:
       webapps.defaultRoot.resources.requests.cpu: 25m
     asserts:
       - equal:
-          path: spec.template.spec.initContainers[0].image
+          path: spec.template.spec.initContainers[1].image
           value: docker.io/library/busybox:1.37
       - equal:
-          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          path: spec.template.spec.initContainers[1].resources.requests.cpu
           value: 25m
+
+  - it: should copy image webapps before mounting the shared webapps volume
+    template: deployment.yaml
+    set:
+      image.repository: registry.example.com/apps/custom-tomcat
+      image.tag: "1.2.3"
+      webapps.defaultRoot.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: copy-image-webapps
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/apps/custom-tomcat:1.2.3
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "cp -R .*/webapps/\\.\" /webapps/"
+
+  - it: should allow disabling image webapps copy
+    template: deployment.yaml
+    set:
+      webapps.copyImageContent.enabled: false
+      webapps.defaultRoot.enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
 
   - it: should allow user-provided HTTP probes when default root is disabled
     template: deployment.yaml

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -92,8 +92,15 @@ tests:
     template: deployment.yaml
     set:
       jmx.enabled: true
+      jmx.port: 9999
       jmx.rmiPort: 9011
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: jmx
+            containerPort: 9999
+            protocol: TCP
       - contains:
           path: spec.template.spec.containers[0].ports
           content:

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -65,13 +65,16 @@ tests:
             <%@ page contentType="text/plain; charset=UTF-8" %>
             OK
 
-  - it: should fail http probes when default root is disabled
+  - it: should allow user-provided HTTP probes when default root is disabled
     template: deployment.yaml
     set:
       webapps.defaultRoot.enabled: false
+      startupProbe.enabled: true
+      startupProbe.path: /custom/health
     asserts:
-      - failedTemplate:
-          errorMessage: "startupProbe.mode=http requires webapps.defaultRoot.enabled=true or a user-provided app at startupProbe.path"
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /custom/health
 
   - it: should allow tcp probes without default root
     template: deployment.yaml
@@ -84,3 +87,16 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
           value: http
+
+  - it: should expose a separate JMX RMI container port when configured
+    template: deployment.yaml
+    set:
+      jmx.enabled: true
+      jmx.rmiPort: 9011
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: jmx-rmi
+            containerPort: 9011
+            protocol: TCP

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -65,6 +65,17 @@ tests:
             <%@ page contentType="text/plain; charset=UTF-8" %>
             OK
 
+  - it: should use runtime init image for default root seeding
+    template: deployment.yaml
+    set:
+      tests.image.repository: registry.example.com/private/test-only
+      webapps.defaultRoot.initImage.repository: docker.io/library/busybox
+      webapps.defaultRoot.initImage.tag: "1.37"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/busybox:1.37
+
   - it: should allow user-provided HTTP probes when default root is disabled
     template: deployment.yaml
     set:

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -188,3 +188,14 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].env[0].value
           pattern: "-Djava\\.rmi\\.server\\.hostname=tomcat-jmx\\.example\\.com"
+
+  - it: should reject duplicate JMX registry and RMI service ports
+    template: deployment.yaml
+    set:
+      jmx.enabled: true
+      jmx.port: 9999
+      service.ports.jmx: 9010
+      service.ports.jmxRmi: 9010
+    asserts:
+      - failedTemplate:
+          errorMessage: "service.ports.jmxRmi must differ from service.ports.jmx when jmx.rmiPort differs from jmx.port"

--- a/charts/tomcat/tests/exposure_test.yaml
+++ b/charts/tomcat/tests/exposure_test.yaml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Exposure
+templates:
+  - ingress.yaml
+  - httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingress
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: tomcat.example.local
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: tomcat.example.local
+
+  - it: should render HTTPRoute
+    template: httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public-gateway
+          namespace: gateway-system
+      gatewayAPI.hostnames:
+        - tomcat.example.local
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public-gateway
+
+  - it: should require Gateway API parentRefs
+    template: httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true"

--- a/charts/tomcat/tests/operations_test.yaml
+++ b/charts/tomcat/tests/operations_test.yaml
@@ -41,3 +41,27 @@ tests:
       - contains:
           path: spec.policyTypes
           content: Egress
+
+  - it: should deny ingress when no ingress peers are configured
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.allowSameNamespace: false
+      networkPolicy.ingress.extraFrom: []
+    asserts:
+      - equal:
+          path: spec.ingress
+          value: []
+
+  - it: should expose JMX RMI port in NetworkPolicy when configured
+    template: networkpolicy.yaml
+    set:
+      jmx.enabled: true
+      jmx.rmiPort: 9011
+      networkPolicy.enabled: true
+    asserts:
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: jmx-rmi

--- a/charts/tomcat/tests/operations_test.yaml
+++ b/charts/tomcat/tests/operations_test.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Operations
+templates:
+  - hpa.yaml
+  - pdb.yaml
+  - networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render HPA
+    template: hpa.yaml
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+
+  - it: should render PDB
+    template: pdb.yaml
+    set:
+      pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should render NetworkPolicy
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Egress

--- a/charts/tomcat/tests/operations_test.yaml
+++ b/charts/tomcat/tests/operations_test.yaml
@@ -65,3 +65,25 @@ tests:
           content:
             protocol: TCP
             port: jmx-rmi
+
+  - it: should nest extra egress peers under to
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowDNS: false
+      networkPolicy.egress.allowHTTPS: false
+      networkPolicy.egress.extraTo:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: database
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgresql
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: database
+      - equal:
+          path: spec.egress[0].to[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: postgresql

--- a/charts/tomcat/tests/service_test.yaml
+++ b/charts/tomcat/tests/service_test.yaml
@@ -48,3 +48,16 @@ tests:
             port: 9010
             targetPort: jmx
             protocol: TCP
+
+  - it: should expose separate JMX RMI service port when configured
+    set:
+      jmx.enabled: true
+      jmx.rmiPort: 9011
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: jmx-rmi
+            port: 9011
+            targetPort: jmx-rmi
+            protocol: TCP

--- a/charts/tomcat/tests/service_test.yaml
+++ b/charts/tomcat/tests/service_test.yaml
@@ -54,12 +54,13 @@ tests:
       jmx.enabled: true
       jmx.port: 9999
       jmx.rmiPort: 9011
+      service.ports.jmx: 19010
     asserts:
       - contains:
           path: spec.ports
           content:
             name: jmx
-            port: 9999
+            port: 19010
             targetPort: jmx
             protocol: TCP
       - contains:

--- a/charts/tomcat/tests/service_test.yaml
+++ b/charts/tomcat/tests/service_test.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render service on port 80 targeting Tomcat 8080
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-tomcat
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+            protocol: TCP
+
+  - it: should support dual-stack values
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6
+
+  - it: should expose JMX when enabled
+    set:
+      jmx.enabled: true
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: jmx
+            port: 9010
+            targetPort: jmx
+            protocol: TCP

--- a/charts/tomcat/tests/service_test.yaml
+++ b/charts/tomcat/tests/service_test.yaml
@@ -70,3 +70,23 @@ tests:
             port: 9011
             targetPort: jmx-rmi
             protocol: TCP
+
+  - it: should use a dedicated RMI service port when only the JVM JMX port changes
+    set:
+      jmx.enabled: true
+      jmx.port: 9999
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: jmx
+            port: 9010
+            targetPort: jmx
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            name: jmx-rmi
+            port: 9011
+            targetPort: jmx-rmi
+            protocol: TCP

--- a/charts/tomcat/tests/service_test.yaml
+++ b/charts/tomcat/tests/service_test.yaml
@@ -52,8 +52,16 @@ tests:
   - it: should expose separate JMX RMI service port when configured
     set:
       jmx.enabled: true
+      jmx.port: 9999
       jmx.rmiPort: 9011
     asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: jmx
+            port: 9999
+            targetPort: jmx
+            protocol: TCP
       - contains:
           path: spec.ports
           content:

--- a/charts/tomcat/tests/testconnection_test.yaml
+++ b/charts/tomcat/tests/testconnection_test.yaml
@@ -16,3 +16,11 @@ tests:
       - matchRegex:
           path: spec.containers[0].args[0]
           pattern: "/health.jsp"
+
+  - it: should use tcp smoke when readiness probe is tcp
+    set:
+      readinessProbe.mode: tcp
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "nc -z -w5"

--- a/charts/tomcat/tests/testconnection_test.yaml
+++ b/charts/tomcat/tests/testconnection_test.yaml
@@ -24,3 +24,15 @@ tests:
       - matchRegex:
           path: spec.containers[0].args[0]
           pattern: "nc -z -w5"
+
+  - it: should use tcp smoke when readiness probe is disabled
+    set:
+      webapps.defaultRoot.enabled: false
+      readinessProbe.enabled: false
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "nc -z -w5"
+      - notMatchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "/health.jsp"

--- a/charts/tomcat/tests/testconnection_test.yaml
+++ b/charts/tomcat/tests/testconnection_test.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: TestConnection
+templates:
+  - tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render helm test pod
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "/health.jsp"

--- a/charts/tomcat/values.schema.json
+++ b/charts/tomcat/values.schema.json
@@ -34,7 +34,8 @@
           "type": "object",
           "properties": {
             "http": { "type": "integer" },
-            "jmx": { "type": "integer" }
+            "jmx": { "type": "integer" },
+            "jmxRmi": { "type": "integer" }
           }
         },
         "ipFamilyPolicy": {

--- a/charts/tomcat/values.schema.json
+++ b/charts/tomcat/values.schema.json
@@ -72,6 +72,12 @@
       "type": "object",
       "properties": {
         "mountPath": { "type": "string" },
+        "copyImageContent": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
         "persistence": { "$ref": "#/definitions/persistence" },
         "defaultRoot": {
           "type": "object",

--- a/charts/tomcat/values.schema.json
+++ b/charts/tomcat/values.schema.json
@@ -77,6 +77,8 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
+            "initImage": { "type": "object" },
+            "resources": { "type": "object" },
             "index": { "type": "string" },
             "health": { "type": "string" }
           }

--- a/charts/tomcat/values.schema.json
+++ b/charts/tomcat/values.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "tomcat Helm Chart Values",
+  "description": "Default values for the Apache Tomcat Helm chart.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "containerPorts": {
+      "type": "object",
+      "properties": {
+        "http": { "type": "integer" },
+        "jmx": { "type": "integer" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "annotations": { "type": "object" },
+        "ports": {
+          "type": "object",
+          "properties": {
+            "http": { "type": "integer" },
+            "jmx": { "type": "integer" }
+          }
+        },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "tomcat": {
+      "type": "object",
+      "properties": {
+        "catalinaOpts": { "type": "string" },
+        "javaOpts": { "type": "string" },
+        "serverXml": { "type": "string" },
+        "existingServerXmlConfigMap": { "type": "string" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "extraEnvFrom": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "webapps": {
+      "type": "object",
+      "properties": {
+        "mountPath": { "type": "string" },
+        "persistence": { "$ref": "#/definitions/persistence" },
+        "defaultRoot": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "index": { "type": "string" },
+            "health": { "type": "string" }
+          }
+        }
+      }
+    },
+    "logs": {
+      "type": "object",
+      "properties": {
+        "persistence": { "$ref": "#/definitions/persistence" }
+      }
+    },
+    "jmx": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "port": { "type": "integer" },
+        "rmiPort": { "type": "integer" },
+        "authenticate": { "type": "boolean" },
+        "ssl": { "type": "boolean" },
+        "hostname": { "type": "string" },
+        "extraOpts": { "type": "string" }
+      }
+    },
+    "ingress": { "type": "object" },
+    "gatewayAPI": { "type": "object" },
+    "networkPolicy": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "startupProbe": { "$ref": "#/definitions/probe" },
+    "livenessProbe": { "$ref": "#/definitions/probe" },
+    "readinessProbe": { "$ref": "#/definitions/probe" },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer" },
+        "maxReplicas": { "type": "integer" },
+        "targetCPUUtilizationPercentage": { "type": "integer" }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] }
+      }
+    },
+    "tests": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "type": "object" },
+        "resources": { "type": "object" }
+      }
+    }
+  },
+  "definitions": {
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingClaim": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": { "type": "array", "items": { "type": "string" } },
+        "size": { "type": "string" }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "mode": { "type": "string", "enum": ["http", "tcp"] },
+        "path": { "type": "string" },
+        "initialDelaySeconds": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" },
+        "failureThreshold": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -40,6 +40,8 @@ service:
     http: 80
     # -- Service port for the JMX registry when JMX is enabled.
     jmx: 9010
+    # -- Service port for JMX RMI when jmx.rmiPort differs from jmx.port.
+    jmxRmi: 9011
   # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ~
   # -- Service IP families override. Empty uses cluster default.

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -62,6 +62,10 @@ webapps:
   defaultRoot:
     # -- Render a small ROOT webapp so default installs have deterministic health checks.
     enabled: true
+    initImage:
+      repository: docker.io/library/busybox
+      tag: "1.37"
+      pullPolicy: IfNotPresent
     index: |
       <%@ page contentType="text/plain; charset=UTF-8" %>
       Apache Tomcat is running on HelmForge.

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -88,7 +88,7 @@ jmx:
   rmiPort: 9010
   authenticate: false
   ssl: false
-  hostname: 127.0.0.1
+  hostname: ""
   extraOpts: ""
 
 ingress:

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Apache Tomcat Helm Chart - Default Values
+# =============================================================================
+
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+image:
+  repository: docker.io/library/tomcat
+  tag: "11.0.22-jdk17-temurin-noble"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+containerPorts:
+  http: 8080
+  jmx: 9010
+
+service:
+  type: ClusterIP
+  annotations: {}
+  ports:
+    http: 80
+    jmx: 9010
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+tomcat:
+  # -- Extra CATALINA_OPTS appended before JMX options.
+  catalinaOpts: ""
+  # -- Extra JAVA_OPTS.
+  javaOpts: ""
+  # -- Optional server.xml override. Use only when you need connector/proxy customizations.
+  serverXml: ""
+  # -- Existing ConfigMap with key server.xml.
+  existingServerXmlConfigMap: ""
+  # -- Extra environment variables.
+  extraEnv: []
+  extraEnvFrom: []
+
+webapps:
+  mountPath: /usr/local/tomcat/webapps
+  persistence:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+  defaultRoot:
+    # -- Render a small ROOT webapp so default installs have deterministic health checks.
+    enabled: true
+    index: |
+      <%@ page contentType="text/plain; charset=UTF-8" %>
+      Apache Tomcat is running on HelmForge.
+    health: |
+      <%@ page contentType="text/plain; charset=UTF-8" %>
+      OK
+
+logs:
+  persistence:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 4Gi
+
+jmx:
+  enabled: false
+  port: 9010
+  rmiPort: 9010
+  authenticate: false
+  ssl: false
+  hostname: 127.0.0.1
+  extraOpts: ""
+
+ingress:
+  enabled: false
+  annotations: {}
+  ingressClassName: ""
+  hosts:
+    - host: tomcat.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gatewayAPI:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  filters: []
+
+networkPolicy:
+  enabled: false
+  ingress:
+    allowSameNamespace: true
+    extraFrom: []
+  egress:
+    enabled: false
+    allowDNS: true
+    allowHTTP: false
+    allowHTTPS: true
+    extraTo: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+podSecurityContext:
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+startupProbe:
+  enabled: true
+  mode: http
+  path: /health.jsp
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+livenessProbe:
+  enabled: true
+  mode: http
+  path: /health.jsp
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  enabled: true
+  mode: http
+  path: /health.jsp
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+podLabels: {}
+podAnnotations: {}
+annotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 60
+
+extraInitContainers: []
+extraContainers: []
+extraVolumes: []
+extraVolumeMounts: []
+
+tests:
+  enabled: true
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -72,6 +72,9 @@ tomcat:
 webapps:
   # -- Tomcat webapps directory mount path.
   mountPath: /usr/local/tomcat/webapps
+  copyImageContent:
+    # -- Copy applications already present in the Tomcat image into the mounted webapps volume when it is empty.
+    enabled: true
   persistence:
     # -- Enable PVC for the webapps directory.
     enabled: false

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -3,28 +3,42 @@
 # Apache Tomcat Helm Chart - Default Values
 # =============================================================================
 
+# -- Number of Tomcat pods when autoscaling is disabled.
 replicaCount: 1
 
+# -- Override the chart name used in generated resource names.
 nameOverride: ""
+# -- Override the full release name used in generated resource names.
 fullnameOverride: ""
+# -- Labels added to all chart resources.
 commonLabels: {}
 
 image:
+  # -- Tomcat image repository. Uses the official Docker image.
   repository: docker.io/library/tomcat
+  # -- Tomcat image tag.
   tag: "11.0.22-jdk17-temurin-noble"
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
 
+# -- Optional image pull secrets.
 imagePullSecrets: []
 
 containerPorts:
+  # -- Tomcat HTTP container port.
   http: 8080
+  # -- Deprecated compatibility value for JMX. The chart exposes jmx.port when JMX is enabled.
   jmx: 9010
 
 service:
+  # -- Kubernetes Service type.
   type: ClusterIP
+  # -- Service annotations.
   annotations: {}
   ports:
+    # -- Service port for HTTP traffic.
     http: 80
+    # -- Service port for the JMX registry when JMX is enabled.
     jmx: 9010
   # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ~
@@ -32,9 +46,13 @@ service:
   ipFamilies: []
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: false
+  # -- ServiceAccount name. Empty uses the chart fullname when create=true.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
+  # -- Mount Kubernetes API credentials into the Tomcat pod.
   automountServiceAccountToken: false
 
 tomcat:
@@ -48,84 +66,137 @@ tomcat:
   existingServerXmlConfigMap: ""
   # -- Extra environment variables.
   extraEnv: []
+  # -- Extra envFrom entries.
   extraEnvFrom: []
 
 webapps:
+  # -- Tomcat webapps directory mount path.
   mountPath: /usr/local/tomcat/webapps
   persistence:
+    # -- Enable PVC for the webapps directory.
     enabled: false
+    # -- Existing PVC for the webapps directory.
     existingClaim: ""
+    # -- Storage class for the webapps PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for the webapps PVC.
     accessModes:
       - ReadWriteOnce
+    # -- Size for the webapps PVC.
     size: 8Gi
   defaultRoot:
     # -- Render a small ROOT webapp so default installs have deterministic health checks.
     enabled: true
     initImage:
+      # -- Default ROOT seeding init container image repository.
       repository: docker.io/library/busybox
+      # -- Default ROOT seeding init container image tag.
       tag: "1.37"
+      # -- Default ROOT seeding init container image pull policy.
       pullPolicy: IfNotPresent
+    # -- Resources for the default ROOT seeding init container.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+    # -- index.jsp content for the default ROOT webapp.
     index: |
       <%@ page contentType="text/plain; charset=UTF-8" %>
       Apache Tomcat is running on HelmForge.
+    # -- health.jsp content for the default ROOT webapp and default probes.
     health: |
       <%@ page contentType="text/plain; charset=UTF-8" %>
       OK
 
 logs:
   persistence:
+    # -- Enable PVC for Tomcat logs.
     enabled: false
+    # -- Existing PVC for Tomcat logs.
     existingClaim: ""
+    # -- Storage class for the logs PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for the logs PVC.
     accessModes:
       - ReadWriteOnce
+    # -- Size for the logs PVC.
     size: 4Gi
 
 jmx:
+  # -- Enable JMX remote JVM options and Service ports.
   enabled: false
+  # -- JMX registry port exposed by the Tomcat JVM.
   port: 9010
+  # -- JMX RMI port exposed by the Tomcat JVM.
   rmiPort: 9010
+  # -- Enable JMX authentication. Mount required password/access files through extraVolumes and extraVolumeMounts.
   authenticate: false
+  # -- Enable JMX SSL. Mount required trust/key stores through extraVolumes and extraVolumeMounts.
   ssl: false
+  # -- Hostname advertised by RMI. Empty uses the pod IP through the Downward API.
   hostname: ""
+  # -- Extra JMX JVM flags appended to CATALINA_OPTS.
   extraOpts: ""
 
 ingress:
+  # -- Render a Kubernetes Ingress.
   enabled: false
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress class name.
   ingressClassName: ""
+  # -- Ingress hosts and paths.
   hosts:
     - host: tomcat.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS entries.
   tls: []
 
 gatewayAPI:
+  # -- Render a Gateway API HTTPRoute. Requires Gateway API CRDs and an existing Gateway.
   enabled: false
+  # -- HTTPRoute apiVersion.
   apiVersion: gateway.networking.k8s.io/v1
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- HTTPRoute parentRefs.
   parentRefs: []
+  # -- HTTPRoute hostnames.
   hostnames: []
+  # -- HTTPRoute matches.
   matches:
     - path:
         type: PathPrefix
         value: /
+  # -- HTTPRoute filters.
   filters: []
 
 networkPolicy:
+  # -- Create a NetworkPolicy for Tomcat pods.
   enabled: false
   ingress:
+    # -- Allow ingress from pods in the same namespace.
     allowSameNamespace: true
+    # -- Additional ingress "from" rules.
     extraFrom: []
   egress:
+    # -- Add explicit egress rules. Disabled keeps CNI default egress behavior.
     enabled: false
+    # -- Allow DNS egress.
     allowDNS: true
+    # -- Allow HTTP egress.
     allowHTTP: false
+    # -- Allow HTTPS egress for downloads and external integrations.
     allowHTTPS: true
+    # -- Additional egress peer rules rendered under egress[].to.
     extraTo: []
 
+# -- Tomcat container resources.
 resources:
   requests:
     cpu: 100m
@@ -134,11 +205,13 @@ resources:
     cpu: 1000m
     memory: 1Gi
 
+# -- Pod-level security context.
 podSecurityContext:
   fsGroup: 1001
   seccompProfile:
     type: RuntimeDefault
 
+# -- Tomcat container security context.
 securityContext:
   runAsUser: 1001
   runAsGroup: 1001
@@ -150,8 +223,11 @@ securityContext:
       - ALL
 
 startupProbe:
+  # -- Enable startup probe.
   enabled: true
+  # -- Probe mode: http or tcp.
   mode: http
+  # -- HTTP probe path when mode=http.
   path: /health.jsp
   initialDelaySeconds: 5
   periodSeconds: 10
@@ -159,8 +235,11 @@ startupProbe:
   failureThreshold: 30
 
 livenessProbe:
+  # -- Enable liveness probe.
   enabled: true
+  # -- Probe mode: http or tcp.
   mode: http
+  # -- HTTP probe path when mode=http.
   path: /health.jsp
   initialDelaySeconds: 30
   periodSeconds: 20
@@ -168,8 +247,11 @@ livenessProbe:
   failureThreshold: 6
 
 readinessProbe:
+  # -- Enable readiness probe.
   enabled: true
+  # -- Probe mode: http or tcp.
   mode: http
+  # -- HTTP probe path when mode=http.
   path: /health.jsp
   initialDelaySeconds: 10
   periodSeconds: 10
@@ -177,36 +259,60 @@ readinessProbe:
   failureThreshold: 3
 
 autoscaling:
+  # -- Render a HorizontalPodAutoscaler.
   enabled: false
+  # -- Minimum HPA replicas.
   minReplicas: 1
+  # -- Maximum HPA replicas.
   maxReplicas: 5
+  # -- Target average CPU utilization percentage.
   targetCPUUtilizationPercentage: 80
 
 pdb:
+  # -- Render a PodDisruptionBudget.
   enabled: false
+  # -- Minimum available pods when PDB is enabled.
   minAvailable: 1
 
+# -- Labels added to the Tomcat pod template.
 podLabels: {}
+# -- Annotations added to the Tomcat pod template.
 podAnnotations: {}
+# -- Annotations added to top-level resources that support annotations.
 annotations: {}
+# -- Node selector for Tomcat pods.
 nodeSelector: {}
+# -- Tolerations for Tomcat pods.
 tolerations: []
+# -- Affinity for Tomcat pods.
 affinity: {}
+# -- Topology spread constraints for Tomcat pods.
 topologySpreadConstraints: []
+# -- Priority class name for Tomcat pods.
 priorityClassName: ""
+# -- Termination grace period for Tomcat pods.
 terminationGracePeriodSeconds: 60
 
+# -- Extra init containers appended to the pod.
 extraInitContainers: []
+# -- Extra sidecar containers appended to the pod.
 extraContainers: []
+# -- Extra volumes appended to the pod.
 extraVolumes: []
+# -- Extra volume mounts appended to the Tomcat container.
 extraVolumeMounts: []
 
 tests:
+  # -- Render Helm test resources.
   enabled: true
   image:
+    # -- Helm test image repository.
     repository: docker.io/library/busybox
+    # -- Helm test image tag.
     tag: "1.37"
+    # -- Helm test image pull policy.
     pullPolicy: IfNotPresent
+  # -- Resources for Helm test pods.
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary

Adds the HelmForge `tomcat` chart as a stable chart using the official `docker.io/library/tomcat:11.0.22-jdk17-temurin-noble` image.

Closes #359.

## Scope

- official Tomcat image with pinned defaults
- Gateway API, Ingress, dual-stack Service fields, NetworkPolicy, HPA, PDB, JMX, PVC support for webapps/logs, and production examples
- deterministic default ROOT health app for fresh installs
- immutable app image support: image-baked `/usr/local/tomcat/webapps` content is copied into the mounted webapps volume when the volume is empty
- Helm test respects disabled readiness probes and falls back to TCP smoke checks

## Validation

Latest local validation after review fixes:

- `helm dependency build charts/tomcat` and `helm dependency list charts/tomcat` - no dependencies
- `helm lint charts/tomcat`
- `helm lint charts/tomcat --strict`
- `helm unittest charts/tomcat` - 5 suites, 27 tests passed
- `npx --yes markdownlint-cli2 "charts/tomcat/**/*.md"` - 3 files, 0 errors
- strict kubeconform for default render - 4 valid, 0 invalid
- strict kubeconform for all `charts/tomcat/ci/*.yaml` scenarios: dual-stack, gateway-api, hardening, ingress, jmx, standalone
- `ah lint charts/tomcat` - Tomcat package lint succeeded; repository scan 66 packages, 0 errors
- Kubescape NSA on `ci/hardening.yaml`: 98.33%, threshold 90
- MCP HelmForge: CI evidence PASS, security evidence PASS

## k3d validation

Validated on local cluster `k3d-helmforge-tests-wsl` after review fixes:

- namespace `hf-tomcat-standard`: `helm install --wait` with `ci/standalone.yaml`, `helm test` succeeded, `/health.jsp` returned `OK`
- namespace `hf-tomcat-no-readiness`: `webapps.defaultRoot.enabled=false`, `readinessProbe.enabled=false`, startup/liveness TCP; `helm install --wait`, `helm test`, and TCP smoke succeeded
- all Tomcat pods Ready with zero restarts
- no Warning events in either namespace
- logs scanned for `error|fatal|panic|exception|back-off|failed`; no matches
- namespaces `hf-tomcat-standard` and `hf-tomcat-no-readiness` deleted after validation