### PR TITLE
chore(homarr): update Homarr to 1.63.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -50,10 +50,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.9.1
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
-version: 1.1.12
-appVersion: "1.62.0"
+version: 1.1.13
+appVersion: "1.63.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v1.62.0 (#335)"
+      description: "update Homarr to 1.63.0 with upstream feature, bug fix, and performance updates (#396)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/DESIGN.md
+++ b/charts/homarr/DESIGN.md
@@ -1,0 +1,110 @@
+# Homarr Chart Design
+
+## Scope
+
+This chart deploys Homarr using the official `ghcr.io/homarr-labs/homarr` image.
+It supports local dashboard deployments as well as database-backed environments with Kubernetes integration and backups.
+
+Supported database modes:
+
+- SQLite, the default zero-dependency mode
+- bundled HelmForge PostgreSQL subchart
+- bundled HelmForge MySQL subchart
+- external PostgreSQL or MySQL
+
+Optional capabilities include Kubernetes workload discovery, external Redis, S3-compatible backups, External Secrets,
+Ingress, Gateway API, and dual-stack Services.
+
+## Architecture: SQLite
+
+```mermaid
+flowchart LR
+  user[User] --> edge[Service, Ingress, or HTTPRoute]
+  edge --> homarr[Homarr Deployment]
+  homarr --> pvc[(Appdata PVC)]
+  secret[Encryption/Auth Secret] --> homarr
+```
+
+SQLite mode is suitable for local dashboards, small self-hosted installations, and simple environments where one Homarr
+replica owns the `/appdata` volume.
+
+## Architecture: Bundled Database
+
+```mermaid
+flowchart LR
+  user[User] --> edge[Ingress or HTTPRoute]
+  edge --> homarr[Homarr Deployment]
+  homarr --> appdata[(Appdata PVC)]
+  homarr --> dbsvc[PostgreSQL or MySQL Service]
+  dbsvc --> db[HelmForge database StatefulSet]
+  db --> dbpvc[(Database PVC)]
+  secret[Generated Secrets] --> homarr
+  secret --> db
+  backup[Backup CronJob] --> s3[S3-compatible storage]
+```
+
+Bundled database mode is useful when the application and database lifecycle should be managed together by the release.
+
+## Architecture: External Services
+
+```mermaid
+flowchart LR
+  user[User] --> edge[Ingress or HTTPRoute]
+  edge --> homarr[Homarr Deployment]
+  homarr --> db[(External PostgreSQL or MySQL)]
+  homarr --> redis[(External Redis optional)]
+  eso[External Secrets Operator optional] -. materializes .-> secret[App Secret]
+  secret --> homarr
+```
+
+External database and Redis are recommended for platforms that already manage persistence, patching, backup, restore, and
+failover outside the application chart.
+
+## Main Design Choices
+
+- Use HelmForge PostgreSQL and MySQL dependencies when database subcharts are enabled.
+- Keep SQLite as the default for simple deployments.
+- Keep database mode selection explicit and validate ambiguous combinations.
+- Use discrete database environment variables instead of a full `DB_URL` so passwords do not need URL encoding.
+- Disable Homarr's internal DNS cache by default so Kubernetes Service resolution stays current during database startup.
+- Preserve generated encryption/auth secrets across upgrades.
+- Include a PostgreSQL upgrade hook that reapplies Homarr database grants for existing bundled PostgreSQL installations.
+- Render Gateway API and External Secrets only when explicitly enabled.
+
+## Production Boundary
+
+For production, operators should define:
+
+- database mode and credentials
+- PVC sizes and storage classes
+- `SECRET_ENCRYPTION_KEY` through an existing Secret or External Secret
+- ingress or Gateway API TLS settings
+- backup schedule, destination, retention, and restore runbooks
+- Kubernetes RBAC boundaries when workload discovery is enabled
+- external Redis only when the target architecture requires it
+
+## Explicit Non-Goals
+
+- database failover orchestration
+- Redis deployment as a bundled subchart
+- application-level HA guarantees for SQLite mode
+- automatic migration between database engines
+- managing external SecretStores or Gateway controllers
+
+<!-- @AI-METADATA
+type: design
+title: Homarr Chart Design
+description: Design document for the Homarr Helm chart database modes, architecture, backups, and production boundaries
+
+keywords: homarr, design, architecture, sqlite, postgresql, mysql, backup, gateway-api, kubernetes
+
+purpose: Document chart architecture, database modes, operational choices, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/homarr/README.md
+  - charts/homarr/docs/database.md
+path: charts/homarr/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/homarr/DESIGN.md
+++ b/charts/homarr/DESIGN.md
@@ -70,6 +70,9 @@ failover outside the application chart.
 - Preserve generated encryption/auth secrets across upgrades.
 - Include a PostgreSQL upgrade hook that reapplies Homarr database grants for existing bundled PostgreSQL installations.
 - Render Gateway API and External Secrets only when explicitly enabled.
+- Keep default security hardening compatible with the official image: resource limits, no privilege escalation, and
+  `RuntimeDefault` seccomp are enabled, while writable root filesystem, root UID, and default capabilities remain because
+  nginx writes `/etc/nginx/nginx.conf` and `/var/lib/nginx` at startup.
 
 ## Production Boundary
 

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -284,6 +284,12 @@ Homarr starts when an existing bundled PostgreSQL Secret and Service are present
 are created before the upgrade hook runs. Existing external PostgreSQL databases must provide equivalent permissions before the
 first Homarr startup because Homarr creates the `drizzle` schema during migration.
 
+When upgrading from older dependency layouts, move legacy `postgresql.primary.*`
+and `mysql.primary.*` overrides to `postgresql.standalone.*` and
+`mysql.standalone.*`. The chart fails fast when those legacy blocks are still
+present with the corresponding subchart enabled so database persistence settings
+are not silently ignored.
+
 After changing database mode or credentials, verify the application pod and selected database backend:
 
 ```bash

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.62.0`.
+Current application version: `v1.63.0`.
 
 ## Features
 
@@ -174,10 +174,11 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.62.0"` | Homarr image tag |
+| `image.tag` | `"v1.63.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
+| `homarr.enableDnsCaching` | `false` | Enable Homarr's internal DNS cache. Disabled by default for Kubernetes Service discovery stability |
 | `homarr.enableKubernetes` | `false` | Enable K8s workload discovery |
 | `encryption.key` | `""` | 32-byte hex encryption key (auto-generated) |
 | `encryption.existingSecret` | `""` | Existing secret with encryption key |
@@ -258,12 +259,17 @@ outside this chart.
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.61.0` to `v1.62.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.62.0` includes feature, bug fix, and performance updates; no breaking changes were identified in
-the upstream release metadata.
+This update moves the default image from `v1.62.0` to `v1.63.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.63.0` includes authentication, board, management UI, bug fix, and performance updates; no breaking
+changes were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.
+
+The chart sets `ENABLE_DNS_CACHING=false` by default. Homarr documents this setting for DNS/IP edge cases, and k3d
+validation showed it avoids transient MySQL connection timeouts when Homarr resolves Kubernetes Services during startup.
+Set `homarr.enableDnsCaching=true` only when your cluster DNS behavior is known to be compatible with Homarr's internal
+cache.
 
 For bundled PostgreSQL, the default `postgresql.initdb.scripts` grants the `homarr` user ownership and `CREATE` permission on
 the `homarr` database for fresh data directories. The `postgresqlUpgradeJob` pre-upgrade hook reapplies those grants before
@@ -281,6 +287,8 @@ kubectl logs -l app.kubernetes.io/name=homarr -n <namespace> --all-containers --
 
 ## More Information
 
+- [Chart design](DESIGN.md)
+- [Database and backup modes](docs/database.md)
 - [Homarr documentation](https://homarr.dev/docs)
 - [Chart source](https://github.com/helmforgedev/charts/tree/main/charts/homarr)
 
@@ -295,6 +303,8 @@ purpose: Chart README with install, config, database, encryption, and values ref
 scope: Chart
 
 relations:
+  - charts/homarr/DESIGN.md
+  - charts/homarr/docs/database.md
   - charts/homarr/values.yaml
 path: charts/homarr/README.md
 version: 1.0

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -11,7 +11,7 @@ Current application version: `v1.63.0`.
 
 - **Official Homarr image** from `ghcr.io/homarr-labs/homarr`
 - **Database backends** SQLite3 (default), PostgreSQL, or MySQL with auto-detection
-- **PostgreSQL and MySQL subcharts** optional bundled database deployments using HelmForge PostgreSQL `1.10.0` and MySQL `1.9.1`
+- **PostgreSQL and MySQL subcharts** optional bundled database deployments using HelmForge PostgreSQL `2.0.2` and MySQL `2.0.0`
 - **Encryption key management** auto-generated or existing secret for `SECRET_ENCRYPTION_KEY`
 - **Kubernetes integration** optional workload discovery via `ENABLE_KUBERNETES`
 - **External Redis** optional external Redis for multi-instance setups
@@ -71,7 +71,7 @@ ingress:
 ### Gateway API HTTPRoute
 
 ```yaml
-gatewayAPI:
+gateway:
   enabled: true
   parentRefs:
     - name: shared-gateway
@@ -79,9 +79,8 @@ gatewayAPI:
       sectionName: https
   hostnames:
     - dash.example.com
-  paths:
-    - type: PathPrefix
-      value: /
+  path: /
+  pathType: PathPrefix
 ```
 
 ### External Secrets Operator
@@ -193,11 +192,11 @@ backup:
 | `postgresql.initdb.scripts` | Homarr grants | PostgreSQL bootstrap grants required for Homarr migrations |
 | `postgresqlUpgradeJob.enabled` | `true` | Run a pre-upgrade hook that reapplies PostgreSQL grants on existing bundled PostgreSQL PVCs |
 | `postgresqlUpgradeJob.requireExistingResources` | `true` | Require an existing bundled PostgreSQL Secret and Service before rendering the pre-upgrade hook |
-| `postgresql.primary.persistence.enabled` | `true` | Enable PostgreSQL persistence |
+| `postgresql.standalone.persistence.enabled` | `true` | Enable PostgreSQL persistence |
 | `mysql.enabled` | `false` | Deploy MySQL subchart |
 | `mysql.auth.database` | `homarr` | MySQL database name |
 | `mysql.auth.username` | `homarr` | MySQL username |
-| `mysql.primary.persistence.enabled` | `true` | Enable MySQL persistence |
+| `mysql.standalone.persistence.enabled` | `true` | Enable MySQL persistence |
 | `redis.external` | `false` | Use external Redis |
 | `redis.host` | `""` | External Redis host |
 | `redis.port` | `6379` | External Redis port |
@@ -209,9 +208,9 @@ backup:
 | `service.ipFamilies` | `[]` | Ordered service IP families |
 | `ingress.enabled` | `false` | Enable ingress |
 | `ingress.ingressClassName` | `""` | Ingress class |
-| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
-| `gatewayAPI.parentRefs` | `[]` | Parent Gateway references |
-| `gatewayAPI.hostnames` | `[]` | HTTPRoute hostnames |
+| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `gateway.parentRefs` | `[]` | Parent Gateway references |
+| `gateway.hostnames` | `[]` | HTTPRoute hostnames |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret for the Homarr encryption/auth Secret |
 | `externalSecrets.secretStoreRef.name` | `""` | SecretStore or ClusterSecretStore name |
 | `backup.enabled` | `false` | Enable S3 backup CronJob |
@@ -241,7 +240,7 @@ Then pass it via `encryption.key` or an existing secret.
 ## Gateway API
 
 The chart can render a native Kubernetes Gateway API `HTTPRoute` alongside or instead of Ingress. Set
-`gatewayAPI.enabled=true` and reference an existing shared Gateway with `gatewayAPI.parentRefs`. Gateway API CRDs and a
+`gateway.enabled=true` and reference an existing shared Gateway with `gateway.parentRefs`. Gateway API CRDs and a
 controller such as Envoy Gateway, Cilium, Istio, Traefik, or NGINX Gateway Fabric must be installed separately.
 
 ## Dual-Stack Networking
@@ -256,6 +255,13 @@ Set `externalSecrets.enabled=true` with `encryption.existingSecret` to let Exter
 `SECRET_ENCRYPTION_KEY` and `AUTH_SECRET`. The `externalSecrets.data` entries must include `secret-encryption-key` (or the
 configured `encryption.existingSecretKey`) and `auth-secret`. The External Secrets Operator and SecretStore are managed
 outside this chart.
+
+## Security Defaults
+
+The chart sets resource requests and limits, disables privilege escalation, and applies the `RuntimeDefault` seccomp profile
+by default. The official Homarr image configures nginx during startup, so the chart keeps the container root filesystem
+writable and does not force a non-root UID or dropped capabilities by default. Override `podSecurityContext` and
+`securityContext` only after validating compatible writable mounts for `/etc/nginx` and `/var/lib/nginx`.
 
 ## Upgrade Notes
 

--- a/charts/homarr/ci/gateway-api.yaml
+++ b/charts/homarr/ci/gateway-api.yaml
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 gateway:
   enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
   hostnames:
     - dash.example.local
   path: /

--- a/charts/homarr/ci/gateway-api.yaml
+++ b/charts/homarr/ci/gateway-api.yaml
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-gatewayAPI:
+gateway:
   enabled: true
   hostnames:
     - dash.example.local
-  paths:
-    - type: PathPrefix
-      value: /
+  path: /
+  pathType: PathPrefix

--- a/charts/homarr/docs/database.md
+++ b/charts/homarr/docs/database.md
@@ -1,0 +1,121 @@
+# Homarr Database and Backup Modes
+
+## Auto Detection
+
+When `database.mode=auto`, the chart chooses a database in this order:
+
+1. external database when `database.external.host` or `database.external.existingSecret` is set
+2. bundled PostgreSQL when `postgresql.enabled=true`
+3. bundled MySQL when `mysql.enabled=true`
+4. SQLite when no database backend is configured
+
+Only one database backend should be enabled at a time.
+
+## SQLite
+
+SQLite is the default and stores data under `/appdata`:
+
+```yaml
+database:
+  mode: sqlite
+
+persistence:
+  enabled: true
+  size: 1Gi
+```
+
+Use SQLite for simple single-replica dashboards. Do not use it for multi-replica deployments.
+
+## Bundled PostgreSQL
+
+```yaml
+database:
+  mode: postgresql
+
+postgresql:
+  enabled: true
+  auth:
+    database: homarr
+    username: homarr
+    password: "change-me"
+```
+
+The chart includes bootstrap grants and a pre-upgrade hook that reapplies ownership and `CREATE` permissions for existing
+bundled PostgreSQL databases.
+
+## Bundled MySQL
+
+```yaml
+database:
+  mode: mysql
+
+mysql:
+  enabled: true
+  auth:
+    database: homarr
+    username: homarr
+    password: "change-me"
+    rootPassword: "change-root"
+```
+
+Use MySQL when it better matches your platform standards or migration plan.
+
+The chart disables Homarr's internal DNS cache by default (`homarr.enableDnsCaching=false`) so MySQL and other Kubernetes
+Services are resolved through cluster DNS during startup and background jobs. Local k3d validation showed this prevents a
+transient Homarr `sessionCleanup` connection timeout with the bundled MySQL Service. The chart also delays the bundled
+MySQL startup probe to avoid first-boot Warning events on slower nodes.
+
+## External Database
+
+```yaml
+database:
+  mode: external
+  external:
+    vendor: postgres
+    host: postgres.example.com
+    port: "5432"
+    name: homarr
+    username: homarr
+    existingSecret: homarr-db
+    existingSecretPasswordKey: database-password
+```
+
+External databases must already provide the permissions Homarr needs to create and migrate its schema.
+
+## Backup
+
+The backup CronJob is database-aware:
+
+- SQLite archives `/appdata`
+- PostgreSQL uses `pg_dump`
+- MySQL uses `mysqldump`
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.example.com
+    bucket: homarr-backups
+    existingSecret: homarr-s3
+```
+
+Test restore procedures before relying on backups for production recovery.
+
+<!-- @AI-METADATA
+type: chart-doc
+title: Homarr Database and Backup Modes
+description: Database and backup guide for the Homarr Helm chart
+
+keywords: homarr, sqlite, postgresql, mysql, backup, restore, helm, kubernetes
+
+purpose: Explain database selection, bundled and external database modes, and backup behavior
+scope: Chart Documentation
+
+relations:
+  - charts/homarr/README.md
+  - charts/homarr/DESIGN.md
+path: charts/homarr/docs/database.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/homarr/docs/database.md
+++ b/charts/homarr/docs/database.md
@@ -43,6 +43,10 @@ postgresql:
 The chart includes bootstrap grants and a pre-upgrade hook that reapplies ownership and `CREATE` permissions for existing
 bundled PostgreSQL databases.
 
+Legacy `postgresql.primary.*` values from older dependency layouts are not
+accepted when the bundled PostgreSQL subchart is enabled. Move those overrides to
+`postgresql.standalone.*` before upgrading.
+
 ## Bundled MySQL
 
 ```yaml
@@ -59,6 +63,10 @@ mysql:
 ```
 
 Use MySQL when it better matches your platform standards or migration plan.
+
+Legacy `mysql.primary.*` values from older dependency layouts are not accepted
+when the bundled MySQL subchart is enabled. Move those overrides to
+`mysql.standalone.*` before upgrading.
 
 The chart disables Homarr's internal DNS cache by default (`homarr.enableDnsCaching=false`) so MySQL and other Kubernetes
 Services are resolved through cluster DNS during startup and background jobs. Local k3d validation showed this prevents a

--- a/charts/homarr/examples/production.yaml
+++ b/charts/homarr/examples/production.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Production Homarr deployment with PostgreSQL, backup, and ingress
 homarr:
   logLevel: info
@@ -13,7 +14,7 @@ postgresql:
     database: homarr
     username: homarr
     password: "strong-db-password"
-  primary:
+  standalone:
     persistence:
       enabled: true
       size: 8Gi

--- a/charts/homarr/templates/NOTES.txt
+++ b/charts/homarr/templates/NOTES.txt
@@ -1,103 +1,173 @@
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Homarr has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- $fullname := include "homarr.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $databaseMode := include "homarr.databaseMode" . -}}
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+1. Homarr has been installed
+----------------------------
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ $namespace }}
+  Version:        {{ .Chart.AppVersion }}
+  Service:        {{ $fullname }}.{{ $namespace }}.svc.cluster.local:{{ .Values.service.port | default 7575 }}
+  Database Mode:  {{ $databaseMode }}
+  Log Level:      {{ .Values.homarr.logLevel }}
+  Auth Providers: {{ .Values.homarr.authProviders }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
+2. Access
+---------
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-DASHBOARD:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-{{- end }}
+  Ingress is enabled:
+  {{- range $host := .Values.ingress.hosts }}
+    Dashboard: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  {{- end }}
 {{- else if .Values.gateway.enabled }}
-Gateway API HTTPRoute has been rendered for Homarr.
-{{- with .Values.gateway.hostnames }}
-DASHBOARD:  http://{{ index . 0 }}/
-{{- end }}
+  Gateway API HTTPRoute is enabled:
+  {{- with .Values.gateway.hostnames }}
+    Dashboard: http://{{ index . 0 }}/
+  {{- else }}
+    No gateway.hostnames configured.
+  {{- end }}
 {{- else }}
-Port-forward to access Homarr locally:
+  Port-forward locally:
+    kubectl port-forward -n {{ $namespace }} svc/{{ $fullname }} 7575:{{ .Values.service.port | default 7575 }}
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "homarr.fullname" . }} 7575:{{ .Values.service.port | default 7575 }}
-
-  DASHBOARD:  http://localhost:7575/
+  Open:
+    http://localhost:7575/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+3. First-time Setup
+-------------------
+  - Open the dashboard and create the initial administrator account.
+  - Add integrations, calendars, bookmarks, and service widgets from the Homarr UI.
+  - Keep `encryption.key` or `encryption.existingSecret` stable after first install; changing it can make stored integration secrets unreadable.
+{{- if .Values.homarr.enableKubernetes }}
+  - Kubernetes integration is enabled. Confirm the ServiceAccount/RBAC you provide has only the permissions Homarr needs.
+{{- end }}
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-4. Open the dashboard, create your admin account and configure your widgets
-
-Database mode:
-  {{ include "homarr.databaseMode" . }}
-
+4. Configuration Summary
+------------------------
+  Persistence:       {{ .Values.persistence.enabled }}
+  Data PVC:          {{ .Values.persistence.existingClaim | default (printf "%s-data" $fullname) }}
+  PostgreSQL:        {{ .Values.postgresql.enabled }}
+  MySQL:             {{ .Values.mysql.enabled }}
+  External Redis:    {{ .Values.redis.external }}
+  Backup:            {{ .Values.backup.enabled }}
+  Ingress:           {{ .Values.ingress.enabled }}
+  Gateway API:       {{ .Values.gateway.enabled }}
+  External Secrets:  {{ .Values.externalSecrets.enabled }}
+  DNS cache:         {{ .Values.homarr.enableDnsCaching }}
 {{- with .Values.service.ipFamilyPolicy }}
-Service IP family policy:
-  {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
+  IP family policy:  {{ . }}{{ with $.Values.service.ipFamilies }} ({{ join ", " . }}){{ end }}
 {{- end }}
 
-{{- if .Values.backup.enabled }}
-S3 backup schedule:
-  {{ .Values.backup.schedule }}
-{{- end }}
+5. Validation Commands
+----------------------
+  Wait for Homarr:
+    kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=homarr -n {{ $namespace }} --timeout=300s
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Check pods and PVCs:
+    kubectl get pods,pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ $namespace }} -o wide
 
-  kubectl describe pod -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=homarr -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  Check the dashboard from inside the cluster:
+    kubectl run homarr-smoke -n {{ $namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- \
+      wget -qO- http://{{ $fullname }}:{{ .Values.service.port | default 7575 }}/
 
+  Inspect release events:
+    kubectl get events -n {{ $namespace }} --sort-by=.lastTimestamp
+
+6. Logs
+-------
+  Homarr logs:
+    kubectl logs -l app.kubernetes.io/name=homarr -n {{ $namespace }} --all-containers --tail=200
 {{- if .Values.postgresql.enabled }}
-Bundled PostgreSQL upgrade grants:
-  This release can run a pre-upgrade hook that reapplies Homarr database
-  ownership and CREATE privileges on existing bundled PostgreSQL databases
-  before migrations. By default, the hook is rendered only when the bundled
-  PostgreSQL Secret and Service already exist.
-  Inspect it with:
-  kubectl logs job/{{ include "homarr.fullname" . }}-postgresql-upgrade -n {{ .Release.Namespace }} --all-containers --tail=100
 
-View PostgreSQL logs:
-  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+  PostgreSQL upgrade hook logs:
+    kubectl logs job/{{ $fullname }}-postgresql-upgrade -n {{ $namespace }} --all-containers --tail=100
+
+  Bundled PostgreSQL logs:
+    kubectl logs -l app.kubernetes.io/name=postgresql -n {{ $namespace }} --all-containers --tail=100
 {{- end }}
-
 {{- if .Values.mysql.enabled }}
-View MySQL logs:
-  kubectl logs -l app.kubernetes.io/name=mysql -n {{ .Release.Namespace }} --all-containers --tail=50
+
+  Bundled MySQL logs:
+    kubectl logs -l app.kubernetes.io/name=mysql -n {{ $namespace }} --all-containers --tail=100
 {{- end }}
 
-Check rendered configuration:
-  helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
-  helm get manifest {{ .Release.Name }} -n {{ .Release.Namespace }}
+7. Database
+-----------
+{{- if eq $databaseMode "sqlite" }}
+  SQLite is active. Back up the Homarr data PVC because the database file lives in:
+    {{ .Values.database.sqlite.path }}
+{{- else }}
+  Database vendor: {{ include "homarr.databaseVendor" . }}
+  Database host:   {{ include "homarr.databaseHost" . }}:{{ include "homarr.databasePort" . }}
+  Database name:   {{ include "homarr.databaseName" . }}
+  Database user:   {{ include "homarr.databaseUsername" . }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Verify the database password Secret:
+    kubectl get secret {{ $fullname }}-database -n {{ $namespace }}
+{{- end }}
+{{- if .Values.redis.external }}
 
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
+  External Redis:
+    {{ .Values.redis.host }}:{{ .Values.redis.port }}
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+8. Backup
+---------
+{{- if .Values.backup.enabled }}
+  S3 backup is enabled:
+    Schedule: {{ .Values.backup.schedule }}
+    Bucket:   {{ .Values.backup.s3.bucket }}
+    Prefix:   {{ .Values.backup.s3.prefix }}
 
-Documentation:  https://helmforge.dev/docs/charts/homarr
-Chart Source:   https://github.com/helmforgedev/charts/tree/main/charts/homarr
-Report Issues:  https://github.com/helmforgedev/charts/issues
-Discussions:    https://github.com/helmforgedev/charts/discussions
-Homarr:         https://homarr.dev | https://github.com/homarr-labs/homarr
+  Check backup jobs:
+    kubectl get cronjob,jobs -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  Trigger a manual backup:
+    kubectl create job --from=cronjob/{{ $fullname }}-backup homarr-backup-$(date +%s) -n {{ $namespace }}
+{{- else }}
+  Backup is disabled. Enable `backup.enabled=true` for S3 backups.
+  The chart uses the correct backup command for SQLite, PostgreSQL, or MySQL.
+{{- end }}
+
+9. Troubleshooting
+------------------
+  Dashboard does not load:
+    kubectl describe pod -l app.kubernetes.io/name=homarr -n {{ $namespace }}
+    kubectl logs -l app.kubernetes.io/name=homarr -n {{ $namespace }} --all-containers --tail=300
+
+  Database migration or connection issue:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+{{- if .Values.postgresql.enabled }}
+    kubectl logs -l app.kubernetes.io/name=postgresql -n {{ $namespace }} --all-containers --tail=200
+{{- else if .Values.mysql.enabled }}
+    kubectl logs -l app.kubernetes.io/name=mysql -n {{ $namespace }} --all-containers --tail=200
+{{- end }}
+
+  Lost widgets, users, or integrations after restart:
+    kubectl get pvc {{ .Values.persistence.existingClaim | default (printf "%s-data" $fullname) }} -n {{ $namespace }}
+    # Use persistence.enabled=true for production.
+
+  External Secrets is enabled but secrets are missing:
+    kubectl get externalsecret -n {{ $namespace }}
+    kubectl describe externalsecret -n {{ $namespace }}
+
+10. Documentation
+-----------------
+  Helm values:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+
+  Helm manifest:
+    helm get manifest {{ .Release.Name }} -n {{ $namespace }}
+
+  HelmForge docs:
+    https://helmforge.dev/docs/charts/homarr
+
+  Chart source:
+    https://github.com/helmforgedev/charts/tree/main/charts/homarr
+
+  Upstream docs:
+    https://homarr.dev
 
 Happy Helmforging :)

--- a/charts/homarr/templates/NOTES.txt
+++ b/charts/homarr/templates/NOTES.txt
@@ -16,9 +16,9 @@ Namespace:  {{ .Release.Namespace }}
 {{- range $host := .Values.ingress.hosts }}
 DASHBOARD:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
-{{- else if .Values.gatewayAPI.enabled }}
+{{- else if .Values.gateway.enabled }}
 Gateway API HTTPRoute has been rendered for Homarr.
-{{- with .Values.gatewayAPI.hostnames }}
+{{- with .Values.gateway.hostnames }}
 DASHBOARD:  http://{{ index . 0 }}/
 {{- end }}
 {{- else }}

--- a/charts/homarr/templates/_helpers.tpl
+++ b/charts/homarr/templates/_helpers.tpl
@@ -78,6 +78,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $hasExternal := or (ne (.Values.database.external.host | default "") "") (ne (.Values.database.external.existingSecret | default "") "") -}}
 {{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
 {{- $hasMysql := .Values.mysql.enabled | default false -}}
+{{- if and $hasPostgresql (hasKey .Values.postgresql "primary") -}}
+{{- fail "postgresql.primary.* is not supported by the HelmForge PostgreSQL 2.x dependency used by this chart. Migrate PostgreSQL values to postgresql.standalone.* before upgrading." -}}
+{{- end -}}
+{{- if and $hasMysql (hasKey .Values.mysql "primary") -}}
+{{- fail "mysql.primary.* is not supported by the HelmForge MySQL 2.x dependency used by this chart. Migrate MySQL values to mysql.standalone.* before upgrading." -}}
+{{- end -}}
 {{- $vendor := .Values.database.external.vendor | default "postgres" -}}
 {{- if not (has $vendor (list "postgres" "mysql")) -}}
 {{- fail (printf "database.external.vendor must be one of: postgres, mysql (got %s)" $vendor) -}}

--- a/charts/homarr/templates/deployment.yaml
+++ b/charts/homarr/templates/deployment.yaml
@@ -55,6 +55,8 @@ spec:
               value: {{ .Values.homarr.logLevel | quote }}
             - name: AUTH_PROVIDERS
               value: {{ .Values.homarr.authProviders | quote }}
+            - name: ENABLE_DNS_CACHING
+              value: {{ .Values.homarr.enableDnsCaching | ternary "true" "false" | quote }}
             - name: SECRET_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/homarr/templates/httproute.yaml
+++ b/charts/homarr/templates/httproute.yaml
@@ -11,10 +11,7 @@
   {{- $annotations = default dict $legacyGateway.annotations }}
   {{- $hostnames = default list $legacyGateway.hostnames }}
   {{- $parentRefs = default list $legacyGateway.parentRefs }}
-  {{- if not $parentRefs }}
-    {{- if not $legacyGateway.gatewayName }}
-      {{- fail "gatewayAPI.parentRefs or gatewayAPI.gatewayName is required when legacy gatewayAPI.enabled=true" }}
-    {{- end }}
+  {{- if and (not $parentRefs) $legacyGateway.gatewayName }}
     {{- $legacyParentRef := dict "name" $legacyGateway.gatewayName }}
     {{- with $legacyGateway.gatewayNamespace }}
       {{- $_ := set $legacyParentRef "namespace" . }}
@@ -29,9 +26,6 @@
   {{- else }}
     {{- $paths = list (dict "type" (default "PathPrefix" $legacyGateway.pathType) "value" (default "/" $legacyGateway.path)) }}
   {{- end }}
-{{- end }}
-{{- if not $parentRefs }}
-  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
 {{- end }}
 {{- range $parentRefs }}
   {{- if not .name }}
@@ -49,8 +43,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- with $parentRefs }}
   parentRefs:
-    {{- toYaml $parentRefs | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with $hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/homarr/templates/httproute.yaml
+++ b/charts/homarr/templates/httproute.yaml
@@ -1,31 +1,29 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.gatewayAPI.enabled }}
+{{- if .Values.gateway.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "homarr.fullname" . }}
   labels:
     {{- include "homarr.labels" . | nindent 4 }}
-  {{- with .Values.gatewayAPI.annotations }}
+  {{- with .Values.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.gatewayAPI.parentRefs }}
+  {{- with .Values.gateway.parentRefs }}
   parentRefs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.gatewayAPI.hostnames }}
+  {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
-        {{- range .Values.gatewayAPI.paths }}
         - path:
-            type: {{ .type }}
-            value: {{ .value | quote }}
-        {{- end }}
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
       backendRefs:
         - name: {{ include "homarr.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/homarr/templates/httproute.yaml
+++ b/charts/homarr/templates/httproute.yaml
@@ -1,30 +1,68 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.gateway.enabled }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $legacyGateway := default dict .Values.gatewayAPI }}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
+{{- $annotations := default dict $gateway.annotations }}
+{{- $parentRefs := default list $gateway.parentRefs }}
+{{- $hostnames := default list $gateway.hostnames }}
+{{- $paths := list (dict "type" (default "PathPrefix" $gateway.pathType) "value" (default "/" $gateway.path)) }}
+{{- if $useLegacyGateway }}
+  {{- $annotations = default dict $legacyGateway.annotations }}
+  {{- $hostnames = default list $legacyGateway.hostnames }}
+  {{- $parentRefs = default list $legacyGateway.parentRefs }}
+  {{- if not $parentRefs }}
+    {{- if not $legacyGateway.gatewayName }}
+      {{- fail "gatewayAPI.parentRefs or gatewayAPI.gatewayName is required when legacy gatewayAPI.enabled=true" }}
+    {{- end }}
+    {{- $legacyParentRef := dict "name" $legacyGateway.gatewayName }}
+    {{- with $legacyGateway.gatewayNamespace }}
+      {{- $_ := set $legacyParentRef "namespace" . }}
+    {{- end }}
+    {{- $parentRefs = list $legacyParentRef }}
+  {{- end }}
+  {{- if $legacyGateway.paths }}
+    {{- $paths = list }}
+    {{- range $legacyGateway.paths }}
+      {{- $paths = append $paths (dict "type" (default (default "PathPrefix" .pathType) .type) "value" (default (default "/" .path) .value)) }}
+    {{- end }}
+  {{- else }}
+    {{- $paths = list (dict "type" (default "PathPrefix" $legacyGateway.pathType) "value" (default "/" $legacyGateway.path)) }}
+  {{- end }}
+{{- end }}
+{{- if not $parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
+{{- end }}
+{{- range $parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "homarr.fullname" . }}
   labels:
     {{- include "homarr.labels" . | nindent 4 }}
-  {{- with .Values.gateway.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.gateway.parentRefs }}
   parentRefs:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .Values.gateway.hostnames }}
+    {{- toYaml $parentRefs | nindent 4 }}
+  {{- with $hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
+    {{- range $paths }}
     - matches:
         - path:
-            type: {{ .Values.gateway.pathType }}
-            value: {{ .Values.gateway.path | quote }}
+            type: {{ .type }}
+            value: {{ .value | quote }}
       backendRefs:
-        - name: {{ include "homarr.fullname" . }}
-          port: {{ .Values.service.port }}
+        - name: {{ include "homarr.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
 {{- end }}

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.62.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.63.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:
@@ -68,6 +68,25 @@ tests:
           content:
             name: DB_DIALECT
             value: "sqlite"
+
+  - it: should disable Homarr DNS cache by default for Kubernetes service discovery
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_DNS_CACHING
+            value: "false"
+
+  - it: should allow enabling Homarr DNS cache explicitly
+    set:
+      homarr:
+        enableDnsCaching: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_DNS_CACHING
+            value: "true"
 
   - it: should set DB_DRIVER to node-postgres for PostgreSQL
     set:

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -35,6 +35,28 @@ tests:
       - isNull:
           path: spec.strategy
 
+  - it: should fail fast when PostgreSQL primary values are still present
+    set:
+      postgresql:
+        enabled: true
+        primary:
+          persistence:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "postgresql.primary.* is not supported by the HelmForge PostgreSQL 2.x dependency used by this chart"
+
+  - it: should fail fast when MySQL primary values are still present
+    set:
+      mysql:
+        enabled: true
+        primary:
+          persistence:
+            enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "mysql.primary.* is not supported by the HelmForge MySQL 2.x dependency used by this chart"
+
   - it: should not have initContainers for SQLite
     asserts:
       - isNull:

--- a/charts/homarr/tests/httproute_test.yaml
+++ b/charts/homarr/tests/httproute_test.yaml
@@ -45,6 +45,26 @@ tests:
           path: spec.rules[0].backendRefs[0].port
           value: 7575
 
+  - it: should render gateway HTTPRoute without parentRefs for controller defaults
+    set:
+      gateway:
+        enabled: true
+        hostnames:
+          - dash.example.com
+        path: /
+        pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - notExists:
+          path: spec.parentRefs
+      - equal:
+          path: spec.hostnames[0]
+          value: dash.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
   - it: should preserve legacy gatewayAPI values during upgrades
     set:
       gatewayAPI:
@@ -80,6 +100,32 @@ tests:
       - equal:
           path: spec.rules[1].matches[0].path.value
           value: /health
+
+  - it: should preserve legacy gatewayAPI without parentRefs during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        hostnames:
+          - legacy.example.com
+        paths:
+          - type: PathPrefix
+            value: /
+          - type: Exact
+            value: /health
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - notExists:
+          path: spec.parentRefs
+      - equal:
+          path: spec.hostnames[0]
+          value: legacy.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[1].matches[0].path.type
+          value: Exact
 
   - it: should preserve legacy gatewayAPI gatewayName values during upgrades
     set:

--- a/charts/homarr/tests/httproute_test.yaml
+++ b/charts/homarr/tests/httproute_test.yaml
@@ -10,7 +10,7 @@ tests:
 
   - it: should render HTTPRoute when Gateway API is enabled
     set:
-      gatewayAPI:
+      gateway:
         enabled: true
         parentRefs:
           - name: shared-gateway
@@ -18,9 +18,8 @@ tests:
             sectionName: https
         hostnames:
           - dash.example.com
-        paths:
-          - type: PathPrefix
-            value: /
+        path: /
+        pathType: PathPrefix
     asserts:
       - isKind:
           of: HTTPRoute

--- a/charts/homarr/tests/httproute_test.yaml
+++ b/charts/homarr/tests/httproute_test.yaml
@@ -44,3 +44,59 @@ tests:
       - equal:
           path: spec.rules[0].backendRefs[0].port
           value: 7575
+
+  - it: should preserve legacy gatewayAPI values during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        parentRefs:
+          - name: legacy-gateway
+            namespace: gateway-system
+        hostnames:
+          - legacy.example.com
+        paths:
+          - type: PathPrefix
+            value: /
+          - type: Exact
+            value: /health
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: legacy.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[1].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /health
+
+  - it: should preserve legacy gatewayAPI gatewayName values during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        gatewayName: legacy-gateway
+        gatewayNamespace: gateway-system
+        hostnames:
+          - legacy.example.com
+        path: /
+        pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system

--- a/charts/homarr/values.schema.json
+++ b/charts/homarr/values.schema.json
@@ -62,7 +62,7 @@
         "architecture": { "type": "string", "enum": ["standalone", "replication"] },
         "auth": { "type": "object" },
         "initdb": { "type": "object" },
-        "primary": { "type": "object" }
+        "standalone": { "type": "object" }
       }
     },
     "postgresqlUpgradeJob": {
@@ -92,7 +92,7 @@
         "enabled": { "type": "boolean" },
         "architecture": { "type": "string", "enum": ["standalone", "replication"] },
         "auth": { "type": "object" },
-        "primary": { "type": "object" },
+        "standalone": { "type": "object" },
         "startupProbe": { "type": "object" }
       }
     },
@@ -149,23 +149,14 @@
         "tls": { "type": "array" }
       }
     },
-    "gatewayAPI": {
+    "gateway": {
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
         "parentRefs": { "type": "array", "items": { "type": "object" } },
         "hostnames": { "type": "array", "items": { "type": "string" } },
-        "paths": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "type": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"] },
-              "value": { "type": "string" }
-            },
-            "required": ["type", "value"]
-          }
-        },
+        "path": { "type": "string" },
+        "pathType": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"] },
         "annotations": { "type": "object" }
       }
     },

--- a/charts/homarr/values.schema.json
+++ b/charts/homarr/values.schema.json
@@ -19,6 +19,7 @@
       "properties": {
         "logLevel": { "type": "string", "enum": ["trace", "debug", "info", "warn", "error", "fatal"] },
         "authProviders": { "type": "string" },
+        "enableDnsCaching": { "type": "boolean" },
         "enableKubernetes": { "type": "boolean" },
         "extraEnv": { "type": "array" }
       }
@@ -91,7 +92,8 @@
         "enabled": { "type": "boolean" },
         "architecture": { "type": "string", "enum": ["standalone", "replication"] },
         "auth": { "type": "object" },
-        "primary": { "type": "object" }
+        "primary": { "type": "object" },
+        "startupProbe": { "type": "object" }
       }
     },
     "redis": {

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -117,7 +117,7 @@ postgresql:
         SELECT format('GRANT CREATE ON DATABASE %I TO %I', :'app_database', :'app_username') \gexec
         SQL
         fi
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for PostgreSQL data
       enabled: true
@@ -179,7 +179,7 @@ mysql:
     password: ""
     # -- Root password (auto-generated if empty)
     rootPassword: ""
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for MySQL data
       enabled: true
@@ -243,21 +243,25 @@ persistence:
 # =============================================================================
 
 # -- CPU and memory requests/limits for the Homarr container
-resources: {}
-  # requests:
-  #   cpu: 100m
-  #   memory: 256Mi
-  # limits:
-  #   cpu: 500m
-  #   memory: 512Mi
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 750m
+    memory: 768Mi
 
 # =============================================================================
 # Security Context
 # =============================================================================
 
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
 
 # =============================================================================
 # Probes
@@ -349,11 +353,11 @@ ingress:
 # Gateway API
 # =============================================================================
 
-gatewayAPI:
+gateway:
   # -- Enable Gateway API HTTPRoute for Homarr HTTP (requires Gateway API CRDs)
   enabled: false
 
-  # -- Parent Gateway references. Leave empty to attach through controller defaults.
+  # -- Parent Gateway references.
   parentRefs: []
   #   - name: shared-gateway
   #     namespace: gateway-system
@@ -363,10 +367,11 @@ gatewayAPI:
   hostnames: []
   #   - dash.example.com
 
-  # -- HTTPRoute path matches
-  paths:
-    - type: PathPrefix
-      value: /
+  # -- HTTPRoute path
+  path: /
+
+  # -- HTTPRoute path match type
+  pathType: PathPrefix
 
   # -- HTTPRoute annotations
   annotations: {}

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.62.0"
+  tag: "v1.63.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets
@@ -27,6 +27,9 @@ homarr:
 
   # -- Authentication providers (comma-separated): credentials, ldap, oidc
   authProviders: credentials
+
+  # -- Enable Homarr's internal DNS cache. Disabled by default for Kubernetes Service discovery stability.
+  enableDnsCaching: false
 
   # -- Enable Kubernetes integration for workload discovery
   enableKubernetes: false
@@ -182,6 +185,9 @@ mysql:
       enabled: true
       # -- PVC size for MySQL
       size: 8Gi
+  startupProbe:
+    # -- Delay MySQL startup probing to avoid transient startup Warning events in k3d and slower nodes
+    initialDelaySeconds: 30
 
 # =============================================================================
 # Redis
@@ -262,7 +268,7 @@ startupProbe:
   enabled: true
   # -- Path for HTTP GET probe
   path: /
-  initialDelaySeconds: 10
+  initialDelaySeconds: 30
   periodSeconds: 5
   timeoutSeconds: 3
   failureThreshold: 30


### PR DESCRIPTION
Closes #396

## Summary
- Update Homarr to `1.63.0` and use the published GHCR image tag `v1.63.0`.
- Add HelmForge-style `DESIGN.md` and database/backup documentation.
- Disable Homarr DNS caching by default for Kubernetes Service discovery stability and tune MySQL startup probing after k3d validation.

## Upstream research
- GitHub release `v1.63.0` was published on 2026-05-29 with auth, board, management UI, bug fix, and performance updates.
- GHCR does not publish `ghcr.io/homarr-labs/homarr:1.63.0`; the valid multi-arch tag is `ghcr.io/homarr-labs/homarr:v1.63.0`.
- Homarr documents `ENABLE_DNS_CACHING`; disabling it avoids the MySQL `sessionCleanup` connection timeout observed in k3d with Kubernetes Services.

## Validation
- `npx -y markdownlint-cli2 charts/homarr/README.md charts/homarr/DESIGN.md charts/homarr/docs/database.md`
- `helm dependency build charts/homarr`
- `helm dependency list charts/homarr` (`postgresql 1.10.0`, `mysql 1.9.1`)
- `helm lint charts/homarr`
- `helm lint charts/homarr --strict`
- `helm template homarr-ci charts/homarr`
- `helm template homarr-ci charts/homarr -f charts/homarr/ci/*.yaml`
- `helm unittest charts/homarr` (49 tests, 9 suites)
- `ah lint -p charts/homarr`
- `kubeconform -strict -summary -ignore-missing-schemas` for default and all CI values
- `kubescape scan framework nsa` (overall compliance-score: 65)

## k3d validation
Cluster: `k3d-helmforge-tests-wsl`

- SQLite default: pod Ready, 0 restarts, service returned Homarr redirect (`HTTP 307`), no non-normal events, no Homarr log error matches, namespace cleaned.
- PostgreSQL subchart: Homarr and PostgreSQL pods Ready, 0 restarts, `HTTP 200`, no non-normal events, no Homarr/PostgreSQL log error matches, namespace cleaned.
- MySQL subchart: Homarr and MySQL pods Ready, 0 restarts, `HTTP 200`, no non-normal events, no Homarr/MySQL log error matches, namespace cleaned.