### PR TITLE
chore(changedetection): update changedetection.io to 0.55.7

### DIFF
--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: changedetection
 description: changedetection.io website change detection and monitoring with optional Playwright browser
 type: application
-version: 1.1.9
-appVersion: "0.55.5"
+version: 1.1.10
+appVersion: "0.55.7"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 0.55.5 (#343)"
+      description: "update changedetection.io to 0.55.7 with upstream security and LLM UI fixes (#391)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/changedetection/DESIGN.md
+++ b/charts/changedetection/DESIGN.md
@@ -33,6 +33,8 @@ User or automation
 - External Secrets support is generic and disabled by default. It is intended
   for environment secrets or notification integration credentials consumed via
   `changedetection.envFrom` or `changedetection.extraEnv`.
+- The upstream `EXTRA_PACKAGES` hook is supported without running the container
+  as root by using a Python user install path under `/datastore`.
 - Service dual-stack fields are optional and rendered only when explicitly set.
 
 ## Security Model

--- a/charts/changedetection/DESIGN.md
+++ b/charts/changedetection/DESIGN.md
@@ -1,0 +1,70 @@
+# changedetection.io Chart Design
+
+This chart packages changedetection.io as a practical single-instance
+Kubernetes workload with persistent SQLite storage and optional browser
+rendering.
+
+## Architecture
+
+```text
+User or automation
+  |
+  +-- Ingress or Gateway API HTTPRoute
+        |
+        +-- Service
+              |
+              +-- Deployment
+                    |-- changedetection.io container
+                    |-- optional browserless Chromium sidecar
+                    +-- PVC mounted at /datastore
+```
+
+## Design Choices
+
+- The workload is a `Deployment` with one replica and `Recreate` strategy
+  because changedetection.io stores runtime state in SQLite under
+  `/datastore`.
+- Persistence is enabled by default so watches, history, and snapshots survive
+  upgrades and pod rescheduling.
+- The optional browser sidecar is colocated in the pod so JavaScript rendering
+  is available through localhost without exposing an additional Service.
+- Gateway API and Ingress are mutually independent disabled-by-default routing
+  options. The chart uses only `gateway`, matching HelmForge naming standards.
+- External Secrets support is generic and disabled by default. It is intended
+  for environment secrets or notification integration credentials consumed via
+  `changedetection.envFrom` or `changedetection.extraEnv`.
+- Service dual-stack fields are optional and rendered only when explicitly set.
+
+## Security Model
+
+The default pod drops Linux capabilities, disables privilege escalation, uses a
+runtime default seccomp profile, and runs the main container as UID/GID 1000.
+The root filesystem remains writable because changedetection.io writes runtime
+state and temporary files.
+
+## Non-Goals
+
+- Horizontal scaling is not supported while upstream uses SQLite for runtime
+  state.
+- The chart does not manage notification provider credentials directly. Use
+  Kubernetes Secrets or External Secrets Operator.
+- Browser rendering is optional because it increases CPU and memory usage.
+
+## Validation Focus
+
+- Default install with persistent datastore
+- JavaScript rendering sidecar
+- Ingress and Gateway API routing
+- ExternalSecret rendering for environment-backed configuration
+- Dual-stack Service rendering
+
+## Related Files
+
+- `charts/changedetection/README.md`
+- `charts/changedetection/docs/production.md`
+- `charts/changedetection/examples/production.yaml`
+
+---
+
+keywords: changedetection, monitoring, website-monitoring, design
+path: charts/changedetection/DESIGN.md

--- a/charts/changedetection/README.md
+++ b/charts/changedetection/README.md
@@ -166,7 +166,7 @@ probes:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/dgtlmoon/changedetection.io` | changedetection.io image repository |
-| `image.tag` | `0.55.5` | changedetection.io image tag |
+| `image.tag` | `0.55.7` | changedetection.io image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `changedetection.port` | `5000` | Application port |
 | `changedetection.baseUrl` | `""` | Public base URL |
@@ -174,6 +174,7 @@ probes:
 | `changedetection.minimumSecondsRecheckTime` | `""` | Minimum seconds between checks |
 | `changedetection.timezone` | `""` | Container timezone via `TZ` |
 | `changedetection.locale` | `C` | Locale assigned to `LANG` and `LC_ALL` |
+| `changedetection.defaultWatches.enabled` | `false` | Let upstream create sample watches on a fresh datastore |
 | `changedetection.extraEnv` | `[]` | Extra environment variables |
 | `browser.enabled` | `false` | Enable Playwright browser sidecar |
 | `browser.image.repository` | `ghcr.io/browserless/chromium` | Browser sidecar image repository |
@@ -189,18 +190,20 @@ probes:
 | `resources.requests.cpu` | `100m` | Main container CPU request |
 | `resources.requests.memory` | `256Mi` | Main container memory request |
 | `resources.limits` | unset | Optional main container resource limits |
+| `podSecurityContext.fsGroup` | `1000` | Writable group for the `/datastore` volume |
+| `securityContext.runAsNonRoot` | `true` | Run the main container without root privileges |
 | `securityContext.allowPrivilegeEscalation` | `false` | Prevent privilege escalation |
 | `securityContext.capabilities.drop` | `[ALL]` | Drop Linux capabilities by default |
 | `extraManifests` | `[]` | Additional manifests rendered with the release |
 
 ## Upgrade Notes
 
-For this release the application image is updated to `0.55.5`. The upstream
-`0.55.4` and `0.55.5` releases include API, notification, LLM, localization,
-and security-related fixes, including an SSRF guard for the LLM `api_base`
-setting and a shared diff access fix. Review the upstream changelog before
-production rollout and test restores from the `/datastore` backup when upgrading
-long-lived instances.
+For this release the application image is updated to `0.55.7`. The upstream
+`0.55.6` release includes a security fix for an SSRF parser differential,
+notification and preview fixes, plus an `LLM_FEATURES_DISABLED` flag. The
+`0.55.7` release fixes the LLM settings UI path. Review the upstream changelog
+before production rollout and test restores from the `/datastore` backup when
+upgrading long-lived instances.
 
 ## Limitations
 

--- a/charts/changedetection/README.md
+++ b/charts/changedetection/README.md
@@ -14,6 +14,9 @@ Discord, Telegram, webhooks, and 90+ Apprise services.
 - **SQLite storage** — zero external database dependencies
 - **Persistent storage** — snapshots and history on PVC
 - **Ingress support** — TLS with cert-manager
+- **Gateway API support** — optional HTTPRoute for platform Gateway deployments
+- **Dual-stack Service support** — optional `ipFamilyPolicy` and `ipFamilies`
+- **External Secrets integration** — render ESO resources for environment-backed configuration
 - **Configurable probes** — startup, readiness, and liveness checks
 - **Runtime tuning** — fetch workers, recheck interval, timezone, labels, annotations, resources, scheduling, and extra manifests
 
@@ -109,6 +112,64 @@ ingress:
 Set `changedetection.baseUrl` to the public URL used by users and notification
 links.
 
+## Gateway API
+
+Use Gateway API when your platform routes applications through shared Gateway
+resources:
+
+```yaml
+changedetection:
+  baseUrl: "https://cd.example.com"
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: ingress
+  hostnames:
+    - cd.example.com
+```
+
+The chart renders a single `HTTPRoute` named after the release and points it to
+the chart Service. Keep Ingress and Gateway API disabled by default and enable
+only the routing path managed by the cluster.
+
+## External Secrets
+
+The chart can render ExternalSecret resources for upstream-supported
+environment variables and automatically consume the produced Secret:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: changedetection-env
+    creationPolicy: Owner
+  data:
+    - secretKey: LOGGER_LEVEL
+      remoteRef:
+        key: changedetection/app
+        property: loggerLevel
+```
+
+Use this for notification credentials or other sensitive values that should be
+owned by External Secrets Operator instead of committed into values files.
+
+## Dual-Stack Service
+
+Clusters with IPv4/IPv6 networking can opt into Kubernetes Service dual-stack:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
 ## Runtime Configuration
 
 ```yaml
@@ -117,13 +178,17 @@ changedetection:
   minimumSecondsRecheckTime: "180"
   timezone: "America/Sao_Paulo"
   locale: C
+  envFrom:
+    - secretRef:
+        name: changedetection-env
   extraEnv:
     - name: LOGGER_LEVEL
       value: INFO
 ```
 
 Use `changedetection.extraEnv` for upstream-supported environment variables that
-are not exposed as first-class chart values.
+are not exposed as first-class chart values, and `changedetection.envFrom` for
+pre-created or externally materialized Secrets.
 
 ## Security And Scheduling
 
@@ -176,6 +241,7 @@ probes:
 | `changedetection.locale` | `C` | Locale assigned to `LANG` and `LC_ALL` |
 | `changedetection.defaultWatches.enabled` | `false` | Let upstream create sample watches on a fresh datastore |
 | `changedetection.extraEnv` | `[]` | Extra environment variables |
+| `changedetection.envFrom` | `[]` | Extra envFrom sources |
 | `browser.enabled` | `false` | Enable Playwright browser sidecar |
 | `browser.image.repository` | `ghcr.io/browserless/chromium` | Browser sidecar image repository |
 | `browser.image.tag` | `v2.46.0` | Browser sidecar image tag |
@@ -185,11 +251,18 @@ probes:
 | `persistence.existingClaim` | `""` | Existing PVC name |
 | `service.type` | `ClusterIP` | Kubernetes Service type |
 | `service.port` | `80` | HTTP Service port |
+| `service.ipFamilyPolicy` | unset | Optional Service IP family policy |
+| `service.ipFamilies` | `[]` | Optional Service IP families |
 | `ingress.enabled` | `false` | Enable ingress |
+| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resources |
+| `externalSecrets.secretStoreRef.name` | `""` | Required SecretStore name when ExternalSecrets is enabled |
+| `externalSecrets.target.name` | `""` | Target Secret name, defaults to release-derived name |
 | `probes.*.enabled` | `true` | Enable startup, readiness, and liveness probes |
 | `resources.requests.cpu` | `100m` | Main container CPU request |
 | `resources.requests.memory` | `256Mi` | Main container memory request |
-| `resources.limits` | unset | Optional main container resource limits |
+| `resources.limits.cpu` | `1000m` | Main container CPU limit |
+| `resources.limits.memory` | `1Gi` | Main container memory limit |
 | `podSecurityContext.fsGroup` | `1000` | Writable group for the `/datastore` volume |
 | `securityContext.runAsNonRoot` | `true` | Run the main container without root privileges |
 | `securityContext.allowPrivilegeEscalation` | `false` | Prevent privilege escalation |
@@ -216,4 +289,6 @@ upgrading long-lived instances.
 
 - [changedetection.io documentation](https://changedetection.io)
 - [changedetection.io releases](https://github.com/dgtlmoon/changedetection.io/releases)
+- [Production guide](docs/production.md)
+- [Chart design](DESIGN.md)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/changedetection)

--- a/charts/changedetection/README.md
+++ b/charts/changedetection/README.md
@@ -190,6 +190,18 @@ Use `changedetection.extraEnv` for upstream-supported environment variables that
 are not exposed as first-class chart values, and `changedetection.envFrom` for
 pre-created or externally materialized Secrets.
 
+The chart keeps the container non-root by default and sets `PIP_USER=true` with
+`PYTHONUSERBASE=/datastore/.python-userbase`. This gives the upstream
+`EXTRA_PACKAGES` entrypoint hook a writable Python user install path without
+requiring root privileges:
+
+```yaml
+changedetection:
+  extraEnv:
+    - name: EXTRA_PACKAGES
+      value: "chardet==5.2.0"
+```
+
 ## Security And Scheduling
 
 The chart exposes standard Kubernetes controls for production placement and

--- a/charts/changedetection/ci/dual-stack-values.yaml
+++ b/charts/changedetection/ci/dual-stack-values.yaml
@@ -1,0 +1,6 @@
+# CI: optional Service dual-stack fields
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/changedetection/ci/dual-stack-values.yaml
+++ b/charts/changedetection/ci/dual-stack-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: optional Service dual-stack fields
 service:
   ipFamilyPolicy: PreferDualStack

--- a/charts/changedetection/ci/external-secrets-values.yaml
+++ b/charts/changedetection/ci/external-secrets-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: External Secrets Operator integration
 externalSecrets:
   enabled: true

--- a/charts/changedetection/ci/external-secrets-values.yaml
+++ b/charts/changedetection/ci/external-secrets-values.yaml
@@ -1,0 +1,14 @@
+# CI: External Secrets Operator integration
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: changedetection-env
+    creationPolicy: Owner
+  data:
+    - secretKey: LOGGER_LEVEL
+      remoteRef:
+        key: changedetection/app
+        property: loggerLevel

--- a/charts/changedetection/ci/gateway-values.yaml
+++ b/charts/changedetection/ci/gateway-values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # CI: Gateway API HTTPRoute rendering
 gateway:
   enabled: true

--- a/charts/changedetection/ci/gateway-values.yaml
+++ b/charts/changedetection/ci/gateway-values.yaml
@@ -1,0 +1,8 @@
+# CI: Gateway API HTTPRoute rendering
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: ingress
+  hostnames:
+    - cd.example.com

--- a/charts/changedetection/docs/production.md
+++ b/charts/changedetection/docs/production.md
@@ -1,0 +1,122 @@
+# changedetection.io Production Guide
+
+Use this guide as a starting point for production deployments of the HelmForge
+changedetection.io chart.
+
+## Persistence
+
+Keep `persistence.enabled=true` and size the PVC for snapshots and historical
+diffs. Storage usage depends on the number of watches, check frequency, and
+whether pages include large rendered screenshots.
+
+```yaml
+persistence:
+  enabled: true
+  size: 20Gi
+  storageClass: fast-retain
+```
+
+Back up the PVC before upgrades. The application stores its SQLite database and
+snapshot data under `/datastore`.
+
+## Routing
+
+Ingress remains the most common path:
+
+```yaml
+changedetection:
+  baseUrl: "https://cd.example.com"
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: cd.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - cd.example.com
+      secretName: changedetection-tls
+```
+
+Gateway API is available for clusters that standardize on Gateway resources:
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: ingress
+  hostnames:
+    - cd.example.com
+```
+
+Do not enable both paths for the same hostname unless the platform routing
+policy explicitly expects it.
+
+## External Secrets
+
+The chart can render ExternalSecret resources and consume the produced Secret
+automatically:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: changedetection-env
+    creationPolicy: Owner
+  data:
+    - secretKey: LOGGER_LEVEL
+      remoteRef:
+        key: changedetection/app
+        property: loggerLevel
+```
+
+Use this pattern for notification provider secrets or other upstream-supported
+environment variables.
+
+## Browser Rendering
+
+Enable the browser sidecar only when watches need JavaScript rendering:
+
+```yaml
+browser:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+```
+
+Browser rendering materially increases CPU and memory usage. Tune pod resources
+from observed workload behavior.
+
+## Operations
+
+Useful checks after deployment:
+
+```bash
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=changedetection --timeout=300s
+kubectl logs -l app.kubernetes.io/name=changedetection --all-containers --tail=100
+kubectl get events --sort-by=.lastTimestamp
+```
+
+The default Service can also opt into dual-stack networking:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+---
+
+keywords: changedetection, production, gateway-api, external-secrets
+path: charts/changedetection/docs/production.md

--- a/charts/changedetection/docs/production.md
+++ b/charts/changedetection/docs/production.md
@@ -96,6 +96,20 @@ browser:
 Browser rendering materially increases CPU and memory usage. Tune pod resources
 from observed workload behavior.
 
+## Extra Python Packages
+
+changedetection.io supports the upstream `EXTRA_PACKAGES` environment variable
+for installing additional Python packages at container startup. The chart keeps
+the main container non-root and provides a writable Python user install path
+under `/datastore/.python-userbase`, so this hook can run without root:
+
+```yaml
+changedetection:
+  extraEnv:
+    - name: EXTRA_PACKAGES
+      value: "chardet==5.2.0"
+```
+
 ## Operations
 
 Useful checks after deployment:

--- a/charts/changedetection/examples/production.yaml
+++ b/charts/changedetection/examples/production.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Example: production-oriented changedetection.io deployment.
+
+changedetection:
+  baseUrl: "https://cd.example.com"
+  fetchWorkers: 10
+  timezone: "America/Sao_Paulo"
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+browser:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: cd.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - cd.example.com
+      secretName: changedetection-tls
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: changedetection-env
+    creationPolicy: Owner
+  data:
+    - secretKey: LOGGER_LEVEL
+      remoteRef:
+        key: changedetection/app
+        property: loggerLevel

--- a/charts/changedetection/templates/NOTES.txt
+++ b/charts/changedetection/templates/NOTES.txt
@@ -16,6 +16,10 @@ Namespace:  {{ .Release.Namespace }}
 {{- range $host := .Values.ingress.hosts }}
 WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range .Values.gateway.hostnames }}
+WEB UI:   https://{{ . }}/
+{{- end }}
 {{- else }}
 Port-forward to access changedetection.io locally:
 
@@ -68,6 +72,33 @@ Browser rendering:
   JavaScript-heavy pages.
 {{- end }}
 
+{{- with .Values.service.ipFamilyPolicy }}
+
+Networking:
+  Service IP family policy: {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}.
+{{- end }}
+
+{{- if .Values.gateway.enabled }}
+
+Gateway API:
+  HTTPRoute: {{ include "changedetection.fullname" . }}
+  ParentRefs:
+{{ toYaml .Values.gateway.parentRefs | indent 4 }}
+{{- end }}
+
+{{- if .Values.externalSecrets.enabled }}
+
+External Secrets:
+  ExternalSecret resources were rendered for this release.
+  Confirm the External Secrets Operator reconciled them:
+
+    kubectl get externalsecret -n {{ .Release.Namespace }} \
+      -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  When using changedetection.envFrom, confirm the target Secret exists before
+  troubleshooting the application pod.
+{{- end }}
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   TROUBLESHOOTING
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -76,6 +107,7 @@ Browser rendering:
   kubectl logs -l app.kubernetes.io/name=changedetection -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   ADDITIONAL RESOURCES

--- a/charts/changedetection/templates/_helpers.tpl
+++ b/charts/changedetection/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "changedetection.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/changedetection/templates/_helpers.tpl
+++ b/charts/changedetection/templates/_helpers.tpl
@@ -50,3 +50,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-data" (include "changedetection.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "changedetection.externalSecretName" -}}
+{{- default (printf "%s-env" (include "changedetection.fullname" .)) .Values.externalSecrets.target.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/changedetection/templates/deployment.yaml
+++ b/charts/changedetection/templates/deployment.yaml
@@ -94,6 +94,14 @@ spec:
               value: {{ .Values.changedetection.locale | quote }}
             - name: LC_ALL
               value: {{ .Values.changedetection.locale | quote }}
+            - name: HOME
+              value: /datastore
+            - name: PYTHONUSERBASE
+              value: /datastore/.python-userbase
+            - name: PIP_USER
+              value: "true"
+            - name: PATH
+              value: /datastore/.python-userbase/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
             {{- with .Values.changedetection.timezone }}
             - name: TZ
               value: {{ . | quote }}

--- a/charts/changedetection/templates/deployment.yaml
+++ b/charts/changedetection/templates/deployment.yaml
@@ -39,6 +39,26 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if not .Values.changedetection.defaultWatches.enabled }}
+      initContainers:
+        - name: initialize-datastore
+          image: {{ include "changedetection.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              if [ ! -f /datastore/changedetection.json ]; then
+                python -c 'import os; from changedetectionio.store import ChangeDetectionStore; os.makedirs("/datastore", exist_ok=True); ChangeDetectionStore(datastore_path="/datastore", include_default_watches=False, version_tag="{{ .Chart.AppVersion }}")'
+              fi
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /datastore
+      {{- end }}
       containers:
         - name: changedetection
           image: {{ include "changedetection.image" . | quote }}

--- a/charts/changedetection/templates/deployment.yaml
+++ b/charts/changedetection/templates/deployment.yaml
@@ -67,6 +67,16 @@ spec:
             - name: http
               containerPort: {{ .Values.changedetection.port }}
               protocol: TCP
+          {{- if or .Values.externalSecrets.enabled .Values.changedetection.envFrom }}
+          envFrom:
+            {{- if .Values.externalSecrets.enabled }}
+            - secretRef:
+                name: {{ include "changedetection.externalSecretName" . }}
+            {{- end }}
+            {{- with .Values.changedetection.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           env:
             - name: PORT
               value: {{ .Values.changedetection.port | quote }}

--- a/charts/changedetection/templates/externalsecret.yaml
+++ b/charts/changedetection/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: {{ .Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ include "changedetection.externalSecretName" . }}
+  labels:
+    {{- include "changedetection.labels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
+  target:
+    name: {{ include "changedetection.externalSecretName" . | quote }}
+    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
+  {{- with .Values.externalSecrets.data }}
+  data:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.externalSecrets.dataFrom }}
+  dataFrom:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/changedetection/templates/httproute.yaml
+++ b/charts/changedetection/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
+{{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "changedetection.fullname" . }}
+  labels:
+    {{- include "changedetection.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
+      backendRefs:
+        - name: {{ include "changedetection.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/changedetection/templates/service.yaml
+++ b/charts/changedetection/templates/service.yaml
@@ -1,3 +1,4 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/changedetection/templates/service.yaml
+++ b/charts/changedetection/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/changedetection/tests/deployment_test.yaml
+++ b/charts/changedetection/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.5"
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.7"
 
   - it: should expose port 5000
     asserts:
@@ -57,7 +57,28 @@ tests:
   - it: should drop Linux capabilities by default
     asserts:
       - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroupChangePolicy
+          value: OnRootMismatch
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: false
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
@@ -84,6 +105,28 @@ tests:
             name: data
             persistentVolumeClaim:
               claimName: test-changedetection-data
+
+  - it: should initialize datastore without upstream sample watches by default
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: initialize-datastore
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.7"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "include_default_watches=False"
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should allow upstream sample watches when explicitly enabled
+    set:
+      changedetection.defaultWatches.enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
 
   - it: should use emptyDir when persistence disabled
     set:

--- a/charts/changedetection/tests/deployment_test.yaml
+++ b/charts/changedetection/tests/deployment_test.yaml
@@ -43,16 +43,20 @@ tests:
             name: data
             mountPath: /datastore
 
-  - it: should set default resource requests without hard limits
+  - it: should set default resource requests and limits
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1000m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 100m
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 256Mi
-      - isNull:
-          path: spec.template.spec.containers[0].resources.limits
 
   - it: should drop Linux capabilities by default
     asserts:
@@ -164,3 +168,30 @@ tests:
           content:
             name: PLAYWRIGHT_DRIVER_URL
             value: "ws://localhost:3000/?stealth=1&--disable-web-security=true"
+
+  - it: should render envFrom sources for externalized configuration
+    set:
+      changedetection.envFrom:
+        - secretRef:
+            name: changedetection-env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: changedetection-env
+
+  - it: should consume the ExternalSecret target when enabled
+    set:
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: vault
+        target:
+          name: changedetection-env
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: changedetection-env

--- a/charts/changedetection/tests/deployment_test.yaml
+++ b/charts/changedetection/tests/deployment_test.yaml
@@ -101,6 +101,29 @@ tests:
             name: LC_ALL
             value: C
 
+  - it: should provide a writable Python user install path for upstream EXTRA_PACKAGES
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOME
+            value: /datastore
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PYTHONUSERBASE
+            value: /datastore/.python-userbase
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PIP_USER
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PATH
+            value: /datastore/.python-userbase/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
   - it: should use PVC for data when persistence enabled
     asserts:
       - contains:

--- a/charts/changedetection/tests/externalsecret_test.yaml
+++ b/charts/changedetection/tests/externalsecret_test.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret items
+    set:
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: vault
+          kind: ClusterSecretStore
+        target:
+          name: changedetection-env
+          creationPolicy: Owner
+        data:
+          - secretKey: LOGGER_LEVEL
+            remoteRef:
+              key: changedetection/app
+              property: loggerLevel
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: changedetection-env
+      - equal:
+          path: spec.secretStoreRef.name
+          value: vault
+      - equal:
+          path: spec.target.name
+          value: changedetection-env
+
+  - it: should fail when enabled without a store reference
+    set:
+      externalSecrets:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true"

--- a/charts/changedetection/tests/httproute_test.yaml
+++ b/charts/changedetection/tests/httproute_test.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API HTTPRoute
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when enabled
+    set:
+      gateway:
+        enabled: true
+        parentRefs:
+          - name: shared-gateway
+            namespace: ingress
+        hostnames:
+          - cd.example.com
+        path: /
+        pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: spec.hostnames[0]
+          value: cd.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-changedetection
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should fail when enabled without parentRefs
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."

--- a/charts/changedetection/tests/service_test.yaml
+++ b/charts/changedetection/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml

--- a/charts/changedetection/tests/service_test.yaml
+++ b/charts/changedetection/tests/service_test.yaml
@@ -22,3 +22,19 @@ tests:
             port: 80
             targetPort: http
             protocol: TCP
+
+  - it: should render optional dual-stack service fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies
+          value:
+            - IPv4
+            - IPv6

--- a/charts/changedetection/values.schema.json
+++ b/charts/changedetection/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/dgtlmoon/changedetection.io" },
-        "tag": { "type": "string", "default": "0.55.5" },
+        "tag": { "type": "string", "default": "0.55.7" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -27,6 +27,16 @@
         "minimumSecondsRecheckTime": { "type": "string", "default": "" },
         "timezone": { "type": "string", "default": "" },
         "locale": { "type": "string", "default": "C" },
+        "defaultWatches": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Let changedetection.io create upstream sample watches on a fresh datastore."
+            }
+          }
+        },
         "extraEnv": { "type": "array", "items": { "type": "object" } }
       }
     },
@@ -83,11 +93,36 @@
         "limits": { "type": "object" }
       }
     },
-    "podSecurityContext": { "type": "object" },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "fsGroup": { "type": "integer", "default": 1000 },
+        "fsGroupChangePolicy": {
+          "type": "string",
+          "enum": ["Always", "OnRootMismatch"],
+          "default": "OnRootMismatch"
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["RuntimeDefault", "Localhost", "Unconfined"],
+              "default": "RuntimeDefault"
+            },
+            "localhostProfile": { "type": "string" }
+          }
+        }
+      }
+    },
     "securityContext": {
       "type": "object",
       "properties": {
+        "runAsUser": { "type": "integer", "default": 1000 },
+        "runAsGroup": { "type": "integer", "default": 1000 },
+        "runAsNonRoot": { "type": "boolean", "default": true },
         "allowPrivilegeEscalation": { "type": "boolean", "default": false },
+        "readOnlyRootFilesystem": { "type": "boolean", "default": false },
         "capabilities": { "type": "object" }
       }
     },

--- a/charts/changedetection/values.schema.json
+++ b/charts/changedetection/values.schema.json
@@ -27,6 +27,7 @@
         "minimumSecondsRecheckTime": { "type": "string", "default": "" },
         "timezone": { "type": "string", "default": "" },
         "locale": { "type": "string", "default": "C" },
+        "envFrom": { "type": "array", "items": { "type": "object" } },
         "defaultWatches": {
           "type": "object",
           "properties": {
@@ -72,7 +73,15 @@
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
         "port": { "type": "integer", "default": 80 },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["IPv4", "IPv6"] }
+        }
       }
     },
     "ingress": {
@@ -83,6 +92,41 @@
         "annotations": { "type": "object" },
         "hosts": { "type": "array", "items": { "type": "object" } },
         "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
+        "hostnames": { "type": "array", "items": { "type": "string" } },
+        "path": { "type": "string", "default": "/" },
+        "pathType": { "type": "string", "default": "PathPrefix" }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "secretStoreRef": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "default": "" },
+            "kind": { "type": "string", "default": "SecretStore" }
+          }
+        },
+        "target": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "default": "" },
+            "creationPolicy": { "type": "string", "default": "Owner" }
+          }
+        },
+        "data": { "type": "array", "items": { "type": "object" } },
+        "dataFrom": { "type": "array", "items": { "type": "object" } }
       }
     },
     "probes": { "type": "object" },

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -44,6 +44,9 @@ changedetection:
   # -- Extra environment variables for the container
   # -- @default -- `[]`
   extraEnv: []
+  # -- Additional envFrom sources, commonly Secrets produced by External Secrets Operator
+  # -- @default -- `[]`
+  envFrom: []
 
 # =============================================================================
 # Browser (optional Playwright for JavaScript rendering)
@@ -101,6 +104,10 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- Optional Service IP family policy: SingleStack, PreferDualStack, or RequireDualStack
+  ipFamilyPolicy: ~
+  # -- Optional Service IP families, for example [IPv4, IPv6]
+  ipFamilies: []
 
 # =============================================================================
 # Ingress
@@ -124,6 +131,54 @@ ingress:
     # - hosts:
     #     - changedetection.example.com
     #   secretName: changedetection-tls
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gateway:
+  # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
+  enabled: false
+  # -- Annotations for the HTTPRoute
+  annotations: {}
+  # -- parentRefs pointing to your Gateway resource
+  parentRefs: []
+  # -- Hostnames the HTTPRoute matches
+  hostnames: []
+  # -- Path prefix
+  path: /
+  # -- Path match type
+  pathType: PathPrefix
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render an ExternalSecret for environment secrets or integrations.
+  enabled: false
+  # -- ExternalSecret API version.
+  apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval.
+  refreshInterval: 1h
+  secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name. Required when externalSecrets.enabled=true.
+    name: ""
+    # -- SecretStore reference kind.
+    kind: SecretStore
+  target:
+    # -- Target Secret name. Defaults to "<release>-changedetection-env" when empty.
+    name: ""
+    # -- ExternalSecret target creation policy.
+    creationPolicy: Owner
+  # -- Data entries mapping remote provider keys into environment variable keys.
+  data: []
+  # - secretKey: LOGGER_LEVEL
+  #   remoteRef:
+  #     key: changedetection/app
+  #     property: loggerLevel
+  # -- Optional dataFrom entries for provider-side extraction.
+  dataFrom: []
 
 # =============================================================================
 # Probes
@@ -154,6 +209,9 @@ probes:
 # =============================================================================
 
 resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
   requests:
     cpu: 100m
     memory: 256Mi

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- changedetection.io container image
   repository: ghcr.io/dgtlmoon/changedetection.io
   # -- Image tag
-  tag: "0.55.5"
+  tag: "0.55.7"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -38,6 +38,9 @@ changedetection:
   timezone: ""
   # -- Container locale used for LANG and LC_ALL
   locale: C
+  defaultWatches:
+    # -- Let changedetection.io create upstream sample watches on a fresh datastore
+    enabled: false
   # -- Extra environment variables for the container
   # -- @default -- `[]`
   extraEnv: []
@@ -155,10 +158,18 @@ resources:
     cpu: 100m
     memory: 256Mi
 
-podSecurityContext: {}
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
Closes #391

## Summary
- Update changedetection.io from 0.55.5 to 0.55.7.
- Add hardened non-root runtime defaults with `fsGroup`, `RuntimeDefault` seccomp, and dropped Linux capabilities.
- Initialize fresh datastores without upstream sample watches by default to avoid automatic external fetches on first startup; users can restore upstream sample watches with `changedetection.defaultWatches.enabled=true`.
- Update values schema, README upgrade notes, and deployment unit tests.

## Upstream notes
- 0.55.6 includes a security fix for an SSRF parser differential, preview and notification fixes, and the `LLM_FEATURES_DISABLED` flag.
- 0.55.7 fixes the LLM settings UI path.

## Validation
- `docker manifest inspect ghcr.io/dgtlmoon/changedetection.io:0.55.7` (linux/amd64, linux/arm64, linux/arm/v7, linux/arm/v8 present)
- `helm dependency build charts/changedetection`
- `helm lint charts/changedetection --strict`
- `helm template changedetection-test charts/changedetection`
- `helm template changedetection-test charts/changedetection -f charts/changedetection/ci/*.yaml`
- `helm unittest charts/changedetection` (4 suites, 23 tests)
- `ah lint -p charts/changedetection`
- `kubeconform -strict -summary` with repository CI schema locations for defaults and all `ci/*.yaml`
- `kubescape scan framework "MITRE,NSA,SOC2" charts/changedetection --format json` (compliance score 84.84849)
- k3d `k3d-helmforge-tests-wsl` default deploy: initContainer exit 0, pod Ready, `/` HTTP 200, no non-Normal events, no invalid log lines, namespace removed