### PR TITLE
feat(jupyterhub): add JupyterHub chart

### DIFF
--- a/charts/jupyterhub/.helmignore
+++ b/charts/jupyterhub/.helmignore
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+.DS_Store
+Thumbs.db
+.git/
+.gitignore
+.gitattributes
+.helmignore
+.vscode/
+.idea/
+*.code-workspace
+*.orig
+*.rej
+*.swp
+*.tmp
+*.log
+*.bak

--- a/charts/jupyterhub/Chart.yaml
+++ b/charts/jupyterhub/Chart.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: jupyterhub
+description: JupyterHub Helm Chart with configurable-http-proxy, KubeSpawner, Gateway API, and secure Kubernetes defaults
+type: application
+version: 1.0.0
+appVersion: "5.4.6"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - jupyterhub
+  - jupyter
+  - notebooks
+  - data-science
+  - kubespawner
+  - education
+  - research
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts
+  - https://github.com/jupyterhub/jupyterhub
+  - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
+icon: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add JupyterHub chart with proxy token management, KubeSpawner, Gateway API, dual-stack, NetworkPolicy, ExternalSecret, and ServiceMonitor support"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: ai-machine-learning
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://jupyter.org/hub
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/jupyterhub
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/jupyterhub
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql

--- a/charts/jupyterhub/DESIGN.md
+++ b/charts/jupyterhub/DESIGN.md
@@ -25,6 +25,7 @@ flowchart LR
 - KubeSpawner disables automounted tokens for single-user pods.
 - Public exposure with DummyAuthenticator requires either `auth.dummyPassword` or an explicit insecure opt-in.
 - Public exposure with custom authenticators requires `hub.extraConfig` to set `authenticator_class`.
+- Prometheus metrics remain authenticated by default, and public anonymous metrics require an explicit opt-in.
 - The Hub Deployment uses `Recreate` while the default SQLite PVC is enabled.
 - The proxy runs separately from the Hub, so `hub.cleanupServers=false` keeps user notebook pods running across Hub restarts.
 

--- a/charts/jupyterhub/DESIGN.md
+++ b/charts/jupyterhub/DESIGN.md
@@ -26,6 +26,7 @@ flowchart LR
 - Public exposure with DummyAuthenticator requires either `auth.dummyPassword` or an explicit insecure opt-in.
 - Public exposure with custom authenticators requires `hub.extraConfig` to set `authenticator_class`.
 - The Hub Deployment uses `Recreate` while the default SQLite PVC is enabled.
+- The proxy runs separately from the Hub, so `hub.cleanupServers=false` keeps user notebook pods running across Hub restarts.
 
 ## Persistence
 

--- a/charts/jupyterhub/DESIGN.md
+++ b/charts/jupyterhub/DESIGN.md
@@ -38,3 +38,6 @@ PostgreSQL chart.
 ## Networking
 
 Ingress uses `ingress.ingressClassName`. Gateway API uses the single standard `gateway` block and renders an `HTTPRoute` to the public proxy Service.
+When the Service is dual-stack or IPv6, configurable-http-proxy binds public and
+API listeners to `::`; `proxy.bind.ip` and `proxy.bind.apiIp` can override the
+detected bind addresses.

--- a/charts/jupyterhub/DESIGN.md
+++ b/charts/jupyterhub/DESIGN.md
@@ -1,0 +1,39 @@
+# JupyterHub Chart Design
+
+## Goals
+
+- Deploy JupyterHub with configurable-http-proxy and KubeSpawner using secure Kubernetes defaults.
+- Keep the default install useful for local and classroom scenarios while validating unsafe public exposure.
+- Support Ingress, Gateway API, dual-stack Services, NetworkPolicy, ServiceMonitor, PDB, and ExternalSecret.
+- Generate or reuse the configurable-http-proxy token without storing credentials in ConfigMaps.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  User --> Proxy[configurable-http-proxy]
+  Proxy --> Hub[JupyterHub Hub]
+  Hub --> API[Kubernetes API]
+  API --> UserPods[Single-user notebook pods]
+  Secret[Proxy token Secret] --> Proxy
+  Secret --> Hub
+```
+
+## Security Defaults
+
+- Hub and proxy containers run as non-root with dropped Linux capabilities and runtime default seccomp.
+- KubeSpawner disables automounted tokens for single-user pods.
+- Public exposure with DummyAuthenticator requires either `auth.dummyPassword` or an explicit insecure opt-in.
+- Public exposure with custom authenticators requires `hub.extraConfig` to set `authenticator_class`.
+- The Hub Deployment uses `Recreate` while the default SQLite PVC is enabled.
+
+## Persistence
+
+The default Hub database is SQLite on the Hub PVC for a low-friction single-node
+install. For larger production deployments, use `hub.extraConfig` to configure
+an external JupyterHub database and manage that database with the HelmForge
+PostgreSQL chart.
+
+## Networking
+
+Ingress uses `ingress.ingressClassName`. Gateway API uses the single standard `gateway` block and renders an `HTTPRoute` to the public proxy Service.

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -26,6 +26,8 @@ set `proxy.existingSecret` and optionally render an `ExternalSecret`.
 Keep the default SQLite Hub database to one Hub replica. For larger deployments,
 configure an external database with `hub.extraConfig` and manage it with the
 HelmForge PostgreSQL chart.
+Set `c.JupyterHub.db_url` in `hub.extraConfig` before increasing
+`hub.replicaCount` above `1`.
 
 ## Single-User Image
 

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -37,6 +37,11 @@ each other's login cookies.
 The chart runs configurable-http-proxy separately from the Hub and defaults
 `hub.cleanupServers=false`, so notebook pods are not stopped during normal Hub
 rollouts or node drains.
+Prometheus metrics stay authenticated by default. If you enable a
+ServiceMonitor, set `metrics.authenticatePrometheus=false` only for private
+scrape paths, or explicitly set
+`metrics.allowPublicUnauthenticatedPrometheus=true` when public exposure should
+also allow anonymous `/hub/metrics`.
 
 ## Single-User Image
 

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -31,6 +31,9 @@ Set `c.JupyterHub.db_url` in `hub.extraConfig` before increasing
 When running multiple Hub replicas, disable Hub persistence or use multi-writer
 storage; `ReadWriteOnce` and `ReadWriteOncePod` PVCs are intentionally rejected
 for HA Hub deployments.
+The chart runs configurable-http-proxy separately from the Hub and defaults
+`hub.cleanupServers=false`, so notebook pods are not stopped during normal Hub
+rollouts or node drains.
 
 ## Single-User Image
 

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -31,6 +31,9 @@ Set `c.JupyterHub.db_url` in `hub.extraConfig` before increasing
 When running multiple Hub replicas, disable Hub persistence or use multi-writer
 storage; `ReadWriteOnce` and `ReadWriteOncePod` PVCs are intentionally rejected
 for HA Hub deployments.
+If Hub persistence is disabled for HA, set `hub.cookieSecret.existingSecret` so
+all Hub replicas read the same `jupyterhub_cookie_secret` file and can decrypt
+each other's login cookies.
 The chart runs configurable-http-proxy separately from the Hub and defaults
 `hub.cleanupServers=false`, so notebook pods are not stopped during normal Hub
 rollouts or node drains.

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -1,10 +1,13 @@
 # JupyterHub
 
-JupyterHub provides multi-user notebook servers for teams, classrooms, and research platforms.
+JupyterHub provides multi-user notebook servers for teams, classrooms, and
+research platforms.
 
-This HelmForge chart deploys a JupyterHub Hub and configurable-http-proxy pair with a managed proxy token Secret,
-KubeSpawner configuration, namespaced RBAC for user pods, optional user PVCs, Gateway API, Ingress, dual-stack Service,
-NetworkPolicy, ExternalSecret, ServiceMonitor, PodDisruptionBudget, schema, and Helm tests.
+This HelmForge chart deploys a JupyterHub Hub and configurable-http-proxy pair
+with a managed proxy token Secret, KubeSpawner configuration, namespaced RBAC for
+user pods, optional user PVCs, Gateway API, Ingress, dual-stack Service,
+NetworkPolicy, ExternalSecret, ServiceMonitor, PodDisruptionBudget, schema, and
+Helm tests.
 
 ## Install
 
@@ -15,8 +18,14 @@ helm install jupyterhub helmforge/jupyterhub
 
 ## Proxy Token
 
-The chart generates a proxy token by default. For GitOps-managed credentials, set `proxy.existingSecret`
-and optionally render an `ExternalSecret`.
+The chart generates a proxy token by default. For GitOps-managed credentials,
+set `proxy.existingSecret` and optionally render an `ExternalSecret`.
+
+## Production Notes
+
+Keep the default SQLite Hub database to one Hub replica. For larger deployments,
+configure an external database with `hub.extraConfig` and manage it with the
+HelmForge PostgreSQL chart.
 
 ## Single-User Image
 

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -28,6 +28,9 @@ configure an external database with `hub.extraConfig` and manage it with the
 HelmForge PostgreSQL chart.
 Set `c.JupyterHub.db_url` in `hub.extraConfig` before increasing
 `hub.replicaCount` above `1`.
+When running multiple Hub replicas, disable Hub persistence or use multi-writer
+storage; `ReadWriteOnce` and `ReadWriteOncePod` PVCs are intentionally rejected
+for HA Hub deployments.
 
 ## Single-User Image
 

--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -1,0 +1,41 @@
+# JupyterHub
+
+JupyterHub provides multi-user notebook servers for teams, classrooms, and research platforms.
+
+This HelmForge chart deploys a JupyterHub Hub and configurable-http-proxy pair with a managed proxy token Secret,
+KubeSpawner configuration, namespaced RBAC for user pods, optional user PVCs, Gateway API, Ingress, dual-stack Service,
+NetworkPolicy, ExternalSecret, ServiceMonitor, PodDisruptionBudget, schema, and Helm tests.
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm install jupyterhub helmforge/jupyterhub
+```
+
+## Proxy Token
+
+The chart generates a proxy token by default. For GitOps-managed credentials, set `proxy.existingSecret`
+and optionally render an `ExternalSecret`.
+
+## Single-User Image
+
+```yaml
+singleuser:
+  image:
+    name: quay.io/jupyter/scipy-notebook
+    tag: "2026-05-26"
+```
+
+## Profiles
+
+```yaml
+singleuser:
+  profiles:
+    - display_name: Standard
+      slug: standard
+      default: true
+      kubespawner_override:
+        cpu_limit: 1
+        mem_limit: 2G
+```

--- a/charts/jupyterhub/ci/default-values.yaml
+++ b/charts/jupyterhub/ci/default-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+hub:
+  replicaCount: 1

--- a/charts/jupyterhub/ci/dual-stack-values.yaml
+++ b/charts/jupyterhub/ci/dual-stack-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/jupyterhub/ci/external-secrets-values.yaml
+++ b/charts/jupyterhub/ci/external-secrets-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+proxy:
+  existingSecret: jupyterhub-proxy-managed
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: proxy-token
+      remoteRef:
+        key: jupyterhub/proxy
+        property: token

--- a/charts/jupyterhub/ci/gateway-api-values.yaml
+++ b/charts/jupyterhub/ci/gateway-api-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - jupyterhub.example.local

--- a/charts/jupyterhub/ci/gateway-api-values.yaml
+++ b/charts/jupyterhub/ci/gateway-api-values.yaml
@@ -6,3 +6,5 @@ gateway:
       namespace: gateway-system
   hostnames:
     - jupyterhub.example.local
+auth:
+  dummyPassword: helmforge

--- a/charts/jupyterhub/ci/ingress-values.yaml
+++ b/charts/jupyterhub/ci/ingress-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: jupyterhub.example.local
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/jupyterhub/ci/ingress-values.yaml
+++ b/charts/jupyterhub/ci/ingress-values.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   hosts:
     - host: jupyterhub.example.local
       paths:

--- a/charts/jupyterhub/ci/ingress-values.yaml
+++ b/charts/jupyterhub/ci/ingress-values.yaml
@@ -7,3 +7,5 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+auth:
+  dummyPassword: helmforge

--- a/charts/jupyterhub/ci/k3d-values.yaml
+++ b/charts/jupyterhub/ci/k3d-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  dummyPassword: helmforge
+hub:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 768Mi
+proxy:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 96Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi

--- a/charts/jupyterhub/ci/network-policy-values.yaml
+++ b/charts/jupyterhub/ci/network-policy-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true

--- a/charts/jupyterhub/ci/security-values.yaml
+++ b/charts/jupyterhub/ci/security-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+pdb:
+  enabled: true
+singleuser:
+  storage:
+    enabled: true
+    capacity: 1Gi
+networkPolicy:
+  enabled: true
+auth:
+  dummyPassword: helmforge

--- a/charts/jupyterhub/ci/security-values.yaml
+++ b/charts/jupyterhub/ci/security-values.yaml
@@ -7,5 +7,10 @@ singleuser:
     capacity: 1Gi
 networkPolicy:
   enabled: true
+proxy:
+  existingSecret: jupyterhub-proxy-token
 auth:
-  dummyPassword: helmforge
+  type: custom
+hub:
+  extraConfig: |
+    c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"

--- a/charts/jupyterhub/ci/servicemonitor-values.yaml
+++ b/charts/jupyterhub/ci/servicemonitor-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+metrics:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus

--- a/charts/jupyterhub/ci/servicemonitor-values.yaml
+++ b/charts/jupyterhub/ci/servicemonitor-values.yaml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 metrics:
+  authenticatePrometheus: false
   serviceMonitor:
     enabled: true
     labels:

--- a/charts/jupyterhub/docs/external-secrets.md
+++ b/charts/jupyterhub/docs/external-secrets.md
@@ -1,0 +1,7 @@
+# JupyterHub External Secrets
+
+ExternalSecret support manages the configurable-http-proxy token Secret.
+
+Set `proxy.existingSecret` to the target Secret name, enable `externalSecrets.enabled`, and provide either `externalSecrets.data` or `externalSecrets.dataFrom`.
+
+The target Secret must contain the key configured by `proxy.existingSecretTokenKey`, which defaults to `proxy-token`.

--- a/charts/jupyterhub/docs/networking.md
+++ b/charts/jupyterhub/docs/networking.md
@@ -1,0 +1,13 @@
+# JupyterHub Networking
+
+## Ingress
+
+Use `ingress.ingressClassName` to select the ingress controller. Public Ingress requires a secure authenticator configuration or an explicit dummy-auth opt-in for local testing.
+
+## Gateway API
+
+Use `gateway.enabled=true` and set `gateway.parentRefs` to the Gateway that should serve JupyterHub traffic.
+
+## NetworkPolicy
+
+Enable `networkPolicy.enabled=true` to restrict Hub, proxy, and single-user notebook traffic to the expected paths.

--- a/charts/jupyterhub/docs/production.md
+++ b/charts/jupyterhub/docs/production.md
@@ -12,6 +12,10 @@ external database in `hub.extraConfig` and manage that database with the
 HelmForge PostgreSQL chart.
 The chart fails rendering when `hub.replicaCount > 1` and no external
 `c.JupyterHub.db_url` is configured, because SQLite is single-writer storage.
+Because the chart runs configurable-http-proxy separately from the Hub, it sets
+`c.JupyterHub.cleanup_servers = False` by default through
+`hub.cleanupServers=false`. Keep this default to preserve running user servers
+across Hub rollouts, checksum-triggered restarts, and node drains.
 
 ## Single-User Pods
 

--- a/charts/jupyterhub/docs/production.md
+++ b/charts/jupyterhub/docs/production.md
@@ -12,6 +12,10 @@ external database in `hub.extraConfig` and manage that database with the
 HelmForge PostgreSQL chart.
 The chart fails rendering when `hub.replicaCount > 1` and no external
 `c.JupyterHub.db_url` is configured, because SQLite is single-writer storage.
+For HA Hubs without Hub persistence, create a shared Secret containing the
+hex-encoded JupyterHub cookie secret and set `hub.cookieSecret.existingSecret`.
+Without that shared file, each replica generates its own secret and
+load-balanced login sessions can fail when requests land on another replica.
 Because the chart runs configurable-http-proxy separately from the Hub, it sets
 `c.JupyterHub.cleanup_servers = False` by default through
 `hub.cleanupServers=false`. Keep this default to preserve running user servers

--- a/charts/jupyterhub/docs/production.md
+++ b/charts/jupyterhub/docs/production.md
@@ -21,6 +21,16 @@ Because the chart runs configurable-http-proxy separately from the Hub, it sets
 `hub.cleanupServers=false`. Keep this default to preserve running user servers
 across Hub rollouts, checksum-triggered restarts, and node drains.
 
+## Metrics
+
+The chart keeps `c.JupyterHub.authenticate_prometheus = True` by default so
+public Ingress, Gateway, LoadBalancer, and NodePort routes do not expose
+`/hub/metrics` anonymously. The current ServiceMonitor integration does not
+wire scrape credentials, so enabling it requires
+`metrics.authenticatePrometheus=false`. For public deployments this also
+requires `metrics.allowPublicUnauthenticatedPrometheus=true` as an explicit
+acknowledgement that anonymous metrics are reachable through the public proxy.
+
 ## Single-User Pods
 
 Use `singleuser.profiles` to offer controlled notebook profiles. Enable `singleuser.storage.enabled=true` when users need persistent home directories.

--- a/charts/jupyterhub/docs/production.md
+++ b/charts/jupyterhub/docs/production.md
@@ -1,0 +1,16 @@
+# JupyterHub Production Notes
+
+## Authentication
+
+Do not expose the default DummyAuthenticator without a password. For production, set `auth.type=custom` and configure an authenticator in `hub.extraConfig`.
+
+## Persistence
+
+The default Hub state uses a SQLite database on the Hub PVC. Keep Hub replicas
+at one for this mode. For larger deployments, configure JupyterHub to use an
+external database in `hub.extraConfig` and manage that database with the
+HelmForge PostgreSQL chart.
+
+## Single-User Pods
+
+Use `singleuser.profiles` to offer controlled notebook profiles. Enable `singleuser.storage.enabled=true` when users need persistent home directories.

--- a/charts/jupyterhub/docs/production.md
+++ b/charts/jupyterhub/docs/production.md
@@ -10,6 +10,8 @@ The default Hub state uses a SQLite database on the Hub PVC. Keep Hub replicas
 at one for this mode. For larger deployments, configure JupyterHub to use an
 external database in `hub.extraConfig` and manage that database with the
 HelmForge PostgreSQL chart.
+The chart fails rendering when `hub.replicaCount > 1` and no external
+`c.JupyterHub.db_url` is configured, because SQLite is single-writer storage.
 
 ## Single-User Pods
 

--- a/charts/jupyterhub/examples/external-secrets.yaml
+++ b/charts/jupyterhub/examples/external-secrets.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+proxy:
+  existingSecret: jupyterhub-proxy-token
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: proxy-token
+      remoteRef:
+        key: jupyterhub/proxy
+        property: proxy-token

--- a/charts/jupyterhub/examples/gateway.yaml
+++ b/charts/jupyterhub/examples/gateway.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  dummyPassword: local-password
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - hub.example.com

--- a/charts/jupyterhub/examples/production.yaml
+++ b/charts/jupyterhub/examples/production.yaml
@@ -5,6 +5,10 @@ auth:
 hub:
   extraConfig: |
     c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
+    # Set c.JupyterHub.db_url here before increasing hub.replicaCount.
+  cookieSecret:
+    # Required for HA Hubs when hub.persistence.enabled=false.
+    existingSecret: ""
   persistence:
     enabled: true
     storageClass: fast-retain

--- a/charts/jupyterhub/examples/production.yaml
+++ b/charts/jupyterhub/examples/production.yaml
@@ -45,7 +45,11 @@ networkPolicy:
   enabled: true
 
 metrics:
+  authenticatePrometheus: true
   serviceMonitor:
-    enabled: true
+    # Enable only after configuring a private scrape path or explicitly
+    # accepting anonymous public /hub/metrics with
+    # metrics.allowPublicUnauthenticatedPrometheus=true.
+    enabled: false
     labels:
       release: prometheus

--- a/charts/jupyterhub/examples/production.yaml
+++ b/charts/jupyterhub/examples/production.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  type: custom
+
+hub:
+  extraConfig: |
+    c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
+  persistence:
+    enabled: true
+    storageClass: fast-retain
+    size: 20Gi
+
+singleuser:
+  storage:
+    enabled: true
+    storageClass: fast-retain
+    capacity: 20Gi
+  profiles:
+    - display_name: Standard Lab
+      slug: standard
+      default: true
+      kubespawner_override:
+        default_url: /lab
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: hub.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: jupyterhub-tls
+      hosts:
+        - hub.example.com
+
+networkPolicy:
+  enabled: true
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus

--- a/charts/jupyterhub/templates/NOTES.txt
+++ b/charts/jupyterhub/templates/NOTES.txt
@@ -1,0 +1,8 @@
+JupyterHub has been deployed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Service: {{ include "jupyterhub.proxyName" . }}
+
+Internal URL:
+  http://{{ include "jupyterhub.proxyName" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/

--- a/charts/jupyterhub/templates/NOTES.txt
+++ b/charts/jupyterhub/templates/NOTES.txt
@@ -1,8 +1,66 @@
-JupyterHub has been deployed.
+=============================================================================
+JupyterHub deployed successfully!
+=============================================================================
 
-Release: {{ .Release.Name }}
-Namespace: {{ .Release.Namespace }}
-Service: {{ include "jupyterhub.proxyName" . }}
+ACCESS:
+   kubectl port-forward svc/{{ include "jupyterhub.proxyName" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
+   Open: http://localhost:8080{{ .Values.hub.baseUrl }}
 
-Internal URL:
-  http://{{ include "jupyterhub.proxyName" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/
+SERVICES:
+   Proxy: {{ include "jupyterhub.proxyName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Proxy API: {{ include "jupyterhub.proxyApiName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.proxyApiPort }}
+   Hub: {{ include "jupyterhub.hubName" . }}.{{ .Release.Namespace }}.svc.cluster.local:8081
+
+AUTHENTICATION:
+   Auth type: {{ .Values.auth.type }}
+{{- if and (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) }}
+   Dummy password: empty
+{{- else if eq .Values.auth.type "dummy" }}
+   Dummy password: configured
+{{- end }}
+
+PERSISTENCE:
+{{- if .Values.hub.persistence.enabled }}
+   Hub PVC: {{ include "jupyterhub.hubDataClaimName" . }}
+{{- else }}
+   Hub state: emptyDir
+{{- end }}
+{{- if .Values.singleuser.storage.enabled }}
+   Single-user PVCs: enabled
+{{- else }}
+   Single-user PVCs: disabled
+{{- end }}
+
+NETWORKING:
+{{- if .Values.ingress.enabled }}
+   Ingress: enabled
+   Class: {{ .Values.ingress.ingressClassName | default "(cluster default)" }}
+{{- else }}
+   Ingress: disabled
+{{- end }}
+{{- if .Values.gateway.enabled }}
+   Gateway API: enabled
+   HTTPRoute: {{ include "jupyterhub.fullname" . }}
+{{- else }}
+   Gateway API: disabled
+{{- end }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "jupyterhub.hubName" . }}
+
+SECURITY REMINDERS:
+   1. Do not expose DummyAuthenticator publicly without auth.dummyPassword.
+   2. Use a real authenticator through hub.extraConfig for production.
+   3. Keep the proxy token in an existing Secret or ExternalSecret for GitOps.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/jupyterhub
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/jupyterhub
+   JupyterHub: https://jupyter.org/hub
+
+=============================================================================

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -67,6 +67,19 @@ annotations:
 {{- define "jupyterhub.proxyToken" -}}
 {{- if .Values.proxy.secretToken }}{{ .Values.proxy.secretToken }}{{- else if .Values.proxy.existingSecret }}{{ "" }}{{- else }}{{ randAlphaNum 64 }}{{- end -}}
 {{- end -}}
+{{- define "jupyterhub.proxyDefaultBindIp" -}}
+{{- if or (has "IPv6" .Values.service.ipFamilies) (eq .Values.service.ipFamilyPolicy "PreferDualStack") (eq .Values.service.ipFamilyPolicy "RequireDualStack") -}}
+::
+{{- else -}}
+0.0.0.0
+{{- end -}}
+{{- end -}}
+{{- define "jupyterhub.proxyBindIp" -}}
+{{- default (include "jupyterhub.proxyDefaultBindIp" .) .Values.proxy.bind.ip -}}
+{{- end -}}
+{{- define "jupyterhub.proxyApiBindIp" -}}
+{{- default (include "jupyterhub.proxyDefaultBindIp" .) .Values.proxy.bind.apiIp -}}
+{{- end -}}
 {{- define "jupyterhub.validateValues" -}}
 {{- $publicExposure := or .Values.ingress.enabled .Values.gateway.enabled (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") -}}
 {{- if and $publicExposure (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) (not .Values.auth.allowInsecureDummy) -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "jupyterhub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "jupyterhub.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}{{ .Release.Name | trunc 63 | trimSuffix "-" }}{{- else -}}{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- define "jupyterhub.chart" -}}{{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- define "jupyterhub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jupyterhub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+{{- define "jupyterhub.labels" -}}
+helm.sh/chart: {{ include "jupyterhub.chart" . }}
+{{ include "jupyterhub.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}{{ toYaml . }}{{- end }}
+{{- end -}}
+{{- define "jupyterhub.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}{{ default (include "jupyterhub.fullname" .) .Values.serviceAccount.name }}{{- else }}{{ default "default" .Values.serviceAccount.name }}{{- end -}}
+{{- end -}}
+{{- define "jupyterhub.hubName" -}}{{ include "jupyterhub.fullname" . }}-hub{{- end -}}
+{{- define "jupyterhub.proxyName" -}}{{ include "jupyterhub.fullname" . }}{{- end -}}
+{{- define "jupyterhub.secretName" -}}
+{{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.fullname" . }}-proxy{{- end -}}
+{{- end -}}
+{{- define "jupyterhub.proxyToken" -}}
+{{- if .Values.proxy.secretToken }}{{ .Values.proxy.secretToken }}{{- else if .Values.proxy.existingSecret }}{{ "" }}{{- else }}{{ randAlphaNum 64 }}{{- end -}}
+{{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -21,7 +21,9 @@ helm.sh/chart: {{ include "jupyterhub.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: helmforge
-{{- with .Values.commonLabels }}{{ toYaml . }}{{- end }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 {{- define "jupyterhub.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}{{ default (include "jupyterhub.fullname" .) .Values.serviceAccount.name }}{{- else }}{{ default "default" .Values.serviceAccount.name }}{{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -49,8 +49,11 @@ app.kubernetes.io/part-of: helmforge
 {{- if .Values.proxy.secretToken }}{{ .Values.proxy.secretToken }}{{- else if .Values.proxy.existingSecret }}{{ "" }}{{- else }}{{ randAlphaNum 64 }}{{- end -}}
 {{- end -}}
 {{- define "jupyterhub.validateValues" -}}
-{{- $publicExposure := or .Values.ingress.enabled .Values.gateway.enabled (eq .Values.service.type "LoadBalancer") -}}
-{{- if and $publicExposure (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) (not .Values.auth.allowInsecureDummy) (not .Values.hub.extraConfig) -}}
-{{- fail "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true" -}}
+{{- $publicExposure := or .Values.ingress.enabled .Values.gateway.enabled (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") -}}
+{{- if and $publicExposure (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) (not .Values.auth.allowInsecureDummy) -}}
+{{- fail "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true" -}}
+{{- end -}}
+{{- if and $publicExposure (ne .Values.auth.type "dummy") (not .Values.hub.extraConfig) -}}
+{{- fail "public exposure with a custom authenticator requires hub.extraConfig" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -85,7 +85,7 @@ annotations:
 {{- if and $publicExposure (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) (not .Values.auth.allowInsecureDummy) -}}
 {{- fail "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true" -}}
 {{- end -}}
-{{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "authenticator_class" .Values.hub.extraConfig)) -}}
+{{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "(?m)^\\s*c\\.JupyterHub\\.authenticator_class\\s*=" .Values.hub.extraConfig)) -}}
 {{- fail "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class" -}}
 {{- end -}}
 {{- $hasExternalHubDb := regexMatch "(?m)^\\s*c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -75,11 +75,12 @@ annotations:
 {{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "authenticator_class" .Values.hub.extraConfig)) -}}
 {{- fail "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class" -}}
 {{- end -}}
-{{- if and (gt (int .Values.hub.replicaCount) 1) (not (regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig)) -}}
+{{- $hasExternalHubDb := regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
+{{- if and (gt (int .Values.hub.replicaCount) 1) (not $hasExternalHubDb) -}}
 {{- fail "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica" -}}
 {{- end -}}
 {{- $singleWriterHubPVC := or (has "ReadWriteOnce" .Values.hub.persistence.accessModes) (has "ReadWriteOncePod" .Values.hub.persistence.accessModes) -}}
-{{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled $singleWriterHubPVC -}}
+{{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled (not .Values.hub.persistence.existingClaim) $singleWriterHubPVC -}}
 {{- fail "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce or ReadWriteOncePod, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC" -}}
 {{- end -}}
 {{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -75,7 +75,7 @@ annotations:
 {{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "authenticator_class" .Values.hub.extraConfig)) -}}
 {{- fail "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class" -}}
 {{- end -}}
-{{- $hasExternalHubDb := regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
+{{- $hasExternalHubDb := regexMatch "(?m)^\\s*c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
 {{- if and (gt (int .Values.hub.replicaCount) 1) (not $hasExternalHubDb) -}}
 {{- fail "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica" -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -96,6 +96,14 @@ annotations:
 {{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled (not .Values.hub.persistence.existingClaim) $singleWriterHubPVC -}}
 {{- fail "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce or ReadWriteOncePod, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC" -}}
 {{- end -}}
+{{- if and .Values.metrics.serviceMonitor.enabled .Values.metrics.authenticatePrometheus -}}
+{{- fail "metrics.serviceMonitor.enabled=true requires metrics.authenticatePrometheus=false until ServiceMonitor scrape credentials are configured" -}}
+{{- end -}}
+{{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
+{{- if hasKey $.Values.commonLabels $key -}}
+{{- fail (printf "commonLabels cannot override reserved selector label %s" $key) -}}
+{{- end -}}
+{{- end -}}
 {{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
 {{- if hasKey $.Values.podLabels $key -}}
 {{- fail (printf "podLabels cannot override reserved selector label %s" $key) -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -96,6 +96,12 @@ annotations:
 {{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled (not .Values.hub.persistence.existingClaim) $singleWriterHubPVC -}}
 {{- fail "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce or ReadWriteOncePod, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC" -}}
 {{- end -}}
+{{- if and (gt (int .Values.hub.replicaCount) 1) $hasExternalHubDb (not .Values.hub.persistence.enabled) (not .Values.hub.cookieSecret.existingSecret) -}}
+{{- fail "hub.replicaCount > 1 with hub.persistence.enabled=false requires hub.cookieSecret.existingSecret so every Hub replica uses the same JupyterHub cookie secret" -}}
+{{- end -}}
+{{- if and .Values.hub.cookieSecret.fileName (contains "/" .Values.hub.cookieSecret.fileName) -}}
+{{- fail "hub.cookieSecret.fileName must be a file name, not a path" -}}
+{{- end -}}
 {{- if and .Values.metrics.serviceMonitor.enabled .Values.metrics.authenticatePrometheus -}}
 {{- fail "metrics.serviceMonitor.enabled=true requires metrics.authenticatePrometheus=false until ServiceMonitor scrape credentials are configured" -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -53,7 +53,7 @@ app.kubernetes.io/part-of: helmforge
 {{- if and $publicExposure (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) (not .Values.auth.allowInsecureDummy) -}}
 {{- fail "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true" -}}
 {{- end -}}
-{{- if and $publicExposure (ne .Values.auth.type "dummy") (not .Values.hub.extraConfig) -}}
-{{- fail "public exposure with a custom authenticator requires hub.extraConfig" -}}
+{{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "authenticator_class" .Values.hub.extraConfig)) -}}
+{{- fail "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -43,11 +43,14 @@ annotations:
 {{- define "jupyterhub.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}{{ default (include "jupyterhub.fullname" .) .Values.serviceAccount.name }}{{- else }}{{ default "default" .Values.serviceAccount.name }}{{- end -}}
 {{- end -}}
-{{- define "jupyterhub.hubName" -}}{{ include "jupyterhub.fullname" . }}-hub{{- end -}}
+{{- define "jupyterhub.hubName" -}}{{ printf "%s-hub" (include "jupyterhub.fullname" . | trunc 59 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}{{- end -}}
 {{- define "jupyterhub.proxyName" -}}{{ include "jupyterhub.fullname" . }}{{- end -}}
-{{- define "jupyterhub.proxyApiName" -}}{{ include "jupyterhub.fullname" . }}-proxy-api{{- end -}}
+{{- define "jupyterhub.proxyDeploymentName" -}}{{ printf "%s-proxy" (include "jupyterhub.fullname" . | trunc 57 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- define "jupyterhub.proxyApiName" -}}{{ printf "%s-proxy-api" (include "jupyterhub.fullname" . | trunc 53 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- define "jupyterhub.singleuserNetworkPolicyName" -}}{{ printf "%s-singleuser" (include "jupyterhub.fullname" . | trunc 52 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}{{- end -}}
+{{- define "jupyterhub.testName" -}}{{ printf "%s-test-connection" (include "jupyterhub.fullname" . | trunc 47 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}{{- end -}}
 {{- define "jupyterhub.hubDataClaimName" -}}
-{{- if .Values.hub.persistence.existingClaim }}{{ .Values.hub.persistence.existingClaim }}{{- else }}{{ include "jupyterhub.hubName" . }}-data{{- end -}}
+{{- if .Values.hub.persistence.existingClaim }}{{ .Values.hub.persistence.existingClaim }}{{- else }}{{ printf "%s-hub-data" (include "jupyterhub.fullname" . | trunc 54 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}{{- end -}}
 {{- end -}}
 {{- define "jupyterhub.hubHealthPath" -}}
 {{- $base := trimSuffix "/" .Values.hub.baseUrl -}}
@@ -62,7 +65,7 @@ annotations:
 {{- if eq $base "" -}}/hub/error{{- else -}}{{ printf "%s/hub/error" $base }}{{- end -}}
 {{- end -}}
 {{- define "jupyterhub.secretName" -}}
-{{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.fullname" . }}-proxy{{- end -}}
+{{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.proxyDeploymentName" . }}{{- end -}}
 {{- end -}}
 {{- define "jupyterhub.proxyToken" -}}
 {{- if .Values.proxy.secretToken }}{{ .Values.proxy.secretToken }}{{- else if .Values.proxy.existingSecret }}{{ "" }}{{- else }}{{ randAlphaNum 64 }}{{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -78,8 +78,9 @@ annotations:
 {{- if and (gt (int .Values.hub.replicaCount) 1) (not (regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig)) -}}
 {{- fail "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica" -}}
 {{- end -}}
-{{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled (has "ReadWriteOnce" .Values.hub.persistence.accessModes) -}}
-{{- fail "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC" -}}
+{{- $singleWriterHubPVC := or (has "ReadWriteOnce" .Values.hub.persistence.accessModes) (has "ReadWriteOncePod" .Values.hub.persistence.accessModes) -}}
+{{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled $singleWriterHubPVC -}}
+{{- fail "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce or ReadWriteOncePod, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC" -}}
 {{- end -}}
 {{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
 {{- if hasKey $.Values.podLabels $key -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -25,6 +25,12 @@ app.kubernetes.io/part-of: helmforge
 {{ toYaml . }}
 {{- end }}
 {{- end -}}
+{{- define "jupyterhub.podLabels" -}}
+{{- $labels := omit .Values.podLabels "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
+{{- with $labels -}}
+{{- toYaml . -}}
+{{- end -}}
+{{- end -}}
 {{- define "jupyterhub.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}{{ default (include "jupyterhub.fullname" .) .Values.serviceAccount.name }}{{- else }}{{ default "default" .Values.serviceAccount.name }}{{- end -}}
 {{- end -}}
@@ -55,5 +61,10 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 {{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "authenticator_class" .Values.hub.extraConfig)) -}}
 {{- fail "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class" -}}
+{{- end -}}
+{{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
+{{- if hasKey $.Values.podLabels $key -}}
+{{- fail (printf "podLabels cannot override reserved selector label %s" $key) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -105,6 +105,9 @@ annotations:
 {{- if and .Values.metrics.serviceMonitor.enabled .Values.metrics.authenticatePrometheus -}}
 {{- fail "metrics.serviceMonitor.enabled=true requires metrics.authenticatePrometheus=false until ServiceMonitor scrape credentials are configured" -}}
 {{- end -}}
+{{- if and $publicExposure (not .Values.metrics.authenticatePrometheus) (not .Values.metrics.allowPublicUnauthenticatedPrometheus) -}}
+{{- fail "public exposure with unauthenticated Prometheus metrics requires metrics.allowPublicUnauthenticatedPrometheus=true" -}}
+{{- end -}}
 {{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
 {{- if hasKey $.Values.commonLabels $key -}}
 {{- fail (printf "commonLabels cannot override reserved selector label %s" $key) -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -66,6 +66,9 @@ app.kubernetes.io/part-of: helmforge
 {{- if and $publicExposure (ne .Values.auth.type "dummy") (not (regexMatch "authenticator_class" .Values.hub.extraConfig)) -}}
 {{- fail "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class" -}}
 {{- end -}}
+{{- if and (gt (int .Values.hub.replicaCount) 1) (not (regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig)) -}}
+{{- fail "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica" -}}
+{{- end -}}
 {{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
 {{- if hasKey $.Values.podLabels $key -}}
 {{- fail (printf "podLabels cannot override reserved selector label %s" $key) -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -30,6 +30,10 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 {{- define "jupyterhub.hubName" -}}{{ include "jupyterhub.fullname" . }}-hub{{- end -}}
 {{- define "jupyterhub.proxyName" -}}{{ include "jupyterhub.fullname" . }}{{- end -}}
+{{- define "jupyterhub.proxyApiName" -}}{{ include "jupyterhub.fullname" . }}-proxy-api{{- end -}}
+{{- define "jupyterhub.hubDataClaimName" -}}
+{{- if .Values.hub.persistence.existingClaim }}{{ .Values.hub.persistence.existingClaim }}{{- else }}{{ include "jupyterhub.hubName" . }}-data{{- end -}}
+{{- end -}}
 {{- define "jupyterhub.secretName" -}}
 {{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.fullname" . }}-proxy{{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -78,6 +78,9 @@ annotations:
 {{- if and (gt (int .Values.hub.replicaCount) 1) (not (regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig)) -}}
 {{- fail "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica" -}}
 {{- end -}}
+{{- if and (gt (int .Values.hub.replicaCount) 1) .Values.hub.persistence.enabled (has "ReadWriteOnce" .Values.hub.persistence.accessModes) -}}
+{{- fail "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC" -}}
+{{- end -}}
 {{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
 {{- if hasKey $.Values.podLabels $key -}}
 {{- fail (printf "podLabels cannot override reserved selector label %s" $key) -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -48,3 +48,9 @@ app.kubernetes.io/part-of: helmforge
 {{- define "jupyterhub.proxyToken" -}}
 {{- if .Values.proxy.secretToken }}{{ .Values.proxy.secretToken }}{{- else if .Values.proxy.existingSecret }}{{ "" }}{{- else }}{{ randAlphaNum 64 }}{{- end -}}
 {{- end -}}
+{{- define "jupyterhub.validateValues" -}}
+{{- $publicExposure := or .Values.ingress.enabled .Values.gateway.enabled (eq .Values.service.type "LoadBalancer") -}}
+{{- if and $publicExposure (eq .Values.auth.type "dummy") (not .Values.auth.dummyPassword) (not .Values.auth.allowInsecureDummy) (not .Values.hub.extraConfig) -}}
+{{- fail "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -34,6 +34,10 @@ app.kubernetes.io/part-of: helmforge
 {{- define "jupyterhub.hubDataClaimName" -}}
 {{- if .Values.hub.persistence.existingClaim }}{{ .Values.hub.persistence.existingClaim }}{{- else }}{{ include "jupyterhub.hubName" . }}-data{{- end -}}
 {{- end -}}
+{{- define "jupyterhub.hubHealthPath" -}}
+{{- $base := trimSuffix "/" .Values.hub.baseUrl -}}
+{{- if eq $base "" -}}/hub/health{{- else -}}{{ printf "%s/hub/health" $base }}{{- end -}}
+{{- end -}}
 {{- define "jupyterhub.secretName" -}}
 {{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.fullname" . }}-proxy{{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -48,6 +48,10 @@ app.kubernetes.io/part-of: helmforge
 {{- $base := trimSuffix "/" .Values.hub.baseUrl -}}
 {{- if eq $base "" -}}/hub/metrics{{- else -}}{{ printf "%s/hub/metrics" $base }}{{- end -}}
 {{- end -}}
+{{- define "jupyterhub.hubErrorPath" -}}
+{{- $base := trimSuffix "/" .Values.hub.baseUrl -}}
+{{- if eq $base "" -}}/hub/error{{- else -}}{{ printf "%s/hub/error" $base }}{{- end -}}
+{{- end -}}
 {{- define "jupyterhub.secretName" -}}
 {{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.fullname" . }}-proxy{{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -25,6 +25,15 @@ app.kubernetes.io/part-of: helmforge
 {{ toYaml . }}
 {{- end }}
 {{- end -}}
+{{- define "jupyterhub.renderAnnotations" -}}
+{{- $common := .common | default dict -}}
+{{- $specific := .specific | default dict -}}
+{{- $annotations := mergeOverwrite (deepCopy $common) $specific -}}
+{{- with $annotations }}
+annotations:
+{{ toYaml . | nindent 2 }}
+{{- end -}}
+{{- end -}}
 {{- define "jupyterhub.podLabels" -}}
 {{- $labels := omit .Values.podLabels "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
 {{- with $labels -}}

--- a/charts/jupyterhub/templates/_helpers.tpl
+++ b/charts/jupyterhub/templates/_helpers.tpl
@@ -38,6 +38,10 @@ app.kubernetes.io/part-of: helmforge
 {{- $base := trimSuffix "/" .Values.hub.baseUrl -}}
 {{- if eq $base "" -}}/hub/health{{- else -}}{{ printf "%s/hub/health" $base }}{{- end -}}
 {{- end -}}
+{{- define "jupyterhub.hubMetricsPath" -}}
+{{- $base := trimSuffix "/" .Values.hub.baseUrl -}}
+{{- if eq $base "" -}}/hub/metrics{{- else -}}{{ printf "%s/hub/metrics" $base }}{{- end -}}
+{{- end -}}
 {{- define "jupyterhub.secretName" -}}
 {{- if .Values.proxy.existingSecret }}{{ .Values.proxy.existingSecret }}{{- else }}{{ include "jupyterhub.fullname" . }}-proxy{{- end -}}
 {{- end -}}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
     c.JupyterHub.base_url = "{{ .Values.hub.baseUrl }}"
     c.JupyterHub.db_url = "sqlite:///{{ .Values.hub.dbPath }}"
     c.JupyterHub.log_level = "{{ .Values.hub.logLevel }}"
+    c.JupyterHub.authenticate_prometheus = {{ ternary "True" "False" .Values.metrics.authenticatePrometheus }}
 
     c.ConfigurableHTTPProxy.should_start = False
     c.ConfigurableHTTPProxy.api_url = "http://{{ include "jupyterhub.proxyApiName" . }}:{{ .Values.service.proxyApiPort }}"
@@ -53,8 +54,8 @@ data:
     {{- with .Values.singleuser.storage.storageClass }}
     c.KubeSpawner.storage_class = "{{ . }}"
     {{- end }}
-    c.KubeSpawner.pvc_name_template = "claim-{username}"
-    c.KubeSpawner.volumes = [{"name": "home", "persistentVolumeClaim": {"claimName": "claim-{username}"}}]
+    c.KubeSpawner.pvc_name_template = "{{ include "jupyterhub.fullname" . }}-claim-{username}"
+    c.KubeSpawner.volumes = [{"name": "home", "persistentVolumeClaim": {"claimName": "{{ include "jupyterhub.fullname" . }}-claim-{username}"}}]
     c.KubeSpawner.volume_mounts = [{"name": "home", "mountPath": "/home/jovyan"}]
     {{- end }}
     {{- with .Values.singleuser.profiles }}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -29,6 +29,11 @@ data:
     c.KubeSpawner.automount_service_account_token = False
     c.KubeSpawner.image = "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
     c.KubeSpawner.image_pull_policy = "{{ .Values.singleuser.image.pullPolicy }}"
+    c.KubeSpawner.extra_labels = {
+        "app.kubernetes.io/name": "{{ include "jupyterhub.name" . }}",
+        "app.kubernetes.io/instance": "{{ .Release.Name }}",
+        "app.kubernetes.io/component": "singleuser",
+    }
     {{- with .Values.imagePullSecrets }}
     c.KubeSpawner.image_pull_secrets = {{ . | toJson }}
     {{- end }}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -42,6 +42,9 @@ data:
     c.KubeSpawner.storage_pvc_ensure = True
     c.KubeSpawner.storage_capacity = "{{ .Values.singleuser.storage.capacity }}"
     c.KubeSpawner.storage_access_modes = {{ .Values.singleuser.storage.accessModes | toJson }}
+    {{- with .Values.singleuser.storage.storageClass }}
+    c.KubeSpawner.storage_class = "{{ . }}"
+    {{- end }}
     c.KubeSpawner.pvc_name_template = "claim-{username}"
     c.KubeSpawner.volumes = [{"name": "home", "persistentVolumeClaim": {"claimName": "claim-{username}"}}]
     c.KubeSpawner.volume_mounts = [{"name": "home", "mountPath": "/home/jovyan"}]

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -9,6 +9,7 @@ metadata:
 data:
   jupyterhub_config.py: |
     import os
+    import json
 
     c.JupyterHub.bind_url = "http://:8081/hub/"
     c.JupyterHub.hub_bind_url = "http://:8081"
@@ -62,7 +63,7 @@ data:
     c.KubeSpawner.volume_mounts = [{"name": "home", "mountPath": "/home/jovyan"}]
     {{- end }}
     {{- with .Values.singleuser.profiles }}
-    c.KubeSpawner.profile_list = {{ . | toJson }}
+    c.KubeSpawner.profile_list = json.loads({{ . | toJson | quote }})
     {{- end }}
     {{- with .Values.hub.extraConfig }}
 {{ . | nindent 4 }}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "jupyterhub.hubName" . }}-config
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 data:
   jupyterhub_config.py: |
     import os

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -1,0 +1,54 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jupyterhub.hubName" . }}-config
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+data:
+  jupyterhub_config.py: |
+    import os
+
+    c.JupyterHub.bind_url = "http://:8081/hub/"
+    c.JupyterHub.hub_bind_url = "http://:8081"
+    c.JupyterHub.hub_connect_url = "http://{{ include "jupyterhub.hubName" . }}:8081"
+    c.JupyterHub.base_url = "{{ .Values.hub.baseUrl }}"
+    c.JupyterHub.db_url = "sqlite:///{{ .Values.hub.dbPath }}"
+    c.JupyterHub.log_level = "{{ .Values.hub.logLevel }}"
+
+    c.ConfigurableHTTPProxy.should_start = False
+    c.ConfigurableHTTPProxy.api_url = "http://{{ include "jupyterhub.proxyName" . }}:{{ .Values.service.proxyApiPort }}"
+    c.ConfigurableHTTPProxy.auth_token = os.environ["CONFIGPROXY_AUTH_TOKEN"]
+
+    c.JupyterHub.authenticator_class = "dummy"
+    c.DummyAuthenticator.password = os.environ.get("DUMMY_PASSWORD", "")
+
+    c.JupyterHub.spawner_class = "kubespawner.KubeSpawner"
+    c.KubeSpawner.namespace = os.environ["POD_NAMESPACE"]
+    c.KubeSpawner.service_account = "{{ include "jupyterhub.serviceAccountName" . }}"
+    c.KubeSpawner.automount_service_account_token = False
+    c.KubeSpawner.image = "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
+    c.KubeSpawner.image_pull_policy = "{{ .Values.singleuser.image.pullPolicy }}"
+    c.KubeSpawner.start_timeout = {{ .Values.singleuser.startTimeout }}
+    c.KubeSpawner.default_url = "{{ .Values.singleuser.defaultUrl }}"
+    c.KubeSpawner.cpu_guarantee = {{ .Values.singleuser.cpu.guarantee }}
+    c.KubeSpawner.cpu_limit = {{ .Values.singleuser.cpu.limit }}
+    c.KubeSpawner.mem_guarantee = "{{ .Values.singleuser.memory.guarantee }}"
+    c.KubeSpawner.mem_limit = "{{ .Values.singleuser.memory.limit }}"
+    c.KubeSpawner.uid = 1000
+    c.KubeSpawner.gid = 100
+    c.KubeSpawner.fs_gid = 100
+    {{- if .Values.singleuser.storage.enabled }}
+    c.KubeSpawner.storage_pvc_ensure = True
+    c.KubeSpawner.storage_capacity = "{{ .Values.singleuser.storage.capacity }}"
+    c.KubeSpawner.storage_access_modes = {{ .Values.singleuser.storage.accessModes | toJson }}
+    c.KubeSpawner.pvc_name_template = "claim-{username}"
+    c.KubeSpawner.volumes = [{"name": "home", "persistentVolumeClaim": {"claimName": "claim-{username}"}}]
+    c.KubeSpawner.volume_mounts = [{"name": "home", "mountPath": "/home/jovyan"}]
+    {{- end }}
+    {{- with .Values.singleuser.profiles }}
+    c.KubeSpawner.profile_list = {{ . | toJson }}
+    {{- end }}
+    {{- with .Values.hub.extraConfig }}
+{{ . | nindent 4 }}
+    {{- end }}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -22,8 +22,10 @@ data:
     c.ConfigurableHTTPProxy.api_url = "http://{{ include "jupyterhub.proxyApiName" . }}:{{ .Values.service.proxyApiPort }}"
     c.ConfigurableHTTPProxy.auth_token = os.environ["CONFIGPROXY_AUTH_TOKEN"]
 
+    {{- if eq .Values.auth.type "dummy" }}
     c.JupyterHub.authenticator_class = "dummy"
     c.DummyAuthenticator.password = os.environ.get("DUMMY_PASSWORD", "")
+    {{- end }}
 
     c.JupyterHub.spawner_class = "kubespawner.KubeSpawner"
     c.KubeSpawner.namespace = os.environ["POD_NAMESPACE"]

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -39,6 +39,9 @@ data:
         "app.kubernetes.io/name": "{{ include "jupyterhub.name" . }}",
         "app.kubernetes.io/instance": "{{ .Release.Name }}",
         "app.kubernetes.io/component": "singleuser",
+        {{- range $key, $value := omit .Values.podLabels "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" }}
+        {{ $key | quote }}: {{ $value | toString | quote }},
+        {{- end }}
     }
     {{- with .Values.imagePullSecrets }}
     c.KubeSpawner.image_pull_secrets = {{ . | toJson }}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "jupyterhub.validateValues" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -17,6 +17,9 @@ data:
     c.JupyterHub.hub_connect_url = "http://{{ include "jupyterhub.hubName" . }}:8081"
     c.JupyterHub.base_url = "{{ .Values.hub.baseUrl }}"
     c.JupyterHub.db_url = "sqlite:///{{ .Values.hub.dbPath }}"
+    {{- with .Values.hub.cookieSecret.existingSecret }}
+    c.JupyterHub.cookie_secret_file = "/srv/jupyterhub/{{ $.Values.hub.cookieSecret.fileName }}"
+    {{- end }}
     c.JupyterHub.log_level = "{{ .Values.hub.logLevel }}"
     c.JupyterHub.cleanup_servers = {{ ternary "True" "False" .Values.hub.cleanupServers }}
     c.JupyterHub.authenticate_prometheus = {{ ternary "True" "False" .Values.metrics.authenticatePrometheus }}

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     c.JupyterHub.log_level = "{{ .Values.hub.logLevel }}"
 
     c.ConfigurableHTTPProxy.should_start = False
-    c.ConfigurableHTTPProxy.api_url = "http://{{ include "jupyterhub.proxyName" . }}:{{ .Values.service.proxyApiPort }}"
+    c.ConfigurableHTTPProxy.api_url = "http://{{ include "jupyterhub.proxyApiName" . }}:{{ .Values.service.proxyApiPort }}"
     c.ConfigurableHTTPProxy.auth_token = os.environ["CONFIGPROXY_AUTH_TOKEN"]
 
     c.JupyterHub.authenticator_class = "dummy"

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
     c.JupyterHub.base_url = "{{ .Values.hub.baseUrl }}"
     c.JupyterHub.db_url = "sqlite:///{{ .Values.hub.dbPath }}"
     c.JupyterHub.log_level = "{{ .Values.hub.logLevel }}"
+    c.JupyterHub.cleanup_servers = {{ ternary "True" "False" .Values.hub.cleanupServers }}
     c.JupyterHub.authenticate_prometheus = {{ ternary "True" "False" .Values.metrics.authenticatePrometheus }}
 
     c.ConfigurableHTTPProxy.should_start = False

--- a/charts/jupyterhub/templates/configmap.yaml
+++ b/charts/jupyterhub/templates/configmap.yaml
@@ -29,6 +29,9 @@ data:
     c.KubeSpawner.automount_service_account_token = False
     c.KubeSpawner.image = "{{ .Values.singleuser.image.name }}:{{ .Values.singleuser.image.tag }}"
     c.KubeSpawner.image_pull_policy = "{{ .Values.singleuser.image.pullPolicy }}"
+    {{- with .Values.imagePullSecrets }}
+    c.KubeSpawner.image_pull_secrets = {{ . | toJson }}
+    {{- end }}
     c.KubeSpawner.start_timeout = {{ .Values.singleuser.startTimeout }}
     c.KubeSpawner.default_url = "{{ .Values.singleuser.defaultUrl }}"
     c.KubeSpawner.cpu_guarantee = {{ .Values.singleuser.cpu.guarantee }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: hub
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "jupyterhub.serviceAccountName" . }}
       securityContext:

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -46,6 +46,28 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- with .Values.hub.cookieSecret.existingSecret }}
+        - name: prepare-cookie-secret
+          image: "{{ $.Values.hub.image.repository }}:{{ $.Values.hub.image.tag }}"
+          imagePullPolicy: {{ $.Values.hub.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              umask 077
+              cp "/var/run/jupyterhub-cookie-secret/{{ $.Values.hub.cookieSecret.existingSecretKey }}" "/srv/jupyterhub/{{ $.Values.hub.cookieSecret.fileName }}"
+              chmod 600 "/srv/jupyterhub/{{ $.Values.hub.cookieSecret.fileName }}"
+          resources:
+            {{- toYaml $.Values.hub.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml $.Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /srv/jupyterhub
+            - name: cookie-secret
+              mountPath: /var/run/jupyterhub-cookie-secret
+              readOnly: true
+        {{- end }}
         - name: wait-for-proxy-api
           image: docker.io/curlimages/curl:8.17.0
           imagePullPolicy: IfNotPresent
@@ -149,6 +171,14 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.hub.cookieSecret.existingSecret }}
+        - name: cookie-secret
+          secret:
+            secretName: {{ . }}
+            items:
+              - key: {{ $.Values.hub.cookieSecret.existingSecretKey }}
+                path: {{ $.Values.hub.cookieSecret.existingSecretKey }}
+        {{- end }}
         - name: tmp
           emptyDir: {}
         {{- with .Values.extraVolumes }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -18,7 +18,7 @@ spec:
         {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: hub
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- include "jupyterhub.podLabels" $ | nindent 8 }}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -46,7 +46,7 @@ spec:
             - sh
             - -ec
             - |
-              until code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: token ${CONFIGPROXY_AUTH_TOKEN}" "http://{{ include "jupyterhub.proxyApiName" . }}:{{ .Values.service.proxyApiPort }}/api/routes" || true)" && [ "$code" = "200" ]; do
+              until code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: token ${CONFIGPROXY_AUTH_TOKEN}" "http://{{ include "jupyterhub.proxyApiName" . }}:{{ .Values.service.proxyApiPort }}/api/routes" 2>/dev/null || true)" && [ "$code" = "200" ]; do
                 echo "waiting for proxy api"
                 sleep 2
               done

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.hub.replicaCount }}
   {{- $hasExternalHubDb := regexMatch "(?m)^\\s*c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
   {{- $haHubWithExternalDb := and (gt (int .Values.hub.replicaCount) 1) $hasExternalHubDb -}}
-  {{- if and .Values.hub.persistence.enabled (not $haHubWithExternalDb) }}
+  {{- if not $haHubWithExternalDb }}
   strategy:
     type: Recreate
   {{- end }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   replicas: {{ .Values.hub.replicaCount }}
-  {{- $hasExternalHubDb := regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
+  {{- $hasExternalHubDb := regexMatch "(?m)^\\s*c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
   {{- $haHubWithExternalDb := and (gt (int .Values.hub.replicaCount) 1) $hasExternalHubDb -}}
   {{- if and .Values.hub.persistence.enabled (not $haHubWithExternalDb) }}
   strategy:

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -1,0 +1,85 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jupyterhub.hubName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub
+spec:
+  replicas: {{ .Values.hub.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hub
+  template:
+    metadata:
+      labels:
+        {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hub
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "jupyterhub.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: hub
+          image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag }}"
+          imagePullPolicy: {{ .Values.hub.image.pullPolicy }}
+          command: ["jupyterhub"]
+          args: ["-f", "/etc/jupyterhub/jupyterhub_config.py"]
+          ports:
+            - name: hub
+              containerPort: 8081
+          env:
+            - name: CONFIGPROXY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jupyterhub.secretName" . }}
+                  key: {{ .Values.proxy.existingSecretTokenKey }}
+            - name: DUMMY_PASSWORD
+              value: {{ .Values.auth.dummyPassword | quote }}
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HOME
+              value: /srv/jupyterhub
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /hub/health
+              port: hub
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /hub/health
+              port: hub
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /hub/health
+              port: hub
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.hub.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/jupyterhub
+            - name: data
+              mountPath: /srv/jupyterhub
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "jupyterhub.hubName" . }}-config
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -66,17 +66,17 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /hub/health
+              path: {{ include "jupyterhub.hubHealthPath" . | quote }}
               port: hub
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
-              path: /hub/health
+              path: {{ include "jupyterhub.hubHealthPath" . | quote }}
               port: hub
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
             httpGet:
-              path: /hub/health
+              path: {{ include "jupyterhub.hubHealthPath" . | quote }}
               port: hub
             {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -8,6 +8,10 @@ metadata:
     app.kubernetes.io/component: hub
 spec:
   replicas: {{ .Values.hub.replicaCount }}
+  {{- if .Values.hub.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jupyterhub.selectorLabels" . | nindent 6 }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: hub
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   replicas: {{ .Values.hub.replicaCount }}
   {{- if .Values.hub.persistence.enabled }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -93,8 +93,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "jupyterhub.secretName" . }}
                   key: {{ .Values.proxy.existingSecretTokenKey }}
+            {{- if eq .Values.auth.type "dummy" }}
             - name: DUMMY_PASSWORD
               value: {{ .Values.auth.dummyPassword | quote }}
+            {{- end }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -22,6 +22,10 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -80,14 +84,25 @@ spec:
               mountPath: /srv/jupyterhub
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "jupyterhub.hubName" . }}-config
         - name: data
+          {{- if .Values.hub.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "jupyterhub.hubDataClaimName" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -17,9 +17,15 @@ spec:
       labels:
         {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: hub
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -9,7 +9,9 @@ metadata:
   {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   replicas: {{ .Values.hub.replicaCount }}
-  {{- if .Values.hub.persistence.enabled }}
+  {{- $hasExternalHubDb := regexMatch "c\\.JupyterHub\\.db_url\\s*=" .Values.hub.extraConfig -}}
+  {{- $haHubWithExternalDb := and (gt (int .Values.hub.replicaCount) 1) $hasExternalHubDb -}}
+  {{- if and .Values.hub.persistence.enabled (not $haHubWithExternalDb) }}
   strategy:
     type: Recreate
   {{- end }}

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -38,6 +38,42 @@ spec:
       serviceAccountName: {{ include "jupyterhub.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-proxy-api
+          image: docker.io/curlimages/curl:8.17.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: token ${CONFIGPROXY_AUTH_TOKEN}" "http://{{ include "jupyterhub.proxyApiName" . }}:{{ .Values.service.proxyApiPort }}/api/routes" || true)" && [ "$code" = "200" ]; do
+                echo "waiting for proxy api"
+                sleep 2
+              done
+          env:
+            - name: CONFIGPROXY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jupyterhub.secretName" . }}
+                  key: {{ .Values.proxy.existingSecretTokenKey }}
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       containers:
         - name: hub
           image: "{{ .Values.hub.image.repository }}:{{ .Values.hub.image.tag }}"

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -21,6 +21,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       serviceAccountName: {{ include "jupyterhub.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -84,3 +88,19 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -46,7 +46,7 @@ spec:
             - --api-ip=0.0.0.0
             - --api-port=8001
             - --default-target=http://{{ include "jupyterhub.hubName" . }}:8081
-            - --error-target=http://{{ include "jupyterhub.hubName" . }}:8081/hub/error
+            - --error-target=http://{{ include "jupyterhub.hubName" . }}:8081{{ include "jupyterhub.hubErrorPath" . }}
             - --log-level={{ .Values.proxy.logLevel }}
           ports:
             - name: http

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -20,6 +20,10 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -53,3 +57,19 @@ spec:
             {{- toYaml .Values.proxy.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: proxy
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -18,7 +18,7 @@ spec:
         {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: proxy
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- include "jupyterhub.podLabels" $ | nindent 8 }}
         {{- end }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   replicas: 1
   selector:

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -17,8 +17,14 @@ spec:
       labels:
         {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: proxy
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jupyterhub.proxyName" . }}-proxy
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: proxy
+  template:
+    metadata:
+      labels:
+        {{- include "jupyterhub.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: proxy
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: proxy
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          args:
+            - --ip=0.0.0.0
+            - --port=8000
+            - --api-ip=0.0.0.0
+            - --api-port=8001
+            - --default-target=http://{{ include "jupyterhub.hubName" . }}:8081
+            - --error-target=http://{{ include "jupyterhub.hubName" . }}:8081/hub/error
+            - --log-level={{ .Values.proxy.logLevel }}
+          ports:
+            - name: http
+              containerPort: 8000
+            - name: api
+              containerPort: 8001
+          env:
+            - name: CONFIGPROXY_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "jupyterhub.secretName" . }}
+                  key: {{ .Values.proxy.existingSecretTokenKey }}
+          readinessProbe:
+            tcpSocket:
+              port: api
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.proxy.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -42,9 +42,9 @@ spec:
           image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
           imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
           args:
-            - --ip=0.0.0.0
+            - {{ printf "--ip=%s" (include "jupyterhub.proxyBindIp" .) | quote }}
             - --port=8000
-            - --api-ip=0.0.0.0
+            - {{ printf "--api-ip=%s" (include "jupyterhub.proxyApiBindIp" .) | quote }}
             - --api-port=8001
             - --default-target=http://{{ include "jupyterhub.hubName" . }}:8081
             - --error-target=http://{{ include "jupyterhub.hubName" . }}:8081{{ include "jupyterhub.hubErrorPath" . }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -21,6 +21,10 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/charts/jupyterhub/templates/deployment-proxy.yaml
+++ b/charts/jupyterhub/templates/deployment-proxy.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "jupyterhub.proxyName" . }}-proxy
+  name: {{ include "jupyterhub.proxyDeploymentName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy

--- a/charts/jupyterhub/templates/externalsecret.yaml
+++ b/charts/jupyterhub/templates/externalsecret.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- if not .Values.proxy.existingSecret }}
+  {{- fail "externalSecrets.enabled requires proxy.existingSecret to be set." }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}-proxy
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.proxy.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/jupyterhub/templates/externalsecret.yaml
+++ b/charts/jupyterhub/templates/externalsecret.yaml
@@ -11,7 +11,7 @@
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
-  name: {{ include "jupyterhub.fullname" . }}-proxy
+  name: {{ include "jupyterhub.proxyDeploymentName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}

--- a/charts/jupyterhub/templates/externalsecret.yaml
+++ b/charts/jupyterhub/templates/externalsecret.yaml
@@ -3,6 +3,11 @@
 {{- if not .Values.proxy.existingSecret }}
   {{- fail "externalSecrets.enabled requires proxy.existingSecret to be set." }}
 {{- end }}
+{{- $externalSecretData := .Values.externalSecrets.data | default list -}}
+{{- $externalSecretDataFrom := .Values.externalSecrets.dataFrom | default list -}}
+{{- if eq (add (len $externalSecretData) (len $externalSecretDataFrom)) 0 }}
+  {{- fail "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:
@@ -17,6 +22,12 @@ spec:
   target:
     name: {{ .Values.proxy.existingSecret | quote }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  {{- if $externalSecretData }}
   data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+    {{- toYaml $externalSecretData | nindent 4 }}
+  {{- end }}
+  {{- if $externalSecretDataFrom }}
+  dataFrom:
+    {{- toYaml $externalSecretDataFrom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/jupyterhub/templates/externalsecret.yaml
+++ b/charts/jupyterhub/templates/externalsecret.yaml
@@ -14,6 +14,7 @@ metadata:
   name: {{ include "jupyterhub.fullname" . }}-proxy
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
   secretStoreRef:

--- a/charts/jupyterhub/templates/extra-manifests.yaml
+++ b/charts/jupyterhub/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{- toYaml . | nindent 0 }}
+{{- end }}

--- a/charts/jupyterhub/templates/httproute.yaml
+++ b/charts/jupyterhub/templates/httproute.yaml
@@ -1,0 +1,31 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+apiVersion: {{ .Values.gateway.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    {{- with .Values.gateway.labels }}{{- toYaml . | nindent 4 }}{{- end }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.gateway.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "jupyterhub.proxyName" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/jupyterhub/templates/httproute.yaml
+++ b/charts/jupyterhub/templates/httproute.yaml
@@ -7,10 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     {{- with .Values.gateway.labels }}{{- toYaml . | nindent 4 }}{{- end }}
-  {{- with .Values.gateway.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations "specific" .Values.gateway.annotations) | nindent 2 }}
 spec:
   parentRefs:
     {{- toYaml .Values.gateway.parentRefs | nindent 4 }}

--- a/charts/jupyterhub/templates/ingress.yaml
+++ b/charts/jupyterhub/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "jupyterhub.proxyName" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/jupyterhub/templates/ingress.yaml
+++ b/charts/jupyterhub/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . | quote }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/charts/jupyterhub/templates/ingress.yaml
+++ b/charts/jupyterhub/templates/ingress.yaml
@@ -6,10 +6,7 @@ metadata:
   name: {{ include "jupyterhub.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations "specific" .Values.ingress.annotations) | nindent 2 }}
 spec:
   {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . | quote }}

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -1,0 +1,20 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+{{- end }}

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -79,4 +79,25 @@ spec:
           port: 443
     - to:
         - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}-singleuser
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: singleuser
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: singleuser
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: proxy
 {{- end }}

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -98,10 +98,25 @@ spec:
       app.kubernetes.io/component: singleuser
   policyTypes:
     - Ingress
+    - Egress
   ingress:
     - from:
         - podSelector:
             matchLabels:
               {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: proxy
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: hub
+      ports:
+        - protocol: TCP
+          port: hub
 {{- end }}

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   podSelector:
     matchLabels:
@@ -51,6 +52,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: hub
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   podSelector:
     matchLabels:
@@ -83,6 +85,9 @@ spec:
           port: 443
     - to:
         - podSelector: {}
+    {{- with .Values.networkPolicy.hub.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -91,6 +96,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: singleuser
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -3,18 +3,80 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "jupyterhub.fullname" . }}
+  name: {{ include "jupyterhub.fullname" . }}-proxy
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
 spec:
   podSelector:
     matchLabels:
       {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: proxy
   policyTypes:
     - Ingress
     - Egress
   ingress:
-    - {}
+    - ports:
+        - protocol: TCP
+          port: http
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: hub
+      ports:
+        - protocol: TCP
+          port: api
   egress:
-    - {}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: hub
+      ports:
+        - protocol: TCP
+          port: hub
+    - to:
+        - podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}-hub
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hub
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: proxy
+      ports:
+        - protocol: TCP
+          port: hub
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - podSelector: {}
 {{- end }}

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -105,6 +105,10 @@ spec:
             matchLabels:
               {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: proxy
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: hub
   egress:
     - ports:
         - protocol: UDP

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -65,6 +65,10 @@ spec:
             matchLabels:
               {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
               app.kubernetes.io/component: proxy
+        - podSelector:
+            matchLabels:
+              {{- include "jupyterhub.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: singleuser
       ports:
         - protocol: TCP
           port: hub

--- a/charts/jupyterhub/templates/networkpolicy.yaml
+++ b/charts/jupyterhub/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "jupyterhub.fullname" . }}-proxy
+  name: {{ include "jupyterhub.proxyDeploymentName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
@@ -48,7 +48,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "jupyterhub.fullname" . }}-hub
+  name: {{ include "jupyterhub.hubName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: hub
@@ -92,7 +92,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "jupyterhub.fullname" . }}-singleuser
+  name: {{ include "jupyterhub.singleuserNetworkPolicyName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: singleuser

--- a/charts/jupyterhub/templates/pdb.yaml
+++ b/charts/jupyterhub/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/jupyterhub/templates/pdb.yaml
+++ b/charts/jupyterhub/templates/pdb.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "jupyterhub.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   minAvailable: {{ .Values.pdb.minAvailable }}
   selector:

--- a/charts/jupyterhub/templates/pdb.yaml
+++ b/charts/jupyterhub/templates/pdb.yaml
@@ -11,4 +11,5 @@ spec:
   selector:
     matchLabels:
       {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: hub
 {{- end }}

--- a/charts/jupyterhub/templates/pvc-hub.yaml
+++ b/charts/jupyterhub/templates/pvc-hub.yaml
@@ -1,0 +1,19 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.hub.persistence.enabled (not .Values.hub.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jupyterhub.hubDataClaimName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub
+spec:
+  accessModes:
+    {{- toYaml .Values.hub.persistence.accessModes | nindent 4 }}
+  {{- with .Values.hub.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.hub.persistence.size | quote }}
+{{- end }}

--- a/charts/jupyterhub/templates/pvc-hub.yaml
+++ b/charts/jupyterhub/templates/pvc-hub.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: hub
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   accessModes:
     {{- toYaml .Values.hub.persistence.accessModes | nindent 4 }}

--- a/charts/jupyterhub/templates/rbac.yaml
+++ b/charts/jupyterhub/templates/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "jupyterhub.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events", "persistentvolumeclaims", "services", "secrets"]
@@ -17,6 +18,7 @@ metadata:
   name: {{ include "jupyterhub.fullname" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "jupyterhub.serviceAccountName" . }}

--- a/charts/jupyterhub/templates/rbac.yaml
+++ b/charts/jupyterhub/templates/rbac.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events", "persistentvolumeclaims", "services", "secrets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "jupyterhub.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "jupyterhub.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/jupyterhub/templates/secret.yaml
+++ b/charts/jupyterhub/templates/secret.yaml
@@ -8,6 +8,7 @@ metadata:
   name: {{ include "jupyterhub.secretName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 type: Opaque
 {{- if and (not .Values.proxy.secretToken) $existingSecret $existingSecret.data (hasKey $existingSecret.data $tokenKey) }}
 data:

--- a/charts/jupyterhub/templates/secret.yaml
+++ b/charts/jupyterhub/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if not .Values.proxy.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "jupyterhub.secretName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.proxy.existingSecretTokenKey }}: {{ include "jupyterhub.proxyToken" . | quote }}
+{{- end }}

--- a/charts/jupyterhub/templates/secret.yaml
+++ b/charts/jupyterhub/templates/secret.yaml
@@ -1,5 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if not .Values.proxy.existingSecret }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "jupyterhub.secretName" .) }}
+{{- $tokenKey := .Values.proxy.existingSecretTokenKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +9,11 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
 type: Opaque
+{{- if and (not .Values.proxy.secretToken) $existingSecret $existingSecret.data (hasKey $existingSecret.data $tokenKey) }}
+data:
+  {{ $tokenKey }}: {{ index $existingSecret.data $tokenKey | quote }}
+{{- else }}
 stringData:
-  {{ .Values.proxy.existingSecretTokenKey }}: {{ include "jupyterhub.proxyToken" . | quote }}
+  {{ $tokenKey }}: {{ include "jupyterhub.proxyToken" . | quote }}
+{{- end }}
 {{- end }}

--- a/charts/jupyterhub/templates/service.yaml
+++ b/charts/jupyterhub/templates/service.yaml
@@ -36,6 +36,13 @@ metadata:
     app.kubernetes.io/component: proxy-api
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: proxy-api
       port: {{ .Values.service.proxyApiPort }}
@@ -53,6 +60,13 @@ metadata:
     app.kubernetes.io/component: hub
 spec:
   type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: hub
       port: 8081

--- a/charts/jupyterhub/templates/service.yaml
+++ b/charts/jupyterhub/templates/service.yaml
@@ -1,0 +1,44 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jupyterhub.proxyName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+    - name: proxy-api
+      port: {{ .Values.service.proxyApiPort }}
+      targetPort: api
+  selector:
+    {{- include "jupyterhub.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jupyterhub.hubName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hub
+spec:
+  type: ClusterIP
+  ports:
+    - name: hub
+      port: 8081
+      targetPort: hub
+  selector:
+    {{- include "jupyterhub.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: hub

--- a/charts/jupyterhub/templates/service.yaml
+++ b/charts/jupyterhub/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- with .Values.service.ipFamilyPolicy }}

--- a/charts/jupyterhub/templates/service.yaml
+++ b/charts/jupyterhub/templates/service.yaml
@@ -6,10 +6,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
-  {{- with .Values.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations "specific" .Values.service.annotations) | nindent 2 }}
 spec:
   type: {{ .Values.service.type }}
   {{- with .Values.service.ipFamilyPolicy }}
@@ -34,6 +31,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy-api
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}
@@ -58,6 +56,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     app.kubernetes.io/component: hub
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   type: ClusterIP
   {{- with .Values.service.ipFamilyPolicy }}

--- a/charts/jupyterhub/templates/service.yaml
+++ b/charts/jupyterhub/templates/service.yaml
@@ -23,6 +23,20 @@ spec:
     - name: http
       port: {{ .Values.service.port }}
       targetPort: http
+  selector:
+    {{- include "jupyterhub.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jupyterhub.proxyApiName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: proxy-api
+spec:
+  type: ClusterIP
+  ports:
     - name: proxy-api
       port: {{ .Values.service.proxyApiPort }}
       targetPort: api

--- a/charts/jupyterhub/templates/serviceaccount.yaml
+++ b/charts/jupyterhub/templates/serviceaccount.yaml
@@ -6,8 +6,5 @@ metadata:
   name: {{ include "jupyterhub.serviceAccountName" . }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations "specific" .Values.serviceAccount.annotations) | nindent 2 }}
 {{- end }}

--- a/charts/jupyterhub/templates/serviceaccount.yaml
+++ b/charts/jupyterhub/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jupyterhub.serviceAccountName" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/jupyterhub/templates/servicemonitor.yaml
+++ b/charts/jupyterhub/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "jupyterhub.validateValues" . }}
 {{- if .Values.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/jupyterhub/templates/servicemonitor.yaml
+++ b/charts/jupyterhub/templates/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}{{- toYaml . | nindent 4 }}{{- end }}
+  {{- include "jupyterhub.renderAnnotations" (dict "common" .Values.annotations) | nindent 2 }}
 spec:
   endpoints:
     - port: http

--- a/charts/jupyterhub/templates/servicemonitor.yaml
+++ b/charts/jupyterhub/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jupyterhub.fullname" . }}
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}{{- toYaml . | nindent 4 }}{{- end }}
+spec:
+  endpoints:
+    - port: http
+      path: /hub/metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+  selector:
+    matchLabels:
+      {{- include "jupyterhub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: proxy
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/jupyterhub/templates/servicemonitor.yaml
+++ b/charts/jupyterhub/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpoints:
     - port: http
-      path: /hub/metrics
+      path: {{ include "jupyterhub.hubMetricsPath" . | quote }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
   selector:
     matchLabels:

--- a/charts/jupyterhub/templates/tests/test-connection.yaml
+++ b/charts/jupyterhub/templates/tests/test-connection.yaml
@@ -6,9 +6,13 @@ metadata:
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  automountServiceAccountToken: false
   restartPolicy: Never
   containers:
     - name: curl

--- a/charts/jupyterhub/templates/tests/test-connection.yaml
+++ b/charts/jupyterhub/templates/tests/test-connection.yaml
@@ -17,7 +17,7 @@ spec:
       command:
         - sh
         - -ec
-        - curl -fsS "http://{{ include "jupyterhub.proxyName" . }}:{{ .Values.service.port }}/hub/health"
+        - curl -fsS "http://{{ include "jupyterhub.proxyName" . }}:{{ .Values.service.port }}{{ include "jupyterhub.hubHealthPath" . }}"
       resources:
         requests:
           cpu: 10m

--- a/charts/jupyterhub/templates/tests/test-connection.yaml
+++ b/charts/jupyterhub/templates/tests/test-connection.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "jupyterhub.fullname" . }}-test-connection"
+  name: {{ include "jupyterhub.testName" . | quote }}
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
   annotations:

--- a/charts/jupyterhub/templates/tests/test-connection.yaml
+++ b/charts/jupyterhub/templates/tests/test-connection.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "jupyterhub.fullname" . }}-test-connection"
+  labels:
+    {{- include "jupyterhub.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: docker.io/curlimages/curl:8.17.0
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+        - -ec
+        - curl -fsS "http://{{ include "jupyterhub.proxyName" . }}:{{ .Values.service.port }}/hub/health"
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -201,6 +201,28 @@ tests:
       - failedTemplate:
           errorMessage: "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class"
 
+  - it: should reject custom auth when authenticator_class is only mentioned in a comment
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.type: custom
+      hub.extraConfig: |
+        # c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class"
+
+  - it: should reject custom auth when authenticator_class is only mentioned in a string
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.type: custom
+      hub.extraConfig: |
+        authenticator_example = "c.JupyterHub.authenticator_class = nativeauthenticator.NativeAuthenticator"
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class"
+
   - it: should allow public ingress with a custom authenticator config
     template: configmap.yaml
     set:

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -17,7 +17,7 @@ tests:
           pattern: "KubeSpawner"
       - matchRegex:
           path: data["jupyterhub_config.py"]
-          pattern: "c\\.JupyterHub\\.authenticate_prometheus = False"
+          pattern: "c\\.JupyterHub\\.authenticate_prometheus = True"
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.JupyterHub\\.cleanup_servers = False"
@@ -62,14 +62,14 @@ tests:
           path: data["jupyterhub_config.py"]
           pattern: '"claimName": "test-jupyterhub-claim-\{username\}"'
 
-  - it: should allow authenticated Prometheus metrics when explicitly enabled
+  - it: should allow unauthenticated Prometheus metrics when explicitly disabled
     template: configmap.yaml
     set:
-      metrics.authenticatePrometheus: true
+      metrics.authenticatePrometheus: false
     asserts:
       - matchRegex:
           path: data["jupyterhub_config.py"]
-          pattern: "c\\.JupyterHub\\.authenticate_prometheus = True"
+          pattern: "c\\.JupyterHub\\.authenticate_prometheus = False"
 
   - it: should pass imagePullSecrets to KubeSpawner
     template: configmap.yaml
@@ -170,6 +170,27 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
+
+  - it: should reject public ingress with unauthenticated metrics unless explicitly accepted
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.dummyPassword: chart-testing-password
+      metrics.authenticatePrometheus: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with unauthenticated Prometheus metrics requires metrics.allowPublicUnauthenticatedPrometheus=true"
+
+  - it: should allow public ingress with explicit unauthenticated metrics opt-in
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.dummyPassword: chart-testing-password
+      metrics.authenticatePrometheus: false
+      metrics.allowPublicUnauthenticatedPrometheus: true
+    asserts:
+      - isKind:
+          of: ConfigMap
 
   - it: should reject non-auth extra config as dummy auth proof
     template: configmap.yaml

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -82,6 +82,10 @@ tests:
 
   - it: should label spawned notebook pods for NetworkPolicy
     template: configmap.yaml
+    set:
+      podLabels:
+        backup.velero.io/enabled: "true"
+        team: data-platform
     asserts:
       - matchRegex:
           path: data["jupyterhub_config.py"]
@@ -89,6 +93,12 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: '"app\.kubernetes\.io/instance": "test"'
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: '"backup\.velero\.io/enabled": "true"'
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: '"team": "data-platform"'
 
   - it: should reject public ingress with insecure dummy auth
     template: configmap.yaml

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -21,3 +21,13 @@ tests:
     asserts:
       - isKind:
           of: Secret
+
+  - it: should pass single-user storageClass to KubeSpawner
+    template: configmap.yaml
+    set:
+      singleuser.storage.enabled: true
+      singleuser.storage.storageClass: fast-rwx
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.KubeSpawner\\.storage_class = \"fast-rwx\""

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -60,6 +60,26 @@ tests:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.KubeSpawner\\.image_pull_secrets = \\[{\"name\":\"private-registry\"}\\]"
 
+  - it: should render profiles through JSON parsing for Python literals
+    template: configmap.yaml
+    set:
+      singleuser.profiles:
+        - display_name: Lab
+          default: true
+          kubespawner_override:
+            default_url: /lab
+            extra_resource_limits: null
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "import json"
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.KubeSpawner\\.profile_list = json\\.loads"
+      - notMatchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "default: true"
+
   - it: should label spawned notebook pods for NetworkPolicy
     template: configmap.yaml
     asserts:

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -31,3 +31,13 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.KubeSpawner\\.storage_class = \"fast-rwx\""
+
+  - it: should pass imagePullSecrets to KubeSpawner
+    template: configmap.yaml
+    set:
+      imagePullSecrets:
+        - name: private-registry
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.KubeSpawner\\.image_pull_secrets = \\[{\"name\":\"private-registry\"}\\]"

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -69,3 +69,45 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: '"app\.kubernetes\.io/instance": "test"'
+
+  - it: should reject public ingress with insecure dummy auth
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true"
+
+  - it: should reject public gateway with insecure dummy auth
+    template: configmap.yaml
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true"
+
+  - it: should reject load balancer with insecure dummy auth
+    template: configmap.yaml
+    set:
+      service.type: LoadBalancer
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true"
+
+  - it: should allow public ingress with explicit dummy opt-in
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.allowInsecureDummy: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: should allow public ingress with a dummy password
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.dummyPassword: chart-testing-password
+    asserts:
+      - isKind:
+          of: ConfigMap

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Config
+templates:
+  - configmap.yaml
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render JupyterHub config
+    template: configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "KubeSpawner"
+
+  - it: should render proxy token secret
+    template: secret.yaml
+    asserts:
+      - isKind:
+          of: Secret

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -22,6 +22,15 @@ tests:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.JupyterHub\\.cleanup_servers = False"
 
+  - it: should render shared cookie secret file when configured
+    template: configmap.yaml
+    set:
+      hub.cookieSecret.existingSecret: hub-cookie
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.JupyterHub\\.cookie_secret_file = \"/srv/jupyterhub/jupyterhub_cookie_secret\""
+
   - it: should allow opting into Hub shutdown cleanup of user servers
     template: configmap.yaml
     set:

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -129,6 +129,15 @@ tests:
       - failedTemplate:
           errorMessage: "podLabels cannot override reserved selector label app.kubernetes.io/component"
 
+  - it: should reject common labels that override selector labels
+    template: configmap.yaml
+    set:
+      commonLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "commonLabels cannot override reserved selector label app.kubernetes.io/instance"
+
   - it: should reject public gateway with insecure dummy auth
     template: configmap.yaml
     set:

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -119,7 +119,18 @@ tests:
       auth.type: custom
     asserts:
       - failedTemplate:
-          errorMessage: "public exposure with a custom authenticator requires hub.extraConfig"
+          errorMessage: "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class"
+
+  - it: should reject custom auth without an authenticator class override
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.type: custom
+      hub.extraConfig: |
+        c.JupyterHub.shutdown_on_logout = True
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with a custom authenticator requires hub.extraConfig to set authenticator_class"
 
   - it: should allow public ingress with a custom authenticator config
     template: configmap.yaml
@@ -131,6 +142,9 @@ tests:
     asserts:
       - isKind:
           of: ConfigMap
+      - notMatchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "DummyAuthenticator"
 
   - it: should allow public ingress with explicit dummy opt-in
     template: configmap.yaml

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -18,6 +18,18 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.JupyterHub\\.authenticate_prometheus = False"
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.JupyterHub\\.cleanup_servers = False"
+
+  - it: should allow opting into Hub shutdown cleanup of user servers
+    template: configmap.yaml
+    set:
+      hub.cleanupServers: true
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.JupyterHub\\.cleanup_servers = True"
 
   - it: should render proxy token secret
     template: secret.yaml

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -98,6 +98,15 @@ tests:
       - failedTemplate:
           errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
 
+  - it: should reject pod labels that override selector labels
+    template: configmap.yaml
+    set:
+      podLabels:
+        app.kubernetes.io/component: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels cannot override reserved selector label app.kubernetes.io/component"
+
   - it: should reject public gateway with insecure dummy auth
     template: configmap.yaml
     set:

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -76,7 +76,7 @@ tests:
       ingress.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true"
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
 
   - it: should reject public gateway with insecure dummy auth
     template: configmap.yaml
@@ -84,7 +84,7 @@ tests:
       gateway.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true"
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
 
   - it: should reject load balancer with insecure dummy auth
     template: configmap.yaml
@@ -92,7 +92,45 @@ tests:
       service.type: LoadBalancer
     asserts:
       - failedTemplate:
-          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword, hub.extraConfig with a real authenticator, or auth.allowInsecureDummy=true"
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
+
+  - it: should reject node port with insecure dummy auth
+    template: configmap.yaml
+    set:
+      service.type: NodePort
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
+
+  - it: should reject non-auth extra config as dummy auth proof
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      hub.extraConfig: |
+        c.JupyterHub.shutdown_on_logout = True
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with the default dummy authenticator requires auth.dummyPassword or auth.allowInsecureDummy=true"
+
+  - it: should require extra config for custom authenticators
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.type: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "public exposure with a custom authenticator requires hub.extraConfig"
+
+  - it: should allow public ingress with a custom authenticator config
+    template: configmap.yaml
+    set:
+      ingress.enabled: true
+      auth.type: custom
+      hub.extraConfig: |
+        c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
+    asserts:
+      - isKind:
+          of: ConfigMap
 
   - it: should allow public ingress with explicit dummy opt-in
     template: configmap.yaml

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -41,3 +41,13 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.KubeSpawner\\.image_pull_secrets = \\[{\"name\":\"private-registry\"}\\]"
+
+  - it: should label spawned notebook pods for NetworkPolicy
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: '"app\.kubernetes\.io/component": "singleuser"'
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: '"app\.kubernetes\.io/instance": "test"'

--- a/charts/jupyterhub/tests/config_test.yaml
+++ b/charts/jupyterhub/tests/config_test.yaml
@@ -15,6 +15,9 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: "KubeSpawner"
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.JupyterHub\\.authenticate_prometheus = False"
 
   - it: should render proxy token secret
     template: secret.yaml
@@ -31,6 +34,21 @@ tests:
       - matchRegex:
           path: data["jupyterhub_config.py"]
           pattern: "c\\.KubeSpawner\\.storage_class = \"fast-rwx\""
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: 'c\.KubeSpawner\.pvc_name_template = "test-jupyterhub-claim-\{username\}"'
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: '"claimName": "test-jupyterhub-claim-\{username\}"'
+
+  - it: should allow authenticated Prometheus metrics when explicitly enabled
+    template: configmap.yaml
+    set:
+      metrics.authenticatePrometheus: true
+    asserts:
+      - matchRegex:
+          path: data["jupyterhub_config.py"]
+          pattern: "c\\.JupyterHub\\.authenticate_prometheus = True"
 
   - it: should pass imagePullSecrets to KubeSpawner
     template: configmap.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -157,6 +157,25 @@ tests:
       - equal:
           path: spec.replicas
           value: 2
+      - notExists:
+          path: spec.strategy
+
+  - it: should allow multiple hub replicas with external database and an existing hub claim
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.persistence.existingClaim: hub-rwx-existing
+      hub.extraConfig: |
+        c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+          value: hub-rwx-existing
+      - notExists:
+          path: spec.strategy
 
   - it: should render image pull secrets on hub and proxy pods
     set:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -131,7 +131,19 @@ tests:
         c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
     asserts:
       - failedTemplate:
-          errorMessage: "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC"
+          errorMessage: "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce or ReadWriteOncePod, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC"
+
+  - it: should reject multiple hub replicas with external database and ReadWriteOncePod hub persistence
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.persistence.accessModes:
+        - ReadWriteOncePod
+      hub.extraConfig: |
+        c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - failedTemplate:
+          errorMessage: "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce or ReadWriteOncePod, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC"
 
   - it: should allow multiple hub replicas with external database and RWX hub persistence
     template: deployment-hub.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -103,6 +103,25 @@ tests:
           path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
           value: hub-db-existing
 
+  - it: should reject multiple hub replicas with the default SQLite database
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica"
+
+  - it: should allow multiple hub replicas when external database is configured
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.extraConfig: |
+        c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
   - it: should render image pull secrets on hub and proxy pods
     set:
       imagePullSecrets:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -82,6 +82,30 @@ tests:
           value: private-registry
         template: deployment-proxy.yaml
 
+  - it: should render pod metadata on hub and proxy pods
+    set:
+      podLabels:
+        backup.velero.io/enabled: "true"
+      podAnnotations:
+        reloader.stakater.com/auto: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["backup.velero.io/enabled"]
+          value: "true"
+        template: deployment-hub.yaml
+      - equal:
+          path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+        template: deployment-hub.yaml
+      - equal:
+          path: spec.template.metadata.labels["backup.velero.io/enabled"]
+          value: "true"
+        template: deployment-proxy.yaml
+      - equal:
+          path: spec.template.metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+        template: deployment-proxy.yaml
+
   - it: should render extra volumes and mounts on hub pod
     template: deployment-hub.yaml
     set:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -4,6 +4,7 @@ templates:
   - deployment-hub.yaml
   - deployment-proxy.yaml
   - configmap.yaml
+  - secret.yaml
 release:
   name: test
   namespace: default

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -19,6 +19,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
+      - exists:
+          path: spec.template.metadata.annotations["checksum/secret"]
 
   - it: should render proxy deployment
     template: deployment-proxy.yaml
@@ -28,3 +30,5 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8000
+      - exists:
+          path: spec.template.metadata.annotations["checksum/secret"]

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -5,6 +5,7 @@ templates:
   - deployment-proxy.yaml
   - configmap.yaml
   - secret.yaml
+  - pvc-hub.yaml
 release:
   name: test
   namespace: default
@@ -22,6 +23,9 @@ tests:
           value: true
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
+      - equal:
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+          value: test-jupyterhub-hub-data
 
   - it: should render proxy deployment
     template: deployment-proxy.yaml
@@ -33,6 +37,75 @@ tests:
           value: 8000
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
+
+  - it: should render hub data PVC by default
+    template: pvc-hub.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub-hub-data
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should use emptyDir when hub persistence is disabled
+    template: deployment-hub.yaml
+    set:
+      hub.persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[1].emptyDir
+          value: {}
+
+  - it: should use existing hub data claim when configured
+    template: deployment-hub.yaml
+    set:
+      hub.persistence.existingClaim: hub-db-existing
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+          value: hub-db-existing
+
+  - it: should render image pull secrets on hub and proxy pods
+    set:
+      imagePullSecrets:
+        - name: private-registry
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: private-registry
+        template: deployment-hub.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: private-registry
+        template: deployment-proxy.yaml
+
+  - it: should render extra volumes and mounts on hub pod
+    template: deployment-hub.yaml
+    set:
+      extraVolumes:
+        - name: ca-bundle
+          secret:
+            secretName: ca-bundle
+      extraVolumeMounts:
+        - name: ca-bundle
+          mountPath: /etc/ssl/custom
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: ca-bundle
+            secret:
+              secretName: ca-bundle
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: ca-bundle
+            mountPath: /etc/ssl/custom
+            readOnly: true
 
   - it: should render scheduling controls on hub and proxy pods
     set:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -27,6 +27,9 @@ tests:
           path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
           value: test-jupyterhub-hub-data
       - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-proxy-api
       - matchRegex:
@@ -88,6 +91,8 @@ tests:
       - equal:
           path: spec.template.spec.volumes[1].emptyDir
           value: {}
+      - notExists:
+          path: spec.strategy
 
   - it: should use existing hub data claim when configured
     template: deployment-hub.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -59,6 +59,15 @@ tests:
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
 
+  - it: should prefix proxy error target with baseUrl
+    template: deployment-proxy.yaml
+    set:
+      hub.baseUrl: /notebooks/
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --error-target=http://test-jupyterhub-hub:8081/notebooks/hub/error
+
   - it: should render hub data PVC by default
     template: pvc-hub.yaml
     asserts:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -111,6 +111,26 @@ tests:
       - failedTemplate:
           errorMessage: "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica"
 
+  - it: should reject multiple hub replicas when db_url is only mentioned in a comment
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.extraConfig: |
+        # c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - failedTemplate:
+          errorMessage: "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica"
+
+  - it: should reject multiple hub replicas when db_url is only mentioned in a string
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.extraConfig: |
+        db_url_example = "c.JupyterHub.db_url = postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - failedTemplate:
+          errorMessage: "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica"
+
   - it: should allow multiple hub replicas when external database is configured
     template: deployment-hub.yaml
     set:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - deployment-hub.yaml
+  - deployment-proxy.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render hub deployment
+    template: deployment-hub.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8081
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should render proxy deployment
+    template: deployment-proxy.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8000

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -126,8 +126,9 @@ tests:
       - equal:
           path: spec.template.spec.volumes[1].emptyDir
           value: {}
-      - notExists:
-          path: spec.strategy
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
 
   - it: should use existing hub data claim when configured
     template: deployment-hub.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -33,3 +33,27 @@ tests:
           value: 8000
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
+
+  - it: should render scheduling controls on hub and proxy pods
+    set:
+      priorityClassName: notebook-critical
+      nodeSelector:
+        workload: notebooks
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: notebooks
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: notebook-critical
+        template: deployment-hub.yaml
+      - equal:
+          path: spec.template.spec.nodeSelector.workload
+          value: notebooks
+        template: deployment-hub.yaml
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+        template: deployment-proxy.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -61,6 +61,41 @@ tests:
           value: 8000
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --ip=0.0.0.0
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --api-ip=0.0.0.0
+
+  - it: should bind proxy listeners to IPv6 wildcard for dual-stack services
+    template: deployment-proxy.yaml
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv6
+        - IPv4
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--ip=::"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--api-ip=::"
+
+  - it: should allow explicit proxy bind addresses
+    template: deployment-proxy.yaml
+    set:
+      proxy.bind.ip: 0.0.0.0
+      proxy.bind.apiIp: 127.0.0.1
+      service.ipFamilyPolicy: PreferDualStack
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --ip=0.0.0.0
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --api-ip=127.0.0.1
 
   - it: should prefix proxy error target with baseUrl
     template: deployment-proxy.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -26,6 +26,12 @@ tests:
       - equal:
           path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
           value: test-jupyterhub-hub-data
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-proxy-api
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "jupyterhub-proxy-api:8001/api/routes"
 
   - it: should prefix hub health probes with baseUrl
     template: deployment-hub.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -68,6 +68,35 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --api-ip=0.0.0.0
 
+  - it: should keep derived workload and PVC names within DNS label length
+    set:
+      fullnameOverride: jupyterhub-with-a-very-long-name-that-fills-the-dns-label-limit
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        template: deployment-hub.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: "-hub$"
+        template: deployment-hub.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        template: deployment-proxy.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: "-proxy$"
+        template: deployment-proxy.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        template: pvc-hub.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: "-hub-data$"
+        template: pvc-hub.yaml
+
   - it: should bind proxy listeners to IPv6 wildcard for dual-stack services
     template: deployment-proxy.yaml
     set:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -166,7 +166,7 @@ tests:
       - failedTemplate:
           errorMessage: "hub.replicaCount > 1 requires hub.extraConfig to configure an external c.JupyterHub.db_url; the default SQLite database is single-writer and must run with one Hub replica"
 
-  - it: should allow multiple hub replicas when external database is configured
+  - it: should reject multiple hub replicas with external database, disabled persistence, and no shared cookie secret
     template: deployment-hub.yaml
     set:
       hub.replicaCount: 2
@@ -174,9 +174,42 @@ tests:
       hub.extraConfig: |
         c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
     asserts:
+      - failedTemplate:
+          errorMessage: "hub.replicaCount > 1 with hub.persistence.enabled=false requires hub.cookieSecret.existingSecret so every Hub replica uses the same JupyterHub cookie secret"
+
+  - it: should allow multiple hub replicas with external database and shared cookie secret
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.persistence.enabled: false
+      hub.cookieSecret.existingSecret: hub-cookie
+      hub.extraConfig: |
+        c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
       - equal:
           path: spec.replicas
           value: 2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cookie-secret
+            secret:
+              secretName: hub-cookie
+              items:
+                - key: cookie-secret
+                  path: cookie-secret
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-cookie-secret
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 600 \"/srv/jupyterhub/jupyterhub_cookie_secret\""
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: cookie-secret
+            mountPath: /var/run/jupyterhub-cookie-secret
+            readOnly: true
 
   - it: should reject multiple hub replicas with external database and RWO hub persistence
     template: deployment-hub.yaml

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -115,6 +115,30 @@ tests:
     template: deployment-hub.yaml
     set:
       hub.replicaCount: 2
+      hub.persistence.enabled: false
+      hub.extraConfig: |
+        c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: should reject multiple hub replicas with external database and RWO hub persistence
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.extraConfig: |
+        c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
+    asserts:
+      - failedTemplate:
+          errorMessage: "hub.replicaCount > 1 with hub.persistence.enabled=true requires hub.persistence.accessModes without ReadWriteOnce, or hub.persistence.enabled=false, to avoid multiple Hub replicas sharing a single-writer PVC"
+
+  - it: should allow multiple hub replicas with external database and RWX hub persistence
+    template: deployment-hub.yaml
+    set:
+      hub.replicaCount: 2
+      hub.persistence.accessModes:
+        - ReadWriteMany
       hub.extraConfig: |
         c.JupyterHub.db_url = "postgresql+psycopg2://jupyterhub:secret@postgresql/jupyterhub"
     asserts:

--- a/charts/jupyterhub/tests/deployment_test.yaml
+++ b/charts/jupyterhub/tests/deployment_test.yaml
@@ -27,6 +27,21 @@ tests:
           path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
           value: test-jupyterhub-hub-data
 
+  - it: should prefix hub health probes with baseUrl
+    template: deployment-hub.yaml
+    set:
+      hub.baseUrl: /notebooks/
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /notebooks/hub/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /notebooks/hub/health
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /notebooks/hub/health
+
   - it: should render proxy deployment
     template: deployment-proxy.yaml
     asserts:

--- a/charts/jupyterhub/tests/externalsecret_test.yaml
+++ b/charts/jupyterhub/tests/externalsecret_test.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ExternalSecret data mappings
+    set:
+      proxy.existingSecret: jupyterhub-proxy-token
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.data:
+        - secretKey: proxy-token
+          remoteRef:
+            key: jupyterhub/proxy
+            property: proxy-token
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.target.name
+          value: jupyterhub-proxy-token
+      - equal:
+          path: spec.data[0].secretKey
+          value: proxy-token
+
+  - it: should render ExternalSecret dataFrom mappings
+    set:
+      proxy.existingSecret: jupyterhub-proxy-token
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.dataFrom:
+        - extract:
+            key: jupyterhub/proxy
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: jupyterhub/proxy
+      - notExists:
+          path: spec.data
+
+  - it: should fail when ExternalSecret has no mappings
+    set:
+      proxy.existingSecret: jupyterhub-proxy-token
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true
+        template: externalsecret.yaml

--- a/charts/jupyterhub/tests/ingress_test.yaml
+++ b/charts/jupyterhub/tests/ingress_test.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ingress
+templates:
+  - ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingressClassName using HelmForge values convention
+    set:
+      auth.allowInsecureDummy: true
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: hub.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: hub.example.test

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -106,3 +106,25 @@ tests:
             protocol: TCP
             port: hub
         documentIndex: 2
+
+  - it: should append configured Hub egress rules for external databases
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.hub.egress:
+        - to:
+            - ipBlock:
+                cidr: 10.50.0.0/16
+          ports:
+            - protocol: TCP
+              port: 5432
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.50.0.0/16
+            ports:
+              - protocol: TCP
+                port: 5432
+        documentIndex: 1

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -11,7 +11,7 @@ tests:
       networkPolicy.enabled: true
     asserts:
       - hasDocuments:
-          count: 2
+          count: 3
       - equal:
           path: metadata.name
           value: test-jupyterhub-proxy
@@ -64,3 +64,15 @@ tests:
             protocol: TCP
             port: 443
         documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub-singleuser
+        documentIndex: 2
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: singleuser
+        documentIndex: 2
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: proxy
+        documentIndex: 2

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: NetworkPolicy
+templates:
+  - networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should restrict hub and proxy traffic when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub-proxy
+        documentIndex: 0
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: proxy
+        documentIndex: 0
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: http
+        documentIndex: 0
+      - equal:
+          path: spec.ingress[1].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: hub
+        documentIndex: 0
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+        documentIndex: 0
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: hub
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub-hub
+        documentIndex: 1
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: hub
+        documentIndex: 1
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: proxy
+        documentIndex: 1
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+        documentIndex: 1
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 443
+        documentIndex: 1

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -90,6 +90,36 @@ tests:
           path: spec.ingress[0].from[1].podSelector.matchLabels["app.kubernetes.io/component"]
           value: hub
         documentIndex: 2
+
+  - it: should keep derived network policy names within DNS label length
+    set:
+      networkPolicy.enabled: true
+      fullnameOverride: jupyterhub-with-a-very-long-name-that-fills-the-dns-label-limit
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: "-proxy$"
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: "-hub$"
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        documentIndex: 2
+      - matchRegex:
+          path: metadata.name
+          pattern: "-singleuser$"
+        documentIndex: 2
       - contains:
           path: spec.egress[0].ports
           content:

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -52,6 +52,16 @@ tests:
           path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
           value: proxy
         documentIndex: 1
+      - equal:
+          path: spec.ingress[0].from[1].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: singleuser
+        documentIndex: 1
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: hub
+        documentIndex: 1
       - contains:
           path: spec.egress[0].ports
           content:

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -86,6 +86,10 @@ tests:
           path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
           value: proxy
         documentIndex: 2
+      - equal:
+          path: spec.ingress[0].from[1].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: hub
+        documentIndex: 2
       - contains:
           path: spec.egress[0].ports
           content:

--- a/charts/jupyterhub/tests/networkpolicy_test.yaml
+++ b/charts/jupyterhub/tests/networkpolicy_test.yaml
@@ -86,3 +86,19 @@ tests:
           path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
           value: proxy
         documentIndex: 2
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+        documentIndex: 2
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: hub
+        documentIndex: 2
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: hub
+        documentIndex: 2

--- a/charts/jupyterhub/tests/pdb_test.yaml
+++ b/charts/jupyterhub/tests/pdb_test.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: PDB
+templates:
+  - pdb.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should scope disruption budget to hub component
+    set:
+      pdb.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: hub

--- a/charts/jupyterhub/tests/service_test.yaml
+++ b/charts/jupyterhub/tests/service_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render proxy and hub services
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub-hub
+        documentIndex: 1
+
+  - it: should render dual-stack fields
+    documentIndex: 0
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack

--- a/charts/jupyterhub/tests/service_test.yaml
+++ b/charts/jupyterhub/tests/service_test.yaml
@@ -9,15 +9,30 @@ tests:
   - it: should render proxy and hub services
     asserts:
       - hasDocuments:
-          count: 2
+          count: 3
       - equal:
           path: metadata.name
           value: test-jupyterhub
         documentIndex: 0
+      - notContains:
+          path: spec.ports
+          content:
+            name: proxy-api
+            port: 8001
+            targetPort: api
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-jupyterhub-proxy-api
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+        documentIndex: 1
       - equal:
           path: metadata.name
           value: test-jupyterhub-hub
-        documentIndex: 1
+        documentIndex: 2
 
   - it: should render dual-stack fields
     documentIndex: 0

--- a/charts/jupyterhub/tests/service_test.yaml
+++ b/charts/jupyterhub/tests/service_test.yaml
@@ -30,3 +30,13 @@ tests:
       - equal:
           path: spec.ipFamilyPolicy
           value: PreferDualStack
+
+  - it: should render proxy service annotations
+    documentIndex: 0
+    set:
+      service.annotations:
+        service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
+          value: internet-facing

--- a/charts/jupyterhub/tests/service_test.yaml
+++ b/charts/jupyterhub/tests/service_test.yaml
@@ -34,6 +34,31 @@ tests:
           value: test-jupyterhub-hub
         documentIndex: 2
 
+  - it: should keep derived service names within DNS label length
+    set:
+      fullnameOverride: jupyterhub-with-a-very-long-name-that-fills-the-dns-label-limit
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: "-proxy-api$"
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        documentIndex: 2
+      - matchRegex:
+          path: metadata.name
+          pattern: "-hub$"
+        documentIndex: 2
+
   - it: should render dual-stack fields
     documentIndex: 0
     set:

--- a/charts/jupyterhub/tests/service_test.yaml
+++ b/charts/jupyterhub/tests/service_test.yaml
@@ -56,6 +56,30 @@ tests:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
           value: internet-facing
 
+  - it: should merge common and service annotations
+    documentIndex: 0
+    set:
+      annotations:
+        reloader.stakater.com/auto: "true"
+        policy.example.com/scope: common
+      service.annotations:
+        policy.example.com/scope: service
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["policy.example.com/scope"]
+          value: service
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+        documentIndex: 2
+
   - it: should render common labels on a separate YAML line
     documentIndex: 0
     set:

--- a/charts/jupyterhub/tests/service_test.yaml
+++ b/charts/jupyterhub/tests/service_test.yaml
@@ -40,3 +40,12 @@ tests:
       - equal:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]
           value: internet-facing
+
+  - it: should render common labels on a separate YAML line
+    documentIndex: 0
+    set:
+      commonLabels.foo: bar
+    asserts:
+      - equal:
+          path: metadata.labels.foo
+          value: bar

--- a/charts/jupyterhub/tests/servicemonitor_test.yaml
+++ b/charts/jupyterhub/tests/servicemonitor_test.yaml
@@ -24,3 +24,11 @@ tests:
       - equal:
           path: spec.endpoints[0].path
           value: /hub/metrics
+
+  - it: should reject authenticated metrics without ServiceMonitor credentials
+    set:
+      metrics.serviceMonitor.enabled: true
+      metrics.authenticatePrometheus: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "metrics.serviceMonitor.enabled=true requires metrics.authenticatePrometheus=false until ServiceMonitor scrape credentials are configured"

--- a/charts/jupyterhub/tests/servicemonitor_test.yaml
+++ b/charts/jupyterhub/tests/servicemonitor_test.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ServiceMonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render metrics path with baseUrl
+    set:
+      metrics.serviceMonitor.enabled: true
+      hub.baseUrl: /notebooks/
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].path
+          value: /notebooks/hub/metrics
+
+  - it: should render default metrics path
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /hub/metrics

--- a/charts/jupyterhub/tests/servicemonitor_test.yaml
+++ b/charts/jupyterhub/tests/servicemonitor_test.yaml
@@ -9,6 +9,7 @@ tests:
   - it: should render metrics path with baseUrl
     set:
       metrics.serviceMonitor.enabled: true
+      metrics.authenticatePrometheus: false
       hub.baseUrl: /notebooks/
     asserts:
       - isKind:
@@ -20,6 +21,7 @@ tests:
   - it: should render default metrics path
     set:
       metrics.serviceMonitor.enabled: true
+      metrics.authenticatePrometheus: false
     asserts:
       - equal:
           path: spec.endpoints[0].path

--- a/charts/jupyterhub/tests/test_connection_test.yaml
+++ b/charts/jupyterhub/tests/test_connection_test.yaml
@@ -8,6 +8,9 @@ release:
 tests:
   - it: should render root health check by default
     asserts:
+      - equal:
+          path: spec.automountServiceAccountToken
+          value: false
       - matchRegex:
           path: spec.containers[0].command[2]
           pattern: "http://test-jupyterhub:80/hub/health"

--- a/charts/jupyterhub/tests/test_connection_test.yaml
+++ b/charts/jupyterhub/tests/test_connection_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Helm Test
+templates:
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render root health check by default
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "http://test-jupyterhub:80/hub/health"
+
+  - it: should prefix health check with hub baseUrl
+    set:
+      hub.baseUrl: /notebooks/
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "http://test-jupyterhub:80/notebooks/hub/health"

--- a/charts/jupyterhub/tests/test_connection_test.yaml
+++ b/charts/jupyterhub/tests/test_connection_test.yaml
@@ -22,3 +22,14 @@ tests:
       - matchRegex:
           path: spec.containers[0].command[2]
           pattern: "http://test-jupyterhub:80/notebooks/hub/health"
+
+  - it: should keep helm test pod name within DNS label length
+    set:
+      fullnameOverride: jupyterhub-with-a-very-long-name-that-fills-the-dns-label-limit
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+      - matchRegex:
+          path: metadata.name
+          pattern: "-test-connection$"

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -37,7 +37,17 @@
         }
       }
     },
-    "ingress": { "type": "object", "additionalProperties": true },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
     "gateway": { "type": "object", "additionalProperties": true },
     "networkPolicy": { "type": "object", "additionalProperties": true },
     "serviceAccount": { "type": "object", "additionalProperties": true },
@@ -62,7 +72,15 @@
     "extraVolumes": { "type": "array" },
     "extraVolumeMounts": { "type": "array" },
     "extraManifests": { "type": "array" },
-    "externalSecrets": { "type": "object", "additionalProperties": true }
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "data": { "type": "array", "items": { "type": "object" } },
+        "dataFrom": { "type": "array", "items": { "type": "object" } }
+      }
+    }
   },
   "definitions": {
     "probe": {

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -7,7 +7,13 @@
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "commonLabels": { "type": "object" },
-    "hub": { "type": "object", "additionalProperties": true },
+    "hub": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "cleanupServers": { "type": "boolean" }
+      }
+    },
     "proxy": { "type": "object", "additionalProperties": true },
     "auth": {
       "type": "object",

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "JupyterHub HelmForge values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "hub": { "type": "object", "additionalProperties": true },
+    "proxy": { "type": "object", "additionalProperties": true },
+    "auth": { "type": "object", "additionalProperties": true },
+    "singleuser": { "type": "object", "additionalProperties": true },
+    "imagePullSecrets": { "type": "array" },
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "proxyApiPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] }
+        }
+      }
+    },
+    "ingress": { "type": "object", "additionalProperties": true },
+    "gateway": { "type": "object", "additionalProperties": true },
+    "networkPolicy": { "type": "object", "additionalProperties": true },
+    "serviceAccount": { "type": "object", "additionalProperties": true },
+    "rbac": { "type": "object", "additionalProperties": true },
+    "metrics": { "type": "object", "additionalProperties": true },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "livenessProbe": { "$ref": "#/definitions/probe" },
+    "readinessProbe": { "$ref": "#/definitions/probe" },
+    "startupProbe": { "$ref": "#/definitions/probe" },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "annotations": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 },
+    "pdb": { "type": "object", "additionalProperties": true },
+    "extraEnv": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "extraManifests": { "type": "array" },
+    "externalSecrets": { "type": "object", "additionalProperties": true }
+  },
+  "definitions": {
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -13,7 +13,7 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
-        "type": { "type": "string" },
+        "type": { "type": "string", "enum": ["dummy", "custom"] },
         "dummyPassword": { "type": "string" },
         "allowInsecureDummy": { "type": "boolean" }
       }

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -80,7 +80,23 @@
     "networkPolicy": { "type": "object", "additionalProperties": true },
     "serviceAccount": { "type": "object", "additionalProperties": true },
     "rbac": { "type": "object", "additionalProperties": true },
-    "metrics": { "type": "object", "additionalProperties": true },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "authenticatePrometheus": { "type": "boolean" },
+        "allowPublicUnauthenticatedPrometheus": { "type": "boolean" },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "interval": { "type": "string" },
+            "labels": { "type": "object" }
+          }
+        }
+      }
+    },
     "podSecurityContext": { "type": "object" },
     "securityContext": { "type": "object" },
     "livenessProbe": { "$ref": "#/definitions/probe" },

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -14,7 +14,20 @@
         "cleanupServers": { "type": "boolean" }
       }
     },
-    "proxy": { "type": "object", "additionalProperties": true },
+    "proxy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "bind": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "ip": { "type": "string" },
+            "apiIp": { "type": "string" }
+          }
+        }
+      }
+    },
     "auth": {
       "type": "object",
       "additionalProperties": true,

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -11,7 +11,16 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
-        "cleanupServers": { "type": "boolean" }
+        "cleanupServers": { "type": "boolean" },
+        "cookieSecret": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "existingSecret": { "type": "string" },
+            "existingSecretKey": { "type": "string", "minLength": 1 },
+            "fileName": { "type": "string", "minLength": 1, "pattern": "^[^/]+$" }
+          }
+        }
       }
     },
     "proxy": {

--- a/charts/jupyterhub/values.schema.json
+++ b/charts/jupyterhub/values.schema.json
@@ -9,7 +9,15 @@
     "commonLabels": { "type": "object" },
     "hub": { "type": "object", "additionalProperties": true },
     "proxy": { "type": "object", "additionalProperties": true },
-    "auth": { "type": "object", "additionalProperties": true },
+    "auth": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string" },
+        "dummyPassword": { "type": "string" },
+        "allowInsecureDummy": { "type": "boolean" }
+      }
+    },
     "singleuser": { "type": "object", "additionalProperties": true },
     "imagePullSecrets": { "type": "array" },
     "service": {

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -63,6 +63,11 @@ proxy:
   existingSecretTokenKey: proxy-token
   # -- Proxy log level.
   logLevel: warn
+  bind:
+    # -- Public-facing configurable-http-proxy bind IP. Empty uses 0.0.0.0 for IPv4 services and :: for dual-stack/IPv6 services.
+    ip: ""
+    # -- Proxy API bind IP. Empty uses 0.0.0.0 for IPv4 services and :: for dual-stack/IPv6 services.
+    apiIp: ""
   # -- Proxy container resources.
   resources:
     requests:

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -201,9 +201,11 @@ rbac:
 
 metrics:
   # -- Require authentication for Prometheus metrics.
-  authenticatePrometheus: false
+  authenticatePrometheus: true
+  # -- Explicitly allow anonymous /hub/metrics on public Ingress, Gateway, LoadBalancer, or NodePort exposure.
+  allowPublicUnauthenticatedPrometheus: false
   serviceMonitor:
-    # -- Render a Prometheus Operator ServiceMonitor. Requires metrics.authenticatePrometheus=false.
+    # -- Render a Prometheus Operator ServiceMonitor. Requires metrics.authenticatePrometheus=false until scrape credentials are configured.
     enabled: false
     # -- ServiceMonitor scrape interval.
     interval: 30s

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -31,7 +31,7 @@ hub:
     existingClaim: ""
     # -- StorageClass for the Hub PVC. Empty uses the cluster default.
     storageClass: ""
-    # -- Access modes for the Hub PVC.
+    # -- Access modes for the Hub PVC. Use a multi-writer mode or disable persistence when hub.replicaCount > 1.
     accessModes:
       - ReadWriteOnce
     # -- Hub PVC size.

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -169,6 +169,9 @@ gateway:
 networkPolicy:
   # -- Enable NetworkPolicy resources.
   enabled: false
+  hub:
+    # -- Additional Hub egress rules appended after the default DNS, HTTPS, and same-namespace rules. Use this for external PostgreSQL/MySQL databases or private endpoints.
+    egress: []
 
 serviceAccount:
   # -- Create a dedicated ServiceAccount.

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -116,6 +116,7 @@ rbac:
   create: true
 
 metrics:
+  authenticatePrometheus: false
   serviceMonitor:
     enabled: false
     interval: 30s

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -20,6 +20,13 @@ hub:
   baseUrl: /
   # -- SQLite database path used by the Hub.
   dbPath: /srv/jupyterhub/jupyterhub.sqlite
+  cookieSecret:
+    # -- Existing Secret with a shared JupyterHub cookie secret. Required for HA Hubs when hub.persistence.enabled=false.
+    existingSecret: ""
+    # -- Key in hub.cookieSecret.existingSecret containing the hex-encoded cookie secret.
+    existingSecretKey: cookie-secret
+    # -- File name used when mounting the shared cookie secret into /srv/jupyterhub.
+    fileName: jupyterhub_cookie_secret
   # -- Hub log level.
   logLevel: INFO
   # -- Stop/delete single-user servers when the Hub shuts down. Keep false with the chart-managed external proxy so user servers survive Hub restarts.

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -13,6 +13,13 @@ hub:
   dbPath: /srv/jupyterhub/jupyterhub.sqlite
   logLevel: INFO
   extraConfig: ""
+  persistence:
+    enabled: true
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
   resources:
     requests:
       cpu: 100m

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -1,25 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
+# -- Override the chart name.
 nameOverride: ""
+# -- Override the fully qualified release name.
 fullnameOverride: ""
+# -- Additional labels applied to all chart resources.
 commonLabels: {}
 
 hub:
+  # -- Number of Hub replicas. Keep at 1 when using the default SQLite database.
   replicaCount: 1
   image:
+    # -- JupyterHub Hub image repository.
     repository: quay.io/jupyterhub/k8s-hub
+    # -- JupyterHub Hub image tag.
     tag: "4.3.5"
+    # -- JupyterHub Hub image pull policy.
     pullPolicy: IfNotPresent
+  # -- Public base URL for JupyterHub.
   baseUrl: /
+  # -- SQLite database path used by the Hub.
   dbPath: /srv/jupyterhub/jupyterhub.sqlite
+  # -- Hub log level.
   logLevel: INFO
+  # -- Extra Python config appended to jupyterhub_config.py.
   extraConfig: ""
   persistence:
+    # -- Persist Hub state, including the default SQLite database.
     enabled: true
+    # -- Existing PVC for Hub state.
     existingClaim: ""
+    # -- StorageClass for the Hub PVC. Empty uses the cluster default.
     storageClass: ""
+    # -- Access modes for the Hub PVC.
     accessModes:
       - ReadWriteOnce
+    # -- Hub PVC size.
     size: 10Gi
+  # -- Hub container resources.
   resources:
     requests:
       cpu: 100m
@@ -30,13 +47,21 @@ hub:
 
 proxy:
   image:
+    # -- configurable-http-proxy image repository.
     repository: docker.io/jupyterhub/configurable-http-proxy
+    # -- configurable-http-proxy image tag.
     tag: "4.6.3"
+    # -- configurable-http-proxy image pull policy.
     pullPolicy: IfNotPresent
+  # -- Proxy auth token. Empty generates or reuses a Secret token.
   secretToken: ""
+  # -- Existing Secret containing the proxy auth token.
   existingSecret: ""
+  # -- Secret key containing the proxy auth token.
   existingSecretTokenKey: proxy-token
+  # -- Proxy log level.
   logLevel: warn
+  # -- Proxy container resources.
   resources:
     requests:
       cpu: 50m
@@ -46,60 +71,95 @@ proxy:
       memory: 512Mi
 
 auth:
+  # -- Authenticator type. Use dummy for local testing or custom with hub.extraConfig.
   type: dummy
+  # -- DummyAuthenticator password.
   dummyPassword: ""
   # -- Explicitly allow exposing JupyterHub with DummyAuthenticator and no password.
   allowInsecureDummy: false
 
 singleuser:
   image:
+    # -- Single-user notebook image repository.
     name: quay.io/jupyter/base-notebook
+    # -- Single-user notebook image tag.
     tag: "2026-05-26"
+    # -- Single-user notebook image pull policy.
     pullPolicy: IfNotPresent
   cpu:
+    # -- Guaranteed CPU for single-user pods.
     guarantee: 0.1
+    # -- CPU limit for single-user pods.
     limit: 1
   memory:
+    # -- Guaranteed memory for single-user pods.
     guarantee: 512M
+    # -- Memory limit for single-user pods.
     limit: 2G
   storage:
+    # -- Enable per-user persistent home volumes.
     enabled: false
+    # -- Per-user PVC size.
     capacity: 10Gi
+    # -- Per-user PVC StorageClass. Empty uses the cluster default.
     storageClass: ""
+    # -- Per-user PVC access modes.
     accessModes:
       - ReadWriteOnce
+  # -- KubeSpawner start timeout.
   startTimeout: 300
+  # -- Default URL opened for users.
   defaultUrl: /lab
+  # -- KubeSpawner profile list.
   profiles: []
 
+# -- Image pull secrets.
 imagePullSecrets: []
 
 service:
+  # -- Service type for public proxy traffic.
   type: ClusterIP
+  # -- Service annotations.
   annotations: {}
+  # -- Public proxy service port.
   port: 80
+  # -- Internal configurable-http-proxy API service port.
   proxyApiPort: 8001
+  # -- Service IP family policy. Null uses cluster default.
   ipFamilyPolicy: ~
+  # -- Service IP families.
   ipFamilies: []
 
 ingress:
+  # -- Enable Kubernetes Ingress.
   enabled: false
-  className: ""
+  # -- IngressClass name.
+  ingressClassName: ""
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress host rules.
   hosts:
     - host: jupyterhub.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
 gateway:
+  # -- Enable Gateway API HTTPRoute.
   enabled: false
+  # -- Gateway API version.
   apiVersion: gateway.networking.k8s.io/v1
+  # -- Gateway parentRefs.
   parentRefs: []
+  # -- HTTPRoute hostnames.
   hostnames: []
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- HTTPRoute labels.
   labels: {}
+  # -- HTTPRoute rules.
   rules:
     - matches:
         - path:
@@ -107,29 +167,40 @@ gateway:
             value: /
 
 networkPolicy:
+  # -- Enable NetworkPolicy resources.
   enabled: false
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: true
+  # -- ServiceAccount name override.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
 
 rbac:
+  # -- Create namespaced RBAC for KubeSpawner user pod management.
   create: true
 
 metrics:
+  # -- Require authentication for Prometheus metrics.
   authenticatePrometheus: false
   serviceMonitor:
+    # -- Render a Prometheus Operator ServiceMonitor.
     enabled: false
+    # -- ServiceMonitor scrape interval.
     interval: 30s
+    # -- Additional ServiceMonitor labels.
     labels: {}
 
+# -- Pod-level security context.
 podSecurityContext:
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
 
+# -- Container-level security context.
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
@@ -140,50 +211,77 @@ securityContext:
     drop:
       - ALL
 
+# -- Hub liveness probe settings.
 livenessProbe:
   initialDelaySeconds: 30
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 6
 
+# -- Hub and proxy readiness probe settings.
 readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
 
+# -- Hub startup probe settings.
 startupProbe:
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 60
 
+# -- Additional labels for Hub, proxy, and single-user pods.
 podLabels: {}
+# -- Additional pod annotations.
 podAnnotations: {}
+# -- Additional resource annotations.
 annotations: {}
+# -- Node selector.
 nodeSelector: {}
+# -- Pod tolerations.
 tolerations: []
+# -- Pod affinity.
 affinity: {}
+# -- Pod topology spread constraints.
 topologySpreadConstraints: []
+# -- PriorityClass name.
 priorityClassName: ""
+# -- Pod termination grace period.
 terminationGracePeriodSeconds: 30
 
 pdb:
+  # -- Enable PodDisruptionBudget.
   enabled: false
+  # -- Minimum available pods.
   minAvailable: 1
 
+# -- Additional Hub environment variables.
 extraEnv: []
+# -- Additional Hub volumes.
 extraVolumes: []
+# -- Additional Hub volume mounts.
 extraVolumeMounts: []
+# -- Additional manifests rendered verbatim.
 extraManifests: []
 
 externalSecrets:
+  # -- Render an ExternalSecret for the proxy token.
   enabled: false
+  # -- ExternalSecret API version.
   apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval.
   refreshInterval: "0"
   secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name.
     name: ""
+    # -- Secret store kind.
     kind: SecretStore
   target:
+    # -- ExternalSecret target creation policy.
     creationPolicy: Owner
+  # -- ExternalSecret data entries for individual token keys.
   data: []
+  # -- ExternalSecret dataFrom entries for provider-side extraction.
+  dataFrom: []

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -196,7 +196,7 @@ metrics:
   # -- Require authentication for Prometheus metrics.
   authenticatePrometheus: false
   serviceMonitor:
-    # -- Render a Prometheus Operator ServiceMonitor.
+    # -- Render a Prometheus Operator ServiceMonitor. Requires metrics.authenticatePrometheus=false.
     enabled: false
     # -- ServiceMonitor scrape interval.
     interval: 30s

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -48,6 +48,8 @@ proxy:
 auth:
   type: dummy
   dummyPassword: ""
+  # -- Explicitly allow exposing JupyterHub with DummyAuthenticator and no password.
+  allowInsecureDummy: false
 
 singleuser:
   image:

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -22,6 +22,8 @@ hub:
   dbPath: /srv/jupyterhub/jupyterhub.sqlite
   # -- Hub log level.
   logLevel: INFO
+  # -- Stop/delete single-user servers when the Hub shuts down. Keep false with the chart-managed external proxy so user servers survive Hub restarts.
+  cleanupServers: false
   # -- Extra Python config appended to jupyterhub_config.py.
   extraConfig: ""
   persistence:

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+hub:
+  replicaCount: 1
+  image:
+    repository: quay.io/jupyterhub/k8s-hub
+    tag: "4.3.5"
+    pullPolicy: IfNotPresent
+  baseUrl: /
+  dbPath: /srv/jupyterhub/jupyterhub.sqlite
+  logLevel: INFO
+  extraConfig: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+proxy:
+  image:
+    repository: docker.io/jupyterhub/configurable-http-proxy
+    tag: "4.6.3"
+    pullPolicy: IfNotPresent
+  secretToken: ""
+  existingSecret: ""
+  existingSecretTokenKey: proxy-token
+  logLevel: warn
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+auth:
+  type: dummy
+  dummyPassword: ""
+
+singleuser:
+  image:
+    name: quay.io/jupyter/base-notebook
+    tag: "2026-05-26"
+    pullPolicy: IfNotPresent
+  cpu:
+    guarantee: 0.1
+    limit: 1
+  memory:
+    guarantee: 512M
+    limit: 2G
+  storage:
+    enabled: false
+    capacity: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+  startTimeout: 300
+  defaultUrl: /lab
+  profiles: []
+
+imagePullSecrets: []
+
+service:
+  type: ClusterIP
+  annotations: {}
+  port: 80
+  proxyApiPort: 8001
+  ipFamilyPolicy: ~
+  ipFamilies: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: jupyterhub.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gateway:
+  enabled: false
+  apiVersion: gateway.networking.k8s.io/v1
+  parentRefs: []
+  hostnames: []
+  annotations: {}
+  labels: {}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+networkPolicy:
+  enabled: false
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  create: true
+
+metrics:
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    labels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+livenessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+startupProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 60
+
+podLabels: {}
+podAnnotations: {}
+annotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+pdb:
+  enabled: false
+  minAvailable: 1
+
+extraEnv: []
+extraVolumes: []
+extraVolumeMounts: []
+extraManifests: []
+
+externalSecrets:
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "0"
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  data: []


### PR DESCRIPTION
## Summary

Adds the HelmForge `jupyterhub` chart as a stable JupyterHub chart with Hub, configurable-http-proxy, KubeSpawner, and secure Kubernetes defaults.

Closes #371.

## Scope

- Hub and proxy deployments with managed proxy token Secret
- KubeSpawner configuration for single-user notebook pods
- optional user PVCs, Gateway API, Ingress, dual-stack Service fields, NetworkPolicy, ExternalSecret, ServiceMonitor, PDB, schema, docs, examples, and Helm tests
- public exposure guardrails for DummyAuthenticator/custom authenticator configuration
- multi-replica Hub guardrail: `hub.replicaCount > 1` now requires an external `c.JupyterHub.db_url` in `hub.extraConfig` so the default SQLite database remains single-replica only

## Validation

Latest local validation after review fixes:

- `helm dependency build charts/jupyterhub` and `helm dependency list charts/jupyterhub` - no dependencies
- `helm lint charts/jupyterhub`
- `helm lint charts/jupyterhub --strict`
- `helm unittest charts/jupyterhub` - 9 suites, 45 tests passed
- `npx --yes markdownlint-cli2 "charts/jupyterhub/**/*.md"` - 5 files, 0 errors
- strict kubeconform for default render - 12 valid, 0 invalid
- strict kubeconform for all `charts/jupyterhub/ci/*.yaml`: default, dual-stack, external-secrets, gateway-api, ingress, k3d, network-policy, security, servicemonitor
- `ah lint charts/jupyterhub` - JupyterHub package lint succeeded; repository scan 66 packages, 0 errors
- Kubescape NSA on `ci/security-values.yaml`: 99.17%, threshold 90
- MCP HelmForge: CI evidence PASS, security evidence PASS

## k3d validation

Validated on local cluster `k3d-helmforge-tests-wsl` after review fixes:

- namespace `hf-jupyterhub-standard`
- `helm install jupyterhub-test charts/jupyterhub -f charts/jupyterhub/ci/k3d-values.yaml --wait --timeout 10m`
- `helm test jupyterhub-test` succeeded
- curl smoke against `/hub/health` succeeded
- Hub and proxy pods Ready with zero restarts
- no Warning events in the namespace
- logs scanned for `error|fatal|panic|exception|back-off|failed`; no matches
- namespace `hf-jupyterhub-standard` deleted after validation