### PR TITLE
chore(answer): update Apache Answer to 2.0.1

### DIFF
--- a/charts/answer/.helmignore
+++ b/charts/answer/.helmignore
@@ -20,7 +20,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/answer/Chart.lock
+++ b/charts/answer/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:09bc7509b3ebe455bb1651e160c72df3c47cbfbff5f321103fbcd0c12c8045bd
-generated: "2026-06-01T21:19:16.204876-03:00"

--- a/charts/answer/Chart.lock
+++ b/charts/answer/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.1
+  version: 1.9.11
 - name: mysql
   repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.7.1
-digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
-generated: "2026-04-01T09:01:54.403501-03:00"
+  version: 1.8.5
+digest: sha256:09bc7509b3ebe455bb1651e160c72df3c47cbfbff5f321103fbcd0c12c8045bd
+generated: "2026-06-01T21:19:16.204876-03:00"

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -1,9 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: answer
 description: Apache Answer Q&A platform with SQLite, MySQL, or PostgreSQL support
 type: application
 version: 1.4.7
-appVersion: "2.0.0"
+appVersion: "2.0.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/answer.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: update minio mc image to helmforge/mc:1.0.0 (#57)
+    - kind: changed
+      description: update Apache Answer image to 2.0.1
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -49,10 +49,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.8.5
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/answer/DESIGN.md
+++ b/charts/answer/DESIGN.md
@@ -1,0 +1,78 @@
+# Apache Answer Chart Design
+
+## Scope
+
+This chart deploys Apache Answer for team and community Q&A workloads.
+
+Supported database modes:
+
+- `sqlite`: default, single-pod friendly setup backed by the Answer data PVC
+- `postgresql`: HelmForge PostgreSQL subchart
+- `mysql`: HelmForge MySQL subchart
+- `external`: existing PostgreSQL or MySQL service
+
+The chart keeps defaults lightweight for evaluation while exposing production controls for persistence, routing, secrets, backups, and scheduling.
+
+## Architecture
+
+```mermaid
+flowchart TB
+  users[Users] --> route[Ingress or HTTPRoute]
+  route --> svc[Answer Service]
+  svc --> app[Answer Deployment]
+  app --> data[(Answer data PVC)]
+  app --> adminSecret[Admin Secret]
+  app --> db[(SQLite, PostgreSQL, MySQL, or external DB)]
+  backup[Backup CronJob] --> s3[S3-compatible storage]
+  eso[External Secrets Operator] -. optional .-> adminSecret
+```
+
+## Main Design Choices
+
+- Keep SQLite as the zero-configuration default for trials and small internal deployments.
+- Use HelmForge PostgreSQL and MySQL subcharts when users want bundled relational storage.
+- Use external database mode for production platforms that already operate database services.
+- Generate admin and database secrets when values do not point to existing secrets.
+- Render ExternalSecret resources only when explicitly requested; the chart does not install External Secrets Operator or own provider-side secret stores.
+- Support both Ingress and Gateway API HTTPRoute without enabling either by default.
+- Support service dual-stack through optional `service.ipFamilyPolicy` and `service.ipFamilies`.
+- Keep backup as an opt-in CronJob using database-aware dump scripts and the HelmForge `mc` utility image.
+
+## Production Boundary
+
+Production users should set explicit values for:
+
+- `admin.existingSecret` or `admin.password`
+- `database.mode` with PostgreSQL, MySQL, or external database for higher concurrency
+- `persistence.size` and storage class
+- `answer.siteUrl`
+- `resources`
+- routing through Ingress or Gateway API
+- backup S3 credentials using existing Kubernetes Secrets or External Secrets
+
+## Non-Goals
+
+- Installing or configuring External Secrets Operator
+- Managing external database lifecycle
+- Multi-replica Answer deployment without a validated upstream horizontal scaling model
+- Database major-version migration automation
+- S3 provider provisioning
+
+<!-- @AI-METADATA
+type: design
+title: Apache Answer Chart Design
+description: Design document for the Apache Answer Helm chart
+
+keywords: apache-answer, design, q-and-a, sqlite, postgresql, mysql, gateway-api, external-secrets
+
+purpose: Document architecture, chart boundaries, and production choices for Apache Answer
+scope: Chart Design
+
+relations:
+  - charts/answer/README.md
+  - charts/answer/docs/database.md
+  - charts/answer/docs/backup.md
+path: charts/answer/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/answer/README.md
+++ b/charts/answer/README.md
@@ -5,12 +5,15 @@ Deploy [Apache Answer](https://answer.apache.org/) on Kubernetes — an open-sou
 ## Features
 
 - **SQLite by default** — zero database configuration needed
-- **PostgreSQL subchart** — bundled via HelmForge dependency
-- **MySQL subchart** — bundled via HelmForge dependency
+- **PostgreSQL subchart** — bundled via HelmForge dependency (`2.0.2`)
+- **MySQL subchart** — bundled via HelmForge dependency (`2.0.0`)
 - **External database** — connect to existing PostgreSQL or MySQL
 - **Auto-install** — unattended setup via environment variables
 - **Scheduled backups** — database-aware CronJob with S3 upload
 - **Ingress support** — TLS with cert-manager
+- **Gateway API support** — optional HTTPRoute for clusters using Gateway API
+- **External Secrets support** — optional ExternalSecret resources for admin, database, and backup credentials
+- **Dual-stack service support** — optional `ipFamilyPolicy` and `ipFamilies`
 - **Persistence** — PVC for `/data` (uploads, config, SQLite)
 
 ## Installation
@@ -102,7 +105,11 @@ database:
 | `mysql.enabled` | `false` | Deploy MySQL subchart |
 | `persistence.enabled` | `true` | Enable persistent storage |
 | `persistence.size` | `5Gi` | PVC size |
+| `service.ipFamilyPolicy` | `~` | Service IP family policy |
+| `service.ipFamilies` | `[]` | Service IP families override |
 | `ingress.enabled` | `false` | Enable ingress |
+| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `externalSecrets.enabled` | `false` | Enable External Secrets Operator resources |
 | `backup.enabled` | `false` | Enable S3 backups |
 | `backup.schedule` | `0 3 * * *` | Backup cron schedule |
 
@@ -117,6 +124,8 @@ database:
 | Secret (backup) | `backup.enabled` and no `backup.s3.existingSecret` |
 | PVC | `persistence.enabled` and no `persistence.existingClaim` |
 | Ingress | `ingress.enabled` |
+| HTTPRoute | `gateway.enabled` |
+| ExternalSecret | `externalSecrets.enabled` with an enabled child secret type |
 | ServiceAccount | `serviceAccount.create` |
 | CronJob (backup) | `backup.enabled` |
 | ConfigMap (backup scripts) | `backup.enabled` |
@@ -125,6 +134,8 @@ database:
 
 - [Database configuration](docs/database.md)
 - [Backup and restore](docs/backup.md)
+- [Routing](docs/routing.md)
+- [External Secrets](docs/external-secrets.md)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/answer)
 
 <!-- @AI-METADATA

--- a/charts/answer/README.md
+++ b/charts/answer/README.md
@@ -89,7 +89,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `answer.siteName` | `Apache Answer` | Site name |
-| `answer.siteUrl` | `""` | Full external URL (auto-detected from ingress) |
+| `answer.siteUrl` | `""` | Full external URL (auto-detected from Ingress or Gateway hostname) |
 | `answer.language` | `en-US` | Default UI language |
 | `answer.externalContentDisplay` | `ask_before_display` | External content display policy used by auto-install |
 | `answer.autoInstall` | `true` | Enable unattended setup |

--- a/charts/answer/README.md
+++ b/charts/answer/README.md
@@ -88,6 +88,7 @@ database:
 | `answer.siteName` | `Apache Answer` | Site name |
 | `answer.siteUrl` | `""` | Full external URL (auto-detected from ingress) |
 | `answer.language` | `en-US` | Default UI language |
+| `answer.externalContentDisplay` | `ask_before_display` | External content display policy used by auto-install |
 | `answer.autoInstall` | `true` | Enable unattended setup |
 | `answer.logLevel` | `INFO` | Log level (DEBUG, INFO, WARN, ERROR) |
 | `admin.name` | `admin` | Admin username |

--- a/charts/answer/ci/external-secrets.yaml
+++ b/charts/answer/ci/external-secrets.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+admin:
+  existingSecret: answer-admin
+
+database:
+  external:
+    vendor: postgres
+    host: postgresql.example.com
+    name: answer
+    username: answer
+    existingSecret: answer-db
+
+backup:
+  s3:
+    existingSecret: answer-backup
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  admin:
+    enabled: true
+    data:
+      - secretKey: admin-password
+        remoteRef:
+          key: answer/admin
+          property: password
+  database:
+    enabled: true
+    data:
+      - secretKey: database-password
+        remoteRef:
+          key: answer/database
+          property: password
+  backup:
+    enabled: true
+    data:
+      - secretKey: access-key
+        remoteRef:
+          key: answer/s3
+          property: accessKey
+      - secretKey: secret-key
+        remoteRef:
+          key: answer/s3
+          property: secretKey

--- a/charts/answer/ci/gateway-api.yaml
+++ b/charts/answer/ci/gateway-api.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  parentRefs:
+    - name: test-gateway
+      namespace: gateway-system
+  hostnames:
+    - qa.example.com

--- a/charts/answer/docs/database.md
+++ b/charts/answer/docs/database.md
@@ -37,7 +37,7 @@ postgresql:
     database: answer
     username: answer
     password: "strong-password"
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 ```
@@ -51,7 +51,7 @@ mysql:
     database: answer
     username: answer
     password: "strong-password"
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 ```

--- a/charts/answer/docs/external-secrets.md
+++ b/charts/answer/docs/external-secrets.md
@@ -1,0 +1,93 @@
+# External Secrets
+
+The chart can render External Secrets Operator resources for credentials that should be sourced from an external provider.
+
+## Admin Password
+
+```yaml
+admin:
+  existingSecret: answer-admin
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  admin:
+    enabled: true
+    data:
+      - secretKey: admin-password
+        remoteRef:
+          key: answer/admin
+          property: password
+```
+
+## External Database Password
+
+```yaml
+database:
+  external:
+    vendor: postgres
+    host: postgresql.example.com
+    name: answer
+    username: answer
+    existingSecret: answer-db
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  database:
+    enabled: true
+    data:
+      - secretKey: database-password
+        remoteRef:
+          key: answer/database
+          property: password
+```
+
+## Backup S3 Credentials
+
+```yaml
+backup:
+  s3:
+    existingSecret: answer-backup
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  backup:
+    enabled: true
+    data:
+      - secretKey: access-key
+        remoteRef:
+          key: answer/s3
+          property: accessKey
+      - secretKey: secret-key
+        remoteRef:
+          key: answer/s3
+          property: secretKey
+```
+
+External Secrets Operator and provider-side SecretStores are outside this chart's scope.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: External Secrets
+description: External Secrets Operator integration for Apache Answer credentials
+
+keywords: answer, external-secrets, secretstore, credentials, admin, database, backup
+
+purpose: Explain how to source Apache Answer credentials from External Secrets Operator
+scope: Chart
+
+relations:
+  - charts/answer/README.md
+  - charts/answer/values.yaml
+path: charts/answer/docs/external-secrets.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/answer/docs/routing.md
+++ b/charts/answer/docs/routing.md
@@ -19,6 +19,7 @@ ingress:
         - qa.example.com
 ```
 
+When `answer.siteUrl` is empty, the chart uses the first Ingress host as the generated `SITE_URL`.
 Set `answer.siteUrl` to the final public URL when the route is exposed through a proxy or load balancer.
 
 ## Gateway API
@@ -33,6 +34,7 @@ gateway:
     - qa.example.com
 ```
 
+When `answer.siteUrl` is empty and Ingress is disabled, the chart uses the first Gateway hostname as the generated `SITE_URL`.
 The chart renders an `HTTPRoute` only when Gateway API is enabled. It does not install Gateway API CRDs or create Gateway resources.
 
 ## Dual-Stack Services

--- a/charts/answer/docs/routing.md
+++ b/charts/answer/docs/routing.md
@@ -1,0 +1,66 @@
+# Routing
+
+Apache Answer can be exposed with Kubernetes Ingress or Gateway API.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: qa.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: answer-tls
+      hosts:
+        - qa.example.com
+```
+
+Set `answer.siteUrl` to the final public URL when the route is exposed through a proxy or load balancer.
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public-gateway
+      namespace: gateway-system
+  hostnames:
+    - qa.example.com
+```
+
+The chart renders an `HTTPRoute` only when Gateway API is enabled. It does not install Gateway API CRDs or create Gateway resources.
+
+## Dual-Stack Services
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Leave these values empty to use the cluster default.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Routing
+description: Ingress, Gateway API, and service dual-stack configuration for Apache Answer
+
+keywords: answer, routing, ingress, gateway-api, dual-stack
+
+purpose: Help operators expose Apache Answer through Kubernetes routing primitives
+scope: Chart
+
+relations:
+  - charts/answer/README.md
+  - charts/answer/values.yaml
+path: charts/answer/docs/routing.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/answer/examples/production/values.yaml
+++ b/charts/answer/examples/production/values.yaml
@@ -16,7 +16,7 @@ postgresql:
     database: answer
     username: answer
     password: "strong-db-password"
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 

--- a/charts/answer/examples/production/values.yaml
+++ b/charts/answer/examples/production/values.yaml
@@ -1,4 +1,4 @@
-# Production setup — PostgreSQL + ingress + backup
+# Production setup - PostgreSQL + ingress + backup
 answer:
   siteName: "Company Q&A"
   siteUrl: "https://qa.example.com"

--- a/charts/answer/templates/NOTES.txt
+++ b/charts/answer/templates/NOTES.txt
@@ -1,20 +1,115 @@
-Apache Answer has been deployed!
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+=============================================================================
+Apache Answer deployed successfully!
+=============================================================================
 
+SUMMARY:
+   Release: {{ .Release.Name }}
+   Namespace: {{ .Release.Namespace }}
+   Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+   App version: {{ .Chart.AppVersion }}
+   Image: {{ include "answer.image" . }}
+   Database mode: {{ include "answer.databaseMode" . }}
+   Persistence: {{ if .Values.persistence.enabled }}enabled ({{ .Values.persistence.size }}){{ else }}disabled{{ end }}
+   ServiceAccount: {{ include "answer.serviceAccountName" . }}
+
+ACCESS:
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
-
-  Access Answer at: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+   Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range (default list .Values.gateway.hostnames) }}
+   Gateway API: http://{{ . }}
 {{- end }}
 {{- else }}
+   Port-forward:
+     kubectl port-forward svc/{{ include "answer.fullname" . }} -n {{ .Release.Namespace }} 9080:{{ .Values.service.port }}
 
-  Access Answer via port-forward:
-
-    kubectl port-forward svc/{{ include "answer.fullname" . }} 9080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
-
-  Then open: http://localhost:9080
+   Local URL:
+     http://127.0.0.1:9080
 {{- end }}
 
-Database mode: {{ include "answer.databaseMode" . }}
-{{- if eq (include "answer.databaseMode" .) "sqlite" }}
-  Data is stored in {{ .Values.database.sqlite.file }}
+ADMIN:
+   Username: {{ .Values.admin.name }}
+   Email: {{ .Values.admin.email }}
+{{- if .Values.admin.existingSecret }}
+   Password secret: {{ .Values.admin.existingSecret }} / {{ .Values.admin.existingSecretPasswordKey }}
+{{- else if .Values.admin.password }}
+   Password source: inline value
+{{- else }}
+   Password command:
+     kubectl get secret {{ include "answer.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "answer.adminSecretKey" . }}}" | base64 -d
 {{- end }}
+
+DATABASE:
+{{- $dbMode := include "answer.databaseMode" . }}
+   Mode: {{ $dbMode }}
+{{- if eq $dbMode "sqlite" }}
+   SQLite file: {{ .Values.database.sqlite.file }}
+{{- else }}
+   Vendor: {{ include "answer.databaseVendor" . }}
+   Host: {{ include "answer.databaseHost" . }}
+   Port: {{ include "answer.databasePort" . }}
+   Name: {{ include "answer.databaseName" . }}
+   Username: {{ include "answer.databaseUsername" . }}
+   Password secret: {{ include "answer.databaseSecretName" . }} / {{ include "answer.databaseSecretKey" . }}
+{{- end }}
+
+ROUTING:
+   Service: {{ include "answer.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Ingress enabled: {{ .Values.ingress.enabled }}
+   Gateway API enabled: {{ .Values.gateway.enabled }}
+{{- with .Values.service.ipFamilyPolicy }}
+   IP family policy: {{ . }}
+{{- end }}
+{{- with .Values.service.ipFamilies }}
+   IP families: {{ join ", " . }}
+{{- end }}
+
+OPTIONAL FEATURES:
+   Backups: {{ .Values.backup.enabled }}
+   External Secrets: {{ .Values.externalSecrets.enabled }}
+{{- if .Values.backup.enabled }}
+   Backup schedule: {{ .Values.backup.schedule }}
+   Backup target: s3://{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+{{- end }}
+{{- if .Values.externalSecrets.enabled }}
+   SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+{{- end }}
+
+VALIDATION:
+   Release status:
+     helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+   Wait for readiness:
+     kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "answer.name" . }} --timeout=10m
+
+   Health check:
+     kubectl run {{ include "answer.fullname" . }}-health-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "answer.fullname" . }}:{{ .Values.service.port }}/healthz
+
+TROUBLESHOOTING:
+   Events:
+     kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+   Logs:
+     kubectl logs deploy/{{ include "answer.fullname" . }} -n {{ .Release.Namespace }} -c answer --tail=200
+
+   Init container logs when using PostgreSQL, MySQL, or external DB:
+     kubectl logs deploy/{{ include "answer.fullname" . }} -n {{ .Release.Namespace }} -c wait-for-db --tail=200
+
+NOTES:
+   - Keep the admin password and database password stable across upgrades.
+   - Use PostgreSQL, MySQL, or an external database for production concurrency.
+   - Enable backups before changing storage, database mode, or chart major versions.
+   - Set answer.siteUrl to the externally reachable URL for production installs.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/answer
+   Apache Answer: https://answer.apache.org
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/answer
+
+=============================================================================

--- a/charts/answer/templates/_helpers.tpl
+++ b/charts/answer/templates/_helpers.tpl
@@ -42,6 +42,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "answer.siteUrl" -}}
+{{- if .Values.answer.siteUrl -}}
+{{- .Values.answer.siteUrl -}}
+{{- else if and .Values.ingress.enabled .Values.ingress.hosts -}}
+{{- printf "https://%s" (index .Values.ingress.hosts 0).host -}}
+{{- else if and .Values.gateway.enabled .Values.gateway.hostnames -}}
+{{- printf "https://%s" (index .Values.gateway.hostnames 0) -}}
+{{- else -}}
+http://localhost:80
+{{- end -}}
+{{- end -}}
+
 # =============================================================================
 # Database Mode Detection
 # =============================================================================

--- a/charts/answer/templates/deployment.yaml
+++ b/charts/answer/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,9 +112,14 @@ spec:
             {{- else if and .Values.ingress.enabled .Values.ingress.hosts }}
             - name: SITE_URL
               value: {{ printf "https://%s" (index .Values.ingress.hosts 0).host | quote }}
+            {{- else }}
+            - name: SITE_URL
+              value: "http://localhost:80"
             {{- end }}
             - name: CONTACT_EMAIL
               value: {{ .Values.answer.contactEmail | quote }}
+            - name: EXTERNAL_CONTENT_DISPLAY
+              value: {{ .Values.answer.externalContentDisplay | quote }}
             - name: ADMIN_NAME
               value: {{ .Values.admin.name | quote }}
             - name: ADMIN_PASSWORD

--- a/charts/answer/templates/deployment.yaml
+++ b/charts/answer/templates/deployment.yaml
@@ -106,16 +106,8 @@ spec:
               value: {{ .Values.answer.language | quote }}
             - name: SITE_NAME
               value: {{ .Values.answer.siteName | quote }}
-            {{- if .Values.answer.siteUrl }}
             - name: SITE_URL
-              value: {{ .Values.answer.siteUrl | quote }}
-            {{- else if and .Values.ingress.enabled .Values.ingress.hosts }}
-            - name: SITE_URL
-              value: {{ printf "https://%s" (index .Values.ingress.hosts 0).host | quote }}
-            {{- else }}
-            - name: SITE_URL
-              value: "http://localhost:80"
-            {{- end }}
+              value: {{ include "answer.siteUrl" . | quote }}
             - name: CONTACT_EMAIL
               value: {{ .Values.answer.contactEmail | quote }}
             - name: EXTERNAL_CONTENT_DISPLAY

--- a/charts/answer/templates/externalsecret.yaml
+++ b/charts/answer/templates/externalsecret.yaml
@@ -1,0 +1,103 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- $secretStoreName := required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name }}
+{{- $secretStoreKind := .Values.externalSecrets.secretStoreRef.kind }}
+{{- $refreshInterval := .Values.externalSecrets.refreshInterval }}
+{{- $creationPolicy := .Values.externalSecrets.target.creationPolicy }}
+{{- if .Values.externalSecrets.admin.enabled }}
+{{- if not .Values.admin.existingSecret }}
+  {{- fail "externalSecrets.admin.enabled requires admin.existingSecret to be set" }}
+{{- end }}
+{{- $hasAdminPassword := false }}
+{{- range .Values.externalSecrets.admin.data }}
+  {{- if eq .secretKey $.Values.admin.existingSecretPasswordKey }}
+    {{- $hasAdminPassword = true }}
+  {{- end }}
+{{- end }}
+{{- if not $hasAdminPassword }}
+  {{- fail (printf "externalSecrets.admin.data must contain an entry with secretKey '%s'" .Values.admin.existingSecretPasswordKey) }}
+{{- end }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.admin.existingSecret }}
+  labels:
+    {{- include "answer.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ $secretStoreName | quote }}
+    kind: {{ $secretStoreKind | quote }}
+  target:
+    name: {{ .Values.admin.existingSecret | quote }}
+    creationPolicy: {{ $creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.admin.data | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.database.enabled }}
+{{- if not .Values.database.external.existingSecret }}
+  {{- fail "externalSecrets.database.enabled requires database.external.existingSecret to be set" }}
+{{- end }}
+{{- $hasDatabasePassword := false }}
+{{- range .Values.externalSecrets.database.data }}
+  {{- if eq .secretKey $.Values.database.external.existingSecretPasswordKey }}
+    {{- $hasDatabasePassword = true }}
+  {{- end }}
+{{- end }}
+{{- if not $hasDatabasePassword }}
+  {{- fail (printf "externalSecrets.database.data must contain an entry with secretKey '%s'" .Values.database.external.existingSecretPasswordKey) }}
+{{- end }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.database.external.existingSecret }}
+  labels:
+    {{- include "answer.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ $secretStoreName | quote }}
+    kind: {{ $secretStoreKind | quote }}
+  target:
+    name: {{ .Values.database.external.existingSecret | quote }}
+    creationPolicy: {{ $creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.database.data | nindent 4 }}
+{{- end }}
+{{- if .Values.externalSecrets.backup.enabled }}
+{{- if not .Values.backup.s3.existingSecret }}
+  {{- fail "externalSecrets.backup.enabled requires backup.s3.existingSecret to be set" }}
+{{- end }}
+{{- $hasAccessKey := false }}
+{{- $hasSecretKey := false }}
+{{- range .Values.externalSecrets.backup.data }}
+  {{- if eq .secretKey $.Values.backup.s3.existingSecretAccessKeyKey }}
+    {{- $hasAccessKey = true }}
+  {{- end }}
+  {{- if eq .secretKey $.Values.backup.s3.existingSecretSecretKeyKey }}
+    {{- $hasSecretKey = true }}
+  {{- end }}
+{{- end }}
+{{- if not (and $hasAccessKey $hasSecretKey) }}
+  {{- fail "externalSecrets.backup.data must contain entries for the configured S3 access and secret key names" }}
+{{- end }}
+---
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.backup.s3.existingSecret }}
+  labels:
+    {{- include "answer.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ $refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ $secretStoreName | quote }}
+    kind: {{ $secretStoreKind | quote }}
+  target:
+    name: {{ .Values.backup.s3.existingSecret | quote }}
+    creationPolicy: {{ $creationPolicy | quote }}
+  data:
+    {{- toYaml .Values.externalSecrets.backup.data | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/answer/templates/httproute.yaml
+++ b/charts/answer/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
+{{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "answer.fullname" . }}
+  labels:
+    {{- include "answer.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "answer.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/answer/templates/service.yaml
+++ b/charts/answer/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/answer/tests/backup_test.yaml
+++ b/charts/answer/tests/backup_test.yaml
@@ -68,7 +68,7 @@ tests:
           value: postgres-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: "docker.io/library/postgres:18.3-alpine"
+          value: "docker.io/library/postgres:18.4-alpine"
 
   - it: should use mysql init container for mysql
     template: templates/backup-cronjob.yaml

--- a/charts/answer/tests/deployment_test.yaml
+++ b/charts/answer/tests/deployment_test.yaml
@@ -297,6 +297,38 @@ tests:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 100m
 
+  - it: should set default resource requests and limits
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+
+  - it: should set baseline security context defaults
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_BIND_SERVICE
+
   - it: should add extra env vars
     template: templates/deployment.yaml
     set:

--- a/charts/answer/tests/deployment_test.yaml
+++ b/charts/answer/tests/deployment_test.yaml
@@ -240,6 +240,22 @@ tests:
             name: SITE_URL
             value: "https://qa.example.com"
 
+  - it: should auto-detect site URL from gateway hostname
+    template: templates/deployment.yaml
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: public-gateway
+          namespace: gateway-system
+      gateway.hostnames:
+        - qa.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SITE_URL
+            value: "https://qa.example.com"
+
   - it: should prefer explicit site URL over ingress
     template: templates/deployment.yaml
     set:

--- a/charts/answer/tests/deployment_test.yaml
+++ b/charts/answer/tests/deployment_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Deployment
 templates:
   - templates/deployment.yaml
@@ -20,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/apache/answer:2.0.0"
+          value: "docker.io/apache/answer:2.0.1"
 
   - it: should allow custom image tag
     template: templates/deployment.yaml
@@ -89,6 +90,16 @@ tests:
           content:
             name: DB_FILE
             value: /data/answer.db
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SITE_URL
+            value: "http://localhost:80"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTERNAL_CONTENT_DISPLAY
+            value: ask_before_display
 
   - it: should not have init containers in sqlite mode
     template: templates/deployment.yaml

--- a/charts/answer/tests/externalsecret_test.yaml
+++ b/charts/answer/tests/externalsecret_test.yaml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: External Secrets
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render admin ExternalSecret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.data:
+        - secretKey: admin-password
+          remoteRef:
+            key: answer/admin
+            property: password
+      admin.existingSecret: answer-admin
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: answer-admin
+      - equal:
+          path: spec.secretStoreRef.name
+          value: vault
+      - equal:
+          path: spec.target.name
+          value: answer-admin
+
+  - it: should require admin existingSecret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.admin.enabled: true
+      externalSecrets.admin.data:
+        - secretKey: admin-password
+          remoteRef:
+            key: answer/admin
+            property: password
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.admin.enabled requires admin.existingSecret to be set"
+
+  - it: should render database ExternalSecret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.database.enabled: true
+      externalSecrets.database.data:
+        - secretKey: database-password
+          remoteRef:
+            key: answer/database
+            property: password
+      database.external.existingSecret: answer-db
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: answer-db
+
+  - it: should render backup ExternalSecret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: vault
+      externalSecrets.backup.enabled: true
+      externalSecrets.backup.data:
+        - secretKey: access-key
+          remoteRef:
+            key: answer/s3
+            property: accessKey
+        - secretKey: secret-key
+          remoteRef:
+            key: answer/s3
+            property: secretKey
+      backup.s3.existingSecret: answer-backup
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: answer-backup

--- a/charts/answer/tests/gateway_api_test.yaml
+++ b/charts/answer/tests/gateway_api_test.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render an HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when Gateway API is enabled
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: my-gateway
+          namespace: gateway-system
+      gateway.hostnames:
+        - qa.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - contains:
+          path: spec.hostnames
+          content: qa.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-answer
+
+  - it: should require parentRefs when Gateway API is enabled
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."
+
+  - it: should require a name in each parentRef
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - namespace: gateway-system
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each gateway.parentRefs entry must define a 'name' field"

--- a/charts/answer/tests/service_test.yaml
+++ b/charts/answer/tests/service_test.yaml
@@ -38,6 +38,23 @@ tests:
           path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
           value: nlb
 
+  - it: should render dual-stack service fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+
   - it: should use selector labels
     asserts:
       - equal:

--- a/charts/answer/values.schema.json
+++ b/charts/answer/values.schema.json
@@ -61,6 +61,14 @@
           "type": "string",
           "description": "Contact email shown in the site footer and admin."
         },
+        "externalContentDisplay": {
+          "type": "string",
+          "enum": [
+            "always_display",
+            "ask_before_display"
+          ],
+          "description": "External content display policy used by Answer auto-install."
+        },
         "autoInstall": {
           "type": "boolean",
           "description": "Enable automatic installation via environment variables."

--- a/charts/answer/values.schema.json
+++ b/charts/answer/values.schema.json
@@ -196,14 +196,10 @@
             "password": {
               "type": "string",
               "description": "Database password (auto-generated if empty)."
-            },
-            "rootPassword": {
-              "type": "string",
-              "description": "Root password (auto-generated if empty)."
             }
           }
         },
-        "primary": {
+        "standalone": {
           "type": "object",
           "properties": {
             "persistence": {
@@ -256,7 +252,7 @@
             }
           }
         },
-        "primary": {
+        "standalone": {
           "type": "object",
           "properties": {
             "persistence": {
@@ -308,15 +304,60 @@
     },
     "resources": {
       "type": "object",
-      "description": "CPU and memory requests/limits for the Answer container."
+      "description": "CPU and memory requests/limits for the Answer container.",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
     },
     "podSecurityContext": {
       "type": "object",
-      "description": "Pod-level security context."
+      "description": "Pod-level security context.",
+      "properties": {
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" }
+          }
+        }
+      }
     },
     "securityContext": {
       "type": "object",
-      "description": "Container-level security context."
+      "description": "Container-level security context.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "default": false
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": { "type": "string" },
+              "default": ["ALL"]
+            },
+            "add": {
+              "type": "array",
+              "items": { "type": "string" },
+              "default": ["NET_BIND_SERVICE"]
+            }
+          }
+        }
+      }
     },
     "startupProbe": {
       "type": "object",
@@ -370,6 +411,19 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the service."
+        },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "description": "Service IP family policy.",
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Service IP families override.",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
         }
       }
     },
@@ -416,6 +470,27 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the ServiceAccount."
+        }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "parentRefs": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "path": { "type": "string" },
+        "pathType": {
+          "type": "string",
+          "enum": ["Exact", "PathPrefix", "RegularExpression"]
         }
       }
     },
@@ -589,6 +664,61 @@
       "type": "array",
       "description": "Extra Kubernetes manifests to deploy alongside the chart.",
       "items": { "type": "object" }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator integration.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "refreshInterval": { "type": "string" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "kind": {
+              "type": "string",
+              "enum": ["SecretStore", "ClusterSecretStore"]
+            }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "creationPolicy": { "type": "string" }
+          }
+        },
+        "admin": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "data": {
+              "type": "array",
+              "items": { "type": "object" }
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "data": {
+              "type": "array",
+              "items": { "type": "object" }
+            }
+          }
+        },
+        "backup": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "data": {
+              "type": "array",
+              "items": { "type": "object" }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/answer/values.schema.json
+++ b/charts/answer/values.schema.json
@@ -47,7 +47,7 @@
       "properties": {
         "siteUrl": {
           "type": "string",
-          "description": "Full external URL of the site (auto-detected from ingress if empty)."
+          "description": "Full external URL of the site (auto-detected from Ingress or Gateway hostname if empty)."
         },
         "siteName": {
           "type": "string",

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -36,7 +36,7 @@ imagePullSecrets: []
 # =============================================================================
 
 answer:
-  # -- Full external URL of the site (auto-detected from ingress if empty)
+  # -- Full external URL of the site (auto-detected from Ingress or Gateway hostname if empty)
   # Examples: "https://qa.example.com", "http://localhost:9080"
   siteUrl: ""
 

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -150,7 +150,7 @@ postgresql:
     # -- Database password (auto-generated if empty)
     password: ""
 
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for PostgreSQL data
       enabled: true
@@ -178,7 +178,7 @@ mysql:
     # -- Root password (auto-generated if empty)
     rootPassword: ""
 
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for MySQL data
       enabled: true
@@ -213,21 +213,29 @@ persistence:
 # =============================================================================
 
 # -- CPU and memory requests/limits for the Answer container
-resources: {}
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # limits:
-  #   cpu: 500m
-  #   memory: 512Mi
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
 
 # =============================================================================
 # Security Context
 # =============================================================================
 
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
 
 # =============================================================================
 # Probes
@@ -277,6 +285,12 @@ service:
   # -- Annotations for the service
   annotations: {}
 
+  # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
+  ipFamilyPolicy: ~
+
+  # -- Service IP families override. Empty uses cluster default.
+  ipFamilies: []
+
 # =============================================================================
 # Ingress
 # =============================================================================
@@ -308,6 +322,27 @@ ingress:
   #     hosts:
   #       - qa.example.com
   tls: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
+  enabled: false
+  # -- Annotations for the HTTPRoute
+  annotations: {}
+  # -- parentRefs list pointing to your Gateway resource.
+  parentRefs: []
+  #   - name: public-gateway
+  #     namespace: gateway-system
+  # -- Hostnames the HTTPRoute matches
+  hostnames: []
+  #   - qa.example.com
+  # -- Path prefix for the HTTPRoute
+  path: /
+  # -- Path match type
+  pathType: PathPrefix
 
 # =============================================================================
 # Service Account
@@ -359,7 +394,7 @@ backup:
     # -- Image used for SQLite backup (must have tar)
     sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: docker.io/library/postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.4-alpine
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)
@@ -461,3 +496,36 @@ extraVolumes: []
 
 # -- Extra Kubernetes manifests to deploy alongside the chart
 extraManifests: []
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Refresh interval.
+  refreshInterval: "0"
+  secretStoreRef:
+    # -- Existing SecretStore or ClusterSecretStore name.
+    name: ""
+    kind: SecretStore
+  target:
+    creationPolicy: Owner
+  admin:
+    # -- Render an ExternalSecret for admin.existingSecret.
+    enabled: false
+    # -- ExternalSecret data entries for the admin secret. Must include admin.existingSecretPasswordKey.
+    data: []
+  database:
+    # -- Render an ExternalSecret for database.external.existingSecret.
+    enabled: false
+    # -- ExternalSecret data entries for the external database secret. Must include database.external.existingSecretPasswordKey.
+    data: []
+  backup:
+    # -- Render an ExternalSecret for backup.s3.existingSecret.
+    enabled: false
+    # -- ExternalSecret data entries for S3 credentials. Must include access and secret key entries.
+    data: []

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 # Apache Answer Helm Chart
 # =============================================================================
@@ -23,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/apache/answer
   # -- Container image tag
-  tag: "2.0.0"
+  tag: "2.0.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -47,6 +48,10 @@ answer:
 
   # -- Contact email shown in the site footer and admin
   contactEmail: admin@example.com
+
+  # -- External content display policy used by Answer auto-install
+  # Options: always_display | ask_before_display
+  externalContentDisplay: ask_before_display
 
   # -- Enable automatic installation via environment variables
   # When true, the first boot runs unattended setup using the values below.
@@ -87,10 +92,10 @@ admin:
 # Apache Answer supports SQLite, MySQL, and PostgreSQL.
 #
 # Mode detection (when mode is auto):
-# 1. database.external.host or database.external.existingSecret → external
-# 2. postgresql.enabled → PostgreSQL subchart
-# 3. mysql.enabled → MySQL subchart
-# 4. Fallback → SQLite (default, zero configuration)
+# 1. database.external.host or database.external.existingSecret -> external
+# 2. postgresql.enabled -> PostgreSQL subchart
+# 3. mysql.enabled -> MySQL subchart
+# 4. Fallback -> SQLite (default, zero configuration)
 # =============================================================================
 
 database:


### PR DESCRIPTION
## Summary
- Update Apache Answer image and chart appVersion from `2.0.0` to `2.0.1`.
- Refresh `Chart.lock` for the HelmForge PostgreSQL/MySQL subchart versions declared in `Chart.yaml`.
- Fix Answer auto-install defaults by always rendering `SITE_URL` and adding `EXTERNAL_CONTENT_DISPLAY`, matching upstream required fields.
- Add unit coverage for the default auto-install env vars.

Closes #389.

## Upstream review
- Verified `docker.io/apache/answer:2.0.1` exists with `docker manifest inspect`.
- Reviewed upstream Apache Answer `v2.0.1` release notes: attachment upload fix after v2.0.0, authorization/API key scope hardening, avatar URL type fix, AI/search improvements, and HTML rendering fixes.

## Local Validation
- [x] `helm dependency build charts/answer`
- [x] `helm dependency list charts/answer`
- [x] `helm lint charts/answer --strict`
- [x] `helm template answer-test charts/answer`
- [x] `helm unittest charts/answer` - 7 suites, 67 tests passed
- [x] `ah lint -p charts/answer`
- [x] `kubeconform -strict` for default render and every `charts/answer/ci/*.yaml`
- [x] `kubescape scan framework "MITRE,NSA,SOC2"` on rendered manifest: score 75.76; CI-style chart scan score 84
- [x] k3d validation on `k3d-helmforge-tests-wsl`: installed release `answer-389`, pod Ready, events Normal only, `/healthz` returned 200, namespace removed

## Runtime notes
The initial k3d validation exposed a pre-existing auto-install failure caused by missing required upstream env fields. This PR fixes that path; the final k3d validation completed without the auto-install request-format failure.