### PR TITLE
feat(apache): add Apache chart

### DIFF
--- a/charts/apache/.helmignore
+++ b/charts/apache/.helmignore
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+
+# Lock files
+package-lock.json
+yarn.lock
+Pipfile.lock
+poetry.lock
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/apache/Chart.yaml
+++ b/charts/apache/Chart.yaml
@@ -22,7 +22,7 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/apache/httpd
   - https://hub.docker.com/_/httpd
-icon: https://www.apache.org/logos/res/httpd/default.png
+icon: https://helmforge.dev/icons/charts/apache.png
 annotations:
   artifacthub.io/changes: |
     - kind: added

--- a/charts/apache/Chart.yaml
+++ b/charts/apache/Chart.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: apache
+description: Apache HTTP Server Helm Chart with secure non-root defaults, custom content, Gateway API, and optional metrics
+type: application
+version: 1.0.0
+appVersion: "2.4.67"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - apache
+  - httpd
+  - web
+  - webserver
+  - static-site
+  - gateway-api
+  - prometheus
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/apache/httpd
+  - https://hub.docker.com/_/httpd
+icon: https://www.apache.org/logos/res/httpd/default.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add Apache HTTP Server chart with non-root runtime, custom content/config, Gateway API, dual-stack, NetworkPolicy, ExternalSecret, and optional metrics"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: networking
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://httpd.apache.org
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/apache
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/apache
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/uptime-kuma

--- a/charts/apache/DESIGN.md
+++ b/charts/apache/DESIGN.md
@@ -1,0 +1,75 @@
+# Apache Chart Design
+
+## Scope
+
+This chart deploys the official Apache HTTP Server image for static sites,
+simple reverse proxy configuration, and internal web endpoints that need a
+small, hardened web server.
+
+The chart intentionally focuses on Apache itself. It does not bundle a content
+build system, a certificate manager, an ingress controller, or a monitoring
+stack.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  client[Client] --> svc[Apache Service]
+  svc --> pod[Apache pod]
+  pod --> cfg[Generated httpd.conf]
+  pod --> content[Content ConfigMap]
+  eso[External Secrets Operator optional] -. htpasswd .-> secret[Basic Auth Secret]
+  secret -. mounted .-> pod
+  pod --> logs[stdout and stderr logs]
+```
+
+Optional integrations:
+
+- Ingress for classic controller-based HTTP routing
+- Gateway API HTTPRoute for Gateway-based platforms
+- NetworkPolicy for explicit traffic boundaries
+- Basic Auth from an existing Secret or ExternalSecret
+- Apache exporter sidecar and ServiceMonitor
+
+## Main Design Choices
+
+- Use the official `httpd` image.
+- Run Apache on port `8080` as a non-root user.
+- Keep the root filesystem read-only and write logs to stdout/stderr.
+- Generate a hardened baseline `httpd.conf` from structured values.
+- Keep static content in a generated or user-managed ConfigMap.
+- Support Gateway API and Ingress through separate, non-overlapping values.
+- Support dual-stack Service fields on the primary Service.
+- Render External Secrets Operator resources only when explicitly enabled.
+
+## Security Boundary
+
+Defaults are suitable for internal test and platform-owned static content. For
+production, operators should provide explicit content management, network
+boundaries, TLS at the ingress or Gateway layer, resource sizing, and optional
+Basic Auth or upstream authentication.
+
+## Explicit Non-Goals
+
+- building application assets
+- managing TLS certificates
+- installing an ingress controller or Gateway implementation
+- dynamic application runtimes such as PHP-FPM
+- content synchronization from Git or object storage
+- full web application firewall behavior
+
+<!-- @AI-METADATA
+type: design
+title: Apache Chart Design
+description: Design document for the Apache HTTP Server Helm chart
+keywords: apache, httpd, design, static-site, gateway-api, ingress
+purpose: Document chart architecture, decisions, and production boundaries
+scope: Chart Design
+relations:
+  - charts/apache/README.md
+  - charts/apache/docs/production.md
+  - charts/apache/docs/networking.md
+path: charts/apache/DESIGN.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/apache/README.md
+++ b/charts/apache/README.md
@@ -2,10 +2,12 @@
 
 Apache HTTP Server is a widely used open source web server.
 
-This HelmForge chart deploys the official `httpd` image with a non-root, read-only root filesystem runtime on port 8080.
-It supports custom static content, generated hardening config, extra virtual hosts, optional Basic Auth through an existing Secret,
-Gateway API, Ingress, dual-stack Service fields, NetworkPolicy, ExternalSecret, optional Apache exporter metrics, ServiceMonitor,
-PodDisruptionBudget, HPA, and Helm tests.
+This HelmForge chart deploys the official `httpd` image with a non-root,
+read-only root filesystem runtime on port 8080. It supports custom static
+content, generated hardening config, extra virtual hosts, optional Basic Auth
+through an existing Secret, Gateway API, Ingress, dual-stack Service fields,
+NetworkPolicy, ExternalSecret, optional Apache exporter metrics,
+ServiceMonitor, PodDisruptionBudget, HPA, and Helm tests.
 
 ## Install
 
@@ -24,6 +26,33 @@ content:
 ```
 
 Use `content.existingConfigMap` when content is managed outside the chart.
+
+## Networking
+
+Use `ingress.ingressClassName` for classic Ingress routing:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: apache.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Gateway API uses the single `gateway` values block:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - apache.example.com
+```
 
 ## Extra Apache Config
 
@@ -45,3 +74,10 @@ serverStatus:
 ```
 
 Metrics use the Apache exporter sidecar and `mod_status` endpoint.
+
+## Documentation
+
+- [Design](./DESIGN.md)
+- [Production guide](./docs/production.md)
+- [Networking](./docs/networking.md)
+- [External Secrets](./docs/external-secrets.md)

--- a/charts/apache/README.md
+++ b/charts/apache/README.md
@@ -1,0 +1,47 @@
+# Apache
+
+Apache HTTP Server is a widely used open source web server.
+
+This HelmForge chart deploys the official `httpd` image with a non-root, read-only root filesystem runtime on port 8080.
+It supports custom static content, generated hardening config, extra virtual hosts, optional Basic Auth through an existing Secret,
+Gateway API, Ingress, dual-stack Service fields, NetworkPolicy, ExternalSecret, optional Apache exporter metrics, ServiceMonitor,
+PodDisruptionBudget, HPA, and Helm tests.
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm install apache helmforge/apache
+```
+
+## Custom Content
+
+```yaml
+content:
+  files:
+    index.html: |
+      <h1>Hello from Apache</h1>
+```
+
+Use `content.existingConfigMap` when content is managed outside the chart.
+
+## Extra Apache Config
+
+```yaml
+httpd:
+  extraConfig: |
+    Header always set X-Content-Type-Options "nosniff"
+```
+
+## Metrics
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+serverStatus:
+  require: "all granted"
+```
+
+Metrics use the Apache exporter sidecar and `mod_status` endpoint.

--- a/charts/apache/ci/custom-config-values.yaml
+++ b/charts/apache/ci/custom-config-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+serverName: apache.example.local
+content:
+  files:
+    index.html: |
+      <h1>Custom Apache</h1>
+    healthz.html: |
+      ok
+httpd:
+  extraVhosts:
+    custom: |
+      Alias "/healthz" "/usr/local/apache2/htdocs/healthz.html"

--- a/charts/apache/ci/default-values.yaml
+++ b/charts/apache/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1

--- a/charts/apache/ci/dual-stack-values.yaml
+++ b/charts/apache/ci/dual-stack-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/apache/ci/external-secrets-values.yaml
+++ b/charts/apache/ci/external-secrets-values.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+basicAuth:
+  enabled: true
+  existingSecret: apache-basicauth-managed
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: htpasswd
+      remoteRef:
+        key: apache/basicauth
+        property: htpasswd

--- a/charts/apache/ci/gateway-api-values.yaml
+++ b/charts/apache/ci/gateway-api-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - apache.example.local

--- a/charts/apache/ci/ingress-values.yaml
+++ b/charts/apache/ci/ingress-values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   hosts:
     - host: apache.example.local
       paths:

--- a/charts/apache/ci/ingress-values.yaml
+++ b/charts/apache/ci/ingress-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: apache.example.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/apache/ci/k3d-values.yaml
+++ b/charts/apache/ci/k3d-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 192Mi

--- a/charts/apache/ci/network-policy-values.yaml
+++ b/charts/apache/ci/network-policy-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+networkPolicy:
+  enabled: true
+  ingress:
+    namespaceSelector:
+      kubernetes.io/metadata.name: ingress-nginx

--- a/charts/apache/ci/security-values.yaml
+++ b/charts/apache/ci/security-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+pdb:
+  enabled: true
+autoscaling:
+  enabled: true
+networkPolicy:
+  enabled: true
+basicAuth:
+  enabled: true
+  existingSecret: apache-basicauth
+httpd:
+  extraConfig: |
+    Header always set X-Content-Type-Options "nosniff"

--- a/charts/apache/ci/servicemonitor-values.yaml
+++ b/charts/apache/ci/servicemonitor-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus

--- a/charts/apache/docs/external-secrets.md
+++ b/charts/apache/docs/external-secrets.md
@@ -1,0 +1,34 @@
+# Apache External Secrets
+
+The chart can render an ExternalSecret for the Basic Auth htpasswd Secret.
+
+```yaml
+basicAuth:
+  enabled: true
+  existingSecret: apache-basicauth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: htpasswd
+      remoteRef:
+        key: apache/basicauth
+        property: htpasswd
+```
+
+Use `dataFrom` when your provider can extract all required keys from a single
+remote object:
+
+```yaml
+externalSecrets:
+  enabled: true
+  dataFrom:
+    - extract:
+        key: apache/basicauth
+```
+
+The chart fails rendering when ExternalSecret is enabled without `data` or
+`dataFrom`.

--- a/charts/apache/docs/networking.md
+++ b/charts/apache/docs/networking.md
@@ -1,0 +1,53 @@
+# Apache Networking
+
+The chart supports Kubernetes Service, Ingress, Gateway API, and NetworkPolicy.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: apache.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - apache.example.com
+```
+
+## Dual-Stack Service
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## NetworkPolicy
+
+Enable NetworkPolicy when the cluster CNI enforces it:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: false
+```

--- a/charts/apache/docs/networking.md
+++ b/charts/apache/docs/networking.md
@@ -51,3 +51,5 @@ networkPolicy:
     allowDns: true
     allowInternet: false
 ```
+
+When `allowInternet=true`, the chart allows both `0.0.0.0/0` and `::/0` so IPv4, IPv6, and dual-stack clusters behave consistently.

--- a/charts/apache/docs/production.md
+++ b/charts/apache/docs/production.md
@@ -1,0 +1,58 @@
+# Apache Production Guide
+
+Use this chart in production with explicit values for content, routing,
+resources, and security boundaries.
+
+## Recommended Settings
+
+```yaml
+replicaCount: 3
+
+content:
+  existingConfigMap: apache-site-content
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: false
+```
+
+## Authentication
+
+Basic Auth is optional and expects an htpasswd file in a Secret:
+
+```yaml
+basicAuth:
+  enabled: true
+  existingSecret: apache-basicauth
+  htpasswdKey: htpasswd
+```
+
+For GitOps, use `externalSecrets.enabled=true` to materialize that Secret from
+your configured provider.
+
+## Operational Checks
+
+After deployment:
+
+```bash
+helm test apache -n apache
+kubectl get pods -n apache -l app.kubernetes.io/name=apache
+kubectl logs -n apache deploy/apache
+```
+
+The chart exposes `/healthz` for probes and Helm tests.

--- a/charts/apache/examples/external-secrets.yaml
+++ b/charts/apache/examples/external-secrets.yaml
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-replicaCount: 1
 basicAuth:
   enabled: true
-  existingSecret: apache-basicauth-managed
+  existingSecret: apache-basicauth
+
 externalSecrets:
   enabled: true
   secretStoreRef:
@@ -13,4 +13,3 @@ externalSecrets:
       remoteRef:
         key: apache/basicauth
         property: htpasswd
-  dataFrom: []

--- a/charts/apache/examples/gateway.yaml
+++ b/charts/apache/examples/gateway.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - apache.example.com

--- a/charts/apache/examples/production.yaml
+++ b/charts/apache/examples/production.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 3
+
+content:
+  existingConfigMap: apache-site-content
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1
+    memory: 512Mi
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: false

--- a/charts/apache/templates/NOTES.txt
+++ b/charts/apache/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Apache HTTP Server has been deployed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Service: {{ include "apache.fullname" . }}
+
+Internal URL:
+  http://{{ include "apache.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/

--- a/charts/apache/templates/NOTES.txt
+++ b/charts/apache/templates/NOTES.txt
@@ -1,8 +1,57 @@
-Apache HTTP Server has been deployed.
+=============================================================================
+Apache HTTP Server deployed successfully!
+=============================================================================
 
-Release: {{ .Release.Name }}
-Namespace: {{ .Release.Namespace }}
-Service: {{ include "apache.fullname" . }}
+ACCESS:
+   kubectl port-forward svc/{{ include "apache.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
+   Open: http://localhost:8080/
 
-Internal URL:
-  http://{{ include "apache.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/
+SERVICE:
+   Internal URL: http://{{ include "apache.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/
+   Health URL: http://{{ include "apache.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/healthz
+
+IMAGE:
+   {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+
+CONTENT:
+{{- if .Values.content.existingConfigMap }}
+   Content ConfigMap: {{ .Values.content.existingConfigMap }}
+{{- else }}
+   Content ConfigMap: {{ include "apache.contentConfigMapName" . }}
+   Files: {{ len .Values.content.files }}
+{{- end }}
+
+SECURITY:
+   Non-root runtime: enabled
+   Read-only root filesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+   Basic Auth: {{ ternary "enabled" "disabled" .Values.basicAuth.enabled }}
+{{- if .Values.basicAuth.enabled }}
+   Basic Auth Secret: {{ include "apache.basicAuthSecretName" . }}
+{{- end }}
+
+NETWORKING:
+   Ingress: {{ ternary "enabled" "disabled" .Values.ingress.enabled }}
+   Gateway API: {{ ternary "enabled" "disabled" .Values.gateway.enabled }}
+   NetworkPolicy: {{ ternary "enabled" "disabled" .Values.networkPolicy.enabled }}
+
+OBSERVABILITY:
+   Metrics sidecar: {{ ternary "enabled" "disabled" .Values.metrics.enabled }}
+   ServiceMonitor: {{ ternary "enabled" "disabled" .Values.metrics.serviceMonitor.enabled }}
+{{- if .Values.metrics.enabled }}
+   Metrics endpoint: http://{{ include "apache.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.metricsPort }}/metrics
+{{- end }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "apache.fullname" . }}
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/apache
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/apache
+   Apache HTTP Server: https://httpd.apache.org
+
+=============================================================================

--- a/charts/apache/templates/_helpers.tpl
+++ b/charts/apache/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "apache.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "apache.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "apache.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "apache.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "apache.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "apache.labels" -}}
+helm.sh/chart: {{ include "apache.chart" . }}
+{{ include "apache.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "apache.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "apache.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{- define "apache.configMapName" -}}
+{{- printf "%s-config" (include "apache.fullname" .) -}}
+{{- end -}}
+
+{{- define "apache.contentConfigMapName" -}}
+{{- if .Values.content.existingConfigMap -}}
+{{- .Values.content.existingConfigMap -}}
+{{- else -}}
+{{- printf "%s-content" (include "apache.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "apache.basicAuthSecretName" -}}
+{{- default (printf "%s-basicauth" (include "apache.fullname" .)) .Values.basicAuth.existingSecret -}}
+{{- end -}}

--- a/charts/apache/templates/_helpers.tpl
+++ b/charts/apache/templates/_helpers.tpl
@@ -59,3 +59,9 @@ app.kubernetes.io/part-of: helmforge
 {{- define "apache.basicAuthSecretName" -}}
 {{- default (printf "%s-basicauth" (include "apache.fullname" .)) .Values.basicAuth.existingSecret -}}
 {{- end -}}
+
+{{- define "apache.validate" -}}
+{{- if and .Values.basicAuth.enabled (not .Values.basicAuth.existingSecret) -}}
+{{- fail "basicAuth.enabled requires basicAuth.existingSecret to reference an htpasswd Secret. Create the Secret manually or use externalSecrets.enabled with basicAuth.existingSecret." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -44,7 +44,7 @@ data:
         AuthType Basic
         AuthName "Apache"
         AuthBasicProvider file
-        AuthUserFile "/usr/local/apache2/auth/htpasswd"
+        AuthUserFile "/usr/local/apache2/auth/{{ .Values.basicAuth.htpasswdKey }}"
         Require valid-user
         {{- else }}
         Require all granted

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -33,6 +33,10 @@ data:
     ErrorLog /proc/self/fd/2
     CustomLog /proc/self/fd/1 combined
     DocumentRoot "/usr/local/apache2/htdocs"
+    Alias "/healthz" "/usr/local/apache2/htdocs/index.html"
+    <Location "/healthz">
+        Require all granted
+    </Location>
     <Directory "/usr/local/apache2/htdocs">
         Options {{ .Values.httpd.options }}
         AllowOverride {{ .Values.httpd.allowOverride }}

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "apache.labels" . | nindent 4 }}
 data:
+  healthz.html: |
+    ok
   httpd.conf: |
     ServerRoot "/usr/local/apache2"
     Listen 0.0.0.0:{{ .Values.containerPorts.http }}
@@ -33,7 +35,7 @@ data:
     ErrorLog /proc/self/fd/2
     CustomLog /proc/self/fd/1 combined
     DocumentRoot "/usr/local/apache2/htdocs"
-    Alias "/healthz" "/usr/local/apache2/htdocs/index.html"
+    Alias "/healthz" "/usr/local/apache2/healthz.html"
     <Location "/healthz">
         Require all granted
     </Location>

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
     PidFile /usr/local/apache2/logs/httpd.pid
     LogLevel {{ .Values.httpd.logLevel }}
     LoadModule mpm_event_module modules/mod_mpm_event.so
+    LoadModule authn_core_module modules/mod_authn_core.so
     LoadModule authn_file_module modules/mod_authn_file.so
     LoadModule authz_core_module modules/mod_authz_core.so
     LoadModule authz_host_module modules/mod_authz_host.so

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "apache.validate" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -36,13 +36,14 @@ data:
     <Directory "/usr/local/apache2/htdocs">
         Options {{ .Values.httpd.options }}
         AllowOverride {{ .Values.httpd.allowOverride }}
-        Require all granted
         {{- if .Values.basicAuth.enabled }}
         AuthType Basic
         AuthName "Apache"
         AuthBasicProvider file
         AuthUserFile "/usr/local/apache2/auth/htpasswd"
         Require valid-user
+        {{- else }}
+        Require all granted
         {{- end }}
     </Directory>
     DirectoryIndex index.html

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -1,0 +1,76 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "apache.configMapName" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+data:
+  httpd.conf: |
+    ServerRoot "/usr/local/apache2"
+    Listen 0.0.0.0:{{ .Values.containerPorts.http }}
+    ServerName {{ .Values.serverName }}
+    ServerTokens {{ .Values.httpd.serverTokens }}
+    ServerSignature {{ .Values.httpd.serverSignature }}
+    TraceEnable {{ .Values.httpd.traceEnable }}
+    PidFile /usr/local/apache2/logs/httpd.pid
+    LogLevel {{ .Values.httpd.logLevel }}
+    LoadModule mpm_event_module modules/mod_mpm_event.so
+    LoadModule authn_file_module modules/mod_authn_file.so
+    LoadModule authz_core_module modules/mod_authz_core.so
+    LoadModule authz_host_module modules/mod_authz_host.so
+    LoadModule authz_user_module modules/mod_authz_user.so
+    LoadModule auth_basic_module modules/mod_auth_basic.so
+    LoadModule unixd_module modules/mod_unixd.so
+    LoadModule dir_module modules/mod_dir.so
+    LoadModule mime_module modules/mod_mime.so
+    LoadModule log_config_module modules/mod_log_config.so
+    LoadModule alias_module modules/mod_alias.so
+    LoadModule headers_module modules/mod_headers.so
+    LoadModule status_module modules/mod_status.so
+    TypesConfig conf/mime.types
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
+    ErrorLog /proc/self/fd/2
+    CustomLog /proc/self/fd/1 combined
+    DocumentRoot "/usr/local/apache2/htdocs"
+    <Directory "/usr/local/apache2/htdocs">
+        Options {{ .Values.httpd.options }}
+        AllowOverride {{ .Values.httpd.allowOverride }}
+        Require all granted
+        {{- if .Values.basicAuth.enabled }}
+        AuthType Basic
+        AuthName "Apache"
+        AuthBasicProvider file
+        AuthUserFile "/usr/local/apache2/auth/htpasswd"
+        Require valid-user
+        {{- end }}
+    </Directory>
+    DirectoryIndex index.html
+    {{- if or .Values.serverStatus.enabled .Values.metrics.enabled }}
+    ExtendedStatus On
+    <Location "{{ .Values.serverStatus.path }}">
+        SetHandler server-status
+        Require {{ .Values.serverStatus.require }}
+    </Location>
+    {{- end }}
+    {{- with .Values.httpd.extraConfig }}
+{{ . | nindent 4 }}
+    {{- end }}
+    {{- range $name, $content := .Values.httpd.extraVhosts }}
+    # HelmForge extra vhost: {{ $name }}
+{{ $content | nindent 4 }}
+    {{- end }}
+{{- if not .Values.content.existingConfigMap }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "apache.contentConfigMapName" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+data:
+  {{- range $name, $content := .Values.content.files }}
+  {{ $name }}: |
+{{ $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/apache/templates/configmap.yaml
+++ b/charts/apache/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
     ok
   httpd.conf: |
     ServerRoot "/usr/local/apache2"
-    Listen 0.0.0.0:{{ .Values.containerPorts.http }}
+    Listen {{ .Values.containerPorts.http }}
     ServerName {{ .Values.serverName }}
     ServerTokens {{ .Values.httpd.serverTokens }}
     ServerSignature {{ .Values.httpd.serverSignature }}

--- a/charts/apache/templates/deployment.yaml
+++ b/charts/apache/templates/deployment.yaml
@@ -50,17 +50,17 @@ spec:
               containerPort: {{ .Values.containerPorts.http }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
             {{- toYaml .Values.startupProbe | nindent 12 }}
           {{- with .Values.extraEnv }}

--- a/charts/apache/templates/deployment.yaml
+++ b/charts/apache/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
             - name: config
               mountPath: /usr/local/apache2/conf/httpd.conf
               subPath: httpd.conf
+            - name: config
+              mountPath: /usr/local/apache2/healthz.html
+              subPath: healthz.html
+              readOnly: true
             - name: content
               mountPath: /usr/local/apache2/htdocs
             - name: logs

--- a/charts/apache/templates/deployment.yaml
+++ b/charts/apache/templates/deployment.yaml
@@ -1,0 +1,141 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "apache.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "apache.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "apache.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: apache
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/apache2/conf/httpd.conf
+              subPath: httpd.conf
+            - name: content
+              mountPath: /usr/local/apache2/htdocs
+            - name: logs
+              mountPath: /usr/local/apache2/logs
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.basicAuth.enabled }}
+            - name: basic-auth
+              mountPath: /usr/local/apache2/auth
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: apache-exporter
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          args:
+            - --scrape_uri=http://127.0.0.1:{{ .Values.containerPorts.http }}{{ .Values.serverStatus.path }}?auto
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.containerPorts.metrics }}
+          resources:
+            {{- toYaml .Values.metrics.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "apache.configMapName" . }}
+        - name: content
+          configMap:
+            name: {{ include "apache.contentConfigMapName" . }}
+        - name: logs
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.basicAuth.enabled }}
+        - name: basic-auth
+          secret:
+            secretName: {{ include "apache.basicAuthSecretName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/apache/templates/deployment.yaml
+++ b/charts/apache/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "apache.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/apache/templates/externalsecret.yaml
+++ b/charts/apache/templates/externalsecret.yaml
@@ -3,8 +3,10 @@
 {{- if not .Values.basicAuth.existingSecret }}
   {{- fail "externalSecrets.enabled requires basicAuth.existingSecret to be set." }}
 {{- end }}
-{{- if not .Values.externalSecrets.data }}
-  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- $externalSecretData := .Values.externalSecrets.data | default list -}}
+{{- $externalSecretDataFrom := .Values.externalSecrets.dataFrom | default list -}}
+{{- if eq (add (len $externalSecretData) (len $externalSecretDataFrom)) 0 }}
+  {{- fail "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true" }}
 {{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
@@ -20,6 +22,12 @@ spec:
   target:
     name: {{ .Values.basicAuth.existingSecret | quote }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  {{- if $externalSecretData }}
   data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+    {{- toYaml $externalSecretData | nindent 4 }}
+  {{- end }}
+  {{- if $externalSecretDataFrom }}
+  dataFrom:
+    {{- toYaml $externalSecretDataFrom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/apache/templates/externalsecret.yaml
+++ b/charts/apache/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- if not .Values.basicAuth.existingSecret }}
+  {{- fail "externalSecrets.enabled requires basicAuth.existingSecret to be set." }}
+{{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "apache.fullname" . }}-basicauth
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.basicAuth.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/apache/templates/extra-manifests.yaml
+++ b/charts/apache/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/apache/templates/hpa.yaml
+++ b/charts/apache/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "apache.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/apache/templates/httproute.yaml
+++ b/charts/apache/templates/httproute.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+apiVersion: {{ .Values.gateway.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "apache.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/apache/templates/ingress.yaml
+++ b/charts/apache/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "apache.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/apache/templates/ingress.yaml
+++ b/charts/apache/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . | quote }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/charts/apache/templates/networkpolicy.yaml
+++ b/charts/apache/templates/networkpolicy.yaml
@@ -13,7 +13,9 @@ spec:
       app.kubernetes.io/component: web
   policyTypes:
     - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
     - Egress
+    {{- end }}
   ingress:
     {{- if .Values.networkPolicy.ingress.enabled }}
     - from:
@@ -39,6 +41,7 @@ spec:
     {{- else }}
     []
     {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
   egress:
     {{- if .Values.networkPolicy.egress.allowDns }}
     - to:
@@ -57,4 +60,5 @@ spec:
     {{- with .Values.networkPolicy.egress.extraRules }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/apache/templates/networkpolicy.yaml
+++ b/charts/apache/templates/networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "apache.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress.enabled }}
+    - from:
+        - {{- if .Values.networkPolicy.ingress.namespaceSelector }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingress.namespaceSelector | nindent 14 }}
+          {{- end }}
+          podSelector:
+            {{- if .Values.networkPolicy.ingress.podSelector }}
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingress.podSelector | nindent 14 }}
+            {{- else }}
+            {}
+            {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.containerPorts.http }}
+        {{- if .Values.metrics.enabled }}
+        - protocol: TCP
+          port: {{ .Values.containerPorts.metrics }}
+        {{- end }}
+    {{- else }}
+    []
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDns }}
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowInternet }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/apache/templates/networkpolicy.yaml
+++ b/charts/apache/templates/networkpolicy.yaml
@@ -56,6 +56,8 @@ spec:
     - to:
         - ipBlock:
             cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
     {{- end }}
     {{- with .Values.networkPolicy.egress.extraRules }}
     {{- toYaml . | nindent 4 }}

--- a/charts/apache/templates/networkpolicy.yaml
+++ b/charts/apache/templates/networkpolicy.yaml
@@ -1,5 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.networkPolicy.enabled }}
+{{- if and .Values.networkPolicy.enabled (or .Values.networkPolicy.ingress.enabled .Values.networkPolicy.egress.enabled) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -12,12 +12,14 @@ spec:
       {{- include "apache.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: web
   policyTypes:
+    {{- if .Values.networkPolicy.ingress.enabled }}
     - Ingress
+    {{- end }}
     {{- if .Values.networkPolicy.egress.enabled }}
     - Egress
     {{- end }}
+  {{- if .Values.networkPolicy.ingress.enabled }}
   ingress:
-    {{- if .Values.networkPolicy.ingress.enabled }}
     - from:
         - {{- if .Values.networkPolicy.ingress.namespaceSelector }}
           namespaceSelector:
@@ -38,9 +40,7 @@ spec:
         - protocol: TCP
           port: {{ .Values.containerPorts.metrics }}
         {{- end }}
-    {{- else }}
-    []
-    {{- end }}
+  {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
   egress:
     {{- if .Values.networkPolicy.egress.allowDns }}

--- a/charts/apache/templates/pdb.yaml
+++ b/charts/apache/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "apache.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+{{- end }}

--- a/charts/apache/templates/service.yaml
+++ b/charts/apache/templates/service.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+    {{- end }}
+  selector:
+    {{- include "apache.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/apache/templates/serviceaccount.yaml
+++ b/charts/apache/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "apache.serviceAccountName" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/apache/templates/servicemonitor.yaml
+++ b/charts/apache/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "apache.fullname" . }}
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+  selector:
+    matchLabels:
+      {{- include "apache.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/apache/templates/tests/test-connection.yaml
+++ b/charts/apache/templates/tests/test-connection.yaml
@@ -17,7 +17,7 @@ spec:
       command:
         - sh
         - -ec
-        - curl -fsS "http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/" | grep -q "HelmForge Apache"
+        - curl -fsS "http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/healthz" >/dev/null
       resources:
         requests:
           cpu: 10m

--- a/charts/apache/templates/tests/test-connection.yaml
+++ b/charts/apache/templates/tests/test-connection.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "apache.fullname" . }}-test-connection"
+  labels:
+    {{- include "apache.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: docker.io/curlimages/curl:8.17.0
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+        - -ec
+        - curl -fsS "http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/" | grep -q "HelmForge Apache"
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -43,9 +43,13 @@ tests:
   - it: should expose unauthenticated health endpoint
     documentIndex: 0
     asserts:
+      - equal:
+          path: data["healthz.html"]
+          value: |
+            ok
       - matchRegex:
           path: data["httpd.conf"]
-          pattern: "Alias \"/healthz\""
+          pattern: 'Alias "/healthz" "/usr/local/apache2/healthz.html"'
       - matchRegex:
           path: data["httpd.conf"]
           pattern: "<Location \"/healthz\">[\\s\\S]*Require all granted"

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -28,6 +28,7 @@ tests:
     documentIndex: 0
     set:
       basicAuth.enabled: true
+      basicAuth.existingSecret: apache-basicauth
     asserts:
       - matchRegex:
           path: data["httpd.conf"]
@@ -43,6 +44,7 @@ tests:
     documentIndex: 0
     set:
       basicAuth.enabled: true
+      basicAuth.existingSecret: apache-basicauth
       basicAuth.htpasswdKey: users
     asserts:
       - matchRegex:

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -17,6 +17,12 @@ tests:
       - matchRegex:
           path: data["httpd.conf"]
           pattern: "TraceEnable Off"
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "(?m)^Listen 8080$"
+      - notMatchRegex:
+          path: data["httpd.conf"]
+          pattern: "Listen 0\\.0\\.0\\.0:"
 
   - it: should require valid users when basic auth is enabled
     documentIndex: 0

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Config
+templates:
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render httpd hardening config
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "ServerTokens Prod"
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "TraceEnable Off"
+
+  - it: should render default content ConfigMap
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - exists:
+          path: data["index.html"]

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -28,7 +28,7 @@ tests:
           pattern: "Require valid-user"
       - notMatchRegex:
           path: data["httpd.conf"]
-          pattern: "Require all granted"
+          pattern: "<Directory \"/usr/local/apache2/htdocs\">[\\s\\S]*Require all granted"
 
   - it: should expose unauthenticated health endpoint
     documentIndex: 0

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -30,6 +30,16 @@ tests:
           path: data["httpd.conf"]
           pattern: "<Directory \"/usr/local/apache2/htdocs\">[\\s\\S]*Require all granted"
 
+  - it: should honor custom htpasswd key
+    documentIndex: 0
+    set:
+      basicAuth.enabled: true
+      basicAuth.htpasswdKey: users
+    asserts:
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: 'AuthUserFile "/usr/local/apache2/auth/users"'
+
   - it: should expose unauthenticated health endpoint
     documentIndex: 0
     asserts:

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -50,6 +50,15 @@ tests:
           path: data["httpd.conf"]
           pattern: "<Location \"/healthz\">[\\s\\S]*Require all granted"
 
+  - it: should default server-status to localhost access
+    documentIndex: 0
+    set:
+      metrics.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "<Location \"/server-status\">[\\s\\S]*Require local"
+
   - it: should render default content ConfigMap
     documentIndex: 1
     asserts:

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -18,6 +18,18 @@ tests:
           path: data["httpd.conf"]
           pattern: "TraceEnable Off"
 
+  - it: should require valid users when basic auth is enabled
+    documentIndex: 0
+    set:
+      basicAuth.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "Require valid-user"
+      - notMatchRegex:
+          path: data["httpd.conf"]
+          pattern: "Require all granted"
+
   - it: should render default content ConfigMap
     documentIndex: 1
     asserts:

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -30,6 +30,16 @@ tests:
           path: data["httpd.conf"]
           pattern: "Require all granted"
 
+  - it: should expose unauthenticated health endpoint
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "Alias \"/healthz\""
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "<Location \"/healthz\">[\\s\\S]*Require all granted"
+
   - it: should render default content ConfigMap
     documentIndex: 1
     asserts:

--- a/charts/apache/tests/config_test.yaml
+++ b/charts/apache/tests/config_test.yaml
@@ -26,6 +26,9 @@ tests:
       - matchRegex:
           path: data["httpd.conf"]
           pattern: "Require valid-user"
+      - matchRegex:
+          path: data["httpd.conf"]
+          pattern: "LoadModule authn_core_module modules/mod_authn_core.so"
       - notMatchRegex:
           path: data["httpd.conf"]
           pattern: "<Directory \"/usr/local/apache2/htdocs\">[\\s\\S]*Require all granted"

--- a/charts/apache/tests/deployment_test.yaml
+++ b/charts/apache/tests/deployment_test.yaml
@@ -33,3 +33,30 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].name
           value: apache-exporter
+
+  - it: should require an existing secret when basic auth is enabled
+    template: deployment.yaml
+    set:
+      basicAuth.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "basicAuth.enabled requires basicAuth.existingSecret to reference an htpasswd Secret. Create the Secret manually or use externalSecrets.enabled with basicAuth.existingSecret."
+
+  - it: should mount configured basic auth secret
+    template: deployment.yaml
+    set:
+      basicAuth.enabled: true
+      basicAuth.existingSecret: apache-basicauth
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: basic-auth
+            secret:
+              secretName: apache-basicauth
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: basic-auth
+            mountPath: /usr/local/apache2/auth
+            readOnly: true

--- a/charts/apache/tests/deployment_test.yaml
+++ b/charts/apache/tests/deployment_test.yaml
@@ -21,6 +21,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
 
   - it: should add exporter when metrics are enabled
     template: deployment.yaml

--- a/charts/apache/tests/deployment_test.yaml
+++ b/charts/apache/tests/deployment_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render non-root Apache deployment
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: should add exporter when metrics are enabled
+    template: deployment.yaml
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: apache-exporter

--- a/charts/apache/tests/externalsecret_test.yaml
+++ b/charts/apache/tests/externalsecret_test.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ExternalSecret with data entries
+    values:
+      - ../ci/external-secrets-values.yaml
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.target.name
+          value: apache-basicauth-managed
+      - contains:
+          path: spec.data
+          content:
+            secretKey: htpasswd
+            remoteRef:
+              key: apache/basicauth
+              property: htpasswd
+
+  - it: should render ExternalSecret with dataFrom entries
+    set:
+      basicAuth.enabled: true
+      basicAuth.existingSecret: apache-basicauth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+      externalSecrets.dataFrom[0].extract.key: apache/basicauth
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: apache/basicauth
+
+  - it: should fail when no remote data source is configured
+    set:
+      basicAuth.enabled: true
+      basicAuth.existingSecret: apache-basicauth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true"

--- a/charts/apache/tests/networkpolicy_test.yaml
+++ b/charts/apache/tests/networkpolicy_test.yaml
@@ -19,3 +19,20 @@ tests:
           content: Egress
       - notExists:
           path: spec.egress
+
+  - it: should allow IPv4 and IPv6 internet egress when enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowInternet: true
+    asserts:
+      - contains:
+          path: spec.egress[1].to
+          content:
+            ipBlock:
+              cidr: 0.0.0.0/0
+      - contains:
+          path: spec.egress[1].to
+          content:
+            ipBlock:
+              cidr: ::/0

--- a/charts/apache/tests/networkpolicy_test.yaml
+++ b/charts/apache/tests/networkpolicy_test.yaml
@@ -36,3 +36,20 @@ tests:
           content:
             ipBlock:
               cidr: ::/0
+
+  - it: should render egress-only policy without denying ingress
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress.enabled: false
+      networkPolicy.egress.enabled: true
+    asserts:
+      - notContains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - notExists:
+          path: spec.ingress
+      - exists:
+          path: spec.egress

--- a/charts/apache/tests/networkpolicy_test.yaml
+++ b/charts/apache/tests/networkpolicy_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: NetworkPolicy
+templates:
+  - networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingress-only policy when egress is disabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: false
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - notContains:
+          path: spec.policyTypes
+          content: Egress
+      - notExists:
+          path: spec.egress

--- a/charts/apache/tests/routing_test.yaml
+++ b/charts/apache/tests/routing_test.yaml
@@ -11,10 +11,14 @@ tests:
     template: ingress.yaml
     set:
       ingress.enabled: true
+      ingress.ingressClassName: nginx
       ingress.hosts[0].host: apache.example.local
     asserts:
       - isKind:
           of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
       - equal:
           path: spec.rules[0].host
           value: apache.example.local

--- a/charts/apache/tests/routing_test.yaml
+++ b/charts/apache/tests/routing_test.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Routing
+templates:
+  - ingress.yaml
+  - httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingress
+    template: ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.hosts[0].host: apache.example.local
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: apache.example.local
+
+  - it: should render HTTPRoute
+    template: httproute.yaml
+    set:
+      gateway.enabled: true
+      gateway.parentRefs[0].name: public-gateway
+      gateway.hostnames[0]: apache.example.local
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: apache.example.local

--- a/charts/apache/tests/service_test.yaml
+++ b/charts/apache/tests/service_test.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should expose http port
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-apache
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 80
+            targetPort: http
+
+  - it: should render dual-stack fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/apache/values.schema.json
+++ b/charts/apache/values.schema.json
@@ -171,7 +171,14 @@
     },
     "ingress": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
     },
     "gateway": {
       "type": "object",
@@ -257,7 +264,12 @@
     },
     "externalSecrets": {
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "data": { "type": "array", "items": { "type": "object" } },
+        "dataFrom": { "type": "array", "items": { "type": "object" } }
+      }
     }
   },
   "definitions": {

--- a/charts/apache/values.schema.json
+++ b/charts/apache/values.schema.json
@@ -1,0 +1,287 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Apache HelmForge values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object"
+    },
+    "image": {
+      "type": "object",
+      "required": ["repository", "tag", "pullPolicy"],
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "serverName": {
+      "type": "string"
+    },
+    "containerPorts": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 65535
+        },
+        "metrics": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 65535
+        }
+      }
+    },
+    "httpd": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "serverTokens": {
+          "type": "string"
+        },
+        "serverSignature": {
+          "type": "string"
+        },
+        "traceEnable": {
+          "type": "string"
+        },
+        "logLevel": {
+          "type": "string"
+        },
+        "allowOverride": {
+          "type": "string"
+        },
+        "options": {
+          "type": "string"
+        },
+        "extraConfig": {
+          "type": "string"
+        },
+        "extraVhosts": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingConfigMap": {
+          "type": "string"
+        },
+        "files": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "basicAuth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "htpasswdKey": {
+          "type": "string"
+        }
+      }
+    },
+    "serverStatus": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": "string"
+        },
+        "require": {
+          "type": "string"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "metricsPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "livenessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "startupProbe": {
+      "$ref": "#/definitions/probe"
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "resources": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "annotations": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "pdb": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "extraEnv": {
+      "type": "array"
+    },
+    "extraVolumes": {
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "type": "array"
+    },
+    "extraManifests": {
+      "type": "array"
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/charts/apache/values.yaml
+++ b/charts/apache/values.yaml
@@ -56,7 +56,7 @@ basicAuth:
 serverStatus:
   enabled: false
   path: /server-status
-  require: "all granted"
+  require: "local"
 
 service:
   type: ClusterIP

--- a/charts/apache/values.yaml
+++ b/charts/apache/values.yaml
@@ -150,7 +150,7 @@ networkPolicy:
     enabled: true
     # -- Allow DNS egress.
     allowDns: true
-    # -- Allow general internet egress.
+    # -- Allow general IPv4 and IPv6 internet egress.
     allowInternet: true
     # -- Extra egress rules.
     extraRules: []

--- a/charts/apache/values.yaml
+++ b/charts/apache/values.yaml
@@ -3,37 +3,58 @@
 # Apache HTTP Server Helm Chart - Default Values
 # =============================================================================
 
+# -- Number of Apache pods when autoscaling is disabled.
 replicaCount: 2
 
+# -- Override the chart name.
 nameOverride: ""
+# -- Override the fully qualified release name.
 fullnameOverride: ""
+# -- Additional labels applied to all chart resources.
 commonLabels: {}
 
 image:
+  # -- Apache HTTP Server image repository.
   repository: docker.io/library/httpd
+  # -- Apache HTTP Server image tag.
   tag: "2.4.67"
+  # -- Apache HTTP Server image pull policy.
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets.
 imagePullSecrets: []
 
+# -- ServerName rendered into the generated Apache configuration.
 serverName: localhost
 
 containerPorts:
+  # -- Non-root Apache listener port.
   http: 8080
+  # -- Apache exporter container port.
   metrics: 9117
 
 httpd:
+  # -- Value for ServerTokens.
   serverTokens: Prod
+  # -- Value for ServerSignature.
   serverSignature: "Off"
+  # -- Value for TraceEnable.
   traceEnable: "Off"
+  # -- Apache LogLevel.
   logLevel: warn
+  # -- Directory AllowOverride setting.
   allowOverride: None
+  # -- Directory Options setting.
   options: "-Indexes +FollowSymLinks"
+  # -- Extra Apache configuration appended to httpd.conf.
   extraConfig: ""
+  # -- Extra virtual host snippets rendered into httpd.conf.
   extraVhosts: {}
 
 content:
+  # -- Existing ConfigMap containing site content. Empty renders content.files.
   existingConfigMap: ""
+  # -- Static files rendered into the generated content ConfigMap.
   files:
     index.html: |
       <!doctype html>
@@ -49,41 +70,65 @@ content:
       </html>
 
 basicAuth:
+  # -- Enable Basic Auth using an htpasswd file from a Secret.
   enabled: false
+  # -- Existing Secret containing the htpasswd data.
   existingSecret: ""
+  # -- Secret key containing the htpasswd file.
   htpasswdKey: htpasswd
 
 serverStatus:
+  # -- Enable mod_status endpoint and exporter scraping.
   enabled: false
+  # -- mod_status path.
   path: /server-status
+  # -- Apache Require expression for mod_status.
   require: "local"
 
 service:
+  # -- Service type.
   type: ClusterIP
+  # -- Service annotations.
   annotations: {}
+  # -- Public HTTP service port.
   port: 80
+  # -- Metrics service port when metrics.enabled=true.
   metricsPort: 9117
+  # -- Service IP family policy. Null uses cluster default.
   ipFamilyPolicy: ~
+  # -- Service IP families.
   ipFamilies: []
 
 ingress:
+  # -- Enable Kubernetes Ingress.
   enabled: false
-  className: ""
+  # -- IngressClass name.
+  ingressClassName: ""
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress host rules.
   hosts:
     - host: apache.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
 gateway:
+  # -- Enable Gateway API HTTPRoute.
   enabled: false
+  # -- Gateway API version.
   apiVersion: gateway.networking.k8s.io/v1
+  # -- Gateway parentRefs.
   parentRefs: []
+  # -- HTTPRoute hostnames.
   hostnames: []
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- HTTPRoute labels.
   labels: {}
+  # -- HTTPRoute rules.
   rules:
     - matches:
         - path:
@@ -91,34 +136,48 @@ gateway:
             value: /
 
 networkPolicy:
+  # -- Enable NetworkPolicy resources.
   enabled: false
   ingress:
+    # -- Restrict inbound HTTP traffic to selected namespaces and pods.
     enabled: true
+    # -- Namespace selector allowed to reach Apache.
     namespaceSelector: {}
+    # -- Pod selector allowed to reach Apache.
     podSelector: {}
   egress:
+    # -- Restrict outbound traffic from Apache pods.
     enabled: true
+    # -- Allow DNS egress.
     allowDns: true
+    # -- Allow general internet egress.
     allowInternet: true
+    # -- Extra egress rules.
     extraRules: []
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: true
+  # -- ServiceAccount name override.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
 
+# -- Apache liveness probe settings.
 livenessProbe:
   initialDelaySeconds: 10
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 6
 
+# -- Apache readiness probe settings.
 readinessProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
 
+# -- Apache startup probe settings.
 startupProbe:
   initialDelaySeconds: 5
   periodSeconds: 10
@@ -126,11 +185,16 @@ startupProbe:
   failureThreshold: 30
 
 metrics:
+  # -- Enable Apache exporter sidecar and metrics service port.
   enabled: false
   image:
+    # -- Apache exporter image repository.
     repository: docker.io/lusotycoon/apache-exporter
+    # -- Apache exporter image tag.
     tag: v1.0.11
+    # -- Apache exporter image pull policy.
     pullPolicy: IfNotPresent
+  # -- Apache exporter resources.
   resources:
     requests:
       cpu: 10m
@@ -139,10 +203,14 @@ metrics:
       cpu: 100m
       memory: 128Mi
   serviceMonitor:
+    # -- Render a Prometheus Operator ServiceMonitor.
     enabled: false
+    # -- ServiceMonitor scrape interval.
     interval: 30s
+    # -- Additional ServiceMonitor labels.
     labels: {}
 
+# -- Apache container resources.
 resources:
   requests:
     cpu: 50m
@@ -151,12 +219,14 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# -- Pod-level security context.
 podSecurityContext:
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
 
+# -- Container-level security context.
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
@@ -167,39 +237,67 @@ securityContext:
     drop:
       - ALL
 
+# -- Additional pod labels.
 podLabels: {}
+# -- Additional pod annotations.
 podAnnotations: {}
+# -- Additional resource annotations.
 annotations: {}
 
+# -- Node selector.
 nodeSelector: {}
+# -- Pod tolerations.
 tolerations: []
+# -- Pod affinity.
 affinity: {}
+# -- Pod topology spread constraints.
 topologySpreadConstraints: []
+# -- PriorityClass name.
 priorityClassName: ""
+# -- Pod termination grace period.
 terminationGracePeriodSeconds: 30
 
 pdb:
+  # -- Enable PodDisruptionBudget.
   enabled: false
+  # -- Minimum available pods.
   minAvailable: 1
 
 autoscaling:
+  # -- Enable HorizontalPodAutoscaler.
   enabled: false
+  # -- Minimum HPA replicas.
   minReplicas: 2
+  # -- Maximum HPA replicas.
   maxReplicas: 10
+  # -- Target CPU utilization percentage.
   targetCPUUtilizationPercentage: 80
 
+# -- Additional environment variables for the Apache container.
 extraEnv: []
+# -- Additional pod volumes.
 extraVolumes: []
+# -- Additional Apache container volume mounts.
 extraVolumeMounts: []
+# -- Additional manifests rendered verbatim.
 extraManifests: []
 
 externalSecrets:
+  # -- Render an ExternalSecret for the Basic Auth Secret.
   enabled: false
+  # -- ExternalSecret API version.
   apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval.
   refreshInterval: "0"
   secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name.
     name: ""
+    # -- Secret store kind.
     kind: SecretStore
   target:
+    # -- ExternalSecret target creation policy.
     creationPolicy: Owner
+  # -- ExternalSecret data entries for individual htpasswd keys.
   data: []
+  # -- ExternalSecret dataFrom entries for provider-side extraction.
+  dataFrom: []

--- a/charts/apache/values.yaml
+++ b/charts/apache/values.yaml
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Apache HTTP Server Helm Chart - Default Values
+# =============================================================================
+
+replicaCount: 2
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+image:
+  repository: docker.io/library/httpd
+  tag: "2.4.67"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serverName: localhost
+
+containerPorts:
+  http: 8080
+  metrics: 9117
+
+httpd:
+  serverTokens: Prod
+  serverSignature: "Off"
+  traceEnable: "Off"
+  logLevel: warn
+  allowOverride: None
+  options: "-Indexes +FollowSymLinks"
+  extraConfig: ""
+  extraVhosts: {}
+
+content:
+  existingConfigMap: ""
+  files:
+    index.html: |
+      <!doctype html>
+      <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <title>HelmForge Apache</title>
+      </head>
+      <body>
+        <h1>HelmForge Apache</h1>
+        <p>Apache HTTP Server is running.</p>
+      </body>
+      </html>
+
+basicAuth:
+  enabled: false
+  existingSecret: ""
+  htpasswdKey: htpasswd
+
+serverStatus:
+  enabled: false
+  path: /server-status
+  require: "all granted"
+
+service:
+  type: ClusterIP
+  annotations: {}
+  port: 80
+  metricsPort: 9117
+  ipFamilyPolicy: ~
+  ipFamilies: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: apache.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gateway:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1
+  parentRefs: []
+  hostnames: []
+  annotations: {}
+  labels: {}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+networkPolicy:
+  enabled: false
+  ingress:
+    enabled: true
+    namespaceSelector: {}
+    podSelector: {}
+  egress:
+    enabled: true
+    allowDns: true
+    allowInternet: true
+    extraRules: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+
+metrics:
+  enabled: false
+  image:
+    repository: docker.io/lusotycoon/apache-exporter
+    tag: v1.0.11
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+podLabels: {}
+podAnnotations: {}
+annotations: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+extraManifests: []
+
+externalSecrets:
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "0"
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  data: []


### PR DESCRIPTION
## Summary

Adds the HelmForge `apache` chart as a stable Apache HTTP Server chart using the official `docker.io/library/httpd:2.4.67` image.

Closes #369.

## Scope

- non-root Apache runtime with read-only root filesystem and generated hardened `httpd.conf`
- custom static content ConfigMap, optional existing content ConfigMap, extra vhosts/config snippets
- Service, Ingress, Gateway API, dual-stack Service fields, NetworkPolicy, HPA, PDB, ServiceMonitor, optional Apache exporter, ExternalSecret, and extra manifests
- Basic Auth support now fails fast unless `basicAuth.existingSecret` points to an htpasswd Secret
- NetworkPolicy internet egress allows both IPv4 and IPv6 CIDRs when enabled

## Validation

Latest local validation after review fixes:

- `helm dependency build charts/apache` and `helm dependency list charts/apache` - no dependencies
- `helm lint charts/apache`
- `helm lint charts/apache --strict`
- `helm unittest charts/apache` - 6 suites, 19 tests passed
- `npx --yes markdownlint-cli2 "charts/apache/**/*.md"` - 5 files, 0 errors
- strict kubeconform for default render - 6 valid, 0 invalid
- strict kubeconform for all `charts/apache/ci/*.yaml`: custom-config, default, dual-stack, external-secrets, gateway-api, ingress, k3d, network-policy, security, servicemonitor
- `ah lint charts/apache` - Apache package lint succeeded; repository scan 66 packages, 0 errors
- Kubescape NSA on `ci/network-policy-values.yaml`: 98.33%, threshold 90
- MCP HelmForge: CI evidence PASS, security evidence PASS

## k3d validation

Validated on local cluster `k3d-helmforge-tests-wsl` after review fixes:

- namespace `hf-apache-standard`
- `helm install apache-test charts/apache -f charts/apache/ci/k3d-values.yaml --wait --timeout 10m`
- `helm test apache-test` succeeded
- curl smoke against `/healthz` succeeded
- Apache pod Ready with zero restarts
- no Warning events in the namespace
- logs scanned for `error|fatal|panic|exception|back-off|failed`; no matches
- namespace `hf-apache-standard` deleted after validation