### PR TITLE
chore(charts): promote remaining charts to stable

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "9.4.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
@@ -26,14 +26,16 @@ sources:
   - https://hub.docker.com/_/elasticsearch
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "harden namespace and backup support (#350)"
+    - kind: changed
+      description: "promote chart maturity to stable"
+    - kind: fixed
+      description: "delay startup probe to avoid transient warning events during local startup"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -428,7 +428,7 @@ readinessProbe:
 
 startupProbe:
   enabled: true
-  initialDelaySeconds: 20
+  initialDelaySeconds: 60
   periodSeconds: 15
   timeoutSeconds: 10
   failureThreshold: 40

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: "v1.8.0"
 kubeVersion: ">=1.24.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
@@ -29,8 +29,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "support namespace override (#346)"
+    - kind: changed
+      description: "promote chart maturity to stable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -38,8 +38,7 @@ annotations:
       email: maicon.berloffa@gmail.com
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
-  artifacthub.io/prerelease: "true"
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/fastmcp-server/Chart.yaml
+++ b/charts/fastmcp-server/Chart.yaml
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: fastmcp-server
 description: FastMCP server with dynamic tool, resource, prompt, and knowledge base loading from inline, S3, and Git sources
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: "0.11.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -23,14 +24,14 @@ sources:
 icon: https://helmforge.dev/icons/charts/fastmcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "harden namespace and gateway support (#354)"
+    - kind: changed
+      description: "promote chart maturity to stable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: incubating
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/gophish/Chart.yaml
+++ b/charts/gophish/Chart.yaml
@@ -1,8 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: gophish
 description: Gophish phishing awareness platform with separated admin and campaign traffic
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.12.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -20,14 +21,14 @@ sources:
 icon: https://helmforge.dev/icons/charts/gophish.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add Gateway API routes (#345)"
+    - kind: changed
+      description: "promote chart maturity to stable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -5,7 +5,7 @@ description: Hoppscotch Community Edition for Kubernetes — open-source API dev
 home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "2026.4.1"
 kubeVersion: ">=1.26.0-0"
 
@@ -29,8 +29,8 @@ dependencies:
 
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "harden namespace and database support (#352)"
+    - kind: changed
+      description: "promote chart maturity to stable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -38,7 +38,7 @@ annotations:
       email: maicon.berloffa@gmail.com
   artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/signKey: |

--- a/charts/jupyterhub/Chart.yaml
+++ b/charts/jupyterhub/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: jupyterhub
 description: JupyterHub Helm Chart with configurable-http-proxy, KubeSpawner, Gateway API, and secure Kubernetes defaults
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "5.4.6"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -22,11 +22,11 @@ sources:
   - https://github.com/helmforgedev/charts
   - https://github.com/jupyterhub/jupyterhub
   - https://github.com/jupyterhub/zero-to-jupyterhub-k8s
-icon: https://jupyter.org/assets/logos/rectanglelogo-greytext-orangebody-greymoons.svg
+icon: https://helmforge.dev/icons/charts/jupyterhub.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add JupyterHub chart (#372)"
+    - kind: changed
+      description: "use HelmForge-hosted JupyterHub chart icon"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: memcached
 description: Memcached Helm Chart for standalone and distributed cache topologies
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.6.42"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -24,14 +24,14 @@ sources:
 icon: https://helmforge.dev/icons/charts/memcached.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "apply dual-stack to metrics service (#344)"
+    - kind: changed
+      description: "promote chart maturity to stable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D

--- a/charts/openhab/Chart.yaml
+++ b/charts/openhab/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: openhab
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "5.1.4"
 kubeVersion: ">=1.26.0-0"
 description: Production-ready openHAB home automation platform for Kubernetes
@@ -24,8 +24,8 @@ sources:
   - https://github.com/openhab/openhab-core
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "harden namespace and networking support (#348)"
+    - kind: changed
+      description: "promote chart maturity to stable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -33,8 +33,7 @@ annotations:
       email: maicon.berlofaa@gmail.com
   artifacthub.io/license: Apache-2.0
   artifacthub.io/category: integration-delivery
-  artifacthub.io/prerelease: "true"
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D


### PR DESCRIPTION
## Summary
- Promote the remaining non-stable chart metadata to stable for Elasticsearch, Envoy Gateway, FastMCP Server, Gophish, Hoppscotch, Memcached, and openHAB.
- Remove prerelease annotations where present and move JupyterHub to the HelmForge-hosted icon URL.
- Increase Elasticsearch startup probe delay from 20s to 60s to avoid transient warning events during local startup.

## Validation
- `helm dependency build` and `helm dependency list` passed for all changed charts.
- `helm lint` and `helm lint --strict` passed for all changed charts.
- `helm template` default and all `ci/*.yaml` scenarios passed for all changed charts.
- `helm unittest --with-subchart=false` passed for changed charts with test suites.
- `ah lint -p` passed for all changed charts.
- `kubeconform -strict -summary` passed with the default schemas and Datree CRD catalog for all changed charts.
- `kubescape scan framework "MITRE,NSA,SOC2"` passed locally; lowest score was Envoy Gateway at 74.75.
- Runtime validation passed on local `k3d-helmforge-tests-wsl` using CI values for Elasticsearch, Envoy Gateway, FastMCP Server, Gophish, Hoppscotch, JupyterHub, Memcached, and openHAB.
- Runtime logs and Warning events were checked clean; Helm test passed for Hoppscotch, JupyterHub, and Memcached.
- Test namespaces and temporary Gateway API / Envoy Gateway CRDs were removed after validation.

## Site
- Matching site metadata and icon updates are in helmforgedev/site PR.