### PR TITLE
feat(sonarqube): add SonarQube chart

### DIFF
--- a/charts/sonarqube/.helmignore
+++ b/charts/sonarqube/.helmignore
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+.git/
+.github/
+.DS_Store
+*.swp
+*.tmp
+*.bak
+*.tgz
+charts/

--- a/charts/sonarqube/.helmignore
+++ b/charts/sonarqube/.helmignore
@@ -1,9 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
-.git/
-.github/
+# OS
 .DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
 *.swp
 *.tmp
+
+# Lock files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Pipfile.lock
+poetry.lock
+Gemfile.lock
+
+# Logs
+*.log
+
+# CI / misc
 *.bak
-*.tgz
-charts/

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: sonarqube
+description: SonarQube Community Build Helm chart with plugin automation and production controls
+type: application
+version: 0.1.0
+appVersion: "26.4.0.121862"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - sonarqube
+  - code-quality
+  - static-analysis
+  - clean-code
+  - ci
+  - devsecops
+  - java
+  - quality-gate
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://hub.docker.com/_/sonarqube
+  - https://github.com/SonarSource/docker-sonarqube
+  - https://github.com/mc1arke/sonarqube-community-branch-plugin
+icon: https://helmforge.dev/icons/charts/sonarqube.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add SonarQube chart with plugin automation and production controls (#361)"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: security
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.sonarsource.com/products/sonarqube/
+    - name: Official Image
+      url: https://hub.docker.com/_/sonarqube
+    - name: Source
+      url: https://github.com/SonarSource/docker-sonarqube
+    - name: Community Branch Plugin
+      url: https://github.com/mc1arke/sonarqube-community-branch-plugin
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/sonarqube
+    - name: Chart Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/sonarqube
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/jenkins

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -60,3 +60,8 @@ annotations:
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
     - url: https://artifacthub.io/packages/helm/helmforge/jenkins
+dependencies:
+  - name: postgresql
+    version: 2.0.2
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled

--- a/charts/sonarqube/DESIGN.md
+++ b/charts/sonarqube/DESIGN.md
@@ -8,15 +8,21 @@ This chart packages a single SonarQube Community Build node. It is designed for 
 
 The chart uses a Deployment with `Recreate` strategy because a single SonarQube instance owns local data, extensions, logs, and embedded search state.
 Production deployments should back the application with PostgreSQL and persistent volumes.
+The chart can either connect to an external PostgreSQL endpoint or deploy the HelmForge PostgreSQL chart as an optional dependency.
 
 The default image is pinned to `docker.io/library/sonarqube:26.4.0.121862-community`.
 This line matches the default `communityBranchPlugin.version` of `26.4.0`, allowing the plugin automation to be enabled without version guesswork.
 
-`sonarqube.databaseMode=embedded` exists for k3d smoke tests and temporary evaluation only.
-Production should use `external` mode with a PostgreSQL JDBC URL and a password from an existing Secret or ExternalSecret.
+`sonarqube.databaseMode=auto` chooses an external database when external settings are provided, then the HelmForge PostgreSQL subchart when `postgresql.enabled=true`.
+If neither is configured, it falls back to embedded evaluation mode.
+The embedded mode exists only for temporary evaluation.
+Durable environments should use `postgresql` mode with the HelmForge subchart or `external` mode with a PostgreSQL JDBC URL and a password from a Secret.
 
 The chart keeps plugin installation in an init container.
 This makes the main container use the official image unchanged while still allowing clusters to persist extensions or replace the webapp for the community branch plugin.
+
+When bundled PostgreSQL is enabled, a small wait init container checks TCP readiness before SonarQube starts.
+This prevents a first-start crash loop while the PostgreSQL subchart finishes bootstrap.
 
 ## Security
 
@@ -36,7 +42,11 @@ The chart includes:
 - dual-stack Service fields
 - Helm test connection pod
 - External Secrets Operator integration for database and monitoring passcode material
+- optional HelmForge PostgreSQL subchart integration for self-contained environments
+- bundled PostgreSQL readiness gate before application startup
 
 ## Non-goals
 
-This chart does not deploy PostgreSQL as a dependency. Database ownership is intentionally external so teams can use their platform-standard PostgreSQL chart, operator, or managed service.
+This chart does not run clustered SonarQube application nodes.
+Teams that need database lifecycle ownership outside the release can disable the bundled PostgreSQL dependency and use a platform PostgreSQL chart, operator, or managed service.
+That mode is selected with `sonarqube.databaseMode=external`.

--- a/charts/sonarqube/DESIGN.md
+++ b/charts/sonarqube/DESIGN.md
@@ -1,0 +1,42 @@
+# SonarQube Chart Design
+
+## Scope
+
+This chart packages a single SonarQube Community Build node. It is designed for straightforward Kubernetes operation while keeping production requirements explicit.
+
+## Decisions
+
+The chart uses a Deployment with `Recreate` strategy because a single SonarQube instance owns local data, extensions, logs, and embedded search state.
+Production deployments should back the application with PostgreSQL and persistent volumes.
+
+The default image is pinned to `docker.io/library/sonarqube:26.4.0.121862-community`.
+This line matches the default `communityBranchPlugin.version` of `26.4.0`, allowing the plugin automation to be enabled without version guesswork.
+
+`sonarqube.databaseMode=embedded` exists for k3d smoke tests and temporary evaluation only.
+Production should use `external` mode with a PostgreSQL JDBC URL and a password from an existing Secret or ExternalSecret.
+
+The chart keeps plugin installation in an init container.
+This makes the main container use the official image unchanged while still allowing clusters to persist extensions or replace the webapp for the community branch plugin.
+
+## Security
+
+The default runtime drops all Linux capabilities, disallows privilege escalation, runs as UID/GID 1000, and disables service account token mounting.
+Writable paths are modeled as explicit volumes so the main container can keep a read-only root filesystem.
+
+NetworkPolicy is optional because clusters differ in CNI behavior.
+When enabled, ingress is limited to the SonarQube HTTP port and egress can be restricted to DNS, HTTP, HTTPS, and PostgreSQL.
+
+## Operations
+
+The chart includes:
+
+- startup, readiness, and liveness probes against `/api/system/status`
+- optional PodDisruptionBudget
+- optional Gateway API and Ingress exposure
+- dual-stack Service fields
+- Helm test connection pod
+- External Secrets Operator integration for database and monitoring passcode material
+
+## Non-goals
+
+This chart does not deploy PostgreSQL as a dependency. Database ownership is intentionally external so teams can use their platform-standard PostgreSQL chart, operator, or managed service.

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -1,0 +1,156 @@
+# SonarQube
+
+SonarQube Community Build for Kubernetes using the official Docker image, with explicit local and production database modes, plugin automation, and optional support for the community branch plugin.
+
+## Install
+
+### HTTPS repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install sonarqube helmforge/sonarqube -f values.yaml
+```
+
+### OCI registry
+
+```bash
+helm install sonarqube oci://ghcr.io/helmforgedev/helm/sonarqube -f values.yaml
+```
+
+## What this chart covers
+
+- official `docker.io/library/sonarqube` image
+- `embedded` mode for disposable local validation
+- `external` mode for PostgreSQL-backed production deployments
+- generated, existing, or External Secrets Operator-backed database password handling
+- optional monitoring passcode secret handling
+- plugin download init container with persistent extensions volume
+- first-class community branch plugin wiring, including Java agents and webapp replacement
+- Gateway API `HTTPRoute`, Ingress, and dual-stack Service fields
+- default non-root pod security context, dropped Linux capabilities, and read-only root filesystem
+- optional NetworkPolicy, PodDisruptionBudget, persistence, extra containers, and extra volumes
+- Helm test pod that validates the SonarQube system status endpoint
+
+## Database Modes
+
+The default `embedded` mode is intentionally scoped to local smoke tests and disposable evaluation. Use external PostgreSQL for production.
+
+```yaml
+sonarqube:
+  databaseMode: external
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.database.svc.cluster.local:5432/sonarqube
+    username: sonar
+    existingSecret: sonarqube-database
+    existingSecretPasswordKey: jdbc-password
+```
+
+## External Secrets
+
+```yaml
+sonarqube:
+  databaseMode: external
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.database.svc.cluster.local:5432/sonarqube
+    username: sonar
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: sonarqube/database
+      property: password
+```
+
+## Community Branch Plugin
+
+The chart can install the community branch plugin and patch the SonarQube web application during startup.
+
+```yaml
+communityBranchPlugin:
+  enabled: true
+  version: "26.4.0"
+```
+
+Keep the plugin major and minor version aligned with the SonarQube version. The default chart image is pinned to `26.4.0.121862-community` to match the default plugin line.
+
+See [Community Branch Plugin](docs/community-branch-plugin.md).
+
+## Exposure
+
+Ingress:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: sonarqube.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Gateway API:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - sonarqube.example.com
+```
+
+Dual-stack Service:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## Main Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `docker.io/library/sonarqube` | Official SonarQube image repository |
+| `image.tag` | `26.4.0.121862-community` | SonarQube Community Build image tag |
+| `sonarqube.databaseMode` | `embedded` | `embedded` for local testing or `external` for PostgreSQL |
+| `database.external.jdbcUrl` | `""` | JDBC URL when using external mode |
+| `database.external.existingSecret` | `""` | Existing database password Secret |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resources |
+| `plugins.enabled` | `false` | Enable plugin download init container |
+| `communityBranchPlugin.enabled` | `false` | Install and wire the branch plugin |
+| `persistence.data.enabled` | `true` | Persist SonarQube data |
+| `persistence.extensions.enabled` | `true` | Persist installed plugins |
+| `service.ipFamilyPolicy` | `~` | Optional Kubernetes Service IP family policy |
+| `ingress.enabled` | `false` | Render Ingress |
+| `gatewayAPI.enabled` | `false` | Render Gateway API HTTPRoute |
+| `networkPolicy.enabled` | `false` | Render NetworkPolicy |
+| `pdb.enabled` | `false` | Render PodDisruptionBudget |
+
+## Production Notes
+
+Before production use, read [Production](docs/production.md).
+SonarQube embeds Elasticsearch and requires host kernel settings for production bootstrap checks.
+The chart defaults to disabled bootstrap checks for k3d and evaluation; production clusters should set the host requirements and use external PostgreSQL.
+
+## References
+
+- [SonarQube Community Build](https://docs.sonarsource.com/sonarqube-community-build/)
+- [Official SonarQube Docker image](https://hub.docker.com/_/sonarqube)
+- [SonarQube Docker source](https://github.com/SonarSource/docker-sonarqube)
+- [Community branch plugin](https://github.com/mc1arke/sonarqube-community-branch-plugin)

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -1,6 +1,7 @@
 # SonarQube
 
-SonarQube Community Build for Kubernetes using the official Docker image, with explicit local and production database modes, plugin automation, and optional support for the community branch plugin.
+SonarQube Community Build for Kubernetes using the official Docker image.
+It supports embedded evaluation mode, HelmForge PostgreSQL, external PostgreSQL, plugin automation, and the community branch plugin.
 
 ## Install
 
@@ -22,10 +23,12 @@ helm install sonarqube oci://ghcr.io/helmforgedev/helm/sonarqube -f values.yaml
 
 - official `docker.io/library/sonarqube` image
 - `embedded` mode for disposable local validation
+- `postgresql` mode backed by the HelmForge PostgreSQL subchart
 - `external` mode for PostgreSQL-backed production deployments
 - generated, existing, or External Secrets Operator-backed database password handling
 - optional monitoring passcode secret handling
 - plugin download init container with persistent extensions volume
+- bundled PostgreSQL wait init container to avoid first-start connection races
 - first-class community branch plugin wiring, including Java agents and webapp replacement
 - Gateway API `HTTPRoute`, Ingress, and dual-stack Service fields
 - default non-root pod security context, dropped Linux capabilities, and read-only root filesystem
@@ -34,7 +37,23 @@ helm install sonarqube oci://ghcr.io/helmforgedev/helm/sonarqube -f values.yaml
 
 ## Database Modes
 
-The default `embedded` mode is intentionally scoped to local smoke tests and disposable evaluation. Use external PostgreSQL for production.
+The default `auto` mode uses external settings when provided, then `postgresql.enabled`, and otherwise falls back to embedded evaluation mode. The embedded mode is intentionally scoped to disposable evaluation.
+
+Bundled HelmForge PostgreSQL:
+
+```yaml
+sonarqube:
+  databaseMode: postgresql
+
+postgresql:
+  enabled: true
+  auth:
+    database: sonarqube
+    username: sonar
+    password: change-me
+```
+
+External PostgreSQL:
 
 ```yaml
 sonarqube:
@@ -128,7 +147,9 @@ service:
 |-----|---------|-------------|
 | `image.repository` | `docker.io/library/sonarqube` | Official SonarQube image repository |
 | `image.tag` | `26.4.0.121862-community` | SonarQube Community Build image tag |
-| `sonarqube.databaseMode` | `embedded` | `embedded` for local testing or `external` for PostgreSQL |
+| `sonarqube.databaseMode` | `auto` | `auto`, `embedded`, `postgresql`, or `external` |
+| `postgresql.enabled` | `false` | Deploy HelmForge PostgreSQL as a subchart |
+| `waitForDatabase.enabled` | `true` | Wait for bundled PostgreSQL before starting SonarQube |
 | `database.external.jdbcUrl` | `""` | JDBC URL when using external mode |
 | `database.external.existingSecret` | `""` | Existing database password Secret |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret resources |
@@ -146,7 +167,7 @@ service:
 
 Before production use, read [Production](docs/production.md).
 SonarQube embeds Elasticsearch and requires host kernel settings for production bootstrap checks.
-The chart defaults to disabled bootstrap checks for k3d and evaluation; production clusters should set the host requirements and use external PostgreSQL.
+The chart defaults to disabled bootstrap checks for k3d and evaluation; production clusters should set the host requirements and use bundled or external PostgreSQL.
 
 ## References
 

--- a/charts/sonarqube/ci/dual-stack.yaml
+++ b/charts/sonarqube/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/sonarqube/ci/external-db.yaml
+++ b/charts/sonarqube/ci/external-db.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+sonarqube:
+  databaseMode: external
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.default.svc.cluster.local:5432/sonarqube
+    username: sonar
+    password: change-me

--- a/charts/sonarqube/ci/external-secrets.yaml
+++ b/charts/sonarqube/ci/external-secrets.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+sonarqube:
+  databaseMode: external
+  monitoringPasscode: ""
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.default.svc.cluster.local:5432/sonarqube
+    username: sonar
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  database:
+    enabled: true
+    passwordRemoteRef:
+      key: sonarqube/database
+      property: password
+  monitoringPasscode:
+    enabled: true
+    remoteRef:
+      key: sonarqube/monitoring
+      property: passcode

--- a/charts/sonarqube/ci/gateway-api.yaml
+++ b/charts/sonarqube/ci/gateway-api.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - sonarqube.example.com
+  filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+          - name: X-Forwarded-Proto
+            value: https

--- a/charts/sonarqube/ci/hardening.yaml
+++ b/charts/sonarqube/ci/hardening.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+
+pdb:
+  enabled: true
+
+serviceAccount:
+  create: true

--- a/charts/sonarqube/ci/ingress.yaml
+++ b/charts/sonarqube/ci/ingress.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: sonarqube.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sonarqube-tls
+      hosts:
+        - sonarqube.example.com

--- a/charts/sonarqube/ci/plugins.yaml
+++ b/charts/sonarqube/ci/plugins.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+plugins:
+  enabled: true
+  install:
+    - name: sonar-auth-oidc
+      url: https://example.com/sonar-auth-oidc.jar
+
+communityBranchPlugin:
+  enabled: true
+  version: "26.4.0"

--- a/charts/sonarqube/ci/smoke.yaml
+++ b/charts/sonarqube/ci/smoke.yaml
@@ -1,9 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 sonarqube:
-  databaseMode: embedded
   webJavaOpts: "-Xms128m -Xmx384m"
   ceJavaOpts: "-Xms128m -Xmx384m"
   searchJavaOpts: "-Xms384m -Xmx384m"
+
+postgresql:
+  enabled: true
+  auth:
+    database: sonarqube
+    username: sonar
+    password: sonar-ci-password
+  standalone:
+    persistence:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
 
 persistence:
   data:

--- a/charts/sonarqube/ci/smoke.yaml
+++ b/charts/sonarqube/ci/smoke.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+sonarqube:
+  databaseMode: embedded
+  webJavaOpts: "-Xms128m -Xmx384m"
+  ceJavaOpts: "-Xms128m -Xmx384m"
+  searchJavaOpts: "-Xms384m -Xmx384m"
+
+persistence:
+  data:
+    enabled: false
+  extensions:
+    enabled: false
+  logs:
+    enabled: false
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 1536Mi
+  limits:
+    cpu: 2
+    memory: 2304Mi

--- a/charts/sonarqube/docs/community-branch-plugin.md
+++ b/charts/sonarqube/docs/community-branch-plugin.md
@@ -1,0 +1,42 @@
+# Community Branch Plugin
+
+The chart can install the community branch plugin during pod initialization.
+
+```yaml
+communityBranchPlugin:
+  enabled: true
+  version: "26.4.0"
+```
+
+When enabled, the chart:
+
+- downloads the plugin JAR to `/opt/sonarqube/extensions/plugins`
+- downloads and unpacks `sonarqube-webapp.zip`
+- mounts the patched web application at `/opt/sonarqube/web`
+- writes the required web and compute engine Java agent properties
+
+The default URLs are derived from the configured plugin version. Override them when mirroring artifacts internally:
+
+```yaml
+communityBranchPlugin:
+  enabled: true
+  version: "26.4.0"
+  jarUrl: https://artifacts.example.com/sonarqube-community-branch-plugin-26.4.0.jar
+  webappUrl: https://artifacts.example.com/sonarqube-webapp.zip
+```
+
+Keep the plugin major and minor version aligned with the SonarQube major and minor version.
+
+## Additional Plugins
+
+Use `plugins.install` for extra plugin JARs:
+
+```yaml
+plugins:
+  enabled: true
+  install:
+    - name: sonar-auth-oidc
+      url: https://example.com/sonar-auth-oidc.jar
+```
+
+Use an internal artifact repository for production so startup does not depend on public internet availability.

--- a/charts/sonarqube/docs/production.md
+++ b/charts/sonarqube/docs/production.md
@@ -1,0 +1,70 @@
+# Production
+
+Use `sonarqube.databaseMode=external` for production.
+
+```yaml
+sonarqube:
+  databaseMode: external
+  esBootstrapChecksDisable: false
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.database.svc.cluster.local:5432/sonarqube
+    username: sonar
+    existingSecret: sonarqube-database
+    existingSecretPasswordKey: jdbc-password
+```
+
+## Host Requirements
+
+SonarQube embeds Elasticsearch. Production nodes must satisfy the SonarQube host requirements before enabling bootstrap checks:
+
+- `vm.max_map_count=524288`
+- `fs.file-max=131072`
+- file descriptor limit of `131072`
+- process limit of `8192`
+
+Keep `sonarqube.esBootstrapChecksDisable=true` only for disposable local environments.
+
+## Persistence
+
+Keep the data and extensions volumes persistent:
+
+```yaml
+persistence:
+  data:
+    enabled: true
+    size: 50Gi
+  extensions:
+    enabled: true
+    size: 10Gi
+```
+
+Use `existingClaim` when PVC lifecycle is managed outside Helm.
+
+## Network
+
+Use Gateway API or Ingress for HTTP exposure. SonarQube should normally be served behind TLS at the edge.
+
+Enable NetworkPolicy when your CNI enforces it:
+
+```yaml
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+```
+
+## Monitoring Passcode
+
+When using endpoints that require a system passcode, provide it from a Secret:
+
+```yaml
+sonarqube:
+  existingMonitoringPasscodeSecret: sonarqube-monitoring
+  existingMonitoringPasscodeSecretKey: monitoring-passcode
+```
+
+## Upgrades
+
+Read SonarSource upgrade notes before changing `image.tag`. Keep plugins compatible with the target SonarQube version, especially when `communityBranchPlugin.enabled=true`.

--- a/charts/sonarqube/docs/production.md
+++ b/charts/sonarqube/docs/production.md
@@ -1,6 +1,25 @@
 # Production
 
-Use `sonarqube.databaseMode=external` for production.
+Use PostgreSQL for production. For a self-contained release, enable the HelmForge PostgreSQL subchart:
+
+```yaml
+sonarqube:
+  databaseMode: postgresql
+  esBootstrapChecksDisable: false
+
+postgresql:
+  enabled: true
+  auth:
+    database: sonarqube
+    username: sonar
+    password: change-me
+  standalone:
+    persistence:
+      enabled: true
+      size: 50Gi
+```
+
+For platform-managed database services, use `sonarqube.databaseMode=external`.
 
 ```yaml
 sonarqube:
@@ -28,7 +47,7 @@ Keep `sonarqube.esBootstrapChecksDisable=true` only for disposable local environ
 
 ## Persistence
 
-Keep the data and extensions volumes persistent:
+Keep the SonarQube data and extensions volumes persistent:
 
 ```yaml
 persistence:
@@ -41,6 +60,8 @@ persistence:
 ```
 
 Use `existingClaim` when PVC lifecycle is managed outside Helm.
+
+If `postgresql.enabled=true`, also size and back up the PostgreSQL PVC according to your retention requirements.
 
 ## Network
 

--- a/charts/sonarqube/examples/bundled-postgresql.yaml
+++ b/charts/sonarqube/examples/bundled-postgresql.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+sonarqube:
+  databaseMode: postgresql
+  esBootstrapChecksDisable: false
+
+postgresql:
+  enabled: true
+  auth:
+    database: sonarqube
+    username: sonar
+    password: change-me
+  standalone:
+    persistence:
+      enabled: true
+      size: 50Gi
+
+persistence:
+  data:
+    enabled: true
+    size: 50Gi
+  extensions:
+    enabled: true
+    size: 10Gi

--- a/charts/sonarqube/examples/community-branch-plugin.yaml
+++ b/charts/sonarqube/examples/community-branch-plugin.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+communityBranchPlugin:
+  enabled: true
+  version: "26.4.0"
+
+plugins:
+  enabled: true
+
+persistence:
+  extensions:
+    enabled: true
+    size: 10Gi

--- a/charts/sonarqube/examples/external-postgresql.yaml
+++ b/charts/sonarqube/examples/external-postgresql.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+sonarqube:
+  databaseMode: external
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.database.svc.cluster.local:5432/sonarqube
+    username: sonar
+    existingSecret: sonarqube-database
+    existingSecretPasswordKey: jdbc-password

--- a/charts/sonarqube/examples/production.yaml
+++ b/charts/sonarqube/examples/production.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+sonarqube:
+  databaseMode: external
+  esBootstrapChecksDisable: false
+
+database:
+  external:
+    jdbcUrl: jdbc:postgresql://postgresql.database.svc.cluster.local:5432/sonarqube
+    username: sonar
+    existingSecret: sonarqube-database
+    existingSecretPasswordKey: jdbc-password
+
+persistence:
+  data:
+    enabled: true
+    size: 50Gi
+  extensions:
+    enabled: true
+    size: 10Gi
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: sonarqube.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sonarqube-tls
+      hosts:
+        - sonarqube.example.com
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+
+pdb:
+  enabled: true

--- a/charts/sonarqube/templates/NOTES.txt
+++ b/charts/sonarqube/templates/NOTES.txt
@@ -1,12 +1,34 @@
-SonarQube has been installed.
+{{- $databaseMode := include "sonarqube.databaseMode" . }}
+SonarQube Community Build has been deployed.
 
 Service:
-  http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.port }}{{ .Values.sonarqube.context }}
+  http://{{ include "sonarqube.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.port }}{{ .Values.sonarqube.context }}
 
-{{- if eq .Values.sonarqube.databaseMode "embedded" }}
-This release uses the embedded database mode. Use sonarqube.databaseMode=external with PostgreSQL for production.
+Database:
+{{- if eq $databaseMode "embedded" }}
+  mode: embedded
+  status: evaluation only; use bundled or external PostgreSQL for durable environments
+{{- else if eq $databaseMode "postgresql" }}
+  mode: bundled HelmForge PostgreSQL
+  jdbc: {{ include "sonarqube.postgresqlJdbcUrl" . }}
+  secret: {{ include "sonarqube.databaseSecretName" . }} / {{ include "sonarqube.databaseSecretKey" . }}
+{{- else }}
+  mode: external PostgreSQL
+  jdbc: {{ .Values.database.external.jdbcUrl }}
+  secret: {{ include "sonarqube.databaseSecretName" . }} / {{ include "sonarqube.databaseSecretKey" . }}
 {{- end }}
 
+Health:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "sonarqube.fullname" . }} 9000:{{ .Values.service.port }}
+  curl -fsS http://127.0.0.1:9000{{ include "sonarqube.probePath" (dict "root" . "path" "/api/system/status") }}
+
+Validation:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "sonarqube.fullname" . }}
+
 {{- if .Values.communityBranchPlugin.enabled }}
-The community branch plugin is enabled. Keep communityBranchPlugin.version aligned with the SonarQube major/minor version.
+Community branch plugin:
+  enabled: true
+  version: {{ .Values.communityBranchPlugin.version }}
+  Keep the plugin version aligned with the SonarQube Community Build version.
 {{- end }}

--- a/charts/sonarqube/templates/NOTES.txt
+++ b/charts/sonarqube/templates/NOTES.txt
@@ -1,0 +1,12 @@
+SonarQube has been installed.
+
+Service:
+  http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.port }}{{ .Values.sonarqube.context }}
+
+{{- if eq .Values.sonarqube.databaseMode "embedded" }}
+This release uses the embedded database mode. Use sonarqube.databaseMode=external with PostgreSQL for production.
+{{- end }}
+
+{{- if .Values.communityBranchPlugin.enabled }}
+The community branch plugin is enabled. Keep communityBranchPlugin.version aligned with the SonarQube major/minor version.
+{{- end }}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -122,6 +122,17 @@ app.kubernetes.io/part-of: sonarqube
 {{- printf "sonarqube-community-branch-plugin-%s.jar" .Values.communityBranchPlugin.version }}
 {{- end }}
 
+{{- define "sonarqube.probePath" -}}
+{{- $root := .root -}}
+{{- $path := .path | default "/" -}}
+{{- $context := trimSuffix "/" ($root.Values.sonarqube.context | default "") -}}
+{{- if and $context (not (or (eq $path $context) (hasPrefix (printf "%s/" $context) $path))) -}}
+{{- printf "%s%s" $context $path -}}
+{{- else -}}
+{{- $path -}}
+{{- end -}}
+{{- end }}
+
 {{- define "sonarqube.externalSecretDataItem" -}}
 - secretKey: {{ .secretKey | quote }}
   remoteRef:

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -58,6 +58,44 @@ app.kubernetes.io/part-of: sonarqube
 {{- printf "%s-secrets" (include "sonarqube.fullname" .) }}
 {{- end }}
 
+{{- define "sonarqube.postgresqlFullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sonarqube.postgresqlHost" -}}
+{{- printf "%s.%s.svc.%s" (include "sonarqube.postgresqlFullname" .) .Release.Namespace .Values.clusterDomain -}}
+{{- end }}
+
+{{- define "sonarqube.postgresqlJdbcUrl" -}}
+{{- $service := .Values.postgresql.service | default dict -}}
+{{- $port := get $service "port" | default 5432 -}}
+{{- printf "jdbc:postgresql://%s:%v/%s" (include "sonarqube.postgresqlHost" .) $port .Values.postgresql.auth.database -}}
+{{- end }}
+
+{{- define "sonarqube.postgresqlPort" -}}
+{{- $service := .Values.postgresql.service | default dict -}}
+{{- get $service "port" | default 5432 -}}
+{{- end }}
+
+{{- define "sonarqube.databaseMode" -}}
+{{- if eq .Values.sonarqube.databaseMode "auto" -}}
+  {{- if or .Values.database.external.jdbcUrl .Values.database.external.existingSecret (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled) .Values.database.external.password -}}
+external
+  {{- else if .Values.postgresql.enabled -}}
+postgresql
+  {{- else -}}
+embedded
+  {{- end -}}
+{{- else -}}
+{{- .Values.sonarqube.databaseMode -}}
+{{- end -}}
+{{- end }}
+
 {{- define "sonarqube.dataClaimName" -}}
 {{- default (printf "%s-data" (include "sonarqube.fullname" .)) .Values.persistence.data.existingClaim }}
 {{- end }}
@@ -71,7 +109,14 @@ app.kubernetes.io/part-of: sonarqube
 {{- end }}
 
 {{- define "sonarqube.databaseSecretName" -}}
-{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}
+{{- $mode := include "sonarqube.databaseMode" . -}}
+{{- if eq $mode "postgresql" -}}
+{{- if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "sonarqube.postgresqlFullname" .) -}}
+{{- end -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}
 {{- .Values.externalSecrets.database.targetName -}}
 {{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled -}}
 {{- printf "%s-database" (include "sonarqube.fullname" .) -}}
@@ -83,7 +128,12 @@ app.kubernetes.io/part-of: sonarqube
 {{- end }}
 
 {{- define "sonarqube.databaseSecretKey" -}}
+{{- $mode := include "sonarqube.databaseMode" . -}}
+{{- if eq $mode "postgresql" -}}
+{{- .Values.postgresql.auth.existingSecretUserPasswordKey | default "user-password" -}}
+{{- else -}}
 {{- .Values.database.external.existingSecretPasswordKey -}}
+{{- end -}}
 {{- end }}
 
 {{- define "sonarqube.monitoringSecretName" -}}
@@ -155,13 +205,20 @@ app.kubernetes.io/part-of: sonarqube
 {{- end }}
 
 {{- define "sonarqube.validate" -}}
+{{- $mode := include "sonarqube.databaseMode" . -}}
 {{- if gt (.Values.replicaCount | int) 1 -}}
 {{- fail "replicaCount greater than 1 is unsupported for this SonarQube Community chart" -}}
 {{- end -}}
-{{- if not (has .Values.sonarqube.databaseMode (list "embedded" "external")) -}}
-{{- fail "sonarqube.databaseMode must be embedded or external" -}}
+{{- if not (has .Values.sonarqube.databaseMode (list "auto" "embedded" "external" "postgresql")) -}}
+{{- fail "sonarqube.databaseMode must be auto, embedded, external, or postgresql" -}}
 {{- end -}}
-{{- if eq .Values.sonarqube.databaseMode "external" -}}
+{{- if and (eq .Values.sonarqube.databaseMode "postgresql") (not .Values.postgresql.enabled) -}}
+{{- fail "postgresql.enabled must be true when sonarqube.databaseMode=postgresql" -}}
+{{- end -}}
+{{- if and (eq $mode "external") .Values.postgresql.enabled -}}
+{{- fail "postgresql.enabled must be false when SonarQube is configured for external database mode" -}}
+{{- end -}}
+{{- if eq $mode "external" -}}
   {{- if not .Values.database.external.jdbcUrl -}}
     {{- fail "database.external.jdbcUrl is required when sonarqube.databaseMode=external" -}}
   {{- end -}}
@@ -170,6 +227,14 @@ app.kubernetes.io/part-of: sonarqube
   {{- end -}}
   {{- if and (not .Values.database.external.password) (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) -}}
     {{- fail "database.external.password, database.external.existingSecret, or externalSecrets.database.enabled is required when sonarqube.databaseMode=external" -}}
+  {{- end -}}
+{{- end -}}
+{{- if eq $mode "postgresql" -}}
+  {{- if not .Values.postgresql.auth.database -}}
+    {{- fail "postgresql.auth.database is required when using bundled PostgreSQL" -}}
+  {{- end -}}
+  {{- if not .Values.postgresql.auth.username -}}
+    {{- fail "postgresql.auth.username is required when using bundled PostgreSQL" -}}
   {{- end -}}
 {{- end -}}
 {{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -1,0 +1,175 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "sonarqube.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "sonarqube.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "sonarqube.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "sonarqube.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sonarqube.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "sonarqube.labels" -}}
+helm.sh/chart: {{ include "sonarqube.chart" . }}
+{{ include "sonarqube.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: sonarqube
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "sonarqube.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sonarqube.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "sonarqube.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+{{- end }}
+
+{{- define "sonarqube.configMapName" -}}
+{{- printf "%s-config" (include "sonarqube.fullname" .) }}
+{{- end }}
+
+{{- define "sonarqube.secretName" -}}
+{{- printf "%s-secrets" (include "sonarqube.fullname" .) }}
+{{- end }}
+
+{{- define "sonarqube.dataClaimName" -}}
+{{- default (printf "%s-data" (include "sonarqube.fullname" .)) .Values.persistence.data.existingClaim }}
+{{- end }}
+
+{{- define "sonarqube.extensionsClaimName" -}}
+{{- default (printf "%s-extensions" (include "sonarqube.fullname" .)) .Values.persistence.extensions.existingClaim }}
+{{- end }}
+
+{{- define "sonarqube.logsClaimName" -}}
+{{- default (printf "%s-logs" (include "sonarqube.fullname" .)) .Values.persistence.logs.existingClaim }}
+{{- end }}
+
+{{- define "sonarqube.databaseSecretName" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled .Values.externalSecrets.database.targetName -}}
+{{- .Values.externalSecrets.database.targetName -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled -}}
+{{- printf "%s-database" (include "sonarqube.fullname" .) -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- include "sonarqube.secretName" . -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sonarqube.databaseSecretKey" -}}
+{{- .Values.database.external.existingSecretPasswordKey -}}
+{{- end }}
+
+{{- define "sonarqube.monitoringSecretName" -}}
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.monitoringPasscode.enabled .Values.externalSecrets.monitoringPasscode.targetName -}}
+{{- .Values.externalSecrets.monitoringPasscode.targetName -}}
+{{- else if and .Values.externalSecrets.enabled .Values.externalSecrets.monitoringPasscode.enabled -}}
+{{- printf "%s-monitoring" (include "sonarqube.fullname" .) -}}
+{{- else if .Values.sonarqube.existingMonitoringPasscodeSecret -}}
+{{- .Values.sonarqube.existingMonitoringPasscodeSecret -}}
+{{- else -}}
+{{- include "sonarqube.secretName" . -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sonarqube.monitoringSecretKey" -}}
+{{- .Values.sonarqube.existingMonitoringPasscodeSecretKey -}}
+{{- end }}
+
+{{- define "sonarqube.communityBranchJarUrl" -}}
+{{- if .Values.communityBranchPlugin.jarUrl -}}
+{{- .Values.communityBranchPlugin.jarUrl -}}
+{{- else -}}
+{{- printf "https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/%s/sonarqube-community-branch-plugin-%s.jar" .Values.communityBranchPlugin.version .Values.communityBranchPlugin.version -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sonarqube.communityBranchWebappUrl" -}}
+{{- if .Values.communityBranchPlugin.webappUrl -}}
+{{- .Values.communityBranchPlugin.webappUrl -}}
+{{- else -}}
+{{- printf "https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/%s/sonarqube-webapp.zip" .Values.communityBranchPlugin.version -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sonarqube.communityBranchJarName" -}}
+{{- printf "sonarqube-community-branch-plugin-%s.jar" .Values.communityBranchPlugin.version }}
+{{- end }}
+
+{{- define "sonarqube.externalSecretDataItem" -}}
+- secretKey: {{ .secretKey | quote }}
+  remoteRef:
+    {{- if not .remoteRef.key }}
+    {{- fail (printf "%s.key is required when %s=true" .remoteRefName .enabledName) }}
+    {{- end }}
+    key: {{ .remoteRef.key | quote }}
+    {{- with .remoteRef.property }}
+    property: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.version }}
+    version: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.decodingStrategy }}
+    decodingStrategy: {{ . | quote }}
+    {{- end }}
+    {{- with .remoteRef.conversionStrategy }}
+    conversionStrategy: {{ . | quote }}
+    {{- end }}
+{{- end }}
+
+{{- define "sonarqube.validate" -}}
+{{- if not (has .Values.sonarqube.databaseMode (list "embedded" "external")) -}}
+{{- fail "sonarqube.databaseMode must be embedded or external" -}}
+{{- end -}}
+{{- if eq .Values.sonarqube.databaseMode "external" -}}
+  {{- if not .Values.database.external.jdbcUrl -}}
+    {{- fail "database.external.jdbcUrl is required when sonarqube.databaseMode=external" -}}
+  {{- end -}}
+  {{- if not .Values.database.external.username -}}
+    {{- fail "database.external.username is required when sonarqube.databaseMode=external" -}}
+  {{- end -}}
+  {{- if and (not .Values.database.external.password) (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) -}}
+    {{- fail "database.external.password, database.external.existingSecret, or externalSecrets.database.enabled is required when sonarqube.databaseMode=external" -}}
+  {{- end -}}
+{{- end -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
+{{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.database.enabled (not .Values.externalSecrets.enabled) -}}
+{{- fail "externalSecrets.enabled must be true when externalSecrets.database.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.monitoringPasscode.enabled (not .Values.externalSecrets.enabled) -}}
+{{- fail "externalSecrets.enabled must be true when externalSecrets.monitoringPasscode.enabled=true" -}}
+{{- end -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if not .Values.externalSecrets.secretStoreRef.name -}}
+    {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/sonarqube/templates/_helpers.tpl
+++ b/charts/sonarqube/templates/_helpers.tpl
@@ -155,6 +155,9 @@ app.kubernetes.io/part-of: sonarqube
 {{- end }}
 
 {{- define "sonarqube.validate" -}}
+{{- if gt (.Values.replicaCount | int) 1 -}}
+{{- fail "replicaCount greater than 1 is unsupported for this SonarQube Community chart" -}}
+{{- end -}}
 {{- if not (has .Values.sonarqube.databaseMode (list "embedded" "external")) -}}
 {{- fail "sonarqube.databaseMode must be embedded or external" -}}
 {{- end -}}

--- a/charts/sonarqube/templates/configmap.yaml
+++ b/charts/sonarqube/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sonarqube.configMapName" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sonarqube
+data:
+  sonar.properties: |
+    {{- if .Values.sonarqube.context }}
+    sonar.web.context={{ .Values.sonarqube.context }}
+    {{- end }}
+    {{- if .Values.communityBranchPlugin.enabled }}
+    sonar.web.javaAdditionalOpts=-javaagent:/opt/sonarqube/extensions/plugins/{{ include "sonarqube.communityBranchJarName" . }}=web
+    sonar.ce.javaAdditionalOpts=-javaagent:/opt/sonarqube/extensions/plugins/{{ include "sonarqube.communityBranchJarName" . }}=ce
+    {{- end }}
+    {{- range $key, $value := .Values.sonarqube.sonarProperties }}
+    {{ $key }}={{ $value }}
+    {{- end }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -41,8 +41,31 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- if or .Values.plugins.enabled .Values.communityBranchPlugin.enabled .Values.extraInitContainers }}
+      {{- $databaseMode := include "sonarqube.databaseMode" . }}
+      {{- if or (and .Values.waitForDatabase.enabled (eq $databaseMode "postgresql")) .Values.plugins.enabled .Values.communityBranchPlugin.enabled .Values.extraInitContainers }}
       initContainers:
+        {{- if and .Values.waitForDatabase.enabled (eq $databaseMode "postgresql") }}
+        - name: wait-for-database
+          image: "{{ .Values.waitForDatabase.image.repository }}:{{ .Values.waitForDatabase.image.tag }}"
+          imagePullPolicy: {{ .Values.waitForDatabase.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              attempts=$((({{ .Values.waitForDatabase.timeoutSeconds }} + 1) / 2))
+              attempt=0
+              until nc -z {{ include "sonarqube.postgresqlHost" . | quote }} {{ include "sonarqube.postgresqlPort" . }}; do
+                attempt=$((attempt + 1))
+                if [ "${attempt}" -ge "${attempts}" ]; then
+                  echo "PostgreSQL did not become reachable before timeout" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.waitForDatabase.resources | nindent 12 }}
+        {{- end }}
         {{- if or .Values.plugins.enabled .Values.communityBranchPlugin.enabled }}
         - name: install-plugins
           image: "{{ .Values.plugins.image.repository }}:{{ .Values.plugins.image.tag }}"
@@ -103,11 +126,21 @@ spec:
               value: {{ .Values.containerPorts.http | quote }}
             - name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
               value: {{ .Values.sonarqube.esBootstrapChecksDisable | quote }}
-            {{- if eq .Values.sonarqube.databaseMode "external" }}
+            {{- if eq $databaseMode "external" }}
             - name: SONAR_JDBC_URL
               value: {{ .Values.database.external.jdbcUrl | quote }}
             - name: SONAR_JDBC_USERNAME
               value: {{ .Values.database.external.username | quote }}
+            - name: SONAR_JDBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sonarqube.databaseSecretName" . }}
+                  key: {{ include "sonarqube.databaseSecretKey" . }}
+            {{- else if eq $databaseMode "postgresql" }}
+            - name: SONAR_JDBC_URL
+              value: {{ include "sonarqube.postgresqlJdbcUrl" . | quote }}
+            - name: SONAR_JDBC_USERNAME
+              value: {{ .Values.postgresql.auth.username | quote }}
             - name: SONAR_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -159,7 +159,7 @@ spec:
                 - sh
                 - -ec
                 - |
-                  wget -qO- "http://127.0.0.1:${SONAR_WEB_PORT}{{ include "sonarqube.probePath" (dict "root" . "path" .Values.readinessProbe.path) }}" | grep -q '"status":"UP"'
+                  curl -fsS "http://127.0.0.1:${SONAR_WEB_PORT}{{ include "sonarqube.probePath" (dict "root" . "path" .Values.readinessProbe.path) }}" | grep -q '"status":"UP"'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -154,9 +154,12 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            httpGet:
-              path: {{ include "sonarqube.probePath" (dict "root" . "path" .Values.readinessProbe.path) | quote }}
-              port: http
+            exec:
+              command:
+                - sh
+                - -ec
+                - |
+                  wget -qO- "http://127.0.0.1:${SONAR_WEB_PORT}{{ include "sonarqube.probePath" (dict "root" . "path" .Values.readinessProbe.path) }}" | grep -q '"status":"UP"'
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
               wget -O "/extensions/plugins/{{ .name }}.jar" {{ .url | quote }}
               {{- end }}
               {{- if .Values.communityBranchPlugin.enabled }}
+              rm -f /extensions/plugins/sonarqube-community-branch-plugin-*.jar
               wget -O "/extensions/plugins/{{ include "sonarqube.communityBranchJarName" . }}" {{ include "sonarqube.communityBranchJarUrl" . | quote }}
               mkdir -p /web
               wget -O /tmp/sonarqube-webapp.zip {{ include "sonarqube.communityBranchWebappUrl" . | quote }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ .Values.startupProbe.path }}
+              path: {{ include "sonarqube.probePath" (dict "root" . "path" .Values.startupProbe.path) | quote }}
               port: http
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -140,7 +140,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.path }}
+              path: {{ include "sonarqube.probePath" (dict "root" . "path" .Values.livenessProbe.path) | quote }}
               port: http
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -150,7 +150,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.path }}
+              path: {{ include "sonarqube.probePath" (dict "root" . "path" .Values.readinessProbe.path) | quote }}
               port: http
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -97,6 +97,8 @@ spec:
               value: {{ .Values.sonarqube.ceJavaOpts | quote }}
             - name: SONAR_SEARCH_JAVAOPTS
               value: {{ .Values.sonarqube.searchJavaOpts | quote }}
+            - name: SONAR_WEB_PORT
+              value: {{ .Values.containerPorts.http | quote }}
             - name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
               value: {{ .Values.sonarqube.esBootstrapChecksDisable | quote }}
             {{- if eq .Values.sonarqube.databaseMode "external" }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -24,11 +24,11 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "sonarqube.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: sonarqube
-        {{- with .Values.podLabels }}
+        {{- with omit .Values.podLabels "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "sonarqube.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: sonarqube
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -57,12 +57,14 @@ spec:
               {{- end }}
               {{- if .Values.communityBranchPlugin.enabled }}
               rm -f /extensions/plugins/sonarqube-community-branch-plugin-*.jar
-              wget -O "/extensions/plugins/{{ include "sonarqube.communityBranchJarName" . }}" {{ include "sonarqube.communityBranchJarUrl" . | quote }}
+              branch_plugin="/extensions/plugins/{{ include "sonarqube.communityBranchJarName" . }}"
+              wget -O "${branch_plugin}" {{ include "sonarqube.communityBranchJarUrl" . | quote }}
               mkdir -p /web
               wget -O /tmp/sonarqube-webapp.zip {{ include "sonarqube.communityBranchWebappUrl" . | quote }}
               unzip -o /tmp/sonarqube-webapp.zip -d /web
               rm -f /tmp/sonarqube-webapp.zip
-              find /extensions/plugins /web -mindepth 1 -exec chmod g=u {} +
+              chmod g=u "${branch_plugin}"
+              find /web -mindepth 1 -exec chmod g=u {} +
               {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               wget -O /tmp/sonarqube-webapp.zip {{ include "sonarqube.communityBranchWebappUrl" . | quote }}
               unzip -o /tmp/sonarqube-webapp.zip -d /web
               rm -f /tmp/sonarqube-webapp.zip
-              chmod -R g=u /extensions /web
+              find /extensions/plugins /web -mindepth 1 -exec chmod g=u {} +
               {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/sonarqube/templates/deployment.yaml
+++ b/charts/sonarqube/templates/deployment.yaml
@@ -1,0 +1,244 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "sonarqube.validate" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sonarqube
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "sonarqube.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sonarqube
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "sonarqube.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: sonarqube
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sonarqube.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or .Values.plugins.enabled .Values.communityBranchPlugin.enabled .Values.extraInitContainers }}
+      initContainers:
+        {{- if or .Values.plugins.enabled .Values.communityBranchPlugin.enabled }}
+        - name: install-plugins
+          image: "{{ .Values.plugins.image.repository }}:{{ .Values.plugins.image.tag }}"
+          imagePullPolicy: {{ .Values.plugins.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - |
+              set -eu
+              mkdir -p /extensions/plugins
+              {{- range .Values.plugins.install }}
+              wget -O "/extensions/plugins/{{ .name }}.jar" {{ .url | quote }}
+              {{- end }}
+              {{- if .Values.communityBranchPlugin.enabled }}
+              wget -O "/extensions/plugins/{{ include "sonarqube.communityBranchJarName" . }}" {{ include "sonarqube.communityBranchJarUrl" . | quote }}
+              mkdir -p /web
+              wget -O /tmp/sonarqube-webapp.zip {{ include "sonarqube.communityBranchWebappUrl" . | quote }}
+              unzip -o /tmp/sonarqube-webapp.zip -d /web
+              rm -f /tmp/sonarqube-webapp.zip
+              chmod -R g=u /extensions /web
+              {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.plugins.resources | nindent 12 }}
+          volumeMounts:
+            - name: extensions
+              mountPath: /extensions
+            {{- if .Values.communityBranchPlugin.enabled }}
+            - name: webapp
+              mountPath: /web
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: sonarqube
+          image: {{ include "sonarqube.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: SONAR_WEB_JAVAOPTS
+              value: {{ .Values.sonarqube.webJavaOpts | quote }}
+            - name: SONAR_CE_JAVAOPTS
+              value: {{ .Values.sonarqube.ceJavaOpts | quote }}
+            - name: SONAR_SEARCH_JAVAOPTS
+              value: {{ .Values.sonarqube.searchJavaOpts | quote }}
+            - name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
+              value: {{ .Values.sonarqube.esBootstrapChecksDisable | quote }}
+            {{- if eq .Values.sonarqube.databaseMode "external" }}
+            - name: SONAR_JDBC_URL
+              value: {{ .Values.database.external.jdbcUrl | quote }}
+            - name: SONAR_JDBC_USERNAME
+              value: {{ .Values.database.external.username | quote }}
+            - name: SONAR_JDBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sonarqube.databaseSecretName" . }}
+                  key: {{ include "sonarqube.databaseSecretKey" . }}
+            {{- end }}
+            {{- if or .Values.sonarqube.monitoringPasscode .Values.sonarqube.existingMonitoringPasscodeSecret .Values.externalSecrets.monitoringPasscode.enabled }}
+            - name: SONAR_WEB_SYSTEMPASSCODE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sonarqube.monitoringSecretName" . }}
+                  key: {{ include "sonarqube.monitoringSecretKey" . }}
+            {{- end }}
+            {{- with .Values.sonarqube.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.sonarqube.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+              protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /opt/sonarqube/data
+            - name: extensions
+              mountPath: /opt/sonarqube/extensions
+            - name: logs
+              mountPath: /opt/sonarqube/logs
+            - name: temp
+              mountPath: /opt/sonarqube/temp
+            - name: tmp
+              mountPath: /tmp
+            - name: config
+              mountPath: /opt/sonarqube/conf/sonar.properties
+              subPath: sonar.properties
+              readOnly: true
+            {{- if .Values.communityBranchPlugin.enabled }}
+            - name: webapp
+              mountPath: /opt/sonarqube/web
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "sonarqube.dataClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: extensions
+          {{- if .Values.persistence.extensions.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "sonarqube.extensionsClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: logs
+          {{- if .Values.persistence.logs.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "sonarqube.logsClaimName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: temp
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: {{ include "sonarqube.configMapName" . }}
+            items:
+              - key: sonar.properties
+                path: sonar.properties
+        {{- if .Values.communityBranchPlugin.enabled }}
+        - name: webapp
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}

--- a/charts/sonarqube/templates/externalsecret.yaml
+++ b/charts/sonarqube/templates/externalsecret.yaml
@@ -1,0 +1,41 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- if .Values.externalSecrets.database.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "sonarqube.fullname" . }}-database
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "sonarqube.databaseSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "sonarqube.externalSecretDataItem" (dict "secretKey" .Values.database.external.existingSecretPasswordKey "remoteRef" .Values.externalSecrets.database.passwordRemoteRef "remoteRefName" "externalSecrets.database.passwordRemoteRef" "enabledName" "externalSecrets.database.enabled") | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.monitoringPasscode.enabled }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "sonarqube.fullname" . }}-monitoring
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "sonarqube.monitoringSecretName" . }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- include "sonarqube.externalSecretDataItem" (dict "secretKey" .Values.sonarqube.existingMonitoringPasscodeSecretKey "remoteRef" .Values.externalSecrets.monitoringPasscode.remoteRef "remoteRefName" "externalSecrets.monitoringPasscode.remoteRef" "enabledName" "externalSecrets.monitoringPasscode.enabled") | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/httproute.yaml
+++ b/charts/sonarqube/templates/httproute.yaml
@@ -1,0 +1,30 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+apiVersion: {{ .Values.gatewayAPI.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gatewayAPI.parentRefs | nindent 4 }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- toYaml .Values.gatewayAPI.matches | nindent 8 }}
+      {{- with .Values.gatewayAPI.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "sonarqube.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/sonarqube/templates/ingress.yaml
+++ b/charts/sonarqube/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sonarqube.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -1,0 +1,74 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sonarqube.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sonarqube
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+    {{- else }}
+    - from: []
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+    {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTP }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowPostgreSQL }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.postgresqlPort }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -55,9 +55,7 @@ spec:
           port: 443
     {{- end }}
     {{- if .Values.networkPolicy.egress.allowPostgreSQL }}
-    - to:
-        - namespaceSelector: {}
-      ports:
+    - ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.egress.postgresqlPort }}
     {{- end }}

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -27,12 +27,9 @@ spec:
         {{- end }}
       ports:
         - protocol: TCP
-          port: {{ .Values.service.port }}
+          port: http
     {{- else }}
-    - from: []
-      ports:
-        - protocol: TCP
-          port: {{ .Values.service.port }}
+    []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:

--- a/charts/sonarqube/templates/networkpolicy.yaml
+++ b/charts/sonarqube/templates/networkpolicy.yaml
@@ -53,9 +53,7 @@ spec:
           port: 80
     {{- end }}
     {{- if .Values.networkPolicy.egress.allowHTTPS }}
-    - to:
-        - namespaceSelector: {}
-      ports:
+    - ports:
         - protocol: TCP
           port: 443
     {{- end }}

--- a/charts/sonarqube/templates/pdb.yaml
+++ b/charts/sonarqube/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "sonarqube.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sonarqube
+{{- end }}

--- a/charts/sonarqube/templates/pvc.yaml
+++ b/charts/sonarqube/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range $name, $persistence := dict "data" .Values.persistence.data "extensions" .Values.persistence.extensions "logs" .Values.persistence.logs }}
+{{- if and $persistence.enabled (not $persistence.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sonarqube.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "sonarqube.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: sonarqube
+spec:
+  accessModes:
+    {{- toYaml $persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ $persistence.size }}
+  {{- with $persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- $needsDbSecret := and (eq .Values.sonarqube.databaseMode "external") (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) .Values.database.external.password -}}
+{{- $needsMonitoringSecret := and .Values.sonarqube.monitoringPasscode (not .Values.sonarqube.existingMonitoringPasscodeSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.monitoringPasscode.enabled)) -}}
+{{- if or $needsDbSecret $needsMonitoringSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sonarqube.secretName" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if $needsDbSecret }}
+  {{ .Values.database.external.existingSecretPasswordKey }}: {{ .Values.database.external.password | quote }}
+  {{- end }}
+  {{- if $needsMonitoringSecret }}
+  {{ .Values.sonarqube.existingMonitoringPasscodeSecretKey }}: {{ .Values.sonarqube.monitoringPasscode | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/sonarqube/templates/secret.yaml
+++ b/charts/sonarqube/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- $needsDbSecret := and (eq .Values.sonarqube.databaseMode "external") (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) .Values.database.external.password -}}
+{{- $databaseMode := include "sonarqube.databaseMode" . -}}
+{{- $needsDbSecret := and (eq $databaseMode "external") (not .Values.database.external.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.database.enabled)) .Values.database.external.password -}}
 {{- $needsMonitoringSecret := and .Values.sonarqube.monitoringPasscode (not .Values.sonarqube.existingMonitoringPasscodeSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.monitoringPasscode.enabled)) -}}
 {{- if or $needsDbSecret $needsMonitoringSecret }}
 apiVersion: v1

--- a/charts/sonarqube/templates/service.yaml
+++ b/charts/sonarqube/templates/service.yaml
@@ -1,0 +1,29 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sonarqube.fullname" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sonarqube
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    {{- include "sonarqube.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: sonarqube
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/sonarqube/templates/serviceaccount.yaml
+++ b/charts/sonarqube/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sonarqube.serviceAccountName" . }}
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/sonarqube/templates/tests/test-connection.yaml
+++ b/charts/sonarqube/templates/tests/test-connection.yaml
@@ -1,0 +1,37 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "sonarqube.fullname" . }}-test-connection
+  labels:
+    {{- include "sonarqube.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: wget
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      command: ["sh", "-ec"]
+      args:
+        - wget -qO- "http://{{ include "sonarqube.fullname" . }}:{{ .Values.service.port }}{{ .Values.sonarqube.context }}/api/system/status"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        {{- toYaml .Values.tests.resources | nindent 8 }}
+{{- end }}

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -127,6 +127,9 @@ tests:
           pattern: sonarqube-community-branch-plugin-26.4.0.jar
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
+          pattern: "rm -f /extensions/plugins/sonarqube-community-branch-plugin-\\*.jar"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
           pattern: "find /extensions/plugins /web -mindepth 1 -exec chmod g=u"
       - notMatchRegex:
           path: spec.template.spec.initContainers[0].args[0]

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -38,6 +38,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: SONAR_WEB_PORT
+            value: "9000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
             value: "true"
       - equal:
@@ -49,6 +54,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /api/system/status
+
+  - it: should keep SonarQube web port in sync with the container port
+    template: templates/deployment.yaml
+    set:
+      containerPorts.http: 9100
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 9100
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_WEB_PORT
+            value: "9100"
 
   - it: should prefix probes with SonarQube context
     template: templates/deployment.yaml

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -125,6 +125,12 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: sonarqube-community-branch-plugin-26.4.0.jar
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "find /extensions/plugins /web -mindepth 1 -exec chmod g=u"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "chmod -R g=u /extensions /web"
       - exists:
           path: spec.template.spec.containers[0].volumeMounts[6]
 

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -51,9 +51,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /api/system/status
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /api/system/status
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: 'grep -q ''"status":"UP"'''
 
   - it: should keep SonarQube web port in sync with the container port
     template: templates/deployment.yaml
@@ -80,9 +80,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /sonar/api/system/status
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /sonar/api/system/status
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "http://127\\.0\\.0\\.1:\\$\\{SONAR_WEB_PORT\\}/sonar/api/system/status"
 
   - it: should not duplicate context when probe path already includes it
     template: templates/deployment.yaml

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -149,12 +149,36 @@ tests:
           pattern: "rm -f /extensions/plugins/sonarqube-community-branch-plugin-\\*.jar"
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: "find /extensions/plugins /web -mindepth 1 -exec chmod g=u"
+          pattern: 'chmod g=u "\$\{branch_plugin\}"'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "find /web -mindepth 1 -exec chmod g=u"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "find /extensions/plugins"
       - notMatchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: "chmod -R g=u /extensions /web"
       - exists:
           path: spec.template.spec.containers[0].volumeMounts[6]
+
+  - it: should preserve selector labels when podLabels uses selector keys
+    template: templates/deployment.yaml
+    set:
+      podLabels:
+        app.kubernetes.io/component: overridden
+        app.kubernetes.io/name: wrong
+        custom: retained
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: sonarqube
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: sonarqube
+      - equal:
+          path: spec.template.metadata.labels.custom
+          value: retained
 
   - it: should render community branch Java agent properties
     template: templates/configmap.yaml

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -54,6 +54,12 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
           pattern: 'grep -q ''"status":"UP"'''
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "curl -fsS"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "wget"
 
   - it: should keep SonarQube web port in sync with the container port
     template: templates/deployment.yaml

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -50,6 +50,31 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /api/system/status
 
+  - it: should prefix probes with SonarQube context
+    template: templates/deployment.yaml
+    set:
+      sonarqube.context: /sonar
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /sonar/api/system/status
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /sonar/api/system/status
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /sonar/api/system/status
+
+  - it: should not duplicate context when probe path already includes it
+    template: templates/deployment.yaml
+    set:
+      sonarqube.context: /sonar
+      startupProbe.path: /sonar/api/system/status
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /sonar/api/system/status
+
   - it: should reference external database credentials from generated Secret
     template: templates/deployment.yaml
     set:

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -114,8 +114,66 @@ tests:
             name: SONAR_JDBC_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: test-sonarqube-secrets
-                key: jdbc-password
+                  name: test-sonarqube-secrets
+                  key: jdbc-password
+
+  - it: should configure bundled HelmForge PostgreSQL when enabled
+    template: templates/deployment.yaml
+    set:
+      postgresql.enabled: true
+      postgresql.auth.database: sonarqube
+      postgresql.auth.username: sonar
+      postgresql.auth.password: secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_JDBC_URL
+            value: jdbc:postgresql://test-postgresql.default.svc.cluster.local:5432/sonarqube
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_JDBC_USERNAME
+            value: sonar
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_JDBC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-postgresql-auth
+                key: user-password
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-database
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: 'nc -z "test-postgresql.default.svc.cluster.local" 5432'
+
+  - it: should honor bundled PostgreSQL fullnameOverride and secret key
+    template: templates/deployment.yaml
+    set:
+      sonarqube.databaseMode: postgresql
+      postgresql.enabled: true
+      postgresql.fullnameOverride: platform-sonar-postgresql
+      postgresql.auth.database: sonar
+      postgresql.auth.username: sonar
+      postgresql.auth.existingSecret: platform-sonar-db
+      postgresql.auth.existingSecretUserPasswordKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_JDBC_URL
+            value: jdbc:postgresql://platform-sonar-postgresql.default.svc.cluster.local:5432/sonar
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_JDBC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: platform-sonar-db
+                key: password
 
   - it: should use existing PVC names when provided
     template: templates/deployment.yaml

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+  - templates/configmap.yaml
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a hardened Deployment
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-sonarqube
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/library/sonarqube:26.4.0.121862-community
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: should configure JVM and status probes by default
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_ES_BOOTSTRAP_CHECKS_DISABLE
+            value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/system/status
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/system/status
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/system/status
+
+  - it: should reference external database credentials from generated Secret
+    template: templates/deployment.yaml
+    set:
+      sonarqube.databaseMode: external
+      database.external.jdbcUrl: jdbc:postgresql://postgres:5432/sonarqube
+      database.external.username: sonar
+      database.external.password: secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SONAR_JDBC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-sonarqube-secrets
+                key: jdbc-password
+
+  - it: should use existing PVC names when provided
+    template: templates/deployment.yaml
+    set:
+      persistence.data.existingClaim: sonar-data
+      persistence.extensions.existingClaim: sonar-extensions
+      persistence.logs.enabled: true
+      persistence.logs.existingClaim: sonar-logs
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: sonar-data
+      - equal:
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+          value: sonar-extensions
+      - equal:
+          path: spec.template.spec.volumes[2].persistentVolumeClaim.claimName
+          value: sonar-logs
+
+  - it: should install plugins and patch webapp when community branch plugin is enabled
+    template: templates/deployment.yaml
+    set:
+      plugins.enabled: true
+      plugins.install:
+        - name: sonar-auth-oidc
+          url: https://example.com/sonar-auth-oidc.jar
+      communityBranchPlugin.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: install-plugins
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: sonarqube-community-branch-plugin-26.4.0.jar
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts[6]
+
+  - it: should render community branch Java agent properties
+    template: templates/configmap.yaml
+    set:
+      communityBranchPlugin.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["sonar.properties"]
+          pattern: sonar\.web\.javaAdditionalOpts=-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-26\.4\.0\.jar=web
+      - matchRegex:
+          path: data["sonar.properties"]
+          pattern: sonar\.ce\.javaAdditionalOpts=-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-26\.4\.0\.jar=ce

--- a/charts/sonarqube/tests/exposure_test.yaml
+++ b/charts/sonarqube/tests/exposure_test.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Exposure
+templates:
+  - templates/ingress.yaml
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render Ingress by default
+    template: templates/ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render Ingress when enabled
+    template: templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: sonarqube.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: sonarqube.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: test-sonarqube
+
+  - it: should not render HTTPRoute by default
+    template: templates/httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HTTPRoute with filters
+    template: templates/httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public-gateway
+          namespace: gateway-system
+      gatewayAPI.hostnames:
+        - sonarqube.example.com
+      gatewayAPI.filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-Proto
+                value: https
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: sonarqube.example.com
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9000

--- a/charts/sonarqube/tests/operations_test.yaml
+++ b/charts/sonarqube/tests/operations_test.yaml
@@ -32,6 +32,27 @@ tests:
           path: spec.egress[2].ports[0].port
           value: 443
 
+  - it: should deny ingress when no ingress sources are configured
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.allowSameNamespace: false
+      networkPolicy.ingress.extraFrom: []
+    asserts:
+      - equal:
+          path: spec.ingress
+          value: []
+
+  - it: should allow ingress to the named pod port
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      service.port: 80
+    asserts:
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: http
+
   - it: should render PDB when enabled
     template: templates/pdb.yaml
     set:

--- a/charts/sonarqube/tests/operations_test.yaml
+++ b/charts/sonarqube/tests/operations_test.yaml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Operations
+templates:
+  - templates/networkpolicy.yaml
+  - templates/pdb.yaml
+  - templates/externalsecret.yaml
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render NetworkPolicy with egress controls
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[3].ports[0].port
+          value: 5432
+
+  - it: should render PDB when enabled
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should render ExternalSecrets for database and monitoring passcode
+    template: templates/externalsecret.yaml
+    set:
+      sonarqube.databaseMode: external
+      database.external.jdbcUrl: jdbc:postgresql://postgres:5432/sonarqube
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.database.enabled: true
+      externalSecrets.database.passwordRemoteRef:
+        key: sonarqube/database
+        property: password
+      externalSecrets.monitoringPasscode.enabled: true
+      externalSecrets.monitoringPasscode.remoteRef:
+        key: sonarqube/monitoring
+        property: passcode
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: test-sonarqube-database
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: test-sonarqube-monitoring
+        documentIndex: 1
+
+  - it: should render Helm test pod
+    template: templates/tests/test-connection.yaml
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: /api/system/status

--- a/charts/sonarqube/tests/operations_test.yaml
+++ b/charts/sonarqube/tests/operations_test.yaml
@@ -26,6 +26,11 @@ tests:
       - equal:
           path: spec.egress[3].ports[0].port
           value: 5432
+      - notExists:
+          path: spec.egress[2].to
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 443
 
   - it: should render PDB when enabled
     template: templates/pdb.yaml

--- a/charts/sonarqube/tests/operations_test.yaml
+++ b/charts/sonarqube/tests/operations_test.yaml
@@ -27,6 +27,8 @@ tests:
           path: spec.egress[3].ports[0].port
           value: 5432
       - notExists:
+          path: spec.egress[3].to
+      - notExists:
           path: spec.egress[2].to
       - equal:
           path: spec.egress[2].ports[0].port

--- a/charts/sonarqube/tests/service_test.yaml
+++ b/charts/sonarqube/tests/service_test.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should expose the SonarQube HTTP port
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 9000
+            targetPort: http
+            protocol: TCP
+
+  - it: should support dual-stack service settings
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/sonarqube/tests/validation_test.yaml
+++ b/charts/sonarqube/tests/validation_test.yaml
@@ -22,6 +22,13 @@ tests:
       - failedTemplate:
           errorMessage: database.external.password, database.external.existingSecret, or externalSecrets.database.enabled is required when sonarqube.databaseMode=external
 
+  - it: should reject unsupported Community multi-replica deployments
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: replicaCount greater than 1 is unsupported for this SonarQube Community chart
+
   - it: should require Gateway parent refs
     set:
       gatewayAPI.enabled: true

--- a/charts/sonarqube/tests/validation_test.yaml
+++ b/charts/sonarqube/tests/validation_test.yaml
@@ -22,6 +22,23 @@ tests:
       - failedTemplate:
           errorMessage: database.external.password, database.external.existingSecret, or externalSecrets.database.enabled is required when sonarqube.databaseMode=external
 
+  - it: should require postgresql subchart when bundled mode is explicit
+    set:
+      sonarqube.databaseMode: postgresql
+    asserts:
+      - failedTemplate:
+          errorMessage: postgresql.enabled must be true when sonarqube.databaseMode=postgresql
+
+  - it: should reject external database mode while bundled PostgreSQL is enabled
+    set:
+      sonarqube.databaseMode: external
+      database.external.jdbcUrl: jdbc:postgresql://postgres:5432/sonarqube
+      database.external.password: secret
+      postgresql.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: postgresql.enabled must be false when SonarQube is configured for external database mode
+
   - it: should reject unsupported Community multi-replica deployments
     set:
       replicaCount: 2

--- a/charts/sonarqube/tests/validation_test.yaml
+++ b/charts/sonarqube/tests/validation_test.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should require JDBC URL for external database mode
+    set:
+      sonarqube.databaseMode: external
+      database.external.password: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.jdbcUrl is required when sonarqube.databaseMode=external
+
+  - it: should require credentials for external database mode
+    set:
+      sonarqube.databaseMode: external
+      database.external.jdbcUrl: jdbc:postgresql://postgres:5432/sonarqube
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.password, database.external.existingSecret, or externalSecrets.database.enabled is required when sonarqube.databaseMode=external
+
+  - it: should require Gateway parent refs
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true

--- a/charts/sonarqube/values.schema.json
+++ b/charts/sonarqube/values.schema.json
@@ -12,6 +12,7 @@
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "commonLabels": { "type": "object" },
+    "clusterDomain": { "type": "string", "minLength": 1 },
     "image": {
       "type": "object",
       "properties": {
@@ -56,7 +57,7 @@
     "sonarqube": {
       "type": "object",
       "properties": {
-        "databaseMode": { "type": "string", "enum": ["embedded", "external"] },
+        "databaseMode": { "type": "string", "enum": ["auto", "embedded", "external", "postgresql"] },
         "context": { "type": "string" },
         "webJavaOpts": { "type": "string" },
         "ceJavaOpts": { "type": "string" },
@@ -81,6 +82,29 @@
             "password": { "type": "string" },
             "existingSecret": { "type": "string" },
             "existingSecretPasswordKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "architecture": { "type": "string", "enum": ["standalone", "replication"] },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "database": { "type": "string" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretUserPasswordKey": { "type": "string" }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
           }
         }
       }
@@ -134,6 +158,15 @@
         "version": { "type": "string" },
         "jarUrl": { "type": "string" },
         "webappUrl": { "type": "string" }
+      }
+    },
+    "waitForDatabase": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "type": "object" },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "resources": { "type": "object" }
       }
     },
     "persistence": {

--- a/charts/sonarqube/values.schema.json
+++ b/charts/sonarqube/values.schema.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "SonarQube Helm Chart Values",
+  "description": "Configuration for the HelmForge SonarQube Community Build chart",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "minLength": 1 },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "containerPorts": {
+      "type": "object",
+      "properties": {
+        "http": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "annotations": { "type": "object" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "sonarqube": {
+      "type": "object",
+      "properties": {
+        "databaseMode": { "type": "string", "enum": ["embedded", "external"] },
+        "context": { "type": "string" },
+        "webJavaOpts": { "type": "string" },
+        "ceJavaOpts": { "type": "string" },
+        "searchJavaOpts": { "type": "string" },
+        "esBootstrapChecksDisable": { "type": "boolean" },
+        "monitoringPasscode": { "type": "string" },
+        "existingMonitoringPasscodeSecret": { "type": "string" },
+        "existingMonitoringPasscodeSecretKey": { "type": "string" },
+        "extraEnv": { "type": "array" },
+        "extraEnvFrom": { "type": "array" },
+        "sonarProperties": { "type": "object" }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "external": {
+          "type": "object",
+          "properties": {
+            "jdbcUrl": { "type": "string" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "Orphan", "None"] }
+          }
+        },
+        "database": { "type": "object" },
+        "monitoringPasscode": { "type": "object" }
+      }
+    },
+    "plugins": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "type": "object" },
+        "resources": { "type": "object" },
+        "install": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "url"],
+            "properties": {
+              "name": { "type": "string", "pattern": "^[a-zA-Z0-9._-]+$" },
+              "url": { "type": "string", "format": "uri" }
+            }
+          }
+        }
+      }
+    },
+    "communityBranchPlugin": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "version": { "type": "string" },
+        "jarUrl": { "type": "string" },
+        "webappUrl": { "type": "string" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "data": { "$ref": "#/definitions/persistenceVolume" },
+        "extensions": { "$ref": "#/definitions/persistenceVolume" },
+        "logs": { "$ref": "#/definitions/persistenceVolume" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "ingressClassName": { "type": "string" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array" },
+        "hostnames": { "type": "array" },
+        "matches": { "type": "array" },
+        "filters": { "type": "array" }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingress": { "type": "object" },
+        "egress": { "type": "object" }
+      }
+    },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "startupProbe": { "$ref": "#/definitions/probe" },
+    "livenessProbe": { "$ref": "#/definitions/probe" },
+    "readinessProbe": { "$ref": "#/definitions/probe" },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] }
+      }
+    },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "annotations": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 },
+    "extraInitContainers": { "type": "array" },
+    "extraContainers": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "tests": { "type": "object" }
+  },
+  "definitions": {
+    "persistenceVolume": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingClaim": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1
+        },
+        "size": { "type": "string" }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "path": { "type": "string" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# SonarQube Helm Chart - Default Values
+# =============================================================================
+
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+image:
+  repository: docker.io/library/sonarqube
+  tag: "26.4.0.121862-community"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+containerPorts:
+  http: 9000
+
+service:
+  type: ClusterIP
+  annotations: {}
+  port: 9000
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+sonarqube:
+  # -- embedded is for evaluation and k3d smoke tests only. Use external for production PostgreSQL.
+  databaseMode: embedded
+  context: ""
+  webJavaOpts: "-Xms256m -Xmx512m"
+  ceJavaOpts: "-Xms256m -Xmx512m"
+  searchJavaOpts: "-Xms512m -Xmx512m"
+  esBootstrapChecksDisable: true
+  monitoringPasscode: ""
+  existingMonitoringPasscodeSecret: ""
+  existingMonitoringPasscodeSecretKey: monitoring-passcode
+  extraEnv: []
+  extraEnvFrom: []
+  sonarProperties: {}
+
+database:
+  external:
+    jdbcUrl: ""
+    username: sonar
+    password: ""
+    existingSecret: ""
+    existingSecretPasswordKey: jdbc-password
+
+externalSecrets:
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  database:
+    enabled: false
+    targetName: ""
+    passwordRemoteRef:
+      key: ""
+      property: ""
+      version: ""
+      decodingStrategy: ""
+      conversionStrategy: ""
+  monitoringPasscode:
+    enabled: false
+    targetName: ""
+    remoteRef:
+      key: ""
+      property: ""
+      version: ""
+      decodingStrategy: ""
+      conversionStrategy: ""
+
+plugins:
+  enabled: false
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+  install: []
+  # - name: sonar-auth-oidc
+  #   url: https://example.com/sonar-auth-oidc.jar
+
+communityBranchPlugin:
+  enabled: false
+  version: "26.4.0"
+  jarUrl: ""
+  webappUrl: ""
+
+persistence:
+  data:
+    enabled: true
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+  extensions:
+    enabled: true
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+  logs:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+
+ingress:
+  enabled: false
+  annotations: {}
+  ingressClassName: ""
+  hosts:
+    - host: sonarqube.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gatewayAPI:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  filters: []
+
+networkPolicy:
+  enabled: false
+  ingress:
+    allowSameNamespace: true
+    extraFrom: []
+  egress:
+    enabled: false
+    allowDNS: true
+    allowHTTP: true
+    allowHTTPS: true
+    allowPostgreSQL: true
+    postgresqlPort: 5432
+    extraTo: []
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    cpu: 2
+    memory: 3Gi
+
+podSecurityContext:
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+startupProbe:
+  enabled: true
+  path: /api/system/status
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 80
+
+livenessProbe:
+  enabled: true
+  path: /api/system/status
+  initialDelaySeconds: 180
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  enabled: true
+  path: /api/system/status
+  initialDelaySeconds: 60
+  periodSeconds: 15
+  timeoutSeconds: 5
+  failureThreshold: 20
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+podLabels: {}
+podAnnotations: {}
+annotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 120
+
+extraInitContainers: []
+extraContainers: []
+extraVolumes: []
+extraVolumeMounts: []
+
+tests:
+  enabled: true
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -3,25 +3,39 @@
 # SonarQube Helm Chart - Default Values
 # =============================================================================
 
+# -- Number of SonarQube pods. Community Build supports a single application node.
 replicaCount: 1
 
+# -- Override the chart name used in generated resource names.
 nameOverride: ""
+# -- Override the full release name used in generated resource names.
 fullnameOverride: ""
+# -- Labels added to all chart resources.
 commonLabels: {}
+# -- Kubernetes cluster DNS domain used when building bundled PostgreSQL JDBC URLs.
+clusterDomain: cluster.local
 
 image:
+  # -- SonarQube image repository. Uses the official Docker image.
   repository: docker.io/library/sonarqube
+  # -- SonarQube Community Build image tag.
   tag: "26.4.0.121862-community"
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
 
+# -- Optional image pull secrets.
 imagePullSecrets: []
 
 containerPorts:
+  # -- SonarQube HTTP container port.
   http: 9000
 
 service:
+  # -- Kubernetes Service type.
   type: ClusterIP
+  # -- Service annotations.
   annotations: {}
+  # -- Service HTTP port.
   port: 9000
   # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ~
@@ -29,46 +43,99 @@ service:
   ipFamilies: []
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: false
+  # -- ServiceAccount name. Empty uses the chart fullname when create=true.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
+  # -- Mount Kubernetes API credentials into the SonarQube pod.
   automountServiceAccountToken: false
 
 sonarqube:
-  # -- embedded is for evaluation and k3d smoke tests only. Use external for production PostgreSQL.
-  databaseMode: embedded
+  # -- Database mode: auto | embedded | external | postgresql. In auto mode, external settings win, then postgresql.enabled, then embedded evaluation mode.
+  databaseMode: auto
+  # -- HTTP context path, for example /sonar.
   context: ""
+  # -- JVM options for the web process.
   webJavaOpts: "-Xms256m -Xmx512m"
+  # -- JVM options for the compute engine process.
   ceJavaOpts: "-Xms256m -Xmx512m"
+  # -- JVM options for embedded search.
   searchJavaOpts: "-Xms512m -Xmx512m"
+  # -- Disable embedded search bootstrap checks. Keep true for k3d/evaluation; set false only after preparing production nodes.
   esBootstrapChecksDisable: true
+  # -- Inline monitoring passcode. Prefer existingMonitoringPasscodeSecret or External Secrets for production.
   monitoringPasscode: ""
+  # -- Existing Secret containing the monitoring passcode.
   existingMonitoringPasscodeSecret: ""
+  # -- Secret key containing the monitoring passcode.
   existingMonitoringPasscodeSecretKey: monitoring-passcode
+  # -- Extra environment variables for the SonarQube container.
   extraEnv: []
+  # -- Extra envFrom entries for the SonarQube container.
   extraEnvFrom: []
+  # -- Additional sonar.properties entries rendered into the configuration file.
   sonarProperties: {}
 
 database:
   external:
+    # -- JDBC URL used when sonarqube.databaseMode=external.
     jdbcUrl: ""
+    # -- Database username used when sonarqube.databaseMode=external.
     username: sonar
+    # -- Inline database password. Prefer existingSecret or External Secrets for production.
     password: ""
+    # -- Existing Secret containing the external database password.
     existingSecret: ""
+    # -- Secret key containing the external database password.
     existingSecretPasswordKey: jdbc-password
 
-externalSecrets:
+postgresql:
+  # -- Deploy HelmForge PostgreSQL as a subchart for SonarQube.
   enabled: false
+  # -- PostgreSQL architecture from the HelmForge PostgreSQL chart.
+  architecture: standalone
+  auth:
+    # -- Database name created by the PostgreSQL subchart.
+    database: sonarqube
+    # -- Database username created by the PostgreSQL subchart.
+    username: sonar
+    # -- Database password. Leave empty to let the PostgreSQL subchart generate and persist it.
+    password: ""
+  standalone:
+    persistence:
+      # -- Enable PostgreSQL PVC for bundled database mode.
+      enabled: true
+      # -- Storage class for PostgreSQL PVC. Empty uses the cluster default.
+      storageClass: ""
+      # -- Access modes for PostgreSQL PVC.
+      accessModes:
+        - ReadWriteOnce
+      # -- PostgreSQL PVC size.
+      size: 20Gi
+
+externalSecrets:
+  # -- Render ExternalSecret resources for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion.
   apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval.
   refreshInterval: "1h"
   secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name. Required when externalSecrets.enabled=true.
     name: ""
+    # -- Secret store kind.
     kind: SecretStore
   target:
+    # -- ExternalSecret target creation policy.
     creationPolicy: Owner
   database:
+    # -- Manage the external database password with External Secrets Operator.
     enabled: false
+    # -- Target Secret name. Empty defaults to <release>-sonarqube-database.
     targetName: ""
+    # -- Remote reference for the external database password.
     passwordRemoteRef:
       key: ""
       property: ""
@@ -76,8 +143,11 @@ externalSecrets:
       decodingStrategy: ""
       conversionStrategy: ""
   monitoringPasscode:
+    # -- Manage the monitoring passcode with External Secrets Operator.
     enabled: false
+    # -- Target Secret name. Empty defaults to <release>-sonarqube-monitoring.
     targetName: ""
+    # -- Remote reference for the monitoring passcode.
     remoteRef:
       key: ""
       property: ""
@@ -86,11 +156,16 @@ externalSecrets:
       conversionStrategy: ""
 
 plugins:
+  # -- Download additional SonarQube plugin JARs before the main container starts.
   enabled: false
   image:
+    # -- Plugin installer image repository.
     repository: docker.io/library/busybox
+    # -- Plugin installer image tag.
     tag: "1.37"
+    # -- Plugin installer image pull policy.
     pullPolicy: IfNotPresent
+  # -- Resources for the plugin installer init container.
   resources:
     requests:
       cpu: 10m
@@ -98,76 +173,140 @@ plugins:
     limits:
       cpu: 200m
       memory: 128Mi
+  # -- List of plugin JARs to download into /opt/sonarqube/extensions/plugins.
   install: []
   # - name: sonar-auth-oidc
   #   url: https://example.com/sonar-auth-oidc.jar
 
 communityBranchPlugin:
+  # -- Install and wire the SonarQube Community Branch Plugin.
   enabled: false
+  # -- Community Branch Plugin version aligned with the SonarQube Community Build line.
   version: "26.4.0"
+  # -- Override plugin JAR URL. Empty uses the release URL for communityBranchPlugin.version.
   jarUrl: ""
+  # -- Override webapp ZIP URL. Empty uses the release URL for communityBranchPlugin.version.
   webappUrl: ""
+
+waitForDatabase:
+  # -- Wait for bundled PostgreSQL TCP readiness before starting SonarQube.
+  enabled: true
+  image:
+    # -- Wait init container image repository.
+    repository: docker.io/library/busybox
+    # -- Wait init container image tag.
+    tag: "1.37"
+    # -- Wait init container image pull policy.
+    pullPolicy: IfNotPresent
+  # -- Maximum wait time in seconds for PostgreSQL TCP readiness.
+  timeoutSeconds: 180
+  # -- Resources for the wait init container.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
 
 persistence:
   data:
+    # -- Enable PVC for /opt/sonarqube/data.
     enabled: true
+    # -- Existing PVC for /opt/sonarqube/data.
     existingClaim: ""
+    # -- Storage class for data PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for data PVC.
     accessModes:
       - ReadWriteOnce
+    # -- Size for data PVC.
     size: 10Gi
   extensions:
+    # -- Enable PVC for /opt/sonarqube/extensions.
     enabled: true
+    # -- Existing PVC for /opt/sonarqube/extensions.
     existingClaim: ""
+    # -- Storage class for extensions PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for extensions PVC.
     accessModes:
       - ReadWriteOnce
+    # -- Size for extensions PVC.
     size: 5Gi
   logs:
+    # -- Enable PVC for /opt/sonarqube/logs.
     enabled: false
+    # -- Existing PVC for /opt/sonarqube/logs.
     existingClaim: ""
+    # -- Storage class for logs PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for logs PVC.
     accessModes:
       - ReadWriteOnce
+    # -- Size for logs PVC.
     size: 5Gi
 
 ingress:
+  # -- Render a Kubernetes Ingress.
   enabled: false
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress class name.
   ingressClassName: ""
+  # -- Ingress hosts and paths.
   hosts:
     - host: sonarqube.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS entries.
   tls: []
 
 gatewayAPI:
+  # -- Render a Gateway API HTTPRoute. Requires Gateway API CRDs and an existing Gateway.
   enabled: false
+  # -- HTTPRoute apiVersion.
   apiVersion: gateway.networking.k8s.io/v1
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- HTTPRoute parentRefs.
   parentRefs: []
+  # -- HTTPRoute hostnames.
   hostnames: []
+  # -- HTTPRoute matches.
   matches:
     - path:
         type: PathPrefix
         value: /
+  # -- HTTPRoute filters.
   filters: []
 
 networkPolicy:
+  # -- Create a NetworkPolicy for the SonarQube pod.
   enabled: false
   ingress:
+    # -- Allow ingress from pods in the same namespace.
     allowSameNamespace: true
+    # -- Additional ingress "from" rules.
     extraFrom: []
   egress:
+    # -- Add explicit egress rules. Disabled keeps CNI default egress behavior.
     enabled: false
+    # -- Allow DNS egress.
     allowDNS: true
+    # -- Allow HTTP egress for plugin downloads and package endpoints.
     allowHTTP: true
+    # -- Allow HTTPS egress for plugin downloads and external services.
     allowHTTPS: true
+    # -- Allow PostgreSQL egress for bundled or external database access.
     allowPostgreSQL: true
+    # -- PostgreSQL egress port.
     postgresqlPort: 5432
+    # -- Additional egress "to" rules.
     extraTo: []
 
+# -- SonarQube container resources.
 resources:
   requests:
     cpu: 500m
@@ -176,11 +315,13 @@ resources:
     cpu: 2
     memory: 3Gi
 
+# -- Pod-level security context.
 podSecurityContext:
   fsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 
+# -- SonarQube container security context.
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
@@ -192,7 +333,9 @@ securityContext:
       - ALL
 
 startupProbe:
+  # -- Enable startup probe.
   enabled: true
+  # -- Startup probe HTTP path.
   path: /api/system/status
   initialDelaySeconds: 30
   periodSeconds: 15
@@ -200,7 +343,9 @@ startupProbe:
   failureThreshold: 80
 
 livenessProbe:
+  # -- Enable liveness probe.
   enabled: true
+  # -- Liveness probe HTTP path.
   path: /api/system/status
   initialDelaySeconds: 180
   periodSeconds: 30
@@ -208,7 +353,9 @@ livenessProbe:
   failureThreshold: 6
 
 readinessProbe:
+  # -- Enable readiness probe.
   enabled: true
+  # -- Readiness probe HTTP path.
   path: /api/system/status
   initialDelaySeconds: 60
   periodSeconds: 15
@@ -216,30 +363,50 @@ readinessProbe:
   failureThreshold: 20
 
 pdb:
+  # -- Render a PodDisruptionBudget.
   enabled: false
+  # -- Minimum available pods when PDB is enabled.
   minAvailable: 1
 
+# -- Labels added to the SonarQube pod template.
 podLabels: {}
+# -- Annotations added to the SonarQube pod template.
 podAnnotations: {}
+# -- Annotations added to top-level resources that support annotations.
 annotations: {}
+# -- Node selector for SonarQube pods.
 nodeSelector: {}
+# -- Tolerations for SonarQube pods.
 tolerations: []
+# -- Affinity for SonarQube pods.
 affinity: {}
+# -- Topology spread constraints for SonarQube pods.
 topologySpreadConstraints: []
+# -- Priority class name for SonarQube pods.
 priorityClassName: ""
+# -- Termination grace period for SonarQube pods.
 terminationGracePeriodSeconds: 120
 
+# -- Extra init containers appended to the pod.
 extraInitContainers: []
+# -- Extra sidecar containers appended to the pod.
 extraContainers: []
+# -- Extra volumes appended to the pod.
 extraVolumes: []
+# -- Extra volume mounts appended to the SonarQube container.
 extraVolumeMounts: []
 
 tests:
+  # -- Render Helm test resources.
   enabled: true
   image:
+    # -- Helm test image repository.
     repository: docker.io/library/busybox
+    # -- Helm test image tag.
     tag: "1.37"
+    # -- Helm test image pull policy.
     pullPolicy: IfNotPresent
+  # -- Resources for Helm test pods.
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary

- Adds the stable HelmForge SonarQube Community Build chart using the official `docker.io/library/sonarqube` image.
- Adds HelmForge PostgreSQL subchart support (`postgresql.enabled`) alongside external PostgreSQL, with `sonarqube.databaseMode=auto|embedded|postgresql|external`.
- Includes External Secrets Operator wiring, plugin automation, community branch plugin support, Gateway API, Ingress, dual-stack Service, NetworkPolicy, PDB, docs, examples, schema, and helm-unittest coverage.
- Resolves #361

## Type Of Change

- [x] New chart
- [ ] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [x] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream release notes, Docker Hub tags, and the community branch plugin compatibility guidance
- [x] I verified SonarSource database docs support PostgreSQL 14-18 for this SonarQube Community Build line, so HelmForge PostgreSQL `2.0.2` / PostgreSQL 18.4 is compatible.

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [x] N/A - site will be updated after the requested chart PR sequence is complete

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls: `k3d-helmforge-tests-wsl`
- [x] `helm dependency build charts/sonarqube` passed
- [x] `helm dependency list charts/sonarqube` passed: `postgresql 2.0.2 oci://ghcr.io/helmforgedev/helm ok`
- [x] `helm lint charts/sonarqube --strict` passed
- [x] `helm unittest charts/sonarqube` passed: 5 suites, 30 tests
- [x] `helm template sonarqube-default charts/sonarqube | kubeconform -strict -summary` passed: 6 valid, 0 invalid
- [x] All `ci/*.yaml` scenarios rendered with strict kubeconform: dual-stack, external-db, external-secrets, gateway-api, hardening, ingress, plugins, smoke
- [x] `ah lint charts/sonarqube` passed
- [x] `npx --yes markdownlint-cli2 "charts/sonarqube/**/*.md"` passed
- [x] Kubescape NSA passed with compliance score `98.33%` and threshold `85`
- [x] I validated this change on local `k3d` with the PostgreSQL subchart enabled

## k3d Runtime Evidence

- Context: `k3d-helmforge-tests-wsl`
- Namespace: `hf-sonarqube-standard`
- Install: `helm upgrade --install sonarqube-ci charts/sonarqube -n hf-sonarqube-standard -f charts/sonarqube/ci/smoke.yaml --wait --timeout 20m`
- `helm test sonarqube-ci -n hf-sonarqube-standard --timeout 5m --logs` passed and returned `status":"UP"`
- Pod status: SonarQube and PostgreSQL `Ready`, `0` restarts
- PostgreSQL validation: `psql` query confirmed public schema tables were created
- Service smoke: BusyBox `wget` against `http://sonarqube-ci:9000/api/system/status` returned `UP`
- Warning events: none
- Log scan for error patterns in SonarQube, wait init container, and PostgreSQL: no matches
- Namespace cleaned after validation

## Notes

- Default `sonarqube.databaseMode=auto` falls back to embedded only when no external database or bundled PostgreSQL is configured.
- `charts/sonarqube/ci/smoke.yaml` now deploys and validates the HelmForge PostgreSQL subchart path.
- A `wait-for-database` init container prevents the first-start PostgreSQL connection race when bundled PostgreSQL is enabled.