### PR TITLE
feat(opencut): add OpenCut chart

### DIFF
--- a/charts/opencut/.helmignore
+++ b/charts/opencut/.helmignore
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# OS
+.DS_Store
+Thumbs.db
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+
+# Helm
+.helmignore
+
+# Editors / IDE
+.vscode/
+.idea/
+*.code-workspace
+
+# Temporary files
+*.orig
+*.rej
+*.swp
+*.tmp
+
+# Logs
+*.log
+
+# CI / misc
+*.bak

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: opencut
+description: OpenCut open-source video editor with PostgreSQL and Redis HTTP support
+type: application
+version: 1.0.0
+appVersion: "0.3.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - opencut
+  - video-editor
+  - media
+  - nextjs
+  - postgres
+  - redis
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/opencut
+  - https://github.com/OpenCut-app/OpenCut
+  - https://github.com/helmforgedev/opencut
+icon: https://helmforge.dev/icons/charts/opencut.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "initial stable OpenCut chart with HelmForge image, PostgreSQL, Redis HTTP bridge, Gateway API, and runtime tests"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://opencut.app
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/opencut
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/opencut
+    - name: Image Source
+      url: https://github.com/helmforgedev/opencut
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+    - url: https://artifacthub.io/packages/helm/helmforge/redis
+dependencies:
+  - name: postgresql
+    version: 2.0.2
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled
+  - name: redis
+    version: 1.6.15
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: redis.enabled

--- a/charts/opencut/DESIGN.md
+++ b/charts/opencut/DESIGN.md
@@ -1,0 +1,101 @@
+# OpenCut Chart Design
+
+## Scope
+
+This chart deploys OpenCut as a Helm-native web application with the supporting
+services OpenCut expects at runtime.
+
+Supported dependency modes:
+
+- bundled HelmForge PostgreSQL and Redis subcharts for turnkey installs
+- external PostgreSQL and external Redis for platform-managed data services
+- Redis-over-HTTP bridge for OpenCut `UPSTASH_REDIS_REST_*` compatibility
+
+The chart intentionally avoids installing platform controllers such as Ingress,
+Gateway API, External Secrets Operator, storage provisioners, or monitoring
+stacks.
+
+## Architecture: Bundled Dependencies
+
+```mermaid
+flowchart TB
+  browser[Browser] --> route[Ingress or HTTPRoute]
+  route --> web[OpenCut Deployment]
+  web --> pgsvc[PostgreSQL Service]
+  pgsvc --> pg[HelmForge PostgreSQL StatefulSet]
+  pg --> pgpvc[(PostgreSQL PVC)]
+  web --> redisHttp[Redis HTTP bridge]
+  redisHttp --> redissvc[Redis Service]
+  redissvc --> redis[HelmForge Redis StatefulSet]
+  redis --> redispvc[(Redis PVC)]
+  web --> secret[OpenCut app Secret]
+```
+
+Bundled mode is appropriate for local environments, preview environments, and
+small installations where the release should own the complete runtime.
+
+## Architecture: Platform Services
+
+```mermaid
+flowchart TB
+  browser[Browser] --> route[Ingress or HTTPRoute]
+  route --> web[OpenCut Deployment]
+  web --> pg[(External PostgreSQL)]
+  web --> redisHttp[Redis HTTP bridge]
+  redisHttp --> redis[(External Redis)]
+  eso[External Secrets Operator optional] -. materializes .-> secret[Database or Redis Secret]
+  web --> secret
+```
+
+Platform-service mode is preferred when database backup, restore, patching, and
+credential ownership are managed outside the release.
+
+## Main Design Choices
+
+- Use a HelmForge-maintained OpenCut image so the chart can pin a reproducible
+  runtime and publish SBOM/signing evidence with the HelmForge release process.
+- Use HelmForge PostgreSQL and Redis subcharts instead of third-party
+  dependencies so database behavior, guardrails, and values remain consistent.
+- Keep the Redis HTTP bridge explicit because the upstream application consumes
+  HTTP-style Redis environment variables.
+- Use a single `gateway` values block for Gateway API HTTPRoute support.
+- Derive `opencut.siteUrl` from Ingress or Gateway hostnames only when the user
+  does not set it directly.
+- Keep application credentials in Secrets and support External Secrets for
+  externally owned PostgreSQL credentials.
+
+## Explicit Non-Goals
+
+- video transcoding workers outside the upstream OpenCut web runtime
+- bundled object storage
+- installing Gateway API CRDs, Ingress controllers, or External Secrets Operator
+- managing external PostgreSQL or Redis lifecycle
+- automatic database migrations outside the OpenCut application startup path
+
+## Production Boundary
+
+Production users should provide explicit values for:
+
+- `opencut.siteUrl`
+- `opencut.betterAuthSecret`
+- PostgreSQL and Redis credentials through existing Secrets or External Secrets
+- persistence sizes and storage classes
+- CPU and memory resources
+- `networkPolicy.enabled=true`
+- TLS through Ingress or Gateway infrastructure
+
+<!-- @AI-METADATA
+type: design
+title: OpenCut Chart Design
+description: Design document for the OpenCut Helm chart architecture, dependency modes, and production boundaries
+keywords: opencut, design, architecture, postgresql, redis, gateway-api
+purpose: Document chart design choices and operational boundaries
+scope: Chart Design
+relations:
+  - charts/opencut/README.md
+  - charts/opencut/docs/production.md
+  - charts/opencut/docs/external-services.md
+path: charts/opencut/DESIGN.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/opencut/DESIGN.md
+++ b/charts/opencut/DESIGN.md
@@ -10,6 +10,8 @@ Supported dependency modes:
 - bundled HelmForge PostgreSQL and Redis subcharts for turnkey installs
 - external PostgreSQL and external Redis for platform-managed data services
 - Redis-over-HTTP bridge for OpenCut `UPSTASH_REDIS_REST_*` compatibility
+- external Redis REST endpoint for platforms that already provide an
+  Upstash-compatible API
 
 The chart intentionally avoids installing platform controllers such as Ingress,
 Gateway API, External Secrets Operator, storage provisioners, or monitoring
@@ -58,6 +60,9 @@ credential ownership are managed outside the release.
   dependencies so database behavior, guardrails, and values remain consistent.
 - Keep the Redis HTTP bridge explicit because the upstream application consumes
   HTTP-style Redis environment variables.
+- Fail fast when the bridge is disabled without an external Redis REST URL and
+  token source, because OpenCut requires both `UPSTASH_REDIS_REST_URL` and
+  `UPSTASH_REDIS_REST_TOKEN` at startup.
 - Use a single `gateway` values block for Gateway API HTTPRoute support.
 - Derive `opencut.siteUrl` from Ingress or Gateway hostnames only when the user
   does not set it directly.

--- a/charts/opencut/README.md
+++ b/charts/opencut/README.md
@@ -37,6 +37,14 @@ database:
     existingSecretPasswordKey: database-password
 ```
 
+## Bundled Subcharts
+
+The chart uses the HelmForge PostgreSQL and Redis subcharts by default. OpenCut
+derives connection hosts and Secret names from the same `nameOverride`,
+`fullnameOverride`, and architecture settings used by those dependencies. Redis
+standalone mode connects through the client Service, while Redis replication
+mode connects the HTTP bridge to the primary Service.
+
 ## Networking
 
 Ingress uses the HelmForge-standard `ingress.ingressClassName` key:

--- a/charts/opencut/README.md
+++ b/charts/opencut/README.md
@@ -9,6 +9,7 @@ Redis-over-HTTP bridge required by the upstream application runtime.
 - HelmForge-maintained `docker.io/helmforge/opencut:v0.3.0` image.
 - PostgreSQL and Redis subcharts for a turnkey install.
 - `serverless-redis-http` bridge for `UPSTASH_REDIS_REST_*` compatibility.
+- External Redis REST endpoint support when the in-cluster bridge is disabled.
 - External Secrets Operator integration for external database credentials.
 - Gateway API, Ingress, dual-stack Service support, HPA, PDB, NetworkPolicy,
   schema, and Helm tests.

--- a/charts/opencut/README.md
+++ b/charts/opencut/README.md
@@ -12,6 +12,7 @@ Redis-over-HTTP bridge required by the upstream application runtime.
 - External Secrets Operator integration for external database credentials.
 - Gateway API, Ingress, dual-stack Service support, HPA, PDB, NetworkPolicy,
   schema, and Helm tests.
+- Production, external-service, and networking guides with runnable examples.
 
 ## Install
 
@@ -35,6 +36,40 @@ database:
     existingSecret: opencut-db
     existingSecretPasswordKey: database-password
 ```
+
+## Networking
+
+Ingress uses the HelmForge-standard `ingress.ingressClassName` key:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: opencut.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Gateway API support is exposed through a single `gateway` block:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+  hostnames:
+    - opencut.example.com
+```
+
+## Documentation
+
+- [Design](DESIGN.md)
+- [Production guide](docs/production.md)
+- [External services](docs/external-services.md)
+- [Networking](docs/networking.md)
+- [Examples](examples/)
 
 ## External Secrets
 
@@ -66,4 +101,5 @@ helm dependency build charts/opencut
 helm lint charts/opencut
 helm template opencut charts/opencut -f charts/opencut/ci/ci-values.yaml
 helm unittest charts/opencut
+kubeconform -strict -summary rendered.yaml
 ```

--- a/charts/opencut/README.md
+++ b/charts/opencut/README.md
@@ -1,0 +1,69 @@
+# OpenCut Helm Chart
+
+OpenCut is an open-source video editor. This HelmForge chart deploys the
+OpenCut web application with PostgreSQL and Redis dependencies, plus a
+Redis-over-HTTP bridge required by the upstream application runtime.
+
+## Highlights
+
+- HelmForge-maintained `docker.io/helmforge/opencut:v0.3.0` image.
+- PostgreSQL and Redis subcharts for a turnkey install.
+- `serverless-redis-http` bridge for `UPSTASH_REDIS_REST_*` compatibility.
+- External Secrets Operator integration for external database credentials.
+- Gateway API, Ingress, dual-stack Service support, HPA, PDB, NetworkPolicy,
+  schema, and Helm tests.
+
+## Install
+
+```bash
+helm install opencut oci://ghcr.io/helmforgedev/helm/opencut \
+  --set opencut.siteUrl=https://opencut.example.com \
+  --set opencut.betterAuthSecret="$(openssl rand -hex 32)"
+```
+
+## External Database
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    name: opencut
+    username: opencut
+    existingSecret: opencut-db
+    existingSecretPasswordKey: database-password
+```
+
+## External Secrets
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    existingSecret: opencut-db
+    existingSecretPasswordKey: database-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+  data:
+    - secretKey: database-password
+      remoteRef:
+        key: opencut/database
+        property: password
+```
+
+## Local Validation
+
+```bash
+helm dependency build charts/opencut
+helm lint charts/opencut
+helm template opencut charts/opencut -f charts/opencut/ci/ci-values.yaml
+helm unittest charts/opencut
+```

--- a/charts/opencut/ci/ci-values.yaml
+++ b/charts/opencut/ci/ci-values.yaml
@@ -14,7 +14,7 @@ service:
 
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   hosts:
     - host: opencut.example.test
       paths:

--- a/charts/opencut/ci/ci-values.yaml
+++ b/charts/opencut/ci/ci-values.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+opencut:
+  siteUrl: https://opencut.example.test
+  betterAuthSecret: ci-better-auth-secret-ci-better-auth-secret
+  marbleWorkspaceKey: ci-workspace
+  freesoundClientId: ci-client
+  freesoundApiKey: ci-api-key
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: opencut.example.test
+      paths:
+        - path: /
+          pathType: Prefix
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+  hostnames:
+    - opencut.example.test
+
+networkPolicy:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+
+postgresql:
+  standalone:
+    persistence:
+      enabled: false
+
+redis:
+  standalone:
+    persistence:
+      enabled: false

--- a/charts/opencut/ci/k3d-values.yaml
+++ b/charts/opencut/ci/k3d-values.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+
+opencut:
+  siteUrl: http://opencut.localtest.me
+  betterAuthSecret: k3d-better-auth-secret-k3d-better-auth-secret
+  marbleWorkspaceKey: k3d-workspace
+  freesoundClientId: k3d-client
+  freesoundApiKey: k3d-api-key
+
+postgresql:
+  auth:
+    password: opencut
+    postgresPassword: opencut-postgres
+  standalone:
+    persistence:
+      enabled: false
+
+redis:
+  standalone:
+    persistence:
+      enabled: false
+
+pdb:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 750m
+    memory: 768Mi

--- a/charts/opencut/docs/external-services.md
+++ b/charts/opencut/docs/external-services.md
@@ -1,0 +1,86 @@
+# External Services
+
+OpenCut can consume platform-managed PostgreSQL and Redis instead of the bundled
+HelmForge subcharts.
+
+## External PostgreSQL
+
+Disable the PostgreSQL subchart and provide the connection details:
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: opencut
+    username: opencut
+    existingSecret: opencut-db
+    existingSecretPasswordKey: database-password
+```
+
+The target database and user must exist before OpenCut starts.
+
+## External Redis
+
+Disable the Redis subchart and point the Redis HTTP bridge at an external Redis
+endpoint:
+
+```yaml
+redis:
+  enabled: false
+  external:
+    host: redis.example.com
+    port: 6379
+    existingSecret: opencut-redis
+    existingSecretPasswordKey: redis-password
+```
+
+`redisHttp.enabled` should remain enabled unless the OpenCut runtime is changed
+to consume another Redis HTTP-compatible endpoint directly.
+
+## External Secrets Operator
+
+For externally managed PostgreSQL credentials:
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    existingSecret: opencut-db
+    existingSecretPasswordKey: database-password
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: database-password
+      remoteRef:
+        key: opencut/database
+        property: password
+```
+
+The chart does not create the `SecretStore` or install External Secrets
+Operator.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: OpenCut External Services
+description: External PostgreSQL, Redis, and External Secrets configuration for OpenCut
+keywords: opencut, postgresql, redis, external-secrets
+purpose: Explain externally managed dependency configuration
+scope: Chart Operations
+relations:
+  - charts/opencut/DESIGN.md
+  - charts/opencut/examples/external-services.yaml
+path: charts/opencut/docs/external-services.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/opencut/docs/external-services.md
+++ b/charts/opencut/docs/external-services.md
@@ -38,8 +38,22 @@ redis:
     existingSecretPasswordKey: redis-password
 ```
 
-`redisHttp.enabled` should remain enabled unless the OpenCut runtime is changed
-to consume another Redis HTTP-compatible endpoint directly.
+`redisHttp.enabled` should remain enabled unless OpenCut can reach another
+Redis REST-compatible endpoint directly. When disabling the in-cluster bridge,
+provide the required `UPSTASH_REDIS_REST_*` settings through
+`redisHttp.external`:
+
+```yaml
+redis:
+  enabled: false
+
+redisHttp:
+  enabled: false
+  external:
+    url: https://redis-rest.example.com
+    existingSecret: opencut-redis-rest
+    existingSecretTokenKey: redis-rest-token
+```
 
 ## External Secrets Operator
 

--- a/charts/opencut/docs/networking.md
+++ b/charts/opencut/docs/networking.md
@@ -1,0 +1,62 @@
+# Networking
+
+The chart exposes OpenCut through a ClusterIP Service by default. Public access
+is configured through Ingress or Gateway API.
+
+## Service
+
+The Service supports explicit IP family settings for dual-stack clusters:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+## Ingress
+
+Use `ingress.ingressClassName` to match HelmForge chart conventions:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: opencut.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Gateway API
+
+`gateway.enabled` renders one `HTTPRoute`. `gateway.parentRefs` is required so
+the chart never creates an orphaned route.
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+  hostnames:
+    - opencut.example.com
+```
+
+The chart does not install Gateway API CRDs or a Gateway controller.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: OpenCut Networking
+description: Service, Ingress, and Gateway API configuration for OpenCut
+keywords: opencut, networking, ingress, gateway-api, dual-stack
+purpose: Explain OpenCut chart networking options
+scope: Chart Operations
+relations:
+  - charts/opencut/README.md
+  - charts/opencut/examples/gateway.yaml
+path: charts/opencut/docs/networking.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/opencut/docs/production.md
+++ b/charts/opencut/docs/production.md
@@ -1,0 +1,94 @@
+# Production
+
+The default values are suitable for local and preview environments. Production
+deployments should use an explicit values file with stable credentials, storage,
+network boundaries, and public URL settings.
+
+Use [examples/production.yaml](../examples/production.yaml) as a starting point.
+
+## Required Decisions
+
+- Set `opencut.siteUrl` to the public HTTPS URL.
+- Set `opencut.betterAuthSecret` from a secret generator and keep it stable.
+- Decide whether the release owns PostgreSQL and Redis or consumes platform
+  services.
+- Set persistence sizes and storage classes for bundled dependencies.
+- Set CPU and memory resources for OpenCut and the Redis HTTP bridge.
+- Enable `networkPolicy.enabled=true` once namespace traffic requirements are
+  known.
+
+## Secrets
+
+Prefer existing Kubernetes Secrets or External Secrets over inline passwords:
+
+```yaml
+postgresql:
+  auth:
+    existingSecret: opencut-postgresql-auth
+    existingSecretUserPasswordKey: user-password
+
+redis:
+  auth:
+    enabled: true
+    existingSecret: opencut-redis-auth
+    existingSecretPasswordKey: redis-password
+```
+
+For external PostgreSQL, set `database.external.existingSecret`. The chart can
+also render an `ExternalSecret` when External Secrets Operator is already
+installed in the cluster.
+
+## Networking
+
+Expose OpenCut with either Ingress or Gateway API, not both for the same host.
+The chart does not install controllers or CRDs.
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: opencut.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Gateway API example:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - opencut.example.com
+```
+
+## Validation
+
+After install or upgrade:
+
+```bash
+helm test opencut -n opencut
+kubectl get events -n opencut --sort-by=.lastTimestamp
+kubectl logs -n opencut deploy/opencut --since=10m
+```
+
+<!-- @AI-METADATA
+type: chart-docs
+title: OpenCut Production
+description: Production deployment guidance for the OpenCut Helm chart
+keywords: opencut, production, secrets, ingress, gateway-api
+purpose: Production hardening guide for OpenCut
+scope: Chart Operations
+relations:
+  - charts/opencut/README.md
+  - charts/opencut/examples/production.yaml
+path: charts/opencut/docs/production.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/opencut/docs/production.md
+++ b/charts/opencut/docs/production.md
@@ -12,6 +12,10 @@ Use [examples/production.yaml](../examples/production.yaml) as a starting point.
 - Set `opencut.betterAuthSecret` from a secret generator and keep it stable.
 - Decide whether the release owns PostgreSQL and Redis or consumes platform
   services.
+- When overriding bundled dependency names, use `postgresql.nameOverride`,
+  `postgresql.fullnameOverride`, `redis.nameOverride`, or
+  `redis.fullnameOverride`; OpenCut derives service and Secret names from the
+  same HelmForge subchart rules.
 - Set persistence sizes and storage classes for bundled dependencies.
 - Set CPU and memory resources for OpenCut and the Redis HTTP bridge.
 - Enable `networkPolicy.enabled=true` once namespace traffic requirements are

--- a/charts/opencut/examples/external-services.yaml
+++ b/charts/opencut/examples/external-services.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OpenCut with platform-managed PostgreSQL and Redis
 
 opencut:

--- a/charts/opencut/examples/external-services.yaml
+++ b/charts/opencut/examples/external-services.yaml
@@ -1,0 +1,38 @@
+# OpenCut with platform-managed PostgreSQL and Redis
+
+opencut:
+  siteUrl: https://opencut.example.com
+  betterAuthSecret: replace-with-a-stable-secret
+  marbleWorkspaceKey: replace-with-workspace-key
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: opencut
+    username: opencut
+    existingSecret: opencut-db
+    existingSecretPasswordKey: database-password
+
+redis:
+  enabled: false
+  external:
+    host: redis.example.com
+    port: 6379
+    existingSecret: opencut-redis
+    existingSecretPasswordKey: redis-password
+
+networkPolicy:
+  enabled: true
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: opencut.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/opencut/examples/gateway.yaml
+++ b/charts/opencut/examples/gateway.yaml
@@ -1,0 +1,18 @@
+# OpenCut exposed with Gateway API
+
+opencut:
+  siteUrl: https://opencut.example.com
+  betterAuthSecret: replace-with-a-stable-secret
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - opencut.example.com
+  path: /
+  pathType: PathPrefix
+
+networkPolicy:
+  enabled: true

--- a/charts/opencut/examples/gateway.yaml
+++ b/charts/opencut/examples/gateway.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # OpenCut exposed with Gateway API
 
 opencut:

--- a/charts/opencut/examples/production.yaml
+++ b/charts/opencut/examples/production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Production OpenCut with bundled HelmForge PostgreSQL and Redis
 
 opencut:

--- a/charts/opencut/examples/production.yaml
+++ b/charts/opencut/examples/production.yaml
@@ -1,0 +1,81 @@
+# Production OpenCut with bundled HelmForge PostgreSQL and Redis
+
+opencut:
+  siteUrl: https://opencut.example.com
+  betterAuthSecret: replace-with-a-stable-secret
+  marbleWorkspaceKey: replace-with-workspace-key
+
+postgresql:
+  auth:
+    existingSecret: opencut-postgresql-auth
+    existingSecretUserPasswordKey: user-password
+  standalone:
+    persistence:
+      enabled: true
+      storageClass: fast-retain
+      size: 50Gi
+
+redis:
+  auth:
+    enabled: true
+    existingSecret: opencut-redis-auth
+    existingSecretPasswordKey: redis-password
+  standalone:
+    persistence:
+      enabled: true
+      storageClass: fast-retain
+      size: 8Gi
+
+redisHttp:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: opencut.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: opencut-tls
+      hosts:
+        - opencut.example.com
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 768Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: opencut

--- a/charts/opencut/templates/NOTES.txt
+++ b/charts/opencut/templates/NOTES.txt
@@ -1,0 +1,10 @@
+OpenCut has been deployed.
+
+Service:
+  {{ include "opencut.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Health:
+  /api/health
+
+Image:
+  {{ include "opencut.image" . }}

--- a/charts/opencut/templates/NOTES.txt
+++ b/charts/opencut/templates/NOTES.txt
@@ -32,15 +32,18 @@ DATABASE:
 {{- end }}
 
 REDIS:
-{{- if .Values.redis.enabled }}
+{{- if .Values.redisHttp.enabled }}
+  {{- if .Values.redis.enabled }}
    Redis: bundled HelmForge subchart
    Service: {{ include "opencut.redisHost" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "ports" "redis" 6379 .Values.redis }}
-{{- else }}
+  {{- else }}
    Redis: external
    Host: {{ .Values.redis.external.host }}:{{ .Values.redis.external.port }}
-{{- end }}
-{{- if .Values.redisHttp.enabled }}
+  {{- end }}
    Redis HTTP bridge: enabled ({{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }})
+{{- else }}
+   Redis: external REST-compatible endpoint
+   Redis HTTP endpoint: external ({{ .Values.redisHttp.external.url }})
 {{- end }}
 
 OPERATIONS:

--- a/charts/opencut/templates/NOTES.txt
+++ b/charts/opencut/templates/NOTES.txt
@@ -1,10 +1,64 @@
-OpenCut has been deployed.
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+=============================================================================
+OpenCut deployed successfully!
+=============================================================================
 
-Service:
-  {{ include "opencut.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+ACCESS:
+{{- if .Values.ingress.enabled }}
+  {{- range .Values.ingress.hosts }}
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+  {{- end }}
+{{- else if and .Values.gateway.enabled .Values.gateway.hostnames }}
+  {{- range .Values.gateway.hostnames }}
+   https://{{ . }}
+  {{- end }}
+{{- else }}
+   kubectl port-forward svc/{{ include "opencut.fullname" . }} -n {{ .Release.Namespace }} 3000:{{ .Values.service.port }}
+   Open: http://localhost:3000
+{{- end }}
 
-Health:
-  /api/health
+SERVICE:
+   Internal: {{ include "opencut.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Health:   /api/health
+   Image:    {{ include "opencut.image" . }}
 
-Image:
-  {{ include "opencut.image" . }}
+DATABASE:
+{{- if .Values.postgresql.enabled }}
+   PostgreSQL: bundled HelmForge subchart
+   Service: {{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "port" 5432 .Values.postgresql }}
+{{- else }}
+   PostgreSQL: external
+   Host: {{ .Values.database.external.host }}:{{ .Values.database.external.port }}
+{{- end }}
+
+REDIS:
+{{- if .Values.redis.enabled }}
+   Redis: bundled HelmForge subchart
+   Service: {{ .Release.Name }}-redis-client.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "ports" "redis" 6379 .Values.redis }}
+{{- else }}
+   Redis: external
+   Host: {{ .Values.redis.external.host }}:{{ .Values.redis.external.port }}
+{{- end }}
+{{- if .Values.redisHttp.enabled }}
+   Redis HTTP bridge: enabled ({{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }})
+{{- end }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "opencut.fullname" . }}
+
+PRODUCTION REMINDERS:
+   1. Set opencut.siteUrl and opencut.betterAuthSecret explicitly.
+   2. Use existingSecret or External Secrets for database and Redis credentials.
+   3. Enable persistence, resources, NetworkPolicy, and external TLS before exposing publicly.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/opencut
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/opencut
+   OpenCut: https://github.com/OpenCut-app/OpenCut
+
+=============================================================================

--- a/charts/opencut/templates/NOTES.txt
+++ b/charts/opencut/templates/NOTES.txt
@@ -25,7 +25,7 @@ SERVICE:
 DATABASE:
 {{- if .Values.postgresql.enabled }}
    PostgreSQL: bundled HelmForge subchart
-   Service: {{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "port" 5432 .Values.postgresql }}
+   Service: {{ include "opencut.databaseHost" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "port" 5432 .Values.postgresql }}
 {{- else }}
    PostgreSQL: external
    Host: {{ .Values.database.external.host }}:{{ .Values.database.external.port }}
@@ -34,7 +34,7 @@ DATABASE:
 REDIS:
 {{- if .Values.redis.enabled }}
    Redis: bundled HelmForge subchart
-   Service: {{ .Release.Name }}-redis-client.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "ports" "redis" 6379 .Values.redis }}
+   Service: {{ include "opencut.redisHost" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ dig "service" "ports" "redis" 6379 .Values.redis }}
 {{- else }}
    Redis: external
    Host: {{ .Values.redis.external.host }}:{{ .Values.redis.external.port }}

--- a/charts/opencut/templates/NOTES.txt
+++ b/charts/opencut/templates/NOTES.txt
@@ -6,7 +6,7 @@ OpenCut deployed successfully!
 ACCESS:
 {{- if .Values.ingress.enabled }}
   {{- range .Values.ingress.hosts }}
-   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+   {{ ternary "https" "http" (eq (include "opencut.ingressHostHasTls" (dict "root" $ "host" .host)) "true") }}://{{ .host }}
   {{- end }}
 {{- else if and .Values.gateway.enabled .Values.gateway.hostnames }}
   {{- range .Values.gateway.hostnames }}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -78,11 +78,11 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.databaseSecretName" -}}
-{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else -}}{{ printf "%s-postgresql-auth" .Release.Name }}{{- end -}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else if .Values.postgresql.auth.existingSecret -}}{{ .Values.postgresql.auth.existingSecret }}{{- else -}}{{ printf "%s-postgresql-auth" .Release.Name }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.databaseSecretKey" -}}
-{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecretPasswordKey | default "database-password" }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}database-password{{- else -}}user-password{{- end -}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecretPasswordKey | default "database-password" }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}database-password{{- else -}}{{ .Values.postgresql.auth.existingSecretUserPasswordKey | default "user-password" }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.redisHost" -}}
@@ -91,6 +91,18 @@ app.kubernetes.io/part-of: helmforge
 
 {{- define "opencut.redisPort" -}}
 {{- if .Values.redis.external.host -}}{{ .Values.redis.external.port | toString }}{{- else -}}6379{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisAuthEnabled" -}}
+{{- if or (and (not .Values.redis.external.host) .Values.redis.auth.enabled) .Values.redis.external.password .Values.redis.external.existingSecret -}}true{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisSecretName" -}}
+{{- if .Values.redis.external.existingSecret -}}{{ .Values.redis.external.existingSecret }}{{- else if .Values.redis.external.password -}}{{ include "opencut.secretName" . }}{{- else if .Values.redis.auth.existingSecret -}}{{ .Values.redis.auth.existingSecret }}{{- else -}}{{ printf "%s-redis-auth" .Release.Name }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisSecretKey" -}}
+{{- if .Values.redis.external.existingSecret -}}{{ .Values.redis.external.existingSecretPasswordKey | default "redis-password" }}{{- else if .Values.redis.external.password -}}redis-password{{- else -}}{{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.redisHttpName" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -160,7 +160,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.redisHttpName" -}}
-{{- printf "%s-redis-http" (include "opencut.fullname" .) -}}
+{{- printf "%s-redis-http" (include "opencut.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "opencut.validateRedisRest" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -160,7 +160,11 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.redisHttpName" -}}
-{{- printf "%s-redis-http" (include "opencut.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-redis-http" (include "opencut.fullname" . | trunc 52 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "opencut.testName" -}}
+{{- printf "%s-test" (include "opencut.fullname" . | trunc 58 | trimSuffix "-") | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "opencut.validateRedisRest" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -66,7 +66,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.databasePort" -}}
-{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.port | toString }}{{- else -}}5432{{- end -}}
+{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.port | toString }}{{- else -}}{{ dig "service" "port" 5432 .Values.postgresql | toString }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.databaseName" -}}
@@ -91,7 +91,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.redisPort" -}}
-{{- if .Values.redis.external.host -}}{{ .Values.redis.external.port | toString }}{{- else -}}6379{{- end -}}
+{{- if .Values.redis.external.host -}}{{ .Values.redis.external.port | toString }}{{- else -}}{{ dig "service" "ports" "redis" 6379 .Values.redis | toString }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.redisAuthEnabled" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -78,7 +78,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.databaseSecretName" -}}
-{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else if .Values.postgresql.auth.existingSecret -}}{{ .Values.postgresql.auth.existingSecret }}{{- else -}}{{ printf "%s-postgresql-auth" .Release.Name }}{{- end -}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else if .Values.postgresql.auth.existingSecret -}}{{ .Values.postgresql.auth.existingSecret }}{{- else if and .Values.postgresql.externalSecrets.enabled .Values.postgresql.externalSecrets.auth.enabled .Values.postgresql.externalSecrets.auth.targetName -}}{{ .Values.postgresql.externalSecrets.auth.targetName }}{{- else -}}{{ printf "%s-postgresql-auth" .Release.Name }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.databaseSecretKey" -}}
@@ -86,6 +86,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.redisHost" -}}
+{{- if and .Values.redisHttp.enabled (not .Values.redis.enabled) (not .Values.redis.external.host) -}}{{- fail "redisHttp.enabled requires redis.enabled=true or redis.external.host to be set" -}}{{- end -}}
 {{- if .Values.redis.external.host -}}{{ .Values.redis.external.host }}{{- else -}}{{ printf "%s-redis-client" .Release.Name }}{{- end -}}
 {{- end -}}
 

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -203,8 +203,20 @@ app.kubernetes.io/part-of: helmforge
 {{- .Values.redisHttp.external.existingSecretTokenKey | default "redis-rest-token" -}}
 {{- end -}}
 
+{{- define "opencut.ingressHostHasTls" -}}
+{{- $host := .host -}}
+{{- $root := .root -}}
+{{- $hasTls := false -}}
+{{- range $tls := $root.Values.ingress.tls -}}
+{{- if has $host ($tls.hosts | default list) -}}
+{{- $hasTls = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $hasTls -}}true{{- end -}}
+{{- end -}}
+
 {{- define "opencut.siteUrl" -}}
-{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "%s://%s" (ternary "https" "http" (gt (len .Values.ingress.tls) 0)) (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
+{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{- $host := (index .Values.ingress.hosts 0).host -}}{{ printf "%s://%s" (ternary "https" "http" (eq (include "opencut.ingressHostHasTls" (dict "root" . "host" $host)) "true")) $host }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
 {{- end -}}
 
 {{- define "opencut.betterAuthSecret" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -167,8 +167,27 @@ app.kubernetes.io/part-of: helmforge
 {{- if and (not .Values.redisHttp.enabled) (not .Values.redisHttp.external.url) -}}
 {{- fail "redisHttp.enabled=false requires redisHttp.external.url so OpenCut receives UPSTASH_REDIS_REST_URL" -}}
 {{- end -}}
+{{- if and (not .Values.redisHttp.enabled) .Values.redisHttp.external.url (not (or (hasPrefix "http://" .Values.redisHttp.external.url) (hasPrefix "https://" .Values.redisHttp.external.url))) -}}
+{{- fail "redisHttp.enabled=false requires redisHttp.external.url to start with http:// or https:// so the chart can derive the NetworkPolicy egress port" -}}
+{{- end -}}
 {{- if and (not .Values.redisHttp.enabled) (not .Values.redisHttp.external.token) (not .Values.redisHttp.external.existingSecret) -}}
 {{- fail "redisHttp.enabled=false requires redisHttp.external.token or redisHttp.external.existingSecret so OpenCut receives UPSTASH_REDIS_REST_TOKEN" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisRestEgressPort" -}}
+{{- if .Values.redisHttp.enabled -}}
+{{- .Values.redisHttp.service.port | toString -}}
+{{- else -}}
+{{- $url := .Values.redisHttp.external.url | default "" -}}
+{{- $explicitPort := regexFind ":[0-9]+" $url -}}
+{{- if $explicitPort -}}
+{{- trimPrefix ":" $explicitPort -}}
+{{- else if hasPrefix "http://" $url -}}
+{{- "80" -}}
+{{- else -}}
+{{- "443" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -184,9 +184,16 @@ app.kubernetes.io/part-of: helmforge
 {{- .Values.redisHttp.service.port | toString -}}
 {{- else -}}
 {{- $url := .Values.redisHttp.external.url | default "" -}}
-{{- $explicitPort := regexFind ":[0-9]+" $url -}}
+{{- $withoutScheme := regexReplaceAll "^[a-zA-Z][a-zA-Z0-9+.-]*://" $url "" -}}
+{{- $authority := regexReplaceAll "[/?#].*$" $withoutScheme "" -}}
+{{- $explicitPort := "" -}}
+{{- if hasPrefix "[" $authority -}}
+{{- $explicitPort = regexFind "\\]:[0-9]+$" $authority -}}
+{{- else -}}
+{{- $explicitPort = regexFind ":[0-9]+$" $authority -}}
+{{- end -}}
 {{- if $explicitPort -}}
-{{- trimPrefix ":" $explicitPort -}}
+{{- trimPrefix ":" (trimPrefix "]:" $explicitPort) -}}
 {{- else if hasPrefix "http://" $url -}}
 {{- "80" -}}
 {{- else -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -163,6 +163,23 @@ app.kubernetes.io/part-of: helmforge
 {{- printf "%s-redis-http" (include "opencut.fullname" .) -}}
 {{- end -}}
 
+{{- define "opencut.validateRedisRest" -}}
+{{- if and (not .Values.redisHttp.enabled) (not .Values.redisHttp.external.url) -}}
+{{- fail "redisHttp.enabled=false requires redisHttp.external.url so OpenCut receives UPSTASH_REDIS_REST_URL" -}}
+{{- end -}}
+{{- if and (not .Values.redisHttp.enabled) (not .Values.redisHttp.external.token) (not .Values.redisHttp.external.existingSecret) -}}
+{{- fail "redisHttp.enabled=false requires redisHttp.external.token or redisHttp.external.existingSecret so OpenCut receives UPSTASH_REDIS_REST_TOKEN" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisRestExternalSecretName" -}}
+{{- if .Values.redisHttp.external.existingSecret -}}{{ .Values.redisHttp.external.existingSecret }}{{- else -}}{{ include "opencut.secretName" . }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisRestExternalSecretKey" -}}
+{{- .Values.redisHttp.external.existingSecretTokenKey | default "redis-rest-token" -}}
+{{- end -}}
+
 {{- define "opencut.siteUrl" -}}
 {{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "%s://%s" (ternary "https" "http" (gt (len .Values.ingress.tls) 0)) (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
 {{- end -}}
@@ -174,5 +191,5 @@ app.kubernetes.io/part-of: helmforge
 
 {{- define "opencut.redisRestToken" -}}
 {{- $secretName := include "opencut.secretName" . -}}
-{{- if .Values.redisHttp.token -}}{{ .Values.redisHttp.token }}{{- else -}}{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}{{- if and $existing (index $existing.data "redis-rest-token") -}}{{ index $existing.data "redis-rest-token" | b64dec }}{{- else -}}{{ randAlphaNum 32 }}{{- end -}}{{- end -}}
+{{- if and (not .Values.redisHttp.enabled) .Values.redisHttp.external.token -}}{{ .Values.redisHttp.external.token }}{{- else if .Values.redisHttp.token -}}{{ .Values.redisHttp.token }}{{- else -}}{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}{{- if and $existing (index $existing.data "redis-rest-token") -}}{{ index $existing.data "redis-rest-token" | b64dec }}{{- else -}}{{ randAlphaNum 32 }}{{- end -}}{{- end -}}
 {{- end -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -164,7 +164,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.siteUrl" -}}
-{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "https://%s" (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
+{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "%s://%s" (ternary "https" "http" (gt (len .Values.ingress.tls) 0)) (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
 {{- end -}}
 
 {{- define "opencut.betterAuthSecret" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -52,6 +52,59 @@ app.kubernetes.io/part-of: helmforge
 {{- printf "%s-app" (include "opencut.fullname" .) -}}
 {{- end -}}
 
+{{- define "opencut.postgresqlName" -}}
+{{- default "postgresql" .Values.postgresql.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "opencut.postgresqlFullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "opencut.postgresqlName" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.postgresqlServiceName" -}}
+{{- if eq (.Values.postgresql.architecture | default "standalone") "replication" -}}
+{{- printf "%s-primary" (include "opencut.postgresqlFullname" .) -}}
+{{- else -}}
+{{- include "opencut.postgresqlFullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisName" -}}
+{{- default "redis" .Values.redis.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "opencut.redisFullname" -}}
+{{- if .Values.redis.fullnameOverride -}}
+{{- .Values.redis.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "opencut.redisName" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisClientServiceName" -}}
+{{- printf "%s-client" (include "opencut.redisFullname" .) -}}
+{{- end -}}
+
+{{- define "opencut.redisPrimaryServiceName" -}}
+{{- printf "%s-primary" (include "opencut.redisFullname" .) -}}
+{{- end -}}
+
+{{- define "opencut.redisServiceName" -}}
+{{- if eq (.Values.redis.architecture | default "standalone") "replication" -}}
+{{- include "opencut.redisPrimaryServiceName" . -}}
+{{- else -}}
+{{- include "opencut.redisClientServiceName" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "opencut.databaseMode" -}}
 {{- $hasExternal := ne (.Values.database.external.host | default "") "" -}}
 {{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
@@ -62,7 +115,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.databaseHost" -}}
-{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.host }}{{- else -}}{{ printf "%s-postgresql" .Release.Name }}{{- end -}}
+{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.host }}{{- else -}}{{ include "opencut.postgresqlServiceName" . }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.databasePort" -}}
@@ -78,7 +131,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.databaseSecretName" -}}
-{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else if .Values.postgresql.auth.existingSecret -}}{{ .Values.postgresql.auth.existingSecret }}{{- else if and .Values.postgresql.externalSecrets.enabled .Values.postgresql.externalSecrets.auth.enabled .Values.postgresql.externalSecrets.auth.targetName -}}{{ .Values.postgresql.externalSecrets.auth.targetName }}{{- else -}}{{ printf "%s-postgresql-auth" .Release.Name }}{{- end -}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else if .Values.postgresql.auth.existingSecret -}}{{ .Values.postgresql.auth.existingSecret }}{{- else if and .Values.postgresql.externalSecrets.enabled .Values.postgresql.externalSecrets.auth.enabled .Values.postgresql.externalSecrets.auth.targetName -}}{{ .Values.postgresql.externalSecrets.auth.targetName }}{{- else -}}{{ printf "%s-auth" (include "opencut.postgresqlFullname" .) }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.databaseSecretKey" -}}
@@ -87,7 +140,7 @@ app.kubernetes.io/part-of: helmforge
 
 {{- define "opencut.redisHost" -}}
 {{- if and .Values.redisHttp.enabled (not .Values.redis.enabled) (not .Values.redis.external.host) -}}{{- fail "redisHttp.enabled requires redis.enabled=true or redis.external.host to be set" -}}{{- end -}}
-{{- if .Values.redis.external.host -}}{{ .Values.redis.external.host }}{{- else -}}{{ printf "%s-redis-client" .Release.Name }}{{- end -}}
+{{- if .Values.redis.external.host -}}{{ .Values.redis.external.host }}{{- else -}}{{ include "opencut.redisServiceName" . }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.redisPort" -}}
@@ -99,7 +152,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.redisSecretName" -}}
-{{- if .Values.redis.external.existingSecret -}}{{ .Values.redis.external.existingSecret }}{{- else if .Values.redis.external.password -}}{{ include "opencut.secretName" . }}{{- else if .Values.redis.auth.existingSecret -}}{{ .Values.redis.auth.existingSecret }}{{- else -}}{{ printf "%s-redis-auth" .Release.Name }}{{- end -}}
+{{- if .Values.redis.external.existingSecret -}}{{ .Values.redis.external.existingSecret }}{{- else if .Values.redis.external.password -}}{{ include "opencut.secretName" . }}{{- else if .Values.redis.auth.existingSecret -}}{{ .Values.redis.auth.existingSecret }}{{- else -}}{{ printf "%s-auth" (include "opencut.redisFullname" .) }}{{- end -}}
 {{- end -}}
 
 {{- define "opencut.redisSecretKey" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -1,0 +1,112 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "opencut.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "opencut.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "opencut.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "opencut.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "opencut.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "opencut.labels" -}}
+helm.sh/chart: {{ include "opencut.chart" . }}
+{{ include "opencut.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "opencut.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{- define "opencut.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "opencut.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencut.secretName" -}}
+{{- printf "%s-app" (include "opencut.fullname" .) -}}
+{{- end -}}
+
+{{- define "opencut.databaseMode" -}}
+{{- $hasExternal := ne (.Values.database.external.host | default "") "" -}}
+{{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
+{{- if and $hasExternal $hasPostgresql -}}
+{{- fail "opencut database selection is ambiguous: configure only one of database.external.host or postgresql.enabled" -}}
+{{- end -}}
+{{- if $hasExternal -}}external{{- else if $hasPostgresql -}}postgresql{{- else -}}{{- fail "opencut requires PostgreSQL: enable postgresql.enabled or set database.external.host" -}}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.databaseHost" -}}
+{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.host }}{{- else -}}{{ printf "%s-postgresql" .Release.Name }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.databasePort" -}}
+{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.port | toString }}{{- else -}}5432{{- end -}}
+{{- end -}}
+
+{{- define "opencut.databaseName" -}}
+{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.name }}{{- else -}}{{ .Values.postgresql.auth.database }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.databaseUsername" -}}
+{{- if eq (include "opencut.databaseMode" .) "external" -}}{{ .Values.database.external.username }}{{- else -}}{{ .Values.postgresql.auth.username }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.databaseSecretName" -}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecret }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}{{ printf "%s-database" (include "opencut.fullname" .) }}{{- else -}}{{ printf "%s-postgresql-auth" .Release.Name }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.databaseSecretKey" -}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") .Values.database.external.existingSecret -}}{{ .Values.database.external.existingSecretPasswordKey | default "database-password" }}{{- else if eq (include "opencut.databaseMode" .) "external" -}}database-password{{- else -}}user-password{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisHost" -}}
+{{- if .Values.redis.external.host -}}{{ .Values.redis.external.host }}{{- else -}}{{ printf "%s-redis-client" .Release.Name }}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisPort" -}}
+{{- if .Values.redis.external.host -}}{{ .Values.redis.external.port | toString }}{{- else -}}6379{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisHttpName" -}}
+{{- printf "%s-redis-http" (include "opencut.fullname" .) -}}
+{{- end -}}
+
+{{- define "opencut.siteUrl" -}}
+{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "https://%s" (index .Values.ingress.hosts 0).host }}{{- else -}}http://localhost:3000{{- end -}}
+{{- end -}}
+
+{{- define "opencut.betterAuthSecret" -}}
+{{- $secretName := include "opencut.secretName" . -}}
+{{- if .Values.opencut.betterAuthSecret -}}{{ .Values.opencut.betterAuthSecret }}{{- else -}}{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}{{- if and $existing (index $existing.data "better-auth-secret") -}}{{ index $existing.data "better-auth-secret" | b64dec }}{{- else -}}{{ randAlphaNum 48 }}{{- end -}}{{- end -}}
+{{- end -}}
+
+{{- define "opencut.redisRestToken" -}}
+{{- $secretName := include "opencut.secretName" . -}}
+{{- if .Values.redisHttp.token -}}{{ .Values.redisHttp.token }}{{- else -}}{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}{{- if and $existing (index $existing.data "redis-rest-token") -}}{{ index $existing.data "redis-rest-token" | b64dec }}{{- else -}}{{ randAlphaNum 32 }}{{- end -}}{{- end -}}
+{{- end -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -111,7 +111,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.siteUrl" -}}
-{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "https://%s" (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gatewayAPI.enabled (gt (len .Values.gatewayAPI.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gatewayAPI.hostnames 0) }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
+{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "https://%s" (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
 {{- end -}}
 
 {{- define "opencut.betterAuthSecret" -}}

--- a/charts/opencut/templates/_helpers.tpl
+++ b/charts/opencut/templates/_helpers.tpl
@@ -111,7 +111,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "opencut.siteUrl" -}}
-{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "https://%s" (index .Values.ingress.hosts 0).host }}{{- else -}}http://localhost:3000{{- end -}}
+{{- if .Values.opencut.siteUrl -}}{{ .Values.opencut.siteUrl }}{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}{{ printf "https://%s" (index .Values.ingress.hosts 0).host }}{{- else if and .Values.gatewayAPI.enabled (gt (len .Values.gatewayAPI.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gatewayAPI.hostnames 0) }}{{- else if and .Values.gateway.enabled (gt (len .Values.gateway.hostnames) 0) -}}{{ printf "https://%s" (index .Values.gateway.hostnames 0) }}{{- else -}}http://localhost:3000{{- end -}}
 {{- end -}}
 
 {{- define "opencut.betterAuthSecret" -}}

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -135,6 +135,8 @@ spec:
               value: 0.0.0.0
             - name: NEXT_PUBLIC_SITE_URL
               value: {{ include "opencut.siteUrl" . | quote }}
+            - name: BETTER_AUTH_URL
+              value: {{ include "opencut.siteUrl" . | quote }}
             - name: NEXT_PUBLIC_MARBLE_API_URL
               value: {{ .Values.opencut.marbleApiUrl | quote }}
             - name: DATABASE_USERNAME

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -1,0 +1,196 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "opencut.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "opencut.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "opencut.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: docker.io/library/busybox:1.37.0
+          command:
+            - sh
+            - -ec
+            - |
+              until nc -z -w2 {{ include "opencut.databaseHost" . }} {{ include "opencut.databasePort" . }}; do sleep 2; done
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+        {{- if .Values.redisHttp.enabled }}
+        - name: wait-for-redis-http
+          image: docker.io/library/busybox:1.37.0
+          command:
+            - sh
+            - -ec
+            - |
+              until wget -qO- http://{{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }}/ >/dev/null; do sleep 2; done
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+        {{- end }}
+      containers:
+        - name: opencut
+          image: {{ include "opencut.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: PORT
+              value: "3000"
+            - name: HOSTNAME
+              value: 0.0.0.0
+            - name: NEXT_PUBLIC_SITE_URL
+              value: {{ include "opencut.siteUrl" . | quote }}
+            - name: NEXT_PUBLIC_MARBLE_API_URL
+              value: {{ .Values.opencut.marbleApiUrl | quote }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.databaseSecretName" . }}
+                  key: {{ include "opencut.databaseSecretKey" . }}
+            - name: DATABASE_URL
+              value: {{ printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%s/%s" (include "opencut.databaseUsername" .) (include "opencut.databaseHost" .) (include "opencut.databasePort" .) (include "opencut.databaseName" .) | quote }}
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.secretName" . }}
+                  key: better-auth-secret
+            - name: UPSTASH_REDIS_REST_URL
+              value: "http://{{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }}"
+            - name: UPSTASH_REDIS_REST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.secretName" . }}
+                  key: redis-rest-token
+            - name: MARBLE_WORKSPACE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.secretName" . }}
+                  key: marble-workspace-key
+            - name: FREESOUND_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.secretName" . }}
+                  key: freesound-client-id
+            - name: FREESOUND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.secretName" . }}
+                  key: freesound-api-key
+            {{- with .Values.opencut.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             - sh
             - -ec
             - |
-              until nc -z -w2 {{ include "opencut.databaseHost" . }} {{ include "opencut.databasePort" . }}; do sleep 2; done
+              until nc -z -w2 {{ include "opencut.databaseHost" . }} {{ include "opencut.databasePort" . }} >/dev/null 2>&1; do sleep 2; done
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -63,7 +63,7 @@ spec:
             - sh
             - -ec
             - |
-              until wget -qO- http://{{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }}/ >/dev/null; do sleep 2; done
+              until wget -qO- http://{{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }}/ >/dev/null 2>&1; do sleep 2; done
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -38,6 +38,21 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
+        - name: prepare-runtime-app
+          image: {{ include "opencut.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp -R /app/. /app-runtime/
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: runtime-app
+              mountPath: /app-runtime
+            - name: tmp
+              mountPath: /tmp
         - name: wait-for-postgresql
           image: docker.io/library/busybox:1.37.0
           command:
@@ -93,6 +108,14 @@ spec:
               database_name="$(url_encode "$DATABASE_NAME")"
               export DATABASE_URL="postgresql://${database_username}:${database_password}@${DATABASE_HOST}:${DATABASE_PORT}/${database_name}"
               unset database_username database_password database_name
+              site_url_replacement="$(printf '%s' "$NEXT_PUBLIC_SITE_URL" | sed -e 's/[\/&|]/\\&/g')"
+              for public_env_dir in apps/web/.next apps/web/public; do
+                if [ -d "$public_env_dir" ]; then
+                  find "$public_env_dir" -type f \( -name '*.js' -o -name '*.mjs' -o -name '*.html' -o -name '*.json' -o -name '*.css' \) \
+                    -exec sed -i "s|http://localhost:3000|${site_url_replacement}|g" {} +
+                fi
+              done
+              unset site_url_replacement public_env_dir
               exec docker-entrypoint.sh node apps/web/server.js
           ports:
             - name: http
@@ -189,12 +212,16 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
+            - name: runtime-app
+              mountPath: /app
             - name: tmp
               mountPath: /tmp
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
+        - name: runtime-app
+          emptyDir: {}
         - name: tmp
           emptyDir: {}
         {{- with .Values.extraVolumes }}

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -80,6 +80,20 @@ spec:
         - name: opencut
           image: {{ include "opencut.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              url_encode() {
+                node -e 'process.stdout.write(encodeURIComponent(process.argv[1] || ""))' "$1"
+              }
+              database_username="$(url_encode "$DATABASE_USERNAME")"
+              database_password="$(url_encode "$DATABASE_PASSWORD")"
+              database_name="$(url_encode "$DATABASE_NAME")"
+              export DATABASE_URL="postgresql://${database_username}:${database_password}@${DATABASE_HOST}:${DATABASE_PORT}/${database_name}"
+              unset database_username database_password database_name
+              exec docker-entrypoint.sh node apps/web/server.js
           ports:
             - name: http
               containerPort: 3000
@@ -95,13 +109,19 @@ spec:
               value: {{ include "opencut.siteUrl" . | quote }}
             - name: NEXT_PUBLIC_MARBLE_API_URL
               value: {{ .Values.opencut.marbleApiUrl | quote }}
+            - name: DATABASE_USERNAME
+              value: {{ include "opencut.databaseUsername" . | quote }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "opencut.databaseSecretName" . }}
                   key: {{ include "opencut.databaseSecretKey" . }}
-            - name: DATABASE_URL
-              value: {{ printf "postgresql://%s:$(DATABASE_PASSWORD)@%s:%s/%s" (include "opencut.databaseUsername" .) (include "opencut.databaseHost" .) (include "opencut.databasePort" .) (include "opencut.databaseName" .) | quote }}
+            - name: DATABASE_HOST
+              value: {{ include "opencut.databaseHost" . | quote }}
+            - name: DATABASE_PORT
+              value: {{ include "opencut.databasePort" . | quote }}
+            - name: DATABASE_NAME
+              value: {{ include "opencut.databaseName" . | quote }}
             - name: BETTER_AUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "opencut.validateRedisRest" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -162,6 +163,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "opencut.secretName" . }}
                   key: redis-rest-token
+            {{- else }}
+            - name: UPSTASH_REDIS_REST_URL
+              value: {{ .Values.redisHttp.external.url | quote }}
+            - name: UPSTASH_REDIS_REST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.redisRestExternalSecretName" . }}
+                  key: {{ include "opencut.redisRestExternalSecretKey" . }}
             {{- end }}
             - name: MARBLE_WORKSPACE_KEY
               valueFrom:

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -107,6 +107,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "opencut.secretName" . }}
                   key: better-auth-secret
+            {{- if .Values.redisHttp.enabled }}
             - name: UPSTASH_REDIS_REST_URL
               value: "http://{{ include "opencut.redisHttpName" . }}:{{ .Values.redisHttp.service.port }}"
             - name: UPSTASH_REDIS_REST_TOKEN
@@ -114,6 +115,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "opencut.secretName" . }}
                   key: redis-rest-token
+            {{- end }}
             - name: MARBLE_WORKSPACE_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/opencut/templates/deployment.yaml
+++ b/charts/opencut/templates/deployment.yaml
@@ -109,13 +109,17 @@ spec:
               export DATABASE_URL="postgresql://${database_username}:${database_password}@${DATABASE_HOST}:${DATABASE_PORT}/${database_name}"
               unset database_username database_password database_name
               site_url_replacement="$(printf '%s' "$NEXT_PUBLIC_SITE_URL" | sed -e 's/[\/&|]/\\&/g')"
+              marble_api_url_replacement="$(printf '%s' "$NEXT_PUBLIC_MARBLE_API_URL" | sed -e 's/[\/&|]/\\&/g')"
               for public_env_dir in apps/web/.next apps/web/public; do
                 if [ -d "$public_env_dir" ]; then
                   find "$public_env_dir" -type f \( -name '*.js' -o -name '*.mjs' -o -name '*.html' -o -name '*.json' -o -name '*.css' \) \
-                    -exec sed -i "s|http://localhost:3000|${site_url_replacement}|g" {} +
+                    -exec sed -i \
+                      -e "s|http://localhost:3000|${site_url_replacement}|g" \
+                      -e "s|https://api.marblecms.com|${marble_api_url_replacement}|g" \
+                      {} +
                 fi
               done
-              unset site_url_replacement public_env_dir
+              unset site_url_replacement marble_api_url_replacement public_env_dir
               exec docker-entrypoint.sh node apps/web/server.js
           ports:
             - name: http

--- a/charts/opencut/templates/externalsecret.yaml
+++ b/charts/opencut/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- if not .Values.database.external.existingSecret }}
+  {{- fail "externalSecrets.enabled requires database.external.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- end }}
+{{- if not .Values.externalSecrets.data }}
+  {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.database.external.existingSecret | quote }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ .Values.database.external.existingSecret | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+{{- end }}

--- a/charts/opencut/templates/extra-objects.yaml
+++ b/charts/opencut/templates/extra-objects.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/opencut/templates/hpa.yaml
+++ b/charts/opencut/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "opencut.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/opencut/templates/httproute.yaml
+++ b/charts/opencut/templates/httproute.yaml
@@ -1,11 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- $gateway := .Values.gateway -}}
-{{- if .Values.gatewayAPI.enabled }}
-  {{- $gateway = .Values.gatewayAPI -}}
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
 {{- end }}
-{{- if or .Values.gateway.enabled .Values.gatewayAPI.enabled }}
-{{- if not $gateway.parentRefs }}
-  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -13,22 +14,22 @@ metadata:
   name: {{ include "opencut.fullname" . }}
   labels:
     {{- include "opencut.labels" . | nindent 4 }}
-  {{- with $gateway.annotations }}
+  {{- with .Values.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml $gateway.parentRefs | nindent 4 }}
-  {{- with $gateway.hostnames }}
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ $gateway.pathType }}
-            value: {{ $gateway.path | quote }}
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
       backendRefs:
         - name: {{ include "opencut.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/opencut/templates/httproute.yaml
+++ b/charts/opencut/templates/httproute.yaml
@@ -1,0 +1,35 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- $gateway := .Values.gateway -}}
+{{- if .Values.gatewayAPI.enabled }}
+  {{- $gateway = .Values.gatewayAPI -}}
+{{- end }}
+{{- if or .Values.gateway.enabled .Values.gatewayAPI.enabled }}
+{{- if not $gateway.parentRefs }}
+  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+  {{- with $gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $gateway.parentRefs | nindent 4 }}
+  {{- with $gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ $gateway.pathType }}
+            value: {{ $gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "opencut.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/opencut/templates/ingress.yaml
+++ b/charts/opencut/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/charts/opencut/templates/ingress.yaml
+++ b/charts/opencut/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "opencut.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "opencut.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    - ports:
+        - protocol: TCP
+          port: 3000
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- else }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+    {{- end }}
+{{- end }}

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -15,12 +15,11 @@ spec:
     - Ingress
     - Egress
   ingress:
-    {{- if .Values.networkPolicy.ingress }}
-    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
-    {{- else }}
     - ports:
         - protocol: TCP
           port: 3000
+    {{- with .Values.networkPolicy.ingress }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
   egress:
     - ports:

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -64,7 +64,7 @@ spec:
               app.kubernetes.io/component: web
       ports:
         - protocol: TCP
-          port: {{ .Values.redisHttp.service.port }}
+          port: 80
   egress:
     - ports:
         - protocol: UDP

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -23,9 +23,6 @@ spec:
           port: 3000
     {{- end }}
   egress:
-    {{- if .Values.networkPolicy.egress }}
-    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
-    {{- else }}
     - ports:
         - protocol: UDP
           port: 53
@@ -38,6 +35,8 @@ spec:
           port: {{ .Values.redisHttp.service.port }}
         - protocol: TCP
           port: 443
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- if .Values.redisHttp.enabled }}
 ---

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -10,6 +10,7 @@ spec:
   podSelector:
     matchLabels:
       {{- include "opencut.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
   policyTypes:
     - Ingress
     - Egress
@@ -38,4 +39,35 @@ spec:
         - protocol: TCP
           port: 443
     {{- end }}
+{{- if .Values.redisHttp.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "opencut.redisHttpName" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "opencut.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis-http
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "opencut.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: web
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redisHttp.service.port }}
+  egress:
+    - ports:
+        - protocol: TCP
+          port: {{ include "opencut.redisPort" . }}
+{{- end }}
 {{- end }}

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -1,5 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.networkPolicy.enabled }}
+{{- include "opencut.validateRedisRest" . }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -31,7 +32,7 @@ spec:
         - protocol: TCP
           port: {{ include "opencut.databasePort" . }}
         - protocol: TCP
-          port: {{ .Values.redisHttp.service.port }}
+          port: {{ include "opencut.redisRestEgressPort" . }}
         - protocol: TCP
           port: 443
     {{- with .Values.networkPolicy.egress }}

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -67,6 +67,11 @@ spec:
           port: {{ .Values.redisHttp.service.port }}
   egress:
     - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
         - protocol: TCP
           port: {{ include "opencut.redisPort" . }}
 {{- end }}

--- a/charts/opencut/templates/networkpolicy.yaml
+++ b/charts/opencut/templates/networkpolicy.yaml
@@ -33,9 +33,9 @@ spec:
           port: 53
     - ports:
         - protocol: TCP
-          port: 5432
+          port: {{ include "opencut.databasePort" . }}
         - protocol: TCP
-          port: 80
+          port: {{ .Values.redisHttp.service.port }}
         - protocol: TCP
           port: 443
     {{- end }}

--- a/charts/opencut/templates/pdb.yaml
+++ b/charts/opencut/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "opencut.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+{{- end }}

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -27,6 +27,32 @@ spec:
         - name: redis-http
           image: "{{ .Values.redisHttp.image.repository }}:{{ .Values.redisHttp.image.tag }}"
           imagePullPolicy: {{ .Values.redisHttp.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              url_encode() {
+                printf '%s' "$1" \
+                  | sed -e 's/%/%25/g' \
+                        -e 's/:/%3A/g' \
+                        -e 's/@/%40/g' \
+                        -e 's#/#%2F#g' \
+                        -e 's/?/%3F/g' \
+                        -e 's/#/%23/g' \
+                        -e 's/ /%20/g' \
+                        -e 's/&/%26/g' \
+                        -e 's/=/%3D/g' \
+                        -e 's/+/%2B/g'
+              }
+              if [ -n "${REDIS_PASSWORD:-}" ]; then
+                redis_password="$(url_encode "$REDIS_PASSWORD")"
+                export SRH_CONNECTION_STRING="redis://:${redis_password}@${REDIS_HOST}:${REDIS_PORT}"
+                unset redis_password
+              else
+                export SRH_CONNECTION_STRING="redis://${REDIS_HOST}:${REDIS_PORT}"
+              fi
+              exec _build/prod/rel/prod/bin/prod start
           env:
             - name: SRH_MODE
               value: env
@@ -42,8 +68,10 @@ spec:
                   name: {{ include "opencut.redisSecretName" . }}
                   key: {{ include "opencut.redisSecretKey" . }}
             {{- end }}
-            - name: SRH_CONNECTION_STRING
-              value: "redis://{{- if include "opencut.redisAuthEnabled" . -}}:$(REDIS_PASSWORD)@{{- end -}}{{ include "opencut.redisHost" . }}:{{ include "opencut.redisPort" . }}"
+            - name: REDIS_HOST
+              value: {{ include "opencut.redisHost" . | quote }}
+            - name: REDIS_PORT
+              value: {{ include "opencut.redisPort" . | quote }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -52,7 +52,9 @@ spec:
                         -e 's/ /%20/g' \
                         -e 's/&/%26/g' \
                         -e 's/=/%3D/g' \
-                        -e 's/+/%2B/g'
+                        -e 's/+/%2B/g' \
+                        -e 's/\[/%5B/g' \
+                        -e 's/\]/%5D/g'
               }
               if [ -n "${REDIS_PASSWORD:-}" ]; then
                 redis_password="$(url_encode "$REDIS_PASSWORD")"

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         {{- include "opencut.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis-http
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
       securityContext:

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -22,6 +22,13 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -48,18 +48,36 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          {{- if .Values.redisHttp.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.redisHttp.probes.startup.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.redisHttp.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redisHttp.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.redisHttp.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.redisHttp.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.redisHttp.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.redisHttp.probes.readiness.path }}
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.redisHttp.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redisHttp.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.redisHttp.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.redisHttp.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.redisHttp.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.redisHttp.probes.liveness.path }}
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            initialDelaySeconds: {{ .Values.redisHttp.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.redisHttp.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.redisHttp.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.redisHttp.probes.liveness.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.redisHttp.resources | nindent 12 }}
           securityContext:

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -1,0 +1,79 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.redisHttp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "opencut.redisHttpName" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "opencut.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis-http
+  template:
+    metadata:
+      labels:
+        {{- include "opencut.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis-http
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis-http
+          image: "{{ .Values.redisHttp.image.repository }}:{{ .Values.redisHttp.image.tag }}"
+          imagePullPolicy: {{ .Values.redisHttp.image.pullPolicy }}
+          env:
+            - name: SRH_MODE
+              value: env
+            - name: SRH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.secretName" . }}
+                  key: redis-rest-token
+            - name: SRH_CONNECTION_STRING
+              value: "redis://{{ include "opencut.redisHost" . }}:{{ include "opencut.redisPort" . }}"
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.redisHttp.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.redisHttp.securityContext | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opencut.redisHttpName" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.redisHttp.service.port }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+  selector:
+    {{- include "opencut.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-http
+{{- end }}

--- a/charts/opencut/templates/redis-http.yaml
+++ b/charts/opencut/templates/redis-http.yaml
@@ -35,8 +35,15 @@ spec:
                 secretKeyRef:
                   name: {{ include "opencut.secretName" . }}
                   key: redis-rest-token
+            {{- if include "opencut.redisAuthEnabled" . }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencut.redisSecretName" . }}
+                  key: {{ include "opencut.redisSecretKey" . }}
+            {{- end }}
             - name: SRH_CONNECTION_STRING
-              value: "redis://{{ include "opencut.redisHost" . }}:{{ include "opencut.redisPort" . }}"
+              value: "redis://{{- if include "opencut.redisAuthEnabled" . -}}:$(REDIS_PASSWORD)@{{- end -}}{{ include "opencut.redisHost" . }}:{{ include "opencut.redisPort" . }}"
           ports:
             - name: http
               containerPort: 80

--- a/charts/opencut/templates/secret.yaml
+++ b/charts/opencut/templates/secret.yaml
@@ -1,0 +1,26 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and (eq (include "opencut.databaseMode" .) "external") (not .Values.database.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "opencut.fullname" . }}-database
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  database-password: {{ .Values.database.external.password | quote }}
+---
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "opencut.secretName" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  better-auth-secret: {{ include "opencut.betterAuthSecret" . | quote }}
+  redis-rest-token: {{ include "opencut.redisRestToken" . | quote }}
+  marble-workspace-key: {{ .Values.opencut.marbleWorkspaceKey | quote }}
+  freesound-client-id: {{ .Values.opencut.freesoundClientId | quote }}
+  freesound-api-key: {{ .Values.opencut.freesoundApiKey | quote }}

--- a/charts/opencut/templates/secret.yaml
+++ b/charts/opencut/templates/secret.yaml
@@ -21,6 +21,9 @@ type: Opaque
 stringData:
   better-auth-secret: {{ include "opencut.betterAuthSecret" . | quote }}
   redis-rest-token: {{ include "opencut.redisRestToken" . | quote }}
+  {{- if and .Values.redis.external.host .Values.redis.external.password (not .Values.redis.external.existingSecret) }}
+  redis-password: {{ .Values.redis.external.password | quote }}
+  {{- end }}
   marble-workspace-key: {{ .Values.opencut.marbleWorkspaceKey | quote }}
   freesound-client-id: {{ .Values.opencut.freesoundClientId | quote }}
   freesound-api-key: {{ .Values.opencut.freesoundApiKey | quote }}

--- a/charts/opencut/templates/service.yaml
+++ b/charts/opencut/templates/service.yaml
@@ -1,0 +1,29 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "opencut.fullname" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+  selector:
+    {{- include "opencut.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/charts/opencut/templates/serviceaccount.yaml
+++ b/charts/opencut/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "opencut.serviceAccountName" . }}
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/opencut/templates/tests/test-connection.yaml
+++ b/charts/opencut/templates/tests/test-connection.yaml
@@ -1,0 +1,40 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "opencut.fullname" . }}-test"
+  labels:
+    {{- include "opencut.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      command:
+        - sh
+        - -ec
+        - |
+          wget -qO- http://{{ include "opencut.fullname" . }}:{{ .Values.service.port }}/api/health
+          wget -qO- http://{{ include "opencut.fullname" . }}:{{ .Values.service.port }}/ | grep -qi opencut
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/opencut/templates/tests/test-connection.yaml
+++ b/charts/opencut/templates/tests/test-connection.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "opencut.fullname" . }}-test"
+  name: {{ include "opencut.testName" . | quote }}
   labels:
     {{- include "opencut.labels" . | nindent 4 }}
   annotations:

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -88,8 +88,12 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: DATABASE_URL
-            value: postgresql://opencut:$(DATABASE_PASSWORD)@test-postgresql:15432/opencut
+            name: DATABASE_PORT
+            value: "15432"
+        template: templates/deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "encodeURIComponent"
         template: templates/deployment.yaml
 
   - it: should honor PostgreSQL subchart fullname override in database URL and auth secret
@@ -109,8 +113,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: DATABASE_URL
-            value: postgresql://opencut:$(DATABASE_PASSWORD)@custom-postgresql:5432/opencut
+            name: DATABASE_HOST
+            value: custom-postgresql
         template: templates/deployment.yaml
 
   - it: should use PostgreSQL primary service in replication mode
@@ -121,8 +125,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: DATABASE_URL
-            value: postgresql://opencut:$(DATABASE_PASSWORD)@test-postgresql-primary:5432/opencut
+            name: DATABASE_HOST
+            value: test-postgresql-primary
         template: templates/deployment.yaml
 
   - it: should include bundled Redis auth in redis HTTP bridge URL
@@ -144,8 +148,13 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SRH_CONNECTION_STRING
-            value: redis://:$(REDIS_PASSWORD)@test-redis-client:6379
+            name: REDIS_HOST
+            value: test-redis-client
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "SRH_CONNECTION_STRING"
         template: templates/redis-http.yaml
         documentIndex: 0
 
@@ -167,8 +176,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SRH_CONNECTION_STRING
-            value: redis://:$(REDIS_PASSWORD)@custom-redis-client:6379
+            name: REDIS_HOST
+            value: custom-redis-client
         template: templates/redis-http.yaml
         documentIndex: 0
 
@@ -179,8 +188,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SRH_CONNECTION_STRING
-            value: redis://:$(REDIS_PASSWORD)@test-redis-primary:6379
+            name: REDIS_HOST
+            value: test-redis-primary
         template: templates/redis-http.yaml
         documentIndex: 0
 
@@ -191,8 +200,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SRH_CONNECTION_STRING
-            value: redis://:$(REDIS_PASSWORD)@test-redis-client:16379
+            name: REDIS_PORT
+            value: "16379"
         template: templates/redis-http.yaml
         documentIndex: 0
 
@@ -214,8 +223,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: SRH_CONNECTION_STRING
-            value: redis://:$(REDIS_PASSWORD)@redis.example.com:6379
+            name: REDIS_HOST
+            value: redis.example.com
         template: templates/redis-http.yaml
         documentIndex: 0
       - equal:

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -36,3 +36,14 @@ tests:
           value: docker.io/hiett/serverless-redis-http:0.0.10
         template: templates/redis-http.yaml
         documentIndex: 0
+
+  - it: should omit Upstash bridge env when redis HTTP bridge is disabled
+    set:
+      redisHttp.enabled: false
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPSTASH_REDIS_REST_URL
+        template: templates/deployment.yaml

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -127,7 +127,17 @@ tests:
         documentIndex: 0
       - matchRegex:
           path: metadata.name
+          pattern: "-redis-http$"
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
           pattern: "^.{1,63}$"
+        template: templates/redis-http.yaml
+        documentIndex: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: "-redis-http$"
         template: templates/redis-http.yaml
         documentIndex: 1
 

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -37,6 +37,74 @@ tests:
         template: templates/redis-http.yaml
         documentIndex: 0
 
+  - it: should honor PostgreSQL subchart auth secret overrides
+    set:
+      postgresql.auth.existingSecret: pg-auth
+      postgresql.auth.existingSecretUserPasswordKey: password
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pg-auth
+                key: password
+        template: templates/deployment.yaml
+
+  - it: should include bundled Redis auth in redis HTTP bridge URL
+    set:
+      redis.auth.enabled: true
+      redis.auth.existingSecret: redis-auth
+      redis.auth.existingSecretPasswordKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: redis-auth
+                key: password
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SRH_CONNECTION_STRING
+            value: redis://:$(REDIS_PASSWORD)@test-redis-client:6379
+        template: templates/redis-http.yaml
+        documentIndex: 0
+
+  - it: should include external Redis password in redis HTTP bridge URL
+    set:
+      redis.external.host: redis.example.com
+      redis.external.password: redis-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-opencut-app
+                key: redis-password
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SRH_CONNECTION_STRING
+            value: redis://:$(REDIS_PASSWORD)@redis.example.com:6379
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - equal:
+          path: stringData["redis-password"]
+          value: redis-secret
+        template: templates/secret.yaml
+        documentIndex: 0
+
   - it: should omit Upstash bridge env when redis HTTP bridge is disabled
     set:
       redisHttp.enabled: false

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -464,6 +464,37 @@ tests:
             value: https://opencut.example.test
         template: templates/deployment.yaml
 
+  - it: should derive HTTP site URL when selected ingress host is not covered by TLS
+    set:
+      opencut.betterAuthSecret: test-secret
+      ingress.enabled: true
+      ingress.hosts:
+        - host: opencut-http.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+        - host: opencut-https.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - secretName: opencut-tls
+          hosts:
+            - opencut-https.example.test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXT_PUBLIC_SITE_URL
+            value: http://opencut-http.example.test
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BETTER_AUTH_URL
+            value: http://opencut-http.example.test
+        template: templates/deployment.yaml
+
   - it: should fail when redis HTTP bridge has no Redis backend
     set:
       redis.enabled: false

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -251,6 +251,16 @@ tests:
           pattern: "SRH_CONNECTION_STRING"
         template: templates/redis-http.yaml
         documentIndex: 0
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "s/\\\\\\[/%5B/g"
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "s/\\\\\\]/%5D/g"
+        template: templates/redis-http.yaml
+        documentIndex: 0
 
   - it: should honor Redis subchart fullname override in redis HTTP bridge URL and auth secret
     set:

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -53,6 +53,23 @@ tests:
                 key: password
         template: templates/deployment.yaml
 
+  - it: should honor PostgreSQL subchart ExternalSecret target overrides
+    set:
+      postgresql.externalSecrets.enabled: true
+      postgresql.externalSecrets.auth.enabled: true
+      postgresql.externalSecrets.auth.targetName: pg-auth-from-eso
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: pg-auth-from-eso
+                key: user-password
+        template: templates/deployment.yaml
+
   - it: should include bundled Redis auth in redis HTTP bridge URL
     set:
       redis.auth.enabled: true
@@ -115,3 +132,12 @@ tests:
           content:
             name: UPSTASH_REDIS_REST_URL
         template: templates/deployment.yaml
+
+  - it: should fail when redis HTTP bridge has no Redis backend
+    set:
+      redis.enabled: false
+      redis.external.host: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: redisHttp.enabled requires redis.enabled=true or redis.external.host to be set
+        template: templates/redis-http.yaml

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -48,6 +48,12 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "NEXT_PUBLIC_SITE_URL"
         template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BETTER_AUTH_URL
+            value: http://localhost:3000
+        template: templates/deployment.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "https://api.marblecms.com"
@@ -340,6 +346,12 @@ tests:
             name: NEXT_PUBLIC_SITE_URL
             value: https://opencut.gateway.example
         template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BETTER_AUTH_URL
+            value: https://opencut.gateway.example
+        template: templates/deployment.yaml
 
   - it: should derive HTTP site URL from non-TLS ingress
     set:
@@ -355,6 +367,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: NEXT_PUBLIC_SITE_URL
+            value: http://opencut.example.test
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BETTER_AUTH_URL
             value: http://opencut.example.test
         template: templates/deployment.yaml
 
@@ -376,6 +394,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: NEXT_PUBLIC_SITE_URL
+            value: https://opencut.example.test
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BETTER_AUTH_URL
             value: https://opencut.example.test
         template: templates/deployment.yaml
 

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -265,15 +265,59 @@ tests:
         template: templates/secret.yaml
         documentIndex: 0
 
-  - it: should omit Upstash bridge env when redis HTTP bridge is disabled
+  - it: should fail when redis HTTP bridge is disabled without an external Redis REST URL
     set:
       redisHttp.enabled: false
       opencut.betterAuthSecret: test-secret
     asserts:
-      - notContains:
+      - failedTemplate:
+          errorMessage: redisHttp.enabled=false requires redisHttp.external.url so OpenCut receives UPSTASH_REDIS_REST_URL
+        template: templates/deployment.yaml
+
+  - it: should render external Redis REST env when redis HTTP bridge is disabled
+    set:
+      redisHttp.enabled: false
+      redisHttp.external.url: https://redis-rest.example.com
+      redisHttp.external.token: external-token
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: UPSTASH_REDIS_REST_URL
+            value: https://redis-rest.example.com
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPSTASH_REDIS_REST_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: test-opencut-app
+                key: redis-rest-token
+        template: templates/deployment.yaml
+      - equal:
+          path: stringData["redis-rest-token"]
+          value: external-token
+        template: templates/secret.yaml
+        documentIndex: 0
+
+  - it: should use an existing Secret for external Redis REST token
+    set:
+      redisHttp.enabled: false
+      redisHttp.external.url: https://redis-rest.example.com
+      redisHttp.external.existingSecret: redis-rest-auth
+      redisHttp.external.existingSecretTokenKey: token
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UPSTASH_REDIS_REST_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: redis-rest-auth
+                key: token
         template: templates/deployment.yaml
 
   - it: should derive site URL from Gateway hostnames

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -92,6 +92,39 @@ tests:
             value: postgresql://opencut:$(DATABASE_PASSWORD)@test-postgresql:15432/opencut
         template: templates/deployment.yaml
 
+  - it: should honor PostgreSQL subchart fullname override in database URL and auth secret
+    set:
+      postgresql.fullnameOverride: custom-postgresql
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: custom-postgresql-auth
+                key: user-password
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: postgresql://opencut:$(DATABASE_PASSWORD)@custom-postgresql:5432/opencut
+        template: templates/deployment.yaml
+
+  - it: should use PostgreSQL primary service in replication mode
+    set:
+      postgresql.architecture: replication
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: postgresql://opencut:$(DATABASE_PASSWORD)@test-postgresql-primary:5432/opencut
+        template: templates/deployment.yaml
+
   - it: should include bundled Redis auth in redis HTTP bridge URL
     set:
       redis.auth.enabled: true
@@ -116,6 +149,41 @@ tests:
         template: templates/redis-http.yaml
         documentIndex: 0
 
+  - it: should honor Redis subchart fullname override in redis HTTP bridge URL and auth secret
+    set:
+      redis.fullnameOverride: custom-redis
+      redis.auth.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: custom-redis-auth
+                key: redis-password
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SRH_CONNECTION_STRING
+            value: redis://:$(REDIS_PASSWORD)@custom-redis-client:6379
+        template: templates/redis-http.yaml
+        documentIndex: 0
+
+  - it: should use Redis primary service in replication mode
+    set:
+      redis.architecture: replication
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SRH_CONNECTION_STRING
+            value: redis://:$(REDIS_PASSWORD)@test-redis-primary:6379
+        template: templates/redis-http.yaml
+        documentIndex: 0
+
   - it: should honor bundled Redis service port in redis HTTP bridge URL
     set:
       redis.service.ports.redis: 16379
@@ -124,7 +192,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: SRH_CONNECTION_STRING
-            value: redis://test-redis-client:16379
+            value: redis://:$(REDIS_PASSWORD)@test-redis-client:16379
         template: templates/redis-http.yaml
         documentIndex: 0
 

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -24,6 +24,30 @@ tests:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
         template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-runtime-app
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: runtime-app
+            mountPath: /app-runtime
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: runtime-app
+            mountPath: /app
+        template: templates/deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "http://localhost:3000"
+        template: templates/deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "NEXT_PUBLIC_SITE_URL"
+        template: templates/deployment.yaml
 
   - it: should render redis HTTP bridge by default
     asserts:

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -260,6 +260,44 @@ tests:
             value: https://opencut.gateway.example
         template: templates/deployment.yaml
 
+  - it: should derive HTTP site URL from non-TLS ingress
+    set:
+      opencut.betterAuthSecret: test-secret
+      ingress.enabled: true
+      ingress.hosts:
+        - host: opencut.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXT_PUBLIC_SITE_URL
+            value: http://opencut.example.test
+        template: templates/deployment.yaml
+
+  - it: should derive HTTPS site URL from TLS ingress
+    set:
+      opencut.betterAuthSecret: test-secret
+      ingress.enabled: true
+      ingress.hosts:
+        - host: opencut.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - secretName: opencut-tls
+          hosts:
+            - opencut.example.test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXT_PUBLIC_SITE_URL
+            value: https://opencut.example.test
+        template: templates/deployment.yaml
+
   - it: should fail when redis HTTP bridge has no Redis backend
     set:
       redis.enabled: false

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -90,6 +90,32 @@ tests:
         template: templates/redis-http.yaml
         documentIndex: 0
 
+  - it: should render pull secrets and priority class on web and redis bridge pods
+    set:
+      imagePullSecrets:
+        - name: private-registry
+      priorityClassName: platform-critical
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: private-registry
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: platform-critical
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: private-registry
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: platform-critical
+        template: templates/redis-http.yaml
+        documentIndex: 0
+
   - it: should keep redis HTTP bridge names within DNS label length
     set:
       fullnameOverride: opencut-with-a-very-long-name-that-fills-the-dns-label-limit

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -36,6 +36,16 @@ tests:
           value: docker.io/hiett/serverless-redis-http:0.0.10
         template: templates/redis-http.yaml
         documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 12
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 60
+        template: templates/redis-http.yaml
+        documentIndex: 0
 
   - it: should honor PostgreSQL subchart auth secret overrides
     set:
@@ -171,22 +181,6 @@ tests:
           content:
             name: NEXT_PUBLIC_SITE_URL
             value: https://opencut.gateway.example
-        template: templates/deployment.yaml
-
-  - it: should derive site URL from Gateway API hostnames
-    set:
-      opencut.betterAuthSecret: test-secret
-      gatewayAPI.enabled: true
-      gatewayAPI.parentRefs:
-        - name: public
-      gatewayAPI.hostnames:
-        - opencut.gateway-api.example
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: NEXT_PUBLIC_SITE_URL
-            value: https://opencut.gateway-api.example
         template: templates/deployment.yaml
 
   - it: should fail when redis HTTP bridge has no Redis backend

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -157,6 +157,38 @@ tests:
             name: UPSTASH_REDIS_REST_URL
         template: templates/deployment.yaml
 
+  - it: should derive site URL from Gateway hostnames
+    set:
+      opencut.betterAuthSecret: test-secret
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: public
+      gateway.hostnames:
+        - opencut.gateway.example
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXT_PUBLIC_SITE_URL
+            value: https://opencut.gateway.example
+        template: templates/deployment.yaml
+
+  - it: should derive site URL from Gateway API hostnames
+    set:
+      opencut.betterAuthSecret: test-secret
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public
+      gatewayAPI.hostnames:
+        - opencut.gateway-api.example
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXT_PUBLIC_SITE_URL
+            value: https://opencut.gateway-api.example
+        template: templates/deployment.yaml
+
   - it: should fail when redis HTTP bridge has no Redis backend
     set:
       redis.enabled: false

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -90,6 +90,21 @@ tests:
         template: templates/redis-http.yaml
         documentIndex: 0
 
+  - it: should keep redis HTTP bridge names within DNS label length
+    set:
+      fullnameOverride: opencut-with-a-very-long-name-that-fills-the-dns-label-limit
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+        template: templates/redis-http.yaml
+        documentIndex: 1
+
   - it: should honor PostgreSQL subchart auth secret overrides
     set:
       postgresql.auth.existingSecret: pg-auth

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -78,6 +78,11 @@ tests:
           value: 60
         template: templates/redis-http.yaml
         documentIndex: 0
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: templates/redis-http.yaml
+        documentIndex: 0
 
   - it: should honor PostgreSQL subchart auth secret overrides
     set:

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -48,6 +48,14 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "NEXT_PUBLIC_SITE_URL"
         template: templates/deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "https://api.marblecms.com"
+        template: templates/deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "NEXT_PUBLIC_MARBLE_API_URL"
+        template: templates/deployment.yaml
 
   - it: should render redis HTTP bridge by default
     asserts:

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+  - templates/secret.yaml
+  - templates/redis-http.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should use HelmForge OpenCut image and hardened pod settings
+    set:
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/helmforge/opencut:v0.3.0
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+        template: templates/deployment.yaml
+
+  - it: should render redis HTTP bridge by default
+    asserts:
+      - isKind:
+          of: Deployment
+        template: templates/redis-http.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/hiett/serverless-redis-http:0.0.10
+        template: templates/redis-http.yaml
+        documentIndex: 0

--- a/charts/opencut/tests/deployment_test.yaml
+++ b/charts/opencut/tests/deployment_test.yaml
@@ -70,6 +70,18 @@ tests:
                 key: user-password
         template: templates/deployment.yaml
 
+  - it: should honor bundled PostgreSQL service port in database URL
+    set:
+      postgresql.service.port: 15432
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: postgresql://opencut:$(DATABASE_PASSWORD)@test-postgresql:15432/opencut
+        template: templates/deployment.yaml
+
   - it: should include bundled Redis auth in redis HTTP bridge URL
     set:
       redis.auth.enabled: true
@@ -91,6 +103,18 @@ tests:
           content:
             name: SRH_CONNECTION_STRING
             value: redis://:$(REDIS_PASSWORD)@test-redis-client:6379
+        template: templates/redis-http.yaml
+        documentIndex: 0
+
+  - it: should honor bundled Redis service port in redis HTTP bridge URL
+    set:
+      redis.service.ports.redis: 16379
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SRH_CONNECTION_STRING
+            value: redis://test-redis-client:16379
         template: templates/redis-http.yaml
         documentIndex: 0
 

--- a/charts/opencut/tests/externalsecret_test.yaml
+++ b/charts/opencut/tests/externalsecret_test.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render an ExternalSecret for the external database password
+    set:
+      postgresql.enabled: false
+      database.external.host: postgres.example.com
+      database.external.existingSecret: opencut-db
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.data:
+        - secretKey: database-password
+          remoteRef:
+            key: opencut/database
+            property: password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: opencut-db
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: opencut-db
+      - equal:
+          path: spec.data[0].secretKey
+          value: database-password

--- a/charts/opencut/tests/gateway_test.yaml
+++ b/charts/opencut/tests/gateway_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render HTTPRoute when enabled
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: public
+      gateway.hostnames:
+        - opencut.example.test
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -93,6 +93,27 @@ tests:
             protocol: TCP
             port: 8079
 
+  - it: should derive external Redis REST port from IPv6 URL authority
+    set:
+      networkPolicy.enabled: true
+      redis.enabled: false
+      redisHttp.enabled: false
+      redisHttp.external.url: https://[2001:db8::1]:8079/redis
+      redisHttp.external.token: test-token
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 8079
+      - notContains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 2001
+
   - it: should fail when external Redis REST URL has no supported scheme
     set:
       networkPolicy.enabled: true

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -34,3 +34,24 @@ tests:
             protocol: UDP
             port: 53
         documentIndex: 1
+
+  - it: should honor external database and Redis HTTP ports in web egress
+    set:
+      networkPolicy.enabled: true
+      postgresql.enabled: false
+      database.external.host: postgres.example.com
+      database.external.port: 15432
+      redisHttp.service.port: 8080
+    asserts:
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 15432
+        documentIndex: 0
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 8080
+        documentIndex: 0

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -76,3 +76,35 @@ tests:
           path: spec.egress[1].ports[0].port
           value: 16379
         documentIndex: 1
+
+  - it: should append custom web egress rules to the defaults
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress:
+        - to:
+            - ipBlock:
+                cidr: 10.10.0.0/16
+          ports:
+            - protocol: TCP
+              port: 8443
+    asserts:
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
+        documentIndex: 0
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 5432
+        documentIndex: 0
+      - equal:
+          path: spec.egress[2].to[0].ipBlock.cidr
+          value: 10.10.0.0/16
+        documentIndex: 0
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 8443
+        documentIndex: 0

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -55,6 +55,10 @@ tests:
             protocol: TCP
             port: 8080
         documentIndex: 0
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 80
+        documentIndex: 1
 
   - it: should honor bundled PostgreSQL and Redis service ports in egress
     set:

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -108,3 +108,24 @@ tests:
           path: spec.egress[2].ports[0].port
           value: 8443
         documentIndex: 0
+
+  - it: should append custom web ingress rules without dropping the default web port
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: ingress-nginx
+          ports:
+            - protocol: TCP
+              port: 3000
+    asserts:
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 3000
+        documentIndex: 0
+      - equal:
+          path: spec.ingress[1].from[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: ingress-nginx
+        documentIndex: 0

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -55,3 +55,20 @@ tests:
             protocol: TCP
             port: 8080
         documentIndex: 0
+
+  - it: should honor bundled PostgreSQL and Redis service ports in egress
+    set:
+      networkPolicy.enabled: true
+      postgresql.service.port: 15432
+      redis.service.ports.redis: 16379
+    asserts:
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 15432
+        documentIndex: 0
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 16379
+        documentIndex: 1

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: NetworkPolicy
+templates:
+  - templates/networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should scope web policy to web pods and protect redis-http bridge
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: web
+        documentIndex: 0
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: redis-http
+        documentIndex: 1
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: web
+        documentIndex: 1
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 6379
+        documentIndex: 1

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -77,6 +77,33 @@ tests:
           value: 16379
         documentIndex: 1
 
+  - it: should derive external Redis REST port for web egress when bridge is disabled
+    set:
+      networkPolicy.enabled: true
+      redis.enabled: false
+      redisHttp.enabled: false
+      redisHttp.external.url: http://redis-rest.example.com:8079
+      redisHttp.external.token: test-token
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.egress[1].ports
+          content:
+            protocol: TCP
+            port: 8079
+
+  - it: should fail when external Redis REST URL has no supported scheme
+    set:
+      networkPolicy.enabled: true
+      redis.enabled: false
+      redisHttp.enabled: false
+      redisHttp.external.url: redis-rest.example.com:8079
+      redisHttp.external.token: test-token
+    asserts:
+      - failedTemplate:
+          errorMessage: "redisHttp.enabled=false requires redisHttp.external.url to start with http:// or https:// so the chart can derive the NetworkPolicy egress port"
+
   - it: should append custom web egress rules to the defaults
     set:
       networkPolicy.enabled: true

--- a/charts/opencut/tests/networkpolicy_test.yaml
+++ b/charts/opencut/tests/networkpolicy_test.yaml
@@ -25,6 +25,12 @@ tests:
           value: web
         documentIndex: 1
       - equal:
-          path: spec.egress[0].ports[0].port
+          path: spec.egress[1].ports[0].port
           value: 6379
+        documentIndex: 1
+      - contains:
+          path: spec.egress[0].ports
+          content:
+            protocol: UDP
+            port: 53
         documentIndex: 1

--- a/charts/opencut/tests/postgresql_naming_test.yaml
+++ b/charts/opencut/tests/postgresql_naming_test.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: PostgreSQL naming
+templates:
+  - templates/deployment.yaml
+  - templates/secret.yaml
+release:
+  name: team-postgresql
+  namespace: default
+tests:
+  - it: should match the bundled PostgreSQL chart name when release already contains postgresql
+    set:
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_HOST
+            value: team-postgresql-postgresql
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: team-postgresql-postgresql-auth
+                key: user-password
+        template: templates/deployment.yaml
+
+  - it: should match the bundled PostgreSQL primary service in replication mode
+    set:
+      postgresql.architecture: replication
+      opencut.betterAuthSecret: test-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_HOST
+            value: team-postgresql-postgresql-primary
+        template: templates/deployment.yaml

--- a/charts/opencut/tests/service_test.yaml
+++ b/charts/opencut/tests/service_test.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render the HTTP service
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+
+  - it: should support dual-stack service settings
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv6
+        - IPv4
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv4

--- a/charts/opencut/tests/test_connection_test.yaml
+++ b/charts/opencut/tests/test_connection_test.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Helm Test
+templates:
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should keep helm test pod name within DNS label length
+    set:
+      fullnameOverride: opencut-with-a-very-long-name-that-fills-the-dns-label-limit
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "^.{1,63}$"
+      - matchRegex:
+          path: metadata.name
+          pattern: "-test$"

--- a/charts/opencut/values.schema.json
+++ b/charts/opencut/values.schema.json
@@ -71,8 +71,58 @@
         "data": { "type": "array", "items": { "type": "object" } }
       }
     },
-    "postgresql": { "type": "object" },
-    "redis": { "type": "object" },
+    "postgresql": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "nameOverride": { "type": "string" },
+        "fullnameOverride": { "type": "string" },
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "architecture": { "type": "string", "enum": ["standalone", "replication"] },
+        "auth": { "type": "object" },
+        "standalone": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "resourcesPreset": { "type": "string", "enum": ["none", "small", "medium", "large"] },
+            "persistence": { "type": "object" }
+          }
+        },
+        "replication": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "primary": { "type": "object" },
+            "readReplicas": { "type": "object" }
+          }
+        }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "nameOverride": { "type": "string" },
+        "fullnameOverride": { "type": "string" },
+        "architecture": { "type": "string", "enum": ["standalone", "replication"] },
+        "auth": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" }
+          }
+        },
+        "standalone": { "type": "object" },
+        "replication": { "type": "object" },
+        "securityContext": { "type": "object" },
+        "external": { "type": "object" }
+      }
+    },
     "redisHttp": {
       "type": "object",
       "additionalProperties": true,
@@ -87,7 +137,8 @@
             "tag": { "type": "string", "not": { "const": "latest" } },
             "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
           }
-        }
+        },
+        "securityContext": { "type": "object" }
       }
     },
     "serviceAccount": { "type": "object" },

--- a/charts/opencut/values.schema.json
+++ b/charts/opencut/values.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "OpenCut Helm Chart Values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "revisionHistoryLimit": { "type": "integer", "minimum": 0 },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "not": { "const": "latest" } },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "opencut": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "siteUrl": { "type": "string" },
+        "betterAuthSecret": { "type": "string" },
+        "marbleApiUrl": { "type": "string" },
+        "marbleWorkspaceKey": { "type": "string" },
+        "freesoundClientId": { "type": "string" },
+        "freesoundApiKey": { "type": "string" },
+        "extraEnv": { "type": "array" }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "mode": { "type": "string" },
+        "external": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "host": { "type": "string" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "name": { "type": "string" },
+            "username": { "type": "string" },
+            "password": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretPasswordKey": { "type": "string" }
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "name": { "type": "string" },
+            "kind": { "type": "string", "enum": ["SecretStore", "ClusterSecretStore"] }
+          }
+        },
+        "target": { "type": "object" },
+        "data": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "postgresql": { "type": "object" },
+    "redis": { "type": "object" },
+    "redisHttp": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "token": { "type": "string" },
+        "image": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "repository": { "type": "string", "minLength": 1 },
+            "tag": { "type": "string", "not": { "const": "latest" } },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+          }
+        }
+      }
+    },
+    "serviceAccount": { "type": "object" },
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "ingress": { "type": "object" },
+    "gateway": { "type": "object" },
+    "gatewayAPI": { "type": "object" },
+    "networkPolicy": { "type": "object" },
+    "autoscaling": { "type": "object" },
+    "pdb": { "type": "object" },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "extraVolumes": { "type": "array" },
+    "extraVolumeMounts": { "type": "array" },
+    "test": { "type": "object" },
+    "extraObjects": { "type": "array", "items": { "type": "object" } }
+  }
+}

--- a/charts/opencut/values.schema.json
+++ b/charts/opencut/values.schema.json
@@ -101,9 +101,29 @@
         "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
       }
     },
-    "ingress": { "type": "object" },
-    "gateway": { "type": "object" },
-    "gatewayAPI": { "type": "object" },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "path": { "type": "string" },
+        "pathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] }
+      }
+    },
     "networkPolicy": { "type": "object" },
     "autoscaling": { "type": "object" },
     "pdb": { "type": "object" },

--- a/charts/opencut/values.schema.json
+++ b/charts/opencut/values.schema.json
@@ -129,6 +129,16 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "token": { "type": "string" },
+        "external": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "url": { "type": "string" },
+            "token": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "existingSecretTokenKey": { "type": "string", "minLength": 1 }
+          }
+        },
         "image": {
           "type": "object",
           "additionalProperties": true,

--- a/charts/opencut/values.yaml
+++ b/charts/opencut/values.yaml
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# OpenCut Helm Chart - Default Values
+# =============================================================================
+
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+replicaCount: 1
+revisionHistoryLimit: 3
+
+image:
+  repository: docker.io/helmforge/opencut
+  tag: "v0.3.0"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+opencut:
+  siteUrl: ""
+  betterAuthSecret: ""
+  marbleApiUrl: https://api.marblecms.com
+  marbleWorkspaceKey: placeholder
+  freesoundClientId: ""
+  freesoundApiKey: ""
+  extraEnv: []
+
+database:
+  mode: auto
+  external:
+    host: ""
+    port: 5432
+    name: opencut
+    username: opencut
+    password: ""
+    existingSecret: ""
+    existingSecretPasswordKey: database-password
+
+externalSecrets:
+  # -- Render an ExternalSecret for the external PostgreSQL password.
+  # Requires database.external.existingSecret to prevent credential drift.
+  enabled: false
+  # -- ExternalSecret API version.
+  apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval.
+  refreshInterval: "0"
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    # -- Secret store kind: SecretStore or ClusterSecretStore.
+    kind: SecretStore
+  target:
+    # -- ExternalSecret target creation policy.
+    creationPolicy: Owner
+  # -- Data entries mapping remote secret data to database.external.existingSecretPasswordKey.
+  data: []
+  #   - secretKey: database-password
+  #     remoteRef:
+  #       key: opencut/database
+  #       property: password
+
+postgresql:
+  enabled: true
+  architecture: standalone
+  auth:
+    database: opencut
+    username: opencut
+    password: ""
+    postgresPassword: ""
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false
+  standalone:
+    persistence:
+      enabled: true
+      size: 1Gi
+  external:
+    host: ""
+    port: 6379
+
+redisHttp:
+  enabled: true
+  image:
+    repository: docker.io/hiett/serverless-redis-http
+    tag: "0.0.10"
+    pullPolicy: IfNotPresent
+  token: ""
+  service:
+    port: 80
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  port: 80
+  annotations: {}
+  ipFamilyPolicy: ""
+  ipFamilies: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: opencut.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gateway:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+gatewayAPI:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+probes:
+  startup:
+    enabled: true
+    path: /api/health
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 18
+  liveness:
+    enabled: true
+    path: /api/health
+    initialDelaySeconds: 30
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /api/health
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+podAnnotations: {}
+podLabels: {}
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+extraVolumes: []
+extraVolumeMounts: []
+
+test:
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37.0"
+    pullPolicy: IfNotPresent
+
+extraObjects: []

--- a/charts/opencut/values.yaml
+++ b/charts/opencut/values.yaml
@@ -68,6 +68,8 @@ postgresql:
     username: opencut
     password: ""
     postgresPassword: ""
+    existingSecret: ""
+    existingSecretUserPasswordKey: user-password
   standalone:
     persistence:
       enabled: true
@@ -78,6 +80,9 @@ redis:
   architecture: standalone
   auth:
     enabled: false
+    password: ""
+    existingSecret: ""
+    existingSecretPasswordKey: redis-password
   standalone:
     persistence:
       enabled: true
@@ -85,6 +90,9 @@ redis:
   external:
     host: ""
     port: 6379
+    password: ""
+    existingSecret: ""
+    existingSecretPasswordKey: redis-password
 
 redisHttp:
   enabled: true

--- a/charts/opencut/values.yaml
+++ b/charts/opencut/values.yaml
@@ -74,6 +74,11 @@ postgresql:
     persistence:
       enabled: true
       size: 8Gi
+  externalSecrets:
+    enabled: false
+    auth:
+      enabled: false
+      targetName: ""
 
 redis:
   enabled: true

--- a/charts/opencut/values.yaml
+++ b/charts/opencut/values.yaml
@@ -247,6 +247,15 @@ redisHttp:
     pullPolicy: IfNotPresent
   # -- Static Redis REST token. Empty lets the chart generate and persist a token in the app Secret.
   token: ""
+  external:
+    # -- External Redis REST URL used when the in-cluster Redis HTTP bridge is disabled.
+    url: ""
+    # -- External Redis REST token used when the in-cluster Redis HTTP bridge is disabled. Prefer existingSecret for production.
+    token: ""
+    # -- Existing Secret containing the external Redis REST token.
+    existingSecret: ""
+    # -- Secret key containing the external Redis REST token.
+    existingSecretTokenKey: redis-rest-token
   service:
     # -- Redis HTTP bridge service port.
     port: 80

--- a/charts/opencut/values.yaml
+++ b/charts/opencut/values.yaml
@@ -75,6 +75,14 @@ database:
 postgresql:
   # -- Enable the HelmForge PostgreSQL subchart.
   enabled: true
+  # -- PostgreSQL subchart name override.
+  nameOverride: ""
+  # -- PostgreSQL subchart full name override.
+  fullnameOverride: ""
+  # -- Extra PostgreSQL environment variables inherited by the subchart.
+  extraEnv:
+    - name: POSTGRES_INITDB_ARGS
+      value: "--auth-local=scram-sha-256 --auth-host=scram-sha-256"
   # -- PostgreSQL architecture used by the subchart.
   architecture: standalone
   auth:
@@ -91,11 +99,20 @@ postgresql:
     # -- Key in the PostgreSQL auth Secret containing the OpenCut user password.
     existingSecretUserPasswordKey: user-password
   standalone:
+    # -- PostgreSQL standalone resource preset inherited by the subchart.
+    resourcesPreset: small
     persistence:
       # -- Enable PostgreSQL persistence.
       enabled: true
       # -- PostgreSQL PVC size.
       size: 8Gi
+  replication:
+    primary:
+      # -- PostgreSQL primary resource preset when architecture=replication.
+      resourcesPreset: small
+    readReplicas:
+      # -- PostgreSQL read replica resource preset when architecture=replication.
+      resourcesPreset: small
   externalSecrets:
     # -- Enable PostgreSQL subchart External Secrets support.
     enabled: false
@@ -134,11 +151,15 @@ externalSecrets:
 redis:
   # -- Enable the HelmForge Redis subchart for OpenCut cache/session data.
   enabled: true
-  # -- Redis architecture used by the subchart.
+  # -- Redis subchart name override.
+  nameOverride: ""
+  # -- Redis subchart full name override.
+  fullnameOverride: ""
+  # -- Redis architecture used by the subchart. OpenCut supports standalone or replication.
   architecture: standalone
   auth:
     # -- Enable Redis password authentication.
-    enabled: false
+    enabled: true
     # -- Redis password. Prefer existingSecret for production.
     password: ""
     # -- Existing Secret containing the Redis password.
@@ -151,6 +172,57 @@ redis:
       enabled: true
       # -- Redis PVC size.
       size: 1Gi
+    # -- Redis standalone resources inherited by the subchart.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+  replication:
+    primary:
+      persistence:
+        # -- Enable Redis primary persistence when architecture=replication.
+        enabled: true
+      # -- Redis primary resources when architecture=replication.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+    replica:
+      persistence:
+        # -- Enable Redis replica persistence when architecture=replication.
+        enabled: true
+      # -- Redis replica resources when architecture=replication.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+  securityContext:
+    # -- Redis container user inherited by the subchart.
+    runAsUser: 999
+    # -- Redis container group inherited by the subchart.
+    runAsGroup: 999
+    # -- Run Redis as non-root.
+    runAsNonRoot: true
+    # -- Disable Redis privilege escalation.
+    allowPrivilegeEscalation: false
+    # -- Keep writable root filesystem because Redis may write runtime files outside /data depending on configuration.
+    readOnlyRootFilesystem: false
+    # -- Drop all Linux capabilities from Redis.
+    capabilities:
+      drop:
+        - ALL
+    # -- Use the runtime default seccomp profile for Redis.
+    seccompProfile:
+      type: RuntimeDefault
   external:
     # -- External Redis hostname used instead of the bundled Redis service.
     host: ""
@@ -230,6 +302,9 @@ redisHttp:
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
     capabilities:
       drop:
         - ALL

--- a/charts/opencut/values.yaml
+++ b/charts/opencut/values.yaml
@@ -3,43 +3,110 @@
 # OpenCut Helm Chart - Default Values
 # =============================================================================
 
+# -- Override the chart name.
 nameOverride: ""
+
+# -- Override the fully qualified release name.
 fullnameOverride: ""
+
+# -- Additional labels applied to all chart resources.
 commonLabels: {}
 
+# -- Number of OpenCut web replicas. Keep at 1 when using local persistent state.
 replicaCount: 1
+
+# -- Number of old ReplicaSets retained by the Deployment.
 revisionHistoryLimit: 3
 
 image:
+  # -- OpenCut image repository maintained by HelmForge.
   repository: docker.io/helmforge/opencut
+  # -- OpenCut image tag. Do not use latest.
   tag: "v0.3.0"
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets used by OpenCut and helper workloads.
 imagePullSecrets: []
 
+# =============================================================================
+# OpenCut Runtime
+# =============================================================================
+
 opencut:
+  # -- Public URL used by authentication callbacks and browser-facing links. When empty, the chart derives it from Ingress or Gateway hostnames.
   siteUrl: ""
+  # -- Better Auth secret. Set explicitly for production to avoid rotation on reinstall.
   betterAuthSecret: ""
+  # -- Marble CMS API URL consumed by OpenCut.
   marbleApiUrl: https://api.marblecms.com
+  # -- Marble workspace key. Replace the placeholder for real deployments.
   marbleWorkspaceKey: placeholder
+  # -- Optional Freesound client ID.
   freesoundClientId: ""
+  # -- Optional Freesound API key.
   freesoundApiKey: ""
+  # -- Extra environment variables appended to the OpenCut container.
   extraEnv: []
 
+# =============================================================================
+# PostgreSQL
+# =============================================================================
+
 database:
+  # -- Database selection mode. auto uses bundled PostgreSQL unless database.external.host is set.
   mode: auto
   external:
+    # -- External PostgreSQL hostname. Setting this disables bundled PostgreSQL only when postgresql.enabled=false.
     host: ""
+    # -- External PostgreSQL port.
     port: 5432
+    # -- External PostgreSQL database name.
     name: opencut
+    # -- External PostgreSQL username.
     username: opencut
+    # -- External PostgreSQL password. Prefer existingSecret or externalSecrets for production.
     password: ""
+    # -- Existing Secret containing the external PostgreSQL password.
     existingSecret: ""
+    # -- Secret key containing the external PostgreSQL password.
     existingSecretPasswordKey: database-password
 
+postgresql:
+  # -- Enable the HelmForge PostgreSQL subchart.
+  enabled: true
+  # -- PostgreSQL architecture used by the subchart.
+  architecture: standalone
+  auth:
+    # -- PostgreSQL database created for OpenCut.
+    database: opencut
+    # -- PostgreSQL user created for OpenCut.
+    username: opencut
+    # -- PostgreSQL user password. Empty lets the subchart generate it.
+    password: ""
+    # -- PostgreSQL superuser password. Empty lets the subchart generate it.
+    postgresPassword: ""
+    # -- Existing Secret consumed by the PostgreSQL subchart.
+    existingSecret: ""
+    # -- Key in the PostgreSQL auth Secret containing the OpenCut user password.
+    existingSecretUserPasswordKey: user-password
+  standalone:
+    persistence:
+      # -- Enable PostgreSQL persistence.
+      enabled: true
+      # -- PostgreSQL PVC size.
+      size: 8Gi
+  externalSecrets:
+    # -- Enable PostgreSQL subchart External Secrets support.
+    enabled: false
+    auth:
+      # -- Render a PostgreSQL auth ExternalSecret from the subchart.
+      enabled: false
+      # -- Target Secret name rendered by the PostgreSQL auth ExternalSecret.
+      targetName: ""
+
 externalSecrets:
-  # -- Render an ExternalSecret for the external PostgreSQL password.
-  # Requires database.external.existingSecret to prevent credential drift.
+  # -- Render an ExternalSecret for the external PostgreSQL password. Requires database.external.existingSecret to prevent credential drift.
   enabled: false
   # -- ExternalSecret API version.
   apiVersion: external-secrets.io/v1
@@ -60,54 +127,98 @@ externalSecrets:
   #       key: opencut/database
   #       property: password
 
-postgresql:
-  enabled: true
-  architecture: standalone
-  auth:
-    database: opencut
-    username: opencut
-    password: ""
-    postgresPassword: ""
-    existingSecret: ""
-    existingSecretUserPasswordKey: user-password
-  standalone:
-    persistence:
-      enabled: true
-      size: 8Gi
-  externalSecrets:
-    enabled: false
-    auth:
-      enabled: false
-      targetName: ""
+# =============================================================================
+# Redis and HTTP Bridge
+# =============================================================================
 
 redis:
+  # -- Enable the HelmForge Redis subchart for OpenCut cache/session data.
   enabled: true
+  # -- Redis architecture used by the subchart.
   architecture: standalone
   auth:
+    # -- Enable Redis password authentication.
     enabled: false
+    # -- Redis password. Prefer existingSecret for production.
     password: ""
+    # -- Existing Secret containing the Redis password.
     existingSecret: ""
+    # -- Key in the Redis auth Secret containing the Redis password.
     existingSecretPasswordKey: redis-password
   standalone:
     persistence:
+      # -- Enable Redis persistence.
       enabled: true
+      # -- Redis PVC size.
       size: 1Gi
   external:
+    # -- External Redis hostname used instead of the bundled Redis service.
     host: ""
+    # -- External Redis port.
     port: 6379
+    # -- External Redis password. Prefer existingSecret for production.
     password: ""
+    # -- Existing Secret containing the external Redis password.
     existingSecret: ""
+    # -- Secret key containing the external Redis password.
     existingSecretPasswordKey: redis-password
 
 redisHttp:
+  # -- Enable the Redis-over-HTTP bridge required by the OpenCut runtime.
   enabled: true
   image:
+    # -- Redis HTTP bridge image repository.
     repository: docker.io/hiett/serverless-redis-http
+    # -- Redis HTTP bridge image tag.
     tag: "0.0.10"
+    # -- Redis HTTP bridge pull policy.
     pullPolicy: IfNotPresent
+  # -- Static Redis REST token. Empty lets the chart generate and persist a token in the app Secret.
   token: ""
   service:
+    # -- Redis HTTP bridge service port.
     port: 80
+  probes:
+    startup:
+      # -- Enable Redis HTTP bridge startup probe.
+      enabled: true
+      # -- Redis HTTP bridge startup probe path.
+      path: /
+      # -- Redis HTTP bridge startup probe initial delay in seconds.
+      initialDelaySeconds: 60
+      # -- Redis HTTP bridge startup probe period in seconds.
+      periodSeconds: 5
+      # -- Redis HTTP bridge startup probe timeout in seconds.
+      timeoutSeconds: 3
+      # -- Redis HTTP bridge startup probe failure threshold.
+      failureThreshold: 12
+    readiness:
+      # -- Enable Redis HTTP bridge readiness probe.
+      enabled: true
+      # -- Redis HTTP bridge readiness probe path.
+      path: /
+      # -- Redis HTTP bridge readiness probe initial delay in seconds.
+      initialDelaySeconds: 60
+      # -- Redis HTTP bridge readiness probe period in seconds.
+      periodSeconds: 10
+      # -- Redis HTTP bridge readiness probe timeout in seconds.
+      timeoutSeconds: 3
+      # -- Redis HTTP bridge readiness probe failure threshold.
+      failureThreshold: 6
+    liveness:
+      # -- Enable Redis HTTP bridge liveness probe.
+      enabled: true
+      # -- Redis HTTP bridge liveness probe path.
+      path: /
+      # -- Redis HTTP bridge liveness probe initial delay in seconds.
+      initialDelaySeconds: 90
+      # -- Redis HTTP bridge liveness probe period in seconds.
+      periodSeconds: 20
+      # -- Redis HTTP bridge liveness probe timeout in seconds.
+      timeoutSeconds: 3
+      # -- Redis HTTP bridge liveness probe failure threshold.
+      failureThreshold: 3
+  # -- Redis HTTP bridge resource requests and limits.
   resources:
     requests:
       cpu: 25m
@@ -115,6 +226,7 @@ redisHttp:
     limits:
       cpu: 250m
       memory: 256Mi
+  # -- Redis HTTP bridge container security context.
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -122,85 +234,159 @@ redisHttp:
       drop:
         - ALL
 
+# =============================================================================
+# Service Account
+# =============================================================================
+
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: true
+  # -- ServiceAccount name override.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
+  # -- Mount the ServiceAccount token into OpenCut pods.
   automountServiceAccountToken: false
 
+# =============================================================================
+# Service
+# =============================================================================
+
 service:
+  # -- Service type for OpenCut HTTP traffic.
   type: ClusterIP
+  # -- Service port for OpenCut HTTP traffic.
   port: 80
+  # -- Service annotations.
   annotations: {}
+  # -- Service IP family policy: SingleStack, PreferDualStack, RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ""
+  # -- Service IP families override. Empty uses cluster default.
   ipFamilies: []
 
+# =============================================================================
+# Ingress
+# =============================================================================
+
 ingress:
+  # -- Enable Ingress for OpenCut.
   enabled: false
-  className: ""
+  # -- Ingress class name.
+  # ingressClassName: traefik
+  ingressClassName: ""
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress hosts and paths.
   hosts:
     - host: opencut.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
+# =============================================================================
+# Gateway API
+# =============================================================================
+
 gateway:
+  # -- Enable Gateway API HTTPRoute. Requires Gateway API CRDs and parentRefs.
   enabled: false
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- parentRefs pointing to existing Gateway resources.
   parentRefs: []
+  # -- Hostnames matched by the HTTPRoute.
   hostnames: []
+  # -- HTTPRoute path value.
   path: /
+  # -- HTTPRoute path match type.
   pathType: PathPrefix
 
-gatewayAPI:
-  enabled: false
-  annotations: {}
-  parentRefs: []
-  hostnames: []
-  path: /
-  pathType: PathPrefix
+# =============================================================================
+# Network Policy
+# =============================================================================
 
 networkPolicy:
+  # -- Enable NetworkPolicies for OpenCut and the Redis HTTP bridge.
   enabled: false
+  # -- Additional ingress rules appended to the OpenCut web policy.
   ingress: []
+  # -- Additional egress rules appended to the OpenCut web policy.
   egress: []
 
+# =============================================================================
+# Autoscaling and Availability
+# =============================================================================
+
 autoscaling:
+  # -- Enable HorizontalPodAutoscaler for OpenCut web pods.
   enabled: false
+  # -- Minimum OpenCut web replicas.
   minReplicas: 1
+  # -- Maximum OpenCut web replicas.
   maxReplicas: 4
+  # -- Target CPU utilization percentage.
   targetCPUUtilizationPercentage: 70
+  # -- Target memory utilization percentage.
   targetMemoryUtilizationPercentage: 80
 
 pdb:
+  # -- Enable PodDisruptionBudget for OpenCut web pods.
   enabled: true
+  # -- Minimum available pods for the PodDisruptionBudget.
   minAvailable: 1
+
+# =============================================================================
+# Probes
+# =============================================================================
 
 probes:
   startup:
+    # -- Enable OpenCut startup probe.
     enabled: true
+    # -- Startup probe path.
     path: /api/health
+    # -- Startup probe initial delay in seconds.
     initialDelaySeconds: 20
+    # -- Startup probe period in seconds.
     periodSeconds: 10
+    # -- Startup probe timeout in seconds.
     timeoutSeconds: 5
+    # -- Startup probe failure threshold.
     failureThreshold: 18
   liveness:
+    # -- Enable OpenCut liveness probe.
     enabled: true
+    # -- Liveness probe path.
     path: /api/health
+    # -- Liveness probe initial delay in seconds.
     initialDelaySeconds: 30
+    # -- Liveness probe period in seconds.
     periodSeconds: 20
+    # -- Liveness probe timeout in seconds.
     timeoutSeconds: 5
+    # -- Liveness probe failure threshold.
     failureThreshold: 3
   readiness:
+    # -- Enable OpenCut readiness probe.
     enabled: true
+    # -- Readiness probe path.
     path: /api/health
+    # -- Readiness probe initial delay in seconds.
     initialDelaySeconds: 10
+    # -- Readiness probe period in seconds.
     periodSeconds: 10
+    # -- Readiness probe timeout in seconds.
     timeoutSeconds: 5
+    # -- Readiness probe failure threshold.
     failureThreshold: 6
 
+# =============================================================================
+# Security and Resources
+# =============================================================================
+
+# -- OpenCut web container resource requests and limits.
 resources:
   requests:
     cpu: 100m
@@ -209,6 +395,7 @@ resources:
     cpu: "1"
     memory: 1Gi
 
+# -- Pod security context for OpenCut web pods.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 1001
@@ -217,6 +404,7 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# -- Container security context for the OpenCut web container.
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -224,21 +412,52 @@ securityContext:
     drop:
       - ALL
 
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+# -- Additional pod annotations.
 podAnnotations: {}
+
+# -- Additional pod labels.
 podLabels: {}
+
+# -- Priority class name.
 priorityClassName: ""
+
+# -- Grace period for shutdown in seconds.
 terminationGracePeriodSeconds: 30
+
+# -- Node selector for pod scheduling.
 nodeSelector: {}
+
+# -- Tolerations for pod scheduling.
 tolerations: []
+
+# -- Affinity rules for pod scheduling.
 affinity: {}
+
+# -- Topology spread constraints for pod scheduling.
 topologySpreadConstraints: []
+
+# -- Extra volumes mounted into OpenCut web pods.
 extraVolumes: []
+
+# -- Extra volume mounts mounted into the OpenCut web container.
 extraVolumeMounts: []
+
+# =============================================================================
+# Tests and Extensions
+# =============================================================================
 
 test:
   image:
+    # -- Helm test image repository.
     repository: docker.io/library/busybox
+    # -- Helm test image tag.
     tag: "1.37.0"
+    # -- Helm test image pull policy.
     pullPolicy: IfNotPresent
 
+# -- Extra Kubernetes manifests rendered with the release.
 extraObjects: []


### PR DESCRIPTION
## Summary
- Adds the stable OpenCut chart with the HelmForge-maintained `docker.io/helmforge/opencut:v0.3.0` image.
- Includes PostgreSQL and Redis dependency integration, Redis HTTP bridge, Gateway API, Ingress, dual-stack Service settings, HPA, PDB, NetworkPolicy, schema, README, and Helm unit tests.
- Adds External Secrets Operator support for external database credentials.

## Research
- Tavily search was attempted first and failed with the current plan limit, so I used fallback research with Context7/GitHub/source inspection.
- Reviewed upstream OpenCut `v0.3.0` release from 2026-04-15, upstream Dockerfile, docker-compose, and environment requirements.
- Created and validated the public HelmForge image repository `helmforgedev/opencut`; the GitHub Actions build/push workflow passed and `docker.io/helmforge/opencut:v0.3.0` was pulled successfully.

## Local validation
- `helm dependency build charts/opencut` passed.
- `helm lint charts/opencut --strict` passed.
- `helm lint charts/opencut -f charts/opencut/ci/ci-values.yaml --strict` passed.
- `helm lint charts/opencut -f charts/opencut/ci/k3d-values.yaml --strict` passed.
- `helm unittest charts/opencut` passed: 4 suites, 6 tests.
- `helm template` default, CI, and k3d renders passed.
- `kubeconform -strict -summary -ignore-missing-schemas` passed: default 18 valid/0 invalid; CI 21 valid/1 skipped/0 invalid; k3d 17 valid/0 invalid.
- `ah lint -p charts/opencut` passed.
- `npx -y markdownlint-cli2 charts/opencut/README.md` passed.
- MCP HelmForge chart validation passed with no blockers; expected warnings only for initial new-chart version and stateless web autoscaling.
- Kubescape local scan passed minimum score: overall 90.23, MITRE 100.00, NSA 87.00, SOC2 87.50, critical findings 0.

## k3d runtime validation
- Cluster/context: `k3d-helmforge-tests-wsl`.
- Namespace: `hf-opencut`.
- `helm upgrade --install opencut charts/opencut -n hf-opencut -f charts/opencut/ci/k3d-values.yaml --wait --timeout 8m` passed.
- `helm test opencut -n hf-opencut --timeout 3m --logs` passed with `/api/health` returning `OK` and the home page containing `OpenCut`.
- All pods were Running and Ready with 0 restarts: web, PostgreSQL, Redis, Redis HTTP bridge.
- Log scan found no `error`, `fatal`, `panic`, `exception`, or `traceback` matches.
- Kubernetes Warning events: none.
- Namespace `hf-opencut` was deleted after validation.

Resolves #375
