### PR TITLE
chore(ghost): update Ghost to 6.42.0

### DIFF
--- a/charts/ghost/.helmignore
+++ b/charts/ghost/.helmignore
@@ -21,7 +21,6 @@ Thumbs.db
 *.rej
 *.swp
 *.tmp
-*.lock
 
 # Logs
 *.log

--- a/charts/ghost/Chart.lock
+++ b/charts/ghost/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:43ea75f43a616dbac5ea9837826a9cb806646d5c2c3c7029008fa5b3a0ad22c3
-generated: "2026-05-20T00:46:13.5184904-03:00"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 1.8.5
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
-version: 1.1.11
-appVersion: "6.39.0"
+version: 1.1.12
+appVersion: "6.42.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 6.39.0 (#279)"
+      description: "update Ghost to 6.42.0 with upstream publishing and comment fixes (#395)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/DESIGN.md
+++ b/charts/ghost/DESIGN.md
@@ -1,0 +1,101 @@
+# Ghost Chart Design
+
+## Scope
+
+This chart deploys Ghost using the official `docker.io/library/ghost` image and a MySQL-compatible database.
+It focuses on a single Ghost instance because Ghost content storage, themes, uploads, and runtime behavior are not
+designed for horizontal scaling without additional shared storage and application-level planning.
+
+Supported database modes:
+
+- bundled HelmForge MySQL subchart
+- external MySQL-compatible database
+
+Supported edge options:
+
+- ClusterIP service with port-forward access
+- Kubernetes Ingress
+- Gateway API HTTPRoute
+
+## Architecture: Bundled MySQL
+
+```mermaid
+flowchart LR
+  user[Reader or editor] --> edge[Ingress or HTTPRoute]
+  edge --> svc[Ghost Service]
+  svc --> ghost[Ghost Deployment]
+  ghost --> content[(Content PVC)]
+  ghost --> mysqlSvc[MySQL Service]
+  mysqlSvc --> mysql[HelmForge MySQL StatefulSet]
+  mysql --> mysqlPvc[(MySQL PVC)]
+  secrets[Generated Secrets] --> ghost
+  secrets --> mysql
+```
+
+This mode is appropriate for small sites, development, and self-contained deployments where the database lifecycle is
+managed with the Ghost release.
+
+## Architecture: External Database
+
+```mermaid
+flowchart LR
+  user[Reader or editor] --> edge[Ingress or HTTPRoute]
+  edge --> svc[Ghost Service]
+  svc --> ghost[Ghost Deployment]
+  ghost --> content[(Content PVC)]
+  ghost --> db[(External MySQL)]
+  eso[External Secrets Operator optional] -. materializes .-> secret[Database Secret]
+  secret --> ghost
+```
+
+External database mode is recommended when the platform already provides backup, restore, replication, patching, and
+failover for MySQL.
+
+## Main Design Choices
+
+- Use the official Ghost image.
+- Use the HelmForge MySQL subchart by default.
+- Keep Ghost single-instance by default.
+- Persist `/var/lib/ghost/content` because it contains themes, images, media, and uploaded files.
+- Keep database credentials in Secrets and allow External Secrets for platform-managed credentials.
+- Provide S3-compatible content backups through an optional CronJob.
+- Render Ingress and Gateway API only when explicitly enabled.
+
+## Production Boundary
+
+For production, operators should define:
+
+- `ghost.url` with the public canonical URL
+- explicit database credentials or an existing database Secret
+- PVC size, storage class, and backup retention
+- ingress or Gateway API TLS settings
+- mail settings through `ghost.extraEnv`
+- content backup and database backup runbooks
+- staging validation for themes, custom integrations, newsletters, comments, and member signup flows
+
+## Explicit Non-Goals
+
+- horizontal scaling by default
+- managed database failover
+- Ghost theme installation automation
+- newsletter provider provisioning
+- Stripe or payment provider configuration
+- automatic major-version migration beyond the official Ghost entrypoint behavior
+
+<!-- @AI-METADATA
+type: design
+title: Ghost Chart Design
+description: Design document for the Ghost Helm chart with database modes, persistence, edge routing, and production boundaries
+
+keywords: ghost, design, architecture, mysql, cms, publishing, backup, gateway-api, kubernetes
+
+purpose: Document chart architecture, operational decisions, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/ghost/README.md
+  - charts/ghost/docs/database.md
+path: charts/ghost/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/ghost/DESIGN.md
+++ b/charts/ghost/DESIGN.md
@@ -55,6 +55,9 @@ failover for MySQL.
 
 - Use the official Ghost image.
 - Use the HelmForge MySQL subchart by default.
+- Keep the bundled MySQL image on MySQL 8 because Ghost production support is
+  tied to MySQL 8 even when the HelmForge MySQL dependency supports newer
+  MySQL majors.
 - Keep Ghost single-instance by default.
 - Persist `/var/lib/ghost/content` because it contains themes, images, media, and uploaded files.
 - Keep database credentials in Secrets and allow External Secrets for platform-managed credentials.

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -67,6 +67,7 @@ database:
 | `ghost.url` | `""` | Public URL of the Ghost instance |
 | `image.tag` | `6.42.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
+| `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
 | `persistence.size` | `10Gi` | Content PVC size |
 | `backup.enabled` | `false` | Enable S3 content backups |
@@ -98,7 +99,7 @@ backup:
 ## Limitations
 
 - **Single instance** — Ghost does not support horizontal scaling out of the box
-- **MySQL only** — Ghost requires MySQL 8; PostgreSQL is not supported
+- **MySQL only** — Ghost requires MySQL 8; PostgreSQL is not supported. The bundled HelmForge MySQL dependency is kept on MySQL 8 through `mysql.image.tag`.
 
 ## More Information
 

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -12,6 +12,8 @@ for building blogs, newsletters, and membership-based content with built-in mone
 - **Headless CMS** — REST and Content API for headless usage
 - **Memberships** — built-in subscriptions, newsletters, and payments
 - **Ingress support** — TLS with cert-manager
+- **Gateway API support** — optional HTTPRoute for modern ingress stacks
+- **External Secrets support** — optional database password synchronization
 
 ## Installation
 
@@ -63,11 +65,22 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
+| `image.tag` | `6.42.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `persistence.enabled` | `true` | Enable content persistence |
 | `persistence.size` | `10Gi` | Content PVC size |
 | `backup.enabled` | `false` | Enable S3 content backups |
 | `ingress.enabled` | `false` | Enable ingress |
+| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret for database password |
+
+## Upgrade Notes
+
+`docker.io/library/ghost:6.42.0` is an upstream image update from `6.39.0`.
+Review the upstream Ghost release notes before upgrading production sites, take
+a content and database backup, and verify themes, custom integrations,
+newsletter flows, comments, and member signup paths in staging before reusing
+existing PVCs.
 
 ## S3 Backup
 
@@ -89,5 +102,7 @@ backup:
 
 ## More Information
 
+- [Chart design](DESIGN.md)
+- [Database modes](docs/database.md)
 - [Ghost documentation](https://ghost.org/docs/)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/ghost)

--- a/charts/ghost/docs/database.md
+++ b/charts/ghost/docs/database.md
@@ -7,12 +7,17 @@ The default configuration deploys Ghost with the HelmForge MySQL dependency:
 ```yaml
 mysql:
   enabled: true
+  image:
+    tag: "8.4.7"
   auth:
     database: ghost
     username: ghost
 ```
 
-This mode is useful for self-contained deployments and local validation. Size the MySQL PVC explicitly for real sites.
+This mode is useful for self-contained deployments and local validation. Ghost
+production supports MySQL 8, so this chart keeps the bundled HelmForge MySQL
+dependency on a MySQL 8 image tag by default. Size the MySQL PVC explicitly for
+real sites.
 
 ## External MySQL
 
@@ -62,7 +67,7 @@ externalSecrets:
 
 ## Notes
 
-- Ghost production mode requires MySQL.
+- Ghost production mode requires MySQL 8.
 - SQLite is only a development-mode option in the official image and is intentionally not part of this chart contract.
 - Back up both the database and `/var/lib/ghost/content` before upgrades.
 

--- a/charts/ghost/docs/database.md
+++ b/charts/ghost/docs/database.md
@@ -1,0 +1,85 @@
+# Ghost Database Modes
+
+## Bundled MySQL
+
+The default configuration deploys Ghost with the HelmForge MySQL dependency:
+
+```yaml
+mysql:
+  enabled: true
+  auth:
+    database: ghost
+    username: ghost
+```
+
+This mode is useful for self-contained deployments and local validation. Size the MySQL PVC explicitly for real sites.
+
+## External MySQL
+
+Use an external database when MySQL is managed by your platform or cloud provider:
+
+```yaml
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: mysql.example.com
+    port: "3306"
+    name: ghost
+    username: ghost
+    existingSecret: ghost-db
+    existingSecretPasswordKey: password
+```
+
+The referenced Secret must contain the database password key.
+
+## External Secrets
+
+When using External Secrets, set `database.external.existingSecret` to the target Secret name. This prevents the
+chart-managed database Secret and the ExternalSecret from drifting.
+
+```yaml
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: mysql.example.com
+    existingSecret: ghost-db
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: password
+      remoteRef:
+        key: ghost/database
+        property: password
+```
+
+## Notes
+
+- Ghost production mode requires MySQL.
+- SQLite is only a development-mode option in the official image and is intentionally not part of this chart contract.
+- Back up both the database and `/var/lib/ghost/content` before upgrades.
+
+<!-- @AI-METADATA
+type: chart-doc
+title: Ghost Database Modes
+description: Database mode guide for the Ghost Helm chart
+
+keywords: ghost, mysql, database, external-secrets, backup, helm, kubernetes
+
+purpose: Explain bundled MySQL, external database, and External Secrets usage
+scope: Chart Documentation
+
+relations:
+  - charts/ghost/README.md
+  - charts/ghost/DESIGN.md
+path: charts/ghost/docs/database.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/ghost/examples/backup.yaml
+++ b/charts/ghost/examples/backup.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: "https://s3.example.com"
+    bucket: ghost-backups
+    prefix: ghost
+    existingSecret: ghost-s3
+    existingSecretAccessKeyKey: access-key
+    existingSecretSecretKeyKey: secret-key

--- a/charts/ghost/examples/external-db.yaml
+++ b/charts/ghost/examples/external-db.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+ghost:
+  url: "https://blog.example.com"
+
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: mysql.example.com
+    port: "3306"
+    name: ghost
+    username: ghost
+    existingSecret: ghost-db
+    existingSecretPasswordKey: password

--- a/charts/ghost/examples/simple.yaml
+++ b/charts/ghost/examples/simple.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+ghost:
+  url: "https://blog.example.com"
+
+mysql:
+  enabled: true
+  auth:
+    password: "change-me"
+
+persistence:
+  size: 20Gi

--- a/charts/ghost/templates/NOTES.txt
+++ b/charts/ghost/templates/NOTES.txt
@@ -1,70 +1,133 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
---------------------------------------------------------------------
-  Ghost has been successfully deployed!
---------------------------------------------------------------------
+=============================================================================
+Ghost publishing platform deployed successfully!
+=============================================================================
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+Release:            {{ .Release.Name }}
+Namespace:          {{ .Release.Namespace }}
+Chart Version:      {{ .Chart.Version }}
+App Version:        {{ .Chart.AppVersion }}
+Image:              {{ include "ghost.image" . }}
+Service:            {{ include "ghost.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+Content PVC:        {{ include "ghost.contentClaimName" . }}
+Database Host:      {{ include "ghost.dbHost" . }}:{{ include "ghost.dbPort" . }}
+Database Name:      {{ include "ghost.dbName" . }}
+Database User:      {{ include "ghost.dbUsername" . }}
 
---------------------------------------------------------------------
-  ACCESS INFORMATION
---------------------------------------------------------------------
+=============================================================================
+ACCESS
+=============================================================================
 
 {{- if .Values.ingress.enabled }}
+Ingress is enabled:
 {{- range $host := .Values.ingress.hosts }}
-BLOG:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-ADMIN:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/ghost/
+  Blog:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  Admin:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/ghost/
+{{- end }}
+{{- else if .Values.gateway.enabled }}
+Gateway API is enabled. Resolve one of the configured HTTPRoute hostnames to
+your Gateway address, then open:
+{{- range .Values.gateway.hostnames }}
+  Blog:   http://{{ . }}/
+  Admin:  http://{{ . }}/ghost/
 {{- end }}
 {{- else }}
-Port-forward to access Ghost locally:
-
+Use port-forward for local access:
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ghost.fullname" . }} 2368:{{ .Values.service.port }}
 
-  BLOG:   http://localhost:2368/
-  ADMIN:  http://localhost:2368/ghost/
+Then open:
+  Blog:   http://localhost:2368/
+  Admin:  http://localhost:2368/ghost/
 {{- end }}
 
---------------------------------------------------------------------
-  GETTING STARTED
---------------------------------------------------------------------
+=============================================================================
+CONFIGURATION
+=============================================================================
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-4. Open /ghost/ and complete setup wizard to create your admin account
+{{- if .Values.ghost.url }}
+- Public URL is configured as `{{ .Values.ghost.url }}`.
+{{- else }}
+- `ghost.url` is not set. Set it to the public canonical URL before enabling
+  email, newsletters, memberships, or production SEO workflows.
+{{- end }}
+{{- if .Values.mysql.enabled }}
+- Bundled HelmForge MySQL is enabled as the application database.
+{{- else }}
+- External MySQL is enabled. The chart reads the database password from
+  Secret `{{ include "ghost.dbSecretName" . }}` key `{{ include "ghost.dbSecretPasswordKey" . }}`.
+{{- end }}
+{{- if .Values.persistence.enabled }}
+- Content persistence is enabled. Back up both this PVC and the database before upgrades.
+{{- else }}
+- Content persistence is disabled. Uploaded media and generated assets are ephemeral.
+{{- end }}
+{{- with .Values.service.ipFamilyPolicy }}
+- Service IP family policy: `{{ . }}`{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}.
+{{- end }}
+{{- if .Values.gateway.enabled }}
+- Gateway API HTTPRoute is enabled. Ensure Gateway API CRDs and the referenced
+  Gateway parentRefs exist before expecting external traffic.
+{{- end }}
+{{- if .Values.externalSecrets.enabled }}
+- External Secrets Operator is enabled. Ensure the operator and
+  {{ .Values.externalSecrets.secretStoreRef.kind }} `{{ .Values.externalSecrets.secretStoreRef.name }}`
+  exist and populate Secret `{{ include "ghost.dbSecretName" . }}`.
+{{- end }}
+{{- if .Values.backup.enabled }}
+- S3 content backup CronJob is enabled with schedule `{{ .Values.backup.schedule }}`.
+{{- end }}
 
---------------------------------------------------------------------
-  TROUBLESHOOTING
---------------------------------------------------------------------
+=============================================================================
+GETTING STARTED
+=============================================================================
 
-  kubectl describe pod -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=ghost -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+1. Wait for Ghost and dependencies to become ready:
+   kubectl wait --for=condition=ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --timeout=600s
+
+2. Check resources and PVCs:
+   kubectl get all,pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+3. Open `/ghost/` and complete the first-user setup wizard.
+
+4. Validate the admin site endpoint:
+   kubectl run ghost-smoke -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- \
+     wget -qO- http://{{ include "ghost.fullname" . }}:{{ .Values.service.port }}/ghost/api/admin/site/
+
+=============================================================================
+VALIDATION
+=============================================================================
+
+Inspect recent logs from every pod/container in the release:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200
+
+Inspect events for warning or error conditions:
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+Check pod restarts:
+  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
 
 {{- if .Values.mysql.enabled }}
-View MySQL logs:
-  kubectl logs -l app.kubernetes.io/name=mysql -n {{ .Release.Namespace }} --all-containers --tail=50
+Check bundled MySQL logs:
+  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name=mysql --all-containers --tail=200
 {{- end }}
 
---------------------------------------------------------------------
-  WARNINGS
---------------------------------------------------------------------
-
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
-Ghost requires a public URL to send emails and for SEO.
+{{- if .Values.backup.enabled }}
+Check backup CronJob status:
+  kubectl get cronjob,jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 {{- end }}
 
---------------------------------------------------------------------
-  ADDITIONAL RESOURCES
---------------------------------------------------------------------
+=============================================================================
+UPGRADE REMINDER
+=============================================================================
 
-Documentation:  https://helmforge.dev/docs/charts/ghost
-Ghost:          https://ghost.org | https://github.com/TryGhost/Ghost
+Before upgrading production Ghost sites:
+  - Back up the MySQL database and `/var/lib/ghost/content`.
+  - Validate themes, custom integrations, comments, newsletters, and member signup.
+  - Review upstream Ghost release notes for migration notes.
 
-Happy Helmforging :)
+Documentation:
+  Chart: https://helmforge.dev/docs/charts/ghost
+  Ghost: https://ghost.org/docs/
+  Source: https://github.com/helmforgedev/charts/tree/main/charts/ghost
+
+=============================================================================

--- a/charts/ghost/templates/NOTES.txt
+++ b/charts/ghost/templates/NOTES.txt
@@ -1,133 +1,167 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-=============================================================================
-Ghost publishing platform deployed successfully!
-=============================================================================
+{{- $fullname := include "ghost.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
 
-Release:            {{ .Release.Name }}
-Namespace:          {{ .Release.Namespace }}
-Chart Version:      {{ .Chart.Version }}
-App Version:        {{ .Chart.AppVersion }}
-Image:              {{ include "ghost.image" . }}
-Service:            {{ include "ghost.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
-Content PVC:        {{ include "ghost.contentClaimName" . }}
-Database Host:      {{ include "ghost.dbHost" . }}:{{ include "ghost.dbPort" . }}
-Database Name:      {{ include "ghost.dbName" . }}
-Database User:      {{ include "ghost.dbUsername" . }}
+1. Ghost has been installed
+---------------------------
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ $namespace }}
+  Version:        {{ .Chart.AppVersion }}
+  Image:          {{ include "ghost.image" . }}
+  Service:        {{ $fullname }}.{{ $namespace }}.svc.cluster.local:{{ .Values.service.port }}
+  Content PVC:    {{ include "ghost.contentClaimName" . }}
+  Database Host:  {{ include "ghost.dbHost" . }}:{{ include "ghost.dbPort" . }}
+  Database Name:  {{ include "ghost.dbName" . }}
+  Database User:  {{ include "ghost.dbUsername" . }}
 
-=============================================================================
-ACCESS
-=============================================================================
-
+2. Access
+---------
 {{- if .Values.ingress.enabled }}
-Ingress is enabled:
-{{- range $host := .Values.ingress.hosts }}
-  Blog:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-  Admin:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/ghost/
-{{- end }}
+  Ingress is enabled:
+  {{- range $host := .Values.ingress.hosts }}
+    Blog:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+    Admin: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/ghost/
+  {{- end }}
 {{- else if .Values.gateway.enabled }}
-Gateway API is enabled. Resolve one of the configured HTTPRoute hostnames to
-your Gateway address, then open:
-{{- range .Values.gateway.hostnames }}
-  Blog:   http://{{ . }}/
-  Admin:  http://{{ . }}/ghost/
-{{- end }}
+  Gateway API HTTPRoute is enabled. Point the configured hostname to the Gateway address:
+  {{- range .Values.gateway.hostnames }}
+    Blog:  http://{{ . }}/
+    Admin: http://{{ . }}/ghost/
+  {{- else }}
+    No gateway.hostnames configured.
+  {{- end }}
 {{- else }}
-Use port-forward for local access:
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ghost.fullname" . }} 2368:{{ .Values.service.port }}
+  Port-forward locally:
+    kubectl port-forward -n {{ $namespace }} svc/{{ $fullname }} 2368:{{ .Values.service.port }}
 
-Then open:
-  Blog:   http://localhost:2368/
-  Admin:  http://localhost:2368/ghost/
+  Open:
+    Blog:  http://localhost:2368/
+    Admin: http://localhost:2368/ghost/
 {{- end }}
 
-=============================================================================
-CONFIGURATION
-=============================================================================
+3. First-time Setup
+-------------------
+  - Open `/ghost/` and complete the owner account setup wizard.
+  - Set `ghost.url` to the final public URL before enabling newsletters, memberships, email, or SEO-sensitive production traffic.
+  - Configure SMTP with `ghost.extraEnv` before sending member or staff email.
 
-{{- if .Values.ghost.url }}
-- Public URL is configured as `{{ .Values.ghost.url }}`.
-{{- else }}
-- `ghost.url` is not set. Set it to the public canonical URL before enabling
-  email, newsletters, memberships, or production SEO workflows.
-{{- end }}
-{{- if .Values.mysql.enabled }}
-- Bundled HelmForge MySQL is enabled as the application database.
-{{- else }}
-- External MySQL is enabled. The chart reads the database password from
-  Secret `{{ include "ghost.dbSecretName" . }}` key `{{ include "ghost.dbSecretPasswordKey" . }}`.
-{{- end }}
-{{- if .Values.persistence.enabled }}
-- Content persistence is enabled. Back up both this PVC and the database before upgrades.
-{{- else }}
-- Content persistence is disabled. Uploaded media and generated assets are ephemeral.
-{{- end }}
+4. Configuration Summary
+------------------------
+  Public URL:       {{ default "not configured" .Values.ghost.url }}
+  Database:         {{ if .Values.mysql.enabled }}HelmForge MySQL subchart{{ else }}external MySQL{{ end }}
+  DB Secret:        {{ include "ghost.dbSecretName" . }} / {{ include "ghost.dbSecretPasswordKey" . }}
+  Persistence:      {{ .Values.persistence.enabled }}
+  Backup:           {{ .Values.backup.enabled }}
+  Ingress:          {{ .Values.ingress.enabled }}
+  Gateway API:      {{ .Values.gateway.enabled }}
+  External Secrets: {{ .Values.externalSecrets.enabled }}
 {{- with .Values.service.ipFamilyPolicy }}
-- Service IP family policy: `{{ . }}`{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}.
+  IP family policy: {{ . }}{{ with $.Values.service.ipFamilies }} ({{ join ", " . }}){{ end }}
+{{- end }}
+
+5. Validation Commands
+----------------------
+  Wait for Ghost and dependencies:
+    kubectl wait --for=condition=Ready pod -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --timeout=600s
+
+  Check resources:
+    kubectl get all,pvc -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  Check pod restarts:
+    kubectl get pods -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
+
+  Validate the admin site endpoint from inside the cluster:
+    kubectl run ghost-smoke -n {{ $namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- \
+      wget -qO- http://{{ $fullname }}:{{ .Values.service.port }}/ghost/api/admin/site/
+
+  Inspect release events:
+    kubectl get events -n {{ $namespace }} --sort-by=.lastTimestamp
+
+6. Logs
+-------
+  Ghost logs:
+    kubectl logs -n {{ $namespace }} deploy/{{ $fullname }} --tail=200
+
+  Init container logs:
+    kubectl logs -n {{ $namespace }} deploy/{{ $fullname }} -c wait-for-database --tail=100
+{{- if .Values.mysql.enabled }}
+
+  Bundled MySQL logs:
+    kubectl logs -n {{ $namespace }} -l app.kubernetes.io/name=mysql --all-containers --tail=200
+{{- end }}
+
+7. Backup
+---------
+{{- if .Values.backup.enabled }}
+  S3 content backup is enabled:
+    Schedule: {{ .Values.backup.schedule }}
+    Bucket:   {{ .Values.backup.s3.bucket }}
+    Prefix:   {{ .Values.backup.s3.prefix }}
+
+  Check backup CronJobs:
+    kubectl get cronjob,jobs -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  Trigger a manual backup:
+    kubectl create job --from=cronjob/{{ $fullname }}-backup ghost-backup-$(date +%s) -n {{ $namespace }}
+{{- else }}
+  Backup is disabled. For production, back up both:
+    - MySQL database `{{ include "ghost.dbName" . }}`
+    - Content PVC `{{ include "ghost.contentClaimName" . }}`
+
+  Enable scheduled S3 content backups with `backup.enabled=true` and S3 credentials.
+{{- end }}
+
+8. External Integrations
+------------------------
+{{- if .Values.externalSecrets.enabled }}
+  External Secrets Operator is enabled.
+  SecretStore: {{ .Values.externalSecrets.secretStoreRef.kind }}/{{ .Values.externalSecrets.secretStoreRef.name }}
+  Target Secret: {{ include "ghost.dbSecretName" . }}
+{{- else }}
+  External Secrets Operator is disabled.
 {{- end }}
 {{- if .Values.gateway.enabled }}
-- Gateway API HTTPRoute is enabled. Ensure Gateway API CRDs and the referenced
-  Gateway parentRefs exist before expecting external traffic.
-{{- end }}
-{{- if .Values.externalSecrets.enabled }}
-- External Secrets Operator is enabled. Ensure the operator and
-  {{ .Values.externalSecrets.secretStoreRef.kind }} `{{ .Values.externalSecrets.secretStoreRef.name }}`
-  exist and populate Secret `{{ include "ghost.dbSecretName" . }}`.
-{{- end }}
-{{- if .Values.backup.enabled }}
-- S3 content backup CronJob is enabled with schedule `{{ .Values.backup.schedule }}`.
+
+  Gateway API is enabled. Confirm Gateway API CRDs and parentRefs exist:
+    kubectl get gateway -A
+    kubectl get httproute -n {{ $namespace }}
 {{- end }}
 
-=============================================================================
-GETTING STARTED
-=============================================================================
+9. Troubleshooting
+------------------
+  Ghost stays unavailable:
+    kubectl describe pod -n {{ $namespace }} -l app.kubernetes.io/name=ghost
+    kubectl logs -n {{ $namespace }} deploy/{{ $fullname }} --tail=300
 
-1. Wait for Ghost and dependencies to become ready:
-   kubectl wait --for=condition=ready pod -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --timeout=600s
-
-2. Check resources and PVCs:
-   kubectl get all,pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
-
-3. Open `/ghost/` and complete the first-user setup wizard.
-
-4. Validate the admin site endpoint:
-   kubectl run ghost-smoke -n {{ .Release.Namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- \
-     wget -qO- http://{{ include "ghost.fullname" . }}:{{ .Values.service.port }}/ghost/api/admin/site/
-
-=============================================================================
-VALIDATION
-=============================================================================
-
-Inspect recent logs from every pod/container in the release:
-  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200
-
-Inspect events for warning or error conditions:
-  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
-
-Check pod restarts:
-  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -o wide
-
+  Database connection errors:
+    kubectl get secret {{ include "ghost.dbSecretName" . }} -n {{ $namespace }}
+    kubectl logs -n {{ $namespace }} deploy/{{ $fullname }} -c wait-for-database --tail=200
 {{- if .Values.mysql.enabled }}
-Check bundled MySQL logs:
-  kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/name=mysql --all-containers --tail=200
+    kubectl get pods -n {{ $namespace }} -l app.kubernetes.io/name=mysql
 {{- end }}
 
-{{- if .Values.backup.enabled }}
-Check backup CronJob status:
-  kubectl get cronjob,jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
-{{- end }}
+  Media uploads disappear after restart:
+    kubectl get pvc {{ include "ghost.contentClaimName" . }} -n {{ $namespace }}
+    # Ensure persistence.enabled=true for production.
 
-=============================================================================
-UPGRADE REMINDER
-=============================================================================
+  Public links or email URLs are wrong:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+    # Set ghost.url to the canonical external URL.
 
-Before upgrading production Ghost sites:
-  - Back up the MySQL database and `/var/lib/ghost/content`.
-  - Validate themes, custom integrations, comments, newsletters, and member signup.
-  - Review upstream Ghost release notes for migration notes.
+10. Documentation
+-----------------
+  HelmForge docs:
+    https://helmforge.dev/docs/charts/ghost
 
-Documentation:
-  Chart: https://helmforge.dev/docs/charts/ghost
-  Ghost: https://ghost.org/docs/
-  Source: https://github.com/helmforgedev/charts/tree/main/charts/ghost
+  Chart source:
+    https://github.com/helmforgedev/charts/tree/main/charts/ghost
 
-=============================================================================
+  Upstream docs:
+    https://ghost.org/docs/
+
+Upgrade reminder:
+  Back up the MySQL database and `/var/lib/ghost/content`, then review upstream
+  Ghost release notes for migrations that affect themes, integrations, members,
+  newsletters, or custom email configuration.
+
+Happy Helmforging :)

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
                 sleep 2
               done
               echo "Database is ready."
+          {{- with .Values.waitForDatabase.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: ghost
           image: {{ include "ghost.image" . | quote }}

--- a/charts/ghost/templates/httproute.yaml
+++ b/charts/ghost/templates/httproute.yaml
@@ -1,7 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.enabled }}
 {{- if not .Values.gateway.parentRefs }}
-  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
 {{- end }}
 {{- range .Values.gateway.parentRefs }}
   {{- if not .name }}

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -40,6 +40,33 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: 64Mi
+
+  - it: should set default container resources
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 768Mi
+
+  - it: should set practical default hardening without changing the image user
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: false
 
   - it: should set database env vars for MySQL subchart
     asserts:

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.39.0"
+          value: "docker.io/library/ghost:6.42.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/tests/gateway_test.yaml
+++ b/charts/ghost/tests/gateway_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Gateway API
 templates:
   - templates/httproute.yaml

--- a/charts/ghost/tests/gateway_test.yaml
+++ b/charts/ghost/tests/gateway_test.yaml
@@ -1,0 +1,53 @@
+suite: Gateway API
+templates:
+  - templates/httproute.yaml
+tests:
+  - it: does not render an HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an HTTPRoute when gateway is enabled
+    set:
+      gateway:
+        enabled: true
+        parentRefs:
+          - name: platform-gateway
+            namespace: gateway-system
+        hostnames:
+          - blog.example.com
+        path: /
+        pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: platform-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: blog.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: fails when gateway parentRefs is empty
+    set:
+      gateway:
+        enabled: true
+        parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute.

--- a/charts/ghost/tests/mysql_subchart_test.yaml
+++ b/charts/ghost/tests/mysql_subchart_test.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: MySQL subchart
+templates:
+  - charts/mysql/templates/configmap.yaml
+  - charts/mysql/templates/statefulset-source.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should keep bundled MySQL on the Ghost-supported MySQL 8 image
+    template: charts/mysql/templates/statefulset-source.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/library/mysql:8.4.7"

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -183,7 +183,23 @@
                                       "type":  "object"
                                   },
                        "resources":  {
-                                         "type":  "object"
+                                         "type":  "object",
+                                         "properties": {
+                                             "requests": {
+                                                 "type": "object",
+                                                 "properties": {
+                                                     "cpu": { "type": "string" },
+                                                     "memory": { "type": "string" }
+                                                 }
+                                             },
+                                             "limits": {
+                                                 "type": "object",
+                                                 "properties": {
+                                                     "cpu": { "type": "string" },
+                                                     "memory": { "type": "string" }
+                                                 }
+                                             }
+                                         }
                                      },
                        "podSecurityContext":  {
                                                   "type":  "object"
@@ -191,6 +207,12 @@
                        "securityContext":  {
                                                "type":  "object"
                                            },
+                       "waitForDatabase": {
+                                           "type": "object",
+                                           "properties": {
+                                               "resources": { "type": "object" }
+                                           }
+                                       },
                        "nodeSelector":  {
                                             "type":  "object"
                                         },
@@ -247,6 +269,18 @@
                                                         "enabled":  {
                                                                         "type":  "boolean",
                                                                         "default":  true
+                                                                    },
+                                                        "architecture": {
+                                                                        "type": "string",
+                                                                        "enum": ["standalone", "replication"]
+                                                                    },
+                                                        "auth": { "type": "object" },
+                                                        "standalone": {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "persistence": { "type": "object" },
+                                                                            "resources": { "type": "object" }
+                                                                        }
                                                                     }
                                                     }
                                  },

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -266,14 +266,22 @@
                        "mysql":  {
                                      "type":  "object",
                                      "properties":  {
-                                                        "enabled":  {
-                                                                        "type":  "boolean",
-                                                                        "default":  true
-                                                                    },
-                                                        "architecture": {
-                                                                        "type": "string",
-                                                                        "enum": ["standalone", "replication"]
-                                                                    },
+                                                          "enabled":  {
+                                                                          "type":  "boolean",
+                                                                          "default":  true
+                                                                      },
+                                                          "image": {
+                                                                          "type": "object",
+                                                                          "properties": {
+                                                                              "repository": { "type": "string" },
+                                                                              "tag": { "type": "string" },
+                                                                              "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+                                                                          }
+                                                                      },
+                                                         "architecture": {
+                                                                          "type": "string",
+                                                                         "enum": ["standalone", "replication"]
+                                                                      },
                                                         "auth": { "type": "object" },
                                                         "standalone": {
                                                                         "type": "object",

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.39.0"
+                                                                    "default":  "6.42.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -256,6 +256,11 @@ extraManifests: []
 mysql:
   # -- Deploy MySQL as a subchart
   enabled: true
+  image:
+    # -- Ghost production supports MySQL 8; keep the HelmForge MySQL dependency on the supported image major.
+    repository: docker.io/library/mysql
+    tag: "8.4.7"
+    pullPolicy: IfNotPresent
   architecture: standalone
   auth:
     database: ghost

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -200,11 +200,30 @@ probes:
 # Resources and Security
 # =============================================================================
 
-resources: {}
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
 
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+
+waitForDatabase:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
 
 # =============================================================================
 # Scheduling
@@ -243,6 +262,17 @@ mysql:
     username: ghost
     # -- MySQL password (auto-generated if empty)
     password: ""
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi
 
 # =============================================================================
 # Gateway API

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.39.0"
+  tag: "6.42.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Update Ghost to 6.42.0.
- Add chart design and database mode documentation.
- Add simple, external database, and backup examples.

## Upstream Research
- GitHub release `v6.42.0` was published on 2026-05-27.
- Release notes include pinned comments, threaded comments, comment dislikes, permalink fixes, and comment thread rendering fixes.
- Verified `docker.io/library/ghost:6.42.0` image manifest for `linux/amd64`, `linux/arm/v7`, `linux/arm64`, and `linux/s390x`.

## Validation
- [x] `npx -y markdownlint-cli2 charts/ghost/README.md charts/ghost/DESIGN.md charts/ghost/docs/database.md`
- [x] `helm dependency build charts/ghost`
- [x] `helm dependency list charts/ghost` (`mysql 1.8.5`, HelmForge OCI, ok)
- [x] `helm lint charts/ghost`
- [x] `helm lint --strict charts/ghost`
- [x] `helm template ghost-test charts/ghost`
- [x] `helm template` for CI values: `default-values`, `ingress-values`, `gateway-api`, `external-secrets`, `external-db-values`, `dual-stack`
- [x] `helm unittest charts/ghost` (17 tests, 4 suites)
- [x] `ah lint -p charts/ghost`
- [x] `kubeconform -strict -summary` for defaults and all CI values with Datree CRD catalog
- [x] `kubescape scan framework mitre,nsa,soc2` (overall compliance-score 82)
- [x] Live k3d validation on `k3d-helmforge-tests-wsl` with the bundled HelmForge MySQL subchart: pods Ready, blog HTTP 200, admin HTTP 200, zero non-normal events, invalid log lines 0, namespace cleaned

Note: `helm dependency build` still prints the known local repo warning for `devlake` returning 404, but the Ghost dependency resolution succeeds and `mysql 1.8.5` is ok.

Closes #395