### PR TITLE
feat(kibana): add Kibana chart

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -60,12 +60,18 @@ jobs:
         run: helm dependency build charts/${{ matrix.chart }}
 
       - name: Install Kubescape
-        run: curl -s https://raw.githubusercontent.com/kubescape/kubescape/master/install.sh | bash
+        run: |
+          KUBESCAPE_VERSION="4.0.9"
+          curl -fsSL \
+            -o /tmp/kubescape.tar.gz \
+            "https://github.com/kubescape/kubescape/releases/download/v${KUBESCAPE_VERSION}/kubescape_${KUBESCAPE_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/kubescape.tar.gz -C /tmp kubescape
+          install -m 0755 /tmp/kubescape /usr/local/bin/kubescape
+          kubescape version
 
       - name: Run security scan
         id: scan
         run: |
-          export PATH="$PATH:$HOME/.kubescape/bin"
           REPORT="/tmp/${{ matrix.chart }}-scan.json"
 
           kubescape scan framework "MITRE,NSA,SOC2" "charts/${{ matrix.chart }}" \

--- a/charts/kibana/.helmignore
+++ b/charts/kibana/.helmignore
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+.DS_Store
+.git/
+.gitignore
+.helmignore
+.idea/
+.vscode/
+*.swp
+*.tmp
+*.bak
+/ci/
+/docs/
+/examples/
+/tests/

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: kibana
+description: Production-ready Kibana with secure Elasticsearch connectivity, Wolfi image support, Gateway API, and dual-stack services
+type: application
+version: 1.0.0
+appVersion: "9.4.2"
+kubeVersion: ">=1.26.0-0"
+icon: https://helmforge.dev/icons/charts/kibana.png
+home: https://helmforge.dev
+keywords:
+  - kibana
+  - elastic
+  - elasticsearch
+  - observability
+  - analytics
+  - dashboards
+  - elk
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/elastic/kibana
+  - https://www.docker.elastic.co/r/kibana
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Add production-ready Kibana chart with official Elastic image support"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: monitoring-logging
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.elastic.co/kibana
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/kibana
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/kibana
+    - name: Support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/elasticsearch

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -51,3 +51,9 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/helmforge/elasticsearch
+dependencies:
+  - name: elasticsearch
+    alias: bundled-elasticsearch
+    version: 1.0.6
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: bundledElasticsearch.enabled

--- a/charts/kibana/DESIGN.md
+++ b/charts/kibana/DESIGN.md
@@ -1,0 +1,75 @@
+# Kibana Chart Design
+
+## Scope
+
+This chart deploys Kibana as the Elastic Stack UI, connected to an existing
+Elasticsearch service or to an optional HelmForge Elasticsearch subchart for
+local and development environments.
+
+Kibana state is mostly stored in Elasticsearch. The chart only persists
+`/usr/share/kibana/data` when operators explicitly enable persistence for local
+plugins and runtime cache.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[Users] --> svc[Kibana Service]
+  svc --> deploy[Kibana Deployment]
+  deploy --> cfg[kibana.yml ConfigMap]
+  deploy --> secret[Kibana Secret]
+  deploy --> es[Elasticsearch]
+  bundled[HelmForge Elasticsearch subchart optional] -. provides .-> es
+  eso[External Secrets Operator optional] -. materializes .-> secret
+```
+
+Optional integrations:
+
+- HelmForge Elasticsearch subchart through `bundledElasticsearch.enabled`
+- Ingress or Gateway API HTTPRoute
+- NetworkPolicy for inbound and Elasticsearch egress boundaries
+- ExternalSecret for service account tokens and encryption keys
+- Wolfi image flavor for hardened runtime baselines
+- ServiceMonitor for Prometheus-compatible metrics endpoints
+
+## Main Design Choices
+
+- Use Elastic's official Kibana image by default.
+- Keep the Wolfi image opt-in through `image.flavor=wolfi`.
+- Keep Elasticsearch connectivity explicit in `elasticsearch.hosts`.
+- Use a dependency alias for bundled Elasticsearch to avoid breaking the
+  existing `elasticsearch.*` connection values.
+- Require stable encryption keys for multi-replica deployments.
+- Render External Secrets Operator resources only when requested.
+- Keep Gateway API and Ingress as separate, non-overlapping entry points.
+
+## Production Boundary
+
+Production deployments should connect to a managed or separately operated
+Elasticsearch cluster with TLS, authentication, and static Kibana encryption
+keys. The bundled Elasticsearch subchart is primarily for local validation,
+development, demos, and tightly scoped platform-owned stacks.
+
+## Explicit Non-Goals
+
+- operating a full Elastic Stack lifecycle
+- Elasticsearch data migration orchestration
+- Fleet Server, APM Server, or Beats deployment
+- automatic Kibana saved object migration rollback
+- installing ingress, Gateway, Prometheus, or External Secrets operators
+
+<!-- @AI-METADATA
+type: design
+title: Kibana Chart Design
+description: Design document for the Kibana Helm chart
+keywords: kibana, elasticsearch, observability, dashboard, gateway-api
+purpose: Document chart architecture, decisions, and production boundaries
+scope: Chart Design
+relations:
+  - charts/kibana/README.md
+  - charts/kibana/docs/production.md
+  - charts/kibana/docs/elasticsearch.md
+path: charts/kibana/DESIGN.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/kibana/README.md
+++ b/charts/kibana/README.md
@@ -2,7 +2,9 @@
 
 Kibana is the Elastic Stack analytics and visualization UI for Elasticsearch.
 
-This HelmForge chart deploys Kibana with the official Elastic image, optional Wolfi image hardening, secure Elasticsearch credential wiring, and static encryption key support.
+This HelmForge chart deploys Kibana with the official Elastic image, optional
+Wolfi image hardening, secure Elasticsearch credential wiring, optional
+HelmForge Elasticsearch subchart support, and static encryption key support.
 
 It also includes Gateway API, dual-stack services, NetworkPolicy, PDB, External Secrets Operator integration, and focused Helm tests.
 
@@ -15,12 +17,35 @@ helm install kibana helmforge/kibana \
   --set elasticsearch.hosts[0]=http://elasticsearch:9200
 ```
 
-Elastic recommends running the same Elastic Stack version across Kibana and Elasticsearch. The default chart version targets Kibana `9.4.2`.
+Elastic recommends running the same Elastic Stack version across Kibana and
+Elasticsearch. The default chart version targets Kibana `9.4.2`.
+
+## HelmForge Elasticsearch Subchart
+
+The chart can deploy HelmForge Elasticsearch as an optional dependency for local
+or self-contained environments:
+
+```yaml
+bundledElasticsearch:
+  enabled: true
+
+elasticsearch:
+  hosts:
+    - http://kibana-bundled-elasticsearch:9200
+
+bundled-elasticsearch:
+  image:
+    tag: "9.4.2"
+```
+
+For production, keep `bundledElasticsearch.enabled=false` and connect to an
+independently operated Elasticsearch cluster.
 
 ## Production Notes
 
-Use static encryption keys for HA deployments. Kibana uses these keys for sessions, reporting, and encrypted saved objects.
-Rotating pods without stable keys can invalidate sessions and break encrypted object access.
+Use static encryption keys for HA deployments. Kibana uses these keys for
+sessions, reporting, and encrypted saved objects. Rotating pods without stable
+keys can invalidate sessions and break encrypted object access.
 
 ```yaml
 replicaCount: 2
@@ -74,10 +99,12 @@ gateway:
 | `image.tag` | Kibana image tag | `9.4.2` |
 | `replicaCount` | Number of Kibana replicas | `1` |
 | `elasticsearch.hosts` | Elasticsearch URLs | `[http://elasticsearch:9200]` |
+| `bundledElasticsearch.enabled` | Enable HelmForge Elasticsearch dependency | `false` |
 | `elasticsearch.auth.type` | Elasticsearch auth mode: `none`, `basic`, `serviceAccountToken` | `none` |
 | `elasticsearch.auth.existingSecret` | Secret containing Elasticsearch credentials | `""` |
 | `elasticsearch.tls.enabled` | Configure Elasticsearch CA trust | `false` |
 | `encryptionKeys.existingSecret` | Secret containing Kibana encryption keys | `""` |
+| `waitForElasticsearch.enabled` | Wait for the first Elasticsearch endpoint before starting Kibana | `false` |
 | `service.ipFamilyPolicy` | Dual-stack ipFamilyPolicy | `null` |
 | `ingress.enabled` | Create Kubernetes Ingress | `false` |
 | `gateway.enabled` | Create Gateway API HTTPRoute | `false` |
@@ -93,3 +120,11 @@ helm lint --strict charts/kibana
 helm unittest charts/kibana
 helm template kibana-test charts/kibana | kubeconform -strict -summary
 ```
+
+## Documentation
+
+- [Design](./DESIGN.md)
+- [Production guide](./docs/production.md)
+- [Elasticsearch connectivity](./docs/elasticsearch.md)
+- [Networking](./docs/networking.md)
+- [External Secrets](./docs/external-secrets.md)

--- a/charts/kibana/README.md
+++ b/charts/kibana/README.md
@@ -1,0 +1,95 @@
+# Kibana
+
+Kibana is the Elastic Stack analytics and visualization UI for Elasticsearch.
+
+This HelmForge chart deploys Kibana with the official Elastic image, optional Wolfi image hardening, secure Elasticsearch credential wiring, and static encryption key support.
+
+It also includes Gateway API, dual-stack services, NetworkPolicy, PDB, External Secrets Operator integration, and focused Helm tests.
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install kibana helmforge/kibana \
+  --set elasticsearch.hosts[0]=http://elasticsearch:9200
+```
+
+Elastic recommends running the same Elastic Stack version across Kibana and Elasticsearch. The default chart version targets Kibana `9.4.2`.
+
+## Production Notes
+
+Use static encryption keys for HA deployments. Kibana uses these keys for sessions, reporting, and encrypted saved objects.
+Rotating pods without stable keys can invalidate sessions and break encrypted object access.
+
+```yaml
+replicaCount: 2
+encryptionKeys:
+  existingSecret: kibana-encryption-keys
+```
+
+For secured Elasticsearch clusters, use either basic auth or an Elasticsearch service account token:
+
+```yaml
+elasticsearch:
+  hosts:
+    - https://elasticsearch:9200
+  auth:
+    type: serviceAccountToken
+    existingSecret: kibana-elasticsearch-token
+  tls:
+    enabled: true
+    certificateAuthoritiesSecret: elasticsearch-ca
+    verificationMode: certificate
+```
+
+## Hardened Image
+
+Elastic publishes a Wolfi-based Kibana image. Enable it with:
+
+```yaml
+image:
+  flavor: wolfi
+```
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+  hostnames:
+    - kibana.example.com
+```
+
+## Parameters
+
+| Name | Description | Default |
+| --- | --- | --- |
+| `image.repository` | Official Elastic Kibana image repository | `docker.elastic.co/kibana/kibana` |
+| `image.wolfiRepository` | Official Elastic Kibana Wolfi image repository | `docker.elastic.co/kibana/kibana-wolfi` |
+| `image.flavor` | Image flavor: `default` or `wolfi` | `default` |
+| `image.tag` | Kibana image tag | `9.4.2` |
+| `replicaCount` | Number of Kibana replicas | `1` |
+| `elasticsearch.hosts` | Elasticsearch URLs | `[http://elasticsearch:9200]` |
+| `elasticsearch.auth.type` | Elasticsearch auth mode: `none`, `basic`, `serviceAccountToken` | `none` |
+| `elasticsearch.auth.existingSecret` | Secret containing Elasticsearch credentials | `""` |
+| `elasticsearch.tls.enabled` | Configure Elasticsearch CA trust | `false` |
+| `encryptionKeys.existingSecret` | Secret containing Kibana encryption keys | `""` |
+| `service.ipFamilyPolicy` | Dual-stack ipFamilyPolicy | `null` |
+| `ingress.enabled` | Create Kubernetes Ingress | `false` |
+| `gateway.enabled` | Create Gateway API HTTPRoute | `false` |
+| `networkPolicy.enabled` | Create NetworkPolicy | `false` |
+| `externalSecrets.enabled` | Create ExternalSecret for Kibana secrets | `false` |
+| `serviceMonitor.enabled` | Create ServiceMonitor | `false` |
+
+## Validation
+
+```bash
+helm dependency build charts/kibana
+helm lint --strict charts/kibana
+helm unittest charts/kibana
+helm template kibana-test charts/kibana | kubeconform -strict -summary
+```

--- a/charts/kibana/ci/bundled-elasticsearch-values.yaml
+++ b/charts/kibana/ci/bundled-elasticsearch-values.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+bundledElasticsearch:
+  enabled: true
+
+elasticsearch:
+  hosts:
+    - http://kibana-ci-bundled-elasticsearch:9200
+
+bundled-elasticsearch:
+  clusterProfile: dev
+  clusterName: kibana-ci
+  image:
+    tag: "9.4.2"
+  master:
+    persistence:
+      enabled: false
+    resources:
+      requests:
+        cpu: 250m
+        memory: 768Mi
+      limits:
+        cpu: "1"
+        memory: 1536Mi
+  startupProbe:
+    initialDelaySeconds: 120
+  data:
+    replicaCount: 0
+  coordinating:
+    replicaCount: 0
+  security:
+    enabled: false
+  sysctlInit:
+    enabled: false

--- a/charts/kibana/ci/default-values.yaml
+++ b/charts/kibana/ci/default-values.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+elasticsearch:
+  hosts:
+    - http://elasticsearch:9200
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi

--- a/charts/kibana/ci/dual-stack-values.yaml
+++ b/charts/kibana/ci/dual-stack-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/kibana/ci/external-secrets-values.yaml
+++ b/charts/kibana/ci/external-secrets-values.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+elasticsearch:
+  auth:
+    type: serviceAccountToken
+
+encryptionKeys:
+  requireForMultipleReplicas: true
+
+externalSecrets:
+  enabled: true
+  skipCRDCheck: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: service-account-token
+      remoteRef:
+        key: elastic/kibana
+        property: service-account-token
+    - secretKey: xpack-security-encryption-key
+      remoteRef:
+        key: elastic/kibana
+        property: security-key
+    - secretKey: xpack-reporting-encryption-key
+      remoteRef:
+        key: elastic/kibana
+        property: reporting-key
+    - secretKey: xpack-encrypted-saved-objects-encryption-key
+      remoteRef:
+        key: elastic/kibana
+        property: saved-objects-key

--- a/charts/kibana/ci/gateway-api-values.yaml
+++ b/charts/kibana/ci/gateway-api-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  skipCRDCheck: true
+  hostnames:
+    - kibana.example.com
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system

--- a/charts/kibana/ci/ingress-values.yaml
+++ b/charts/kibana/ci/ingress-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: kibana.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/kibana/ci/k3d-values.yaml
+++ b/charts/kibana/ci/k3d-values.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+elasticsearch:
+  hosts:
+    - http://elasticsearch:9200
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 768Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+startupProbe:
+  initialDelaySeconds: 120
+  failureThreshold: 90
+
+readinessProbe:
+  failureThreshold: 20
+
+extraConfig:
+  xpack.securitySolution.enabled: false

--- a/charts/kibana/ci/k3d-values.yaml
+++ b/charts/kibana/ci/k3d-values.yaml
@@ -3,6 +3,14 @@ elasticsearch:
   hosts:
     - http://elasticsearch:9200
 
+encryptionKeys:
+  securityKey: "01234567890123456789012345678901"
+  reportingKey: "abcdefghijklmnopqrstuvwxyz123456"
+  encryptedSavedObjectsKey: "savedobjects01234567890123456789"
+
+waitForElasticsearch:
+  enabled: true
+
 resources:
   requests:
     cpu: 100m
@@ -12,7 +20,7 @@ resources:
     memory: 1Gi
 
 startupProbe:
-  initialDelaySeconds: 120
+  initialDelaySeconds: 180
   failureThreshold: 90
 
 readinessProbe:
@@ -20,3 +28,4 @@ readinessProbe:
 
 extraConfig:
   xpack.securitySolution.enabled: false
+  xpack.screenshotting.browser.chromium.disableSandbox: true

--- a/charts/kibana/ci/network-policy-values.yaml
+++ b/charts/kibana/ci/network-policy-values.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDns: true
+    elasticsearch:
+      enabled: true
+      ports:
+        - 9200

--- a/charts/kibana/ci/persistence-values.yaml
+++ b/charts/kibana/ci/persistence-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: true
+  size: 1Gi

--- a/charts/kibana/ci/security-values.yaml
+++ b/charts/kibana/ci/security-values.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+elasticsearch:
+  hosts:
+    - https://elasticsearch:9200
+  auth:
+    type: basic
+    username: kibana_system
+    password: "change-me-in-production"
+  tls:
+    enabled: true
+    verificationMode: certificate
+    certificateAuthoritiesSecret: elasticsearch-ca
+
+encryptionKeys:
+  securityKey: "01234567890123456789012345678901"
+  reportingKey: "abcdefghijklmnopqrstuvwxyz123456"
+  encryptedSavedObjectsKey: "savedobjects01234567890123456789"

--- a/charts/kibana/ci/security-values.yaml
+++ b/charts/kibana/ci/security-values.yaml
@@ -15,3 +15,13 @@ encryptionKeys:
   securityKey: "01234567890123456789012345678901"
   reportingKey: "abcdefghijklmnopqrstuvwxyz123456"
   encryptedSavedObjectsKey: "savedobjects01234567890123456789"
+
+podSecurityContext:
+  runAsGroup: 1000
+
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsGroup: 1000
+
+networkPolicy:
+  enabled: true

--- a/charts/kibana/ci/servicemonitor-values.yaml
+++ b/charts/kibana/ci/servicemonitor-values.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+serviceMonitor:
+  enabled: true
+  labels:
+    release: prometheus

--- a/charts/kibana/ci/wolfi-values.yaml
+++ b/charts/kibana/ci/wolfi-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+image:
+  flavor: wolfi

--- a/charts/kibana/docs/elasticsearch.md
+++ b/charts/kibana/docs/elasticsearch.md
@@ -1,0 +1,52 @@
+# Kibana Elasticsearch Connectivity
+
+By default, Kibana connects to an external Elasticsearch endpoint:
+
+```yaml
+elasticsearch:
+  hosts:
+    - http://elasticsearch:9200
+```
+
+## HelmForge Elasticsearch Subchart
+
+Enable the bundled HelmForge Elasticsearch subchart for local development or
+self-contained test environments:
+
+```yaml
+bundledElasticsearch:
+  enabled: true
+
+elasticsearch:
+  hosts:
+    - http://kibana-bundled-elasticsearch:9200
+
+bundled-elasticsearch:
+  image:
+    tag: "9.4.2"
+```
+
+When using a custom release name, set the host to the service rendered by the
+aliased dependency:
+
+```yaml
+elasticsearch:
+  hosts:
+    - http://<release-name>-bundled-elasticsearch:9200
+```
+
+For production, operate Elasticsearch separately and keep the subchart disabled.
+
+## Secured Elasticsearch
+
+```yaml
+elasticsearch:
+  hosts:
+    - https://elasticsearch:9200
+  auth:
+    type: serviceAccountToken
+    existingSecret: kibana-elasticsearch-token
+  tls:
+    enabled: true
+    certificateAuthoritiesSecret: elasticsearch-ca
+```

--- a/charts/kibana/docs/external-secrets.md
+++ b/charts/kibana/docs/external-secrets.md
@@ -1,14 +1,15 @@
-# SPDX-License-Identifier: Apache-2.0
+# Kibana External Secrets
+
+The chart can render an ExternalSecret for Elasticsearch credentials and Kibana
+encryption keys.
+
+```yaml
 elasticsearch:
   auth:
     type: serviceAccountToken
 
-encryptionKeys:
-  requireForMultipleReplicas: true
-
 externalSecrets:
   enabled: true
-  skipCRDCheck: true
   secretStoreRef:
     name: cluster-secrets
     kind: ClusterSecretStore
@@ -21,12 +22,17 @@ externalSecrets:
       remoteRef:
         key: elastic/kibana
         property: security-key
-    - secretKey: xpack-reporting-encryption-key
-      remoteRef:
+```
+
+Use `dataFrom` when the remote secret contains all expected keys:
+
+```yaml
+externalSecrets:
+  enabled: true
+  dataFrom:
+    - extract:
         key: elastic/kibana
-        property: reporting-key
-    - secretKey: xpack-encrypted-saved-objects-encryption-key
-      remoteRef:
-        key: elastic/kibana
-        property: saved-objects-key
-  dataFrom: []
+```
+
+The chart fails rendering when ExternalSecret is enabled without `data` or
+`dataFrom`.

--- a/charts/kibana/docs/networking.md
+++ b/charts/kibana/docs/networking.md
@@ -1,0 +1,39 @@
+# Kibana Networking
+
+The chart supports Service, Ingress, Gateway API, dual-stack Service fields,
+and NetworkPolicy.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: kibana.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+  hostnames:
+    - kibana.example.com
+```
+
+## Dual-Stack Service
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```

--- a/charts/kibana/docs/production.md
+++ b/charts/kibana/docs/production.md
@@ -1,0 +1,47 @@
+# Kibana Production Guide
+
+Use production deployments with explicit Elasticsearch authentication, TLS, and
+stable encryption keys.
+
+```yaml
+replicaCount: 2
+
+elasticsearch:
+  hosts:
+    - https://elasticsearch:9200
+  auth:
+    type: serviceAccountToken
+    existingSecret: kibana-elasticsearch-token
+  tls:
+    enabled: true
+    certificateAuthoritiesSecret: elasticsearch-ca
+    verificationMode: certificate
+
+encryptionKeys:
+  existingSecret: kibana-encryption-keys
+
+networkPolicy:
+  enabled: true
+```
+
+## Encryption Keys
+
+Kibana uses encryption keys for sessions, reporting, and encrypted saved
+objects. Multi-replica deployments must use stable keys through
+`encryptionKeys.existingSecret` or static values.
+
+## Authentication
+
+Use `serviceAccountToken` for Elastic Stack service account authentication when
+available. Basic auth is also supported for environments that still use the
+`kibana_system` user.
+
+## Operations
+
+After deployment:
+
+```bash
+helm test kibana -n observability
+kubectl get pods -n observability -l app.kubernetes.io/name=kibana
+kubectl logs -n observability deploy/kibana
+```

--- a/charts/kibana/examples/bundled-elasticsearch.yaml
+++ b/charts/kibana/examples/bundled-elasticsearch.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+bundledElasticsearch:
+  enabled: true
+
+elasticsearch:
+  hosts:
+    - http://kibana-bundled-elasticsearch:9200
+
+bundled-elasticsearch:
+  clusterProfile: dev
+  image:
+    tag: "9.4.2"
+  kibana:
+    enabled: false
+  master:
+    persistence:
+      enabled: false
+  sysctlInit:
+    enabled: false

--- a/charts/kibana/examples/external-secrets.yaml
+++ b/charts/kibana/examples/external-secrets.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+elasticsearch:
+  auth:
+    type: serviceAccountToken
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: service-account-token
+      remoteRef:
+        key: elastic/kibana
+        property: service-account-token

--- a/charts/kibana/examples/gateway.yaml
+++ b/charts/kibana/examples/gateway.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+  hostnames:
+    - kibana.example.com

--- a/charts/kibana/examples/production.yaml
+++ b/charts/kibana/examples/production.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+elasticsearch:
+  hosts:
+    - https://elasticsearch:9200
+  auth:
+    type: serviceAccountToken
+    existingSecret: kibana-elasticsearch-token
+  tls:
+    enabled: true
+    certificateAuthoritiesSecret: elasticsearch-ca
+    verificationMode: certificate
+
+encryptionKeys:
+  existingSecret: kibana-encryption-keys
+
+networkPolicy:
+  enabled: true

--- a/charts/kibana/templates/NOTES.txt
+++ b/charts/kibana/templates/NOTES.txt
@@ -1,0 +1,18 @@
+Kibana has been installed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Internal URL:
+  http://{{ include "kibana.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+{{- if .Values.ingress.enabled }}
+Ingress hosts:
+{{- range .Values.ingress.hosts }}
+  - {{ .host }}
+{{- end }}
+{{- end }}
+
+{{- if eq .Values.elasticsearch.auth.type "none" }}
+Elasticsearch authentication is disabled in chart values. Enable elasticsearch.auth.type for secured clusters.
+{{- end }}

--- a/charts/kibana/templates/NOTES.txt
+++ b/charts/kibana/templates/NOTES.txt
@@ -1,18 +1,55 @@
-Kibana has been installed.
+=============================================================================
+Kibana deployed successfully!
+=============================================================================
 
-Release: {{ .Release.Name }}
-Namespace: {{ .Release.Namespace }}
+ACCESS:
+   kubectl port-forward svc/{{ include "kibana.fullname" . }} -n {{ .Release.Namespace }} 5601:{{ .Values.service.port }}
+   Open: http://localhost:5601/
 
-Internal URL:
-  http://{{ include "kibana.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+SERVICE:
+   Internal URL: http://{{ include "kibana.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Status URL: http://{{ include "kibana.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}{{ include "kibana.probePath" . }}
 
-{{- if .Values.ingress.enabled }}
-Ingress hosts:
-{{- range .Values.ingress.hosts }}
-  - {{ .host }}
+IMAGE:
+   {{ include "kibana.image" . }}
+
+ELASTICSEARCH:
+   Hosts:
+{{- range .Values.elasticsearch.hosts }}
+     - {{ . }}
 {{- end }}
-{{- end }}
+   Auth type: {{ .Values.elasticsearch.auth.type }}
+   Bundled Elasticsearch subchart: {{ ternary "enabled" "disabled" .Values.bundledElasticsearch.enabled }}
 
-{{- if eq .Values.elasticsearch.auth.type "none" }}
-Elasticsearch authentication is disabled in chart values. Enable elasticsearch.auth.type for secured clusters.
-{{- end }}
+CONFIGURATION:
+   Persistence: {{ ternary "enabled" "disabled" .Values.persistence.enabled }}
+   Wolfi image: {{ ternary "enabled" "disabled" (eq .Values.image.flavor "wolfi") }}
+   ExternalSecret: {{ ternary "enabled" "disabled" .Values.externalSecrets.enabled }}
+
+NETWORKING:
+   Ingress: {{ ternary "enabled" "disabled" .Values.ingress.enabled }}
+   Gateway API: {{ ternary "enabled" "disabled" .Values.gateway.enabled }}
+   NetworkPolicy: {{ ternary "enabled" "disabled" .Values.networkPolicy.enabled }}
+
+OBSERVABILITY:
+   ServiceMonitor: {{ ternary "enabled" "disabled" .Values.serviceMonitor.enabled }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "kibana.fullname" . }}
+
+SECURITY REMINDERS:
+   1. Use static encryption keys for multiple replicas.
+   2. Use Elasticsearch TLS and authentication for production clusters.
+   3. Prefer ExternalSecret or existing Secrets for tokens and encryption keys.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/kibana
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/kibana
+   Kibana: https://www.elastic.co/kibana
+
+=============================================================================

--- a/charts/kibana/templates/_helpers.tpl
+++ b/charts/kibana/templates/_helpers.tpl
@@ -1,0 +1,154 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{- define "kibana.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kibana.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "kibana.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "kibana.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kibana.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "kibana.labels" -}}
+helm.sh/chart: {{ include "kibana.chart" . }}
+{{ include "kibana.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "kibana.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "kibana.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- if eq .Values.image.flavor "default" -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- else if eq .Values.image.flavor "wolfi" -}}
+{{- printf "%s:%s" .Values.image.wolfiRepository $tag -}}
+{{- else -}}
+{{- fail "image.flavor must be one of: default, wolfi" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.secretName" -}}
+{{- if .Values.elasticsearch.auth.existingSecret -}}
+{{- .Values.elasticsearch.auth.existingSecret -}}
+{{- else if .Values.encryptionKeys.existingSecret -}}
+{{- .Values.encryptionKeys.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "kibana.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.elasticsearchAuthSecretName" -}}
+{{- if .Values.elasticsearch.auth.existingSecret -}}
+{{- .Values.elasticsearch.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "kibana.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.encryptionSecretName" -}}
+{{- if .Values.encryptionKeys.existingSecret -}}
+{{- .Values.encryptionKeys.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secrets" (include "kibana.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.managedSecretNeeded" -}}
+{{- $auth := .Values.elasticsearch.auth.type -}}
+{{- $needsAuth := and (ne $auth "none") (not .Values.externalSecrets.enabled) (not .Values.elasticsearch.auth.existingSecret) -}}
+{{- $needsKeys := and (not .Values.externalSecrets.enabled) (not .Values.encryptionKeys.existingSecret) (or .Values.encryptionKeys.securityKey .Values.encryptionKeys.reportingKey .Values.encryptionKeys.encryptedSavedObjectsKey) -}}
+{{- if or $needsAuth $needsKeys -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "kibana.hasEnv" -}}
+{{- $auth := ne .Values.elasticsearch.auth.type "none" -}}
+{{- $keys := or .Values.encryptionKeys.existingSecret .Values.encryptionKeys.securityKey .Values.encryptionKeys.reportingKey .Values.encryptionKeys.encryptedSavedObjectsKey -}}
+{{- if or $auth $keys .Values.extraEnv -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "kibana.probePath" -}}
+{{- $basePath := trimSuffix "/" .Values.server.basePath -}}
+{{- if $basePath -}}
+{{- printf "%s/api/status" $basePath -}}
+{{- else -}}
+/api/status
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.validate" -}}
+{{- $auth := .Values.elasticsearch.auth.type -}}
+{{- if not (has $auth (list "none" "basic" "serviceAccountToken")) -}}
+{{- fail "elasticsearch.auth.type must be one of: none, basic, serviceAccountToken" -}}
+{{- end -}}
+{{- if and (eq $auth "basic") (not .Values.externalSecrets.enabled) (not .Values.elasticsearch.auth.existingSecret) (not .Values.elasticsearch.auth.password) -}}
+{{- fail "elasticsearch.auth.password or elasticsearch.auth.existingSecret is required when elasticsearch.auth.type=basic" -}}
+{{- end -}}
+{{- if and (eq $auth "serviceAccountToken") (not .Values.externalSecrets.enabled) (not .Values.elasticsearch.auth.existingSecret) (not .Values.elasticsearch.auth.serviceAccountToken) -}}
+{{- fail "elasticsearch.auth.serviceAccountToken or elasticsearch.auth.existingSecret is required when elasticsearch.auth.type=serviceAccountToken" -}}
+{{- end -}}
+{{- if and .Values.elasticsearch.tls.enabled (not (has .Values.elasticsearch.tls.verificationMode (list "full" "certificate" "none"))) -}}
+{{- fail "elasticsearch.tls.verificationMode must be one of: full, certificate, none" -}}
+{{- end -}}
+{{- if and .Values.elasticsearch.tls.enabled (not .Values.elasticsearch.tls.certificateAuthoritiesSecret) -}}
+{{- fail "elasticsearch.tls.certificateAuthoritiesSecret is required when elasticsearch.tls.enabled=true" -}}
+{{- end -}}
+{{- if and (gt (int .Values.replicaCount) 1) .Values.encryptionKeys.requireForMultipleReplicas (not .Values.externalSecrets.enabled) (not .Values.encryptionKeys.existingSecret) (or (not .Values.encryptionKeys.securityKey) (not .Values.encryptionKeys.reportingKey) (not .Values.encryptionKeys.encryptedSavedObjectsKey)) -}}
+{{- fail "replicaCount > 1 requires encryptionKeys.existingSecret or all static encryption key values when encryptionKeys.requireForMultipleReplicas=true" -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
+{{- fail "gateway.parentRefs is required when gateway.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
+{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.data) -}}
+{{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.assertGatewayAPICRDs" -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.skipCRDCheck) -}}
+{{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "httproutes.gateway.networking.k8s.io" -}}
+{{- if and $crd (not (hasKey $crd "metadata")) -}}
+{{- fail "ERROR: Gateway API CRDs not found in cluster. Install Gateway API CRDs or set gateway.skipCRDCheck=true." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kibana.assertExternalSecretsCRDs" -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.skipCRDCheck) -}}
+{{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "externalsecrets.external-secrets.io" -}}
+{{- if and $crd (not (hasKey $crd "metadata")) -}}
+{{- fail "ERROR: External Secrets Operator CRDs not found in cluster. Install ESO or set externalSecrets.skipCRDCheck=true." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kibana/templates/_helpers.tpl
+++ b/charts/kibana/templates/_helpers.tpl
@@ -130,8 +130,10 @@ app.kubernetes.io/part-of: helmforge
 {{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
 {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
 {{- end -}}
-{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.data) -}}
-{{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" -}}
+{{- $externalSecretData := .Values.externalSecrets.data | default list -}}
+{{- $externalSecretDataFrom := .Values.externalSecrets.dataFrom | default list -}}
+{{- if and .Values.externalSecrets.enabled (eq (add (len $externalSecretData) (len $externalSecretDataFrom)) 0) -}}
+{{- fail "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kibana/templates/configmap.yaml
+++ b/charts/kibana/templates/configmap.yaml
@@ -1,0 +1,30 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "kibana.validate" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kibana.fullname" . }}-config
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+data:
+  kibana.yml: |
+    server.name: {{ include "kibana.fullname" . | quote }}
+    server.host: "0.0.0.0"
+    elasticsearch.hosts:
+      {{- toYaml .Values.elasticsearch.hosts | nindent 6 }}
+    telemetry.enabled: {{ .Values.telemetry.enabled }}
+    {{- if .Values.server.publicBaseUrl }}
+    server.publicBaseUrl: {{ .Values.server.publicBaseUrl | quote }}
+    {{- end }}
+    {{- if .Values.server.basePath }}
+    server.basePath: {{ .Values.server.basePath | quote }}
+    server.rewriteBasePath: {{ .Values.server.rewriteBasePath }}
+    {{- end }}
+    {{- if .Values.elasticsearch.tls.enabled }}
+    elasticsearch.ssl.certificateAuthorities:
+      - /usr/share/kibana/config/certs/{{ .Values.elasticsearch.tls.certificateAuthoritiesKey }}
+    elasticsearch.ssl.verificationMode: {{ .Values.elasticsearch.tls.verificationMode | quote }}
+    {{- end }}
+    {{- with .Values.extraConfig }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/kibana/templates/deployment.yaml
+++ b/charts/kibana/templates/deployment.yaml
@@ -1,0 +1,181 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "kibana.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "kibana.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if eq (include "kibana.managedSecretNeeded" .) "true" }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "kibana.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: kibana
+          image: {{ include "kibana.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 5601
+              protocol: TCP
+          {{- if eq (include "kibana.hasEnv" .) "true" }}
+          env:
+            {{- if eq .Values.elasticsearch.auth.type "basic" }}
+            - name: ELASTICSEARCH_USERNAME
+              value: {{ .Values.elasticsearch.auth.username | quote }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kibana.elasticsearchAuthSecretName" . }}
+                  key: {{ .Values.elasticsearch.auth.passwordKey }}
+            {{- end }}
+            {{- if eq .Values.elasticsearch.auth.type "serviceAccountToken" }}
+            - name: ELASTICSEARCH_SERVICEACCOUNTTOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kibana.elasticsearchAuthSecretName" . }}
+                  key: {{ .Values.elasticsearch.auth.serviceAccountTokenKey }}
+            {{- end }}
+            {{- if or .Values.encryptionKeys.existingSecret .Values.encryptionKeys.securityKey }}
+            - name: XPACK_SECURITY_ENCRYPTIONKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kibana.encryptionSecretName" . }}
+                  key: {{ .Values.encryptionKeys.securityKeyKey }}
+            {{- end }}
+            {{- if or .Values.encryptionKeys.existingSecret .Values.encryptionKeys.reportingKey }}
+            - name: XPACK_REPORTING_ENCRYPTIONKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kibana.encryptionSecretName" . }}
+                  key: {{ .Values.encryptionKeys.reportingKeyKey }}
+            {{- end }}
+            {{- if or .Values.encryptionKeys.existingSecret .Values.encryptionKeys.encryptedSavedObjectsKey }}
+            - name: XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kibana.encryptionSecretName" . }}
+                  key: {{ .Values.encryptionKeys.encryptedSavedObjectsKeyKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /usr/share/kibana/config/kibana.yml
+              subPath: kibana.yml
+              readOnly: true
+            - name: data
+              mountPath: /usr/share/kibana/data
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.elasticsearch.tls.enabled }}
+            - name: elasticsearch-ca
+              mountPath: /usr/share/kibana/config/certs
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ include "kibana.probePath" . }}
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ include "kibana.probePath" . }}
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ include "kibana.probePath" . }}
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kibana.fullname" . }}-config
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-data" (include "kibana.fullname" .)) .Values.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.elasticsearch.tls.enabled }}
+        - name: elasticsearch-ca
+          secret:
+            secretName: {{ .Values.elasticsearch.tls.certificateAuthoritiesSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/kibana/templates/deployment.yaml
+++ b/charts/kibana/templates/deployment.yaml
@@ -56,6 +56,32 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.waitForElasticsearch.enabled }}
+      initContainers:
+        - name: wait-for-elasticsearch
+          image: "{{ .Values.waitForElasticsearch.image.repository }}:{{ .Values.waitForElasticsearch.image.tag }}"
+          imagePullPolicy: {{ .Values.waitForElasticsearch.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.waitForElasticsearch.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.waitForElasticsearch.resources | nindent 12 }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              endpoint={{ first .Values.elasticsearch.hosts | quote }}
+              timeout={{ .Values.waitForElasticsearch.timeoutSeconds }}
+              interval={{ .Values.waitForElasticsearch.intervalSeconds }}
+              elapsed=0
+              until wget -q -O /dev/null "$endpoint" 2>/dev/null; do
+                if [ "$elapsed" -ge "$timeout" ]; then
+                  echo "Timed out waiting for Elasticsearch at $endpoint" >&2
+                  exit 1
+                fi
+                sleep "$interval"
+                elapsed=$((elapsed + interval))
+              done
+      {{- end }}
       containers:
         - name: kibana
           image: {{ include "kibana.image" . | quote }}

--- a/charts/kibana/templates/externalsecret.yaml
+++ b/charts/kibana/templates/externalsecret.yaml
@@ -1,6 +1,11 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- include "kibana.assertExternalSecretsCRDs" . }}
+{{- $externalSecretData := .Values.externalSecrets.data | default list -}}
+{{- $externalSecretDataFrom := .Values.externalSecrets.dataFrom | default list -}}
+{{- if eq (add (len $externalSecretData) (len $externalSecretDataFrom)) 0 }}
+  {{- fail "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
@@ -10,11 +15,17 @@ metadata:
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
   secretStoreRef:
-    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
     kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
   target:
     name: {{ include "kibana.fullname" . }}-secrets
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  {{- if $externalSecretData }}
   data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+    {{- toYaml $externalSecretData | nindent 4 }}
+  {{- end }}
+  {{- if $externalSecretDataFrom }}
+  dataFrom:
+    {{- toYaml $externalSecretDataFrom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/kibana/templates/externalsecret.yaml
+++ b/charts/kibana/templates/externalsecret.yaml
@@ -1,0 +1,20 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- include "kibana.assertExternalSecretsCRDs" . }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "kibana.fullname" . }}-secrets
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "kibana.fullname" . }}-secrets
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/kibana/templates/httproute.yaml
+++ b/charts/kibana/templates/httproute.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+{{- include "kibana.assertGatewayAPICRDs" . }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ default "/" .Values.server.basePath | quote }}
+      backendRefs:
+        - name: {{ include "kibana.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "kibana.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kibana/templates/networkpolicy.yaml
+++ b/charts/kibana/templates/networkpolicy.yaml
@@ -1,0 +1,88 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kibana.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 5601
+      from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- range .Values.networkPolicy.ingress.namespaceSelectors }}
+        - namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- range .Values.networkPolicy.ingress.podSelectors }}
+        - podSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- range .Values.networkPolicy.ingress.ipBlocks }}
+        - ipBlock:
+            cidr: {{ .cidr | quote }}
+            {{- with .except }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if not (or .Values.networkPolicy.ingress.allowSameNamespace .Values.networkPolicy.ingress.namespaceSelectors .Values.networkPolicy.ingress.podSelectors .Values.networkPolicy.ingress.ipBlocks .Values.networkPolicy.ingress.extraFrom) }}
+        []
+        {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDns }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.elasticsearch.enabled }}
+    - ports:
+        {{- range .Values.networkPolicy.egress.elasticsearch.ports }}
+        - protocol: TCP
+          port: {{ . }}
+        {{- end }}
+      to:
+        {{- range .Values.networkPolicy.egress.elasticsearch.namespaceSelectors }}
+        - namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- range .Values.networkPolicy.egress.elasticsearch.podSelectors }}
+        - podSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- range .Values.networkPolicy.egress.elasticsearch.ipBlocks }}
+        - ipBlock:
+            cidr: {{ .cidr | quote }}
+            {{- with .except }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- end }}
+        {{- if not (or .Values.networkPolicy.egress.elasticsearch.namespaceSelectors .Values.networkPolicy.egress.elasticsearch.podSelectors .Values.networkPolicy.egress.elasticsearch.ipBlocks) }}
+        - podSelector: {}
+        {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extra }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/kibana/templates/pdb.yaml
+++ b/charts/kibana/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kibana.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/kibana/templates/pvc.yaml
+++ b/charts/kibana/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kibana.fullname" . }}-data
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/kibana/templates/secret.yaml
+++ b/charts/kibana/templates/secret.yaml
@@ -1,0 +1,26 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if eq (include "kibana.managedSecretNeeded" .) "true" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kibana.fullname" . }}-secrets
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if and (eq .Values.elasticsearch.auth.type "basic") (not .Values.elasticsearch.auth.existingSecret) }}
+  {{ .Values.elasticsearch.auth.passwordKey }}: {{ .Values.elasticsearch.auth.password | quote }}
+  {{- end }}
+  {{- if and (eq .Values.elasticsearch.auth.type "serviceAccountToken") (not .Values.elasticsearch.auth.existingSecret) }}
+  {{ .Values.elasticsearch.auth.serviceAccountTokenKey }}: {{ .Values.elasticsearch.auth.serviceAccountToken | quote }}
+  {{- end }}
+  {{- if and .Values.encryptionKeys.securityKey (not .Values.encryptionKeys.existingSecret) }}
+  {{ .Values.encryptionKeys.securityKeyKey }}: {{ .Values.encryptionKeys.securityKey | quote }}
+  {{- end }}
+  {{- if and .Values.encryptionKeys.reportingKey (not .Values.encryptionKeys.existingSecret) }}
+  {{ .Values.encryptionKeys.reportingKeyKey }}: {{ .Values.encryptionKeys.reportingKey | quote }}
+  {{- end }}
+  {{- if and .Values.encryptionKeys.encryptedSavedObjectsKey (not .Values.encryptionKeys.existingSecret) }}
+  {{ .Values.encryptionKeys.encryptedSavedObjectsKeyKey }}: {{ .Values.encryptionKeys.encryptedSavedObjectsKey | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/kibana/templates/service.yaml
+++ b/charts/kibana/templates/service.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "kibana.selectorLabels" . | nindent 4 }}

--- a/charts/kibana/templates/serviceaccount.yaml
+++ b/charts/kibana/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kibana.serviceAccountName" . }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/kibana/templates/servicemonitor.yaml
+++ b/charts/kibana/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kibana.fullname" . }}
+  {{- with .Values.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kibana.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/charts/kibana/templates/tests/test-connection.yaml
+++ b/charts/kibana/templates/tests/test-connection.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "kibana.fullname" . }}-test-connection
+  labels:
+    {{- include "kibana.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: wget
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+      resources:
+        {{- toYaml .Values.test.resources | nindent 8 }}
+      command:
+        - /bin/sh
+        - -ec
+        - wget -qO- "http://{{ include "kibana.fullname" . }}:{{ .Values.service.port }}{{ include "kibana.probePath" . }}"

--- a/charts/kibana/templates/tests/test-connection.yaml
+++ b/charts/kibana/templates/tests/test-connection.yaml
@@ -14,6 +14,7 @@ spec:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1000
+    runAsGroup: 1000
     seccompProfile:
       type: RuntimeDefault
   containers:
@@ -28,6 +29,7 @@ spec:
         readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 1000
+        runAsGroup: 1000
       resources:
         {{- toYaml .Values.test.resources | nindent 8 }}
       command:

--- a/charts/kibana/tests/config_test.yaml
+++ b/charts/kibana/tests/config_test.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: kibana - config
+templates:
+  - templates/configmap.yaml
+  - templates/secret.yaml
+
+tests:
+  - it: renders kibana.yml with Elasticsearch hosts
+    template: templates/configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["kibana.yml"]
+          pattern: "elasticsearch.hosts:"
+      - matchRegex:
+          path: data["kibana.yml"]
+          pattern: "http://elasticsearch:9200"
+
+  - it: renders TLS configuration
+    template: templates/configmap.yaml
+    set:
+      elasticsearch:
+        hosts:
+          - https://elasticsearch:9200
+        tls:
+          enabled: true
+          verificationMode: certificate
+          certificateAuthoritiesSecret: elasticsearch-ca
+    asserts:
+      - matchRegex:
+          path: data["kibana.yml"]
+          pattern: "elasticsearch.ssl.verificationMode: \"certificate\""
+
+  - it: creates a managed secret for inline auth and encryption keys
+    template: templates/secret.yaml
+    set:
+      elasticsearch:
+        auth:
+          type: basic
+          password: super-secret
+      encryptionKeys:
+        securityKey: "01234567890123456789012345678901"
+        reportingKey: "abcdefghijklmnopqrstuvwxyz123456"
+        encryptedSavedObjectsKey: "savedobjects01234567890123456789"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.elasticsearch-password
+          value: super-secret

--- a/charts/kibana/tests/deployment_test.yaml
+++ b/charts/kibana/tests/deployment_test.yaml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: kibana - deployment
+templates:
+  - templates/configmap.yaml
+  - templates/secret.yaml
+  - templates/deployment.yaml
+
+tests:
+  - it: renders deployment with official Elastic image
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.elastic.co/kibana/kibana:9.4.2
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 5601
+
+  - it: supports Wolfi image flavor
+    template: templates/deployment.yaml
+    set:
+      image:
+        flavor: wolfi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.elastic.co/kibana/kibana-wolfi:9.4.2
+
+  - it: wires basic Elasticsearch authentication from a Secret
+    template: templates/deployment.yaml
+    set:
+      elasticsearch:
+        auth:
+          type: basic
+          password: super-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_USERNAME
+            value: kibana_system
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-kibana-secrets
+                key: elasticsearch-password
+
+  - it: wires service account token authentication
+    template: templates/deployment.yaml
+    set:
+      elasticsearch:
+        auth:
+          type: serviceAccountToken
+          serviceAccountToken: token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_SERVICEACCOUNTTOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-kibana-secrets
+                key: service-account-token
+
+  - it: prefixes probes with server basePath
+    template: templates/deployment.yaml
+    set:
+      server:
+        basePath: /kibana
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /kibana/api/status
+
+  - it: mounts Elasticsearch CA when TLS is enabled
+    template: templates/deployment.yaml
+    set:
+      elasticsearch:
+        tls:
+          enabled: true
+          certificateAuthoritiesSecret: elasticsearch-ca
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: elasticsearch-ca
+            secret:
+              secretName: elasticsearch-ca
+
+  - it: fails multi-replica deployments without static encryption keys
+    template: templates/deployment.yaml
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "replicaCount > 1 requires encryptionKeys.existingSecret or all static encryption key values when encryptionKeys.requireForMultipleReplicas=true"

--- a/charts/kibana/tests/deployment_test.yaml
+++ b/charts/kibana/tests/deployment_test.yaml
@@ -77,6 +77,22 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /kibana/api/status
 
+  - it: can wait for Elasticsearch before starting Kibana
+    template: templates/deployment.yaml
+    set:
+      waitForElasticsearch:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-elasticsearch
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/busybox:1.37.0
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "http://elasticsearch:9200"
+
   - it: mounts Elasticsearch CA when TLS is enabled
     template: templates/deployment.yaml
     set:

--- a/charts/kibana/tests/routing_test.yaml
+++ b/charts/kibana/tests/routing_test.yaml
@@ -32,9 +32,13 @@ tests:
     set:
       ingress:
         enabled: true
+        ingressClassName: nginx
     asserts:
       - isKind:
           of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
 
   - it: renders Gateway API HTTPRoute
     template: templates/httproute.yaml
@@ -109,3 +113,39 @@ tests:
       - equal:
           path: spec.secretStoreRef.name
           value: cluster-secrets
+
+  - it: renders ExternalSecret with dataFrom
+    template: templates/externalsecret.yaml
+    set:
+      elasticsearch:
+        auth:
+          type: serviceAccountToken
+      externalSecrets:
+        enabled: true
+        skipCRDCheck: true
+        secretStoreRef:
+          name: cluster-secrets
+        dataFrom:
+          - extract:
+              key: elastic/kibana
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: elastic/kibana
+
+  - it: fails ExternalSecret without data or dataFrom
+    template: templates/externalsecret.yaml
+    set:
+      elasticsearch:
+        auth:
+          type: serviceAccountToken
+      externalSecrets:
+        enabled: true
+        skipCRDCheck: true
+        secretStoreRef:
+          name: cluster-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true"

--- a/charts/kibana/tests/routing_test.yaml
+++ b/charts/kibana/tests/routing_test.yaml
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: kibana - routing and policies
+templates:
+  - templates/service.yaml
+  - templates/ingress.yaml
+  - templates/httproute.yaml
+  - templates/networkpolicy.yaml
+  - templates/pdb.yaml
+  - templates/servicemonitor.yaml
+  - templates/pvc.yaml
+  - templates/externalsecret.yaml
+
+tests:
+  - it: renders dual-stack service fields
+    template: templates/service.yaml
+    set:
+      service:
+        ipFamilyPolicy: PreferDualStack
+        ipFamilies:
+          - IPv4
+          - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
+  - it: renders ingress when enabled
+    template: templates/ingress.yaml
+    set:
+      ingress:
+        enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+
+  - it: renders Gateway API HTTPRoute
+    template: templates/httproute.yaml
+    set:
+      gateway:
+        enabled: true
+        skipCRDCheck: true
+        hostnames:
+          - kibana.example.com
+        parentRefs:
+          - name: shared-gateway
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 5601
+
+  - it: renders NetworkPolicy with egress controls
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+
+  - it: renders persistence PVC
+    template: templates/pvc.yaml
+    set:
+      persistence:
+        enabled: true
+        size: 1Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi
+
+  - it: renders ServiceMonitor
+    template: templates/servicemonitor.yaml
+    set:
+      serviceMonitor:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+
+  - it: renders ExternalSecret
+    template: templates/externalsecret.yaml
+    set:
+      elasticsearch:
+        auth:
+          type: serviceAccountToken
+      externalSecrets:
+        enabled: true
+        skipCRDCheck: true
+        secretStoreRef:
+          name: cluster-secrets
+        data:
+          - secretKey: service-account-token
+            remoteRef:
+              key: elastic/kibana
+              property: service-account-token
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.secretStoreRef.name
+          value: cluster-secrets

--- a/charts/kibana/values.schema.json
+++ b/charts/kibana/values.schema.json
@@ -1,0 +1,368 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "wolfiRepository": {
+          "type": "string"
+        },
+        "flavor": {
+          "type": "string",
+          "enum": [
+            "default",
+            "wolfi"
+          ]
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "elasticsearch": {
+      "type": "object",
+      "properties": {
+        "hosts": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "none",
+                "basic",
+                "serviceAccountToken"
+              ]
+            },
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "serviceAccountToken": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "passwordKey": {
+              "type": "string"
+            },
+            "serviceAccountTokenKey": {
+              "type": "string"
+            }
+          }
+        },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "verificationMode": {
+              "type": "string",
+              "enum": [
+                "full",
+                "certificate",
+                "none"
+              ]
+            },
+            "certificateAuthoritiesSecret": {
+              "type": "string"
+            },
+            "certificateAuthoritiesKey": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "publicBaseUrl": {
+          "type": "string"
+        },
+        "basePath": {
+          "type": "string"
+        },
+        "rewriteBasePath": {
+          "type": "boolean"
+        }
+      }
+    },
+    "telemetry": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "encryptionKeys": {
+      "type": "object",
+      "properties": {
+        "existingSecret": {
+          "type": "string"
+        },
+        "securityKeyKey": {
+          "type": "string"
+        },
+        "reportingKeyKey": {
+          "type": "string"
+        },
+        "encryptedSavedObjectsKeyKey": {
+          "type": "string"
+        },
+        "securityKey": {
+          "type": "string"
+        },
+        "reportingKey": {
+          "type": "string"
+        },
+        "encryptedSavedObjectsKey": {
+          "type": "string"
+        },
+        "requireForMultipleReplicas": {
+          "type": "boolean"
+        }
+      }
+    },
+    "extraConfig": {
+      "type": "object"
+    },
+    "extraEnv": {
+      "type": "array"
+    },
+    "extraVolumes": {
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "type": "array"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "resources": {
+      "type": "object"
+    },
+    "livenessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "startupProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "size": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "targetPort": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ]
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "ipFamilyPolicy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "IPv4",
+              "IPv6"
+            ]
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object"
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "hostnames": {
+          "type": "array"
+        },
+        "parentRefs": {
+          "type": "array"
+        },
+        "skipCRDCheck": {
+          "type": "boolean"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "pdb": {
+      "type": "object"
+    },
+    "networkPolicy": {
+      "type": "object"
+    },
+    "serviceMonitor": {
+      "type": "object"
+    },
+    "externalSecrets": {
+      "type": "object"
+    },
+    "test": {
+      "type": "object"
+    }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/charts/kibana/values.schema.json
+++ b/charts/kibana/values.schema.json
@@ -112,6 +112,17 @@
         }
       }
     },
+    "bundledElasticsearch": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "bundled-elasticsearch": {
+      "type": "object"
+    },
     "server": {
       "type": "object",
       "properties": {
@@ -174,6 +185,9 @@
     },
     "extraVolumeMounts": {
       "type": "array"
+    },
+    "waitForElasticsearch": {
+      "type": "object"
     },
     "podAnnotations": {
       "type": "object"
@@ -333,7 +347,39 @@
       "type": "object"
     },
     "externalSecrets": {
-      "type": "object"
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "secretStoreRef": {
+          "type": "object"
+        },
+        "target": {
+          "type": "object"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "dataFrom": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "skipCRDCheck": {
+          "type": "boolean"
+        }
+      }
     },
     "test": {
       "type": "object"

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Kibana Helm Chart
+# =============================================================================
+# Production-ready Kibana deployment using official Elastic images.
+#
+# Quick start:
+#   helm install kibana helmforge/kibana \
+#     --set elasticsearch.hosts[0]=http://elasticsearch:9200
+#
+# Hardened image:
+#   helm install kibana helmforge/kibana --set image.flavor=wolfi
+# =============================================================================
+
+# -- Override the chart name used in resource names
+nameOverride: ""
+
+# -- Override the full release name used in resource names
+fullnameOverride: ""
+
+# -- Labels added to every resource created by this chart
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+image:
+  # -- Official Elastic Kibana image repository
+  repository: docker.elastic.co/kibana/kibana
+  # -- Official Elastic Wolfi image repository for hardened deployments
+  wolfiRepository: docker.elastic.co/kibana/kibana-wolfi
+  # -- Image flavor. Valid values: default, wolfi
+  flavor: default
+  # -- Kibana image tag. Defaults to the chart appVersion.
+  tag: "9.4.2"
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Number of Kibana replicas
+replicaCount: 1
+
+# =============================================================================
+# Elasticsearch Connection
+# =============================================================================
+elasticsearch:
+  # -- Elasticsearch URLs. Elastic recommends matching Kibana and Elasticsearch versions.
+  hosts:
+    - http://elasticsearch:9200
+
+  auth:
+    # -- Authentication type for Kibana to Elasticsearch. Valid values: none, basic, serviceAccountToken
+    type: none
+    # -- Username used when auth.type=basic
+    username: kibana_system
+    # -- Password used when auth.type=basic and no existingSecret is set
+    password: ""
+    # -- Service account token used when auth.type=serviceAccountToken and no existingSecret is set
+    serviceAccountToken: ""
+    # -- Existing secret containing Elasticsearch credentials
+    existingSecret: ""
+    # -- Secret key for the basic-auth password
+    passwordKey: elasticsearch-password
+    # -- Secret key for the service account token
+    serviceAccountTokenKey: service-account-token
+
+  tls:
+    # -- Enable TLS trust configuration for Elasticsearch connections
+    enabled: false
+    # -- TLS certificate verification mode. Valid values: full, certificate, none
+    verificationMode: full
+    # -- Existing secret containing the Elasticsearch CA certificate
+    certificateAuthoritiesSecret: ""
+    # -- Secret key containing the CA certificate
+    certificateAuthoritiesKey: ca.crt
+
+# =============================================================================
+# Kibana Configuration
+# =============================================================================
+server:
+  # -- Public base URL used by Kibana for absolute URLs
+  publicBaseUrl: ""
+  # -- Base path when Kibana is served behind a reverse proxy path
+  basePath: ""
+  # -- Rewrite base path from incoming requests
+  rewriteBasePath: false
+
+telemetry:
+  # -- Enable Elastic telemetry
+  enabled: false
+
+encryptionKeys:
+  # -- Existing secret containing Kibana encryption keys
+  existingSecret: ""
+  # -- Key name for xpack.security.encryptionKey
+  securityKeyKey: xpack-security-encryption-key
+  # -- Key name for xpack.reporting.encryptionKey
+  reportingKeyKey: xpack-reporting-encryption-key
+  # -- Key name for xpack.encryptedSavedObjects.encryptionKey
+  encryptedSavedObjectsKeyKey: xpack-encrypted-saved-objects-encryption-key
+  # -- Value for xpack.security.encryptionKey. Use at least 32 characters.
+  securityKey: ""
+  # -- Value for xpack.reporting.encryptionKey. Use at least 32 characters.
+  reportingKey: ""
+  # -- Value for xpack.encryptedSavedObjects.encryptionKey. Use at least 32 characters.
+  encryptedSavedObjectsKey: ""
+  # -- Require static keys when replicaCount > 1 to keep sessions and reporting stable
+  requireForMultipleReplicas: true
+
+# -- Additional kibana.yml settings
+extraConfig: {}
+
+# -- Extra environment variables
+extraEnv: []
+
+# -- Extra volumes
+extraVolumes: []
+
+# -- Extra volume mounts
+extraVolumeMounts: []
+
+# =============================================================================
+# Workload
+# =============================================================================
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 90
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 5
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 15
+  timeoutSeconds: 10
+  failureThreshold: 12
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 90
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 60
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 120
+
+# =============================================================================
+# Persistence
+# =============================================================================
+persistence:
+  # -- Persist /usr/share/kibana/data
+  enabled: false
+  # -- Existing PVC name
+  existingClaim: ""
+  # -- Storage class name
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- PVC size
+  size: 10Gi
+  annotations: {}
+
+# =============================================================================
+# Service
+# =============================================================================
+service:
+  type: ClusterIP
+  port: 5601
+  targetPort: http
+  annotations: {}
+  # -- Set the ipFamilyPolicy for dual-stack clusters
+  ipFamilyPolicy: ~
+  # -- Set the ipFamilies for dual-stack clusters
+  ipFamilies: []
+
+# =============================================================================
+# Ingress
+# =============================================================================
+ingress:
+  enabled: false
+  ingressClassName: traefik
+  annotations: {}
+  hosts:
+    - host: kibana.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+gateway:
+  enabled: false
+  hostnames: []
+  parentRefs: []
+  # -- Skip the live CRD presence check when CRDs are managed externally
+  skipCRDCheck: false
+
+# =============================================================================
+# Service Account
+# =============================================================================
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+# =============================================================================
+# Pod Disruption Budget
+# =============================================================================
+pdb:
+  enabled: true
+  minAvailable: 1
+  maxUnavailable: ""
+
+# =============================================================================
+# Network Policy
+# =============================================================================
+networkPolicy:
+  enabled: false
+  ingress:
+    allowSameNamespace: true
+    namespaceSelectors: []
+    podSelectors: []
+    ipBlocks: []
+    extraFrom: []
+  egress:
+    enabled: true
+    allowDns: true
+    elasticsearch:
+      enabled: true
+      ports:
+        - 9200
+      namespaceSelectors: []
+      podSelectors: []
+      ipBlocks: []
+    extra: []
+
+# =============================================================================
+# Prometheus Operator
+# =============================================================================
+serviceMonitor:
+  # -- Create a ServiceMonitor for deployments that expose Prometheus-compatible Kibana metrics
+  enabled: false
+  namespace: ""
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /metrics
+  labels: {}
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+externalSecrets:
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "0"
+  secretStoreRef:
+    name: ""
+    kind: ClusterSecretStore
+  target:
+    creationPolicy: Owner
+  data: []
+  # -- Skip the live CRD presence check when CRDs are managed externally
+  skipCRDCheck: false
+
+# =============================================================================
+# Helm Test
+# =============================================================================
+test:
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37.0"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -76,6 +76,28 @@ elasticsearch:
     # -- Secret key containing the CA certificate
     certificateAuthoritiesKey: ca.crt
 
+bundledElasticsearch:
+  # -- Enable the HelmForge Elasticsearch subchart for local/dev deployments.
+  # Keep disabled when connecting to an existing Elasticsearch service.
+  enabled: false
+
+bundled-elasticsearch:
+  # -- Values passed to the aliased HelmForge Elasticsearch subchart.
+  clusterProfile: dev
+  image:
+    # -- Keep bundled Elasticsearch aligned with the Kibana appVersion.
+    tag: "9.4.2"
+  # -- Disable nested Kibana from the Elasticsearch chart.
+  kibana:
+    enabled: false
+  # -- Keep the subchart lightweight by default when enabled for local tests.
+  master:
+    persistence:
+      enabled: false
+  sysctlInit:
+    enabled: false
+  resources: {}
+
 # =============================================================================
 # Kibana Configuration
 # =============================================================================
@@ -120,6 +142,32 @@ extraVolumes: []
 
 # -- Extra volume mounts
 extraVolumeMounts: []
+
+# -- Wait for the first configured Elasticsearch endpoint before starting Kibana
+waitForElasticsearch:
+  enabled: false
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37.0"
+    pullPolicy: IfNotPresent
+  timeoutSeconds: 300
+  intervalSeconds: 5
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
 
 # =============================================================================
 # Workload
@@ -297,7 +345,10 @@ externalSecrets:
     kind: ClusterSecretStore
   target:
     creationPolicy: Owner
+  # -- ExternalSecret data entries for individual Kibana secret keys.
   data: []
+  # -- ExternalSecret dataFrom entries for provider-side extraction.
+  dataFrom: []
   # -- Skip the live CRD presence check when CRDs are managed externally
   skipCRDCheck: false
 


### PR DESCRIPTION
Resolves #365

## Summary
- Align Kibana with HelmForge chart standards: `DESIGN.md`, docs, examples, expanded NOTES, commented defaults, and focused Helm unittest coverage.
- Add optional HelmForge Elasticsearch dependency via `bundledElasticsearch.enabled` using the `bundled-elasticsearch` alias, with runtime version aligned to Kibana `9.4.2`.
- Add ExternalSecret `dataFrom`, stricter ExternalSecret validation, security profile hardening, and optional `waitForElasticsearch` init container for clean bundled deployments.

## Local Validation Evidence
- [x] `helm dependency build charts/kibana`
- [x] `helm dependency list charts/kibana` (`elasticsearch` 1.0.6 from `oci://ghcr.io/helmforgedev/helm`, status `ok`)
- [x] `helm lint --strict charts/kibana`
- [x] `helm unittest charts/kibana` (3 suites, 20 tests)
- [x] `npx -y markdownlint-cli2 "charts/kibana/README.md" "charts/kibana/DESIGN.md" "charts/kibana/docs/*.md"`
- [x] `ah lint charts/kibana` (66 packages, 0 errors)
- [x] `kubeconform -strict -summary` for default, ingress, Gateway API, ExternalSecret, dual-stack, security, network-policy, ServiceMonitor, persistence, Wolfi, and k3d bundled-Elasticsearch renders
- [x] `kubescape scan framework nsa` on security render: 20/20 controls passed, 100.00% score

## k3d Runtime Evidence
- Cluster: `k3d-helmforge-tests-wsl`
- Namespace: `hf-kibana-standard`
- Installed with `charts/kibana/ci/k3d-values.yaml` + `charts/kibana/ci/bundled-elasticsearch-values.yaml` and `--dependency-update --wait --timeout 20m`.
- HelmForge Elasticsearch subchart deployed as `kibana-ci-bundled-elasticsearch` with image `docker.io/library/elasticsearch:9.4.2`.
- `helm test kibana-ci -n hf-kibana-standard --logs`: Succeeded.
- Smoke test verified Kibana `/api/status` reports `Elasticsearch is available` and Elasticsearch reports version `9.4.2`.
- Pods Ready `1/1`, restarts `0`.
- Warning events: none.
- Error-level log scan: no `ERROR`, `FATAL`, `panic`, or `traceback` in Kibana or Elasticsearch logs.
- Cleanup: namespace `hf-kibana-standard` deleted and verified absent.

## Documentation Sources
- Context7 Elastic/Kibana docs confirmed static encryption keys and Docker Chromium sandbox setting.
- Elastic docs confirm `xpack.fleet.agents.enabled` and Fleet defaults; no unsupported Fleet overrides were added.