### PR TITLE
chore(hoppscotch): update Hoppscotch to 2026.5.0

### DIFF
--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -5,8 +5,8 @@ description: Hoppscotch Community Edition for Kubernetes — open-source API dev
 home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
-version: 1.1.1
-appVersion: "2026.4.1"
+version: 1.1.2
+appVersion: "2026.5.0"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -30,7 +30,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "promote remaining charts to stable (#406)"
+      description: "update Hoppscotch to 2026.5.0 with proxy URL configuration and security fixes (#397)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
 

--- a/charts/hoppscotch/DESIGN.md
+++ b/charts/hoppscotch/DESIGN.md
@@ -36,7 +36,7 @@ endpoint, and admin dashboard.
 - Run Prisma migrations in an init container before the application starts.
 - Bootstrap `pg_trgm` on fresh bundled PostgreSQL databases and keep a pre-upgrade hook for existing PVCs.
 - Persist `DATA_ENCRYPTION_KEY` and `WEBAPP_SERVER_SIGNING_KEY` through Kubernetes Secrets.
-- Prefer `ingress.ingressClassName` while keeping `ingress.className` as a legacy compatibility alias.
+- Use the HelmForge-standard `ingress.ingressClassName` field for Ingress class selection.
 - Expose `proxy.appUrl` as an optional `PROXY_APP_URL` bootstrap value for self-hosted proxy defaults.
 
 ## Production Boundary

--- a/charts/hoppscotch/DESIGN.md
+++ b/charts/hoppscotch/DESIGN.md
@@ -1,0 +1,78 @@
+# Hoppscotch Chart Design
+
+## Scope
+
+This chart deploys Hoppscotch Community Edition using the official AIO image. It is designed for self-hosted API
+workspaces that need a single Kubernetes workload with frontend, backend, admin dashboard, PostgreSQL, authentication,
+SMTP, and edge routing managed consistently.
+
+Supported deployment modes:
+
+- development mode with bundled HelmForge PostgreSQL enabled by default
+- production mode with bundled or external PostgreSQL
+- optional OAuth, SMTP, External Secrets, Gateway API, NetworkPolicy, and ServiceMonitor integrations
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[User] --> edge[Ingress, HTTPRoute, or Service]
+  edge --> hoppscotch[Hoppscotch AIO Deployment]
+  hoppscotch --> svcFrontend[Frontend path]
+  hoppscotch --> svcBackend[Backend path]
+  hoppscotch --> svcAdmin[Admin path]
+  hoppscotch --> dbsvc[PostgreSQL Service]
+  dbsvc --> db[HelmForge PostgreSQL StatefulSet or external PostgreSQL]
+  secret[Chart, ExternalSecret, or existing Secrets] --> hoppscotch
+```
+
+The chart enables subpath based access so one service and one hostname can expose the web app, backend APIs, WebSocket
+endpoint, and admin dashboard.
+
+## Main Design Choices
+
+- Use the official `docker.io/hoppscotch/hoppscotch` AIO image to keep the chart operationally simple.
+- Use the HelmForge PostgreSQL subchart for bundled persistence.
+- Run Prisma migrations in an init container before the application starts.
+- Bootstrap `pg_trgm` on fresh bundled PostgreSQL databases and keep a pre-upgrade hook for existing PVCs.
+- Persist `DATA_ENCRYPTION_KEY` and `WEBAPP_SERVER_SIGNING_KEY` through Kubernetes Secrets.
+- Prefer `ingress.ingressClassName` while keeping `ingress.className` as a legacy compatibility alias.
+- Expose `proxy.appUrl` as an optional `PROXY_APP_URL` bootstrap value for self-hosted proxy defaults.
+
+## Production Boundary
+
+For production, operators should define:
+
+- stable `DATA_ENCRYPTION_KEY` and `WEBAPP_SERVER_SIGNING_KEY` through existing Secrets or External Secrets
+- PostgreSQL storage class, size, backup, restore, and retention policy
+- hostname, TLS, and WebSocket-capable ingress or Gateway API configuration
+- OAuth provider credentials and callback URLs
+- SMTP settings for magic links and invitations
+- resource requests, limits, PDB, and NetworkPolicy settings
+
+## Explicit Non-Goals
+
+- deploying Hoppscotch's split frontend/backend/admin image topology
+- managing OAuth application registration in external identity providers
+- managing PostgreSQL backups directly in this chart
+- provisioning ingress controllers, Gateway controllers, or SecretStores
+
+<!-- @AI-METADATA
+type: design
+title: Hoppscotch Chart Design
+description: Design document for the Hoppscotch Helm chart architecture, database model, routing, and production boundaries
+
+keywords: hoppscotch, design, architecture, postgresql, ingress, gateway-api, oauth, smtp, helm, kubernetes
+
+purpose: Document chart architecture, operational choices, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/hoppscotch/README.md
+  - charts/hoppscotch/docs/database.md
+  - charts/hoppscotch/docs/authentication.md
+  - charts/hoppscotch/docs/production.md
+path: charts/hoppscotch/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -16,7 +16,7 @@ helm install hoppscotch helmforge/hoppscotch
 
 ```bash
 helm install hoppscotch oci://ghcr.io/helmforgedev/helm/hoppscotch \
-  --version 0.1.0
+  --version 1.1.2
 ```
 
 ## Quick Start
@@ -35,7 +35,7 @@ helm install hoppscotch helmforge/hoppscotch \
 helm install hoppscotch helmforge/hoppscotch \
   --set mode=production \
   --set ingress.enabled=true \
-  --set ingress.className=nginx \
+  --set ingress.ingressClassName=nginx \
   --set ingress.host=hoppscotch.example.com \
   --set "ingress.tls[0].secretName=hoppscotch-tls" \
   --set "ingress.tls[0].hosts[0]=hoppscotch.example.com" \
@@ -49,6 +49,7 @@ helm install hoppscotch helmforge/hoppscotch \
 - **Prisma migrations** — automatic via init container on every deploy
 - **OAuth providers** — GitHub, Google, Microsoft, EMAIL (magic links)
 - **SMTP support** — URL mode or field-by-field
+- **Proxy URL bootstrap** — optional `PROXY_APP_URL` default for self-hosted deployments
 - **ExternalSecrets Operator** — native support
 - **Gateway API** — HTTPRoute support
 - **Dual-stack networking** — `ipFamilyPolicy` and `ipFamilies` on Service
@@ -72,7 +73,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.4.1` |
+| `image.tag` | Hoppscotch image tag | `2026.5.0` |
 | `namespaceOverride` | Namespace for chart-managed resources. Use with an external database; bundled PostgreSQL remains in the Helm release namespace. | `""` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
@@ -88,6 +89,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | `serviceAccount.automountServiceAccountToken` | Mount the Kubernetes API token into Hoppscotch pods and hook jobs | `false` |
 | `auth.providers` | Enabled auth providers | `EMAIL` |
 | `mailer.enabled` | Enable SMTP | `false` |
+| `proxy.appUrl` | Default proxy URL exposed as `PROXY_APP_URL` | `""` |
 | `gatewayAPI.enabled` | Enable HTTPRoute | `false` |
 | `externalSecrets.enabled` | Enable ExternalSecret | `false` |
 | `externalSecrets.apiVersion` | ExternalSecret API version | `external-secrets.io/v1` |
@@ -96,11 +98,9 @@ All traffic goes through a single Ingress/Service on port 80.
 
 ## Upgrade Notes
 
-Hoppscotch `2026.4.1` includes the latest upstream Hoppscotch fixes after
-the `2026.4.0` release, which added collection-level pre-request and test scripts,
-API documentation publishing refinements, self-hosted SMTP OAuth2 support,
-desktop settings improvements, security patches, and bug fixes. Back up the
-PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
+Hoppscotch `2026.5.0` adds OpenAPI 3.1 collection export, configurable proxy URLs through environment/admin settings,
+Mongolian language support, security patches, and fixes that prevent secret variable values from leaking to the backend.
+Back up the PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
 The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
 user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs
 a pre-upgrade hook to apply `pg_trgm` to existing bundled PostgreSQL PVCs before
@@ -124,6 +124,7 @@ separately managed Secret.
 - [Authentication](docs/authentication.md)
 - [SMTP](docs/smtp.md)
 - [Production Hardening](docs/production.md)
+- [Chart Design](DESIGN.md)
 
 ## Connecting
 

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -78,7 +78,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.host` | Primary hostname (auto-derives all URLs) | `""` |
-| `postgresql.enabled` | Enable PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) | `true` |
+| `postgresql.enabled` | Enable PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) | `true` |
 | `postgresql.initdb.scripts` | Bootstrap Hoppscotch PostgreSQL extensions | `pg_trgm` |
 | `postgresqlExtensionsJob.enabled` | Run the pre-upgrade hook that ensures `pg_trgm` exists on bundled PostgreSQL PVCs before Prisma migrations | `true` |
 | `postgresqlExtensionsJob.requireExistingResources` | Only render the `pg_trgm` pre-upgrade hook when bundled PostgreSQL resources already exist | `true` |
@@ -90,7 +90,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | `auth.providers` | Enabled auth providers | `EMAIL` |
 | `mailer.enabled` | Enable SMTP | `false` |
 | `proxy.appUrl` | Default proxy URL exposed as `PROXY_APP_URL` | `""` |
-| `gatewayAPI.enabled` | Enable HTTPRoute | `false` |
+| `gateway.enabled` | Enable HTTPRoute | `false` |
 | `externalSecrets.enabled` | Enable ExternalSecret | `false` |
 | `externalSecrets.apiVersion` | ExternalSecret API version | `external-secrets.io/v1` |
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -67,6 +67,10 @@ Hoppscotch AIO uses subpath-based routing (`ENABLE_SUBPATH_BASED_ACCESS=true`):
 | `/admin` | Admin Dashboard |
 
 All traffic goes through a single Ingress/Service on port 80.
+Inside the pod, the AIO Caddy server listens on non-root port `8081` via
+`HOPP_AIO_ALTERNATE_PORT`; the Kubernetes Service maps external port `80` to
+that named container port. Port `8080` remains reserved for the Hoppscotch
+backend process inside the AIO image.
 
 ## Configuration
 
@@ -90,6 +94,7 @@ All traffic goes through a single Ingress/Service on port 80.
 | `auth.providers` | Enabled auth providers | `EMAIL` |
 | `mailer.enabled` | Enable SMTP | `false` |
 | `proxy.appUrl` | Default proxy URL exposed as `PROXY_APP_URL` | `""` |
+| `service.containerPort` | Internal non-root Hoppscotch AIO HTTP port | `8081` |
 | `gateway.enabled` | Enable HTTPRoute | `false` |
 | `externalSecrets.enabled` | Enable ExternalSecret | `false` |
 | `externalSecrets.apiVersion` | ExternalSecret API version | `external-secrets.io/v1` |

--- a/charts/hoppscotch/ci/gateway-api.yaml
+++ b/charts/hoppscotch/ci/gateway-api.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-gatewayAPI:
+gateway:
   enabled: true
   hostnames:
     - hoppscotch.example.local

--- a/charts/hoppscotch/docs/database.md
+++ b/charts/hoppscotch/docs/database.md
@@ -13,7 +13,7 @@ postgresql:
     database: hoppscotch
     username: hoppscotch
     password: ""        # auto-generated if empty
-  primary:
+  standalone:
     persistence:
       enabled: true
       size: 10Gi

--- a/charts/hoppscotch/docs/production.md
+++ b/charts/hoppscotch/docs/production.md
@@ -64,7 +64,7 @@ ExternalSecret data, or set `signingKey.existingSecret` and
 ```yaml
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   host: hoppscotch.example.com
   tls:
     - secretName: hoppscotch-tls
@@ -89,6 +89,18 @@ ingress:
 ```
 
 For Traefik, use middleware with websocket passthrough configured.
+
+## Default Proxy URL
+
+Hoppscotch `2026.5.0` can read a default proxy URL from `PROXY_APP_URL`. Set it when you run a self-hosted proxy and want
+new users to inherit a default without configuring it individually:
+
+```yaml
+proxy:
+  appUrl: https://proxy.example.com
+```
+
+Leave `proxy.appUrl` empty when the default should be managed from the Admin Dashboard instead.
 
 ## Multi-Replica Deployment
 

--- a/charts/hoppscotch/docs/production.md
+++ b/charts/hoppscotch/docs/production.md
@@ -156,3 +156,10 @@ containerSecurityContext:
 ```
 
 `readOnlyRootFilesystem` is set to `false` because Hoppscotch writes temporary files at runtime.
+
+The Hoppscotch AIO image serves the frontend, admin dashboard, and backend
+through Caddy. The chart sets `HOPP_AIO_ALTERNATE_PORT=8081` by default so that
+Caddy can bind while the container runs as non-root and all Linux capabilities
+remain dropped. The Service still exposes port `80` and routes to the named
+container port. The upstream backend process remains on the image's internal
+`localhost:8080` listener.

--- a/charts/hoppscotch/examples/full-production.yaml
+++ b/charts/hoppscotch/examples/full-production.yaml
@@ -35,7 +35,7 @@ mailer:
   from: noreply@example.com
   existingSecret: hoppscotch-smtp
 
-gatewayAPI:
+gateway:
   enabled: true
   hostnames:
     - hoppscotch.example.com

--- a/charts/hoppscotch/examples/production.yaml
+++ b/charts/hoppscotch/examples/production.yaml
@@ -15,7 +15,7 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 postgresql:
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 resources:

--- a/charts/hoppscotch/examples/production.yaml
+++ b/charts/hoppscotch/examples/production.yaml
@@ -4,7 +4,7 @@
 mode: production
 ingress:
   enabled: true
-  className: nginx
+  ingressClassName: nginx
   host: hoppscotch.example.com
   tls:
     - secretName: hoppscotch-tls

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -41,7 +41,7 @@ For nginx-ingress, add these annotations to your ingress:
 ========================
   Database:         {{- if .Values.postgresql.enabled }} PostgreSQL subchart{{- else if .Values.database.external.enabled }} External PostgreSQL{{- else }} Not configured{{- end }}
   SMTP:             {{- if .Values.mailer.enabled }} enabled{{- else }} disabled{{- end }}
-  Gateway API:      {{- if .Values.gatewayAPI.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:      {{- if .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
   External Secrets: {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
   Network Policy:   {{- if .Values.networkPolicy.enabled }} enabled{{- else }} disabled{{- end }}
   PDB:              {{- if .Values.podDisruptionBudget.enabled }} enabled (minAvailable={{ .Values.podDisruptionBudget.minAvailable }}){{- else }} disabled{{- end }}

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -35,7 +35,7 @@ For nginx-ingress, add these annotations to your ingress:
 ===================
   - The FIRST user to log in via the Admin Dashboard becomes the administrator.
   - Admin URL: {{ include "hoppscotch.adminUrl" . }}
-  - No seed required — just navigate to /admin and log in.
+  - No seed required - just navigate to /admin and log in.
   - After setup, generate an InfraToken for API access: Admin > InfraTokens
 
 4. Configuration Summary
@@ -62,6 +62,8 @@ Upgrade reminder:
   and the pre-upgrade hook applies pg_trgm to existing bundled PostgreSQL PVCs
   before Prisma migrations run. By default, the hook renders only when the
   bundled PostgreSQL Secret and Service already exist.
+  Legacy bundled PostgreSQL overrides under postgresql.primary.* must be moved
+  to postgresql.standalone.* before upgrading to this chart generation.
   WEBAPP_SERVER_SIGNING_KEY is persisted in the chart Secret to keep web
   bundle signatures stable across pod restarts. With External Secrets, provide
   webapp-server-signing-key in externalSecrets.data or point signingKey.* to a
@@ -99,15 +101,15 @@ Upgrade reminder:
     -> Add proxy-read-timeout and upgrade annotations (see section 2)
 
   DATA_ENCRYPTION_KEY warning:
-    -> Never change this key after first install — it will corrupt encrypted data
+    -> Never change this key after first install - it will corrupt encrypted data
     -> Use encryption.existingSecret in production to manage the key externally
 
   Database connection refused:
-    -> wait-for-db init container will keep retrying — check PostgreSQL pod status
+    -> wait-for-db init container will keep retrying - check PostgreSQL pod status
     -> If using external DB: verify host, port, credentials
 
   Admin dashboard shows 403:
-    -> Clear cookies and retry — first login always succeeds
+    -> Clear cookies and retry - first login always succeeds
     -> Check VITE_ADMIN_URL matches actual admin URL
 
   PostgreSQL subchart "database does not exist":
@@ -119,7 +121,7 @@ Upgrade reminder:
 ============
   Hoppscotch collects anonymous usage data (no API content, no personal data).
   Frequency: once per week. Payload: instance UUID, user count, workspace count, version.
-  To disable: Admin Dashboard > Settings > Data Sharing (UI only — no env var available).
+  To disable: Admin Dashboard > Settings > Data Sharing (UI only - no env var available).
 
 9. Upgrading
 ============

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -1,5 +1,6 @@
 {{- $namespace := include "hoppscotch.namespace" . -}}
 {{- $releaseNamespace := .Release.Namespace -}}
+{{- $legacyGateway := default dict .Values.gatewayAPI -}}
 1. Hoppscotch has been installed
 ================================
   Release:        {{ .Release.Name }}
@@ -41,7 +42,7 @@ For nginx-ingress, add these annotations to your ingress:
 ========================
   Database:         {{- if .Values.postgresql.enabled }} PostgreSQL subchart{{- else if .Values.database.external.enabled }} External PostgreSQL{{- else }} Not configured{{- end }}
   SMTP:             {{- if .Values.mailer.enabled }} enabled{{- else }} disabled{{- end }}
-  Gateway API:      {{- if .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:      {{- if or .Values.gateway.enabled (default false $legacyGateway.enabled) }} enabled{{- else }} disabled{{- end }}
   External Secrets: {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
   Network Policy:   {{- if .Values.networkPolicy.enabled }} enabled{{- else }} disabled{{- end }}
   PDB:              {{- if .Values.podDisruptionBudget.enabled }} enabled (minAvailable={{ .Values.podDisruptionBudget.minAvailable }}){{- else }} disabled{{- end }}

--- a/charts/hoppscotch/templates/NOTES.txt
+++ b/charts/hoppscotch/templates/NOTES.txt
@@ -78,7 +78,7 @@ Upgrade reminder:
 
   # Test backend health
   kubectl exec -n {{ $namespace }} deploy/{{ include "hoppscotch.fullname" . }} -- \
-    sh -c "wget -qO- http://localhost/backend/health" 2>/dev/null || echo "backend not ready"
+    sh -c "wget -qO- http://localhost:{{ .Values.service.containerPort }}/backend/health" 2>/dev/null || echo "backend not ready"
 
 7. Troubleshooting
 ==================

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -106,8 +106,8 @@ validateAll — fail-fast on misconfigured values
 {{- if and .Values.mailer.enabled (not .Values.mailer.useCustomConfigs) (not .Values.mailer.smtpUrl) (not .Values.mailer.existingSecret) -}}
   {{- fail "mailer.smtpUrl is required when mailer.enabled=true and mailer.useCustomConfigs=false (or set mailer.existingSecret)" -}}
 {{- end -}}
-{{- if and .Values.gatewayAPI.enabled (not .Values.gatewayAPI.parentRefs) -}}
-  {{- fail "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true" -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
+  {{- fail "gateway.parentRefs is required when gateway.enabled=true" -}}
 {{- end -}}
 {{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
   {{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -109,6 +109,9 @@ validateAll — fail-fast on misconfigured values
 {{- if eq (int .Values.service.containerPort) 8080 -}}
   {{- fail "service.containerPort must not be 8080 because the Hoppscotch AIO backend already listens on localhost:8080" -}}
 {{- end -}}
+{{- if and .Values.postgresql.enabled (hasKey .Values.postgresql "primary") -}}
+  {{- fail "postgresql.primary.* is no longer supported by the bundled HelmForge PostgreSQL subchart; migrate these overrides to postgresql.standalone.* before upgrading" -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
   {{- fail "gateway.parentRefs is required when gateway.enabled=true" -}}
 {{- end -}}

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -106,6 +106,9 @@ validateAll — fail-fast on misconfigured values
 {{- if and .Values.mailer.enabled (not .Values.mailer.useCustomConfigs) (not .Values.mailer.smtpUrl) (not .Values.mailer.existingSecret) -}}
   {{- fail "mailer.smtpUrl is required when mailer.enabled=true and mailer.useCustomConfigs=false (or set mailer.existingSecret)" -}}
 {{- end -}}
+{{- if eq (int .Values.service.containerPort) 8080 -}}
+  {{- fail "service.containerPort must not be 8080 because the Hoppscotch AIO backend already listens on localhost:8080" -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
   {{- fail "gateway.parentRefs is required when gateway.enabled=true" -}}
 {{- end -}}

--- a/charts/hoppscotch/templates/configmap.yaml
+++ b/charts/hoppscotch/templates/configmap.yaml
@@ -21,6 +21,9 @@ data:
   {{- with .Values.privacyPolicyLink }}
   VITE_APP_PRIVACY_POLICY_LINK: {{ . | quote }}
   {{- end }}
+  {{- with .Values.proxy.appUrl }}
+  PROXY_APP_URL: {{ . | quote }}
+  {{- end }}
   {{- if .Values.mailer.enabled }}
   MAILER_SMTP_ENABLE: "true"
   MAILER_ADDRESS_FROM: {{ .Values.mailer.from | quote }}

--- a/charts/hoppscotch/templates/configmap.yaml
+++ b/charts/hoppscotch/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
   VITE_BACKEND_API_URL: {{ include "hoppscotch.backendApiUrl" . | quote }}
   VITE_ALLOWED_AUTH_PROVIDERS: {{ include "hoppscotch.authProviders" . | quote }}
   ENABLE_SUBPATH_BASED_ACCESS: "true"
+  HOPP_AIO_ALTERNATE_PORT: {{ .Values.service.containerPort | toString | quote }}
   WHITELISTED_ORIGINS: {{ include "hoppscotch.whitelistedOrigins" . | quote }}
   {{- with .Values.tosLink }}
   VITE_APP_TOS_LINK: {{ . | quote }}

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -199,7 +199,7 @@ spec:
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.containerPort }}
               protocol: TCP
           envFrom:
             - configMapRef:

--- a/charts/hoppscotch/templates/httproute.yaml
+++ b/charts/hoppscotch/templates/httproute.yaml
@@ -1,24 +1,48 @@
 # SPDX-License-Identifier: Apache-2.0
-{{- if .Values.gateway.enabled }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $legacyGateway := default dict .Values.gatewayAPI }}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
+{{- $annotations := default dict $gateway.annotations }}
+{{- $parentRefs := default list $gateway.parentRefs }}
+{{- $hostnames := default list $gateway.hostnames }}
+{{- $path := default "/" $gateway.path }}
+{{- $pathType := default "PathPrefix" $gateway.pathType }}
+{{- if $useLegacyGateway }}
+  {{- $annotations = default dict $legacyGateway.annotations }}
+  {{- $parentRefs = default list $legacyGateway.parentRefs }}
+  {{- $hostnames = default list $legacyGateway.hostnames }}
+  {{- $path = default "/" $legacyGateway.path }}
+  {{- $pathType = default "PathPrefix" $legacyGateway.pathType }}
+  {{- if and (not $parentRefs) $legacyGateway.gatewayName }}
+    {{- $legacyParentRef := dict "name" $legacyGateway.gatewayName }}
+    {{- with $legacyGateway.gatewayNamespace }}
+      {{- $_ := set $legacyParentRef "namespace" . }}
+    {{- end }}
+    {{- $parentRefs = list $legacyParentRef }}
+  {{- end }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "hoppscotch.fullname" . }}
   namespace: {{ include "hoppscotch.namespace" . }}
   labels: {{ include "hoppscotch.labels" . | nindent 4 }}
-  {{- with .Values.gateway.annotations }}
+  {{- with $annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  parentRefs: {{- toYaml (required "gateway.parentRefs is required when gateway.enabled=true" .Values.gateway.parentRefs) | nindent 4 }}
-  {{- with .Values.gateway.hostnames }}
+  {{- with $parentRefs }}
+  parentRefs: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $hostnames }}
   hostnames: {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ .Values.gateway.pathType }}
-            value: {{ .Values.gateway.path | quote }}
+            type: {{ $pathType }}
+            value: {{ $path | quote }}
       backendRefs:
         - name: {{ include "hoppscotch.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/hoppscotch/templates/httproute.yaml
+++ b/charts/hoppscotch/templates/httproute.yaml
@@ -8,12 +8,20 @@
 {{- $hostnames := default list $gateway.hostnames }}
 {{- $path := default "/" $gateway.path }}
 {{- $pathType := default "PathPrefix" $gateway.pathType }}
+{{- $matches := list (dict "path" $path "pathType" $pathType) }}
 {{- if $useLegacyGateway }}
   {{- $annotations = default dict $legacyGateway.annotations }}
   {{- $parentRefs = default list $legacyGateway.parentRefs }}
   {{- $hostnames = default list $legacyGateway.hostnames }}
   {{- $path = default "/" $legacyGateway.path }}
   {{- $pathType = default "PathPrefix" $legacyGateway.pathType }}
+  {{- $matches = list (dict "path" $path "pathType" $pathType) }}
+  {{- with $legacyGateway.paths }}
+    {{- $matches = list }}
+    {{- range . }}
+      {{- $matches = append $matches (dict "path" (default "/" .path) "pathType" (default "PathPrefix" .pathType)) }}
+    {{- end }}
+  {{- end }}
   {{- if and (not $parentRefs) $legacyGateway.gatewayName }}
     {{- $legacyParentRef := dict "name" $legacyGateway.gatewayName }}
     {{- with $legacyGateway.gatewayNamespace }}
@@ -40,9 +48,11 @@ spec:
   {{- end }}
   rules:
     - matches:
+        {{- range $matches }}
         - path:
-            type: {{ $pathType }}
-            value: {{ $path | quote }}
+            type: {{ .pathType }}
+            value: {{ .path | quote }}
+        {{- end }}
       backendRefs:
         - name: {{ include "hoppscotch.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/hoppscotch/templates/httproute.yaml
+++ b/charts/hoppscotch/templates/httproute.yaml
@@ -1,27 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
-{{- if .Values.gatewayAPI.enabled }}
+{{- if .Values.gateway.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "hoppscotch.fullname" . }}
   namespace: {{ include "hoppscotch.namespace" . }}
   labels: {{ include "hoppscotch.labels" . | nindent 4 }}
-  {{- with .Values.gatewayAPI.annotations }}
+  {{- with .Values.gateway.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  parentRefs: {{- toYaml (required "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true" .Values.gatewayAPI.parentRefs) | nindent 4 }}
-  {{- with .Values.gatewayAPI.hostnames }}
+  parentRefs: {{- toYaml (required "gateway.parentRefs is required when gateway.enabled=true" .Values.gateway.parentRefs) | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
   hostnames: {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
-    {{- range .Values.gatewayAPI.paths }}
     - matches:
         - path:
-            type: {{ .type }}
-            value: {{ .value }}
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
       backendRefs:
-        - name: {{ include "hoppscotch.fullname" $ }}
-          port: {{ $.Values.service.port }}
-    {{- end }}
+        - name: {{ include "hoppscotch.fullname" . }}
+          port: {{ .Values.service.port }}
 {{- end }}

--- a/charts/hoppscotch/templates/httproute.yaml
+++ b/charts/hoppscotch/templates/httproute.yaml
@@ -19,7 +19,9 @@
   {{- with $legacyGateway.paths }}
     {{- $matches = list }}
     {{- range . }}
-      {{- $matches = append $matches (dict "path" (default "/" .path) "pathType" (default "PathPrefix" .pathType)) }}
+      {{- $legacyPath := default (default "/" .value) .path }}
+      {{- $legacyPathType := default (default "PathPrefix" .type) .pathType }}
+      {{- $matches = append $matches (dict "path" $legacyPath "pathType" $legacyPathType) }}
     {{- end }}
   {{- end }}
   {{- if and (not $parentRefs) $legacyGateway.gatewayName }}

--- a/charts/hoppscotch/templates/ingress.yaml
+++ b/charts/hoppscotch/templates/ingress.yaml
@@ -10,8 +10,9 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- $ingressClassName := .Values.ingress.ingressClassName | default .Values.ingress.className }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls: {{- toYaml . | nindent 4 }}

--- a/charts/hoppscotch/templates/ingress.yaml
+++ b/charts/hoppscotch/templates/ingress.yaml
@@ -10,8 +10,9 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- $ingressClassName := .Values.ingress.ingressClassName | default .Values.ingress.className }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName | quote }}
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls: {{- toYaml . | nindent 4 }}

--- a/charts/hoppscotch/templates/ingress.yaml
+++ b/charts/hoppscotch/templates/ingress.yaml
@@ -10,9 +10,8 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- $ingressClassName := .Values.ingress.ingressClassName | default .Values.ingress.className }}
-  {{- if $ingressClassName }}
-  ingressClassName: {{ $ingressClassName | quote }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls: {{- toYaml . | nindent 4 }}

--- a/charts/hoppscotch/templates/tests/connection-test.yaml
+++ b/charts/hoppscotch/templates/tests/connection-test.yaml
@@ -26,3 +26,10 @@ spec:
             - ALL
         runAsNonRoot: true
         runAsUser: 1000
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi

--- a/charts/hoppscotch/tests/configmap_test.yaml
+++ b/charts/hoppscotch/tests/configmap_test.yaml
@@ -51,6 +51,22 @@ tests:
           path: data.MAILER_SMTP_ENABLE
         template: configmap.yaml
 
+  - it: should not set PROXY_APP_URL by default
+    asserts:
+      - notExists:
+          path: data.PROXY_APP_URL
+        template: configmap.yaml
+
+  - it: should set PROXY_APP_URL when configured
+    set:
+      proxy:
+        appUrl: https://proxy.example.com
+    asserts:
+      - equal:
+          path: data.PROXY_APP_URL
+          value: https://proxy.example.com
+        template: configmap.yaml
+
   - it: should set MAILER when enabled
     set:
       mailer:

--- a/charts/hoppscotch/tests/configmap_test.yaml
+++ b/charts/hoppscotch/tests/configmap_test.yaml
@@ -11,6 +11,13 @@ tests:
           value: "true"
         template: configmap.yaml
 
+  - it: should set non-root AIO Caddy port
+    asserts:
+      - equal:
+          path: data.HOPP_AIO_ALTERNATE_PORT
+          value: "8081"
+        template: configmap.yaml
+
   - it: should set EMAIL as default auth provider
     asserts:
       - equal:

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -263,12 +263,12 @@ tests:
           value: RollingUpdate
         template: deployment.yaml
 
-  - it: should expose port 80
+  - it: should expose the non-root internal HTTP port
     asserts:
       - contains:
           path: spec.template.spec.containers[0].ports
           content:
             name: http
-            containerPort: 80
+            containerPort: 8081
             protocol: TCP
         template: deployment.yaml

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.5.0"
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -53,7 +53,7 @@ tests:
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[1].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.5.0"
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
@@ -87,7 +87,7 @@ tests:
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[2].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.4.1"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.5.0"
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].command[0]

--- a/charts/hoppscotch/tests/httproute_test.yaml
+++ b/charts/hoppscotch/tests/httproute_test.yaml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: httproute tests
+templates:
+  - httproute.yaml
+tests:
+  - it: should not create HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HTTPRoute when gateway is enabled
+    set:
+      gateway:
+        enabled: true
+        parentRefs:
+          - name: shared-gateway
+            namespace: gateway-system
+            sectionName: https
+        hostnames:
+          - hoppscotch.example.com
+        path: /
+        pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: shared-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: hoppscotch.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should preserve legacy gatewayAPI values during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        parentRefs:
+          - name: legacy-gateway
+            namespace: gateway-system
+        hostnames:
+          - legacy.example.com
+        path: /hoppscotch
+        pathType: PathPrefix
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: legacy.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /hoppscotch
+
+  - it: should preserve legacy gatewayAPI gatewayName values during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        gatewayName: legacy-gateway
+        gatewayNamespace: gateway-system
+        hostnames:
+          - legacy.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+
+  - it: should preserve legacy gatewayAPI without parentRefs during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        hostnames:
+          - legacy.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - notExists:
+          path: spec.parentRefs
+      - equal:
+          path: spec.hostnames[0]
+          value: legacy.example.com

--- a/charts/hoppscotch/tests/httproute_test.yaml
+++ b/charts/hoppscotch/tests/httproute_test.yaml
@@ -123,3 +123,31 @@ tests:
       - equal:
           path: spec.rules[0].matches[1].path.type
           value: Exact
+
+  - it: should preserve legacy gatewayAPI path type and value fields during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        gatewayName: legacy-gateway
+        hostnames:
+          - legacy.example.com
+        paths:
+          - type: Exact
+            value: /app
+          - type: PathPrefix
+            value: /admin
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /app
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[1].path.value
+          value: /admin
+      - equal:
+          path: spec.rules[0].matches[1].path.type
+          value: PathPrefix

--- a/charts/hoppscotch/tests/httproute_test.yaml
+++ b/charts/hoppscotch/tests/httproute_test.yaml
@@ -95,3 +95,31 @@ tests:
       - equal:
           path: spec.hostnames[0]
           value: legacy.example.com
+
+  - it: should preserve legacy gatewayAPI paths during upgrades
+    set:
+      gatewayAPI:
+        enabled: true
+        gatewayName: legacy-gateway
+        hostnames:
+          - legacy.example.com
+        paths:
+          - path: /app
+            pathType: PathPrefix
+          - path: /admin
+            pathType: Exact
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /app
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[1].path.value
+          value: /admin
+      - equal:
+          path: spec.rules[0].matches[1].path.type
+          value: Exact

--- a/charts/hoppscotch/tests/ingress_test.yaml
+++ b/charts/hoppscotch/tests/ingress_test.yaml
@@ -58,9 +58,21 @@ tests:
       ingress:
         enabled: true
         host: hoppscotch.example.com
-        className: nginx
+        ingressClassName: nginx
     asserts:
       - equal:
           path: spec.ingressClassName
           value: nginx
+        template: ingress.yaml
+
+  - it: should keep legacy className compatibility
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+        className: nginx-legacy
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx-legacy
         template: ingress.yaml

--- a/charts/hoppscotch/tests/ingress_test.yaml
+++ b/charts/hoppscotch/tests/ingress_test.yaml
@@ -64,15 +64,3 @@ tests:
           path: spec.ingressClassName
           value: nginx
         template: ingress.yaml
-
-  - it: should keep legacy className compatibility
-    set:
-      ingress:
-        enabled: true
-        host: hoppscotch.example.com
-        className: nginx-legacy
-    asserts:
-      - equal:
-          path: spec.ingressClassName
-          value: nginx-legacy
-        template: ingress.yaml

--- a/charts/hoppscotch/tests/ingress_test.yaml
+++ b/charts/hoppscotch/tests/ingress_test.yaml
@@ -64,3 +64,15 @@ tests:
           path: spec.ingressClassName
           value: nginx
         template: ingress.yaml
+
+  - it: should preserve legacy ingress className during upgrades
+    set:
+      ingress:
+        enabled: true
+        host: hoppscotch.example.com
+        className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+        template: ingress.yaml

--- a/charts/hoppscotch/tests/namespace_test.yaml
+++ b/charts/hoppscotch/tests/namespace_test.yaml
@@ -27,7 +27,7 @@ tests:
       ingress:
         enabled: true
         host: hoppscotch.example.com
-      gatewayAPI:
+      gateway:
         enabled: true
         parentRefs:
           - name: shared-gateway

--- a/charts/hoppscotch/tests/notes_test.yaml
+++ b/charts/hoppscotch/tests/notes_test.yaml
@@ -27,3 +27,13 @@ tests:
       - not: true
         matchRegexRaw:
           pattern: "kubectl port-forward svc/hoppscotch-hoppscotch 8080:80 -n release-system"
+
+  - it: should report Gateway API enabled when legacy gatewayAPI is used
+    set:
+      gatewayAPI:
+        enabled: true
+        hostnames:
+          - legacy.example.com
+    asserts:
+      - matchRegexRaw:
+          pattern: "Gateway API:[[:space:]]+enabled"

--- a/charts/hoppscotch/tests/notes_test.yaml
+++ b/charts/hoppscotch/tests/notes_test.yaml
@@ -22,6 +22,8 @@ tests:
           pattern: "Helm Namespace:[[:space:]]+release-system"
       - matchRegexRaw:
           pattern: "kubectl port-forward svc/hoppscotch-hoppscotch 8080:80 -n hoppscotch-system"
+      - matchRegexRaw:
+          pattern: "wget -qO- http://localhost:8081/backend/health"
       - not: true
         matchRegexRaw:
           pattern: "kubectl port-forward svc/hoppscotch-hoppscotch 8080:80 -n release-system"

--- a/charts/hoppscotch/tests/validation_test.yaml
+++ b/charts/hoppscotch/tests/validation_test.yaml
@@ -104,6 +104,17 @@ tests:
           errorMessage: "service.containerPort must not be 8080 because the Hoppscotch AIO backend already listens on localhost:8080"
         template: deployment.yaml
 
+  - it: should fail fast when legacy postgresql primary overrides are used
+    set:
+      postgresql:
+        primary:
+          persistence:
+            size: 20Gi
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.primary.* is no longer supported by the bundled HelmForge PostgreSQL subchart; migrate these overrides to postgresql.standalone.* before upgrading"
+        template: deployment.yaml
+
   - it: should fail when gateway enabled without parentRefs
     set:
       gateway:

--- a/charts/hoppscotch/tests/validation_test.yaml
+++ b/charts/hoppscotch/tests/validation_test.yaml
@@ -95,14 +95,14 @@ tests:
           count: 1
         template: deployment.yaml
 
-  - it: should fail when gatewayAPI enabled without parentRefs
+  - it: should fail when gateway enabled without parentRefs
     set:
-      gatewayAPI:
+      gateway:
         enabled: true
         parentRefs: []
     asserts:
       - failedTemplate:
-          errorMessage: "gatewayAPI.parentRefs is required when gatewayAPI.enabled=true"
+          errorMessage: "gateway.parentRefs is required when gateway.enabled=true"
         template: deployment.yaml
 
   - it: should fail when externalSecrets enabled without secretStoreRef.name

--- a/charts/hoppscotch/tests/validation_test.yaml
+++ b/charts/hoppscotch/tests/validation_test.yaml
@@ -95,6 +95,15 @@ tests:
           count: 1
         template: deployment.yaml
 
+  - it: should fail when service containerPort uses the backend reserved port
+    set:
+      service:
+        containerPort: 8080
+    asserts:
+      - failedTemplate:
+          errorMessage: "service.containerPort must not be 8080 because the Hoppscotch AIO backend already listens on localhost:8080"
+        template: deployment.yaml
+
   - it: should fail when gateway enabled without parentRefs
     set:
       gateway:

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -63,6 +63,13 @@
     "shortcodeBaseUrl": {"type": "string"},
     "tosLink": {"type": "string"},
     "privacyPolicyLink": {"type": "string"},
+    "proxy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "appUrl": {"type": "string"}
+      }
+    },
     "encryption": {
       "type": "object",
       "additionalProperties": false,
@@ -353,6 +360,7 @@
       "additionalProperties": false,
       "properties": {
         "enabled": {"type": "boolean"},
+        "ingressClassName": {"type": "string"},
         "className": {"type": "string"},
         "host": {"type": "string"},
         "annotations": {

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -337,6 +337,12 @@
           "minimum": 1,
           "maximum": 65535
         },
+        "containerPort": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 65535,
+          "default": 8081
+        },
         "ipFamilyPolicy": {
           "oneOf": [
             {

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -361,7 +361,6 @@
       "properties": {
         "enabled": {"type": "boolean"},
         "ingressClassName": {"type": "string"},
-        "className": {"type": "string"},
         "host": {"type": "string"},
         "annotations": {
           "type": "object",
@@ -372,16 +371,16 @@
         }
       }
     },
-    "gatewayAPI": {
+    "gateway": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "enabled": {"type": "boolean"},
         "parentRefs": {"type": "array"},
         "hostnames": {"type": "array", "items": {"type": "string"}},
-        "paths": {"type": "array"},
-        "annotations": {"type": "object"},
-        "tls": {"type": "object"}
+        "path": {"type": "string"},
+        "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]},
+        "annotations": {"type": "object"}
       }
     },
     "externalSecrets": {

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -400,6 +400,17 @@
         "gatewayName": {"type": "string"},
         "gatewayNamespace": {"type": "string"},
         "hostnames": {"type": "array", "items": {"type": "string"}},
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "path": {"type": "string"},
+              "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]}
+            }
+          }
+        },
         "path": {"type": "string"},
         "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]}
       }

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -367,6 +367,7 @@
       "properties": {
         "enabled": {"type": "boolean"},
         "ingressClassName": {"type": "string"},
+        "className": {"type": "string"},
         "host": {"type": "string"},
         "annotations": {
           "type": "object",
@@ -387,6 +388,20 @@
         "path": {"type": "string"},
         "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]},
         "annotations": {"type": "object"}
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "annotations": {"type": "object"},
+        "parentRefs": {"type": "array"},
+        "gatewayName": {"type": "string"},
+        "gatewayNamespace": {"type": "string"},
+        "hostnames": {"type": "array", "items": {"type": "string"}},
+        "path": {"type": "string"},
+        "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]}
       }
     },
     "externalSecrets": {

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -407,7 +407,9 @@
             "additionalProperties": false,
             "properties": {
               "path": {"type": "string"},
-              "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]}
+              "pathType": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]},
+              "value": {"type": "string"},
+              "type": {"type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"]}
             }
           }
         },

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -400,6 +400,10 @@
         "gatewayName": {"type": "string"},
         "gatewayNamespace": {"type": "string"},
         "hostnames": {"type": "array", "items": {"type": "string"}},
+        "tls": {
+          "type": "object",
+          "additionalProperties": true
+        },
         "paths": {
           "type": "array",
           "items": {

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -350,6 +350,9 @@ resources:
 service:
   type: ClusterIP
   port: 80
+  # -- Internal non-root HTTP port used by the Hoppscotch AIO Caddy server.
+  # The AIO image keeps the backend on localhost:8080, so Caddy must use a different non-root port.
+  containerPort: 8081
   # -- Service IP family policy (GR-058 dual-stack)
   # @default -- null (cluster default)
   ipFamilyPolicy: null

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -110,10 +110,17 @@ postgresql:
     username: hoppscotch
     # -- PostgreSQL password. Auto-generated if empty.
     password: ""
-  primary:
+  standalone:
     persistence:
       enabled: true
       size: 10Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
   initdb:
     scripts:
       02-hoppscotch-extensions.sh: |
@@ -359,8 +366,6 @@ ingress:
   enabled: false
   # -- IngressClass name
   ingressClassName: ""
-  # -- Deprecated: use ingress.ingressClassName instead. Kept for backward compatibility.
-  className: ""
   # -- Primary hostname. Used to auto-derive VITE_* URLs when set.
   host: ""
   # -- Additional annotations
@@ -370,21 +375,21 @@ ingress:
   tls: []
 
 # =============================================================================
-# Gateway API (GR-060)
+# Gateway API
 # =============================================================================
 
-gatewayAPI:
+gateway:
   # -- Enable Gateway API HTTPRoute
   enabled: false
   # -- References to Gateway listeners (required when enabled)
   parentRefs: []
   # -- Hostnames for the HTTPRoute
   hostnames: []
-  paths:
-    - type: PathPrefix
-      value: /
+  # -- HTTPRoute path
+  path: /
+  # -- HTTPRoute path match type
+  pathType: PathPrefix
   annotations: {}
-  tls: {}
 
 # =============================================================================
 # External Secrets Operator (GR-061)

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.4.1"
+  tag: "2026.5.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -71,6 +71,10 @@ tosLink: ""
 
 # -- Optional Privacy Policy URL (VITE_APP_PRIVACY_POLICY_LINK).
 privacyPolicyLink: ""
+
+proxy:
+  # -- Default Hoppscotch proxy URL (PROXY_APP_URL). Leave empty to configure it from the Admin Dashboard.
+  appUrl: ""
 
 # =============================================================================
 # Encryption
@@ -354,6 +358,8 @@ ingress:
   # -- Enable Ingress
   enabled: false
   # -- IngressClass name
+  ingressClassName: ""
+  # -- Deprecated: use ingress.ingressClassName instead. Kept for backward compatibility.
   className: ""
   # -- Primary hostname. Used to auto-derive VITE_* URLs when set.
   host: ""


### PR DESCRIPTION
Closes #397

## Summary
- Update Hoppscotch to `2026.5.0`.
- Add `proxy.appUrl` support for the new `PROXY_APP_URL` self-hosted proxy default.
- Add HelmForge-style `DESIGN.md` and refresh production docs.
- Standardize `ingress.ingressClassName` while keeping `ingress.className` as a legacy compatibility alias.

## Upstream research
- Hoppscotch `2026.5.0` adds OpenAPI 3.1 collection export, proxy URL configuration through env/admin settings, Mongolian language support, and security/bug fixes.
- The release includes fixes for secret variable leakage to backend and dependency-chain security patches.
- `docker.io/hoppscotch/hoppscotch:2026.5.0` was verified and supports linux/amd64 and linux/arm64.

## Validation
- `npx -y markdownlint-cli2 charts/hoppscotch/README.md charts/hoppscotch/DESIGN.md charts/hoppscotch/docs/*.md`
- `helm dependency build charts/hoppscotch`
- `helm dependency list charts/hoppscotch` (`postgresql 1.10.0`)
- `helm lint charts/hoppscotch`
- `helm lint charts/hoppscotch --strict`
- `helm template hoppscotch-ci charts/hoppscotch`
- `helm template hoppscotch-ci charts/hoppscotch -f charts/hoppscotch/ci/*.yaml`
- `helm unittest charts/hoppscotch` (66 tests, 10 suites)
- `ah lint -p charts/hoppscotch`
- `kubeconform -strict -summary -ignore-missing-schemas` for default and all CI values
- `kubescape scan framework nsa` (overall compliance-score: 80)

## k3d validation
Cluster: `k3d-helmforge-tests-wsl`

- Default deployment with HelmForge PostgreSQL subchart: Hoppscotch and PostgreSQL pods Ready, 0 restarts.
- Frontend service returned `HTTP 200`.
- Backend `/backend/health` returned `HTTP 200`.
- No non-normal Kubernetes events.
- No error/fatal log matches in Hoppscotch or PostgreSQL logs.
- Namespace cleaned after validation.