### PR TITLE
chore(elasticsearch): update Elasticsearch to 9.4.2

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
-version: 1.1.1
-appVersion: "9.4.1"
+version: 1.1.2
+appVersion: "9.4.2"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev
@@ -27,7 +27,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "promote remaining charts to stable (#406)"
+      description: "update Elasticsearch to 9.4.2 with upstream security fixes (#394)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/elasticsearch/DESIGN.md
+++ b/charts/elasticsearch/DESIGN.md
@@ -1,0 +1,116 @@
+# Elasticsearch Chart Design
+
+## Scope
+
+This chart deploys Elasticsearch using the official `docker.io/library/elasticsearch` image.
+It is built around profile-driven Kubernetes topologies instead of requiring users to assemble every role manually.
+
+Supported profiles:
+
+- `dev`: single-node development profile with lightweight defaults
+- `staging`: representative multi-node profile for validation and integration environments
+- `production-ha`: multi-role high availability profile with master, data, and coordinating nodes
+
+Optional capabilities include S3 snapshots, ILM policies, hot/warm data tiers, cert-manager TLS, External Secrets,
+Gateway API, Prometheus monitoring, Grafana dashboards, and a colocated Kibana deployment.
+
+## Architecture: Dev
+
+```mermaid
+flowchart LR
+  client[Client] --> svc[HTTP Service]
+  svc --> master[Single Elasticsearch StatefulSet]
+  master --> pvc[(Optional PVC)]
+  secret[Credentials Secret] --> master
+  cfg[ConfigMap] --> master
+```
+
+The dev profile keeps the deployment small for local clusters and chart validation. It is not intended for production data.
+
+## Architecture: Staging
+
+```mermaid
+flowchart LR
+  client[Client] --> edge[Ingress or HTTPRoute]
+  edge --> svc[HTTP Service]
+  svc --> master[Master StatefulSet]
+  svc --> data0[Data StatefulSet]
+  master --> masterPvc[(Master PVC)]
+  data0 --> dataPvc[(Data PVCs)]
+  pdb[Data PDB] --> data0
+```
+
+The staging profile validates shard placement, persistence, PDB behavior, and operational settings without the full
+resource footprint of production HA.
+
+## Architecture: Production HA
+
+```mermaid
+flowchart TB
+  clients[Clients] --> edge[Ingress or HTTPRoute]
+  edge --> svc[HTTP Service]
+  svc --> coord[Coordinating StatefulSet]
+  coord --> masters[3 master-eligible pods]
+  coord --> data[Data pods]
+  data --> tiers[Optional hot/warm tiers]
+  cert[cert-manager Certificate] --> masters
+  cert --> data
+  backup[Snapshot CronJob] --> s3[S3-compatible storage]
+  metrics[Exporter sidecars] --> prom[Prometheus]
+```
+
+Production HA separates roles, enables disruption budgets, and provides opt-in TLS, backups, monitoring, and tiered storage.
+Operators should still own capacity planning, shard strategy, snapshots, restore drills, and version upgrade sequencing.
+
+## Main Design Choices
+
+- Use the official Elasticsearch and Kibana images.
+- Keep chart defaults lightweight while exposing production profiles through `clusterProfile`.
+- Generate role-specific StatefulSets instead of using a single generic pod template.
+- Keep Kibana optional and version-aligned with Elasticsearch.
+- Render Gateway API and External Secrets only when explicitly enabled.
+- Use cert-manager integration when TLS is managed by the cluster, and self-signed hook jobs for clusters without it.
+- Provide S3 snapshots as an explicit scheduled backup path, not as a replacement for restore testing.
+
+## Production Boundary
+
+Before production use, operators should define:
+
+- credentials through existing Secrets or External Secrets
+- TLS issuer and certificate lifecycle
+- PVC sizes and storage classes per role or tier
+- resource requests, JVM heap, and shard allocation strategy
+- backup bucket, retention, and restore runbooks
+- monitoring, alert routing, and dashboard ownership
+- upgrade sequencing for Elasticsearch, Kibana, plugins, index templates, and ILM policies
+
+## Explicit Non-Goals
+
+- Elasticsearch operator behavior
+- automatic major version migrations
+- automatic shard rebalancing policy decisions beyond Elasticsearch defaults
+- plugin installation and lifecycle management
+- cross-cluster replication or remote cluster orchestration
+- replacing Elastic Cloud Enterprise, ECK, or managed Elasticsearch platforms
+
+<!-- @AI-METADATA
+type: design
+title: Elasticsearch Chart Design
+description: Design document for the Elasticsearch Helm chart profiles, architecture, production boundary, and non-goals
+
+keywords: elasticsearch, design, architecture, profiles, production-ha, staging, data-tiers, backup, kubernetes
+
+purpose: Document chart architecture, supported profiles, operational decisions, and production boundaries
+scope: Chart Design
+
+relations:
+  - charts/elasticsearch/README.md
+  - charts/elasticsearch/docs/profile-dev.md
+  - charts/elasticsearch/docs/profile-staging.md
+  - charts/elasticsearch/docs/profile-production-ha.md
+  - charts/elasticsearch/docs/backup-restore.md
+  - charts/elasticsearch/docs/security.md
+path: charts/elasticsearch/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -161,7 +161,7 @@ dataTiers:
 | `namespaceOverride` | Namespace for chart-managed namespaced resources | `""` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.4.1` |
+| `image.tag` | Image tag | `9.4.2` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -262,7 +262,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.1` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.2` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -301,11 +301,11 @@ dataTiers:
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.1` is an upstream image update from
-`9.4.0`. Review the upstream Elasticsearch release notes before upgrading
-production clusters, take a snapshot backup, and verify Kibana compatibility,
-plugins, ILM policies, and index templates in a staging environment before
-reusing existing PVCs.
+`docker.io/library/elasticsearch:9.4.2` is an upstream image update from
+`9.4.1` with upstream security fixes. Review the upstream Elasticsearch release
+notes before upgrading production clusters, take a snapshot backup, and verify
+Kibana compatibility, plugins, ILM policies, and index templates in a staging
+environment before reusing existing PVCs.
 
 ## Resources Generated
 
@@ -326,6 +326,7 @@ See the [`examples/`](examples/) directory:
 
 ## Architecture Guides
 
+- [`DESIGN.md`](DESIGN.md) — chart architecture, profiles, boundaries, and non-goals
 - [`docs/profile-dev.md`](docs/profile-dev.md) — when to use single-node dev profile
 - [`docs/profile-staging.md`](docs/profile-staging.md) — when to use staging profile
 - [`docs/profile-production-ha.md`](docs/profile-production-ha.md) — production HA cluster guidance

--- a/charts/elasticsearch/docs/profile-staging.md
+++ b/charts/elasticsearch/docs/profile-staging.md
@@ -1,0 +1,91 @@
+# Elasticsearch Staging Profile
+
+## Scope
+
+The `staging` profile is a representative multi-node Elasticsearch topology for integration environments, release
+validation, and pre-production operational checks.
+
+It is designed to validate behavior that the `dev` profile cannot cover:
+
+- master and data role separation
+- persistent data nodes
+- data PodDisruptionBudget rendering
+- service discovery and cluster formation with more than one pod
+- ingress, Gateway API, monitoring, backup, and security combinations before production
+
+## Recommended Use
+
+```yaml
+clusterProfile: staging
+
+master:
+  persistence:
+    size: 20Gi
+
+data:
+  persistence:
+    size: 100Gi
+
+security:
+  enabled: true
+```
+
+Use staging before production upgrades to verify:
+
+- snapshot and restore workflow
+- Kibana version compatibility
+- plugins and custom index templates
+- ILM policy behavior
+- Prometheus scraping and alert rules
+- Gateway API or Ingress routing
+
+## Architecture
+
+```mermaid
+flowchart LR
+  clients[Clients] --> svc[HTTP Service]
+  svc --> master[Master StatefulSet]
+  svc --> data[Data StatefulSet]
+  master --> masterPvc[(Master PVC)]
+  data --> dataPvcs[(Data PVCs)]
+  dataPdb[Data PDB] --> data
+```
+
+## Production Differences
+
+Compared with `production-ha`, staging intentionally keeps the footprint smaller:
+
+- one master pod instead of three master-eligible pods
+- two data pods instead of the production data default
+- no coordinating nodes by default
+- smaller profile-driven resource and storage defaults
+- only data PDB enabled by default
+
+Do not treat the staging profile as highly available production Elasticsearch. It is a validation profile.
+
+## Operational Notes
+
+- Keep staging on the same minor version as production when testing upgrades.
+- Use a separate snapshot repository or bucket prefix from production.
+- Use production-like index templates and ILM policies when validating behavior.
+- Use explicit PVC sizes and storage classes so test results reflect the target platform.
+
+<!-- @AI-METADATA
+type: chart-doc
+title: Elasticsearch Staging Profile
+description: Operational guide for the Elasticsearch staging profile
+
+keywords: elasticsearch, staging, profile, validation, helm, kubernetes
+
+purpose: Explain when and how to use the staging profile and how it differs from production HA
+scope: Chart Documentation
+
+relations:
+  - charts/elasticsearch/README.md
+  - charts/elasticsearch/DESIGN.md
+  - charts/elasticsearch/docs/profile-dev.md
+  - charts/elasticsearch/docs/profile-production-ha.md
+path: charts/elasticsearch/docs/profile-staging.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/elasticsearch/templates/NOTES.txt
+++ b/charts/elasticsearch/templates/NOTES.txt
@@ -6,195 +6,253 @@
 {{- $coordReplicas := int (include "elasticsearch.coordinating.replicaCount" .) -}}
 {{- $securityEnabled := include "elasticsearch.security.enabled" . -}}
 {{- $scheme := ternary "https" "http" (eq $securityEnabled "true") -}}
-{{- $namespace := (include "elasticsearch.namespace" .) -}}
+{{- $namespace := include "elasticsearch.namespace" . -}}
 {{- $releaseNamespace := .Release.Namespace -}}
 
-------------------------------------------------------------------------
--           Elasticsearch - Deployed via HelmForge                    -
-------------------------------------------------------------------------
+1. Elasticsearch has been installed
+===================================
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ $namespace }}
+  Helm Namespace: {{ $releaseNamespace }}
+  Version:        {{ .Chart.AppVersion }}
+  Cluster Name:   {{ .Values.clusterName }}
+  Profile:        {{ $profile }}
+  Security:       {{ if eq $securityEnabled "true" }}enabled (TLS + authentication){{ else }}disabled{{ end }}
 
--  Deployment complete!
-
-Cluster Profile : {{ $profile | upper }}
-Cluster Name    : {{ .Values.clusterName }}
-Version         : {{ .Chart.AppVersion }}
-Security        : {{ if eq $securityEnabled "true" }}ENABLED (TLS + auth){{ else }}DISABLED (no TLS){{ end }}
-
-CLUSTER TOPOLOGY
--------------------------------------------
-  Master nodes      : {{ $masterReplicas }}
-  Data nodes        : {{ $dataReplicas }}
-  Coordinating nodes: {{ $coordReplicas }}
-  Total nodes       : {{ add $masterReplicas $dataReplicas $coordReplicas }}
-
-{{- if gt $dataReplicas 0 }}
-  Heap (master)     : {{ include "elasticsearch.master.heapSize" . }}
-  Heap (data)       : {{ include "elasticsearch.data.heapSize" . }}
-{{- else }}
-  Heap (master/all) : {{ include "elasticsearch.master.heapSize" . }}
-{{- end }}
-
-ACCESS
--------------------------------------------
-  From inside the cluster:
+2. Access
+=========
+  In-cluster endpoint:
     HOST: {{ $fullname }}.{{ $namespace }}.svc.cluster.local
-    HTTP: {{ $scheme }}://{{ $fullname }}.{{ $namespace }}.svc.cluster.local:9200
+    {{ $scheme }}://{{ $fullname }}.{{ $namespace }}.svc.cluster.local:9200
 
-  Port-forward to your machine:
+  Port-forward locally:
     kubectl port-forward svc/{{ $fullname }} 9200:9200 -n {{ $namespace }}
-    Then: curl {{ $scheme }}://localhost:9200
 
 {{- if eq $securityEnabled "true" }}
-CREDENTIALS
--------------------------------------------
-  Get the elastic user password:
-    kubectl get secret {{ include "elasticsearch.credentialsSecretName" . }} \
-      -n {{ $namespace }} \
-      -o jsonpath='{.data.elastic-password}' | base64 -d
+  Read the generated elastic password:
+    export ELASTIC_PASSWORD=$(kubectl get secret {{ include "elasticsearch.credentialsSecretName" . }} -n {{ $namespace }} -o jsonpath='{.data.elastic-password}' | base64 -d)
 
-  Test with credentials:
-    curl -u elastic:<password> -k {{ $scheme }}://localhost:9200
+  Test the API:
+    curl -k -u elastic:${ELASTIC_PASSWORD} https://localhost:9200
 {{- else }}
-QUICK CHECK
--------------------------------------------
-  Once port-forwarded:
+  Test the API:
     curl http://localhost:9200
-    curl http://localhost:9200/_cluster/health?pretty
+{{- end }}
+{{- if .Values.ingress.enabled }}
+
+  Ingress is enabled:
+  {{- range .Values.ingress.hosts }}
+    - {{ .host }}
+  {{- end }}
+{{- end }}
+{{- if .Values.gateway.enabled }}
+
+  Gateway API HTTPRoute is enabled.
+  Hostnames:
+  {{- range .Values.gateway.hostnames }}
+    - {{ . }}
+  {{- else }}
+    - none configured
+  {{- end }}
 {{- end }}
 
-CLUSTER HEALTH
--------------------------------------------
-  Check health:
-    kubectl exec -it {{ $fullname }}-master-0 -n {{ $namespace }} -- \
-      curl -s{{ if eq $securityEnabled "true" }}ku elastic:$(cat /dev/stdin){{ end }} \
-      {{ $scheme }}://localhost:9200/_cluster/health?pretty
+3. Cluster Topology
+===================
+  Master nodes:       {{ $masterReplicas }}
+  Data nodes:         {{ $dataReplicas }}
+  Coordinating nodes: {{ $coordReplicas }}
+  Total nodes:        {{ add $masterReplicas $dataReplicas $coordReplicas }}
+{{- if gt $dataReplicas 0 }}
+  Master heap:        {{ include "elasticsearch.master.heapSize" . }}
+  Data heap:          {{ include "elasticsearch.data.heapSize" . }}
+{{- else }}
+  Node heap:          {{ include "elasticsearch.master.heapSize" . }}
+{{- end }}
 
-  Watch pod status:
-    kubectl get pods -n {{ $namespace }} -l app.kubernetes.io/name=elasticsearch -w
+4. Configuration Summary
+========================
+  Service type:       {{ .Values.service.type }}
+  HTTP port:          {{ .Values.service.httpPort }}
+  Transport port:     {{ .Values.service.transportPort }}
+  Persistence:        master={{ .Values.master.persistence.enabled }}, data={{ .Values.data.persistence.enabled }}
+  Sysctl init:        {{ .Values.sysctlInit.enabled }}
+  Backup:             {{ .Values.backup.enabled }}
+  ILM logs:           {{ .Values.ilm.logs.enabled }}
+  ILM metrics:        {{ .Values.ilm.metrics.enabled }}
+  ILM traces:         {{ .Values.ilm.traces.enabled }}
+  Monitoring:         {{ .Values.monitoring.enabled }}
+  Kibana:             {{ .Values.kibana.enabled }}
+  External Secrets:   {{ .Values.externalSecrets.enabled }}
 
-  View logs (master-0):
-    kubectl logs {{ $fullname }}-master-0 -n {{ $namespace }} -f
+5. Validation Commands
+======================
+  Wait for all Elasticsearch pods:
+    kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=elasticsearch -n {{ $namespace }} --timeout=300s
 
+  Check pod status:
+    kubectl get pods -n {{ $namespace }} -l app.kubernetes.io/name=elasticsearch -o wide
+
+  Check cluster health:
+{{- if eq $securityEnabled "true" }}
+    export ELASTIC_PASSWORD=$(kubectl get secret {{ include "elasticsearch.credentialsSecretName" . }} -n {{ $namespace }} -o jsonpath='{.data.elastic-password}' | base64 -d)
+    kubectl exec -n {{ $namespace }} {{ $fullname }}-master-0 -- \
+      curl -ks -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/_cluster/health?pretty
+{{- else }}
+    kubectl exec -n {{ $namespace }} {{ $fullname }}-master-0 -- \
+      curl -s http://localhost:9200/_cluster/health?pretty
+{{- end }}
+
+  List nodes:
+{{- if eq $securityEnabled "true" }}
+    kubectl exec -n {{ $namespace }} {{ $fullname }}-master-0 -- \
+      curl -ks -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/_cat/nodes?v
+{{- else }}
+    kubectl exec -n {{ $namespace }} {{ $fullname }}-master-0 -- \
+      curl -s http://localhost:9200/_cat/nodes?v
+{{- end }}
+
+  Inspect logs:
+    kubectl logs {{ $fullname }}-master-0 -n {{ $namespace }} --tail=200
+
+6. Getting Started
+==================
+  Create a test index after port-forwarding:
+{{- if eq $securityEnabled "true" }}
+    curl -k -u elastic:${ELASTIC_PASSWORD} -X PUT https://localhost:9200/helmforge-test \
+      -H 'Content-Type: application/json' \
+      -d '{"settings":{"number_of_shards":1,"number_of_replicas":0}}'
+{{- else }}
+    curl -X PUT http://localhost:9200/helmforge-test \
+      -H 'Content-Type: application/json' \
+      -d '{"settings":{"number_of_shards":1,"number_of_replicas":0}}'
+{{- end }}
+
+  Index a document:
+{{- if eq $securityEnabled "true" }}
+    curl -k -u elastic:${ELASTIC_PASSWORD} -X POST https://localhost:9200/helmforge-test/_doc \
+      -H 'Content-Type: application/json' \
+      -d '{"title":"Hello HelmForge","source":"helm-notes"}'
+{{- else }}
+    curl -X POST http://localhost:9200/helmforge-test/_doc \
+      -H 'Content-Type: application/json' \
+      -d '{"title":"Hello HelmForge","source":"helm-notes"}'
+{{- end }}
+
+  Search:
+{{- if eq $securityEnabled "true" }}
+    curl -k -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/helmforge-test/_search?q=HelmForge\&pretty
+{{- else }}
+    curl http://localhost:9200/helmforge-test/_search?q=HelmForge\&pretty
+{{- end }}
 {{- if .Values.backup.enabled }}
-BACKUP
--------------------------------------------
-  Schedule : {{ .Values.backup.schedule }}
-  Bucket   : {{ .Values.backup.s3.bucket }}
+
+7. Backup
+=========
+  Schedule:  {{ .Values.backup.schedule }}
+  Bucket:    {{ .Values.backup.s3.bucket }}
+  Prefix:    {{ .Values.backup.s3.prefix }}
   Retention: {{ .Values.backup.retention.days }} days
 
   Trigger a manual backup:
-    kubectl create job --from=cronjob/{{ $fullname }}-backup \
-      manual-backup-$(date +%s) -n {{ $namespace }}
+    kubectl create job --from=cronjob/{{ $fullname }}-backup manual-backup-$(date +%s) -n {{ $namespace }}
 
-  List snapshots (after port-forward):
-    curl {{ $scheme }}://localhost:9200/_snapshot/helmforge-s3/_all?pretty
+  List snapshots after port-forwarding:
+{{- if eq $securityEnabled "true" }}
+    curl -k -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/_snapshot/helmforge-s3/_all?pretty
 {{- else }}
---  BACKUP DISABLED - enable with:
-    helm upgrade {{ .Release.Name }} helmforge/elasticsearch \
-      -n {{ $releaseNamespace }} \
+    curl http://localhost:9200/_snapshot/helmforge-s3/_all?pretty
+{{- end }}
+{{- else }}
+
+7. Backup
+=========
+  Backup is disabled. Enable S3 snapshots with:
+    helm upgrade {{ .Release.Name }} helmforge/elasticsearch -n {{ $releaseNamespace }} \
       --set backup.enabled=true \
       --set backup.s3.bucket=<bucket> \
-      --set backup.s3.accessKey=<key> \
-      --set backup.s3.secretKey=<secret>
+      --set backup.s3.accessKey=<access-key> \
+      --set backup.s3.secretKey=<secret-key>
 {{- end }}
-
 {{- if or .Values.ilm.logs.enabled .Values.ilm.metrics.enabled .Values.ilm.traces.enabled }}
-ILM POLICIES
--------------------------------------------
+
+8. ILM and Monitoring
+=====================
+  Enabled ILM policies:
   {{- if .Values.ilm.logs.enabled }}
-  - helmforge-logs   - hot:{{ .Values.ilm.logs.hotDays }}d - warm:{{ .Values.ilm.logs.warmDays }}d - cold:{{ .Values.ilm.logs.coldDays }}d - delete:{{ .Values.ilm.logs.deleteDays }}d
+    - helmforge-logs: hot={{ .Values.ilm.logs.hotDays }}d warm={{ .Values.ilm.logs.warmDays }}d cold={{ .Values.ilm.logs.coldDays }}d delete={{ .Values.ilm.logs.deleteDays }}d
   {{- end }}
   {{- if .Values.ilm.metrics.enabled }}
-  - helmforge-metrics - hot:{{ .Values.ilm.metrics.hotDays }}d - warm:{{ .Values.ilm.metrics.warmDays }}d - delete:{{ .Values.ilm.metrics.deleteDays }}d
+    - helmforge-metrics: hot={{ .Values.ilm.metrics.hotDays }}d warm={{ .Values.ilm.metrics.warmDays }}d delete={{ .Values.ilm.metrics.deleteDays }}d
   {{- end }}
   {{- if .Values.ilm.traces.enabled }}
-  - helmforge-traces  - hot:{{ .Values.ilm.traces.hotDays }}d - warm:{{ .Values.ilm.traces.warmDays }}d - delete:{{ .Values.ilm.traces.deleteDays }}d
+    - helmforge-traces: hot={{ .Values.ilm.traces.hotDays }}d warm={{ .Values.ilm.traces.warmDays }}d delete={{ .Values.ilm.traces.deleteDays }}d
   {{- end }}
+{{- else }}
 
-  Apply ILM policy to an index:
-    curl -X POST "localhost:9200/_ilm/policy/helmforge-logs/_explain?pretty"
+8. ILM and Monitoring
+=====================
+  ILM policies are disabled by default.
 {{- end }}
-
 {{- if .Values.monitoring.enabled }}
-MONITORING
--------------------------------------------
-  - Prometheus exporter running on port 9114
-  {{- if .Values.monitoring.serviceMonitor.enabled }}
-  - ServiceMonitor created for Prometheus Operator
-  {{- end }}
-  {{- if .Values.monitoring.prometheusRule.enabled }}
-  - Alert rules created
-  {{- end }}
+  Prometheus exporter is enabled on port 9114.
+  ServiceMonitor: {{ .Values.monitoring.serviceMonitor.enabled }}
+  PrometheusRule: {{ .Values.monitoring.prometheusRule.enabled }}
 {{- end }}
-
 {{- if .Values.kibana.enabled }}
-KIBANA
--------------------------------------------
-  Port-forward Kibana:
+
+  Kibana access:
     kubectl port-forward svc/{{ $fullname }}-kibana 5601:5601 -n {{ $namespace }}
-    Open: http://localhost:5601
+    Open http://localhost:5601
 {{- end }}
 
-CONFIGURATION
--------------------------------------------
-  View the applied values:
+9. Troubleshooting
+==================
+  Pods pending:
+    kubectl get pvc -n {{ $namespace }}
+    kubectl describe pod {{ $fullname }}-master-0 -n {{ $namespace }}
+
+  Pods fail during bootstrap:
+    kubectl logs {{ $fullname }}-master-0 -n {{ $namespace }} -c sysctl
+    # Elasticsearch requires vm.max_map_count=262144. Keep sysctlInit.enabled=true or configure nodes manually.
+
+  Cluster not forming:
+    kubectl exec -n {{ $namespace }} {{ $fullname }}-master-0 -- env | grep -E 'cluster.name|discovery|initial_master_nodes'
+    kubectl logs {{ $fullname }}-master-0 -n {{ $namespace }} --tail=300
+
+  Security enabled but API returns 401:
+    kubectl get secret {{ include "elasticsearch.credentialsSecretName" . }} -n {{ $namespace }}
+    kubectl get secret {{ include "elasticsearch.tlsSecretName" . }} -n {{ $namespace }}
+
+  Storage pressure or red/yellow health:
+{{- if eq $securityEnabled "true" }}
+    curl -k -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/_cat/allocation?v
+    curl -k -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/_cat/shards?v
+{{- else }}
+    curl http://localhost:9200/_cat/allocation?v
+    curl http://localhost:9200/_cat/shards?v
+{{- end }}
+
+10. Documentation
+=================
+  Helm values:
     helm get values {{ .Release.Name }} -n {{ $releaseNamespace }}
 
-  Upgrade the release with a values file:
-    helm upgrade {{ .Release.Name }} helmforge/elasticsearch \
-      -n {{ $releaseNamespace }} -f values.yaml
+  Upgrade with a values file:
+    helm upgrade {{ .Release.Name }} helmforge/elasticsearch -n {{ $releaseNamespace }} -f values.yaml
 
-GETTING STARTED
--------------------------------------------
-  1. Wait for cluster to form:
-     kubectl wait --for=condition=ready pod \
-       -l app.kubernetes.io/name=elasticsearch \
-       -n {{ $namespace }} --timeout=300s
-
-  2. Create a test index:
-     curl -X PUT "localhost:9200/test-index" \
-       -H 'Content-Type: application/json' \
-       -d '{"settings":{"number_of_shards":1,"number_of_replicas":0}}'
-
-  3. Index a document:
-     curl -X POST "localhost:9200/test-index/_doc" \
-       -H 'Content-Type: application/json' \
-       -d '{"title":"Hello HelmForge","@timestamp":"{{ now | date "2006-01-02T15:04:05" }}"}'
-
-  4. Search:
-     curl "localhost:9200/test-index/_search?q=HelmForge&pretty"
-
-TROUBLESHOOTING
--------------------------------------------
-  Pods stuck in Pending? Check PVC provisioning:
-    kubectl get pvc -n {{ $namespace }}
-
-  Pods stuck in Init? vm.max_map_count not set:
-    kubectl describe pod {{ $fullname }}-master-0 -n {{ $namespace }}
-    # Ensure sysctlInit.enabled=true or set vm.max_map_count=262144 on nodes
-
-  Cluster not forming? Check seed hosts:
-    kubectl exec -it {{ $fullname }}-master-0 -n {{ $namespace }} -- \
-      curl -s localhost:9200/_cat/nodes?v
-
-  Check full chart docs:
+  HelmForge docs:
     https://helmforge.dev/docs/charts/elasticsearch
 
-RESOURCES
--------------------------------------------
   Chart source:
     https://github.com/helmforgedev/charts/tree/main/charts/elasticsearch
 
-  Elasticsearch documentation:
+  Upstream docs:
     https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
 
 {{- if eq $profile "dev" }}
--------------------------------------------
---  Running in DEV profile (single node, no HA)
-    For production use:
-    helm upgrade {{ .Release.Name }} helmforge/elasticsearch \
-      -n {{ $releaseNamespace }} \
-      --set clusterProfile=production-ha
+Production reminder:
+  This release uses the dev profile. For production, use production-ha and size
+  persistent volumes/resources before storing real workloads.
 {{- end }}
 
 Happy Helmforging :)

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.4.1
+          value: docker.io/library/kibana:9.4.2
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.4.1
+          value: docker.io/library/elasticsearch:9.4.2
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -37,7 +37,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.4.1"
+          "default": "9.4.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -247,7 +247,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.4.1"
+              "default": "9.4.2"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.4.1"
+  tag: "9.4.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -324,7 +324,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.4.1"
+    tag: "9.4.2"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
## Summary
- Update Elasticsearch and Kibana to 9.4.2.
- Add chart design documentation for profiles, topology, capabilities, and production boundaries.
- Add the missing staging profile guide already linked from the README.

## Upstream Research
- GitHub release `v9.4.2` was published on 2026-05-28.
- Elastic states 9.4.2 contains fixes for potential security vulnerabilities and recommends upgrading.
- Verified `docker.io/library/elasticsearch:9.4.2` image manifest for `linux/amd64` and `linux/arm64`.

## Validation
- [x] `npx -y markdownlint-cli2 charts/elasticsearch/README.md charts/elasticsearch/DESIGN.md charts/elasticsearch/docs/profile-staging.md`
- [x] `helm dependency build charts/elasticsearch`
- [x] `helm lint charts/elasticsearch`
- [x] `helm lint --strict charts/elasticsearch`
- [x] `helm template elasticsearch-test charts/elasticsearch`
- [x] `helm template` for CI values: `dev-values`, `staging-values`, `production-ha-values`, `data-tiers-values`, `dual-stack`, `external-secrets`, `gateway-api`
- [x] `helm unittest charts/elasticsearch` (96 tests, 14 suites)
- [x] `ah lint -p charts/elasticsearch`
- [x] `kubeconform -strict -summary` for defaults and all CI values with Datree CRD catalog
- [x] `kubescape scan framework mitre,nsa,soc2` (overall compliance-score 89)
- [x] Live k3d validation on `k3d-helmforge-tests-wsl`: dev profile pod Ready, cluster health green, test index/document/search/delete succeeded, zero non-normal events, zero operational log errors, namespace cleaned

Closes #394