### PR TITLE
feat(metrics-server): add Metrics Server chart

### DIFF
--- a/charts/metrics-server/.helmignore
+++ b/charts/metrics-server/.helmignore
@@ -1,8 +1,40 @@
-# SPDX-License-Identifier: Apache-2.0
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+
+# Common VCS dirs
 .git/
+.gitignore
+.gitattributes
 .github/
-/tests/
-/ci/
-/examples/
-/docs/
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# Helm test and documentation assets
+.helmignore
 *.tgz
+Chart.lock
+/ci/
+/docs/
+/examples/
+/tests/
+
+# OS files
+Thumbs.db

--- a/charts/metrics-server/.helmignore
+++ b/charts/metrics-server/.helmignore
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+.git/
+.github/
+/tests/
+/ci/
+/examples/
+/docs/
+*.tgz

--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: metrics-server
+description: Kubernetes Metrics Server chart for autoscaling metrics with secure RBAC and k3d-friendly validation controls
+type: application
+version: 0.1.0
+appVersion: "0.8.1"
+kubeVersion: ">=1.31.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - metrics-server
+  - kubernetes
+  - metrics
+  - autoscaling
+  - hpa
+  - vpa
+  - metrics-api
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/kubernetes-sigs/metrics-server
+  - https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server
+icon: https://helmforge.dev/icons/charts/metrics-server.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add Metrics Server chart with secure RBAC, APIService, HA, and k3d validation controls (#363)"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://github.com/kubernetes-sigs/metrics-server
+    - name: Official Image
+      url: https://registry.k8s.io/metrics-server/metrics-server
+    - name: Upstream Helm Chart
+      url: https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/metrics-server
+    - name: Chart Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/metrics-server
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/prometheus

--- a/charts/metrics-server/DESIGN.md
+++ b/charts/metrics-server/DESIGN.md
@@ -1,0 +1,32 @@
+# Metrics Server Chart Design
+
+## Scope
+
+This chart installs Metrics Server and the Kubernetes API aggregation resources required for `kubectl top`, HPA, and VPA metrics consumption.
+
+## Decisions
+
+The chart uses Metrics Server `v0.8.1`, the latest upstream application release found during implementation.
+The official upstream Helm chart was still published at app version `0.8.0`, so this chart intentionally follows the newer application release while keeping the same upstream operational contract.
+
+Kubelet TLS verification is secure by default.
+A dedicated `metricsServer.kubelet.insecureTLS` value exists for local k3d/kind-style clusters where kubelet serving certificates lack usable SANs.
+
+RBAC and APIService resources are enabled by default because Metrics Server is normally installed as a cluster add-on.
+Disabling RBAC while managing APIService is rejected because delegated authentication and authorization are part of the aggregation contract.
+
+## Security
+
+The default pod runs as non-root, drops all capabilities, disables privilege escalation, uses RuntimeDefault seccomp, and mounts only `/tmp` as writable storage for generated serving certificates.
+
+## Operations
+
+The chart supports:
+
+- typed kubelet connection options
+- high availability through replicas, topology spread, and PDB
+- hostNetwork mode
+- dual-stack Service fields
+- optional NetworkPolicy
+- optional ServiceMonitor
+- Helm test validation against `/readyz`

--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -28,6 +28,7 @@ helm install metrics-server oci://ghcr.io/helmforgedev/helm/metrics-server -n ku
 - optional k3d and kind-compatible `--kubelet-insecure-tls`
 - optional high availability with replicas, topology spread, and PodDisruptionBudget
 - optional hostNetwork mode for clusters where the API server cannot reach pod IPs
+- hostNetwork-safe rollout behavior that avoids single-node host port upgrade deadlocks
 - dual-stack Service fields
 - optional NetworkPolicy and ServiceMonitor
 - Helm test pod that checks `/readyz`

--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -1,0 +1,87 @@
+# Metrics Server
+
+Metrics Server for Kubernetes autoscaling pipelines using the official `registry.k8s.io/metrics-server/metrics-server` image.
+
+## Install
+
+### HTTPS repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install metrics-server helmforge/metrics-server -n kube-system -f values.yaml
+```
+
+### OCI registry
+
+```bash
+helm install metrics-server oci://ghcr.io/helmforgedev/helm/metrics-server -n kube-system -f values.yaml
+```
+
+## What this chart covers
+
+- official Metrics Server image pinned to `v0.8.1`
+- Kubernetes Metrics API `APIService`
+- required ServiceAccount, ClusterRole, ClusterRoleBinding, and delegated authentication RoleBinding
+- typed kubelet flag modeling instead of a single unstructured args list
+- secure default pod and container security contexts
+- optional k3d and kind-compatible `--kubelet-insecure-tls`
+- optional high availability with replicas, topology spread, and PodDisruptionBudget
+- optional hostNetwork mode for clusters where the API server cannot reach pod IPs
+- dual-stack Service fields
+- optional NetworkPolicy and ServiceMonitor
+- Helm test pod that checks `/readyz`
+
+## Kubernetes Compatibility
+
+Metrics Server `0.8.x` supports Kubernetes `1.31+`. The chart therefore declares `kubeVersion: >=1.31.0-0`.
+
+## k3d and Local Clusters
+
+Many local clusters use kubelet serving certificates that do not include the address SANs Metrics Server validates. Use the k3d values file for local validation:
+
+```yaml
+metricsServer:
+  kubelet:
+    insecureTLS: true
+```
+
+Do not use `metricsServer.kubelet.insecureTLS=true` for production unless your platform explicitly accepts that risk.
+
+## High Availability
+
+```yaml
+replicaCount: 2
+
+pdb:
+  enabled: true
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+```
+
+For best HA behavior, configure the kube-apiserver with aggregator routing enabled so APIService requests are distributed across replicas.
+
+## Main Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `registry.k8s.io/metrics-server/metrics-server` | Official image repository |
+| `image.tag` | `v0.8.1` | Metrics Server image tag |
+| `replicaCount` | `1` | Deployment replicas |
+| `apiService.create` | `true` | Create `v1beta1.metrics.k8s.io` APIService |
+| `apiService.insecureSkipTLSVerify` | `true` | Skip APIService backend TLS verification unless `caBundle` is set |
+| `rbac.create` | `true` | Create required RBAC resources |
+| `containerPort` | `10250` | Metrics Server secure serving port |
+| `metricsServer.metricResolution` | `15s` | Metrics collection resolution |
+| `metricsServer.kubelet.insecureTLS` | `false` | Disable kubelet TLS verification for local clusters |
+| `hostNetwork.enabled` | `false` | Use host networking |
+| `service.ipFamilyPolicy` | `~` | Optional Service IP family policy |
+| `pdb.enabled` | `false` | Render PodDisruptionBudget |
+| `networkPolicy.enabled` | `false` | Render NetworkPolicy |
+| `serviceMonitor.enabled` | `false` | Render Prometheus Operator ServiceMonitor |
+
+## References
+
+- [Metrics Server](https://github.com/kubernetes-sigs/metrics-server)
+- [Metrics Server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server)
+- [Metrics Server releases](https://github.com/kubernetes-sigs/metrics-server/releases)

--- a/charts/metrics-server/ci/dual-stack.yaml
+++ b/charts/metrics-server/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/metrics-server/ci/ha.yaml
+++ b/charts/metrics-server/ci/ha.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+pdb:
+  enabled: true
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: metrics-server

--- a/charts/metrics-server/ci/host-network.yaml
+++ b/charts/metrics-server/ci/host-network.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+hostNetwork:
+  enabled: true
+
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule

--- a/charts/metrics-server/ci/k3d.yaml
+++ b/charts/metrics-server/ci/k3d.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+metricsServer:
+  kubelet:
+    insecureTLS: true
+
+apiService:
+  insecureSkipTLSVerify: true

--- a/charts/metrics-server/ci/networkpolicy.yaml
+++ b/charts/metrics-server/ci/networkpolicy.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true

--- a/charts/metrics-server/ci/servicemonitor.yaml
+++ b/charts/metrics-server/ci/servicemonitor.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: prometheus

--- a/charts/metrics-server/docs/production.md
+++ b/charts/metrics-server/docs/production.md
@@ -36,6 +36,9 @@ hostNetwork:
   enabled: true
 ```
 
+When `hostNetwork.enabled=true` and the default rolling update strategy is unchanged, the chart renders `maxUnavailable: 1` and `maxSurge: 0`.
+This avoids single-node upgrades stalling while a replacement pod waits for the same host-network secure port still held by the old pod.
+
 ## NetworkPolicy
 
 Metrics Server must reach kubelets on every node. When enabling egress NetworkPolicy, verify your CNI policy model allows traffic to node IPs and kubelet ports.

--- a/charts/metrics-server/docs/production.md
+++ b/charts/metrics-server/docs/production.md
@@ -1,0 +1,41 @@
+# Production
+
+Use the secure kubelet TLS path in production:
+
+```yaml
+metricsServer:
+  kubelet:
+    insecureTLS: false
+```
+
+If kubelet serving certificates are not signed by a trusted cluster CA or do not include node address SANs, fix kubelet certificate issuance rather than disabling verification.
+
+## High Availability
+
+```yaml
+replicaCount: 2
+
+pdb:
+  enabled: true
+  maxUnavailable: 1
+```
+
+Metrics Server HA works best when kube-apiserver aggregator routing is enabled.
+
+## APIService TLS
+
+The default APIService uses `insecureSkipTLSVerify=true` because Metrics Server generates a self-signed serving certificate.
+Set `apiService.caBundle` when your platform injects or manages a trusted serving CA.
+
+## Host Network
+
+Enable host networking only when the API server cannot reach the Metrics Server pod network:
+
+```yaml
+hostNetwork:
+  enabled: true
+```
+
+## NetworkPolicy
+
+Metrics Server must reach kubelets on every node. When enabling egress NetworkPolicy, verify your CNI policy model allows traffic to node IPs and kubelet ports.

--- a/charts/metrics-server/examples/high-availability.yaml
+++ b/charts/metrics-server/examples/high-availability.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+pdb:
+  enabled: true
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: metrics-server

--- a/charts/metrics-server/examples/k3d.yaml
+++ b/charts/metrics-server/examples/k3d.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+metricsServer:
+  kubelet:
+    insecureTLS: true

--- a/charts/metrics-server/templates/NOTES.txt
+++ b/charts/metrics-server/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Metrics Server has been installed.
+
+Service:
+  https://{{ include "metrics-server.fullname" . }}:{{ .Values.service.port }}
+
+{{- if .Values.metricsServer.kubelet.insecureTLS }}
+Kubelet TLS verification is disabled. Use this only for local clusters whose kubelet serving certificates do not include usable SANs.
+{{- end }}
+
+Verify the Metrics API:
+
+  kubectl get apiservice v1beta1.metrics.k8s.io
+  kubectl top nodes

--- a/charts/metrics-server/templates/NOTES.txt
+++ b/charts/metrics-server/templates/NOTES.txt
@@ -1,13 +1,52 @@
-Metrics Server has been installed.
+=============================================================================
+Metrics Server deployed successfully!
+=============================================================================
 
-Service:
-  https://{{ include "metrics-server.fullname" . }}:{{ .Values.service.port }}
+SERVICE:
+   Internal URL: https://{{ include "metrics-server.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Secure port: {{ include "metrics-server.securePort" . }}
 
+IMAGE:
+   {{ include "metrics-server.image" . }}
+
+METRICS API:
+   APIService created: {{ ternary "yes" "no" .Values.apiService.create }}
+   APIService TLS verification skipped: {{ ternary "yes" "no" .Values.apiService.insecureSkipTLSVerify }}
+   Kubelet insecure TLS: {{ ternary "yes" "no" .Values.metricsServer.kubelet.insecureTLS }}
+   Metric resolution: {{ .Values.metricsServer.metricResolution }}
+
+NETWORKING:
+   Host network: {{ ternary "enabled" "disabled" .Values.hostNetwork.enabled }}
+   Service type: {{ .Values.service.type }}
+   NetworkPolicy: {{ ternary "enabled" "disabled" .Values.networkPolicy.enabled }}
+   ServiceMonitor: {{ ternary "enabled" "disabled" .Values.serviceMonitor.enabled }}
+
+OPERATIONS:
+   Check the APIService:
+     kubectl get apiservice v1beta1.metrics.k8s.io
+
+   Check node metrics:
+     kubectl top nodes
+
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "metrics-server.fullname" . }}
+
+SECURITY REMINDERS:
 {{- if .Values.metricsServer.kubelet.insecureTLS }}
-Kubelet TLS verification is disabled. Use this only for local clusters whose kubelet serving certificates do not include usable SANs.
+   1. Kubelet TLS verification is disabled. Use this only for local clusters whose kubelet serving certificates do not include usable SANs.
+{{- else }}
+   1. Kubelet TLS verification is enabled.
 {{- end }}
+   2. Keep RBAC enabled when APIService is managed by this chart.
+   3. Prefer a caBundle for APIService TLS verification in production.
 
-Verify the Metrics API:
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/metrics-server
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/metrics-server
+   Metrics Server: https://github.com/kubernetes-sigs/metrics-server
 
-  kubectl get apiservice v1beta1.metrics.k8s.io
-  kubectl top nodes
+=============================================================================

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -62,7 +62,9 @@ app.kubernetes.io/part-of: helmforge
 {{- $strategy := deepCopy .Values.deploymentStrategy -}}
 {{- $rolling := default dict $strategy.rollingUpdate -}}
 {{- $usesDefaultRolling := and (eq $strategy.type "RollingUpdate") (eq (toString $rolling.maxUnavailable) "0") (eq (toString $rolling.maxSurge) "1") -}}
-{{- if and .Values.hostNetwork.enabled $usesDefaultRolling }}
+{{- if ne $strategy.type "RollingUpdate" }}
+{{- toYaml (omit $strategy "rollingUpdate") }}
+{{- else if and .Values.hostNetwork.enabled $usesDefaultRolling }}
 type: RollingUpdate
 rollingUpdate:
   maxUnavailable: 1

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -50,9 +50,17 @@ app.kubernetes.io/part-of: metrics-server
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}
 
+{{- define "metrics-server.securePort" -}}
+{{- if and .Values.hostNetwork.enabled (eq (.Values.containerPort | int) 10250) -}}
+4443
+{{- else -}}
+{{- .Values.containerPort -}}
+{{- end -}}
+{{- end }}
+
 {{- define "metrics-server.args" -}}
 - --cert-dir={{ .Values.metricsServer.certDir }}
-- --secure-port={{ .Values.containerPort }}
+- --secure-port={{ include "metrics-server.securePort" . }}
 - --kubelet-preferred-address-types={{ join "," .Values.metricsServer.kubelet.preferredAddressTypes }}
 {{- if .Values.metricsServer.kubelet.useNodeStatusPort }}
 - --kubelet-use-node-status-port

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "metrics-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "metrics-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "metrics-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metrics-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "metrics-server.labels" -}}
+helm.sh/chart: {{ include "metrics-server.chart" . }}
+{{ include "metrics-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: metrics-server
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "metrics-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics-server.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+{{- end }}
+
+{{- define "metrics-server.args" -}}
+- --cert-dir={{ .Values.metricsServer.certDir }}
+- --secure-port={{ .Values.containerPort }}
+- --kubelet-preferred-address-types={{ join "," .Values.metricsServer.kubelet.preferredAddressTypes }}
+{{- if .Values.metricsServer.kubelet.useNodeStatusPort }}
+- --kubelet-use-node-status-port
+{{- end }}
+- --metric-resolution={{ .Values.metricsServer.metricResolution }}
+{{- if .Values.metricsServer.kubelet.insecureTLS }}
+- --kubelet-insecure-tls
+{{- end }}
+{{- with .Values.metricsServer.kubelet.certificateAuthority }}
+- --kubelet-certificate-authority={{ . }}
+{{- end }}
+{{- with .Values.metricsServer.kubelet.requestTimeout }}
+- --kubelet-request-timeout={{ . }}
+{{- end }}
+{{- with .Values.metricsServer.extraArgs }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{- define "metrics-server.validate" -}}
+{{- if and .Values.pdb.enabled .Values.pdb.minAvailable .Values.pdb.maxUnavailable -}}
+{{- fail "pdb.minAvailable and pdb.maxUnavailable are mutually exclusive" -}}
+{{- end -}}
+{{- if and .Values.apiService.create (not .Values.rbac.create) -}}
+{{- fail "rbac.create must be true when apiService.create=true because Metrics API aggregation requires RBAC delegation" -}}
+{{- end -}}
+{{- if empty .Values.metricsServer.kubelet.preferredAddressTypes -}}
+{{- fail "metricsServer.kubelet.preferredAddressTypes must contain at least one address type" -}}
+{{- end -}}
+{{- end }}

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -65,6 +65,9 @@ app.kubernetes.io/part-of: metrics-server
 {{- if .Values.metricsServer.kubelet.useNodeStatusPort }}
 - --kubelet-use-node-status-port
 {{- end }}
+{{- if .Values.serviceMonitor.enabled }}
+- --authorization-always-allow-paths=/livez,/readyz,/metrics
+{{- end }}
 - --metric-resolution={{ .Values.metricsServer.metricResolution }}
 {{- if .Values.metricsServer.kubelet.insecureTLS }}
 - --kubelet-insecure-tls

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -84,9 +84,6 @@ app.kubernetes.io/part-of: metrics-server
 {{- end }}
 
 {{- define "metrics-server.validate" -}}
-{{- if and .Values.pdb.enabled .Values.pdb.minAvailable .Values.pdb.maxUnavailable -}}
-{{- fail "pdb.minAvailable and pdb.maxUnavailable are mutually exclusive" -}}
-{{- end -}}
 {{- if and .Values.apiService.create (not .Values.rbac.create) -}}
 {{- fail "rbac.create must be true when apiService.create=true because Metrics API aggregation requires RBAC delegation" -}}
 {{- end -}}

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -58,6 +58,20 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 {{- end }}
 
+{{- define "metrics-server.deploymentStrategy" -}}
+{{- $strategy := deepCopy .Values.deploymentStrategy -}}
+{{- $rolling := default dict $strategy.rollingUpdate -}}
+{{- $usesDefaultRolling := and (eq $strategy.type "RollingUpdate") (eq (toString $rolling.maxUnavailable) "0") (eq (toString $rolling.maxSurge) "1") -}}
+{{- if and .Values.hostNetwork.enabled $usesDefaultRolling }}
+type: RollingUpdate
+rollingUpdate:
+  maxUnavailable: 1
+  maxSurge: 0
+{{- else }}
+{{- toYaml $strategy }}
+{{- end }}
+{{- end }}
+
 {{- define "metrics-server.args" -}}
 - --cert-dir={{ .Values.metricsServer.certDir }}
 - --secure-port={{ include "metrics-server.securePort" . }}

--- a/charts/metrics-server/templates/_helpers.tpl
+++ b/charts/metrics-server/templates/_helpers.tpl
@@ -32,7 +32,7 @@ helm.sh/chart: {{ include "metrics-server.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: metrics-server
+app.kubernetes.io/part-of: helmforge
 {{- with .Values.commonLabels }}
 {{ toYaml . }}
 {{- end }}

--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.apiService.create }}
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.apiService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: {{ .Values.apiService.groupPriorityMinimum }}
+  version: v1beta1
+  versionPriority: {{ .Values.apiService.versionPriority }}
+  service:
+    name: {{ include "metrics-server.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+    port: {{ .Values.service.port }}
+  {{- if .Values.apiService.caBundle }}
+  caBundle: {{ .Values.apiService.caBundle | quote }}
+  {{- else }}
+  insecureSkipTLSVerify: {{ .Values.apiService.insecureSkipTLSVerify }}
+  {{- end }}
+{{- end }}

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -1,0 +1,123 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "metrics-server.validate" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-server
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "metrics-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics-server
+  template:
+    metadata:
+      labels:
+        {{- include "metrics-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: metrics-server
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "metrics-server.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      hostNetwork: {{ .Values.hostNetwork.enabled }}
+      dnsPolicy: {{ default (ternary "ClusterFirstWithHostNet" "ClusterFirst" .Values.hostNetwork.enabled) .Values.dnsPolicy }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.schedulerName }}
+      schedulerName: {{ . }}
+      {{- end }}
+      containers:
+        - name: metrics-server
+          image: {{ include "metrics-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            {{- include "metrics-server.args" . | nindent 12 }}
+          ports:
+            - name: https
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: {{ .Values.metricsServer.certDir }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: tmp
+          {{- toYaml .Values.tmpVolume | nindent 10 }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             {{- include "metrics-server.args" . | nindent 12 }}
           ports:
             - name: https
-              containerPort: {{ .Values.containerPort }}
+              containerPort: {{ include "metrics-server.securePort" . }}
               protocol: TCP
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/metrics-server/templates/deployment.yaml
+++ b/charts/metrics-server/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   strategy:
-    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
+    {{- include "metrics-server.deploymentStrategy" . | nindent 4 }}
   selector:
     matchLabels:
       {{- include "metrics-server.selectorLabels" . | nindent 6 }}

--- a/charts/metrics-server/templates/networkpolicy.yaml
+++ b/charts/metrics-server/templates/networkpolicy.yaml
@@ -18,22 +18,28 @@ spec:
     - Egress
     {{- end }}
   ingress:
-    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
+    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.allowAPIServer .Values.networkPolicy.ingress.extraFrom }}
     - from:
         {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
         - podSelector: {}
+        {{- end }}
+        {{- if .Values.networkPolicy.ingress.allowAPIServer }}
+        {{- range .Values.networkPolicy.ingress.apiServerCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
         {{- end }}
         {{- with .Values.networkPolicy.ingress.extraFrom }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       ports:
         - protocol: TCP
-          port: {{ .Values.containerPort }}
+          port: {{ include "metrics-server.securePort" . }}
     {{- else }}
     - from: []
       ports:
         - protocol: TCP
-          port: {{ .Values.containerPort }}
+          port: {{ include "metrics-server.securePort" . }}
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
@@ -55,7 +61,10 @@ spec:
     {{- end }}
     {{- if .Values.networkPolicy.egress.allowKubelet }}
     - to:
-        - namespaceSelector: {}
+        {{- range .Values.networkPolicy.egress.kubeletCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.egress.kubeletPort }}

--- a/charts/metrics-server/templates/networkpolicy.yaml
+++ b/charts/metrics-server/templates/networkpolicy.yaml
@@ -36,10 +36,7 @@ spec:
         - protocol: TCP
           port: {{ include "metrics-server.securePort" . }}
     {{- else }}
-    - from: []
-      ports:
-        - protocol: TCP
-          port: {{ include "metrics-server.securePort" . }}
+    []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:

--- a/charts/metrics-server/templates/networkpolicy.yaml
+++ b/charts/metrics-server/templates/networkpolicy.yaml
@@ -54,7 +54,10 @@ spec:
     {{- end }}
     {{- if .Values.networkPolicy.egress.allowAPIServer }}
     - to:
-        - namespaceSelector: {}
+        {{- range .Values.networkPolicy.egress.apiServerCidrs }}
+        - ipBlock:
+            cidr: {{ . | quote }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.egress.apiServerPort }}

--- a/charts/metrics-server/templates/networkpolicy.yaml
+++ b/charts/metrics-server/templates/networkpolicy.yaml
@@ -1,0 +1,68 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "metrics-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics-server
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    {{- if or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.extraFrom }}
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.containerPort }}
+    {{- else }}
+    - from: []
+      ports:
+        - protocol: TCP
+          port: {{ .Values.containerPort }}
+    {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowAPIServer }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.apiServerPort }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowKubelet }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.egress.kubeletPort }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/metrics-server/templates/pdb.yaml
+++ b/charts/metrics-server/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  {{- with .Values.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "metrics-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics-server
+{{- end }}

--- a/charts/metrics-server/templates/rbac.yaml
+++ b/charts/metrics-server/templates/rbac.yaml
@@ -1,0 +1,104 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.rbac.create }}
+{{- if .Values.rbac.aggregatedMetricsReader.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "metrics-server.fullname" . }}:system:auth-delegator
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "metrics-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "metrics-server.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "metrics-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "metrics-server.fullname" . }}:extension-apiserver-authentication-reader
+  namespace: kube-system
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "metrics-server.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/metrics-server/templates/service.yaml
+++ b/charts/metrics-server/templates/service.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-server
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    {{- include "metrics-server.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics-server
+  ports:
+    - name: https
+      port: {{ .Values.service.port }}
+      targetPort: https
+      protocol: TCP

--- a/charts/metrics-server/templates/serviceaccount.yaml
+++ b/charts/metrics-server/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metrics-server.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/metrics-server/templates/servicemonitor.yaml
+++ b/charts/metrics-server/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: {{ .Values.serviceMonitor.apiVersion }}
+kind: ServiceMonitor
+metadata:
+  name: {{ include "metrics-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "metrics-server.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics-server
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: https
+      scheme: https
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/metrics-server/templates/tests/test-connection.yaml
+++ b/charts/metrics-server/templates/tests/test-connection.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "metrics-server.fullname" . }}-test-connection
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metrics-server.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: wget
+      image: "{{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }}"
+      imagePullPolicy: {{ .Values.tests.image.pullPolicy }}
+      command: ["sh", "-ec"]
+      args:
+        - wget --no-check-certificate -qO- "https://{{ include "metrics-server.fullname" . }}:{{ .Values.service.port }}/readyz"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        {{- toYaml .Values.tests.resources | nindent 8 }}
+{{- end }}

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -117,6 +117,16 @@ tests:
           path: spec.strategy.rollingUpdate.maxSurge
           value: 0
 
+  - it: should omit rollingUpdate when deployment strategy is Recreate
+    set:
+      deploymentStrategy.type: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - notExists:
+          path: spec.strategy.rollingUpdate
+
   - it: should render HA replicas and topology spread constraints
     set:
       replicaCount: 2

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -85,6 +85,12 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 4443
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
 
   - it: should honor explicit hostNetwork containerPort override
     set:
@@ -97,6 +103,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 10443
+
+  - it: should honor explicit host network deployment strategy overrides
+    set:
+      hostNetwork.enabled: true
+      deploymentStrategy.rollingUpdate.maxUnavailable: 50%
+      deploymentStrategy.rollingUpdate.maxSurge: 0
+    asserts:
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 50%
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
 
   - it: should render HA replicas and topology spread constraints
     set:

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -25,6 +25,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
           content: ALL
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
 
   - it: should render default Metrics Server args
     asserts:

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -62,6 +62,24 @@ tests:
       - equal:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --secure-port=4443
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 4443
+
+  - it: should honor explicit hostNetwork containerPort override
+    set:
+      hostNetwork.enabled: true
+      containerPort: 10443
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --secure-port=10443
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 10443
 
   - it: should render HA replicas and topology spread constraints
     set:

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: metrics
+tests:
+  - it: should render hardened Metrics Server deployment
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: test-metrics-server
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should render default Metrics Server args
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --cert-dir=/tmp
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --secure-port=10250
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --kubelet-use-node-status-port
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metric-resolution=15s
+
+  - it: should render k3d insecure kubelet TLS flag only when enabled
+    set:
+      metricsServer.kubelet.insecureTLS: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --kubelet-insecure-tls
+
+  - it: should enable host network DNS policy
+    set:
+      hostNetwork.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: should render HA replicas and topology spread constraints
+    set:
+      replicaCount: 2
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -52,6 +52,14 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --kubelet-insecure-tls
 
+  - it: should allow metrics endpoint when ServiceMonitor is enabled
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --authorization-always-allow-paths=/livez,/readyz,/metrics
+
   - it: should enable host network DNS policy
     set:
       hostNetwork.enabled: true

--- a/charts/metrics-server/tests/operations_test.yaml
+++ b/charts/metrics-server/tests/operations_test.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Operations
+templates:
+  - templates/pdb.yaml
+  - templates/networkpolicy.yaml
+  - templates/servicemonitor.yaml
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: metrics
+tests:
+  - it: should render PDB with unhealthy eviction policy
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+      pdb.maxUnavailable: 1
+      pdb.unhealthyPodEvictionPolicy: AlwaysAllow
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - equal:
+          path: spec.unhealthyPodEvictionPolicy
+          value: AlwaysAllow
+
+  - it: should render NetworkPolicy with egress controls
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 10250
+
+  - it: should render ServiceMonitor when enabled
+    template: templates/servicemonitor.yaml
+    set:
+      serviceMonitor.enabled: true
+      serviceMonitor.additionalLabels.release: prometheus
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.labels.release
+          value: prometheus
+      - equal:
+          path: spec.endpoints[0].port
+          value: https
+
+  - it: should render Helm test pod
+    template: templates/tests/test-connection.yaml
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: /readyz

--- a/charts/metrics-server/tests/operations_test.yaml
+++ b/charts/metrics-server/tests/operations_test.yaml
@@ -59,6 +59,16 @@ tests:
           content:
             ipBlock:
               cidr: ::/0
+      - contains:
+          path: spec.egress[1].to
+          content:
+            ipBlock:
+              cidr: 0.0.0.0/0
+      - contains:
+          path: spec.egress[1].to
+          content:
+            ipBlock:
+              cidr: ::/0
 
   - it: should render ServiceMonitor when enabled
     template: templates/servicemonitor.yaml

--- a/charts/metrics-server/tests/operations_test.yaml
+++ b/charts/metrics-server/tests/operations_test.yaml
@@ -70,6 +70,20 @@ tests:
             ipBlock:
               cidr: ::/0
 
+  - it: should render deny-all ingress when no sources are allowed
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.allowSameNamespace: false
+      networkPolicy.ingress.allowAPIServer: false
+      networkPolicy.ingress.extraFrom: []
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.ingress
+          value: []
+
   - it: should render ServiceMonitor when enabled
     template: templates/servicemonitor.yaml
     set:

--- a/charts/metrics-server/tests/operations_test.yaml
+++ b/charts/metrics-server/tests/operations_test.yaml
@@ -25,6 +25,18 @@ tests:
           path: spec.unhealthyPodEvictionPolicy
           value: AlwaysAllow
 
+  - it: should prefer minAvailable when maxUnavailable keeps its default
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+      pdb.minAvailable: 1
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
   - it: should render NetworkPolicy with egress controls
     template: templates/networkpolicy.yaml
     set:

--- a/charts/metrics-server/tests/operations_test.yaml
+++ b/charts/metrics-server/tests/operations_test.yaml
@@ -36,9 +36,29 @@ tests:
       - contains:
           path: spec.policyTypes
           content: Egress
+      - contains:
+          path: spec.ingress[0].from
+          content:
+            ipBlock:
+              cidr: 0.0.0.0/0
+      - contains:
+          path: spec.ingress[0].from
+          content:
+            ipBlock:
+              cidr: ::/0
       - equal:
           path: spec.egress[2].ports[0].port
           value: 10250
+      - contains:
+          path: spec.egress[2].to
+          content:
+            ipBlock:
+              cidr: 0.0.0.0/0
+      - contains:
+          path: spec.egress[2].to
+          content:
+            ipBlock:
+              cidr: ::/0
 
   - it: should render ServiceMonitor when enabled
     template: templates/servicemonitor.yaml

--- a/charts/metrics-server/tests/rbac_test.yaml
+++ b/charts/metrics-server/tests/rbac_test.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: RBAC
+templates:
+  - templates/rbac.yaml
+  - templates/apiservice.yaml
+  - templates/serviceaccount.yaml
+release:
+  name: test
+  namespace: metrics
+tests:
+  - it: should render service account
+    template: templates/serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: test-metrics-server
+
+  - it: should render APIService
+    template: templates/apiservice.yaml
+    asserts:
+      - isKind:
+          of: APIService
+      - equal:
+          path: metadata.name
+          value: v1beta1.metrics.k8s.io
+      - equal:
+          path: spec.service.name
+          value: test-metrics-server
+      - equal:
+          path: spec.insecureSkipTLSVerify
+          value: true
+
+  - it: should render ClusterRole and bindings
+    template: templates/rbac.yaml
+    asserts:
+      - hasDocuments:
+          count: 5
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: system:aggregated-metrics-reader
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-metrics-server
+        documentIndex: 1
+      - equal:
+          path: metadata.namespace
+          value: kube-system
+        documentIndex: 4

--- a/charts/metrics-server/tests/service_test.yaml
+++ b/charts/metrics-server/tests/service_test.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: metrics
+tests:
+  - it: should expose HTTPS service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            name: https
+            port: 443
+            targetPort: https
+            protocol: TCP
+
+  - it: should support dual-stack service settings
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/metrics-server/tests/validation_test.yaml
+++ b/charts/metrics-server/tests/validation_test.yaml
@@ -6,15 +6,6 @@ release:
   name: test
   namespace: metrics
 tests:
-  - it: should reject mutually exclusive PDB settings
-    set:
-      pdb.enabled: true
-      pdb.minAvailable: 1
-      pdb.maxUnavailable: 1
-    asserts:
-      - failedTemplate:
-          errorMessage: pdb.minAvailable and pdb.maxUnavailable are mutually exclusive
-
   - it: should require RBAC when APIService is managed
     set:
       rbac.create: false

--- a/charts/metrics-server/tests/validation_test.yaml
+++ b/charts/metrics-server/tests/validation_test.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: metrics
+tests:
+  - it: should reject mutually exclusive PDB settings
+    set:
+      pdb.enabled: true
+      pdb.minAvailable: 1
+      pdb.maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: pdb.minAvailable and pdb.maxUnavailable are mutually exclusive
+
+  - it: should require RBAC when APIService is managed
+    set:
+      rbac.create: false
+      apiService.create: true
+    asserts:
+      - failedTemplate:
+          errorMessage: rbac.create must be true when apiService.create=true because Metrics API aggregation requires RBAC delegation

--- a/charts/metrics-server/values.schema.json
+++ b/charts/metrics-server/values.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Metrics Server Helm Chart Values",
+  "description": "Configuration for the HelmForge Metrics Server chart",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "minLength": 1 },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "pspEnabled": { "type": "boolean" },
+        "aggregatedMetricsReader": { "type": "object" }
+      }
+    },
+    "apiService": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "insecureSkipTLSVerify": { "type": "boolean" },
+        "caBundle": { "type": "string" },
+        "groupPriorityMinimum": { "type": "integer" },
+        "versionPriority": { "type": "integer" }
+      }
+    },
+    "containerPort": { "type": "integer", "minimum": 1024, "maximum": 65535 },
+    "hostNetwork": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "metricsServer": {
+      "type": "object",
+      "properties": {
+        "certDir": { "type": "string" },
+        "metricResolution": { "type": "string" },
+        "kubelet": {
+          "type": "object",
+          "properties": {
+            "preferredAddressTypes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "minItems": 1
+            },
+            "useNodeStatusPort": { "type": "boolean" },
+            "insecureTLS": { "type": "boolean" },
+            "certificateAuthority": { "type": "string" },
+            "requestTimeout": { "type": "string" }
+          }
+        },
+        "extraArgs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "annotations": { "type": "object" },
+        "labels": { "type": "object" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": [null, "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] },
+          "maxItems": 2
+        }
+      }
+    },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "livenessProbe": { "$ref": "#/definitions/probe" },
+    "readinessProbe": { "$ref": "#/definitions/probe" },
+    "pdb": { "type": "object" },
+    "networkPolicy": { "type": "object" },
+    "serviceMonitor": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "deploymentAnnotations": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "schedulerName": { "type": "string" },
+    "tmpVolume": { "type": "object" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "extraContainers": { "type": "array" },
+    "tests": { "type": "object" }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "path": { "type": "string" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -47,8 +47,8 @@ revisionHistoryLimit: 10
 deploymentStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
-    maxSurge: 0
+    maxUnavailable: 0
+    maxSurge: 1
 
 metricsServer:
   certDir: /tmp
@@ -158,7 +158,8 @@ serviceMonitor:
 podLabels: {}
 podAnnotations: {}
 deploymentAnnotations: {}
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 tolerations: []
 affinity: {}
 topologySpreadConstraints: []

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Metrics Server Helm Chart - Default Values
+# =============================================================================
+
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+image:
+  repository: registry.k8s.io/metrics-server/metrics-server
+  tag: "v0.8.1"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: true
+
+rbac:
+  create: true
+  pspEnabled: false
+  aggregatedMetricsReader:
+    create: true
+
+apiService:
+  create: true
+  annotations: {}
+  insecureSkipTLSVerify: true
+  caBundle: ""
+  groupPriorityMinimum: 100
+  versionPriority: 100
+
+containerPort: 10250
+hostNetwork:
+  enabled: false
+
+dnsPolicy: ""
+priorityClassName: system-cluster-critical
+revisionHistoryLimit: 10
+
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0
+
+metricsServer:
+  certDir: /tmp
+  metricResolution: 15s
+  kubelet:
+    preferredAddressTypes:
+      - InternalIP
+      - ExternalIP
+      - Hostname
+    useNodeStatusPort: true
+    insecureTLS: false
+    certificateAuthority: ""
+    requestTimeout: ""
+  extraArgs: []
+
+service:
+  type: ClusterIP
+  annotations: {}
+  labels: {}
+  port: 443
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 200Mi
+  limits:
+    cpu: 500m
+    memory: 500Mi
+
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  capabilities:
+    drop:
+      - ALL
+
+livenessProbe:
+  enabled: true
+  path: /livez
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  path: /readyz
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+pdb:
+  enabled: false
+  minAvailable: ""
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: ""
+
+networkPolicy:
+  enabled: false
+  ingress:
+    allowSameNamespace: true
+    extraFrom: []
+  egress:
+    enabled: false
+    allowKubelet: true
+    kubeletPort: 10250
+    allowAPIServer: true
+    apiServerPort: 443
+    allowDNS: true
+    extraTo: []
+
+serviceMonitor:
+  enabled: false
+  apiVersion: monitoring.coreos.com/v1
+  additionalLabels: {}
+  interval: 1m
+  scrapeTimeout: 10s
+  metricRelabelings: []
+  relabelings: []
+
+podLabels: {}
+podAnnotations: {}
+deploymentAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+schedulerName: ""
+
+tmpVolume:
+  emptyDir: {}
+
+extraVolumes: []
+extraVolumeMounts: []
+extraContainers: []
+
+tests:
+  enabled: true
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -122,11 +122,21 @@ networkPolicy:
   enabled: false
   ingress:
     allowSameNamespace: true
+    # -- Allow API aggregation traffic from control-plane/node addresses.
+    allowAPIServer: true
+    # -- CIDRs allowed to reach the Metrics Server aggregated API endpoint.
+    apiServerCidrs:
+      - 0.0.0.0/0
+      - ::/0
     extraFrom: []
   egress:
     enabled: false
     allowKubelet: true
     kubeletPort: 10250
+    # -- Node CIDRs allowed for kubelet scrapes. Override to cluster node/pod network ranges in restricted environments.
+    kubeletCidrs:
+      - 0.0.0.0/0
+      - ::/0
     allowAPIServer: true
     apiServerPort: 443
     allowDNS: true

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -139,6 +139,10 @@ networkPolicy:
       - ::/0
     allowAPIServer: true
     apiServerPort: 443
+    # -- API server/control-plane CIDRs allowed for Kubernetes API watches.
+    apiServerCidrs:
+      - 0.0.0.0/0
+      - ::/0
     allowDNS: true
     extraTo: []
 

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -74,7 +74,9 @@ revisionHistoryLimit: 10
 deploymentStrategy:
   type: RollingUpdate
   rollingUpdate:
+    # -- Max unavailable pods during updates. With hostNetwork enabled, the chart uses 1 when this default is unchanged to avoid host port rollout deadlocks.
     maxUnavailable: 0
+    # -- Max surge pods during updates. With hostNetwork enabled, the chart uses 0 when this default is unchanged to avoid host port rollout deadlocks.
     maxSurge: 1
 
 metricsServer:

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -3,47 +3,74 @@
 # Metrics Server Helm Chart - Default Values
 # =============================================================================
 
+# -- Number of Metrics Server replicas
 replicaCount: 1
 
+# -- Override the chart name used in resource names
 nameOverride: ""
+# -- Override the full release name used in resource names
 fullnameOverride: ""
+# -- Labels added to every resource created by this chart
 commonLabels: {}
 
 image:
+  # -- Official Metrics Server image repository
   repository: registry.k8s.io/metrics-server/metrics-server
+  # -- Metrics Server image tag
   tag: "v0.8.1"
+  # -- Image pull policy
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets for private registries
 imagePullSecrets: []
 
 serviceAccount:
+  # -- Create a ServiceAccount for Metrics Server
   create: true
+  # -- ServiceAccount name override
   name: ""
+  # -- ServiceAccount annotations
   annotations: {}
+  # -- Automount the ServiceAccount token. Metrics Server needs Kubernetes API access.
   automountServiceAccountToken: true
 
 rbac:
+  # -- Create RBAC required for Metrics API aggregation
   create: true
+  # -- Create legacy PodSecurityPolicy resources when supported by the cluster
   pspEnabled: false
   aggregatedMetricsReader:
+    # -- Create the aggregated metrics reader ClusterRole
     create: true
 
 apiService:
+  # -- Create the v1beta1.metrics.k8s.io APIService
   create: true
+  # -- APIService annotations
   annotations: {}
+  # -- Skip APIService backend TLS verification unless caBundle is provided
   insecureSkipTLSVerify: true
+  # -- APIService CA bundle for backend verification
   caBundle: ""
+  # -- APIService group priority
   groupPriorityMinimum: 100
+  # -- APIService version priority
   versionPriority: 100
 
+# -- Metrics Server secure serving container port
 containerPort: 10250
 hostNetwork:
+  # -- Use host networking for clusters where the API server cannot reach pod IPs
   enabled: false
 
+# -- Pod DNS policy override. Defaults to ClusterFirstWithHostNet when hostNetwork is enabled.
 dnsPolicy: ""
+# -- PriorityClass assigned to the Metrics Server pod
 priorityClassName: system-cluster-critical
+# -- Deployment revision history limit
 revisionHistoryLimit: 10
 
+# -- Deployment update strategy
 deploymentStrategy:
   type: RollingUpdate
   rollingUpdate:
@@ -51,29 +78,42 @@ deploymentStrategy:
     maxSurge: 1
 
 metricsServer:
+  # -- Directory used by Metrics Server for generated serving certificates
   certDir: /tmp
+  # -- Metrics scrape resolution
   metricResolution: 15s
   kubelet:
+    # -- Ordered node address types used to connect to kubelets
     preferredAddressTypes:
       - InternalIP
       - ExternalIP
       - Hostname
+    # -- Use the kubelet port reported in Node status
     useNodeStatusPort: true
+    # -- Disable kubelet TLS verification. Intended only for local clusters such as k3d/kind.
     insecureTLS: false
+    # -- Path to a kubelet certificate authority bundle mounted into the pod
     certificateAuthority: ""
+    # -- Kubelet request timeout, for example 10s
     requestTimeout: ""
+  # -- Additional raw Metrics Server arguments
   extraArgs: []
 
 service:
+  # -- Kubernetes Service type
   type: ClusterIP
+  # -- Service annotations
   annotations: {}
+  # -- Extra Service labels
   labels: {}
+  # -- Service port exposed to the APIService
   port: 443
   # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ~
   # -- Service IP families override. Empty uses cluster default.
   ipFamilies: []
 
+# -- Metrics Server resource requests and limits
 resources:
   requests:
     cpu: 100m
@@ -82,10 +122,12 @@ resources:
     cpu: 500m
     memory: 500Mi
 
+# -- Pod-level security context
 podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# -- Container-level security context
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -96,6 +138,7 @@ securityContext:
     drop:
       - ALL
 
+# -- Liveness probe configuration
 livenessProbe:
   enabled: true
   path: /livez
@@ -104,6 +147,7 @@ livenessProbe:
   timeoutSeconds: 1
   failureThreshold: 3
 
+# -- Readiness probe configuration
 readinessProbe:
   enabled: true
   path: /readyz
@@ -112,12 +156,14 @@ readinessProbe:
   timeoutSeconds: 1
   failureThreshold: 3
 
+# -- PodDisruptionBudget configuration
 pdb:
   enabled: false
   minAvailable: ""
   maxUnavailable: 1
   unhealthyPodEvictionPolicy: ""
 
+# -- NetworkPolicy configuration for Metrics Server traffic
 networkPolicy:
   enabled: false
   ingress:
@@ -146,6 +192,7 @@ networkPolicy:
     allowDNS: true
     extraTo: []
 
+# -- Prometheus Operator ServiceMonitor configuration
 serviceMonitor:
   enabled: false
   apiVersion: monitoring.coreos.com/v1
@@ -155,29 +202,46 @@ serviceMonitor:
   metricRelabelings: []
   relabelings: []
 
+# -- Extra pod labels
 podLabels: {}
+# -- Extra pod annotations
 podAnnotations: {}
+# -- Extra Deployment annotations
 deploymentAnnotations: {}
+# -- Node selector for Metrics Server pods
 nodeSelector:
   kubernetes.io/os: linux
+# -- Pod tolerations
 tolerations: []
+# -- Pod affinity rules
 affinity: {}
+# -- Pod topology spread constraints
 topologySpreadConstraints: []
+# -- Scheduler name override
 schedulerName: ""
 
+# -- Temporary volume used for generated serving certificates
 tmpVolume:
   emptyDir: {}
 
+# -- Extra pod volumes
 extraVolumes: []
+# -- Extra volume mounts for the Metrics Server container
 extraVolumeMounts: []
+# -- Extra sidecar containers
 extraContainers: []
 
 tests:
+  # -- Enable Helm test pod
   enabled: true
   image:
+    # -- Helm test image repository
     repository: docker.io/library/busybox
+    # -- Helm test image tag
     tag: "1.37"
+    # -- Helm test image pull policy
     pullPolicy: IfNotPresent
+  # -- Helm test pod resources
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## Summary

Adds the HelmForge `metrics-server` chart as a stable chart using the official `registry.k8s.io/metrics-server/metrics-server:v0.8.1` image.

Closes #363.

## Scope

- Metrics APIService, RBAC, ServiceAccount, secure serving configuration, kubelet scrape controls, Service, optional ServiceMonitor, PDB, NetworkPolicy, and dual-stack Service fields
- k3d/kind-friendly insecure kubelet TLS option kept opt-in through values
- hostNetwork support switches the secure port away from kubelet 10250 when needed
- hostNetwork-safe rollout behavior: unchanged default rolling strategy renders `maxUnavailable: 1` and `maxSurge: 0` when host networking is enabled to avoid host port upgrade deadlocks

## Validation

Latest local validation after review fixes:

- `helm dependency build charts/metrics-server` and `helm dependency list charts/metrics-server` - no dependencies
- `helm lint charts/metrics-server`
- `helm lint charts/metrics-server --strict`
- `helm unittest charts/metrics-server` - 5 suites, 20 tests passed
- `npx --yes markdownlint-cli2 "charts/metrics-server/**/*.md"` - 3 files, 0 errors
- strict kubeconform for default render - 10 valid, 0 invalid
- strict kubeconform for all `charts/metrics-server/ci/*.yaml`: dual-stack, ha, host-network, k3d, networkpolicy, servicemonitor
- `ah lint charts/metrics-server` - Metrics Server package lint succeeded; repository scan 66 packages, 0 errors
- Kubescape NSA on `ci/networkpolicy.yaml`: 95.00%, threshold 90
- MCP HelmForge: CI evidence PASS, security evidence PASS

## k3d validation

Validated on local cluster `k3d-helmforge-tests-wsl` after review fixes:

- namespace `hf-metrics-server-hostnet`
- `helm install metrics-test charts/metrics-server -f ci/k3d.yaml -f ci/host-network.yaml --wait --timeout 10m`
- `helm test metrics-test` succeeded
- APIService `v1beta1.metrics.k8s.io` became Available
- `kubectl top nodes` returned node CPU/memory metrics
- live Deployment strategy rendered `maxUnavailable=1` and `maxSurge=0`
- Metrics Server pod Ready with zero restarts
- no Warning events in the namespace
- logs scanned for `error|fatal|panic|exception|back-off|failed`; no matches
- `helm uninstall` executed before deleting namespace so cluster-scoped APIService was removed
- namespace `hf-metrics-server-hostnet` deleted after validation