### PR TITLE
chore(dolibarr): update Dolibarr to 23.0.3

### DIFF
--- a/charts/dolibarr/.helmignore
+++ b/charts/dolibarr/.helmignore
@@ -21,7 +21,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/dolibarr/Chart.lock
+++ b/charts/dolibarr/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:43ea75f43a616dbac5ea9837826a9cb806646d5c2c3c7029008fa5b3a0ad22c3
-generated: "2026-04-29T09:42:06.1802643-03:00"

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -50,6 +50,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 1.8.5
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: dolibarr
 type: application
-version: 1.2.11
-appVersion: "23.0.2"
+version: 1.2.12
+appVersion: "23.0.3"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Dolibarr ERP/CRM on Kubernetes with MySQL support
 icon: https://helmforge.dev/icons/charts/dolibarr.png
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 23.0.2 (#195)"
+      description: "update Dolibarr to 23.0.3 with upstream bug and security fixes (#393)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/dolibarr/DESIGN.md
+++ b/charts/dolibarr/DESIGN.md
@@ -1,0 +1,98 @@
+# Dolibarr Chart Design
+
+## Scope
+
+This chart deploys Dolibarr ERP/CRM on Kubernetes using the official `dolibarr/dolibarr` image and the HelmForge MySQL subchart by default.
+
+Supported database modes:
+
+- `mysql`: bundled HelmForge MySQL dependency for a self-contained release
+- `external`: externally managed MySQL or MariaDB endpoint
+- `auto`: select the bundled dependency unless an external database is configured
+
+The chart intentionally targets the official container's unattended MySQL/MariaDB workflow.
+PostgreSQL is not enabled as a default chart path because the official image does not
+expose the same non-interactive setup contract for this chart's Kubernetes automation.
+
+## Architecture: Bundled MySQL
+
+```mermaid
+flowchart LR
+  user[User] --> ingress[Ingress or HTTPRoute]
+  ingress --> svc[Dolibarr Service]
+  svc --> app[Dolibarr Deployment]
+  app --> documents[(Documents PVC)]
+  app --> custom[(Custom modules PVC)]
+  app --> dbsvc[MySQL Service]
+  dbsvc --> mysql[HelmForge MySQL StatefulSet]
+  mysql --> mysqlpvc[(MySQL PVC)]
+  secrets[Generated Secrets] --> app
+  secrets --> mysql
+```
+
+This mode is appropriate for development, internal tools, and small deployments where the application and database lifecycle can be managed together.
+
+## Architecture: External Database
+
+```mermaid
+flowchart LR
+  user[User] --> edge[Ingress or HTTPRoute]
+  edge --> svc[Dolibarr Service]
+  svc --> app[Dolibarr Deployment]
+  app --> documents[(Documents PVC)]
+  app --> custom[(Custom modules PVC)]
+  app --> db[(External MySQL or MariaDB)]
+  eso[External Secrets Operator optional] -. materializes .-> secrets[Database Secret]
+  secrets --> app
+```
+
+External database mode is recommended when operators already provide backup, restore, replication, failover, and patching through a managed database platform.
+
+## Operational Design
+
+- `initContainers.wait-for-db` blocks application startup until TCP connectivity to the selected database is available.
+- The default startup probe delay accounts for the official container's first-run database import before Apache starts accepting traffic.
+- The bundled MySQL startup probe is delayed slightly from the subchart default to avoid false-positive probe warnings during first-run database initialization.
+- Generated admin, database, and runtime secrets are preserved across upgrades with Helm `lookup`.
+- Documents and custom modules use separate PVCs so generated files and locally installed modules can be sized and restored independently.
+- `DOLI_CRON` is disabled by default. Scheduled jobs should be modeled explicitly once their runtime behavior is validated for Kubernetes.
+- Gateway API and Ingress are both opt-in and use the chart's single HTTP service backend.
+- Backup is opt-in and uses `mysqldump` plus the HelmForge `mc` image to upload compressed dumps to S3-compatible storage.
+
+## Production Boundary
+
+For production, operators should provide explicit values for:
+
+- admin and database credentials through existing Secrets or External Secrets
+- persistent storage classes and sizes
+- resource requests and limits
+- ingress or Gateway API TLS
+- backup destination and retention policy
+- database lifecycle ownership
+- network boundaries outside this chart when required by the cluster baseline
+
+## Explicit Non-Goals
+
+- automated major Dolibarr upgrades or database migrations beyond the official image entrypoint behavior
+- PostgreSQL automation
+- bundled high availability database topology
+- application cron orchestration before a stable Kubernetes validation path exists
+- installing Dolibarr marketplace modules automatically
+
+<!-- @AI-METADATA
+type: design
+title: Dolibarr Chart Design
+description: Design document for the Dolibarr Helm chart with database modes, persistence, ingress, Gateway API, and backup boundaries
+
+keywords: dolibarr, design, architecture, mysql, mariadb, gateway-api, backup, helm, kubernetes
+
+purpose: Document Dolibarr chart architecture, operational choices, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/dolibarr/README.md
+  - charts/dolibarr/docs/database.md
+path: charts/dolibarr/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/dolibarr/README.md
+++ b/charts/dolibarr/README.md
@@ -34,6 +34,8 @@ helm install dolibarr oci://ghcr.io/helmforgedev/helm/dolibarr \
 - **Auto Installation** — unattended setup through `DOLI_*` environment variables
 - **Persistent Storage** — separate PVCs for `/var/www/documents` and `/var/www/html/custom`
 - **Ingress Support** — configurable ingress with TLS for HTTPS access
+- **Gateway API Support** — optional HTTPRoute for clusters using Gateway API
+- **S3 Backups** — optional mysqldump CronJob for S3-compatible storage
 - **Secret Preservation** — admin, runtime, and database secrets preserved across upgrades via `lookup`
 
 ## Configuration
@@ -114,7 +116,7 @@ database:
 
 ## Parameters
 
-### Dolibarr
+### Application
 
 | Key | Default | Description |
 |-----|---------|-------------|
@@ -157,6 +159,7 @@ database:
 | `mysql.auth.database` | `dolibarr` | Database name |
 | `mysql.auth.username` | `dolibarr` | Database username |
 | `mysql.primary.persistence.size` | `8Gi` | MySQL PVC size |
+| `mysql.startupProbe.initialDelaySeconds` | `30` | MySQL startup probe delay used to avoid false-positive bootstrap warnings |
 
 ### Persistence
 
@@ -182,10 +185,12 @@ database:
 - PostgreSQL is not included because the official container workflow is not equivalent to the unattended MySQL path
 - persist both `documents` and `custom` if you plan to keep generated artifacts, modules, or themes across upgrades
 - built-in Dolibarr cron is intentionally not enabled by this first chart release because it still needs a stable Kubernetes validation path
+- the default startup probe delay accounts for the initial database import performed by the official container on a fresh deployment
 
 ## More Information
 
 - [Database Modes](docs/database.md)
+- [Chart Design](DESIGN.md)
 - [Source code and full values reference](https://github.com/helmforgedev/charts/tree/main/charts/dolibarr)
 
 <!-- @AI-METADATA
@@ -199,6 +204,7 @@ purpose: User-facing chart documentation with install, examples, and values refe
 scope: Chart
 
 relations:
+  - charts/dolibarr/DESIGN.md
   - charts/dolibarr/docs/database.md
 path: charts/dolibarr/README.md
 version: 1.0

--- a/charts/dolibarr/README.md
+++ b/charts/dolibarr/README.md
@@ -65,7 +65,7 @@ mysql:
   enabled: true
   auth:
     existingSecret: dolibarr-mysql
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 
@@ -158,7 +158,7 @@ database:
 | `mysql.architecture` | `standalone` | MySQL architecture |
 | `mysql.auth.database` | `dolibarr` | Database name |
 | `mysql.auth.username` | `dolibarr` | Database username |
-| `mysql.primary.persistence.size` | `8Gi` | MySQL PVC size |
+| `mysql.standalone.persistence.size` | `8Gi` | MySQL PVC size |
 | `mysql.startupProbe.initialDelaySeconds` | `30` | MySQL startup probe delay used to avoid false-positive bootstrap warnings |
 
 ### Persistence

--- a/charts/dolibarr/README.md
+++ b/charts/dolibarr/README.md
@@ -161,6 +161,11 @@ database:
 | `mysql.standalone.persistence.size` | `8Gi` | MySQL PVC size |
 | `mysql.startupProbe.initialDelaySeconds` | `30` | MySQL startup probe delay used to avoid false-positive bootstrap warnings |
 
+When upgrading from chart releases that used `mysql.primary.*`, migrate those
+values to `mysql.standalone.*`. The chart fails fast if `mysql.primary` is still
+present so persistence and resource settings are not silently ignored by the
+HelmForge MySQL 2.x dependency.
+
 ### Persistence
 
 | Key | Default | Description |

--- a/charts/dolibarr/ci/gateway-api.yaml
+++ b/charts/dolibarr/ci/gateway-api.yaml
@@ -14,3 +14,5 @@ gateway:
       namespace: default
   hostnames:
     - dolibarr.local
+  path: /
+  pathType: PathPrefix

--- a/charts/dolibarr/docs/database.md
+++ b/charts/dolibarr/docs/database.md
@@ -41,7 +41,11 @@ The referenced secret must contain the database password key.
 
 ## Why This Chart Does Not Support PostgreSQL
 
-Dolibarr itself can work with PostgreSQL, but the official Docker workflow treats that path differently and may require interactive installation or upgrade handling through `/install`. For this chart, the supported automation contract is MySQL/MariaDB only, because it aligns with the official container's unattended setup flow and with the repository's existing database dependency patterns.
+Dolibarr itself can work with PostgreSQL, but the official Docker workflow treats that path
+differently and may require interactive installation or upgrade handling through `/install`.
+For this chart, the supported automation contract is MySQL/MariaDB only, because it aligns
+with the official container's unattended setup flow and with the repository's existing database
+dependency patterns.
 
 ## Operational Notes
 

--- a/charts/dolibarr/docs/database.md
+++ b/charts/dolibarr/docs/database.md
@@ -18,6 +18,23 @@ mysql:
 
 This is the recommended starting point for evaluation environments and simple self-hosted deployments.
 
+## MySQL 2.x Value Migration
+
+This chart uses the HelmForge MySQL 2.x dependency. MySQL settings must use the
+`mysql.standalone.*` structure:
+
+```yaml
+mysql:
+  standalone:
+    persistence:
+      enabled: true
+      size: 20Gi
+```
+
+Legacy `mysql.primary.*` values are not accepted. The chart fails fast when that
+key is present so existing persistence and resource settings are not silently
+ignored during upgrades.
+
 ## External MySQL or MariaDB
 
 To connect Dolibarr to an existing database:

--- a/charts/dolibarr/examples/production.yaml
+++ b/charts/dolibarr/examples/production.yaml
@@ -8,7 +8,7 @@ mysql:
   enabled: true
   auth:
     existingSecret: dolibarr-mysql
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 

--- a/charts/dolibarr/templates/NOTES.txt
+++ b/charts/dolibarr/templates/NOTES.txt
@@ -54,8 +54,8 @@ Service DNS:
   Database Name:    {{ include "dolibarr.databaseName" . }}
   Database User:    {{ include "dolibarr.databaseUsername" . }}
   MySQL subchart:   {{- if .Values.mysql.enabled }} enabled{{- else }} disabled{{- end }}
-  Documents PVC:    {{ include "dolibarr.documentsPvcName" . }}
-  Custom PVC:       {{ include "dolibarr.customPvcName" . }}
+  Documents Volume: {{- if .Values.persistence.documents.enabled }} PVC {{ include "dolibarr.documentsPvcName" . }}{{- else }} emptyDir (not persisted){{- end }}
+  Custom Volume:    {{- if .Values.persistence.custom.enabled }} PVC {{ include "dolibarr.customPvcName" . }}{{- else }} emptyDir (not persisted){{- end }}
   Backup CronJob:   {{- if .Values.backup.enabled }} enabled ({{ .Values.backup.schedule }}){{- else }} disabled{{- end }}
   Ingress:          {{- if .Values.ingress.enabled }} enabled{{- else }} disabled{{- end }}
   Gateway API:      {{- if .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
@@ -112,7 +112,7 @@ Upgrade reminder:
     -> Check password secret {{ include "dolibarr.databaseSecretName" . }} / {{ include "dolibarr.databaseSecretKey" . }}.
 
   Files are not persisted:
-    -> Verify documents and custom PVCs are Bound.
+    -> Verify documents and custom PVCs are Bound when persistence is enabled.
     -> Check existingClaim values if reusing PVCs.
 
   Backup job failed:

--- a/charts/dolibarr/templates/NOTES.txt
+++ b/charts/dolibarr/templates/NOTES.txt
@@ -1,32 +1,111 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-Dolibarr has been deployed!
+=============================================================================
+Dolibarr deployed successfully!
+=============================================================================
 
-Web Interface:
+SUMMARY:
+   Release: {{ .Release.Name }}
+   Namespace: {{ .Release.Namespace }}
+   Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+   App version: {{ .Chart.AppVersion }}
+   Image: {{ include "dolibarr.image" . }}
+   Database mode: {{ include "dolibarr.databaseMode" . }}
+   ServiceAccount: {{ include "dolibarr.serviceAccountName" . }}
+
+ACCESS:
 {{- if .Values.ingress.enabled }}
-  {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
-  {{- end }}
+{{- range .Values.ingress.hosts }}
+   Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else if .Values.gateway.enabled }}
+{{- range (default list .Values.gateway.hostnames) }}
+   Gateway API: http://{{ . }}
+{{- end }}
 {{- else }}
-  kubectl port-forward svc/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
-  Then visit: http://localhost:8080
+   Port-forward:
+     kubectl port-forward svc/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
+
+   Local URL:
+     http://127.0.0.1:8080
 {{- end }}
 
-Admin Credentials:
-  Login: {{ .Values.admin.login }}
+ADMIN:
+   Login: {{ .Values.admin.login }}
 {{- if .Values.admin.existingSecret }}
-  Password: Using existing secret {{ .Values.admin.existingSecret }}
+   Password secret: {{ .Values.admin.existingSecret }} / {{ .Values.admin.existingSecretPasswordKey }}
 {{- else if .Values.admin.password }}
-  Password: Using the password from values.
+   Password source: inline value
 {{- else }}
-  Password (auto-generated):
-    kubectl get secret {{ include "dolibarr.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.admin-password}' | base64 -d
+   Password command:
+     kubectl get secret {{ include "dolibarr.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "dolibarr.adminSecretKey" . }}}" | base64 -d
 {{- end }}
 
-Database:
-  Mode: {{ include "dolibarr.databaseMode" . }}
-  Host: {{ include "dolibarr.databaseHost" . }}:{{ include "dolibarr.databasePort" . }}
-  Name: {{ include "dolibarr.databaseName" . }}
+DATABASE:
+   Mode: {{ include "dolibarr.databaseMode" . }}
+   Host: {{ include "dolibarr.databaseHost" . }}
+   Port: {{ include "dolibarr.databasePort" . }}
+   Name: {{ include "dolibarr.databaseName" . }}
+   Username: {{ include "dolibarr.databaseUsername" . }}
+   Password secret: {{ include "dolibarr.databaseSecretName" . }} / {{ include "dolibarr.databaseSecretKey" . }}
 
-Persistence:
-  Documents PVC: {{ include "dolibarr.documentsPvcName" . }}
-  Custom PVC: {{ include "dolibarr.customPvcName" . }}
+PERSISTENCE:
+   Documents PVC: {{ include "dolibarr.documentsPvcName" . }}
+   Custom PVC: {{ include "dolibarr.customPvcName" . }}
+
+ROUTING:
+   Service: {{ include "dolibarr.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+   Ingress enabled: {{ .Values.ingress.enabled }}
+   Gateway API enabled: {{ .Values.gateway.enabled }}
+{{- with .Values.service.ipFamilyPolicy }}
+   IP family policy: {{ . }}
+{{- end }}
+{{- with .Values.service.ipFamilies }}
+   IP families: {{ join ", " . }}
+{{- end }}
+
+OPTIONAL FEATURES:
+   Backups: {{ .Values.backup.enabled }}
+   External Secrets: {{ .Values.externalSecrets.enabled }}
+{{- if .Values.backup.enabled }}
+   Backup schedule: {{ .Values.backup.schedule }}
+   Backup target: s3://{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+{{- end }}
+{{- if .Values.externalSecrets.enabled }}
+   SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+{{- end }}
+
+VALIDATION:
+   Release status:
+     helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+   Pods:
+     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+   Wait for readiness:
+     kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "dolibarr.name" . }} --timeout=10m
+
+   Health check:
+     kubectl run {{ include "dolibarr.fullname" . }}-health-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "dolibarr.fullname" . }}:{{ .Values.service.port }}/
+
+TROUBLESHOOTING:
+   Events:
+     kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+   Logs:
+     kubectl logs deploy/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} -c dolibarr --tail=200
+
+   Database wait logs:
+     kubectl logs deploy/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} -c wait-for-db --tail=100
+
+NOTES:
+   - Keep the admin, runtime, and database secrets stable across upgrades.
+   - Use external MySQL/MariaDB for production HA or managed database operations.
+   - Enable backups before changing storage, database mode, or chart major versions.
+   - Set dolibarr.siteUrl to the externally reachable URL for production installs.
+
+DOCUMENTATION:
+   Chart: https://helmforge.dev/docs/charts/dolibarr
+   Dolibarr: https://www.dolibarr.org
+   Source: https://github.com/helmforgedev/charts/tree/main/charts/dolibarr
+
+=============================================================================

--- a/charts/dolibarr/templates/NOTES.txt
+++ b/charts/dolibarr/templates/NOTES.txt
@@ -1,111 +1,149 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-=============================================================================
-Dolibarr deployed successfully!
-=============================================================================
+1. Dolibarr has been installed
+==============================
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ .Release.Namespace }}
+  Chart Version:  {{ .Chart.Version }}
+  App Version:    {{ .Chart.AppVersion }}
+  Image:          {{ include "dolibarr.image" . }}
+  Database Mode:  {{ include "dolibarr.databaseMode" . }}
+  ServiceAccount: {{ include "dolibarr.serviceAccountName" . }}
 
-SUMMARY:
-   Release: {{ .Release.Name }}
-   Namespace: {{ .Release.Namespace }}
-   Chart: {{ .Chart.Name }} {{ .Chart.Version }}
-   App version: {{ .Chart.AppVersion }}
-   Image: {{ include "dolibarr.image" . }}
-   Database mode: {{ include "dolibarr.databaseMode" . }}
-   ServiceAccount: {{ include "dolibarr.serviceAccountName" . }}
+2. Access
+=========
+[ClusterIP] Port-forward:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "dolibarr.fullname" . }} 8080:{{ .Values.service.port }}
+  Open: http://127.0.0.1:8080
 
-ACCESS:
 {{- if .Values.ingress.enabled }}
+[Ingress]
 {{- range .Values.ingress.hosts }}
-   Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+  Host: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
 {{- end }}
-{{- else if .Values.gateway.enabled }}
+{{- end }}
+
+{{- if .Values.gateway.enabled }}
+[Gateway API]
+  HTTPRoute: {{ include "dolibarr.fullname" . }}
 {{- range (default list .Values.gateway.hostnames) }}
-   Gateway API: http://{{ . }}
+  Host: http://{{ . }}
 {{- end }}
-{{- else }}
-   Port-forward:
-     kubectl port-forward svc/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
-
-   Local URL:
-     http://127.0.0.1:8080
 {{- end }}
 
-ADMIN:
-   Login: {{ .Values.admin.login }}
+Service DNS:
+  {{ include "dolibarr.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+3. First-time Setup
+===================
+  - Open Dolibarr and finish the application setup when prompted.
+  - Admin login: {{ .Values.admin.login }}
 {{- if .Values.admin.existingSecret }}
-   Password secret: {{ .Values.admin.existingSecret }} / {{ .Values.admin.existingSecretPasswordKey }}
+  - Admin password secret: {{ .Values.admin.existingSecret }} / {{ .Values.admin.existingSecretPasswordKey }}
 {{- else if .Values.admin.password }}
-   Password source: inline value
+  - Admin password source: inline values
 {{- else }}
-   Password command:
-     kubectl get secret {{ include "dolibarr.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "dolibarr.adminSecretKey" . }}}" | base64 -d
+  - Admin password command:
+      kubectl get secret {{ include "dolibarr.adminSecretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ include "dolibarr.adminSecretKey" . }}}" | base64 -d
 {{- end }}
+  - Set dolibarr.siteUrl to the externally reachable URL before production use.
+  - Keep admin, runtime, and database secrets stable across upgrades.
 
-DATABASE:
-   Mode: {{ include "dolibarr.databaseMode" . }}
-   Host: {{ include "dolibarr.databaseHost" . }}
-   Port: {{ include "dolibarr.databasePort" . }}
-   Name: {{ include "dolibarr.databaseName" . }}
-   Username: {{ include "dolibarr.databaseUsername" . }}
-   Password secret: {{ include "dolibarr.databaseSecretName" . }} / {{ include "dolibarr.databaseSecretKey" . }}
-
-PERSISTENCE:
-   Documents PVC: {{ include "dolibarr.documentsPvcName" . }}
-   Custom PVC: {{ include "dolibarr.customPvcName" . }}
-
-ROUTING:
-   Service: {{ include "dolibarr.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
-   Ingress enabled: {{ .Values.ingress.enabled }}
-   Gateway API enabled: {{ .Values.gateway.enabled }}
+4. Configuration Summary
+========================
+  Database:         {{ include "dolibarr.databaseMode" . }} at {{ include "dolibarr.databaseHost" . }}:{{ include "dolibarr.databasePort" . }}
+  Database Name:    {{ include "dolibarr.databaseName" . }}
+  Database User:    {{ include "dolibarr.databaseUsername" . }}
+  MySQL subchart:   {{- if .Values.mysql.enabled }} enabled{{- else }} disabled{{- end }}
+  Documents PVC:    {{ include "dolibarr.documentsPvcName" . }}
+  Custom PVC:       {{ include "dolibarr.customPvcName" . }}
+  Backup CronJob:   {{- if .Values.backup.enabled }} enabled ({{ .Values.backup.schedule }}){{- else }} disabled{{- end }}
+  Ingress:          {{- if .Values.ingress.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:      {{- if .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets: {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
 {{- with .Values.service.ipFamilyPolicy }}
-   IP family policy: {{ . }}
+  IP Family Policy: {{ . }}
 {{- end }}
 {{- with .Values.service.ipFamilies }}
-   IP families: {{ join ", " . }}
+  IP Families:      {{ join ", " . }}
 {{- end }}
 
-OPTIONAL FEATURES:
-   Backups: {{ .Values.backup.enabled }}
-   External Secrets: {{ .Values.externalSecrets.enabled }}
+5. Getting Started
+==================
+  Step 1: Access Dolibarr with the port-forward command from section 2.
+  Step 2: Log in as {{ .Values.admin.login }} and complete company setup.
+  Step 3: Verify document upload persistence.
+  Step 4: Configure modules, email, backups, and a stable external URL.
+
+Upgrade reminder:
+  Dolibarr {{ .Chart.AppVersion }} includes upstream feature, security, and
+  bug-fix changes. Back up the database and documents/custom PVCs before
+  production upgrades. Use an external MySQL/MariaDB service for production HA
+  or managed database operations.
+
+6. Validation Commands
+======================
+  # Release status
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+  # Check pods and storage
+  kubectl get pods,pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  # Wait for the Dolibarr pod
+  kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "dolibarr.name" . }} --timeout=10m
+
+  # Test HTTP response through the Service
+  kubectl run {{ include "dolibarr.fullname" . }}-health-check -n {{ .Release.Namespace }} --rm -i --restart=Never \
+    --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "dolibarr.fullname" . }}:{{ .Values.service.port }}/
+
+  # Inspect routes when enabled
+  kubectl get ingress,httproute -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} 2>/dev/null || true
+
+7. Troubleshooting
+==================
+  Pod not ready:
+    -> Check Dolibarr logs:
+       kubectl logs deploy/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} -c dolibarr --tail=200
+    -> Check database wait logs:
+       kubectl logs deploy/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} -c wait-for-db --tail=100
+
+  Database connection refused:
+    -> Verify database.mode and database.external.* or mysql.enabled.
+    -> Check password secret {{ include "dolibarr.databaseSecretName" . }} / {{ include "dolibarr.databaseSecretKey" . }}.
+
+  Files are not persisted:
+    -> Verify documents and custom PVCs are Bound.
+    -> Check existingClaim values if reusing PVCs.
+
+  Backup job failed:
+    -> Verify backup.s3.endpoint, bucket, and credentials.
+    -> Inspect CronJob/Job logs in the release namespace.
+
+  Routing issue:
+    -> Confirm ingress.ingressClassName or gateway.parentRefs.
+    -> Check events:
+       kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+8. Backup
+=========
 {{- if .Values.backup.enabled }}
-   Backup schedule: {{ .Values.backup.schedule }}
-   Backup target: s3://{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+  Schedule: {{ .Values.backup.schedule }}
+  Target:   s3://{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}
+{{- else }}
+  Built-in S3 database backups are disabled.
+  Enable backup.enabled before high-risk upgrades or storage migrations.
 {{- end }}
-{{- if .Values.externalSecrets.enabled }}
-   SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
-{{- end }}
 
-VALIDATION:
-   Release status:
-     helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+9. Upgrading
+============
+  Minor upgrades: back up database and files, then upgrade normally with Helm.
+  Major upgrades: test with a copy of the database and document PVCs first.
+  Keep admin, runtime.instanceUniqueId, and database credentials stable.
 
-   Pods:
-     kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+10. Documentation
+=================
+  HelmForge docs: https://helmforge.dev/docs/charts/dolibarr
+  Upstream docs:  https://www.dolibarr.org
+  GitHub source:  https://github.com/helmforgedev/charts/tree/main/charts/dolibarr
 
-   Wait for readiness:
-     kubectl wait --for=condition=Ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "dolibarr.name" . }} --timeout=10m
-
-   Health check:
-     kubectl run {{ include "dolibarr.fullname" . }}-health-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- wget -qO- http://{{ include "dolibarr.fullname" . }}:{{ .Values.service.port }}/
-
-TROUBLESHOOTING:
-   Events:
-     kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
-
-   Logs:
-     kubectl logs deploy/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} -c dolibarr --tail=200
-
-   Database wait logs:
-     kubectl logs deploy/{{ include "dolibarr.fullname" . }} -n {{ .Release.Namespace }} -c wait-for-db --tail=100
-
-NOTES:
-   - Keep the admin, runtime, and database secrets stable across upgrades.
-   - Use external MySQL/MariaDB for production HA or managed database operations.
-   - Enable backups before changing storage, database mode, or chart major versions.
-   - Set dolibarr.siteUrl to the externally reachable URL for production installs.
-
-DOCUMENTATION:
-   Chart: https://helmforge.dev/docs/charts/dolibarr
-   Dolibarr: https://www.dolibarr.org
-   Source: https://github.com/helmforgedev/charts/tree/main/charts/dolibarr
-
-=============================================================================
+Happy Helmforging :)

--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -154,7 +154,11 @@ Database mode detection (auto | external | mysql).
 {{- if and (eq (include "dolibarr.databaseMode" .) "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
 {{- else if eq (include "dolibarr.databaseMode" .) "mysql" -}}
+{{- if .Values.mysql.auth.existingSecret -}}
+{{- .Values.mysql.auth.existingSecret -}}
+{{- else -}}
 {{- printf "%s-mysql-auth" .Release.Name -}}
+{{- end -}}
 {{- else -}}
 {{- printf "%s-database" (include "dolibarr.fullname" .) -}}
 {{- end -}}
@@ -164,7 +168,7 @@ Database mode detection (auto | external | mysql).
 {{- if and (eq (include "dolibarr.databaseMode" .) "external") .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecretPasswordKey -}}
 {{- else if eq (include "dolibarr.databaseMode" .) "mysql" -}}
-mysql-user-password
+{{- .Values.mysql.auth.existingSecretUserPasswordKey | default "mysql-user-password" -}}
 {{- else -}}
 database-password
 {{- end -}}

--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -76,6 +76,9 @@ Database mode detection (auto | external | mysql).
 */}}
 {{- define "dolibarr.databaseMode" -}}
 {{- $mode := .Values.database.mode | default "auto" -}}
+{{- if hasKey .Values.mysql "primary" -}}
+{{- fail "mysql.primary.* is not supported by the HelmForge MySQL 2.x dependency used by this chart. Migrate MySQL values to mysql.standalone.* before upgrading." -}}
+{{- end -}}
 {{- if not (has $mode (list "auto" "external" "mysql")) -}}
 {{- fail (printf "database.mode must be one of: auto, external, mysql (got %s)" $mode) -}}
 {{- end -}}

--- a/charts/dolibarr/templates/deployment.yaml
+++ b/charts/dolibarr/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       initContainers:
         - name: wait-for-db
           image: docker.io/library/busybox:1.37
+          {{- with .Values.waitForDatabase.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -57,6 +61,10 @@ spec:
               value: {{ include "dolibarr.databaseHost" . | quote }}
             - name: DB_PORT
               value: {{ include "dolibarr.databasePort" . | quote }}
+          {{- with .Values.waitForDatabase.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: dolibarr
           image: {{ include "dolibarr.image" . }}

--- a/charts/dolibarr/templates/httproute.yaml
+++ b/charts/dolibarr/templates/httproute.yaml
@@ -1,7 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.enabled }}
 {{- if not .Values.gateway.parentRefs }}
-  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
+{{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -9,18 +14,22 @@ metadata:
   name: {{ include "dolibarr.fullname" . }}
   labels:
     {{- include "dolibarr.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
     {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
-  {{- if .Values.gateway.hostnames }}
+  {{- with .Values.gateway.hostnames }}
   hostnames:
-    {{- toYaml .Values.gateway.hostnames | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: PathPrefix
-            value: /
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
       backendRefs:
         - name: {{ include "dolibarr.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -201,6 +201,17 @@ tests:
             name: DOLI_DB_SSL
             value: "1"
 
+  - it: should fail fast when legacy mysql.primary values are used
+    set:
+      mysql:
+        primary:
+          persistence:
+            enabled: true
+            size: 20Gi
+    asserts:
+      - failedTemplate:
+          errorMessage: "mysql.primary.* is not supported by the HelmForge MySQL 2.x dependency used by this chart. Migrate MySQL values to mysql.standalone.* before upgrading."
+
   - it: should auto-detect the ingress host as DOLI_URL_ROOT
     set:
       ingress.enabled: true

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -48,6 +48,32 @@ tests:
           content:
             name: DOLI_DB_USER
             value: "dolibarr"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DOLI_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-mysql-auth
+                key: mysql-user-password
+
+  - it: should use the bundled MySQL existing auth secret for the database password
+    set:
+      mysql:
+        auth:
+          existingSecret: dolibarr-mysql-auth
+          existingSecretUserPasswordKey: user-password
+          existingSecretRootPasswordKey: root-password
+          existingSecretReplicationPasswordKey: replication-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DOLI_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: dolibarr-mysql-auth
+                key: user-password
 
   - it: should set the admin password from the generated secret
     asserts:
@@ -104,7 +130,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
-          value: 120
+          value: 70
 
   - it: should include the wait-for-db init container
     asserts:

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -114,6 +114,29 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: docker.io/library/busybox:1.37
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should set default pod security context and container resources
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 768Mi
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
 
   - it: should mount both Dolibarr PVCs
     asserts:

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/dolibarr/dolibarr:23.0.2
+          value: docker.io/dolibarr/dolibarr:23.0.3
 
   - it: should set database env vars for the MySQL subchart
     asserts:
@@ -99,6 +99,12 @@ tests:
           content:
             name: DOLI_CRON
             value: "0"
+
+  - it: should delay startup probing until first-run bootstrap can complete
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 120
 
   - it: should include the wait-for-db init container
     asserts:

--- a/charts/dolibarr/tests/gateway_api_test.yaml
+++ b/charts/dolibarr/tests/gateway_api_test.yaml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - templates/httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render an HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when Gateway API is enabled
+    set:
+      gateway.enabled: true
+      gateway.annotations:
+        example.com/route: dolibarr
+      gateway.parentRefs:
+        - name: public-gateway
+          namespace: gateway-system
+      gateway.hostnames:
+        - erp.example.com
+      gateway.path: /dolibarr
+      gateway.pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.annotations["example.com/route"]
+          value: dolibarr
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - contains:
+          path: spec.hostnames
+          content: erp.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /dolibarr
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-dolibarr
+
+  - it: should require parentRefs when Gateway API is enabled
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."
+
+  - it: should require a name in each parentRef
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - namespace: gateway-system
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each gateway.parentRefs entry must define a 'name' field"

--- a/charts/dolibarr/values.schema.json
+++ b/charts/dolibarr/values.schema.json
@@ -216,9 +216,9 @@
             }
           }
         },
-        "primary": {
+        "standalone": {
           "type": "object",
-          "description": "MySQL primary configuration",
+          "description": "MySQL standalone configuration",
           "properties": {
             "persistence": {
               "type": "object",
@@ -232,6 +232,10 @@
                   "description": "PVC size for MySQL"
                 }
               }
+            },
+            "resources": {
+              "type": "object",
+              "description": "Resources for standalone MySQL"
             }
           }
         },
@@ -337,15 +341,69 @@
     },
     "resources": {
       "type": "object",
-      "description": "CPU and memory requests/limits for the Dolibarr container"
+      "description": "CPU and memory requests/limits for the Dolibarr container",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
+          }
+        }
+      }
     },
     "podSecurityContext": {
       "type": "object",
-      "description": "Pod-level security context"
+      "description": "Pod-level security context",
+      "properties": {
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" }
+          }
+        }
+      }
     },
     "securityContext": {
       "type": "object",
-      "description": "Container-level security context"
+      "description": "Container-level security context",
+      "properties": {
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "add": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "waitForDatabase": {
+      "type": "object",
+      "description": "wait-for-db init container configuration",
+      "properties": {
+        "resources": {
+          "type": "object",
+          "description": "CPU and memory requests/limits for the wait-for-db init container"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for the wait-for-db init container"
+        }
+      }
     },
     "startupProbe": {
       "type": "object",
@@ -453,6 +511,19 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the Service"
+        },
+        "ipFamilyPolicy": {
+          "type": ["string", "null"],
+          "description": "Service IP family policy",
+          "enum": ["SingleStack", "PreferDualStack", "RequireDualStack", "", null]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Service IP families override",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
         }
       }
     },
@@ -679,8 +750,20 @@
       "description": "Gateway API configuration (GR-060)",
       "properties": {
         "enabled": { "type": "boolean", "default": false },
-        "parentRefs": { "type": "array" },
-        "hostnames": { "type": "array" }
+        "annotations": { "type": "object" },
+        "parentRefs": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "path": { "type": "string" },
+        "pathType": {
+          "type": "string",
+          "enum": ["Exact", "PathPrefix", "RegularExpression"]
+        }
       }
     },
     "externalSecrets": {

--- a/charts/dolibarr/values.schema.json
+++ b/charts/dolibarr/values.schema.json
@@ -213,6 +213,22 @@
             "rootPassword": {
               "type": "string",
               "description": "Root password"
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing MySQL auth secret used by the bundled MySQL subchart"
+            },
+            "existingSecretUserPasswordKey": {
+              "type": "string",
+              "description": "Key in the MySQL auth secret for the application user password"
+            },
+            "existingSecretRootPasswordKey": {
+              "type": "string",
+              "description": "Key in the MySQL auth secret for the root password"
+            },
+            "existingSecretReplicationPasswordKey": {
+              "type": "string",
+              "description": "Key in the MySQL auth secret for the replication password"
             }
           }
         },

--- a/charts/dolibarr/values.schema.json
+++ b/charts/dolibarr/values.schema.json
@@ -234,6 +234,16 @@
               }
             }
           }
+        },
+        "startupProbe": {
+          "type": "object",
+          "description": "MySQL startup probe overrides",
+          "properties": {
+            "initialDelaySeconds": {
+              "type": "integer",
+              "description": "Initial delay before the MySQL startup probe starts"
+            }
+          }
         }
       }
     },

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -64,6 +64,10 @@ mysql:
     username: dolibarr
     password: ""
     rootPassword: ""
+    existingSecret: ""
+    existingSecretUserPasswordKey: mysql-user-password
+    existingSecretRootPasswordKey: mysql-root-password
+    existingSecretReplicationPasswordKey: mysql-replication-password
 
   standalone:
     persistence:
@@ -139,7 +143,7 @@ waitForDatabase:
 startupProbe:
   enabled: true
   path: /
-  initialDelaySeconds: 120
+  initialDelaySeconds: 70
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 30

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -65,10 +65,17 @@ mysql:
     password: ""
     rootPassword: ""
 
-  primary:
+  standalone:
     persistence:
       enabled: true
       size: 8Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi
 
   startupProbe:
     initialDelaySeconds: 30
@@ -96,10 +103,38 @@ php:
   postMaxSize: ""
   maxExecutionTime: ""
 
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
 
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# The official Dolibarr image performs first-run file ownership and Apache setup
+# as root. Keep the default empty; operators can harden this after validating
+# their image/runtime combination.
 securityContext: {}
+
+waitForDatabase:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 65534
+    capabilities:
+      drop:
+        - ALL
 
 startupProbe:
   enabled: true
@@ -130,7 +165,7 @@ service:
   port: 80
   annotations: {}
   # -- Set the ipFamilyPolicy for dual-stack (GR-058)
-  ipFamilyPolicy: ''
+  ipFamilyPolicy: ~
   # -- Set the ipFamilies for dual-stack
   ipFamilies: []
 
@@ -214,11 +249,20 @@ backup:
 
 ## Gateway API configuration (GR-060)
 gateway:
+  # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs).
   enabled: false
-  hostnames: []
+  # -- Annotations for the HTTPRoute.
+  annotations: {}
+  # -- parentRefs list pointing to your Gateway resource.
   parentRefs: []
   #   - name: my-gateway
   #     namespace: default
+  # -- Hostnames the HTTPRoute matches.
+  hostnames: []
+  # -- Path prefix for the HTTPRoute.
+  path: /
+  # -- Path match type.
+  pathType: PathPrefix
 
 ## ExternalSecrets configuration (GR-061)
 externalSecrets:

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/dolibarr/dolibarr
-  tag: "23.0.2"
+  tag: "23.0.3"
   pullPolicy: IfNotPresent
   # Keep tag empty to default to Chart.appVersion.
 
@@ -70,6 +70,9 @@ mysql:
       enabled: true
       size: 8Gi
 
+  startupProbe:
+    initialDelaySeconds: 30
+
 persistence:
   documents:
     enabled: true
@@ -101,7 +104,7 @@ securityContext: {}
 startupProbe:
   enabled: true
   path: /
-  initialDelaySeconds: 20
+  initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 30
@@ -228,4 +231,3 @@ externalSecrets:
   target:
     creationPolicy: Owner
   data: []
-


### PR DESCRIPTION
## Summary
- Update Dolibarr to 23.0.3.
- Add Dolibarr chart design documentation.
- Tune Dolibarr and bundled HelmForge MySQL startup probes based on k3d bootstrap validation.

## Upstream Research
- GitHub release `23.0.3` was published on 2026-05-17.
- Release notes include bug fixes and security fixes, including IDOR, API permission, SSRF, SQL injection, and GHSA fixes.
- Verified `docker.io/dolibarr/dolibarr:23.0.3` image manifest for `linux/amd64` and `linux/arm64`.

## Validation
- [x] `helm dependency build charts/dolibarr`
- [x] `helm dependency list charts/dolibarr` (`mysql 1.8.5`, HelmForge OCI, ok)
- [x] `helm lint charts/dolibarr`
- [x] `helm lint --strict charts/dolibarr`
- [x] `helm template dolibarr-test charts/dolibarr`
- [x] `helm template` for CI values: `default-values`, `ingress-values`, `gateway-api`, `external-secrets`, `external-db-values`, `dual-stack`, `backup-values`
- [x] `helm unittest charts/dolibarr` (42 tests, 8 suites)
- [x] `ah lint -p charts/dolibarr`
- [x] `kubeconform -strict -summary` for defaults and all CI values with Datree CRD catalog
- [x] `kubescape scan framework mitre,nsa,soc2` (overall compliance-score 82)
- [x] Live k3d validation on `k3d-helmforge-tests-wsl` with the bundled HelmForge MySQL subchart: pods Ready, HTTP 200, zero non-normal events, invalid log lines 0, namespace cleaned

Note: `helm dependency build` still prints the known local repo warning for `devlake` returning 404, but the Dolibarr dependency resolution succeeds and `mysql 1.8.5` is ok.

Closes #393