### PR TITLE
feat(openreel-video): add OpenReel Video chart

### DIFF
--- a/charts/openreel-video/.helmignore
+++ b/charts/openreel-video/.helmignore
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+.DS_Store
+Thumbs.db
+.git/
+.gitignore
+.gitattributes
+.helmignore
+.vscode/
+.idea/
+*.code-workspace
+*.orig
+*.rej
+*.swp
+*.tmp
+*.log
+*.bak

--- a/charts/openreel-video/Chart.yaml
+++ b/charts/openreel-video/Chart.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: openreel-video
+description: OpenReel Video browser-based video editor with WebCodecs-ready static hosting
+type: application
+version: 1.0.0
+appVersion: "0.4.0"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+keywords:
+  - openreel
+  - video-editor
+  - browser
+  - webcodecs
+  - wasm
+  - static-site
+home: https://helmforge.dev
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/openreel-video
+  - https://github.com/Augani/openreel-video
+  - https://github.com/helmforgedev/openreel-video
+icon: https://helmforge.dev/icons/charts/openreel-video.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "initial stable OpenReel Video chart with HelmForge image, Gateway API, dual-stack Service, NetworkPolicy, and runtime tests"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://openreel.video
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/openreel-video
+    - name: Source
+      url: https://github.com/Augani/openreel-video
+    - name: Image Source
+      url: https://github.com/helmforgedev/openreel-video
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues

--- a/charts/openreel-video/DESIGN.md
+++ b/charts/openreel-video/DESIGN.md
@@ -1,0 +1,64 @@
+# OpenReel Video Chart Design
+
+## Scope
+
+This chart deploys OpenReel Video as a static browser application served by the
+HelmForge-maintained image.
+
+Supported exposure modes:
+
+- ClusterIP Service with port-forward access
+- Ingress with `ingress.ingressClassName`
+- Gateway API HTTPRoute through the single `gateway` values block
+- ExternalName Service when a platform needs a compatibility Service record
+
+## Architecture
+
+```mermaid
+flowchart TB
+  browser[Browser with WebCodecs/WASM support] --> route[Ingress or HTTPRoute]
+  route --> svc[OpenReel Video Service]
+  svc --> web[OpenReel Video Deployment]
+  web --> tmp[(emptyDir /tmp)]
+```
+
+The workload is intentionally stateless. User media processing happens in the
+browser and the chart does not deploy background workers, databases, object
+storage, or queues.
+
+## Main Design Choices
+
+- Use the HelmForge-maintained `docker.io/helmforge/openreel-video` image.
+- Keep the runtime non-root and read-only, with a small `/tmp` emptyDir for
+  NGINX temporary files.
+- Use one Gateway API values block named `gateway`, matching other HelmForge
+  application charts.
+- Use `ingress.ingressClassName`, matching the consolidated HelmForge values
+  convention.
+- Keep COOP/COEP behavior in the image so browser APIs such as
+  SharedArrayBuffer, WebCodecs, and WASM workflows work behind common
+  Kubernetes routing layers.
+
+## Explicit Non-Goals
+
+- server-side rendering
+- user authentication
+- persistent media storage
+- background encoding workers
+- database, cache, queue, or object-storage subcharts
+- installing Ingress controllers or Gateway API CRDs
+
+<!-- @AI-METADATA
+type: design
+title: OpenReel Video Chart Design
+description: Design document for the OpenReel Video Helm chart architecture and scope
+keywords: openreel-video, design, static-site, webcodecs, gateway-api
+purpose: Document chart design choices and non-goals
+scope: Chart Design
+relations:
+  - charts/openreel-video/README.md
+  - charts/openreel-video/docs/production.md
+path: charts/openreel-video/DESIGN.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/openreel-video/README.md
+++ b/charts/openreel-video/README.md
@@ -1,0 +1,41 @@
+# OpenReel Video Helm Chart
+
+OpenReel Video is an open-source, browser-based video editor. This chart serves
+the static application with the HelmForge-maintained image and Kubernetes
+defaults tuned for WebCodecs and WASM workloads.
+
+## Highlights
+
+- HelmForge-maintained `docker.io/helmforge/openreel-video:v0.4.0` image.
+- Non-root NGINX runtime on port `8080`.
+- `/healthz` endpoint for probes and Helm tests.
+- COOP/COEP headers are included in the image for SharedArrayBuffer, WebCodecs,
+  and WASM-heavy browser workflows.
+- Gateway API, Ingress, dual-stack Service support, HPA, PDB, NetworkPolicy,
+  schema, and Helm tests.
+
+## Install
+
+```bash
+helm install openreel-video oci://ghcr.io/helmforgedev/helm/openreel-video
+```
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - openreel.example.com
+```
+
+## Local Validation
+
+```bash
+helm lint charts/openreel-video --strict
+helm template openreel-video charts/openreel-video -f charts/openreel-video/ci/ci-values.yaml
+helm unittest charts/openreel-video
+```

--- a/charts/openreel-video/README.md
+++ b/charts/openreel-video/README.md
@@ -13,6 +13,7 @@ defaults tuned for WebCodecs and WASM workloads.
   and WASM-heavy browser workflows.
 - Gateway API, Ingress, dual-stack Service support, HPA, PDB, NetworkPolicy,
   schema, and Helm tests.
+- Production, networking, and runtime documentation with runnable examples.
 
 ## Install
 
@@ -23,7 +24,7 @@ helm install openreel-video oci://ghcr.io/helmforgedev/helm/openreel-video
 ## Gateway API
 
 ```yaml
-gatewayAPI:
+gateway:
   enabled: true
   parentRefs:
     - name: public
@@ -32,10 +33,32 @@ gatewayAPI:
     - openreel.example.com
 ```
 
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: openreel.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Documentation
+
+- [Design](DESIGN.md)
+- [Production guide](docs/production.md)
+- [Networking](docs/networking.md)
+- [Runtime](docs/runtime.md)
+- [Examples](examples/)
+
 ## Local Validation
 
 ```bash
 helm lint charts/openreel-video --strict
 helm template openreel-video charts/openreel-video -f charts/openreel-video/ci/ci-values.yaml
 helm unittest charts/openreel-video
+kubeconform -strict -summary rendered.yaml
 ```

--- a/charts/openreel-video/ci/ci-values.yaml
+++ b/charts/openreel-video/ci/ci-values.yaml
@@ -9,13 +9,14 @@ service:
 
 ingress:
   enabled: true
+  ingressClassName: nginx
   hosts:
     - host: openreel.example.com
       paths:
         - path: /
           pathType: Prefix
 
-gatewayAPI:
+gateway:
   enabled: true
   parentRefs:
     - name: public

--- a/charts/openreel-video/ci/ci-values.yaml
+++ b/charts/openreel-video/ci/ci-values.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  hosts:
+    - host: openreel.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - openreel.example.com
+
+networkPolicy:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 4
+
+pdb:
+  enabled: true
+  minAvailable: 1

--- a/charts/openreel-video/ci/k3d-values.yaml
+++ b/charts/openreel-video/ci/k3d-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 1
+
+pdb:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi

--- a/charts/openreel-video/docs/networking.md
+++ b/charts/openreel-video/docs/networking.md
@@ -1,0 +1,55 @@
+# Networking
+
+The chart exposes OpenReel Video through a ClusterIP Service by default.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: openreel.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Gateway API
+
+`gateway.enabled` renders one HTTPRoute. `gateway.parentRefs` is required.
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - openreel.example.com
+```
+
+## Dual Stack
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+<!-- @AI-METADATA
+type: chart-docs
+title: OpenReel Video Networking
+description: Service, Ingress, Gateway API, and dual-stack configuration for OpenReel Video
+keywords: openreel-video, networking, ingress, gateway-api, dual-stack
+purpose: Explain networking options
+scope: Chart Operations
+relations:
+  - charts/openreel-video/README.md
+  - charts/openreel-video/examples/gateway.yaml
+path: charts/openreel-video/docs/networking.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/openreel-video/docs/production.md
+++ b/charts/openreel-video/docs/production.md
@@ -1,0 +1,44 @@
+# Production
+
+OpenReel Video is stateless, but production deployments still need explicit
+networking, resource, and security choices.
+
+Use [examples/production.yaml](../examples/production.yaml) as a starting point.
+
+## Baseline
+
+- Configure HTTPS through Ingress or Gateway API.
+- Keep `resources.requests` and `resources.limits` explicit.
+- Use at least two replicas when running behind a production route.
+- Enable `networkPolicy.enabled=true` after confirming traffic from the chosen
+  ingress controller or Gateway implementation.
+- Keep `tmpVolume.enabled=true` for non-root NGINX temporary files.
+
+## Browser Isolation Headers
+
+The HelmForge image includes COOP/COEP headers for browser APIs used by video
+editing workflows. If an edge proxy rewrites headers, preserve the image
+defaults or add equivalent headers at the proxy layer.
+
+## Validation
+
+```bash
+helm test openreel-video -n openreel-video
+kubectl get events -n openreel-video --sort-by=.lastTimestamp
+kubectl logs -n openreel-video deploy/openreel-video --since=10m
+```
+
+<!-- @AI-METADATA
+type: chart-docs
+title: OpenReel Video Production
+description: Production deployment guidance for the OpenReel Video Helm chart
+keywords: openreel-video, production, webcodecs, ingress, gateway-api
+purpose: Production hardening guide for OpenReel Video
+scope: Chart Operations
+relations:
+  - charts/openreel-video/README.md
+  - charts/openreel-video/examples/production.yaml
+path: charts/openreel-video/docs/production.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/openreel-video/docs/runtime.md
+++ b/charts/openreel-video/docs/runtime.md
@@ -1,0 +1,35 @@
+# Runtime
+
+OpenReel Video is served as static content from the HelmForge image.
+
+## Container
+
+The chart runs the container as a non-root user, drops Linux capabilities, uses
+the runtime default seccomp profile, and keeps the root filesystem read-only.
+
+`tmpVolume.enabled=true` mounts a small `emptyDir` at `/tmp` so NGINX can write
+temporary files without requiring a writable image filesystem.
+
+## Health
+
+The image exposes `/healthz` for readiness, liveness, and Helm tests.
+
+## ExternalName Mode
+
+`service.type=ExternalName` is supported for migration or compatibility
+scenarios where consumers expect the chart Service name but traffic should point
+to another DNS name.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: OpenReel Video Runtime
+description: Runtime and health behavior for OpenReel Video
+keywords: openreel-video, runtime, nginx, health
+purpose: Explain runtime assumptions and health checks
+scope: Chart Operations
+relations:
+  - charts/openreel-video/DESIGN.md
+path: charts/openreel-video/docs/runtime.md
+version: 1.0
+date: 2026-05-29
+-->

--- a/charts/openreel-video/examples/external-name.yaml
+++ b/charts/openreel-video/examples/external-name.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Compatibility Service that points consumers to an externally hosted OpenReel Video endpoint
+
+service:
+  type: ExternalName
+  externalName: openreel-static.example.com
+
+ingress:
+  enabled: false
+
+gateway:
+  enabled: false

--- a/charts/openreel-video/examples/gateway.yaml
+++ b/charts/openreel-video/examples/gateway.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# OpenReel Video exposed with Gateway API
+
+replicaCount: 2
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - openreel.example.com
+  path: /
+  pathType: PathPrefix
+
+networkPolicy:
+  enabled: true

--- a/charts/openreel-video/examples/production.yaml
+++ b/charts/openreel-video/examples/production.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production OpenReel Video with Ingress, dual-stack Service, and HA replicas
+
+replicaCount: 2
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: openreel.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: openreel-video-tls
+      hosts:
+        - openreel.example.com
+
+networkPolicy:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 6
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: openreel-video

--- a/charts/openreel-video/templates/NOTES.txt
+++ b/charts/openreel-video/templates/NOTES.txt
@@ -1,0 +1,10 @@
+OpenReel Video has been deployed.
+
+Service:
+  {{ include "openreel-video.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Health:
+  /healthz
+
+Image:
+  {{ include "openreel-video.image" . }}

--- a/charts/openreel-video/templates/NOTES.txt
+++ b/charts/openreel-video/templates/NOTES.txt
@@ -1,10 +1,48 @@
-OpenReel Video has been deployed.
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+=============================================================================
+OpenReel Video deployed successfully!
+=============================================================================
 
-Service:
-  {{ include "openreel-video.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+ACCESS:
+{{- if .Values.ingress.enabled }}
+  {{- range .Values.ingress.hosts }}
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+  {{- end }}
+{{- else if and .Values.gateway.enabled .Values.gateway.hostnames }}
+  {{- range .Values.gateway.hostnames }}
+   https://{{ . }}
+  {{- end }}
+{{- else }}
+   kubectl port-forward svc/{{ include "openreel-video.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
+   Open: http://localhost:8080
+{{- end }}
 
-Health:
-  /healthz
+SERVICE:
+   Internal: {{ include "openreel-video.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Health:   /healthz
+   Image:    {{ include "openreel-video.image" . }}
 
-Image:
-  {{ include "openreel-video.image" . }}
+RUNTIME:
+   Static web editor: enabled
+   Container port: {{ .Values.service.targetPort }}
+   Temporary volume: {{ ternary "enabled" "disabled" .Values.tmpVolume.enabled }}
+
+OPERATIONS:
+   Run Helm tests:
+     helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Inspect pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+     kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "openreel-video.fullname" . }}
+
+PRODUCTION REMINDERS:
+   1. Configure Ingress or Gateway API with HTTPS and COOP/COEP-compatible edge behavior.
+   2. Keep resource limits explicit for browser-heavy static asset delivery.
+   3. Enable NetworkPolicy after confirming ingress-controller namespace selectors.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/openreel-video
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/openreel-video
+   OpenReel Video: https://github.com/Augani/openreel-video
+
+=============================================================================

--- a/charts/openreel-video/templates/_helpers.tpl
+++ b/charts/openreel-video/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "openreel-video.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "openreel-video.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "openreel-video.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openreel-video.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "openreel-video.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openreel-video.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "openreel-video.labels" -}}
+helm.sh/chart: {{ include "openreel-video.chart" . }}
+{{ include "openreel-video.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "openreel-video.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "openreel-video.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openreel-video.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}

--- a/charts/openreel-video/templates/deployment.yaml
+++ b/charts/openreel-video/templates/deployment.yaml
@@ -13,10 +13,12 @@ spec:
   selector:
     matchLabels:
       {{- include "openreel-video.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
   template:
     metadata:
       labels:
         {{- include "openreel-video.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/openreel-video/templates/deployment.yaml
+++ b/charts/openreel-video/templates/deployment.yaml
@@ -1,0 +1,98 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "openreel-video.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "openreel-video.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "openreel-video.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: openreel-video
+          image: {{ include "openreel-video.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.tmpVolume.enabled }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- end }}
+      {{- if .Values.tmpVolume.enabled }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmpVolume.sizeLimit }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}

--- a/charts/openreel-video/templates/extra-objects.yaml
+++ b/charts/openreel-video/templates/extra-objects.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/openreel-video/templates/hpa.yaml
+++ b/charts/openreel-video/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "openreel-video.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/openreel-video/templates/httproute.yaml
+++ b/charts/openreel-video/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if or .Values.gateway.enabled .Values.gatewayAPI.enabled }}
+{{- $gateway := ternary .Values.gatewayAPI .Values.gateway .Values.gatewayAPI.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+  {{- with $gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $gateway.parentRefs | nindent 4 }}
+  {{- with $gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ $gateway.pathType }}
+            value: {{ $gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "openreel-video.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/openreel-video/templates/httproute.yaml
+++ b/charts/openreel-video/templates/httproute.yaml
@@ -1,28 +1,35 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if or .Values.gateway.enabled .Values.gatewayAPI.enabled }}
-{{- $gateway := ternary .Values.gatewayAPI .Values.gateway .Values.gatewayAPI.enabled }}
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
+{{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "openreel-video.fullname" . }}
   labels:
     {{- include "openreel-video.labels" . | nindent 4 }}
-  {{- with $gateway.annotations }}
+  {{- with .Values.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml $gateway.parentRefs | nindent 4 }}
-  {{- with $gateway.hostnames }}
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ $gateway.pathType }}
-            value: {{ $gateway.path | quote }}
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
       backendRefs:
         - name: {{ include "openreel-video.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/openreel-video/templates/ingress.yaml
+++ b/charts/openreel-video/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "openreel-video.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/openreel-video/templates/ingress.yaml
+++ b/charts/openreel-video/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.ingress.className }}
+  {{- with .Values.ingress.ingressClassName }}
   ingressClassName: {{ . }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/charts/openreel-video/templates/networkpolicy.yaml
+++ b/charts/openreel-video/templates/networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "openreel-video.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress }}
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+    {{- else }}
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: http
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress }}
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- else }}
+    []
+    {{- end }}
+{{- end }}

--- a/charts/openreel-video/templates/networkpolicy.yaml
+++ b/charts/openreel-video/templates/networkpolicy.yaml
@@ -10,6 +10,7 @@ spec:
   podSelector:
     matchLabels:
       {{- include "openreel-video.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
   policyTypes:
     - Ingress
     - Egress

--- a/charts/openreel-video/templates/pdb.yaml
+++ b/charts/openreel-video/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "openreel-video.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/openreel-video/templates/pdb.yaml
+++ b/charts/openreel-video/templates/pdb.yaml
@@ -11,4 +11,5 @@ spec:
   selector:
     matchLabels:
       {{- include "openreel-video.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
 {{- end }}

--- a/charts/openreel-video/templates/service.yaml
+++ b/charts/openreel-video/templates/service.yaml
@@ -32,4 +32,5 @@ spec:
   {{- if ne .Values.service.type "ExternalName" }}
   selector:
     {{- include "openreel-video.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
   {{- end }}

--- a/charts/openreel-video/templates/service.yaml
+++ b/charts/openreel-video/templates/service.yaml
@@ -1,4 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and (eq .Values.service.type "ExternalName") (not .Values.service.externalName) }}
+{{- fail "service.externalName is required when service.type=ExternalName" }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,6 +14,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "ExternalName" }}
+  externalName: {{ .Values.service.externalName | quote }}
+  {{- end }}
   {{- with .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}
@@ -23,5 +29,7 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+  {{- if ne .Values.service.type "ExternalName" }}
   selector:
     {{- include "openreel-video.selectorLabels" . | nindent 4 }}
+  {{- end }}

--- a/charts/openreel-video/templates/service.yaml
+++ b/charts/openreel-video/templates/service.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openreel-video.fullname" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "openreel-video.selectorLabels" . | nindent 4 }}

--- a/charts/openreel-video/templates/serviceaccount.yaml
+++ b/charts/openreel-video/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openreel-video.serviceAccountName" . }}
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/openreel-video/templates/tests/test-connection.yaml
+++ b/charts/openreel-video/templates/tests/test-connection.yaml
@@ -1,0 +1,41 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "openreel-video.fullname" . }}-test"
+  labels:
+    {{- include "openreel-video.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
+      command:
+        - sh
+        - -ec
+        - |
+          wget -qO- http://{{ include "openreel-video.fullname" . }}:{{ .Values.service.port }}/healthz
+          wget -qO- http://{{ include "openreel-video.fullname" . }}:{{ .Values.service.port }}/ | grep -qi openreel
+          wget -qS -O- http://{{ include "openreel-video.fullname" . }}:{{ .Values.service.port }}/ 2>&1 | grep -qi 'Cross-Origin-Embedder-Policy: require-corp'
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/openreel-video/tests/deployment_test.yaml
+++ b/charts/openreel-video/tests/deployment_test.yaml
@@ -20,6 +20,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: web
 
   - it: should omit replicas when autoscaling is enabled
     set:

--- a/charts/openreel-video/tests/deployment_test.yaml
+++ b/charts/openreel-video/tests/deployment_test.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Deployment
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should use HelmForge OpenReel Video image and hardened pod settings
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/helmforge/openreel-video:v0.4.0
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+
+  - it: should omit replicas when autoscaling is enabled
+    set:
+      autoscaling.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas

--- a/charts/openreel-video/tests/gateway_test.yaml
+++ b/charts/openreel-video/tests/gateway_test.yaml
@@ -6,13 +6,13 @@ release:
   name: test
   namespace: default
 tests:
-  - it: should render HTTPRoute with gatewayAPI values
+  - it: should render HTTPRoute with gateway values
     set:
-      gatewayAPI.enabled: true
-      gatewayAPI.parentRefs:
+      gateway.enabled: true
+      gateway.parentRefs:
         - name: public
           namespace: gateway-system
-      gatewayAPI.hostnames:
+      gateway.hostnames:
         - openreel.example.com
     asserts:
       - isKind:
@@ -23,3 +23,10 @@ tests:
       - equal:
           path: spec.hostnames[0]
           value: openreel.example.com
+
+  - it: should require parentRefs when enabled
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute.

--- a/charts/openreel-video/tests/gateway_test.yaml
+++ b/charts/openreel-video/tests/gateway_test.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render HTTPRoute with gatewayAPI values
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - name: public
+          namespace: gateway-system
+      gatewayAPI.hostnames:
+        - openreel.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.hostnames[0]
+          value: openreel.example.com

--- a/charts/openreel-video/tests/service_test.yaml
+++ b/charts/openreel-video/tests/service_test.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Service
+templates:
+  - templates/service.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render the HTTP service with optional dual-stack settings
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http

--- a/charts/openreel-video/tests/service_test.yaml
+++ b/charts/openreel-video/tests/service_test.yaml
@@ -24,3 +24,24 @@ tests:
       - equal:
           path: spec.ports[0].targetPort
           value: http
+
+  - it: should render ExternalName service without selector
+    set:
+      service.type: ExternalName
+      service.externalName: media.example.com
+    asserts:
+      - equal:
+          path: spec.type
+          value: ExternalName
+      - equal:
+          path: spec.externalName
+          value: media.example.com
+      - notExists:
+          path: spec.selector
+
+  - it: should require externalName for ExternalName service
+    set:
+      service.type: ExternalName
+    asserts:
+      - failedTemplate:
+          errorMessage: service.externalName is required when service.type=ExternalName

--- a/charts/openreel-video/values.schema.json
+++ b/charts/openreel-video/values.schema.json
@@ -25,6 +25,7 @@
       "additionalProperties": true,
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"] },
+        "externalName": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },

--- a/charts/openreel-video/values.schema.json
+++ b/charts/openreel-video/values.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "OpenReel Video Helm Chart Values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "revisionHistoryLimit": { "type": "integer", "minimum": 0 },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "not": { "const": "latest" } },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "serviceAccount": { "type": "object" },
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "targetPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "ingress": { "type": "object" },
+    "gateway": { "type": "object" },
+    "gatewayAPI": { "type": "object" },
+    "networkPolicy": { "type": "object" },
+    "autoscaling": { "type": "object" },
+    "pdb": { "type": "object" },
+    "probes": { "type": "object" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 1 },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array" },
+    "tmpVolume": { "type": "object" },
+    "test": { "type": "object" },
+    "extraObjects": { "type": "array", "items": { "type": "object" } }
+  }
+}

--- a/charts/openreel-video/values.schema.json
+++ b/charts/openreel-video/values.schema.json
@@ -32,9 +32,29 @@
         "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
       }
     },
-    "ingress": { "type": "object" },
-    "gateway": { "type": "object" },
-    "gatewayAPI": { "type": "object" },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "path": { "type": "string" },
+        "pathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] }
+      }
+    },
     "networkPolicy": { "type": "object" },
     "autoscaling": { "type": "object" },
     "pdb": { "type": "object" },

--- a/charts/openreel-video/values.yaml
+++ b/charts/openreel-video/values.yaml
@@ -1,92 +1,178 @@
 # SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# OpenReel Video Helm Chart - Default Values
+# =============================================================================
+
+# -- Override the chart name.
 nameOverride: ""
+
+# -- Override the fully qualified release name.
 fullnameOverride: ""
+
+# -- Additional labels applied to all chart resources.
 commonLabels: {}
 
+# -- Number of OpenReel Video replicas when autoscaling is disabled.
 replicaCount: 1
+
+# -- Number of old ReplicaSets retained by the Deployment.
 revisionHistoryLimit: 3
 
 image:
+  # -- OpenReel Video image repository maintained by HelmForge.
   repository: docker.io/helmforge/openreel-video
+  # -- OpenReel Video image tag. Do not use latest.
   tag: "v0.4.0"
+  # -- Image pull policy.
   pullPolicy: IfNotPresent
 
+# -- Image pull secrets.
 imagePullSecrets: []
 
+# =============================================================================
+# Service Account
+# =============================================================================
+
 serviceAccount:
+  # -- Create a dedicated ServiceAccount.
   create: true
+  # -- ServiceAccount name override.
   name: ""
+  # -- ServiceAccount annotations.
   annotations: {}
+  # -- Mount the ServiceAccount token into OpenReel Video pods.
   automountServiceAccountToken: false
 
+# =============================================================================
+# Service
+# =============================================================================
+
 service:
+  # -- Service type for OpenReel Video HTTP traffic.
   type: ClusterIP
+  # -- ExternalName target when service.type=ExternalName.
   externalName: ""
+  # -- Service port.
   port: 80
+  # -- Container target port.
   targetPort: 8080
+  # -- Service annotations.
   annotations: {}
+  # -- Service IP family policy: SingleStack, PreferDualStack, RequireDualStack. Empty uses cluster default.
   ipFamilyPolicy: ""
+  # -- Service IP families override. Empty uses cluster default.
   ipFamilies: []
 
+# =============================================================================
+# Ingress
+# =============================================================================
+
 ingress:
+  # -- Enable Ingress.
   enabled: false
-  className: ""
+  # -- Ingress class name.
+  # ingressClassName: traefik
+  ingressClassName: ""
+  # -- Ingress annotations.
   annotations: {}
+  # -- Ingress hosts and paths.
   hosts:
     - host: openreel.local
       paths:
         - path: /
           pathType: Prefix
+  # -- Ingress TLS configuration.
   tls: []
 
+# =============================================================================
+# Gateway API
+# =============================================================================
+
 gateway:
+  # -- Enable Gateway API HTTPRoute. Requires Gateway API CRDs and parentRefs.
   enabled: false
+  # -- HTTPRoute annotations.
   annotations: {}
+  # -- parentRefs pointing to existing Gateway resources.
   parentRefs: []
+  # -- Hostnames matched by the HTTPRoute.
   hostnames: []
+  # -- HTTPRoute path value.
   path: /
+  # -- HTTPRoute path match type.
   pathType: PathPrefix
 
-gatewayAPI:
-  enabled: false
-  annotations: {}
-  parentRefs: []
-  hostnames: []
-  path: /
-  pathType: PathPrefix
+# =============================================================================
+# Network Policy
+# =============================================================================
 
 networkPolicy:
+  # -- Enable NetworkPolicy for OpenReel Video pods.
   enabled: false
+  # -- Additional ingress rules appended to the default web policy.
   ingress: []
+  # -- Additional egress rules appended to the default web policy.
   egress: []
 
+# =============================================================================
+# Autoscaling and Availability
+# =============================================================================
+
 autoscaling:
+  # -- Enable HorizontalPodAutoscaler.
   enabled: false
+  # -- Minimum replicas.
   minReplicas: 1
+  # -- Maximum replicas.
   maxReplicas: 4
+  # -- Target CPU utilization percentage.
   targetCPUUtilizationPercentage: 70
+  # -- Target memory utilization percentage.
   targetMemoryUtilizationPercentage: 80
 
 pdb:
+  # -- Enable PodDisruptionBudget.
   enabled: true
+  # -- Minimum available pods for the PodDisruptionBudget.
   minAvailable: 1
+
+# =============================================================================
+# Probes
+# =============================================================================
 
 probes:
   liveness:
+    # -- Enable liveness probe.
     enabled: true
+    # -- Liveness probe path.
     path: /healthz
+    # -- Liveness probe initial delay in seconds.
     initialDelaySeconds: 10
+    # -- Liveness probe period in seconds.
     periodSeconds: 20
+    # -- Liveness probe timeout in seconds.
     timeoutSeconds: 5
+    # -- Liveness probe failure threshold.
     failureThreshold: 3
   readiness:
+    # -- Enable readiness probe.
     enabled: true
+    # -- Readiness probe path.
     path: /healthz
+    # -- Readiness probe initial delay in seconds.
     initialDelaySeconds: 5
+    # -- Readiness probe period in seconds.
     periodSeconds: 10
+    # -- Readiness probe timeout in seconds.
     timeoutSeconds: 5
+    # -- Readiness probe failure threshold.
     failureThreshold: 3
 
+# =============================================================================
+# Security and Resources
+# =============================================================================
+
+# -- Container resource requests and limits.
 resources:
   requests:
     cpu: 25m
@@ -95,6 +181,7 @@ resources:
     cpu: 250m
     memory: 128Mi
 
+# -- Pod security context.
 podSecurityContext:
   runAsNonRoot: true
   runAsUser: 101
@@ -103,6 +190,7 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# -- Container security context.
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -110,23 +198,56 @@ securityContext:
     drop:
       - ALL
 
+# =============================================================================
+# Scheduling
+# =============================================================================
+
+# -- Additional pod annotations.
 podAnnotations: {}
+
+# -- Additional pod labels.
 podLabels: {}
+
+# -- Priority class name.
 priorityClassName: ""
+
+# -- Grace period for shutdown in seconds.
 terminationGracePeriodSeconds: 30
+
+# -- Node selector for pod scheduling.
 nodeSelector: {}
+
+# -- Tolerations for pod scheduling.
 tolerations: []
+
+# -- Affinity rules for pod scheduling.
 affinity: {}
+
+# -- Topology spread constraints for pod scheduling.
 topologySpreadConstraints: []
 
+# =============================================================================
+# Runtime Volumes
+# =============================================================================
+
 tmpVolume:
+  # -- Mount an emptyDir at /tmp for the non-root NGINX runtime.
   enabled: true
+  # -- Size limit for the /tmp emptyDir volume.
   sizeLimit: 64Mi
+
+# =============================================================================
+# Tests and Extensions
+# =============================================================================
 
 test:
   image:
+    # -- Helm test image repository.
     repository: docker.io/library/busybox
+    # -- Helm test image tag.
     tag: "1.37.0"
+    # -- Helm test image pull policy.
     pullPolicy: IfNotPresent
 
+# -- Extra Kubernetes manifests rendered with the release.
 extraObjects: []

--- a/charts/openreel-video/values.yaml
+++ b/charts/openreel-video/values.yaml
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+nameOverride: ""
+fullnameOverride: ""
+commonLabels: {}
+
+replicaCount: 1
+revisionHistoryLimit: 3
+
+image:
+  repository: docker.io/helmforge/openreel-video
+  tag: "v0.4.0"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  automountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+  annotations: {}
+  ipFamilyPolicy: ""
+  ipFamilies: []
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: openreel.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+gateway:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+gatewayAPI:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  path: /
+  pathType: PathPrefix
+
+networkPolicy:
+  enabled: false
+  ingress: []
+  egress: []
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+probes:
+  liveness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 10
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+podAnnotations: {}
+podLabels: {}
+priorityClassName: ""
+terminationGracePeriodSeconds: 30
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+tmpVolume:
+  enabled: true
+  sizeLimit: 64Mi
+
+test:
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37.0"
+    pullPolicy: IfNotPresent
+
+extraObjects: []

--- a/charts/openreel-video/values.yaml
+++ b/charts/openreel-video/values.yaml
@@ -21,6 +21,7 @@ serviceAccount:
 
 service:
   type: ClusterIP
+  externalName: ""
   port: 80
   targetPort: 8080
   annotations: {}


### PR DESCRIPTION
## Summary
- Adds the stable OpenReel Video chart using the HelmForge-maintained `docker.io/helmforge/openreel-video:v0.4.0` image.
- Includes Gateway API, Ingress, dual-stack Service settings, HPA, PDB, NetworkPolicy, hardened pod defaults, schema, README, and Helm unit tests.
- Runtime test validates `/healthz`, the SPA home page, and the `Cross-Origin-Embedder-Policy: require-corp` header needed by WebCodecs/WASM-heavy browser workflows.

## Research
- Tavily search was attempted first and failed with the current plan limit, so I used fallback research with Context7/GitHub/source inspection.
- Context7 `/augani/openreel-video` documented Node.js 18+/pnpm 8+, Vite web app on port 5173, production build/preview workflow, and client-side storage/rendering architecture.
- Reviewed upstream latest release `v0.4.0`, published 2026-05-14, with editing templates, audio engine improvements, and performance fixes.
- No suitable public app image was found, so I created `helmforgedev/openreel-video` and configured Docker Hub secrets.

## Image validation
- Local image build passed: `docker build --build-arg OPENREEL_VERSION=v0.4.0 -t helmforge/openreel-video:v0.4.0 .`.
- Local smoke test passed: `/healthz` returned `OK`, `/` contained `OpenReel`, and COOP/COEP headers were present.
- Image workflow passed: https://github.com/helmforgedev/openreel-video/actions/runs/26638979128.
- Published image pulled successfully: `helmforge/openreel-video@sha256:fa0964e6a48ddc4bca89436fc2323cd46b3b97ac9d98f327cc1bb8775650657c`.

## Local validation
- `helm lint charts/openreel-video --strict` passed.
- `helm lint charts/openreel-video -f charts/openreel-video/ci/ci-values.yaml --strict` passed.
- `helm lint charts/openreel-video -f charts/openreel-video/ci/k3d-values.yaml --strict` passed.
- `helm unittest charts/openreel-video` passed: 3 suites, 4 tests.
- `helm template` default, CI, and k3d renders passed.
- `kubeconform -strict -summary -ignore-missing-schemas` passed: default 5 valid/0 invalid; CI 8 valid/1 skipped/0 invalid; k3d 4 valid/0 invalid.
- `ah lint -p charts/openreel-video` passed.
- `npx -y markdownlint-cli2 charts/openreel-video/README.md` passed.
- MCP HelmForge Chart.lock and guardrail checks passed with no blocking repo policy issues after setting chart license to Apache-2.0.
- Kubescape local scan passed minimum score: overall 93.93939, MITRE 100.00, NSA 95.00, SOC2 80.00, critical/high findings 0.

## k3d runtime validation
- Cluster/context: `k3d-helmforge-tests-wsl`.
- Namespace: `hf-openreel-video`.
- `helm install openreel-video charts/openreel-video -n hf-openreel-video -f charts/openreel-video/ci/k3d-values.yaml --wait --timeout 5m` passed.
- `helm test openreel-video -n hf-openreel-video --timeout 3m --logs` passed.
- Pod was Running and Ready with 0 restarts.
- Log scan found no `error`, `fatal`, `panic`, `exception`, or `traceback` matches.
- Kubernetes Warning events: none.
- Namespace `hf-openreel-video` was deleted after validation.

Resolves #377
