### PR TITLE
feat(oauth2-proxy): add OAuth2 Proxy chart

### DIFF
--- a/charts/oauth2-proxy/.helmignore
+++ b/charts/oauth2-proxy/.helmignore
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/oauth2-proxy/Chart.yaml
+++ b/charts/oauth2-proxy/Chart.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: oauth2-proxy
+description: OAuth2 Proxy reverse proxy for OAuth2 and OIDC authentication in Kubernetes
+type: application
+version: 1.0.0
+appVersion: "7.15.2"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - oauth2-proxy
+  - oauth2
+  - oidc
+  - authentication
+  - reverse-proxy
+  - sso
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/oauth2-proxy
+  - https://github.com/oauth2-proxy/oauth2-proxy
+  - https://github.com/oauth2-proxy/manifests
+icon: https://helmforge.dev/icons/charts/oauth2-proxy.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "initial stable OAuth2 Proxy chart with Gateway API, ExternalSecret, trusted proxy hardening, metrics, and runtime tests"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: security
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://oauth2-proxy.github.io/oauth2-proxy/
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/oauth2-proxy
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/oauth2-proxy
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/authelia
+    - url: https://artifacthub.io/packages/helm/helmforge/keycloak
+    - url: https://artifacthub.io/packages/helm/helmforge/redis

--- a/charts/oauth2-proxy/DESIGN.md
+++ b/charts/oauth2-proxy/DESIGN.md
@@ -1,0 +1,41 @@
+# OAuth2 Proxy Chart Design
+
+## Goals
+
+- Deploy the official OAuth2 Proxy image with secure Kubernetes defaults.
+- Keep credentials flexible through chart-managed Secrets, existing Secrets, or ExternalSecret.
+- Support both Ingress and Gateway API with a single HelmForge-standard `gateway` values block.
+- Make reverse-proxy deployments safer by exposing explicit `trustedProxyIps` configuration.
+- Validate rendered configuration before the workload starts by running `oauth2-proxy --config-test`.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Client --> Edge[Ingress or Gateway]
+  Edge --> Service[oauth2-proxy Service]
+  Service --> Pod[oauth2-proxy Pod]
+  Pod --> Provider[OAuth2 or OIDC Provider]
+  Pod --> Upstream[Protected Upstream]
+  ExternalSecret -. optional .-> Secret[Credential Secret]
+  Secret --> Pod
+```
+
+## Security Defaults
+
+- Pods run as non-root with dropped Linux capabilities and runtime default seccomp.
+- The ServiceAccount token is not mounted by default.
+- Cookies are secure by default; local examples explicitly disable this only for HTTP testing.
+- `reverse_proxy` is enabled for Kubernetes edge use cases, but `trusted_proxy_ips` is empty by default so operators must opt in to trusted forwarding ranges.
+- The init container validates the final OAuth2 Proxy configuration and uses the same image, args, env, mounts, and security context as the runtime container.
+
+## Networking
+
+- Ingress uses `ingress.ingressClassName`, matching HelmForge chart conventions.
+- Gateway API support uses only the standard `gateway` values block.
+- Services expose `ipFamilyPolicy` and `ipFamilies` for dual-stack clusters.
+
+## Explicit Non-Goals
+
+- This chart does not deploy an identity provider. Pair it with Keycloak, Authelia, Dex, or an external OAuth2/OIDC provider.
+- This chart does not deploy Redis session storage by default; use OAuth2 Proxy extra args/env with a HelmForge Redis release when that mode is required.

--- a/charts/oauth2-proxy/DESIGN.md
+++ b/charts/oauth2-proxy/DESIGN.md
@@ -5,7 +5,8 @@
 - Deploy the official OAuth2 Proxy image with secure Kubernetes defaults.
 - Keep credentials flexible through chart-managed Secrets, existing Secrets, or ExternalSecret.
 - Support both Ingress and Gateway API with a single HelmForge-standard `gateway` values block.
-- Make reverse-proxy deployments safer by exposing explicit `trustedProxyIps` configuration.
+- Make reverse-proxy deployments safer by disabling proxy header trust by
+  default and requiring explicit `trustedProxyIps` configuration when enabled.
 - Validate rendered configuration before the workload starts by running `oauth2-proxy --config-test`.
 
 ## Architecture
@@ -26,7 +27,9 @@ flowchart LR
 - Pods run as non-root with dropped Linux capabilities and runtime default seccomp.
 - The ServiceAccount token is not mounted by default.
 - Cookies are secure by default; local examples explicitly disable this only for HTTP testing.
-- `reverse_proxy` is enabled for Kubernetes edge use cases, but `trusted_proxy_ips` is empty by default so operators must opt in to trusted forwarding ranges.
+- `reverse_proxy` is disabled by default so direct deployments do not trust
+  forwarded headers. When enabled, `trusted_proxy_ips` must contain at least one
+  trusted edge proxy CIDR.
 - The init container validates the final OAuth2 Proxy configuration and uses the same image, args, env, mounts, and security context as the runtime container.
 
 ## Networking

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -1,0 +1,88 @@
+# OAuth2 Proxy Helm Chart
+
+OAuth2 Proxy is a reverse proxy and authentication gateway for OAuth2 and OIDC
+providers. This HelmForge chart deploys the official upstream image with secure
+Kubernetes defaults, Gateway API support, ExternalSecret integration, metrics,
+and runtime validation.
+
+## Highlights
+
+- Official `quay.io/oauth2-proxy/oauth2-proxy` image.
+- `v7.15.2` default, including the upstream security fixes for critical
+  authentication bypass advisories.
+- Explicit `trusted_proxy_ips` support for deployments behind ingress
+  controllers, gateways, or service mesh edge proxies.
+- Chart-managed Secret, existing Secret, or ExternalSecret credential modes.
+- Config validation init container using `--config-test`.
+- Dual-stack Service defaults, Ingress, Gateway API `HTTPRoute`, ServiceMonitor,
+  HPA, PDB, and optional NetworkPolicy.
+
+## Install
+
+```bash
+helm install oauth2-proxy oci://ghcr.io/helmforgedev/helm/oauth2-proxy \
+  --set auth.clientID=example \
+  --set auth.clientSecret=example-secret \
+  --set auth.cookieSecret=0123456789abcdef0123456789abcdef \
+  --set config.provider=github \
+  --set config.redirectUrl=https://auth.example.com/oauth2/callback
+```
+
+## Credentials
+
+For production, prefer an existing Secret or ExternalSecret:
+
+```yaml
+auth:
+  existingSecret: oauth2-proxy-auth
+  keys:
+    clientID: client-id
+    clientSecret: client-secret
+    cookieSecret: cookie-secret
+```
+
+When `externalSecrets.enabled=true`, `auth.existingSecret` must match the
+ExternalSecret target name.
+
+## Reverse Proxy Hardening
+
+OAuth2 Proxy `v7.15.2` introduced `trusted_proxy_ips` to prevent trusting
+client-supplied `X-Forwarded-*` headers from untrusted sources. Keep this list
+narrow and aligned with the IP ranges used by your ingress controller, Gateway
+implementation, or edge proxy.
+
+```yaml
+config:
+  reverseProxy:
+    enabled: true
+    trustedProxyIps:
+      - 10.42.0.0/16
+```
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+  hostnames:
+    - auth.example.com
+```
+
+## Monitoring
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+```
+
+## Local Validation
+
+```bash
+helm lint charts/oauth2-proxy
+helm template oauth2-proxy charts/oauth2-proxy -f charts/oauth2-proxy/ci/ci-values.yaml
+helm unittest charts/oauth2-proxy
+```

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -86,6 +86,14 @@ metrics:
     enabled: true
 ```
 
+## Alpha Config
+
+When `alphaConfig.enabled=true`, the chart renders the structured
+`alpha-config.yaml` without the legacy TOML file. To keep Kubernetes probes,
+Service traffic, and metrics reachable, the chart injects
+`server.bindAddress: 0.0.0.0:4180` and `metricsServer.bindAddress` when those
+fields are not set explicitly.
+
 ## Local Validation
 
 ```bash

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -10,8 +10,9 @@ and runtime validation.
 - Official `quay.io/oauth2-proxy/oauth2-proxy` image.
 - `v7.15.2` default, including the upstream security fixes for critical
   authentication bypass advisories.
-- Explicit `trusted_proxy_ips` support for deployments behind ingress
-  controllers, gateways, or service mesh edge proxies.
+- Reverse proxy header trust disabled by default, with required explicit
+  `trusted_proxy_ips` CIDRs when enabled behind ingress controllers, gateways,
+  or service mesh edge proxies.
 - Chart-managed Secret, existing Secret, or ExternalSecret credential modes.
 - Config validation init container using `--config-test`.
 - Dual-stack Service defaults, Ingress with `ingressClassName`, Gateway API `HTTPRoute`, ServiceMonitor,
@@ -51,6 +52,11 @@ OAuth2 Proxy `v7.15.2` introduced `trusted_proxy_ips` to prevent trusting
 client-supplied `X-Forwarded-*` headers from untrusted sources. Keep this list
 narrow and aligned with the IP ranges used by your ingress controller, Gateway
 implementation, or edge proxy.
+
+The chart keeps `config.reverseProxy.enabled=false` by default. If you enable
+reverse proxy header handling, the chart requires at least one
+`config.reverseProxy.trustedProxyIps` CIDR so a missing list cannot fall back to
+broad trust.
 
 ```yaml
 config:

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -14,7 +14,7 @@ and runtime validation.
   controllers, gateways, or service mesh edge proxies.
 - Chart-managed Secret, existing Secret, or ExternalSecret credential modes.
 - Config validation init container using `--config-test`.
-- Dual-stack Service defaults, Ingress, Gateway API `HTTPRoute`, ServiceMonitor,
+- Dual-stack Service defaults, Ingress with `ingressClassName`, Gateway API `HTTPRoute`, ServiceMonitor,
   HPA, PDB, and optional NetworkPolicy.
 
 ## Install
@@ -42,7 +42,8 @@ auth:
 ```
 
 When `externalSecrets.enabled=true`, `auth.existingSecret` must match the
-ExternalSecret target name.
+ExternalSecret target name. Provide either `externalSecrets.data` or
+`externalSecrets.dataFrom`.
 
 ## Reverse Proxy Hardening
 

--- a/charts/oauth2-proxy/ci/ci-values.yaml
+++ b/charts/oauth2-proxy/ci/ci-values.yaml
@@ -33,7 +33,7 @@ service:
 
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   hosts:
     - host: oauth2-proxy.example.test
       paths:

--- a/charts/oauth2-proxy/ci/ci-values.yaml
+++ b/charts/oauth2-proxy/ci/ci-values.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+auth:
+  clientID: ci-client
+  clientSecret: ci-client-secret
+  cookieSecret: "0123456789abcdef0123456789abcdef"
+
+config:
+  provider: github
+  redirectUrl: http://oauth2-proxy.example.test/oauth2/callback
+  cookie:
+    secure: false
+  reverseProxy:
+    enabled: true
+    trustedProxyIps:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+  extraConfig: |-
+    skip_provider_button = true
+
+metrics:
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: oauth2-proxy.example.test
+      paths:
+        - path: /
+          pathType: Prefix
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+  hostnames:
+    - oauth2-proxy.example.test
+
+networkPolicy:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+
+authenticatedEmailsFile:
+  enabled: true
+  emails:
+    - user@example.test

--- a/charts/oauth2-proxy/ci/k3d-values.yaml
+++ b/charts/oauth2-proxy/ci/k3d-values.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+
+auth:
+  clientID: k3d-client
+  clientSecret: k3d-client-secret
+  cookieSecret: "0123456789abcdef0123456789abcdef"
+
+config:
+  provider: github
+  redirectUrl: http://oauth2-proxy.localtest.me/oauth2/callback
+  cookie:
+    secure: false
+  reverseProxy:
+    enabled: true
+    trustedProxyIps:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+
+metrics:
+  enabled: true
+
+pdb:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/charts/oauth2-proxy/docs/external-secrets.md
+++ b/charts/oauth2-proxy/docs/external-secrets.md
@@ -1,0 +1,7 @@
+# OAuth2 Proxy External Secrets
+
+Enable `externalSecrets.enabled=true` when credentials are managed by External Secrets Operator.
+
+Set `auth.existingSecret` to the target Secret name and provide either `externalSecrets.data` for individual mappings or `externalSecrets.dataFrom` for provider-side extraction.
+
+The target Secret must provide the keys configured under `auth.keys`: `client-id`, `client-secret`, and `cookie-secret` by default.

--- a/charts/oauth2-proxy/docs/networking.md
+++ b/charts/oauth2-proxy/docs/networking.md
@@ -1,0 +1,13 @@
+# OAuth2 Proxy Networking
+
+## Ingress
+
+Use `ingress.ingressClassName` for the target Ingress controller. Configure TLS at the ingress edge and keep `config.cookie.secure=true` for HTTPS deployments.
+
+## Gateway API
+
+Gateway API is configured with the `gateway` block. Set `gateway.parentRefs` to the Gateway that terminates traffic and `gateway.hostnames` to the public auth hostname.
+
+## Dual Stack
+
+The Service exposes `service.ipFamilyPolicy` and `service.ipFamilies` so IPv4, IPv6, and dual-stack clusters can be configured without template overrides.

--- a/charts/oauth2-proxy/docs/production.md
+++ b/charts/oauth2-proxy/docs/production.md
@@ -1,0 +1,17 @@
+# OAuth2 Proxy Production Notes
+
+## Credentials
+
+Use an existing Secret or ExternalSecret for `client-id`, `client-secret`, and `cookie-secret`.
+
+The cookie secret must be a high-entropy value accepted by OAuth2 Proxy. Generate it outside Helm and rotate it deliberately because changing it invalidates existing sessions.
+
+## Reverse Proxy Headers
+
+When `config.reverseProxy.enabled=true`, set `config.reverseProxy.trustedProxyIps` to only the ingress controller, Gateway implementation, or edge proxy CIDRs that are allowed to set `X-Forwarded-*` headers.
+
+Leaving the list empty avoids broad default trust in direct-client deployments.
+
+## Availability
+
+Use at least two replicas with a PodDisruptionBudget for production. Keep the chart-managed `config-test` init container enabled because it catches invalid OAuth2 Proxy configuration before the pod enters service.

--- a/charts/oauth2-proxy/docs/production.md
+++ b/charts/oauth2-proxy/docs/production.md
@@ -4,14 +4,21 @@
 
 Use an existing Secret or ExternalSecret for `client-id`, `client-secret`, and `cookie-secret`.
 
-The cookie secret must be a high-entropy value accepted by OAuth2 Proxy. Generate it outside Helm and rotate it deliberately because changing it invalidates existing sessions.
+The cookie secret must be a high-entropy value accepted by OAuth2 Proxy.
+Generate it outside Helm and rotate it deliberately because changing it
+invalidates existing sessions.
 
 ## Reverse Proxy Headers
 
-When `config.reverseProxy.enabled=true`, set `config.reverseProxy.trustedProxyIps` to only the ingress controller, Gateway implementation, or edge proxy CIDRs that are allowed to set `X-Forwarded-*` headers.
+When `config.reverseProxy.enabled=true`, set
+`config.reverseProxy.trustedProxyIps` to only the ingress controller, Gateway
+implementation, or edge proxy CIDRs that are allowed to set `X-Forwarded-*`
+headers.
 
 Leaving the list empty avoids broad default trust in direct-client deployments.
 
 ## Availability
 
-Use at least two replicas with a PodDisruptionBudget for production. Keep the chart-managed `config-test` init container enabled because it catches invalid OAuth2 Proxy configuration before the pod enters service.
+Use at least two replicas with a PodDisruptionBudget for production. Keep the
+chart-managed `config-test` init container enabled because it catches invalid
+OAuth2 Proxy configuration before the pod enters service.

--- a/charts/oauth2-proxy/docs/production.md
+++ b/charts/oauth2-proxy/docs/production.md
@@ -10,12 +10,13 @@ invalidates existing sessions.
 
 ## Reverse Proxy Headers
 
-When `config.reverseProxy.enabled=true`, set
-`config.reverseProxy.trustedProxyIps` to only the ingress controller, Gateway
-implementation, or edge proxy CIDRs that are allowed to set `X-Forwarded-*`
-headers.
+The chart disables reverse proxy header handling by default. When
+`config.reverseProxy.enabled=true`, set `config.reverseProxy.trustedProxyIps` to
+only the ingress controller, Gateway implementation, or edge proxy CIDRs that
+are allowed to set `X-Forwarded-*` headers.
 
-Leaving the list empty avoids broad default trust in direct-client deployments.
+The template fails when reverse proxy mode is enabled with an empty trusted CIDR
+list, preventing an accidental trust-all header configuration.
 
 ## Availability
 

--- a/charts/oauth2-proxy/examples/external-secrets.yaml
+++ b/charts/oauth2-proxy/examples/external-secrets.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  createSecret: false
+  existingSecret: oauth2-proxy-auth
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  dataFrom:
+    - extract:
+        key: oauth2-proxy/auth
+
+config:
+  provider: oidc
+  oidcIssuerUrl: https://idp.example.com/realms/platform
+  redirectUrl: https://auth.example.com/oauth2/callback

--- a/charts/oauth2-proxy/examples/gateway.yaml
+++ b/charts/oauth2-proxy/examples/gateway.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  createSecret: false
+  existingSecret: oauth2-proxy-auth
+
+config:
+  provider: oidc
+  oidcIssuerUrl: https://idp.example.com/realms/platform
+  redirectUrl: https://auth.example.com/oauth2/callback
+  reverseProxy:
+    enabled: true
+    trustedProxyIps:
+      - 10.42.0.0/16
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - auth.example.com
+  path: /oauth2
+  pathType: PathPrefix

--- a/charts/oauth2-proxy/examples/production.yaml
+++ b/charts/oauth2-proxy/examples/production.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+auth:
+  createSecret: false
+  existingSecret: oauth2-proxy-auth
+
+config:
+  provider: oidc
+  oidcIssuerUrl: https://idp.example.com/realms/platform
+  redirectUrl: https://auth.example.com/oauth2/callback
+  cookie:
+    secure: true
+    domains:
+      - .example.com
+  reverseProxy:
+    enabled: true
+    trustedProxyIps:
+      - 10.42.0.0/16
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: auth.example.com
+      paths:
+        - path: /oauth2
+          pathType: Prefix
+  tls:
+    - secretName: oauth2-proxy-tls
+      hosts:
+        - auth.example.com
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: prometheus
+
+networkPolicy:
+  enabled: true

--- a/charts/oauth2-proxy/templates/NOTES.txt
+++ b/charts/oauth2-proxy/templates/NOTES.txt
@@ -1,19 +1,58 @@
-OAuth2 Proxy has been deployed.
+=============================================================================
+OAuth2 Proxy deployed successfully!
+=============================================================================
 
-Service:
-  {{ include "oauth2-proxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+ACCESS:
+   kubectl port-forward svc/{{ include "oauth2-proxy.fullname" . }} -n {{ .Release.Namespace }} 4180:{{ .Values.service.port }}
+   Open: http://localhost:4180
 
-Health checks:
-  /ping and /ready are exposed on the HTTP port.
+SERVICE:
+   Internal: {{ include "oauth2-proxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Health:   /ping and /ready
+   Image:    {{ include "oauth2-proxy.image" . }}
 
-Credential source:
+CREDENTIALS:
 {{- if .Values.externalSecrets.enabled }}
-  ExternalSecret target: {{ .Values.auth.existingSecret }}
+   Source: ExternalSecret
+   Target Secret: {{ .Values.auth.existingSecret }}
 {{- else if .Values.auth.existingSecret }}
-  Existing Secret: {{ .Values.auth.existingSecret }}
+   Source: Existing Secret
+   Secret: {{ .Values.auth.existingSecret }}
 {{- else }}
-  Chart-managed Secret: {{ include "oauth2-proxy.secretName" . }}
+   Source: Chart-managed Secret
+   Secret: {{ include "oauth2-proxy.secretName" . }}
 {{- end }}
 
-When running behind a reverse proxy, keep trusted_proxy_ips narrowed to proxies
-that are allowed to set X-Forwarded-* headers.
+NETWORKING:
+{{- if .Values.ingress.enabled }}
+   Ingress: enabled
+   Class: {{ .Values.ingress.ingressClassName | default "(cluster default)" }}
+{{- else }}
+   Ingress: disabled
+{{- end }}
+{{- if .Values.gateway.enabled }}
+   Gateway API: enabled
+   HTTPRoute: {{ include "oauth2-proxy.fullname" . }}
+{{- else }}
+   Gateway API: disabled
+{{- end }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "oauth2-proxy.fullname" . }}
+
+SECURITY REMINDERS:
+   1. Keep cookie secrets stable and generated outside Helm for production.
+   2. Keep config.reverseProxy.trustedProxyIps limited to trusted edge proxy CIDRs.
+   3. Use HTTPS at the edge and keep config.cookie.secure=true outside local tests.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/oauth2-proxy
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/oauth2-proxy
+   OAuth2 Proxy: https://oauth2-proxy.github.io/oauth2-proxy/
+
+=============================================================================

--- a/charts/oauth2-proxy/templates/NOTES.txt
+++ b/charts/oauth2-proxy/templates/NOTES.txt
@@ -1,0 +1,19 @@
+OAuth2 Proxy has been deployed.
+
+Service:
+  {{ include "oauth2-proxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Health checks:
+  /ping and /ready are exposed on the HTTP port.
+
+Credential source:
+{{- if .Values.externalSecrets.enabled }}
+  ExternalSecret target: {{ .Values.auth.existingSecret }}
+{{- else if .Values.auth.existingSecret }}
+  Existing Secret: {{ .Values.auth.existingSecret }}
+{{- else }}
+  Chart-managed Secret: {{ include "oauth2-proxy.secretName" . }}
+{{- end }}
+
+When running behind a reverse proxy, keep trusted_proxy_ips narrowed to proxies
+that are allowed to set X-Forwarded-* headers.

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -111,6 +111,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       key: {{ .Values.auth.keys.cookieSecret }}
 {{- end -}}
 
+{{- define "oauth2-proxy.alphaReverseProxyArgs" -}}
+{{- if and .Values.alphaConfig.enabled .Values.config.reverseProxy.enabled }}
+- --reverse-proxy=true
+- --real-client-ip-header={{ .Values.config.reverseProxy.realClientIpHeader }}
+{{- range .Values.config.reverseProxy.trustedProxyIps }}
+- --trusted-proxy-ip={{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "oauth2-proxy.alphaConfig" -}}
 {{- $alpha := deepCopy .Values.alphaConfig.config -}}
 {{- $server := get $alpha "server" | default (dict) -}}

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -150,4 +150,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.config.reverseProxy.enabled (eq (len $trustedProxyIps) 0) -}}
 {{- fail "config.reverseProxy.trustedProxyIps must contain at least one trusted proxy CIDR when config.reverseProxy.enabled=true" -}}
 {{- end -}}
+{{- range $key := list "app.kubernetes.io/name" "app.kubernetes.io/instance" -}}
+{{- if hasKey $.Values.podLabels $key -}}
+{{- fail (printf "podLabels cannot override reserved selector label %s" $key) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -105,6 +105,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "oauth2-proxy.validate" -}}
+{{- if and (not .Values.auth.createSecret) (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) -}}
+{{- fail "auth.createSecret=false requires auth.existingSecret or externalSecrets.enabled=true so OAuth2 Proxy credentials are available" -}}
+{{- end -}}
 {{- $trustedProxyIps := default (list) .Values.config.reverseProxy.trustedProxyIps -}}
 {{- if and .Values.config.reverseProxy.enabled (eq (len $trustedProxyIps) 0) -}}
 {{- fail "config.reverseProxy.trustedProxyIps must contain at least one trusted proxy CIDR when config.reverseProxy.enabled=true" -}}

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -1,0 +1,105 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "oauth2-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "oauth2-proxy.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.labels" -}}
+helm.sh/chart: {{ include "oauth2-proxy.chart" . }}
+app.kubernetes.io/name: {{ include "oauth2-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "oauth2-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oauth2-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "oauth2-proxy.image" -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default (printf "v%s" .Chart.AppVersion)) -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "oauth2-proxy.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.secretName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.configName" -}}
+{{- printf "%s-config" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.authenticatedEmailsSecretName" -}}
+{{- if .Values.authenticatedEmailsFile.existingSecret -}}
+{{- .Values.authenticatedEmailsFile.existingSecret -}}
+{{- else -}}
+{{- printf "%s-authenticated-emails" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.alphaConfigSecretName" -}}
+{{- if .Values.alphaConfig.existingSecret -}}
+{{- .Values.alphaConfig.existingSecret -}}
+{{- else -}}
+{{- printf "%s-alpha-config" (include "oauth2-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.cookieSecret" -}}
+{{- $secretName := include "oauth2-proxy.secretName" . -}}
+{{- if .Values.auth.cookieSecret -}}
+{{- .Values.auth.cookieSecret -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and $existing (index $existing.data .Values.auth.keys.cookieSecret) -}}
+{{- index $existing.data .Values.auth.keys.cookieSecret | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "oauth2-proxy.secretEnv" -}}
+- name: OAUTH2_PROXY_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "oauth2-proxy.secretName" . }}
+      key: {{ .Values.auth.keys.clientID }}
+- name: OAUTH2_PROXY_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "oauth2-proxy.secretName" . }}
+      key: {{ .Values.auth.keys.clientSecret }}
+- name: OAUTH2_PROXY_COOKIE_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "oauth2-proxy.secretName" . }}
+      key: {{ .Values.auth.keys.cookieSecret }}
+{{- end -}}

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -103,6 +103,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       name: {{ include "oauth2-proxy.secretName" . }}
       key: {{ .Values.auth.keys.cookieSecret }}
 {{- end -}}
+{{- define "oauth2-proxy.cookieSecretEnv" -}}
+- name: OAUTH2_PROXY_COOKIE_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "oauth2-proxy.secretName" . }}
+      key: {{ .Values.auth.keys.cookieSecret }}
+{{- end -}}
 
 {{- define "oauth2-proxy.validate" -}}
 {{- if and (not .Values.auth.createSecret) (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) -}}

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -111,6 +111,27 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       key: {{ .Values.auth.keys.cookieSecret }}
 {{- end -}}
 
+{{- define "oauth2-proxy.alphaConfig" -}}
+{{- $alpha := deepCopy .Values.alphaConfig.config -}}
+{{- $server := get $alpha "server" | default (dict) -}}
+{{- if kindIs "map" $server -}}
+{{- if and (not (hasKey $server "bindAddress")) (not (hasKey $server "BindAddress")) -}}
+{{- $_ := set $server "bindAddress" "0.0.0.0:4180" -}}
+{{- end -}}
+{{- $_ := set $alpha "server" $server -}}
+{{- end -}}
+{{- if .Values.metrics.enabled -}}
+{{- $metricsServer := get $alpha "metricsServer" | default (dict) -}}
+{{- if kindIs "map" $metricsServer -}}
+{{- if and (not (hasKey $metricsServer "bindAddress")) (not (hasKey $metricsServer "BindAddress")) -}}
+{{- $_ := set $metricsServer "bindAddress" (printf "0.0.0.0:%v" .Values.metrics.port) -}}
+{{- end -}}
+{{- $_ := set $alpha "metricsServer" $metricsServer -}}
+{{- end -}}
+{{- end -}}
+{{- toYaml $alpha -}}
+{{- end -}}
+
 {{- define "oauth2-proxy.validate" -}}
 {{- if and (not .Values.auth.createSecret) (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) -}}
 {{- fail "auth.createSecret=false requires auth.existingSecret or externalSecrets.enabled=true so OAuth2 Proxy credentials are available" -}}

--- a/charts/oauth2-proxy/templates/_helpers.tpl
+++ b/charts/oauth2-proxy/templates/_helpers.tpl
@@ -103,3 +103,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
       name: {{ include "oauth2-proxy.secretName" . }}
       key: {{ .Values.auth.keys.cookieSecret }}
 {{- end -}}
+
+{{- define "oauth2-proxy.validate" -}}
+{{- $trustedProxyIps := default (list) .Values.config.reverseProxy.trustedProxyIps -}}
+{{- if and .Values.config.reverseProxy.enabled (eq (len $trustedProxyIps) 0) -}}
+{{- fail "config.reverseProxy.trustedProxyIps must contain at least one trusted proxy CIDR when config.reverseProxy.enabled=true" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/oauth2-proxy/templates/configmap.yaml
+++ b/charts/oauth2-proxy/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "oauth2-proxy.labels" . | nindent 4 }}
 data:
   oauth2_proxy.cfg: |-
+    {{- if .Values.alphaConfig.enabled }}
+    # Alpha configuration is mounted as alpha-config.yaml; legacy TOML options are intentionally omitted.
+    {{- else }}
     http_address = "0.0.0.0:4180"
     {{- if .Values.metrics.enabled }}
     metrics_address = "0.0.0.0:{{ .Values.metrics.port }}"
@@ -22,9 +25,7 @@ data:
     {{- with .Values.config.redirectUrl }}
     redirect_url = {{ . | quote }}
     {{- end }}
-    {{- if not .Values.alphaConfig.enabled }}
     upstreams = {{ .Values.config.upstreams | toJson }}
-    {{- end }}
     email_domains = {{ .Values.config.emailDomains | toJson }}
     {{- with .Values.config.whitelistDomains }}
     whitelist_domains = {{ . | toJson }}
@@ -65,4 +66,5 @@ data:
     {{- end }}
     {{- with .Values.config.extraConfig }}
 {{ . | nindent 4 }}
+    {{- end }}
     {{- end }}

--- a/charts/oauth2-proxy/templates/configmap.yaml
+++ b/charts/oauth2-proxy/templates/configmap.yaml
@@ -1,0 +1,67 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oauth2-proxy.configName" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+data:
+  oauth2_proxy.cfg: |-
+    http_address = "0.0.0.0:4180"
+    {{- if .Values.metrics.enabled }}
+    metrics_address = "0.0.0.0:{{ .Values.metrics.port }}"
+    {{- end }}
+    provider = {{ .Values.config.provider | quote }}
+    {{- with .Values.config.providerDisplayName }}
+    provider_display_name = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.oidcIssuerUrl }}
+    oidc_issuer_url = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.redirectUrl }}
+    redirect_url = {{ . | quote }}
+    {{- end }}
+    {{- if not .Values.alphaConfig.enabled }}
+    upstreams = {{ .Values.config.upstreams | toJson }}
+    {{- end }}
+    email_domains = {{ .Values.config.emailDomains | toJson }}
+    {{- with .Values.config.whitelistDomains }}
+    whitelist_domains = {{ . | toJson }}
+    {{- end }}
+    {{- with .Values.config.cookie.name }}
+    cookie_name = {{ . | quote }}
+    {{- end }}
+    {{- with .Values.config.cookie.domains }}
+    cookie_domains = {{ . | toJson }}
+    {{- end }}
+    cookie_secure = {{ .Values.config.cookie.secure }}
+    cookie_samesite = {{ .Values.config.cookie.sameSite | quote }}
+    cookie_expire = {{ .Values.config.cookie.expire | quote }}
+    {{- with .Values.config.cookie.refresh }}
+    cookie_refresh = {{ . | quote }}
+    {{- end }}
+    reverse_proxy = {{ .Values.config.reverseProxy.enabled }}
+    {{- if .Values.config.reverseProxy.enabled }}
+    real_client_ip_header = {{ .Values.config.reverseProxy.realClientIpHeader | quote }}
+    {{- with .Values.config.reverseProxy.trustedProxyIps }}
+    trusted_proxy_ips = {{ . | toJson }}
+    {{- end }}
+    {{- end }}
+    set_xauthrequest = {{ .Values.config.headers.setXAuthRequest }}
+    pass_authorization_header = {{ .Values.config.headers.passAuthorizationHeader }}
+    pass_access_token = {{ .Values.config.headers.passAccessToken }}
+    pass_user_headers = {{ .Values.config.headers.passUserHeaders }}
+    skip_auth_strip_headers = {{ .Values.config.headers.skipAuthStripHeaders }}
+    standard_logging = {{ .Values.config.logging.standard }}
+    request_logging = {{ .Values.config.logging.request }}
+    auth_logging = {{ .Values.config.logging.auth }}
+    silence_ping_logging = {{ .Values.config.logging.silencePing }}
+    {{- with .Values.config.logging.excludePaths }}
+    exclude_logging_paths = {{ . | toJson }}
+    {{- end }}
+    {{- if .Values.authenticatedEmailsFile.enabled }}
+    authenticated_emails_file = "/etc/oauth2-proxy/authenticated-emails/{{ .Values.authenticatedEmailsFile.secretKey }}"
+    {{- end }}
+    {{- with .Values.config.extraConfig }}
+{{ . | nindent 4 }}
+    {{- end }}

--- a/charts/oauth2-proxy/templates/configmap.yaml
+++ b/charts/oauth2-proxy/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "oauth2-proxy.validate" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
             {{- if and .Values.alphaConfig.enabled .Values.authenticatedEmailsFile.enabled }}
             - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails/{{ .Values.authenticatedEmailsFile.secretKey }}
             {{- end }}
+            {{- include "oauth2-proxy.alphaReverseProxyArgs" . | nindent 12 }}
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
@@ -108,6 +109,7 @@ spec:
             {{- if and .Values.alphaConfig.enabled .Values.authenticatedEmailsFile.enabled }}
             - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails/{{ .Values.authenticatedEmailsFile.secretKey }}
             {{- end }}
+            {{- include "oauth2-proxy.alphaReverseProxyArgs" . | nindent 12 }}
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "oauth2-proxy.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -45,7 +45,9 @@ spec:
           image: {{ include "oauth2-proxy.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            {{- if not .Values.alphaConfig.enabled }}
             - --config=/etc/oauth2-proxy/oauth2_proxy.cfg
+            {{- end }}
             {{- if .Values.alphaConfig.enabled }}
             - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
             {{- end }}
@@ -63,9 +65,11 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if not .Values.alphaConfig.enabled }}
             - name: config
               mountPath: /etc/oauth2-proxy
               readOnly: true
+            {{- end }}
             - name: tmp
               mountPath: /tmp
             {{- if .Values.authenticatedEmailsFile.enabled }}
@@ -88,7 +92,9 @@ spec:
           image: {{ include "oauth2-proxy.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            {{- if not .Values.alphaConfig.enabled }}
             - --config=/etc/oauth2-proxy/oauth2_proxy.cfg
+            {{- end }}
             {{- if .Values.alphaConfig.enabled }}
             - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
             {{- end }}
@@ -148,9 +154,11 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
+            {{- if not .Values.alphaConfig.enabled }}
             - name: config
               mountPath: /etc/oauth2-proxy
               readOnly: true
+            {{- end }}
             - name: tmp
               mountPath: /tmp
             {{- if .Values.authenticatedEmailsFile.enabled }}
@@ -167,9 +175,11 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if not .Values.alphaConfig.enabled }}
         - name: config
           configMap:
             name: {{ include "oauth2-proxy.configName" . }}
+        {{- end }}
         - name: tmp
           emptyDir: {}
         {{- if .Values.authenticatedEmailsFile.enabled }}

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -48,9 +48,19 @@ spec:
             {{- if .Values.alphaConfig.enabled }}
             - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
             {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
             - --config-test
           env:
             {{- include "oauth2-proxy.secretEnv" . | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/oauth2-proxy
@@ -66,6 +76,9 @@ spec:
             - name: alpha-config
               mountPath: /etc/oauth2-proxy/alpha
               readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -57,6 +57,16 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.authenticatedEmailsFile.enabled }}
+            - name: authenticated-emails
+              mountPath: /etc/oauth2-proxy/authenticated-emails
+              readOnly: true
+            {{- end }}
+            {{- if .Values.alphaConfig.enabled }}
+            - name: alpha-config
+              mountPath: /etc/oauth2-proxy/alpha
+              readOnly: true
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
       containers:

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -56,7 +56,11 @@ spec:
             {{- end }}
             - --config-test
           env:
+            {{- if .Values.alphaConfig.enabled }}
+            {{- include "oauth2-proxy.cookieSecretEnv" . | nindent 12 }}
+            {{- else }}
             {{- include "oauth2-proxy.secretEnv" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -102,7 +106,11 @@ spec:
             - --{{ $key }}={{ $value }}
             {{- end }}
           env:
+            {{- if .Values.alphaConfig.enabled }}
+            {{- include "oauth2-proxy.cookieSecretEnv" . | nindent 12 }}
+            {{- else }}
             {{- include "oauth2-proxy.secretEnv" . | nindent 12 }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -51,6 +51,9 @@ spec:
             {{- if .Values.alphaConfig.enabled }}
             - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
             {{- end }}
+            {{- if and .Values.alphaConfig.enabled .Values.authenticatedEmailsFile.enabled }}
+            - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails/{{ .Values.authenticatedEmailsFile.secretKey }}
+            {{- end }}
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}
@@ -101,6 +104,9 @@ spec:
             {{- end }}
             {{- if .Values.alphaConfig.enabled }}
             - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
+            {{- end }}
+            {{- if and .Values.alphaConfig.enabled .Values.authenticatedEmailsFile.enabled }}
+            - --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails/{{ .Values.authenticatedEmailsFile.secretKey }}
             {{- end }}
             {{- range $key, $value := .Values.extraArgs }}
             - --{{ $key }}={{ $value }}

--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -1,0 +1,179 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "oauth2-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oauth2-proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "oauth2-proxy.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: config-test
+          image: {{ include "oauth2-proxy.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --config=/etc/oauth2-proxy/oauth2_proxy.cfg
+            {{- if .Values.alphaConfig.enabled }}
+            - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
+            {{- end }}
+            - --config-test
+          env:
+            {{- include "oauth2-proxy.secretEnv" . | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/oauth2-proxy
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      containers:
+        - name: oauth2-proxy
+          image: {{ include "oauth2-proxy.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --config=/etc/oauth2-proxy/oauth2_proxy.cfg
+            {{- if .Values.alphaConfig.enabled }}
+            - --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
+            {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+          env:
+            {{- include "oauth2-proxy.secretEnv" . | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 4180
+              protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/oauth2-proxy
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.authenticatedEmailsFile.enabled }}
+            - name: authenticated-emails
+              mountPath: /etc/oauth2-proxy/authenticated-emails
+              readOnly: true
+            {{- end }}
+            {{- if .Values.alphaConfig.enabled }}
+            - name: alpha-config
+              mountPath: /etc/oauth2-proxy/alpha
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "oauth2-proxy.configName" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.authenticatedEmailsFile.enabled }}
+        - name: authenticated-emails
+          secret:
+            secretName: {{ include "oauth2-proxy.authenticatedEmailsSecretName" . }}
+        {{- end }}
+        {{- if .Values.alphaConfig.enabled }}
+        - name: alpha-config
+          secret:
+            secretName: {{ include "oauth2-proxy.alphaConfigSecretName" . }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/oauth2-proxy/templates/externalsecret.yaml
+++ b/charts/oauth2-proxy/templates/externalsecret.yaml
@@ -3,8 +3,10 @@
 {{- if not .Values.auth.existingSecret }}
   {{- fail "externalSecrets.enabled requires auth.existingSecret to be set to the ExternalSecret target name" }}
 {{- end }}
-{{- if not .Values.externalSecrets.data }}
-  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- $externalSecretData := .Values.externalSecrets.data | default list -}}
+{{- $externalSecretDataFrom := .Values.externalSecrets.dataFrom | default list -}}
+{{- if eq (add (len $externalSecretData) (len $externalSecretDataFrom)) 0 }}
+  {{- fail "externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true" }}
 {{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
@@ -20,6 +22,12 @@ spec:
   target:
     name: {{ .Values.auth.existingSecret | quote }}
     creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  {{- if $externalSecretData }}
   data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+    {{- toYaml $externalSecretData | nindent 4 }}
+  {{- end }}
+  {{- if $externalSecretDataFrom }}
+  dataFrom:
+    {{- toYaml $externalSecretDataFrom | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/oauth2-proxy/templates/externalsecret.yaml
+++ b/charts/oauth2-proxy/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- if not .Values.auth.existingSecret }}
+  {{- fail "externalSecrets.enabled requires auth.existingSecret to be set to the ExternalSecret target name" }}
+{{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}-auth
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.auth.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/extra-objects.yaml
+++ b/charts/oauth2-proxy/templates/extra-objects.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/hpa.yaml
+++ b/charts/oauth2-proxy/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "oauth2-proxy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/httproute.yaml
+++ b/charts/oauth2-proxy/templates/httproute.yaml
@@ -1,9 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- $gateway := .Values.gateway -}}
-{{- if .Values.gatewayAPI.enabled }}
-  {{- $gateway = .Values.gatewayAPI -}}
-{{- end }}
-{{- if or .Values.gateway.enabled .Values.gatewayAPI.enabled }}
+{{- if .Values.gateway.enabled }}
 {{- if not $gateway.parentRefs }}
   {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
 {{- end }}

--- a/charts/oauth2-proxy/templates/httproute.yaml
+++ b/charts/oauth2-proxy/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- $gateway := .Values.gateway -}}
+{{- if .Values.gatewayAPI.enabled }}
+  {{- $gateway = .Values.gatewayAPI -}}
+{{- end }}
+{{- if or .Values.gateway.enabled .Values.gatewayAPI.enabled }}
+{{- if not $gateway.parentRefs }}
+  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+{{- end }}
+{{- range $gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+  {{- with $gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $gateway.parentRefs | nindent 4 }}
+  {{- with $gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ $gateway.pathType }}
+            value: {{ $gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "oauth2-proxy.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/ingress.yaml
+++ b/charts/oauth2-proxy/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/charts/oauth2-proxy/templates/ingress.yaml
+++ b/charts/oauth2-proxy/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "oauth2-proxy.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/networkpolicy.yaml
+++ b/charts/oauth2-proxy/templates/networkpolicy.yaml
@@ -1,0 +1,43 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "oauth2-proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    - ports:
+        - protocol: TCP
+          port: 4180
+        {{- if .Values.metrics.enabled }}
+        - protocol: TCP
+          port: {{ .Values.metrics.port }}
+        {{- end }}
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- else }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+    {{- end }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/pdb.yaml
+++ b/charts/oauth2-proxy/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "oauth2-proxy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/secret.yaml
+++ b/charts/oauth2-proxy/templates/secret.yaml
@@ -38,5 +38,5 @@ metadata:
 type: Opaque
 stringData:
   alpha-config.yaml: |
-    {{- toYaml .Values.alphaConfig.config | nindent 4 }}
+    {{- include "oauth2-proxy.alphaConfig" . | nindent 4 }}
 {{- end }}

--- a/charts/oauth2-proxy/templates/secret.yaml
+++ b/charts/oauth2-proxy/templates/secret.yaml
@@ -1,0 +1,42 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.auth.createSecret (not .Values.auth.existingSecret) (not .Values.externalSecrets.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oauth2-proxy.secretName" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.auth.keys.clientID }}: {{ .Values.auth.clientID | quote }}
+  {{ .Values.auth.keys.clientSecret }}: {{ .Values.auth.clientSecret | quote }}
+  {{ .Values.auth.keys.cookieSecret }}: {{ include "oauth2-proxy.cookieSecret" . | quote }}
+{{- end }}
+---
+{{- if and .Values.authenticatedEmailsFile.enabled (not .Values.authenticatedEmailsFile.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oauth2-proxy.authenticatedEmailsSecretName" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.authenticatedEmailsFile.secretKey }}: |-
+    {{- range .Values.authenticatedEmailsFile.emails }}
+    {{ . }}
+    {{- end }}
+{{- end }}
+---
+{{- if and .Values.alphaConfig.enabled (not .Values.alphaConfig.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oauth2-proxy.alphaConfigSecretName" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  alpha-config.yaml: |
+    {{- toYaml .Values.alphaConfig.config | nindent 4 }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/service.yaml
+++ b/charts/oauth2-proxy/templates/service.yaml
@@ -1,4 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and (eq .Values.service.type "ExternalName") (not .Values.service.externalName) }}
+{{- fail "service.externalName is required when service.type=ExternalName" }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,6 +14,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "ExternalName" }}
+  externalName: {{ .Values.service.externalName | quote }}
+  {{- end }}
   {{- with .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}
@@ -31,5 +37,7 @@ spec:
       protocol: TCP
       appProtocol: http
     {{- end }}
+  {{- if ne .Values.service.type "ExternalName" }}
   selector:
     {{- include "oauth2-proxy.selectorLabels" . | nindent 4 }}
+  {{- end }}

--- a/charts/oauth2-proxy/templates/service.yaml
+++ b/charts/oauth2-proxy/templates/service.yaml
@@ -1,0 +1,35 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+      appProtocol: http
+    {{- end }}
+  selector:
+    {{- include "oauth2-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/oauth2-proxy/templates/serviceaccount.yaml
+++ b/charts/oauth2-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oauth2-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/servicemonitor.yaml
+++ b/charts/oauth2-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "oauth2-proxy.fullname" . }}
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "oauth2-proxy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/oauth2-proxy/templates/tests/test-connection.yaml
+++ b/charts/oauth2-proxy/templates/tests/test-connection.yaml
@@ -1,0 +1,40 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "oauth2-proxy.fullname" . }}-test"
+  labels:
+    {{- include "oauth2-proxy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      command:
+        - sh
+        - -ec
+        - |
+          wget -qO- http://{{ include "oauth2-proxy.fullname" . }}:{{ .Values.service.port }}/ping
+          wget -qO- http://{{ include "oauth2-proxy.fullname" . }}:{{ .Values.service.port }}/ready
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/oauth2-proxy/templates/tests/test-connection.yaml
+++ b/charts/oauth2-proxy/templates/tests/test-connection.yaml
@@ -9,6 +9,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  automountServiceAccountToken: false
   restartPolicy: Never
   containers:
     - name: wget

--- a/charts/oauth2-proxy/tests/config_test.yaml
+++ b/charts/oauth2-proxy/tests/config_test.yaml
@@ -37,3 +37,44 @@ tests:
       - matchRegex:
           path: data["oauth2_proxy.cfg"]
           pattern: 'redirect_url = "https://auth.example.test/oauth2/callback"'
+
+  - it: should omit alpha-owned legacy options when alpha config is enabled
+    set:
+      alphaConfig.enabled: true
+      config.provider: github
+      config.providerDisplayName: GitHub
+      config.oidcIssuerUrl: https://issuer.example.test
+      config.redirectUrl: https://auth.example.test/oauth2/callback
+      config.headers.passAuthorizationHeader: true
+      config.headers.passAccessToken: true
+    asserts:
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: '^\\s*provider\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'provider_display_name\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'oidc_issuer_url\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'redirect_url\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'upstreams\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'pass_authorization_header\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'pass_access_token\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'http_address\\s*='
+      - notMatchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'metrics_address\\s*='
+      - matchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'legacy TOML options are intentionally omitted'

--- a/charts/oauth2-proxy/tests/config_test.yaml
+++ b/charts/oauth2-proxy/tests/config_test.yaml
@@ -6,17 +6,18 @@ release:
   name: test
   namespace: default
 tests:
-  - it: should not trust broad private proxy ranges by default
+  - it: should disable reverse proxy header trust by default
     asserts:
       - notMatchRegex:
           path: data["oauth2_proxy.cfg"]
           pattern: 'trusted_proxy_ips ='
       - matchRegex:
           path: data["oauth2_proxy.cfg"]
-          pattern: 'reverse_proxy = true'
+          pattern: 'reverse_proxy = false'
 
   - it: should render configured trusted proxy IPs for reverse proxy mode
     set:
+      config.reverseProxy.enabled: true
       config.reverseProxy.trustedProxyIps:
         - 10.10.0.0/16
         - fd42::/64

--- a/charts/oauth2-proxy/tests/config_test.yaml
+++ b/charts/oauth2-proxy/tests/config_test.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Config
+templates:
+  - templates/configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render trusted proxy IPs for reverse proxy mode
+    asserts:
+      - matchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'trusted_proxy_ips = \["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16","fd00::/8"\]'
+      - matchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'reverse_proxy = true'
+
+  - it: should render OIDC issuer and redirect URL when configured
+    set:
+      config.oidcIssuerUrl: https://issuer.example.test
+      config.redirectUrl: https://auth.example.test/oauth2/callback
+    asserts:
+      - matchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'oidc_issuer_url = "https://issuer.example.test"'
+      - matchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'redirect_url = "https://auth.example.test/oauth2/callback"'

--- a/charts/oauth2-proxy/tests/config_test.yaml
+++ b/charts/oauth2-proxy/tests/config_test.yaml
@@ -6,14 +6,24 @@ release:
   name: test
   namespace: default
 tests:
-  - it: should render trusted proxy IPs for reverse proxy mode
+  - it: should not trust broad private proxy ranges by default
     asserts:
-      - matchRegex:
+      - notMatchRegex:
           path: data["oauth2_proxy.cfg"]
-          pattern: 'trusted_proxy_ips = \["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16","fd00::/8"\]'
+          pattern: 'trusted_proxy_ips ='
       - matchRegex:
           path: data["oauth2_proxy.cfg"]
           pattern: 'reverse_proxy = true'
+
+  - it: should render configured trusted proxy IPs for reverse proxy mode
+    set:
+      config.reverseProxy.trustedProxyIps:
+        - 10.10.0.0/16
+        - fd42::/64
+    asserts:
+      - matchRegex:
+          path: data["oauth2_proxy.cfg"]
+          pattern: 'trusted_proxy_ips = \["10.10.0.0/16","fd42::/64"\]'
 
   - it: should render OIDC issuer and redirect URL when configured
     set:

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -42,3 +42,30 @@ tests:
       - hasDocuments:
           count: 0
         template: templates/secret.yaml
+
+  - it: should mount optional config secrets in config-test init container
+    set:
+      auth.clientID: test-client
+      auth.clientSecret: test-secret
+      auth.cookieSecret: "0123456789abcdef0123456789abcdef"
+      authenticatedEmailsFile.enabled: true
+      authenticatedEmailsFile.emails:
+        - user@example.com
+      alphaConfig.enabled: true
+      alphaConfig.config:
+        injectRequestHeaders: []
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: authenticated-emails
+            mountPath: /etc/oauth2-proxy/authenticated-emails
+            readOnly: true
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: alpha-config
+            mountPath: /etc/oauth2-proxy/alpha
+            readOnly: true
+        template: templates/deployment.yaml

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -156,6 +156,58 @@ tests:
         template: templates/secret.yaml
         documentIndex: 0
 
+  - it: should pass reverse proxy trust flags in alpha mode
+    set:
+      auth.createSecret: false
+      externalSecrets.enabled: true
+      alphaConfig.enabled: true
+      alphaConfig.config:
+        providers: []
+        upstreamConfig:
+          upstreams:
+            - id: static
+              path: /
+              static: true
+              staticCode: 200
+      config.reverseProxy.enabled: true
+      config.reverseProxy.realClientIpHeader: X-Forwarded-For
+      config.reverseProxy.trustedProxyIps:
+        - 10.42.0.0/16
+        - fd42::/64
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --reverse-proxy=true
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --real-client-ip-header=X-Forwarded-For
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --trusted-proxy-ip=10.42.0.0/16
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --trusted-proxy-ip=fd42::/64
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --reverse-proxy=true
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --real-client-ip-header=X-Forwarded-For
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --trusted-proxy-ip=10.42.0.0/16
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --trusted-proxy-ip=fd42::/64
+        template: templates/deployment.yaml
+
   - it: should mirror runtime escape hatches in config-test init container
     set:
       auth.clientID: test-client

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -61,6 +61,8 @@ tests:
       authenticatedEmailsFile.enabled: true
       authenticatedEmailsFile.emails:
         - user@example.com
+      auth.createSecret: false
+      externalSecrets.enabled: true
       alphaConfig.enabled: true
       alphaConfig.config:
         injectRequestHeaders: []
@@ -113,6 +115,38 @@ tests:
                 name: test-oauth2-proxy-auth
                 key: cookie-secret
         template: templates/deployment.yaml
+      - matchRegex:
+          path: stringData["alpha-config.yaml"]
+          pattern: 'bindAddress: 0\.0\.0\.0:4180'
+        template: templates/secret.yaml
+        documentIndex: 1
+      - matchRegex:
+          path: stringData["alpha-config.yaml"]
+          pattern: 'metricsServer:\n\s+bindAddress: 0\.0\.0\.0:44180'
+        template: templates/secret.yaml
+        documentIndex: 1
+
+  - it: should preserve explicit alpha listener config
+    set:
+      auth.createSecret: false
+      externalSecrets.enabled: true
+      alphaConfig.enabled: true
+      alphaConfig.config:
+        server:
+          bindAddress: 0.0.0.0:8080
+        metricsServer:
+          bindAddress: "-"
+    asserts:
+      - matchRegex:
+          path: stringData["alpha-config.yaml"]
+          pattern: 'server:\n\s+bindAddress: 0\.0\.0\.0:8080'
+        template: templates/secret.yaml
+        documentIndex: 0
+      - matchRegex:
+          path: stringData["alpha-config.yaml"]
+          pattern: "metricsServer:\\n\\s+bindAddress: ['\"]-['\"]"
+        template: templates/secret.yaml
+        documentIndex: 0
 
   - it: should mirror runtime escape hatches in config-test init container
     set:

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -69,3 +69,47 @@ tests:
             mountPath: /etc/oauth2-proxy/alpha
             readOnly: true
         template: templates/deployment.yaml
+
+  - it: should mirror runtime escape hatches in config-test init container
+    set:
+      auth.clientID: test-client
+      auth.clientSecret: test-secret
+      auth.cookieSecret: "0123456789abcdef0123456789abcdef"
+      extraArgs:
+        oidc-issuer-url: https://issuer.example.test
+      extraEnv:
+        - name: OAUTH2_PROXY_SKIP_PROVIDER_BUTTON
+          value: "true"
+      envFrom:
+        - secretRef:
+            name: oauth2-extra-env
+      extraVolumes:
+        - name: custom-ca
+          secret:
+            secretName: custom-ca
+      extraVolumeMounts:
+        - name: custom-ca
+          mountPath: /etc/ssl/custom
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --oidc-issuer-url=https://issuer.example.test
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: OAUTH2_PROXY_SKIP_PROVIDER_BUTTON
+            value: "true"
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[0].envFrom[0].secretRef.name
+          value: oauth2-extra-env
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: custom-ca
+            mountPath: /etc/ssl/custom
+            readOnly: true
+        template: templates/deployment.yaml

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -85,6 +85,14 @@ tests:
           path: spec.template.spec.initContainers[0].args
           content: --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
         template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails/restricted_user_access
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --authenticated-emails-file=/etc/oauth2-proxy/authenticated-emails/restricted_user_access
+        template: templates/deployment.yaml
       - notContains:
           path: spec.template.spec.initContainers[0].args
           content: --config=/etc/oauth2-proxy/oauth2_proxy.cfg

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -94,6 +94,25 @@ tests:
             mountPath: /etc/oauth2-proxy
             readOnly: true
         template: templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: OAUTH2_PROXY_CLIENT_ID
+        template: templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: OAUTH2_PROXY_CLIENT_SECRET
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: OAUTH2_PROXY_COOKIE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: test-oauth2-proxy-auth
+                key: cookie-secret
+        template: templates/deployment.yaml
 
   - it: should mirror runtime escape hatches in config-test init container
     set:

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -53,6 +53,38 @@ tests:
           errorMessage: auth.createSecret=false requires auth.existingSecret or externalSecrets.enabled=true so OAuth2 Proxy credentials are available
         template: templates/deployment.yaml
 
+  - it: should reject pod labels that override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: podLabels cannot override reserved selector label app.kubernetes.io/instance
+        template: templates/deployment.yaml
+
+  - it: should reject pod labels that override selector name
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: podLabels cannot override reserved selector label app.kubernetes.io/name
+        template: templates/deployment.yaml
+
+  - it: should allow non-selector pod labels
+    set:
+      podLabels:
+        team: platform
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: test
+        template: templates/deployment.yaml
+
   - it: should mount optional config secrets in config-test init container
     set:
       auth.clientID: test-client

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -79,6 +79,21 @@ tests:
             mountPath: /etc/oauth2-proxy/alpha
             readOnly: true
         template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: --alpha-config=/etc/oauth2-proxy/alpha/alpha-config.yaml
+        template: templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.initContainers[0].args
+          content: --config=/etc/oauth2-proxy/oauth2_proxy.cfg
+        template: templates/deployment.yaml
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/oauth2-proxy
+            readOnly: true
+        template: templates/deployment.yaml
 
   - it: should mirror runtime escape hatches in config-test init container
     set:

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -43,6 +43,16 @@ tests:
           count: 0
         template: templates/secret.yaml
 
+  - it: should fail when chart-managed credentials are disabled without another source
+    set:
+      auth.createSecret: false
+      auth.existingSecret: ""
+      externalSecrets.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: auth.createSecret=false requires auth.existingSecret or externalSecrets.enabled=true so OAuth2 Proxy credentials are available
+        template: templates/deployment.yaml
+
   - it: should mount optional config secrets in config-test init container
     set:
       auth.clientID: test-client

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+  - templates/configmap.yaml
+  - templates/secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should use the official image and config-test init container
+    set:
+      auth.clientID: test-client
+      auth.clientSecret: test-secret
+      auth.cookieSecret: "0123456789abcdef0123456789abcdef"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].args[1]
+          value: --config-test
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/oauth2-proxy/oauth2-proxy:v7.15.2
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+        template: templates/deployment.yaml
+
+  - it: should use an existing secret without rendering a chart-managed secret
+    set:
+      auth.existingSecret: oauth2-proxy-existing
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: oauth2-proxy-existing
+        template: templates/deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/secret.yaml

--- a/charts/oauth2-proxy/tests/externalsecret_test.yaml
+++ b/charts/oauth2-proxy/tests/externalsecret_test.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ExternalSecret data mappings
+    set:
+      auth.existingSecret: oauth2-proxy-auth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.data:
+        - secretKey: client-id
+          remoteRef:
+            key: oauth2-proxy
+            property: client-id
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.target.name
+          value: oauth2-proxy-auth
+      - equal:
+          path: spec.data[0].secretKey
+          value: client-id
+
+  - it: should render ExternalSecret dataFrom mappings
+    set:
+      auth.existingSecret: oauth2-proxy-auth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.dataFrom:
+        - extract:
+            key: oauth2-proxy
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: oauth2-proxy
+      - notExists:
+          path: spec.data
+
+  - it: should fail when ExternalSecret has no mappings
+    set:
+      auth.existingSecret: oauth2-proxy-auth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.data or externalSecrets.dataFrom must not be empty when externalSecrets.enabled=true
+        template: templates/externalsecret.yaml

--- a/charts/oauth2-proxy/tests/gateway_test.yaml
+++ b/charts/oauth2-proxy/tests/gateway_test.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render an HTTPRoute when Gateway API is enabled
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: public
+      gateway.hostnames:
+        - auth.example.test
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.hostnames[0]
+          value: auth.example.test
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80

--- a/charts/oauth2-proxy/tests/ingress_test.yaml
+++ b/charts/oauth2-proxy/tests/ingress_test.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render ingressClassName using HelmForge values convention
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: auth.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: auth.example.test

--- a/charts/oauth2-proxy/tests/service_test.yaml
+++ b/charts/oauth2-proxy/tests/service_test.yaml
@@ -47,3 +47,24 @@ tests:
       - lengthEqual:
           path: spec.ports
           count: 1
+
+  - it: should render ExternalName service without selector
+    set:
+      service.type: ExternalName
+      service.externalName: auth.example.com
+    asserts:
+      - equal:
+          path: spec.type
+          value: ExternalName
+      - equal:
+          path: spec.externalName
+          value: auth.example.com
+      - notExists:
+          path: spec.selector
+
+  - it: should require externalName for ExternalName service
+    set:
+      service.type: ExternalName
+    asserts:
+      - failedTemplate:
+          errorMessage: service.externalName is required when service.type=ExternalName

--- a/charts/oauth2-proxy/tests/service_test.yaml
+++ b/charts/oauth2-proxy/tests/service_test.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render an HTTP service with metrics by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[1].name
+          value: metrics
+      - equal:
+          path: spec.ports[1].port
+          value: 44180
+
+  - it: should support dual-stack service settings
+    set:
+      service.ipFamilyPolicy: RequireDualStack
+      service.ipFamilies:
+        - IPv6
+        - IPv4
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: RequireDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv4
+
+  - it: should omit metrics port when metrics are disabled
+    set:
+      metrics.enabled: false
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1

--- a/charts/oauth2-proxy/tests/test_connection_test.yaml
+++ b/charts/oauth2-proxy/tests/test_connection_test.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Test Connection
+templates:
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should run the Helm test without a service account token
+    asserts:
+      - equal:
+          path: spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -57,7 +57,8 @@
             "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "Orphan", "None"], "default": "Owner" }
           }
         },
-        "data": { "type": "array", "items": { "type": "object" }, "default": [] }
+        "data": { "type": "array", "items": { "type": "object" }, "default": [] },
+        "dataFrom": { "type": "array", "items": { "type": "object" }, "default": [] }
       }
     },
     "config": {
@@ -112,20 +113,12 @@
       "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean", "default": false },
-        "className": { "type": "string", "default": "" },
+        "ingressClassName": { "type": "string", "default": "" },
         "hosts": { "type": "array", "items": { "type": "object" } },
         "tls": { "type": "array", "items": { "type": "object" } }
       }
     },
     "gateway": {
-      "type": "object",
-      "additionalProperties": true,
-      "properties": {
-        "enabled": { "type": "boolean", "default": false },
-        "parentRefs": { "type": "array", "items": { "type": "object" }, "default": [] }
-      }
-    },
-    "gatewayAPI": {
       "type": "object",
       "additionalProperties": true,
       "properties": {

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -84,6 +84,7 @@
       "additionalProperties": true,
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"], "default": "ClusterIP" },
+        "externalName": { "type": "string", "default": "" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 80 },
         "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
         "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "OAuth2 Proxy Helm Chart Values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "replicaCount": { "type": "integer", "minimum": 1, "default": 2 },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string", "default": "quay.io/oauth2-proxy/oauth2-proxy" },
+        "tag": { "type": "string", "default": "v7.15.2" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "createSecret": { "type": "boolean", "default": true },
+        "existingSecret": { "type": "string", "default": "" },
+        "clientID": { "type": "string", "default": "" },
+        "clientSecret": { "type": "string", "default": "" },
+        "cookieSecret": { "type": "string", "default": "" },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "clientID": { "type": "string", "default": "client-id" },
+            "clientSecret": { "type": "string", "default": "client-secret" },
+            "cookieSecret": { "type": "string", "default": "cookie-secret" }
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "enum": ["external-secrets.io/v1"], "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "0" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "default": "" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"], "default": "SecretStore" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string", "enum": ["Owner", "Merge", "Orphan", "None"], "default": "Owner" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" }, "default": [] }
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "provider": { "type": "string", "default": "oidc" },
+        "oidcIssuerUrl": { "type": "string", "default": "" },
+        "redirectUrl": { "type": "string", "default": "" },
+        "upstreams": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "emailDomains": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "reverseProxy": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean", "default": true },
+            "trustedProxyIps": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"], "default": "ClusterIP" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 80 },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"], "default": "" },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 44180 },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "interval": { "type": "string", "default": "30s" },
+            "scrapeTimeout": { "type": "string", "default": "10s" }
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "className": { "type": "string", "default": "" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "parentRefs": { "type": "array", "items": { "type": "object" }, "default": [] }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "parentRefs": { "type": "array", "items": { "type": "object" }, "default": [] }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingress": { "type": "array", "items": { "type": "object" }, "default": [] },
+        "egress": { "type": "array", "items": { "type": "object" }, "default": [] }
+      }
+    },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "extraObjects": { "type": "array", "items": { "type": "object" }, "default": [] }
+  }
+}

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -124,6 +124,15 @@
         }
       }
     },
+    "alphaConfig": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "existingSecret": { "type": "string", "default": "" },
+        "config": { "type": "object", "default": {} }
+      }
+    },
     "ingress": {
       "type": "object",
       "additionalProperties": true,

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -74,9 +74,25 @@
           "type": "object",
           "additionalProperties": true,
           "properties": {
-            "enabled": { "type": "boolean", "default": true },
-            "trustedProxyIps": { "type": "array", "items": { "type": "string" } }
-          }
+            "enabled": { "type": "boolean", "default": false },
+            "trustedProxyIps": { "type": "array", "items": { "type": "string" }, "default": [] }
+          },
+          "allOf": [
+            {
+              "if": {
+                "required": ["enabled"],
+                "properties": {
+                  "enabled": { "const": true }
+                }
+              },
+              "then": {
+                "properties": {
+                  "trustedProxyIps": { "minItems": 1 }
+                },
+                "required": ["trustedProxyIps"]
+              }
+            }
+          ]
         }
       }
     },

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -89,11 +89,11 @@ config:
     # -- Optional cookie refresh duration.
     refresh: ""
   reverseProxy:
-    # -- Enable reverse proxy header handling.
-    enabled: true
+    # -- Enable reverse proxy header handling. Requires config.reverseProxy.trustedProxyIps.
+    enabled: false
     # -- Header used to determine real client IP.
     realClientIpHeader: X-Real-IP
-    # -- Explicitly trusted reverse proxies for X-Forwarded-* headers.
+    # -- Explicitly trusted reverse proxies for X-Forwarded-* headers. Required when reverseProxy.enabled=true.
     trustedProxyIps: []
   headers:
     # -- Set X-Auth-Request-* headers.

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# OAuth2 Proxy Helm Chart - Default Values
+# =============================================================================
+# Focus: secure OAuth2/OIDC reverse proxy for Kubernetes ingress and Gateway API.
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+replicaCount: 2
+revisionHistoryLimit: 3
+
+image:
+  # -- Official upstream OAuth2 Proxy image
+  repository: quay.io/oauth2-proxy/oauth2-proxy
+  # -- Image tag
+  tag: "v7.15.2"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+auth:
+  # -- Create a Kubernetes Secret for client and cookie credentials.
+  createSecret: true
+  # -- Existing Secret with keys defined below. Required when externalSecrets.enabled=true.
+  existingSecret: ""
+  clientID: ""
+  clientSecret: ""
+  cookieSecret: ""
+  keys:
+    clientID: client-id
+    clientSecret: client-secret
+    cookieSecret: cookie-secret
+
+externalSecrets:
+  enabled: false
+  apiVersion: external-secrets.io/v1
+  refreshInterval: "0"
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  data: []
+
+config:
+  # -- OAuth2 Proxy provider. Common values: oidc, github, google, gitlab, keycloak-oidc.
+  provider: oidc
+  providerDisplayName: ""
+  oidcIssuerUrl: ""
+  redirectUrl: ""
+  upstreams:
+    - file:///dev/null
+  emailDomains:
+    - "*"
+  whitelistDomains: []
+  cookie:
+    name: ""
+    domains: []
+    secure: true
+    sameSite: lax
+    expire: 168h
+    refresh: ""
+  reverseProxy:
+    enabled: true
+    realClientIpHeader: X-Real-IP
+    # -- Explicitly trusted reverse proxies for X-Forwarded-* headers.
+    trustedProxyIps:
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+      - fd00::/8
+  headers:
+    setXAuthRequest: true
+    passAuthorizationHeader: false
+    passAccessToken: false
+    passUserHeaders: true
+    skipAuthStripHeaders: true
+  logging:
+    standard: true
+    request: true
+    auth: true
+    silencePing: true
+    excludePaths:
+      - /ping
+      - /ready
+      - /metrics
+  # -- Extra TOML appended to oauth2_proxy.cfg.
+  extraConfig: ""
+
+alphaConfig:
+  enabled: false
+  existingSecret: ""
+  config: {}
+
+authenticatedEmailsFile:
+  enabled: false
+  existingSecret: ""
+  secretKey: restricted_user_access
+  emails: []
+
+extraArgs: {}
+extraEnv: []
+envFrom: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+  ipFamilyPolicy: ""
+  ipFamilies: []
+
+metrics:
+  enabled: true
+  port: 44180
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: oauth2-proxy.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gateway:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+gatewayAPI:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+probes:
+  startup:
+    enabled: true
+    path: /ping
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 12
+  liveness:
+    enabled: true
+    path: /ping
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 2000
+  runAsGroup: 2000
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+podAnnotations: {}
+podLabels: {}
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+extraVolumes: []
+extraVolumeMounts: []
+
+test:
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37.0"
+    pullPolicy: IfNotPresent
+
+extraObjects: []

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -112,6 +112,7 @@ serviceAccount:
 
 service:
   type: ClusterIP
+  externalName: ""
   port: 80
   annotations: {}
   ipFamilyPolicy: ""

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -66,11 +66,7 @@ config:
     enabled: true
     realClientIpHeader: X-Real-IP
     # -- Explicitly trusted reverse proxies for X-Forwarded-* headers.
-    trustedProxyIps:
-      - 10.0.0.0/8
-      - 172.16.0.0/12
-      - 192.168.0.0/16
-      - fd00::/8
+    trustedProxyIps: []
   headers:
     setXAuthRequest: true
     passAuthorizationHeader: false

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -4,11 +4,16 @@
 # =============================================================================
 # Focus: secure OAuth2/OIDC reverse proxy for Kubernetes ingress and Gateway API.
 
+# -- Override the chart name.
 nameOverride: ""
+# -- Override the fully qualified release name.
 fullnameOverride: ""
+# -- Additional labels applied to all chart resources.
 commonLabels: {}
 
+# -- Number of OAuth2 Proxy replicas when autoscaling is disabled.
 replicaCount: 2
+# -- Number of old ReplicaSets retained by the Deployment.
 revisionHistoryLimit: 3
 
 image:
@@ -34,50 +39,83 @@ auth:
     cookieSecret: cookie-secret
 
 externalSecrets:
+  # -- Render an ExternalSecret for OAuth2 client and cookie credentials.
   enabled: false
+  # -- ExternalSecret API version.
   apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval.
   refreshInterval: "0"
   secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name.
     name: ""
+    # -- Secret store kind.
     kind: SecretStore
   target:
+    # -- ExternalSecret target creation policy.
     creationPolicy: Owner
+  # -- ExternalSecret data entries for individual credential keys.
   data: []
+  # -- ExternalSecret dataFrom entries for provider-side secret extraction.
+  dataFrom: []
 
 config:
   # -- OAuth2 Proxy provider. Common values: oidc, github, google, gitlab, keycloak-oidc.
   provider: oidc
+  # -- Provider display name shown by OAuth2 Proxy.
   providerDisplayName: ""
+  # -- OIDC issuer URL when using OIDC-compatible providers.
   oidcIssuerUrl: ""
+  # -- OAuth2 redirect URL.
   redirectUrl: ""
+  # -- Upstream targets protected by OAuth2 Proxy.
   upstreams:
     - file:///dev/null
+  # -- Allowed email domains.
   emailDomains:
     - "*"
+  # -- Allowed redirect whitelist domains.
   whitelistDomains: []
   cookie:
+    # -- Cookie name override.
     name: ""
+    # -- Cookie domains.
     domains: []
+    # -- Mark cookies secure.
     secure: true
+    # -- Cookie SameSite mode.
     sameSite: lax
+    # -- Cookie expiration duration.
     expire: 168h
+    # -- Optional cookie refresh duration.
     refresh: ""
   reverseProxy:
+    # -- Enable reverse proxy header handling.
     enabled: true
+    # -- Header used to determine real client IP.
     realClientIpHeader: X-Real-IP
     # -- Explicitly trusted reverse proxies for X-Forwarded-* headers.
     trustedProxyIps: []
   headers:
+    # -- Set X-Auth-Request-* headers.
     setXAuthRequest: true
+    # -- Pass Authorization header to upstreams.
     passAuthorizationHeader: false
+    # -- Pass OAuth access token to upstreams.
     passAccessToken: false
+    # -- Pass user headers to upstreams.
     passUserHeaders: true
+    # -- Strip inbound auth headers before setting trusted headers.
     skipAuthStripHeaders: true
   logging:
+    # -- Enable standard logging.
     standard: true
+    # -- Enable request logging.
     request: true
+    # -- Enable auth logging.
     auth: true
+    # -- Silence ping logging.
     silencePing: true
+    # -- Paths excluded from request logging.
     excludePaths:
       - /ping
       - /ready
@@ -86,109 +124,167 @@ config:
   extraConfig: ""
 
 alphaConfig:
+  # -- Enable OAuth2 Proxy alpha config file support.
   enabled: false
+  # -- Existing Secret containing alpha-config.yaml.
   existingSecret: ""
+  # -- Inline alpha config rendered to a Secret when enabled and no existingSecret is set.
   config: {}
 
 authenticatedEmailsFile:
+  # -- Enable restricted email allow-list file.
   enabled: false
+  # -- Existing Secret containing the allow-list file.
   existingSecret: ""
+  # -- Secret key containing the allow-list file.
   secretKey: restricted_user_access
+  # -- Email addresses rendered into the allow-list file.
   emails: []
 
+# -- Additional CLI arguments rendered as --key=value.
 extraArgs: {}
+# -- Additional environment variables for OAuth2 Proxy.
 extraEnv: []
+# -- Additional envFrom sources for OAuth2 Proxy.
 envFrom: []
 
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: true
+  # -- ServiceAccount name override.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
+  # -- Mount the ServiceAccount token into pods.
   automountServiceAccountToken: false
 
 service:
+  # -- Service type.
   type: ClusterIP
+  # -- ExternalName target when service.type=ExternalName.
   externalName: ""
+  # -- Service HTTP port.
   port: 80
+  # -- Service annotations.
   annotations: {}
+  # -- Service IP family policy: SingleStack, PreferDualStack, RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ""
+  # -- Service IP families.
   ipFamilies: []
 
 metrics:
+  # -- Expose OAuth2 Proxy metrics port.
   enabled: true
+  # -- Metrics port.
   port: 44180
   serviceMonitor:
+    # -- Render a Prometheus Operator ServiceMonitor.
     enabled: false
+    # -- ServiceMonitor scrape interval.
     interval: 30s
+    # -- ServiceMonitor scrape timeout.
     scrapeTimeout: 10s
+    # -- Additional ServiceMonitor labels.
     labels: {}
 
 ingress:
+  # -- Enable Kubernetes Ingress.
   enabled: false
-  className: ""
+  # -- IngressClass name.
+  ingressClassName: ""
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress host rules.
   hosts:
     - host: oauth2-proxy.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
 gateway:
+  # -- Enable Gateway API HTTPRoute.
   enabled: false
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- Gateway parentRefs.
   parentRefs: []
+  # -- HTTPRoute hostnames.
   hostnames: []
+  # -- HTTPRoute match path.
   path: /
-  pathType: PathPrefix
-
-gatewayAPI:
-  enabled: false
-  annotations: {}
-  parentRefs: []
-  hostnames: []
-  path: /
+  # -- HTTPRoute path match type.
   pathType: PathPrefix
 
 networkPolicy:
+  # -- Enable NetworkPolicy for OAuth2 Proxy pods.
   enabled: false
+  # -- Additional ingress rules.
   ingress: []
+  # -- Additional egress rules.
   egress: []
 
 autoscaling:
+  # -- Enable HorizontalPodAutoscaler.
   enabled: false
+  # -- Minimum HPA replicas.
   minReplicas: 2
+  # -- Maximum HPA replicas.
   maxReplicas: 6
+  # -- Target average CPU utilization.
   targetCPUUtilizationPercentage: 70
+  # -- Target average memory utilization.
   targetMemoryUtilizationPercentage: 80
 
 pdb:
+  # -- Enable PodDisruptionBudget.
   enabled: true
+  # -- Minimum available pods for disruption budget.
   minAvailable: 1
 
 probes:
   startup:
+    # -- Enable startup probe.
     enabled: true
+    # -- Startup probe path.
     path: /ping
+    # -- Startup probe initial delay.
     initialDelaySeconds: 5
+    # -- Startup probe period.
     periodSeconds: 5
+    # -- Startup probe timeout.
     timeoutSeconds: 2
+    # -- Startup probe failure threshold.
     failureThreshold: 12
   liveness:
+    # -- Enable liveness probe.
     enabled: true
+    # -- Liveness probe path.
     path: /ping
+    # -- Liveness probe initial delay.
     initialDelaySeconds: 10
+    # -- Liveness probe period.
     periodSeconds: 10
+    # -- Liveness probe timeout.
     timeoutSeconds: 2
+    # -- Liveness probe failure threshold.
     failureThreshold: 3
   readiness:
+    # -- Enable readiness probe.
     enabled: true
+    # -- Readiness probe path.
     path: /ready
+    # -- Readiness probe initial delay.
     initialDelaySeconds: 5
+    # -- Readiness probe period.
     periodSeconds: 10
+    # -- Readiness probe timeout.
     timeoutSeconds: 2
+    # -- Readiness probe failure threshold.
     failureThreshold: 3
 
+# -- Container resource requests and limits.
 resources:
   requests:
     cpu: 50m
@@ -197,6 +293,7 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# -- Pod-level security context.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 2000
@@ -205,6 +302,7 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# -- Container-level security context.
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -212,23 +310,37 @@ securityContext:
     drop:
       - ALL
 
+# -- Additional pod annotations.
 podAnnotations: {}
+# -- Additional pod labels.
 podLabels: {}
+# -- PriorityClass name.
 priorityClassName: ""
+# -- Pod termination grace period.
 terminationGracePeriodSeconds: 30
 
+# -- Node selector.
 nodeSelector: {}
+# -- Pod tolerations.
 tolerations: []
+# -- Pod affinity rules.
 affinity: {}
+# -- Pod topology spread constraints.
 topologySpreadConstraints: []
 
+# -- Additional volumes.
 extraVolumes: []
+# -- Additional volume mounts.
 extraVolumeMounts: []
 
 test:
   image:
+    # -- Helm test image repository.
     repository: docker.io/library/busybox
+    # -- Helm test image tag.
     tag: "1.37.0"
+    # -- Helm test image pull policy.
     pullPolicy: IfNotPresent
 
+# -- Additional Kubernetes objects rendered verbatim.
 extraObjects: []

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -312,7 +312,7 @@ securityContext:
 
 # -- Additional pod annotations.
 podAnnotations: {}
-# -- Additional pod labels.
+# -- Additional pod labels. Do not set reserved selector labels `app.kubernetes.io/name` or `app.kubernetes.io/instance`.
 podLabels: {}
 # -- PriorityClass name.
 priorityClassName: ""

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -128,7 +128,7 @@ alphaConfig:
   enabled: false
   # -- Existing Secret containing alpha-config.yaml.
   existingSecret: ""
-  # -- Inline alpha config rendered to a Secret when enabled and no existingSecret is set.
+  # -- Inline alpha config rendered to a Secret when enabled and no existingSecret is set. The chart adds server.bindAddress and metricsServer.bindAddress defaults when omitted.
   config: {}
 
 authenticatedEmailsFile:


### PR DESCRIPTION
## Summary
- Adds a new stable HelmForge chart for OAuth2 Proxy using the official `quay.io/oauth2-proxy/oauth2-proxy:v7.15.2` image.
- Includes chart-managed Secret, existing Secret, ExternalSecret, config-test init container, Gateway API, Ingress, dual-stack service support, metrics/ServiceMonitor, HPA, PDB, optional NetworkPolicy, schema, README, CI values, and Helm tests.
- Adds v7.15.2-oriented hardening through explicit `trusted_proxy_ips` support for reverse-proxy deployments.

## Research
- Verified upstream latest release via GitHub API: `v7.15.2` published 2026-04-14 with critical security fixes and `trusted-proxy-ip` guidance.
- Reviewed current upstream OAuth2 Proxy chart (`oauth2-proxy/oauth2-proxy` 10.6.0, app 7.15.2) and OAuth2 Proxy docs through Context7.
- Tavily search was attempted first and failed due plan usage limit; native search/GitHub/Helm repo were used as the required fallback.

## Local Validation Evidence
- [x] `helm dependency build charts/oauth2-proxy` / `helm dependency list charts/oauth2-proxy`
- [x] `helm lint charts/oauth2-proxy --strict`
- [x] `helm lint charts/oauth2-proxy -f charts/oauth2-proxy/ci/ci-values.yaml --strict`
- [x] `helm lint charts/oauth2-proxy -f charts/oauth2-proxy/ci/k3d-values.yaml --strict`
- [x] `helm template oauth2-proxy charts/oauth2-proxy`
- [x] `helm template oauth2-proxy charts/oauth2-proxy -f charts/oauth2-proxy/ci/ci-values.yaml`
- [x] `helm template oauth2-proxy charts/oauth2-proxy -f charts/oauth2-proxy/ci/k3d-values.yaml`
- [x] `helm unittest charts/oauth2-proxy` (4 suites / 8 tests)
- [x] `ah lint -p charts/oauth2-proxy`
- [x] `npx -y markdownlint-cli2 charts/oauth2-proxy/README.md`
- [x] strict `kubeconform` for default, CI, and k3d renders (`ServiceMonitor`/`HTTPRoute` CRDs ignored where missing locally)
- [x] ASCII, floating tag, and SPDX checks
- [x] MCP HelmForge checks: chart standards (no blockers), service dual-stack, Gateway API, ExternalSecret, pod security
- [x] Kubescape MITRE/NSA/SOC2 local score: 95

## k3d Runtime Validation
Cluster: `k3d-helmforge-tests-wsl`
Namespace: `hf-oauth2-proxy`

- [x] `helm install oauth2-proxy charts/oauth2-proxy -n hf-oauth2-proxy -f charts/oauth2-proxy/ci/k3d-values.yaml --wait --timeout 5m`
- [x] `helm test oauth2-proxy -n hf-oauth2-proxy --timeout 2m --logs`
- [x] `/ping`, `/ready`, and `/metrics` smoke checks from an in-cluster BusyBox pod
- [x] Pod ready `1/1`, running, `0` restarts
- [x] No Warning events in namespace
- [x] No `error|fatal|panic|exception|traceback` matches in pod/init logs
- [x] Namespace cleaned after validation

Resolves #373