### PR TITLE
fix(redis): deduplicate ServiceMonitor targets

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
-version: 1.6.15
+version: 1.6.16
 appVersion: "8.6.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -26,8 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "update image to 8.6.3 (#263)"
+    - kind: fixed
+      description: "deduplicate Redis ServiceMonitor targets by selecting the dedicated metrics service"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -30,6 +30,7 @@ helm install redis oci://ghcr.io/helmforgedev/helm/redis -f values.yaml
 - optional Redis exporter sidecar and `ServiceMonitor`
 - optional `PodDisruptionBudget`
 - topology-specific Services, StatefulSets, and Redis Cluster bootstrap Job
+- dedicated metrics Service so Prometheus `ServiceMonitor` targets do not duplicate the headless/client Services
 - `extraEnv`, `extraVolumes`, `extraVolumeMounts`, and `extraManifests` extension points
 
 ## Supported architectures
@@ -167,6 +168,11 @@ Enable the Redis exporter sidecar with:
 metrics:
   enabled: true
 ```
+
+When metrics are enabled, the chart creates a dedicated `<release>-redis-metrics`
+Service with `app.kubernetes.io/component=metrics`. The built-in
+`ServiceMonitor` selects only that Service, which avoids duplicate scrape
+targets from the headless and client-facing Services.
 
 When Prometheus Operator is installed, enable a `ServiceMonitor`:
 

--- a/charts/redis/ci/metrics.yaml
+++ b/charts/redis/ci/metrics.yaml
@@ -5,8 +5,24 @@ auth:
   enabled: true
   password: ci-redis-password
 
+standalone:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 metrics:
   enabled: true
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
   serviceMonitor:
     enabled: true
     labels:

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -15,6 +15,7 @@ Redis has been installed.
 - Authentication enabled: {{ .Values.auth.enabled }}
 - Metrics enabled: {{ .Values.metrics.enabled }}
 - ServiceMonitor enabled: {{ and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+- Metrics service: {{ ternary (include "redis.metricsServiceName" .) "(not rendered)" .Values.metrics.enabled }}
 - PodDisruptionBudget enabled: {{ .Values.pdb.enabled }}
 - External Secrets enabled: {{ .Values.externalSecrets.enabled }}
 
@@ -69,6 +70,12 @@ Service IP family policy: {{ .Values.service.ipFamilyPolicy }}
 {{- end }}
 {{- if .Values.service.ipFamilies }}
 Service IP families: {{ join ", " .Values.service.ipFamilies }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+
+Metrics service:
+- Name: {{ include "redis.metricsServiceName" . }}
+- Port: {{ .Values.service.ports.metrics }}
 {{- end }}
 
 3. Credentials

--- a/charts/redis/templates/cluster-statefulset.yaml
+++ b/charts/redis/templates/cluster-statefulset.yaml
@@ -100,6 +100,12 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/redis/templates/replication-primary-statefulset.yaml
+++ b/charts/redis/templates/replication-primary-statefulset.yaml
@@ -89,6 +89,12 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/redis/templates/replication-replica-statefulset.yaml
+++ b/charts/redis/templates/replication-replica-statefulset.yaml
@@ -91,6 +91,12 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.service.ports.metrics }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "redis.headlessServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-headless
 spec:
   clusterIP: None
   publishNotReadyAddresses: true
@@ -24,6 +25,33 @@ spec:
     app.kubernetes.io/component: redis
 {{- end }}
 
+{{- if and .Values.metrics.enabled (or (include "redis.isStandalone" .) (include "redis.isReplication" .) (include "redis.isSentinel" .) (include "redis.isCluster" .)) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.metricsServiceName" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+  selector:
+    {{- include "redis.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}
+
 {{- if include "redis.isStandalone" . }}
 ---
 apiVersion: v1
@@ -32,6 +60,7 @@ metadata:
   name: {{ include "redis.clientServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-client
   {{- with .Values.service.clientAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -68,6 +97,7 @@ metadata:
   name: {{ include "redis.primaryServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-primary
   {{- with .Values.service.primaryAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -101,6 +131,7 @@ metadata:
   name: {{ include "redis.replicaServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-replica
   {{- with .Values.service.replicaAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -137,6 +168,7 @@ metadata:
   name: {{ include "redis.sentinelServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
   {{- with .Values.service.sentinelAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -167,6 +199,7 @@ metadata:
   name: {{ include "redis.clientServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis-client
   {{- with .Values.service.clusterAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -16,6 +16,7 @@ spec:
   selector:
     matchLabels:
       {{- include "redis.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/redis/templates/standalone-statefulset.yaml
+++ b/charts/redis/templates/standalone-statefulset.yaml
@@ -100,6 +100,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/redis/tests/service_test.yaml
+++ b/charts/redis/tests/service_test.yaml
@@ -20,6 +20,9 @@ tests:
           path: metadata.name
           value: test-redis-headless
       - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: redis-headless
+      - equal:
           path: spec.clusterIP
           value: None
 
@@ -31,6 +34,9 @@ tests:
       - equal:
           path: metadata.name
           value: test-redis-client
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: redis-client
       - equal:
           path: spec.type
           value: ClusterIP
@@ -44,3 +50,29 @@ tests:
             name: redis
             port: 6379
             targetPort: redis
+
+  - it: should render a dedicated metrics service when metrics are enabled
+    set:
+      metrics.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: test-redis-metrics
+        documentIndex: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: metrics
+        documentIndex: 1
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: redis
+        documentIndex: 1
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+            port: 9121
+            targetPort: metrics
+        documentIndex: 1

--- a/charts/redis/tests/servicemonitor_test.yaml
+++ b/charts/redis/tests/servicemonitor_test.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ServiceMonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should select only the dedicated metrics service
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.labels.release: prometheus
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.name
+          value: test-redis
+      - equal:
+          path: metadata.labels.release
+          value: prometheus
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: redis
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: test
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: metrics
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -66,6 +66,18 @@ tests:
       - isNotNull:
           path: spec.template.spec.containers[0].readinessProbe
 
+  - it: should harden the metrics exporter when metrics are enabled
+    template: standalone-statefulset.yaml
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+
   - it: should create VolumeClaimTemplate with default 8Gi
     template: standalone-statefulset.yaml
     asserts:


### PR DESCRIPTION
Closes #381

## Summary
- Add a dedicated Redis metrics Service and make the ServiceMonitor select only `app.kubernetes.io/component=metrics`.
- Add distinct component labels to Redis Services so headless, client, primary, replica, sentinel, and metrics Services are selectable independently.
- Apply the chart security context to Redis exporter sidecars and extend Service/ServiceMonitor unit coverage.
- Document the dedicated metrics Service in the Redis README and NOTES.

## Validation
- `helm dependency build charts/redis`
- `helm dependency list charts/redis`
- `helm lint charts/redis`
- `helm lint charts/redis --strict`
- `helm unittest charts/redis` (6 suites, 30 tests)
- `helm template redis-test charts/redis`
- `helm template` for all `charts/redis/ci/*.yaml` scenarios
- `helm template redis-test charts/redis | kubeconform -strict -summary`
- `helm template redis charts/redis -f charts/redis/ci/metrics.yaml | kubeconform -strict -ignore-missing-schemas -summary`
- `ah lint charts/redis`
- `kubescape scan framework nsa` against the metrics scenario (score 85)
- K3D runtime validation on `k3d-helmforge-tests-wsl` with `metrics.enabled=true` and `metrics.serviceMonitor.enabled=true`:
  - installed with `helm upgrade --install --wait`
  - pod `redis-381-0` Ready `2/2`, `0` restarts
  - Redis `PING` returned `PONG`
  - metrics Service returned `redis_up 1`
  - ServiceMonitor selector matched only `service/redis-381-metrics`
  - no Warning events
  - Redis and metrics container logs inspected with no error/fatal/panic/failed lines
  - namespace and temporary ServiceMonitor CRD cleaned