### PR TITLE
feat(jenkins): add Jenkins chart

### DIFF
--- a/charts/jenkins/.helmignore
+++ b/charts/jenkins/.helmignore
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+
+# Lock files
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: jenkins
+description: Jenkins Helm Chart with secure controller defaults, JCasC, plugin bootstrap, Gateway API, and Kubernetes agent RBAC
+type: application
+version: 1.0.0
+appVersion: "2.555.2"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - jenkins
+  - ci
+  - cd
+  - automation
+  - devops
+  - pipeline
+  - jcasc
+  - kubernetes
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/jenkinsci/jenkins
+  - https://github.com/jenkinsci/docker
+  - https://github.com/jenkinsci/helm-charts
+icon: https://www.jenkins.io/images/logos/jenkins/jenkins.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add Jenkins chart with JCasC, plugin bootstrap, Gateway API, dual-stack, NetworkPolicy, ExternalSecret, and ServiceMonitor support"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://www.jenkins.io
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/jenkins
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/jenkins
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/gitea

--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/jenkinsci/jenkins
   - https://github.com/jenkinsci/docker
   - https://github.com/jenkinsci/helm-charts
-icon: https://www.jenkins.io/images/logos/jenkins/jenkins.png
+icon: https://helmforge.dev/icons/charts/jenkins.png
 annotations:
   artifacthub.io/changes: |
     - kind: added

--- a/charts/jenkins/DESIGN.md
+++ b/charts/jenkins/DESIGN.md
@@ -1,0 +1,76 @@
+# Jenkins Chart Design
+
+## Scope
+
+This chart deploys a single Jenkins controller with persistent `JENKINS_HOME`,
+optional Configuration as Code, optional plugin bootstrap, and Kubernetes
+networking integrations.
+
+Jenkins controller high availability is intentionally out of scope because the
+standard Jenkins controller is stateful and single-writer. Production resilience
+comes from persistence, backups, upgrade discipline, and externalized
+configuration.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[Users] --> svc[Jenkins Service]
+  svc --> sts[Controller StatefulSet]
+  sts --> pvc[(JENKINS_HOME PVC)]
+  cfg[ConfigMap: init, JCasC, plugins] --> sts
+  secret[Admin Secret] --> sts
+  eso[External Secrets Operator optional] -. materializes .-> secret
+  agents[Kubernetes agents optional] --> svc
+```
+
+Optional integrations:
+
+- Ingress and Gateway API HTTPRoute
+- NetworkPolicy boundaries
+- ExternalSecret for admin credentials
+- ServiceMonitor for Jenkins Prometheus plugin endpoints
+- RBAC for Kubernetes agent workflows
+
+## Main Design Choices
+
+- Use the official `jenkins/jenkins` LTS image with Java 21.
+- Use a StatefulSet so the controller has stable storage identity.
+- Keep replica count fixed at one.
+- Support initial admin bootstrapping while allowing externally managed
+  credentials.
+- Keep plugin bootstrap opt-in because plugin resolution performs network I/O
+  and changes startup time.
+- Support JCasC as mounted ConfigMap snippets, but do not force the plugin.
+- Render External Secrets Operator resources only when requested.
+
+## Production Boundary
+
+Production users should configure persistence, backups, explicit admin
+credentials, plugin pinning, JCasC, resource sizing, network policy, and a
+controlled upgrade process.
+
+## Explicit Non-Goals
+
+- active-active Jenkins controller HA
+- bundled backup controller
+- automatic plugin upgrade policy
+- installing the Kubernetes plugin by default
+- managing build agents outside Jenkins configuration
+- installing ingress, Gateway, Prometheus, or External Secrets operators
+
+<!-- @AI-METADATA
+type: design
+title: Jenkins Chart Design
+description: Design document for the Jenkins Helm chart
+keywords: jenkins, ci, cd, statefulset, jcasc, plugins
+purpose: Document chart architecture, decisions, and production boundaries
+scope: Chart Design
+relations:
+  - charts/jenkins/README.md
+  - charts/jenkins/docs/production.md
+  - charts/jenkins/docs/jcasc-and-plugins.md
+path: charts/jenkins/DESIGN.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -1,0 +1,58 @@
+# Jenkins
+
+Jenkins is an open source automation server for continuous integration and delivery.
+
+This HelmForge chart deploys the official `jenkins/jenkins` controller image with production-oriented Kubernetes defaults.
+It includes a StatefulSet controller, persistent Jenkins home, secure initial admin bootstrap, optional Jenkins Configuration as Code,
+optional plugin installation with `jenkins-plugin-cli`, optional RBAC for Kubernetes agents, dual-stack Service support,
+Gateway API, Ingress, NetworkPolicy, ExternalSecret, ServiceMonitor, PodDisruptionBudget, and Helm tests.
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm install jenkins helmforge/jenkins
+```
+
+## Admin Credentials
+
+By default the chart creates an initial admin user and stores the generated password in a Kubernetes Secret:
+
+```bash
+kubectl get secret jenkins-admin -o jsonpath='{.data.jenkins-admin-password}' | base64 -d
+```
+
+Use `admin.existingSecret` with `admin.existingSecretUserKey` and `admin.existingSecretPasswordKey` to manage credentials externally.
+
+## Plugins and JCasC
+
+The chart can install pinned plugins before Jenkins starts:
+
+```yaml
+plugins:
+  install:
+    enabled: true
+    initializeOnce: true
+    list:
+      - kubernetes:4423.vb_59f230b_ce53
+      - workflow-aggregator:608.v67378e9d3db_1
+      - git:5.10.1
+      - configuration-as-code:2074.va_57f83f7a_10b_
+```
+
+JCasC files can be mounted and activated with `jcasC.enabled=true`. The `configuration-as-code` plugin must be included in the image or installed through the plugin bootstrap.
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+  hostnames:
+    - jenkins.example.com
+```
+
+## Validation
+
+This chart is tested with Helm lint, strict lint, Helm unittest, kubeconform, Artifact Hub lint, markdown lint, security scans, and k3d runtime validation.

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -2,10 +2,13 @@
 
 Jenkins is an open source automation server for continuous integration and delivery.
 
-This HelmForge chart deploys the official `jenkins/jenkins` controller image with production-oriented Kubernetes defaults.
-It includes a StatefulSet controller, persistent Jenkins home, secure initial admin bootstrap, optional Jenkins Configuration as Code,
-optional plugin installation with `jenkins-plugin-cli`, optional RBAC for Kubernetes agents, dual-stack Service support,
-Gateway API, Ingress, NetworkPolicy, ExternalSecret, ServiceMonitor, PodDisruptionBudget, and Helm tests.
+This HelmForge chart deploys the official `jenkins/jenkins` controller image
+with production-oriented Kubernetes defaults. It includes a StatefulSet
+controller, persistent Jenkins home, secure initial admin bootstrap, optional
+Jenkins Configuration as Code, optional plugin installation with
+`jenkins-plugin-cli`, optional RBAC for Kubernetes agents, dual-stack Service
+support, Gateway API, Ingress, NetworkPolicy, ExternalSecret, ServiceMonitor,
+PodDisruptionBudget, and Helm tests.
 
 ## Install
 
@@ -22,7 +25,8 @@ By default the chart creates an initial admin user and stores the generated pass
 kubectl get secret jenkins-admin -o jsonpath='{.data.jenkins-admin-password}' | base64 -d
 ```
 
-Use `admin.existingSecret` with `admin.existingSecretUserKey` and `admin.existingSecretPasswordKey` to manage credentials externally.
+Use `admin.existingSecret` with `admin.existingSecretUserKey` and
+`admin.existingSecretPasswordKey` to manage credentials externally.
 
 ## Plugins and JCasC
 
@@ -40,7 +44,22 @@ plugins:
       - configuration-as-code:2074.va_57f83f7a_10b_
 ```
 
-JCasC files can be mounted and activated with `jcasC.enabled=true`. The `configuration-as-code` plugin must be included in the image or installed through the plugin bootstrap.
+JCasC files can be mounted and activated with `jcasC.enabled=true`. The
+`configuration-as-code` plugin must be included in the image or installed
+through the plugin bootstrap.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: jenkins.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
 
 ## Gateway API
 
@@ -55,4 +74,13 @@ gateway:
 
 ## Validation
 
-This chart is tested with Helm lint, strict lint, Helm unittest, kubeconform, Artifact Hub lint, markdown lint, security scans, and k3d runtime validation.
+This chart is tested with Helm lint, strict lint, Helm unittest, kubeconform,
+Artifact Hub lint, markdown lint, security scans, and k3d runtime validation.
+
+## Documentation
+
+- [Design](./DESIGN.md)
+- [Production guide](./docs/production.md)
+- [Networking](./docs/networking.md)
+- [External Secrets](./docs/external-secrets.md)
+- [JCasC and plugins](./docs/jcasc-and-plugins.md)

--- a/charts/jenkins/ci/default-values.yaml
+++ b/charts/jenkins/ci/default-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false

--- a/charts/jenkins/ci/dual-stack-values.yaml
+++ b/charts/jenkins/ci/dual-stack-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/jenkins/ci/external-secrets-values.yaml
+++ b/charts/jenkins/ci/external-secrets-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+admin:
+  existingSecret: jenkins-admin-managed
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: jenkins-admin-user
+      remoteRef:
+        key: jenkins/admin
+        property: username
+    - secretKey: jenkins-admin-password
+      remoteRef:
+        key: jenkins/admin
+        property: password

--- a/charts/jenkins/ci/gateway-api-values.yaml
+++ b/charts/jenkins/ci/gateway-api-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - jenkins.example.local

--- a/charts/jenkins/ci/ingress-values.yaml
+++ b/charts/jenkins/ci/ingress-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: jenkins.example.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/jenkins/ci/ingress-values.yaml
+++ b/charts/jenkins/ci/ingress-values.yaml
@@ -3,7 +3,7 @@ persistence:
   enabled: false
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   hosts:
     - host: jenkins.example.local
       paths:

--- a/charts/jenkins/ci/k3d-values.yaml
+++ b/charts/jenkins/ci/k3d-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+admin:
+  password: helmforge-k3d-admin
+resources:
+  requests:
+    cpu: 100m
+    memory: 768Mi
+  limits:
+    cpu: "1"
+    memory: 2Gi
+startupProbe:
+  initialDelaySeconds: 60
+  failureThreshold: 90
+livenessProbe:
+  initialDelaySeconds: 180
+readinessProbe:
+  initialDelaySeconds: 60

--- a/charts/jenkins/ci/network-policy-values.yaml
+++ b/charts/jenkins/ci/network-policy-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+networkPolicy:
+  enabled: true
+  ingress:
+    namespaceSelector:
+      kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    allowDns: true
+    allowInternet: true

--- a/charts/jenkins/ci/persistence-values.yaml
+++ b/charts/jenkins/ci/persistence-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: true
+  size: 1Gi

--- a/charts/jenkins/ci/security-values.yaml
+++ b/charts/jenkins/ci/security-values.yaml
@@ -2,8 +2,15 @@
 persistence:
   enabled: false
 rbac:
-  create: true
-  readSecrets: true
+  create: false
+  readSecrets: false
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowCluster: true
+    allowDns: true
+    allowInternet: false
 pdb:
   enabled: true
 plugins:

--- a/charts/jenkins/ci/security-values.yaml
+++ b/charts/jenkins/ci/security-values.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+rbac:
+  create: true
+  readSecrets: true
+pdb:
+  enabled: true
+plugins:
+  install:
+    enabled: true
+jcasC:
+  enabled: true
+  configScripts:
+    welcome: |
+      jenkins:
+        systemMessage: "Managed by HelmForge"

--- a/charts/jenkins/ci/servicemonitor-values.yaml
+++ b/charts/jenkins/ci/servicemonitor-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false
+metrics:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus

--- a/charts/jenkins/docs/external-secrets.md
+++ b/charts/jenkins/docs/external-secrets.md
@@ -1,0 +1,36 @@
+# Jenkins External Secrets
+
+The chart can render an ExternalSecret for the Jenkins initial admin Secret.
+Set `admin.existingSecret` so the workload and ExternalSecret agree on the
+same target Secret.
+
+```yaml
+admin:
+  existingSecret: jenkins-admin
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: jenkins-admin-user
+      remoteRef:
+        key: jenkins/admin
+        property: username
+    - secretKey: jenkins-admin-password
+      remoteRef:
+        key: jenkins/admin
+        property: password
+```
+
+Use `dataFrom` when your provider can extract all keys from a single remote
+object:
+
+```yaml
+externalSecrets:
+  enabled: true
+  dataFrom:
+    - extract:
+        key: jenkins/admin
+```

--- a/charts/jenkins/docs/jcasc-and-plugins.md
+++ b/charts/jenkins/docs/jcasc-and-plugins.md
@@ -1,0 +1,23 @@
+# Jenkins JCasC And Plugins
+
+JCasC is opt-in because the Configuration as Code plugin must be available in
+the image or installed during plugin bootstrap.
+
+```yaml
+jcasC:
+  enabled: true
+  configScripts:
+    welcome.yaml: |
+      jenkins:
+        systemMessage: "Managed by HelmForge"
+
+plugins:
+  install:
+    enabled: true
+    list:
+      - configuration-as-code:2074.va_57f83f7a_10b_
+      - workflow-aggregator:608.v67378e9d3db_1
+```
+
+For production, pin plugin versions and test plugin upgrades before promoting
+them to the controller.

--- a/charts/jenkins/docs/networking.md
+++ b/charts/jenkins/docs/networking.md
@@ -1,0 +1,49 @@
+# Jenkins Networking
+
+The chart exposes the controller HTTP port and, optionally, the inbound agent
+TCP port on the same Service.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: jenkins.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - jenkins.example.com
+```
+
+## Agents
+
+Disable the inbound agent listener when all builds use web socket agents or
+Kubernetes plugin agents:
+
+```yaml
+agent:
+  enabled: false
+```
+
+## Dual-Stack Service
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```

--- a/charts/jenkins/docs/production.md
+++ b/charts/jenkins/docs/production.md
@@ -1,0 +1,49 @@
+# Jenkins Production Guide
+
+Use explicit values for persistence, credentials, plugin pinning, resources,
+and network boundaries.
+
+```yaml
+persistence:
+  enabled: true
+  size: 100Gi
+
+admin:
+  create: true
+  existingSecret: jenkins-admin
+
+resources:
+  requests:
+    cpu: 1
+    memory: 2Gi
+  limits:
+    cpu: 4
+    memory: 6Gi
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: true
+```
+
+## Credentials
+
+Prefer `admin.existingSecret` or `externalSecrets.enabled=true` for production.
+This avoids chart-generated credentials changing during GitOps reconciliation.
+
+## Plugins
+
+Pin plugin versions in `plugins.install.list`. Avoid `latest=true` in
+production unless upgrades are intentionally tested in a staging environment.
+
+## Operations
+
+After deployment:
+
+```bash
+helm test jenkins -n jenkins
+kubectl get pods -n jenkins -l app.kubernetes.io/name=jenkins
+kubectl logs -n jenkins statefulset/jenkins
+```

--- a/charts/jenkins/examples/external-secrets.yaml
+++ b/charts/jenkins/examples/external-secrets.yaml
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-persistence:
-  enabled: false
 admin:
-  existingSecret: jenkins-admin-managed
+  existingSecret: jenkins-admin
+
 externalSecrets:
   enabled: true
   secretStoreRef:
@@ -17,4 +16,3 @@ externalSecrets:
       remoteRef:
         key: jenkins/admin
         property: password
-  dataFrom: []

--- a/charts/jenkins/examples/gateway.yaml
+++ b/charts/jenkins/examples/gateway.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - jenkins.example.com

--- a/charts/jenkins/examples/jcasc.yaml
+++ b/charts/jenkins/examples/jcasc.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+jcasC:
+  enabled: true
+  configScripts:
+    welcome.yaml: |
+      jenkins:
+        systemMessage: "Managed by HelmForge"
+
+plugins:
+  install:
+    enabled: true
+    list:
+      - configuration-as-code:2074.va_57f83f7a_10b_
+      - workflow-aggregator:608.v67378e9d3db_1

--- a/charts/jenkins/examples/production.yaml
+++ b/charts/jenkins/examples/production.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: true
+  size: 100Gi
+
+admin:
+  existingSecret: jenkins-admin
+
+resources:
+  requests:
+    cpu: 1
+    memory: 2Gi
+  limits:
+    cpu: 4
+    memory: 6Gi
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: true

--- a/charts/jenkins/templates/NOTES.txt
+++ b/charts/jenkins/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Jenkins has been deployed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Service: {{ include "jenkins.fullname" . }}
+
+HTTP endpoint inside the cluster:
+  http://{{ include "jenkins.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.httpPort }}/
+
+{{- if .Values.admin.create }}
+Admin credentials are stored in:
+  kubectl get secret {{ include "jenkins.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.admin.existingSecretPasswordKey }}}' | base64 -d
+{{- end }}

--- a/charts/jenkins/templates/NOTES.txt
+++ b/charts/jenkins/templates/NOTES.txt
@@ -1,13 +1,55 @@
-Jenkins has been deployed.
+=============================================================================
+Jenkins deployed successfully!
+=============================================================================
 
-Release: {{ .Release.Name }}
-Namespace: {{ .Release.Namespace }}
-Service: {{ include "jenkins.fullname" . }}
+ACCESS:
+   kubectl port-forward svc/{{ include "jenkins.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.httpPort }}
+   Open: http://localhost:8080/
 
-HTTP endpoint inside the cluster:
-  http://{{ include "jenkins.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.httpPort }}/
-
-{{- if .Values.admin.create }}
-Admin credentials are stored in:
-  kubectl get secret {{ include "jenkins.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.admin.existingSecretPasswordKey }}}' | base64 -d
+SERVICE:
+   Internal URL: http://{{ include "jenkins.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.httpPort }}/
+{{- if .Values.agent.enabled }}
+   Agent TCP: {{ include "jenkins.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.agent.servicePort }}
 {{- end }}
+
+IMAGE:
+   {{ include "jenkins.image" . }}
+
+ADMIN:
+{{- if .Values.admin.create }}
+   Admin Secret: {{ include "jenkins.adminSecretName" . }}
+   Username:
+     kubectl get secret {{ include "jenkins.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.admin.existingSecretUserKey }}}' | base64 -d
+   Password:
+     kubectl get secret {{ include "jenkins.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.admin.existingSecretPasswordKey }}}' | base64 -d
+{{- else }}
+   Admin bootstrap: disabled
+{{- end }}
+
+CONFIGURATION:
+   JCasC: {{ ternary "enabled" "disabled" .Values.jcasC.enabled }}
+   Plugin bootstrap: {{ ternary "enabled" "disabled" .Values.plugins.install.enabled }}
+   Persistence: {{ ternary "enabled" "disabled" .Values.persistence.enabled }}
+
+NETWORKING:
+   Ingress: {{ ternary "enabled" "disabled" .Values.ingress.enabled }}
+   Gateway API: {{ ternary "enabled" "disabled" .Values.gateway.enabled }}
+   NetworkPolicy: {{ ternary "enabled" "disabled" .Values.networkPolicy.enabled }}
+
+OBSERVABILITY:
+   ServiceMonitor: {{ ternary "enabled" "disabled" .Values.metrics.serviceMonitor.enabled }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} statefulset/{{ include "jenkins.fullname" . }}
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/jenkins
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/jenkins
+   Jenkins: https://www.jenkins.io
+
+=============================================================================

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -87,3 +87,12 @@ app.kubernetes.io/part-of: helmforge
 {{- printf "%s %s" (.Values.controller.jenkinsOpts | default "") $httpPortArg | trim -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "jenkins.javaOpts" -}}
+{{- $javaOpts := .Values.controller.javaOpts | default "" -}}
+{{- if and .Values.admin.create (not (contains "jenkins.install.runSetupWizard" $javaOpts)) -}}
+{{- printf "%s -Djenkins.install.runSetupWizard=false" $javaOpts | trim -}}
+{{- else -}}
+{{- $javaOpts -}}
+{{- end -}}
+{{- end -}}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -78,3 +78,12 @@ app.kubernetes.io/part-of: helmforge
 {{- define "jenkins.image" -}}
 {{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
 {{- end -}}
+
+{{- define "jenkins.controllerOpts" -}}
+{{- $httpPortArg := printf "--httpPort=%v" .Values.controller.httpPort -}}
+{{- if contains "--httpPort" (.Values.controller.jenkinsOpts | default "") -}}
+{{- .Values.controller.jenkinsOpts -}}
+{{- else -}}
+{{- printf "%s %s" (.Values.controller.jenkinsOpts | default "") $httpPortArg | trim -}}
+{{- end -}}
+{{- end -}}

--- a/charts/jenkins/templates/_helpers.tpl
+++ b/charts/jenkins/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "jenkins.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jenkins.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jenkins.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jenkins.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jenkins.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "jenkins.labels" -}}
+helm.sh/chart: {{ include "jenkins.chart" . }}
+{{ include "jenkins.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jenkins.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "jenkins.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "jenkins.adminSecretName" -}}
+{{- if .Values.admin.existingSecret -}}
+{{- .Values.admin.existingSecret -}}
+{{- else -}}
+{{- printf "%s-admin" (include "jenkins.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jenkins.configMapName" -}}
+{{- printf "%s-config" (include "jenkins.fullname" .) -}}
+{{- end -}}
+
+{{- define "jenkins.adminUser" -}}
+{{- default "admin" .Values.admin.user -}}
+{{- end -}}
+
+{{- define "jenkins.adminPassword" -}}
+{{- if .Values.admin.password -}}
+{{- .Values.admin.password -}}
+{{- else if .Values.admin.existingSecret -}}
+{{- "" -}}
+{{- else -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace (include "jenkins.adminSecretName" .) -}}
+{{- if and $secret $secret.data (hasKey $secret.data .Values.admin.existingSecretPasswordKey) -}}
+{{- index $secret.data .Values.admin.existingSecretPasswordKey | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jenkins.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/charts/jenkins/templates/configmap.yaml
+++ b/charts/jenkins/templates/configmap.yaml
@@ -20,11 +20,13 @@ data:
     if (password) {
       def existingRealm = instance.getSecurityRealm()
       def realm = null
+      def createdRealm = false
       if (existingRealm instanceof HudsonPrivateSecurityRealm) {
         realm = existingRealm
       } else if (!instance.isUseSecurity()) {
         realm = new HudsonPrivateSecurityRealm(false)
         instance.setSecurityRealm(realm)
+        createdRealm = true
       } else {
         println("Existing non-local security realm detected; skipping HelmForge admin bootstrap")
         return
@@ -34,9 +36,13 @@ data:
         realm.createAccount(user, password)
       }
 
-      def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
-      strategy.setAllowAnonymousRead(false)
-      instance.setAuthorizationStrategy(strategy)
+      if (createdRealm || !instance.isUseSecurity()) {
+        def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+        strategy.setAllowAnonymousRead(false)
+        instance.setAuthorizationStrategy(strategy)
+      } else {
+        println("Existing authorization strategy detected; preserving configured permissions")
+      }
       instance.save()
     }
   {{- end }}

--- a/charts/jenkins/templates/configmap.yaml
+++ b/charts/jenkins/templates/configmap.yaml
@@ -18,11 +18,21 @@ data:
     def password = System.getenv('JENKINS_ADMIN_PASSWORD')
 
     if (password) {
-      def realm = new HudsonPrivateSecurityRealm(false)
+      def existingRealm = instance.getSecurityRealm()
+      def realm = null
+      if (existingRealm instanceof HudsonPrivateSecurityRealm) {
+        realm = existingRealm
+      } else if (!instance.isUseSecurity()) {
+        realm = new HudsonPrivateSecurityRealm(false)
+        instance.setSecurityRealm(realm)
+      } else {
+        println("Existing non-local security realm detected; skipping HelmForge admin bootstrap")
+        return
+      }
+
       if (realm.getUser(user) == null) {
         realm.createAccount(user, password)
       }
-      instance.setSecurityRealm(realm)
 
       def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
       strategy.setAllowAnonymousRead(false)

--- a/charts/jenkins/templates/configmap.yaml
+++ b/charts/jenkins/templates/configmap.yaml
@@ -1,0 +1,45 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or .Values.admin.create .Values.jcasC.enabled .Values.plugins.install.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jenkins.configMapName" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+data:
+  {{- if .Values.admin.create }}
+  00-basic-security.groovy: |
+    import jenkins.model.Jenkins
+    import hudson.security.HudsonPrivateSecurityRealm
+    import hudson.security.FullControlOnceLoggedInAuthorizationStrategy
+
+    def instance = Jenkins.get()
+    def user = System.getenv('JENKINS_ADMIN_USER') ?: 'admin'
+    def password = System.getenv('JENKINS_ADMIN_PASSWORD')
+
+    if (password) {
+      def realm = new HudsonPrivateSecurityRealm(false)
+      if (realm.getUser(user) == null) {
+        realm.createAccount(user, password)
+      }
+      instance.setSecurityRealm(realm)
+
+      def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+      strategy.setAllowAnonymousRead(false)
+      instance.setAuthorizationStrategy(strategy)
+      instance.save()
+    }
+  {{- end }}
+  {{- if .Values.plugins.install.enabled }}
+  plugins.txt: |
+    {{- range .Values.plugins.install.list }}
+    {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.jcasC.enabled }}
+  {{- range $name, $content := .Values.jcasC.configScripts }}
+  {{ $name }}.yaml: |
+{{ $content | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/jenkins/templates/externalsecret.yaml
+++ b/charts/jenkins/templates/externalsecret.yaml
@@ -3,8 +3,10 @@
 {{- if not .Values.admin.existingSecret }}
   {{- fail "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
 {{- end }}
-{{- if not .Values.externalSecrets.data }}
-  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- $externalSecretData := .Values.externalSecrets.data | default list -}}
+{{- $externalSecretDataFrom := .Values.externalSecrets.dataFrom | default list -}}
+{{- if eq (add (len $externalSecretData) (len $externalSecretDataFrom)) 0 }}
+  {{- fail "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true" }}
 {{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
@@ -20,6 +22,12 @@ spec:
   target:
     name: {{ .Values.admin.existingSecret | quote }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  {{- if $externalSecretData }}
   data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+    {{- toYaml $externalSecretData | nindent 4 }}
+  {{- end }}
+  {{- if $externalSecretDataFrom }}
+  dataFrom:
+    {{- toYaml $externalSecretDataFrom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/jenkins/templates/externalsecret.yaml
+++ b/charts/jenkins/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- if not .Values.admin.existingSecret }}
+  {{- fail "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "jenkins.fullname" . }}-admin
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.admin.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/jenkins/templates/extra-manifests.yaml
+++ b/charts/jenkins/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/jenkins/templates/httproute.yaml
+++ b/charts/jenkins/templates/httproute.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+apiVersion: {{ .Values.gateway.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "jenkins.fullname" $ }}
+          port: {{ $.Values.service.httpPort }}
+    {{- end }}
+{{- end }}

--- a/charts/jenkins/templates/ingress.yaml
+++ b/charts/jenkins/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "jenkins.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/jenkins/templates/ingress.yaml
+++ b/charts/jenkins/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . | quote }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/charts/jenkins/templates/networkpolicy.yaml
+++ b/charts/jenkins/templates/networkpolicy.yaml
@@ -13,7 +13,9 @@ spec:
       app.kubernetes.io/component: controller
   policyTypes:
     - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
     - Egress
+    {{- end }}
   {{- if .Values.networkPolicy.ingress.enabled }}
   ingress:
     - from:
@@ -39,6 +41,7 @@ spec:
   {{- else }}
   ingress: []
   {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
   egress:
     {{- if .Values.networkPolicy.egress.allowCluster }}
     - to:
@@ -61,4 +64,5 @@ spec:
     {{- with .Values.networkPolicy.egress.extraRules }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/jenkins/templates/networkpolicy.yaml
+++ b/charts/jenkins/templates/networkpolicy.yaml
@@ -1,0 +1,64 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "jenkins.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.ingress.enabled }}
+  ingress:
+    - from:
+        - {{- if .Values.networkPolicy.ingress.namespaceSelector }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingress.namespaceSelector | nindent 14 }}
+          {{- end }}
+          podSelector:
+            {{- if .Values.networkPolicy.ingress.podSelector }}
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingress.podSelector | nindent 14 }}
+            {{- else }}
+            {}
+            {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.controller.httpPort }}
+        {{- if .Values.agent.enabled }}
+        - protocol: TCP
+          port: {{ .Values.controller.agentPort }}
+        {{- end }}
+  {{- else }}
+  ingress: []
+  {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowCluster }}
+    - to:
+        - namespaceSelector: {}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowDns }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowInternet }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/jenkins/templates/pdb.yaml
+++ b/charts/jenkins/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "jenkins.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+{{- end }}

--- a/charts/jenkins/templates/rbac.yaml
+++ b/charts/jenkins/templates/rbac.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec", "pods/log", "services", "configmaps", "events", "persistentvolumeclaims"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  {{- if .Values.rbac.readSecrets }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "jenkins.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "jenkins.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/jenkins/templates/secret.yaml
+++ b/charts/jenkins/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.admin.create (not .Values.admin.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "jenkins.adminSecretName" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.admin.existingSecretUserKey }}: {{ include "jenkins.adminUser" . | quote }}
+  {{ .Values.admin.existingSecretPasswordKey }}: {{ include "jenkins.adminPassword" . | quote }}
+{{- end }}

--- a/charts/jenkins/templates/service.yaml
+++ b/charts/jenkins/templates/service.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      targetPort: http
+    {{- if .Values.agent.enabled }}
+    - name: agent
+      port: {{ .Values.agent.servicePort }}
+      targetPort: agent
+    {{- end }}
+  selector:
+    {{- include "jenkins.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: controller

--- a/charts/jenkins/templates/serviceaccount.yaml
+++ b/charts/jenkins/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jenkins.serviceAccountName" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/jenkins/templates/servicemonitor.yaml
+++ b/charts/jenkins/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http
+      path: {{ .Values.metrics.serviceMonitor.path }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+  selector:
+    matchLabels:
+      {{- include "jenkins.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/jenkins/templates/statefulset.yaml
+++ b/charts/jenkins/templates/statefulset.yaml
@@ -1,0 +1,194 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "jenkins.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jenkins.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+  template:
+    metadata:
+      labels:
+        {{- include "jenkins.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "jenkins.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.plugins.install.enabled }}
+      initContainers:
+        - name: install-plugins
+          image: {{ include "jenkins.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              if [ "{{ .Values.plugins.install.initializeOnce }}" = "true" ] && [ -f /var/jenkins_home/.helmforge-plugins-initialized ]; then
+                echo "Plugin initialization already completed"
+                exit 0
+              fi
+              jenkins-plugin-cli \
+                --plugin-file /opt/helmforge/plugins/plugins.txt \
+                --plugin-download-directory /var/jenkins_home/plugins \
+                --latest {{ .Values.plugins.install.latest }} \
+                --latest-specified {{ .Values.plugins.install.latestSpecified }}
+              touch /var/jenkins_home/.helmforge-plugins-initialized
+          volumeMounts:
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
+            - name: config
+              mountPath: /opt/helmforge/plugins
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: jenkins
+          image: {{ include "jenkins.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.controller.httpPort }}
+            {{- if .Values.agent.enabled }}
+            - name: agent
+              containerPort: {{ .Values.controller.agentPort }}
+            {{- end }}
+          env:
+            - name: JENKINS_OPTS
+              value: {{ .Values.controller.jenkinsOpts | quote }}
+            - name: JAVA_OPTS
+              value: {{ .Values.controller.javaOpts | quote }}
+            {{- if .Values.agent.enabled }}
+            - name: JENKINS_SLAVE_AGENT_PORT
+              value: {{ .Values.controller.agentPort | quote }}
+            {{- end }}
+            {{- if .Values.admin.create }}
+            - name: JENKINS_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jenkins.adminSecretName" . }}
+                  key: {{ .Values.admin.existingSecretUserKey }}
+            - name: JENKINS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jenkins.adminSecretName" . }}
+                  key: {{ .Values.admin.existingSecretPasswordKey }}
+            {{- end }}
+            {{- if .Values.jcasC.enabled }}
+            - name: CASC_JENKINS_CONFIG
+              value: {{ .Values.jcasC.folder | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /login
+              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /login
+              port: http
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
+            {{- if .Values.admin.create }}
+            - name: config
+              mountPath: /usr/share/jenkins/ref/init.groovy.d/00-basic-security.groovy
+              subPath: 00-basic-security.groovy
+            {{- end }}
+            {{- if .Values.jcasC.enabled }}
+            - name: config
+              mountPath: {{ .Values.jcasC.folder }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+        {{- if not .Values.persistence.enabled }}
+        - name: jenkins-home
+          emptyDir: {}
+        {{- end }}
+        {{- if or .Values.admin.create .Values.jcasC.enabled .Values.plugins.install.enabled }}
+        - name: config
+          configMap:
+            name: {{ include "jenkins.configMapName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: jenkins-home
+        labels:
+          {{- include "jenkins.selectorLabels" . | nindent 10 }}
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/charts/jenkins/templates/statefulset.yaml
+++ b/charts/jenkins/templates/statefulset.yaml
@@ -85,10 +85,8 @@ spec:
               value: {{ include "jenkins.controllerOpts" . | quote }}
             - name: JAVA_OPTS
               value: {{ .Values.controller.javaOpts | quote }}
-            {{- if .Values.agent.enabled }}
             - name: JENKINS_SLAVE_AGENT_PORT
-              value: {{ .Values.controller.agentPort | quote }}
-            {{- end }}
+              value: {{ ternary (.Values.controller.agentPort | toString) "-1" .Values.agent.enabled | quote }}
             {{- if .Values.admin.create }}
             - name: JENKINS_ADMIN_USER
               valueFrom:

--- a/charts/jenkins/templates/statefulset.yaml
+++ b/charts/jenkins/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
             - name: JENKINS_OPTS
               value: {{ include "jenkins.controllerOpts" . | quote }}
             - name: JAVA_OPTS
-              value: {{ .Values.controller.javaOpts | quote }}
+              value: {{ include "jenkins.javaOpts" . | quote }}
             - name: JENKINS_SLAVE_AGENT_PORT
               value: {{ ternary (.Values.controller.agentPort | toString) "-1" .Values.agent.enabled | quote }}
             {{- if .Values.admin.create }}

--- a/charts/jenkins/templates/statefulset.yaml
+++ b/charts/jenkins/templates/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
             {{- end }}
           env:
             - name: JENKINS_OPTS
-              value: {{ .Values.controller.jenkinsOpts | quote }}
+              value: {{ include "jenkins.controllerOpts" . | quote }}
             - name: JAVA_OPTS
               value: {{ .Values.controller.javaOpts | quote }}
             {{- if .Values.agent.enabled }}

--- a/charts/jenkins/templates/statefulset.yaml
+++ b/charts/jenkins/templates/statefulset.yaml
@@ -58,8 +58,8 @@ spec:
               jenkins-plugin-cli \
                 --plugin-file /opt/helmforge/plugins/plugins.txt \
                 --plugin-download-directory /var/jenkins_home/plugins \
-                --latest {{ .Values.plugins.install.latest }} \
-                --latest-specified {{ .Values.plugins.install.latestSpecified }}
+                --latest {{ .Values.plugins.install.latest }}{{- if .Values.plugins.install.latestSpecified }} \
+                --latest-specified{{- end }}
               touch /var/jenkins_home/.helmforge-plugins-initialized
           volumeMounts:
             - name: jenkins-home

--- a/charts/jenkins/templates/tests/test-connection.yaml
+++ b/charts/jenkins/templates/tests/test-connection.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "jenkins.fullname" . }}-test-connection"
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: docker.io/curlimages/curl:8.17.0
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+        - -ec
+        - curl -fsS "http://{{ include "jenkins.fullname" . }}:{{ .Values.service.httpPort }}/login" >/dev/null
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/jenkins/tests/config_test.yaml
+++ b/charts/jenkins/tests/config_test.yaml
@@ -31,3 +31,15 @@ tests:
           path: data["plugins.txt"]
       - exists:
           path: data["welcome.yaml"]
+
+  - it: should preserve existing security realms during admin bootstrap
+    template: configmap.yaml
+    set:
+      admin.create: true
+    asserts:
+      - matchRegex:
+          path: data["00-basic-security.groovy"]
+          pattern: "existingRealm instanceof HudsonPrivateSecurityRealm"
+      - matchRegex:
+          path: data["00-basic-security.groovy"]
+          pattern: "Existing non-local security realm detected"

--- a/charts/jenkins/tests/config_test.yaml
+++ b/charts/jenkins/tests/config_test.yaml
@@ -43,3 +43,6 @@ tests:
       - matchRegex:
           path: data["00-basic-security.groovy"]
           pattern: "Existing non-local security realm detected"
+      - matchRegex:
+          path: data["00-basic-security.groovy"]
+          pattern: "Existing authorization strategy detected"

--- a/charts/jenkins/tests/config_test.yaml
+++ b/charts/jenkins/tests/config_test.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Config
+templates:
+  - configmap.yaml
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should create admin secret by default
+    template: secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-jenkins-admin
+
+  - it: should render JCasC and plugins config
+    template: configmap.yaml
+    set:
+      plugins.install.enabled: true
+      jcasC.enabled: true
+      jcasC.configScripts.welcome: |
+        jenkins:
+          systemMessage: "Managed by HelmForge"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["plugins.txt"]
+      - exists:
+          path: data["welcome.yaml"]

--- a/charts/jenkins/tests/externalsecret_test.yaml
+++ b/charts/jenkins/tests/externalsecret_test.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ExternalSecret with data entries
+    values:
+      - ../ci/external-secrets-values.yaml
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.target.name
+          value: jenkins-admin-managed
+      - contains:
+          path: spec.data
+          content:
+            secretKey: jenkins-admin-password
+            remoteRef:
+              key: jenkins/admin
+              property: password
+
+  - it: should render ExternalSecret with dataFrom entries
+    set:
+      admin.existingSecret: jenkins-admin-managed
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+      externalSecrets.dataFrom[0].extract.key: jenkins/admin
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: jenkins/admin
+
+  - it: should fail when no remote data source is configured
+    set:
+      admin.existingSecret: jenkins-admin-managed
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true"

--- a/charts/jenkins/tests/networkpolicy_test.yaml
+++ b/charts/jenkins/tests/networkpolicy_test.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: NetworkPolicy
+templates:
+  - networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingress-only policy when egress is disabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: false
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - notContains:
+          path: spec.policyTypes
+          content: Egress
+      - notExists:
+          path: spec.egress
+
+  - it: should render egress rules when egress is enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - exists:
+          path: spec.egress

--- a/charts/jenkins/tests/routing_test.yaml
+++ b/charts/jenkins/tests/routing_test.yaml
@@ -11,10 +11,14 @@ tests:
     template: ingress.yaml
     set:
       ingress.enabled: true
+      ingress.ingressClassName: nginx
       ingress.hosts[0].host: jenkins.example.local
     asserts:
       - isKind:
           of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
       - equal:
           path: spec.rules[0].host
           value: jenkins.example.local

--- a/charts/jenkins/tests/routing_test.yaml
+++ b/charts/jenkins/tests/routing_test.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Routing
+templates:
+  - ingress.yaml
+  - httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingress
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.hosts[0].host: jenkins.example.local
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: jenkins.example.local
+
+  - it: should render HTTPRoute
+    template: httproute.yaml
+    set:
+      gateway.enabled: true
+      gateway.parentRefs[0].name: public-gateway
+      gateway.hostnames[0]: jenkins.example.local
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: jenkins.example.local

--- a/charts/jenkins/tests/service_test.yaml
+++ b/charts/jenkins/tests/service_test.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render controller service with http and agent ports
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-jenkins
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 8080
+            targetPort: http
+      - contains:
+          path: spec.ports
+          content:
+            name: agent
+            port: 50000
+            targetPort: agent
+
+  - it: should render dual-stack fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/jenkins/tests/statefulset_test.yaml
+++ b/charts/jenkins/tests/statefulset_test.yaml
@@ -74,6 +74,19 @@ tests:
             name: JENKINS_OPTS
             value: --httpPort=8081
 
+  - it: should disable inbound agent listener when agent service is disabled
+    template: statefulset.yaml
+    set:
+      agent.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].ports[1]
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JENKINS_SLAVE_AGENT_PORT
+            value: "-1"
+
   - it: should not duplicate an explicit HTTP port option
     template: statefulset.yaml
     set:

--- a/charts/jenkins/tests/statefulset_test.yaml
+++ b/charts/jenkins/tests/statefulset_test.yaml
@@ -98,3 +98,34 @@ tests:
           content:
             name: JENKINS_OPTS
             value: --prefix=/jenkins --httpPort=9090
+
+  - it: should disable setup wizard when admin bootstrap is enabled
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: -Djava.awt.headless=true -Djenkins.install.runSetupWizard=false
+
+  - it: should keep setup wizard available when admin bootstrap is disabled
+    template: statefulset.yaml
+    set:
+      admin.create: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: -Djava.awt.headless=true
+
+  - it: should honor explicit setup wizard java option
+    template: statefulset.yaml
+    set:
+      controller.javaOpts: -Djenkins.install.runSetupWizard=true -Djava.awt.headless=true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: -Djenkins.install.runSetupWizard=true -Djava.awt.headless=true

--- a/charts/jenkins/tests/statefulset_test.yaml
+++ b/charts/jenkins/tests/statefulset_test.yaml
@@ -45,3 +45,29 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: install-plugins
+
+  - it: should pass custom HTTP port to Jenkins startup options
+    template: statefulset.yaml
+    set:
+      controller.httpPort: 8081
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8081
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JENKINS_OPTS
+            value: --httpPort=8081
+
+  - it: should not duplicate an explicit HTTP port option
+    template: statefulset.yaml
+    set:
+      controller.httpPort: 8081
+      controller.jenkinsOpts: --prefix=/jenkins --httpPort=9090
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JENKINS_OPTS
+            value: --prefix=/jenkins --httpPort=9090

--- a/charts/jenkins/tests/statefulset_test.yaml
+++ b/charts/jenkins/tests/statefulset_test.yaml
@@ -45,6 +45,20 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: install-plugins
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--latest-specified false"
+
+  - it: should render latest-specified switch only when enabled
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+      plugins.install.enabled: true
+      plugins.install.latestSpecified: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--latest-specified"
 
   - it: should pass custom HTTP port to Jenkins startup options
     template: statefulset.yaml

--- a/charts/jenkins/tests/statefulset_test.yaml
+++ b/charts/jenkins/tests/statefulset_test.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: StatefulSet
+templates:
+  - statefulset.yaml
+  - configmap.yaml
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a secure Jenkins controller StatefulSet
+    template: statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-jenkins
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - exists:
+          path: spec.volumeClaimTemplates[0]
+
+  - it: should use emptyDir when persistence is disabled
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: jenkins-home
+
+  - it: should add plugin init container when plugin install is enabled
+    template: statefulset.yaml
+    set:
+      persistence.enabled: false
+      plugins.install.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: install-plugins

--- a/charts/jenkins/values.schema.json
+++ b/charts/jenkins/values.schema.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Jenkins HelmForge values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "tag", "pullPolicy"],
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 1
+    },
+    "controller": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "httpPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "agentPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "jenkinsOpts": {
+          "type": "string"
+        },
+        "javaOpts": {
+          "type": "string"
+        },
+        "jenkinsUrl": {
+          "type": "string"
+        }
+      }
+    },
+    "admin": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "existingSecretUserKey": {
+          "type": "string",
+          "minLength": 1
+        },
+        "existingSecretPasswordKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "servicePort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "jcasC": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "folder": {
+          "type": "string",
+          "minLength": 1
+        },
+        "configScripts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "plugins": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "install": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "initializeOnce": {
+              "type": "boolean"
+            },
+            "latest": {
+              "type": "boolean"
+            },
+            "latestSpecified": {
+              "type": "boolean"
+            },
+            "list": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Za-z0-9_.-]+(:[A-Za-z0-9_.-]+)?$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+(Mi|Gi|Ti)$"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "httpPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array"
+        },
+        "tls": {
+          "type": "array"
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "parentRefs": {
+          "type": "array"
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "rules": {
+          "type": "array"
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingress": {
+          "type": "object"
+        },
+        "egress": {
+          "type": "object"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "readSecrets": {
+          "type": "boolean"
+        }
+      }
+    },
+    "livenessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "startupProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "interval": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "annotations": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "array"
+    },
+    "extraVolumes": {
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "type": "array"
+    },
+    "extraManifests": {
+      "type": "array"
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "refreshInterval": {
+          "type": "string"
+        },
+        "secretStoreRef": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": ["SecretStore", "ClusterSecretStore"]
+            }
+          }
+        },
+        "target": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "creationPolicy": {
+              "type": "string",
+              "enum": ["Owner", "Merge", "None", "Orphan"]
+            }
+          }
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/charts/jenkins/values.schema.json
+++ b/charts/jenkins/values.schema.json
@@ -222,7 +222,7 @@
         "enabled": {
           "type": "boolean"
         },
-        "className": {
+        "ingressClassName": {
           "type": "string"
         },
         "annotations": {
@@ -447,6 +447,12 @@
           }
         },
         "data": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "dataFrom": {
           "type": "array",
           "items": {
             "type": "object"

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -1,0 +1,265 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Jenkins Helm Chart - Default Values
+# =============================================================================
+
+# -- Override chart name
+nameOverride: ""
+# -- Override full release name
+fullnameOverride: ""
+
+# -- Extra labels applied to all resources
+commonLabels: {}
+
+# =============================================================================
+# Image
+# =============================================================================
+
+image:
+  repository: docker.io/jenkins/jenkins
+  tag: "2.555.2-lts-jdk21"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# =============================================================================
+# Controller
+# =============================================================================
+
+replicaCount: 1
+
+controller:
+  # -- Jenkins HTTP listen port inside the container
+  httpPort: 8080
+  # -- Jenkins inbound agent TCP port. Set agent.enabled=false to disable.
+  agentPort: 50000
+  # -- Jenkins arguments
+  jenkinsOpts: ""
+  # -- JVM options for Jenkins. The setup wizard is disabled because this chart creates the admin account by default.
+  javaOpts: "-Djenkins.install.runSetupWizard=false -Djava.awt.headless=true"
+  # -- Optional root URL exposed through JCasC snippets or plugins
+  jenkinsUrl: ""
+
+admin:
+  # -- Create an initial admin account with an init Groovy script
+  create: true
+  user: admin
+  password: ""
+  existingSecret: ""
+  existingSecretUserKey: jenkins-admin-user
+  existingSecretPasswordKey: jenkins-admin-password
+
+agent:
+  # -- Expose the inbound Jenkins agent TCP port
+  enabled: true
+  servicePort: 50000
+
+# =============================================================================
+# Configuration as Code and Plugins
+# =============================================================================
+
+jcasC:
+  # -- Mount Jenkins Configuration as Code files and set CASC_JENKINS_CONFIG.
+  # The configuration-as-code plugin must be present in the image or installed through plugins.install.
+  enabled: false
+  folder: /var/jenkins_home/casc_configs
+  configScripts: {}
+  # example: |
+  #   jenkins:
+  #     systemMessage: "Managed by HelmForge"
+
+plugins:
+  install:
+    # -- Install plugins with jenkins-plugin-cli before Jenkins starts.
+    enabled: false
+    initializeOnce: true
+    latest: false
+    latestSpecified: false
+    list:
+      - kubernetes:4423.vb_59f230b_ce53
+      - workflow-aggregator:608.v67378e9d3db_1
+      - git:5.10.1
+      - configuration-as-code:2074.va_57f83f7a_10b_
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 8Gi
+  annotations: {}
+
+# =============================================================================
+# Networking
+# =============================================================================
+
+service:
+  type: ClusterIP
+  annotations: {}
+  httpPort: 8080
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: jenkins.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gateway:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1
+  parentRefs: []
+  hostnames: []
+  annotations: {}
+  labels: {}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+networkPolicy:
+  enabled: false
+  ingress:
+    enabled: true
+    namespaceSelector: {}
+    podSelector: {}
+  egress:
+    enabled: true
+    allowCluster: true
+    allowDns: true
+    allowInternet: true
+    extraRules: []
+
+# =============================================================================
+# Service Account and RBAC
+# =============================================================================
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  # -- Create namespaced RBAC for Jenkins Kubernetes agents.
+  create: false
+  readSecrets: false
+
+# =============================================================================
+# Probes
+# =============================================================================
+
+livenessProbe:
+  initialDelaySeconds: 120
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 12
+
+startupProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 60
+
+# =============================================================================
+# Metrics
+# =============================================================================
+
+metrics:
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    path: /prometheus
+    labels: {}
+
+# =============================================================================
+# Scheduling and Security
+# =============================================================================
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 1Gi
+  limits:
+    cpu: "2"
+    memory: 3Gi
+
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+podLabels: {}
+podAnnotations: {}
+annotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 90
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+# =============================================================================
+# Extra
+# =============================================================================
+
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+extraManifests: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret for the Jenkins admin Secret.
+  # Requires admin.existingSecret to be set to prevent credential drift between
+  # the chart-managed admin Secret and the ExternalSecret.
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "0"
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  data: []
+  #   - secretKey: jenkins-admin-password
+  #     remoteRef:
+  #       key: jenkins/admin
+  #       property: password

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -16,16 +16,21 @@ commonLabels: {}
 # =============================================================================
 
 image:
+  # -- Jenkins controller image repository.
   repository: docker.io/jenkins/jenkins
+  # -- Jenkins controller image tag.
   tag: "2.555.2-lts-jdk21"
+  # -- Jenkins controller image pull policy.
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets.
 imagePullSecrets: []
 
 # =============================================================================
 # Controller
 # =============================================================================
 
+# -- Jenkins controller replica count. Jenkins controller is intentionally single-replica.
 replicaCount: 1
 
 controller:
@@ -43,15 +48,21 @@ controller:
 admin:
   # -- Create an initial admin account with an init Groovy script
   create: true
+  # -- Initial admin username.
   user: admin
+  # -- Initial admin password. Empty generates a random password.
   password: ""
+  # -- Existing Secret containing initial admin credentials.
   existingSecret: ""
+  # -- Secret key containing the initial admin username.
   existingSecretUserKey: jenkins-admin-user
+  # -- Secret key containing the initial admin password.
   existingSecretPasswordKey: jenkins-admin-password
 
 agent:
   # -- Expose the inbound Jenkins agent TCP port
   enabled: true
+  # -- Service port for inbound Jenkins agents.
   servicePort: 50000
 
 # =============================================================================
@@ -62,7 +73,9 @@ jcasC:
   # -- Mount Jenkins Configuration as Code files and set CASC_JENKINS_CONFIG.
   # The configuration-as-code plugin must be present in the image or installed through plugins.install.
   enabled: false
+  # -- Folder where JCasC scripts are mounted.
   folder: /var/jenkins_home/casc_configs
+  # -- JCasC configuration scripts rendered into the chart ConfigMap.
   configScripts: {}
   # example: |
   #   jenkins:
@@ -72,9 +85,13 @@ plugins:
   install:
     # -- Install plugins with jenkins-plugin-cli before Jenkins starts.
     enabled: false
+    # -- Skip plugin installation when the marker file already exists.
     initializeOnce: true
+    # -- Pass --latest to jenkins-plugin-cli.
     latest: false
+    # -- Pass --latest-specified to jenkins-plugin-cli.
     latestSpecified: false
+    # -- Plugin coordinates installed by jenkins-plugin-cli.
     list:
       - kubernetes:4423.vb_59f230b_ce53
       - workflow-aggregator:608.v67378e9d3db_1
@@ -86,11 +103,16 @@ plugins:
 # =============================================================================
 
 persistence:
+  # -- Persist JENKINS_HOME.
   enabled: true
+  # -- StorageClass for the Jenkins home PVC. Empty uses the cluster default.
   storageClass: ""
+  # -- Access modes for the Jenkins home PVC.
   accessModes:
     - ReadWriteOnce
+  # -- Jenkins home PVC size.
   size: 8Gi
+  # -- Jenkins home PVC annotations.
   annotations: {}
 
 # =============================================================================
@@ -98,8 +120,11 @@ persistence:
 # =============================================================================
 
 service:
+  # -- Service type.
   type: ClusterIP
+  # -- Service annotations.
   annotations: {}
+  # -- HTTP service port.
   httpPort: 8080
   # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ~
@@ -107,23 +132,35 @@ service:
   ipFamilies: []
 
 ingress:
+  # -- Enable Kubernetes Ingress.
   enabled: false
-  className: ""
+  # -- IngressClass name.
+  ingressClassName: ""
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress host rules.
   hosts:
     - host: jenkins.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
 gateway:
+  # -- Enable Gateway API HTTPRoute.
   enabled: false
+  # -- Gateway API version.
   apiVersion: gateway.networking.k8s.io/v1
+  # -- Gateway parentRefs.
   parentRefs: []
+  # -- HTTPRoute hostnames.
   hostnames: []
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- HTTPRoute labels.
   labels: {}
+  # -- HTTPRoute rules.
   rules:
     - matches:
         - path:
@@ -131,16 +168,25 @@ gateway:
             value: /
 
 networkPolicy:
+  # -- Enable NetworkPolicy resources.
   enabled: false
   ingress:
+    # -- Restrict inbound traffic to selected namespaces and pods.
     enabled: true
+    # -- Namespace selector allowed to reach Jenkins.
     namespaceSelector: {}
+    # -- Pod selector allowed to reach Jenkins.
     podSelector: {}
   egress:
+    # -- Restrict outbound traffic from Jenkins pods.
     enabled: true
+    # -- Allow egress to cluster CIDRs through namespace/pod selectors.
     allowCluster: true
+    # -- Allow DNS egress.
     allowDns: true
+    # -- Allow general internet egress for update centers and plugin downloads.
     allowInternet: true
+    # -- Extra egress rules.
     extraRules: []
 
 # =============================================================================
@@ -148,8 +194,11 @@ networkPolicy:
 # =============================================================================
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: true
+  # -- ServiceAccount name override.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
 
 rbac:
@@ -185,9 +234,13 @@ startupProbe:
 
 metrics:
   serviceMonitor:
+    # -- Render a Prometheus Operator ServiceMonitor.
     enabled: false
+    # -- ServiceMonitor scrape interval.
     interval: 30s
+    # -- Jenkins Prometheus metrics path.
     path: /prometheus
+    # -- Additional ServiceMonitor labels.
     labels: {}
 
 # =============================================================================
@@ -218,28 +271,43 @@ securityContext:
     drop:
       - ALL
 
+# -- Additional pod labels.
 podLabels: {}
+# -- Additional pod annotations.
 podAnnotations: {}
+# -- Additional resource annotations.
 annotations: {}
 
+# -- Node selector.
 nodeSelector: {}
+# -- Pod tolerations.
 tolerations: []
+# -- Pod affinity.
 affinity: {}
+# -- Pod topology spread constraints.
 topologySpreadConstraints: []
+# -- PriorityClass name.
 priorityClassName: ""
+# -- Pod termination grace period.
 terminationGracePeriodSeconds: 90
 
 pdb:
+  # -- Enable PodDisruptionBudget.
   enabled: false
+  # -- Minimum available pods.
   minAvailable: 1
 
 # =============================================================================
 # Extra
 # =============================================================================
 
+# -- Additional environment variables for the Jenkins container.
 extraEnv: []
+# -- Additional pod volumes.
 extraVolumes: []
+# -- Additional Jenkins container volume mounts.
 extraVolumeMounts: []
+# -- Additional manifests rendered verbatim.
 extraManifests: []
 
 # =============================================================================
@@ -257,8 +325,12 @@ externalSecrets:
     name: ""
     kind: SecretStore
   target:
+    # -- ExternalSecret target creation policy.
     creationPolicy: Owner
+  # -- ExternalSecret data entries for individual admin credential keys.
   data: []
+  # -- ExternalSecret dataFrom entries for provider-side extraction.
+  dataFrom: []
   #   - secretKey: jenkins-admin-password
   #     remoteRef:
   #       key: jenkins/admin

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -35,8 +35,8 @@ controller:
   agentPort: 50000
   # -- Jenkins arguments
   jenkinsOpts: ""
-  # -- JVM options for Jenkins. The setup wizard is disabled because this chart creates the admin account by default.
-  javaOpts: "-Djenkins.install.runSetupWizard=false -Djava.awt.headless=true"
+  # -- JVM options for Jenkins. The chart adds the setup-wizard suppression only when admin.create=true.
+  javaOpts: "-Djava.awt.headless=true"
   # -- Optional root URL exposed through JCasC snippets or plugins
   jenkinsUrl: ""
 


### PR DESCRIPTION
## Summary
- Adds a stable Jenkins chart using the official `jenkins/jenkins:2.555.2-lts-jdk21` image.
- Provides secure controller defaults, initial admin bootstrap, optional JCasC, optional pinned plugin installation, Kubernetes-agent RBAC, persistence, Gateway API, Ingress, dual-stack Service, NetworkPolicy, ExternalSecret, ServiceMonitor, PDB, Helm tests, schema and CI value scenarios.
- Uses the official Jenkins logo URL in chart metadata.

## Research
- Jenkins Docker image/changelog checked with Tavily: `2.555.2-lts-jdk21` is available on Docker Hub and Jenkins 2.555.x LTS requires Java 21+.
- Jenkins docs checked with Context7: official image uses `/var/jenkins_home`, supports `JENKINS_SLAVE_AGENT_PORT`, and JCasC uses `CASC_JENKINS_CONFIG`.
- Jenkins Helm chart docs checked with Context7: plugin versions should be pinned, `initializeOnce` avoids plugin drift, and RBAC/service accounts are used for Kubernetes agents.

## Local validation
- `helm dependency build charts/jenkins`: PASS
- `helm dependency list charts/jenkins`: PASS, no dependencies warning only
- `helm lint charts/jenkins`: PASS
- `helm lint --strict charts/jenkins`: PASS
- `helm template test-release charts/jenkins`: PASS
- CI values rendered successfully: `default-values.yaml`, `dual-stack-values.yaml`, `external-secrets-values.yaml`, `gateway-api-values.yaml`, `ingress-values.yaml`, `k3d-values.yaml`, `network-policy-values.yaml`, `persistence-values.yaml`, `security-values.yaml`, `servicemonitor-values.yaml`
- `helm unittest charts/jenkins`: PASS, 4 suites / 9 tests
- `ah lint -p charts/jenkins`: PASS, 1 package, 0 errors
- `npx markdownlint-cli2 "charts/jenkins/README.md"`: PASS
- `kubeconform -strict` default render with CRD catalog: PASS, 6 valid / 0 invalid
- `kubeconform -strict` all CI values with CRD catalog: PASS, all valid / 0 invalid
- `kubescape scan framework "MITRE,NSA,SOC2" "charts/jenkins"`: PASS, score 93.43434
- SPDX header check for chart YAML/TPL files: PASS
- ASCII/floating-tag checks for `values.yaml`: PASS

## k3d validation
Cluster: `k3d-helmforge-tests-wsl`
Namespace: `hf-jenkins`

- `helm upgrade --install jenkins charts/jenkins -n hf-jenkins -f charts/jenkins/ci/k3d-values.yaml --wait --timeout 15m`: PASS
- `helm test jenkins -n hf-jenkins --timeout 5m`: PASS
- Authenticated runtime check: `GET /whoAmI/api/json` with chart-created admin returned `authenticated=true` and `name=admin`
- Pod status: `jenkins-0` Ready 1/1, Running, 0 restarts
- Events: no Warning events in namespace
- Logs: no matches for `ERROR|FATAL|SEVERE|CrashLoop|BackOff`
- Cleanup: `kubectl delete namespace hf-jenkins --wait=true`: PASS

Resolves #367