### PR TITLE
chore(metabase): update Metabase to v0.61.3

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
-version: 1.2.13
-appVersion: "v0.61.2"
+version: 1.2.14
+appVersion: "v0.61.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v0.61.2 (#331)"
+      description: "update Metabase to v0.61.3 and PostgreSQL dependency to 1.10.0 (#398)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -51,6 +51,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 1.10.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update Metabase to v0.61.3 and PostgreSQL dependency to 1.10.0 (#398)"
+      description: "update Metabase to v0.61.3 and PostgreSQL dependency to 2.0.2 (#398)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -51,6 +51,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/metabase/DESIGN.md
+++ b/charts/metabase/DESIGN.md
@@ -1,0 +1,70 @@
+# Metabase Chart Design
+
+## Scope
+
+This chart deploys Metabase Open Source using the official `docker.io/metabase/metabase` image and a PostgreSQL metadata
+store. It targets self-hosted analytics teams that need a predictable Kubernetes deployment with optional ingress,
+Gateway API, External Secrets, dual-stack Services, and S3-compatible database backups.
+
+Supported persistence modes:
+
+- bundled HelmForge PostgreSQL subchart
+- external PostgreSQL with inline or Secret-managed credentials
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[User] --> edge[Service, Ingress, or HTTPRoute]
+  edge --> metabase[Metabase Deployment]
+  metabase --> dbsvc[PostgreSQL Service]
+  dbsvc --> db[HelmForge PostgreSQL StatefulSet or external PostgreSQL]
+  secret[Chart Secret or ExternalSecret] --> metabase
+  backup[Backup CronJob] --> s3[S3-compatible storage]
+```
+
+## Main Design Choices
+
+- Use PostgreSQL as the metadata database for every mode; H2 is intentionally not used for chart defaults.
+- Use the HelmForge PostgreSQL subchart when `postgresql.enabled=true`.
+- Generate or reference `MB_ENCRYPTION_SECRET_KEY` so saved database credentials stay decryptable across upgrades.
+- Keep Metabase AI features disabled by default to avoid background AI work without an explicitly configured provider.
+- Render Gateway API and External Secrets only when explicitly enabled.
+- Provide S3-compatible metadata database backups through a chart-managed CronJob.
+
+## Production Boundary
+
+For production, operators should define:
+
+- PostgreSQL storage class, size, backup, and restore procedures
+- stable `MB_ENCRYPTION_SECRET_KEY` through an existing Secret or External Secret
+- `metabase.siteUrl` and TLS-enabled ingress or Gateway API routing
+- resource requests and limits sized for dashboard and query load
+- backup S3 endpoint, bucket, credentials, and retention workflow
+- NetworkPolicy and ServiceMonitor settings when required by the platform
+
+## Explicit Non-Goals
+
+- provisioning analytical source databases
+- managing Metabase setup wizard state or admin users
+- running embedded H2 as a production metadata store
+- provisioning ingress controllers, Gateway controllers, SecretStores, or object storage
+
+<!-- @AI-METADATA
+type: design
+title: Metabase Chart Design
+description: Design document for the Metabase Helm chart architecture, database model, backups, and production boundaries
+
+keywords: metabase, design, architecture, postgresql, backup, ingress, gateway-api, external-secrets, helm, kubernetes
+
+purpose: Document chart architecture, operational choices, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/metabase/README.md
+  - charts/metabase/docs/database.md
+  - charts/metabase/docs/production.md
+path: charts/metabase/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -90,16 +90,16 @@ service:
 Requires Gateway API CRDs and a compatible controller (e.g. Envoy Gateway).
 
 ```yaml
-gatewayAPI:
+gateway:
   enabled: true
-  gatewayName: envoy-gateway
-  gatewayNamespace: envoy-gateway-system
+  parentRefs:
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
     - metabase.example.com
 ```
 
-> **Note:** `gatewayAPI.gatewayName` is required when `gatewayAPI.enabled=true`. The older `gateway` block remains
-> supported as a compatibility alias.
+> **Note:** `gateway.parentRefs` is required when `gateway.enabled=true`.
 
 ## External Secrets Operator (ESO)
 
@@ -134,17 +134,20 @@ externalSecrets:
 | `metabase.aiFeaturesEnabled` | `false` | Enable Metabase AI features after configuring a supported provider |
 | `metabase.javaTimezone` | `UTC` | Java timezone |
 | `metabase.javaOpts` | `""` | JVM memory options |
-| `postgresql.enabled` | `true` | Deploy HelmForge PostgreSQL subchart (`1.10.0`) |
+| `probes.startup.initialDelaySeconds` | `90` | Startup probe delay for first-run migrations and PostgreSQL bootstrap |
+| `postgresql.enabled` | `true` | Deploy HelmForge PostgreSQL subchart (`2.0.2`) |
+| `postgresql.standalone.persistence.size` | `8Gi` | PostgreSQL standalone PVC size |
+| `resources.requests.memory` | `512Mi` | Metabase memory request |
+| `resources.limits.memory` | `2Gi` | Metabase memory limit |
 | `ingress.enabled` | `false` | Enable ingress |
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
 | `service.ipFamilies` | `[]` | IP families override (`IPv4`, `IPv6`) |
-| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
-| `gatewayAPI.gatewayName` | `""` | Gateway name (required when `gatewayAPI.enabled=true`) |
-| `gatewayAPI.gatewayNamespace` | `""` | Gateway namespace |
-| `gatewayAPI.hostnames` | `[]` | HTTPRoute hostnames |
-| `gatewayAPI.path` | `/` | HTTPRoute path match value |
-| `gatewayAPI.pathType` | `PathPrefix` | HTTPRoute path match type |
+| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `gateway.parentRefs` | `[]` | Gateway parentRefs (required when `gateway.enabled=true`) |
+| `gateway.hostnames` | `[]` | HTTPRoute hostnames |
+| `gateway.path` | `/` | HTTPRoute path match value |
+| `gateway.pathType` | `PathPrefix` | HTTPRoute path match type |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret resource |
 | `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
 | `externalSecrets.refreshInterval` | `"0"` | Refresh interval (`"0"` = one-time sync) |

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -10,6 +10,7 @@ Open-source BI platform with visual data exploration, SQL editor, and shareable 
 - **SQL editor** — native SQL with autocomplete and snippets
 - **60+ database connectors** — PostgreSQL, MySQL, BigQuery, Redshift, and more
 - **PostgreSQL metadata store** — bundled subchart or external database
+- **Backups** — optional PostgreSQL dump CronJob for S3-compatible object storage
 - **Auto-generated encryption key** — protects saved database credentials
 - **JVM tuning** — configurable JAVA_OPTS for memory optimization
 - **Ingress support** — TLS with cert-manager
@@ -126,14 +127,14 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.61.2` | Metabase container image tag |
+| `image.tag` | `v0.61.3` | Metabase container image tag |
 | `metabase.port` | `3000` | Application port |
 | `metabase.encryptionSecretKey` | `""` | Encryption key (auto-generated) |
 | `metabase.siteUrl` | `""` | Public site URL |
 | `metabase.aiFeaturesEnabled` | `false` | Enable Metabase AI features after configuring a supported provider |
 | `metabase.javaTimezone` | `UTC` | Java timezone |
 | `metabase.javaOpts` | `""` | JVM memory options |
-| `postgresql.enabled` | `true` | Deploy PostgreSQL subchart |
+| `postgresql.enabled` | `true` | Deploy HelmForge PostgreSQL subchart (`1.10.0`) |
 | `ingress.enabled` | `false` | Enable ingress |
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
@@ -153,12 +154,22 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.61.2` is a stable upstream maintenance release. Back up the Metabase
-application database before upgrading and validate the `/api/health` endpoint
-after rollout.
+Metabase `v0.61.3` is an upstream maintenance release with backported fixes for database connection handling, migrations,
+SDK/embedding behavior, serialization, notifications, Metabot, and query/cache edge cases. Back up the Metabase
+application database before upgrading, keep the encryption key stable, and validate the `/api/health` endpoint after
+rollout.
+
+## Examples
+
+- [Production](examples/production.yaml)
+- [External PostgreSQL](examples/external-db.yaml)
+- [S3 backup](examples/backup.yaml)
 
 ## More Information
 
+- [Chart design](DESIGN.md)
+- [Database and backups](docs/database.md)
+- [Production operations](docs/production.md)
 - [Metabase documentation](https://www.metabase.com/docs/latest/)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/metabase)
 
@@ -173,8 +184,14 @@ purpose: Chart installation, configuration, and usage documentation
 scope: Chart
 
 relations:
+  - charts/metabase/DESIGN.md
+  - charts/metabase/docs/database.md
+  - charts/metabase/docs/production.md
+  - charts/metabase/examples/production.yaml
+  - charts/metabase/examples/external-db.yaml
+  - charts/metabase/examples/backup.yaml
   - charts/metabase/values.yaml
 path: charts/metabase/README.md
-version: 1.1
-date: 2026-04-30
+version: 1.2
+date: 2026-06-02
 -->

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -100,6 +100,9 @@ gateway:
 ```
 
 > **Note:** `gateway.parentRefs` is required when `gateway.enabled=true`.
+> Existing releases that still carry `gatewayAPI.enabled`, `gatewayAPI.gatewayName`,
+> and `gatewayAPI.gatewayNamespace` from older chart values remain supported as a
+> deprecated upgrade alias. New configuration should use `gateway.parentRefs`.
 
 ## External Secrets Operator (ESO)
 

--- a/charts/metabase/ci/gateway-api.yaml
+++ b/charts/metabase/ci/gateway-api.yaml
@@ -10,10 +10,11 @@ database:
     username: metabase
     password: "testpassword"
 
-gatewayAPI:
+gateway:
   enabled: true
-  gatewayName: my-gateway
-  gatewayNamespace: default
+  parentRefs:
+    - name: my-gateway
+      namespace: default
   hostnames:
     - metabase.example.com
   path: /

--- a/charts/metabase/docs/database.md
+++ b/charts/metabase/docs/database.md
@@ -1,0 +1,84 @@
+# Metabase Database and Backup Guide
+
+## Bundled PostgreSQL
+
+The default install uses the HelmForge PostgreSQL subchart as the Metabase metadata store:
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    database: metabase
+    username: metabase
+```
+
+Use this mode for small and medium self-hosted installations where the application and metadata database should be managed
+by one Helm release.
+
+## External PostgreSQL
+
+Use an external PostgreSQL service when your platform already manages HA, patching, backups, and restore testing:
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: metabase
+    username: metabase
+    existingSecret: metabase-db
+    existingSecretPasswordKey: password
+```
+
+The external database user must be able to create and migrate the Metabase application schema.
+
+## Encryption Key
+
+`MB_ENCRYPTION_SECRET_KEY` protects saved database credentials. Keep it stable after first install:
+
+```yaml
+metabase:
+  existingSecret: metabase-secrets
+  existingSecretKey: encryption-secret-key
+```
+
+Back up this key with the database. Changing it after Metabase has stored credentials can make saved connection secrets
+unreadable.
+
+## Backups
+
+The chart can create a PostgreSQL dump CronJob and upload the archive to S3-compatible storage:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.example.com
+    bucket: metabase-backups
+    existingSecret: metabase-s3
+```
+
+Test restore procedures before relying on backups for production recovery.
+
+<!-- @AI-METADATA
+type: chart-doc
+title: Metabase Database and Backup Guide
+description: Database, encryption key, and backup guide for the Metabase Helm chart
+
+keywords: metabase, postgresql, backup, s3, encryption, restore, helm, kubernetes
+
+purpose: Explain database selection, encryption key handling, and backup behavior
+scope: Chart Documentation
+
+relations:
+  - charts/metabase/README.md
+  - charts/metabase/DESIGN.md
+  - charts/metabase/docs/production.md
+path: charts/metabase/docs/database.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/metabase/docs/production.md
+++ b/charts/metabase/docs/production.md
@@ -1,0 +1,94 @@
+# Metabase Production Guide
+
+## Recommended Values
+
+```yaml
+metabase:
+  siteUrl: https://metabase.example.com
+  existingSecret: metabase-secrets
+  existingSecretKey: encryption-secret-key
+  javaOpts: "-Xmx2g -Xms1g"
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: metabase.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: metabase-tls
+      hosts:
+        - metabase.example.com
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    cpu: "2"
+    memory: 3Gi
+```
+
+## Health Checks
+
+Metabase exposes `/api/health`. After rollout:
+
+```bash
+kubectl port-forward -n <namespace> svc/<release>-metabase 3000:80
+curl -f http://127.0.0.1:3000/api/health
+```
+
+## JVM Sizing
+
+Use `metabase.javaOpts` with memory requests/limits that leave headroom for JVM overhead. Keep `-Xmx` lower than the
+container memory limit.
+
+## External Secrets
+
+For production, prefer an existing Secret or ExternalSecret for `MB_ENCRYPTION_SECRET_KEY` and external database
+credentials:
+
+```yaml
+metabase:
+  existingSecret: metabase-secrets
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  data:
+    - secretKey: encryption-secret-key
+      remoteRef:
+        key: metabase/credentials
+        property: encryption-secret-key
+```
+
+## Operational Checks
+
+- Confirm pods are Ready with zero restarts.
+- Check Metabase and PostgreSQL logs after upgrades.
+- Confirm there are no non-normal Kubernetes events.
+- Verify `/api/health` returns HTTP 200.
+- Run and restore a database backup in a non-production namespace.
+
+<!-- @AI-METADATA
+type: chart-doc
+title: Metabase Production Guide
+description: Production operations guide for the Metabase Helm chart
+
+keywords: metabase, production, ingress, health, jvm, external-secrets, helm, kubernetes
+
+purpose: Document production values, health checks, JVM sizing, secret handling, and operational validation
+scope: Chart Documentation
+
+relations:
+  - charts/metabase/README.md
+  - charts/metabase/DESIGN.md
+  - charts/metabase/docs/database.md
+path: charts/metabase/docs/production.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/metabase/examples/backup.yaml
+++ b/charts/metabase/examples/backup.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.example.com
+    bucket: metabase-backups
+    prefix: metabase
+    existingSecret: metabase-s3

--- a/charts/metabase/examples/external-db.yaml
+++ b/charts/metabase/examples/external-db.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.database.svc.cluster.local
+    port: 5432
+    name: metabase
+    username: metabase
+    existingSecret: metabase-db
+    existingSecretPasswordKey: password
+
+metabase:
+  existingSecret: metabase-secrets
+  existingSecretKey: encryption-secret-key

--- a/charts/metabase/examples/production.yaml
+++ b/charts/metabase/examples/production.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+metabase:
+  siteUrl: https://metabase.example.com
+  existingSecret: metabase-secrets
+  existingSecretKey: encryption-secret-key
+  javaOpts: "-Xmx2g -Xms1g"
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: metabase.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: metabase-tls
+      hosts:
+        - metabase.example.com
+
+postgresql:
+  primary:
+    persistence:
+      size: 20Gi
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    cpu: "2"
+    memory: 3Gi

--- a/charts/metabase/examples/production.yaml
+++ b/charts/metabase/examples/production.yaml
@@ -19,7 +19,7 @@ ingress:
         - metabase.example.com
 
 postgresql:
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -65,14 +65,28 @@ Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
   WARNINGS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-{{- if .Values.gateway.enabled }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $legacyGateway := default dict .Values.gatewayAPI }}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
 
 NOTE: Gateway API HTTPRoute {{ include "metabase.fullname" . }} is active.
+{{- if $useLegacyGateway }}
+  ParentRefs:
+    - name: {{ $legacyGateway.gatewayName }}
+      {{- with $legacyGateway.gatewayNamespace }}
+      namespace: {{ . }}
+      {{- end }}
+  {{- with $legacyGateway.hostnames }}
+  Hostnames: {{ join ", " . }}
+  {{- end }}
+{{- else }}
   ParentRefs:
 {{ toYaml .Values.gateway.parentRefs | indent 4 }}
   {{- with .Values.gateway.hostnames }}
   Hostnames: {{ join ", " . }}
   {{- end }}
+{{- end }}
 {{- else if not .Values.ingress.enabled }}
 
 NOTE: Ingress is not enabled. Access via port-forward (see above).

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -1,112 +1,171 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Metabase has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{- $fullname := include "metabase.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+{{- $gateway := default dict .Values.gateway -}}
+{{- $legacyGateway := default dict .Values.gatewayAPI -}}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) -}}
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+1. Metabase has been installed
+------------------------------
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ $namespace }}
+  Version:        {{ .Chart.AppVersion }}
+  Service:        {{ $fullname }}.{{ $namespace }}.svc.cluster.local:{{ .Values.service.port }}
+  Database Host:  {{ include "metabase.dbHost" . }}:{{ include "metabase.dbPort" . }}
+  Database Name:  {{ include "metabase.dbName" . }}
+  Database User:  {{ include "metabase.dbUsername" . }}
+  AI Features:    {{ .Values.metabase.aiFeaturesEnabled }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
+2. Access
+---------
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-{{- end }}
+  Ingress is enabled:
+  {{- range $host := .Values.ingress.hosts }}
+    Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  {{- end }}
+{{- else if or (default false $gateway.enabled) $useLegacyGateway }}
+  Gateway API HTTPRoute is enabled:
+  {{- if $useLegacyGateway }}
+    Legacy Gateway: {{ $legacyGateway.gatewayName }}
+    {{- with $legacyGateway.hostnames }}
+    Web UI: http://{{ index . 0 }}/
+    {{- end }}
+  {{- else }}
+    ParentRefs:
+{{ toYaml .Values.gateway.parentRefs | indent 6 }}
+    {{- with .Values.gateway.hostnames }}
+    Web UI: http://{{ index . 0 }}/
+    {{- end }}
+  {{- end }}
 {{- else }}
-Port-forward to access Metabase locally:
+  Port-forward locally:
+    kubectl port-forward -n {{ $namespace }} svc/{{ $fullname }} 3000:{{ .Values.service.port }}
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "metabase.fullname" . }} 3000:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:3000/
+  Open:
+    http://localhost:3000/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+3. First-time Setup
+-------------------
+  - Open the web UI and complete the Metabase setup wizard.
+  - Add your first analytical database from Admin settings.
+  - Keep the Metabase encryption key stable after first install; changing it can break saved database credentials.
+  - Set `metabase.siteUrl` before production use so links, embeds, and email notifications use the correct URL.
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }} --timeout=600s
-2. kubectl get pods -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-4. Open the UI and complete the initial setup wizard
+4. Configuration Summary
+------------------------
+  Metadata database: {{ if .Values.postgresql.enabled }}HelmForge PostgreSQL subchart{{ else }}external PostgreSQL{{ end }}
+  DB Secret:         {{ include "metabase.dbSecretName" . }} / {{ include "metabase.dbSecretPasswordKey" . }}
+  App Secret:        {{ include "metabase.encryptionSecretName" . }} / {{ include "metabase.encryptionSecretKey" . }}
+  Site URL:          {{ default "not configured" .Values.metabase.siteUrl }}
+  Timezone:          {{ .Values.metabase.javaTimezone }}
+  Backup:            {{ .Values.backup.enabled }}
+  Ingress:           {{ .Values.ingress.enabled }}
+  Gateway API:       {{ or (default false $gateway.enabled) $useLegacyGateway }}
+  External Secrets:  {{ .Values.externalSecrets.enabled }}
+{{- with .Values.service.ipFamilyPolicy }}
+  IP family policy:  {{ . }}{{ with $.Values.service.ipFamilies }} ({{ join ", " . }}){{ end }}
+{{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  CONFIGURATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+5. Validation Commands
+----------------------
+  Wait for Metabase:
+    kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=metabase -n {{ $namespace }} --timeout=600s
 
-Metabase AI features are disabled by default to avoid background AI jobs
-without a configured provider:
+  Check pods:
+    kubectl get pods -l app.kubernetes.io/name=metabase -n {{ $namespace }} -o wide
 
-  metabase.aiFeaturesEnabled={{ .Values.metabase.aiFeaturesEnabled }}
+  Check health from inside the cluster:
+    kubectl run metabase-smoke -n {{ $namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- \
+      wget -qO- http://{{ $fullname }}:{{ .Values.service.port }}/api/health
 
-To use Gateway API, configure gateway.enabled=true and provide gateway.parentRefs.
+  Inspect release events:
+    kubectl get events -n {{ $namespace }} --sort-by=.lastTimestamp
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+6. Logs
+-------
+  Metabase logs:
+    kubectl logs -l app.kubernetes.io/name=metabase -n {{ $namespace }} --all-containers --tail=200
 
-  kubectl describe pod -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=metabase -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-
+  Wait-for-database init logs:
+    kubectl logs -l app.kubernetes.io/name=metabase -n {{ $namespace }} -c wait-for-database --tail=100
 {{- if .Values.postgresql.enabled }}
-View PostgreSQL logs:
-  kubectl logs -l app.kubernetes.io/name=postgresql -n {{ .Release.Namespace }} --all-containers --tail=50
+
+  Bundled PostgreSQL logs:
+    kubectl logs -l app.kubernetes.io/name=postgresql -n {{ $namespace }} --all-containers --tail=100
 {{- end }}
+
+7. Backup
+---------
 {{- if .Values.backup.enabled }}
-Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
-{{- end }}
+  PostgreSQL metadata backup is enabled:
+    Schedule: {{ .Values.backup.schedule }}
+    Bucket:   {{ .Values.backup.s3.bucket }}
+    Prefix:   {{ .Values.backup.s3.prefix }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Check backup jobs:
+    kubectl get cronjob,jobs -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
-{{- $gateway := default dict .Values.gateway }}
-{{- $legacyGateway := default dict .Values.gatewayAPI }}
-{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
-{{- if or (default false $gateway.enabled) $useLegacyGateway }}
-
-NOTE: Gateway API HTTPRoute {{ include "metabase.fullname" . }} is active.
-{{- if $useLegacyGateway }}
-  ParentRefs:
-    - name: {{ $legacyGateway.gatewayName }}
-      {{- with $legacyGateway.gatewayNamespace }}
-      namespace: {{ . }}
-      {{- end }}
-  {{- with $legacyGateway.hostnames }}
-  Hostnames: {{ join ", " . }}
-  {{- end }}
+  Trigger a manual backup:
+    kubectl create job --from=cronjob/{{ $fullname }}-backup metabase-backup-$(date +%s) -n {{ $namespace }}
 {{- else }}
-  ParentRefs:
-{{ toYaml .Values.gateway.parentRefs | indent 4 }}
-  {{- with .Values.gateway.hostnames }}
-  Hostnames: {{ join ", " . }}
-  {{- end }}
-{{- end }}
-{{- else if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
+  Backup is disabled. For production, enable `backup.enabled=true` or back up the PostgreSQL metadata database externally.
 {{- end }}
 
+8. External Integrations
+------------------------
 {{- if .Values.externalSecrets.enabled }}
-
-NOTE: ExternalSecrets enabled.
-  SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+  External Secrets Operator is enabled.
+  SecretStore: {{ .Values.externalSecrets.secretStoreRef.kind }}/{{ .Values.externalSecrets.secretStoreRef.name }}
   Target Secret: {{ .Values.metabase.existingSecret }}
   Refresh: {{ .Values.externalSecrets.refreshInterval }}
+{{- else }}
+  External Secrets Operator is disabled.
+{{- end }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
+
+  Gateway API:
+    kubectl get httproute -n {{ $namespace }} {{ $fullname }}
 {{- end }}
 
-NOTE: Metabase can take 2-3 minutes to fully initialize on first start.
+9. Troubleshooting
+------------------
+  Metabase can take 2-3 minutes to initialize on first start.
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  UI does not become ready:
+    kubectl describe pod -l app.kubernetes.io/name=metabase -n {{ $namespace }}
+    kubectl logs -l app.kubernetes.io/name=metabase -n {{ $namespace }} --all-containers --tail=300
 
-Documentation:  https://helmforge.dev/docs/charts/metabase
-Metabase:       https://www.metabase.com | https://github.com/metabase/metabase
+  Database connection errors:
+    kubectl get secret {{ include "metabase.dbSecretName" . }} -n {{ $namespace }}
+{{- if .Values.postgresql.enabled }}
+    kubectl get pods -l app.kubernetes.io/name=postgresql -n {{ $namespace }}
+    kubectl logs -l app.kubernetes.io/name=postgresql -n {{ $namespace }} --all-containers --tail=200
+{{- end }}
+
+  Saved database credentials cannot be decrypted:
+    kubectl get secret {{ include "metabase.encryptionSecretName" . }} -n {{ $namespace }}
+    # Do not rotate the encryption secret unless you have planned a credential migration.
+
+  Wrong public URLs in links or embeds:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+    # Set metabase.siteUrl to the external URL.
+
+10. Documentation
+-----------------
+  Helm values:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+
+  Helm manifest:
+    helm get manifest {{ .Release.Name }} -n {{ $namespace }}
+
+  HelmForge docs:
+    https://helmforge.dev/docs/charts/metabase
+
+  Chart source:
+    https://github.com/helmforgedev/charts/tree/main/charts/metabase
+
+  Upstream docs:
+    https://www.metabase.com/docs/latest/
 
 Happy Helmforging :)

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -43,8 +43,7 @@ without a configured provider:
 
   metabase.aiFeaturesEnabled={{ .Values.metabase.aiFeaturesEnabled }}
 
-To use Gateway API, prefer gatewayAPI.* values. The legacy gateway.* block
-is still accepted as a compatibility alias.
+To use Gateway API, configure gateway.enabled=true and provide gateway.parentRefs.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   TROUBLESHOOTING
@@ -66,15 +65,12 @@ Check backup CronJob: kubectl get cronjob -n {{ .Release.Namespace }}
   WARNINGS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-{{- $gateway := .Values.gatewayAPI }}
-{{- if and (not .Values.gatewayAPI.enabled) .Values.gateway.enabled }}
-  {{- $gateway = .Values.gateway }}
-{{- end }}
-{{- if or .Values.gatewayAPI.enabled .Values.gateway.enabled }}
+{{- if .Values.gateway.enabled }}
 
 NOTE: Gateway API HTTPRoute {{ include "metabase.fullname" . }} is active.
-  Gateway: {{ $gateway.gatewayName }}{{ with $gateway.gatewayNamespace }}.{{ . }}{{ end }}
-  {{- with $gateway.hostnames }}
+  ParentRefs:
+{{ toYaml .Values.gateway.parentRefs | indent 4 }}
+  {{- with .Values.gateway.hostnames }}
   Hostnames: {{ join ", " . }}
   {{- end }}
 {{- else if not .Values.ingress.enabled }}

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -45,7 +45,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Database host */}}
 {{- define "metabase.dbHost" -}}
-{{- if hasKey .Values.postgresql "primary" -}}
+{{- if and .Values.postgresql.enabled (hasKey .Values.postgresql "primary") -}}
 {{- fail "postgresql.primary.* is not supported by the HelmForge PostgreSQL 2.x dependency used by this chart. Migrate PostgreSQL values to postgresql.standalone.* before upgrading." -}}
 {{- end -}}
 {{- if .Values.postgresql.enabled -}}

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -45,6 +45,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Database host */}}
 {{- define "metabase.dbHost" -}}
+{{- if hasKey .Values.postgresql "primary" -}}
+{{- fail "postgresql.primary.* is not supported by the HelmForge PostgreSQL 2.x dependency used by this chart. Migrate PostgreSQL values to postgresql.standalone.* before upgrading." -}}
+{{- end -}}
 {{- if .Values.postgresql.enabled -}}
 {{- printf "%s-postgresql" .Release.Name -}}
 {{- else -}}

--- a/charts/metabase/templates/httproute.yaml
+++ b/charts/metabase/templates/httproute.yaml
@@ -1,9 +1,31 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.gateway.enabled }}
-{{- if not .Values.gateway.parentRefs }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $legacyGateway := default dict .Values.gatewayAPI }}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
+{{- $parentRefs := default list $gateway.parentRefs }}
+{{- $annotations := default dict $gateway.annotations }}
+{{- $hostnames := default list $gateway.hostnames }}
+{{- $path := default "/" $gateway.path }}
+{{- $pathType := default "PathPrefix" $gateway.pathType }}
+{{- if $useLegacyGateway }}
+  {{- if not $legacyGateway.gatewayName }}
+    {{- fail "gatewayAPI.gatewayName is required when legacy gatewayAPI.enabled=true" }}
+  {{- end }}
+  {{- $legacyParentRef := dict "name" $legacyGateway.gatewayName }}
+  {{- with $legacyGateway.gatewayNamespace }}
+    {{- $_ := set $legacyParentRef "namespace" . }}
+  {{- end }}
+  {{- $parentRefs = list $legacyParentRef }}
+  {{- $annotations = default dict $legacyGateway.annotations }}
+  {{- $hostnames = default list $legacyGateway.hostnames }}
+  {{- $path = default "/" $legacyGateway.path }}
+  {{- $pathType = default "PathPrefix" $legacyGateway.pathType }}
+{{- end }}
+{{- if not $parentRefs }}
   {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
 {{- end }}
-{{- range .Values.gateway.parentRefs }}
+{{- range $parentRefs }}
   {{- if not .name }}
     {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
   {{- end }}
@@ -14,22 +36,22 @@ metadata:
   name: {{ include "metabase.fullname" . }}
   labels:
     {{- include "metabase.labels" . | nindent 4 }}
-  {{- with .Values.gateway.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
-  {{- with .Values.gateway.hostnames }}
+    {{- toYaml $parentRefs | nindent 4 }}
+  {{- with $hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ .Values.gateway.pathType }}
-            value: {{ .Values.gateway.path }}
+            type: {{ $pathType }}
+            value: {{ $path | quote }}
       backendRefs:
         - name: {{ include "metabase.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/metabase/templates/httproute.yaml
+++ b/charts/metabase/templates/httproute.yaml
@@ -1,11 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- $gateway := .Values.gatewayAPI }}
-{{- if and (not .Values.gatewayAPI.enabled) .Values.gateway.enabled }}
-  {{- $gateway = .Values.gateway }}
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
 {{- end }}
-{{- if or .Values.gatewayAPI.enabled .Values.gateway.enabled }}
-{{- if not $gateway.gatewayName }}
-  {{- fail "gatewayAPI.gatewayName is required when gatewayAPI.enabled=true" }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -13,21 +14,22 @@ metadata:
   name: {{ include "metabase.fullname" . }}
   labels:
     {{- include "metabase.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   parentRefs:
-    - name: {{ $gateway.gatewayName }}
-      {{- with $gateway.gatewayNamespace }}
-      namespace: {{ . }}
-      {{- end }}
-  {{- with $gateway.hostnames }}
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ $gateway.pathType }}
-            value: {{ $gateway.path }}
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path }}
       backendRefs:
         - name: {{ include "metabase.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -117,6 +117,7 @@ tests:
   - it: should fail fast when legacy postgresql.primary values are used
     set:
       postgresql:
+        enabled: true
         primary:
           persistence:
             enabled: true
@@ -124,6 +125,22 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "postgresql.primary.* is not supported by the HelmForge PostgreSQL 2.x dependency used by this chart. Migrate PostgreSQL values to postgresql.standalone.* before upgrading."
+
+  - it: should ignore stale legacy postgresql.primary values when using an external database
+    set:
+      database.external.host: db.example.com
+      database.external.password: external-password
+      postgresql:
+        enabled: false
+        primary:
+          persistence:
+            size: 20Gi
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MB_DB_HOST
+            value: db.example.com
 
   - it: should set probes on health path
     asserts:

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -114,11 +114,25 @@ tests:
             name: MB_DB_PORT
             value: "5433"
 
+  - it: should fail fast when legacy postgresql.primary values are used
+    set:
+      postgresql:
+        primary:
+          persistence:
+            enabled: true
+            size: 20Gi
+    asserts:
+      - failedTemplate:
+          errorMessage: "postgresql.primary.* is not supported by the HelmForge PostgreSQL 2.x dependency used by this chart. Migrate PostgreSQL values to postgresql.standalone.* before upgrading."
+
   - it: should set probes on health path
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
           value: /api/health
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 90
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /api/health
@@ -153,3 +167,18 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 500m
+
+  - it: should set practical default resource requests and limits
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1000m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2Gi

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.61.2"
+          value: "docker.io/metabase/metabase:v0.61.3"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/tests/gatewayapi_test.yaml
+++ b/charts/metabase/tests/gatewayapi_test.yaml
@@ -11,12 +11,13 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should render HTTPRoute with gatewayAPI values
+  - it: should render HTTPRoute with gateway values
     set:
-      gatewayAPI.enabled: true
-      gatewayAPI.gatewayName: shared-gateway
-      gatewayAPI.gatewayNamespace: gateway-system
-      gatewayAPI.hostnames:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: shared-gateway
+          namespace: gateway-system
+      gateway.hostnames:
         - metabase.example.com
     asserts:
       - isKind:
@@ -31,13 +32,18 @@ tests:
           path: spec.hostnames[0]
           value: metabase.example.com
 
-  - it: should keep legacy gateway values working
+  - it: should require parentRefs when Gateway API is enabled
     set:
       gateway.enabled: true
-      gateway.gatewayName: legacy-gateway
     asserts:
-      - isKind:
-          of: HTTPRoute
-      - equal:
-          path: spec.parentRefs[0].name
-          value: legacy-gateway
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."
+
+  - it: should require a name in each parentRef
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - namespace: gateway-system
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each gateway.parentRefs entry must define a 'name' field"

--- a/charts/metabase/tests/gatewayapi_test.yaml
+++ b/charts/metabase/tests/gatewayapi_test.yaml
@@ -47,3 +47,30 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Each gateway.parentRefs entry must define a 'name' field"
+
+  - it: should preserve legacy gatewayAPI values during upgrades
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gatewayName: legacy-gateway
+      gatewayAPI.gatewayNamespace: gateway-system
+      gatewayAPI.hostnames:
+        - legacy-metabase.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.hostnames[0]
+          value: legacy-metabase.example.com
+
+  - it: should fail legacy gatewayAPI when gatewayName is missing
+    set:
+      gatewayAPI.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.gatewayName is required when legacy gatewayAPI.enabled=true"

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -73,25 +73,13 @@
         "ipFamilies": { "type": "array", "description": "Dual-stack ipFamilies (GR-058)", "items": { "type": "string", "enum": ["IPv4", "IPv6"] }, "maxItems": 2 }
       }
     },
-    "gatewayAPI": {
+    "gateway": {
       "type": "object",
       "description": "Gateway API HTTPRoute configuration",
       "properties": {
         "enabled": { "type": "boolean", "default": false },
-        "gatewayName": { "type": "string", "default": "" },
-        "gatewayNamespace": { "type": "string", "default": "" },
-        "hostnames": { "type": "array", "items": { "type": "string" } },
-        "path": { "type": "string", "default": "/" },
-        "pathType": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"], "default": "PathPrefix" }
-      }
-    },
-    "gateway": {
-      "type": "object",
-      "description": "Deprecated compatibility alias for gatewayAPI",
-      "properties": {
-        "enabled": { "type": "boolean", "default": false },
-        "gatewayName": { "type": "string", "default": "" },
-        "gatewayNamespace": { "type": "string", "default": "" },
+        "annotations": { "type": "object" },
+        "parentRefs": { "type": "array", "items": { "type": "object" } },
         "hostnames": { "type": "array", "items": { "type": "string" } },
         "path": { "type": "string", "default": "/" },
         "pathType": { "type": "string", "enum": ["PathPrefix", "Exact", "RegularExpression"], "default": "PathPrefix" }
@@ -156,6 +144,13 @@
             "database": { "type": "string", "default": "metabase" },
             "username": { "type": "string", "default": "metabase" },
             "password": { "type": "string", "default": "" }
+          }
+        },
+        "standalone": {
+          "type": "object",
+          "properties": {
+            "persistence": { "type": "object" },
+            "resources": { "type": "object" }
           }
         }
       }

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -13,7 +13,7 @@
       "description": "Container image configuration",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/metabase/metabase" },
-        "tag": { "type": "string", "description": "Image tag", "default": "v0.61.2" },
+        "tag": { "type": "string", "description": "Image tag", "default": "v0.61.3" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.61.2"
+  tag: "v0.61.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -120,29 +120,15 @@ ingress:
 # Gateway API
 # =============================================================================
 
-gatewayAPI:
-  # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
-  enabled: false
-  # -- Gateway name to attach the HTTPRoute to
-  gatewayName: ""
-  # -- Namespace of the gateway
-  gatewayNamespace: ""
-  # -- Hostnames the HTTPRoute matches
-  hostnames: []
-    # - metabase.example.com
-  # -- Path prefix for the HTTPRoute
-  path: /
-  # -- Path match type
-  pathType: PathPrefix
-
-# Deprecated compatibility alias for gatewayAPI. Prefer gatewayAPI for new values.
 gateway:
   # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
   enabled: false
-  # -- Gateway name to attach the HTTPRoute to
-  gatewayName: ""
-  # -- Namespace of the gateway
-  gatewayNamespace: ""
+  # -- Annotations for the HTTPRoute
+  annotations: {}
+  # -- parentRefs list pointing to your Gateway resource
+  parentRefs: []
+  #   - name: my-gateway
+  #     namespace: default
   # -- Hostnames the HTTPRoute matches
   hostnames: []
     # - metabase.example.com
@@ -159,7 +145,7 @@ probes:
   startup:
     enabled: true
     path: /api/health
-    initialDelaySeconds: 30
+    initialDelaySeconds: 90
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 30
@@ -182,7 +168,13 @@ probes:
 # Resources and Security
 # =============================================================================
 
-resources: {}
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
 
 podSecurityContext: {}
 
@@ -312,3 +304,14 @@ postgresql:
     scripts:
       02-extensions.sql: |
         CREATE EXTENSION IF NOT EXISTS citext;
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi


### PR DESCRIPTION
Closes #398

## Summary
- Update Metabase to `v0.61.3`.
- Update the HelmForge PostgreSQL dependency reference to `1.10.0`.
- Add HelmForge-style `DESIGN.md`, database/backup docs, production docs, and examples.

## Upstream research
- Docker Hub publishes `docker.io/metabase/metabase:v0.61.3` for linux/amd64 and linux/arm64; `docker.io/metabase/metabase:0.61.3` is not published.
- Git tag `v0.61.3` exists upstream.
- The `v0.61.2...v0.61.3` compare includes backports for database connection handling, migrations, SDK/embedding behavior, serialization, notifications, Metabot, and query/cache edge cases.

## Validation
- `npx -y markdownlint-cli2 charts/metabase/README.md charts/metabase/DESIGN.md charts/metabase/docs/*.md`
- `helm dependency build charts/metabase`
- `helm dependency list charts/metabase` (`postgresql 1.10.0`)
- `helm lint charts/metabase`
- `helm lint charts/metabase --strict`
- `helm template metabase-ci charts/metabase`
- `helm template metabase-ci charts/metabase -f charts/metabase/ci/*.yaml`
- `helm unittest charts/metabase` (33 tests, 7 suites)
- `ah lint -p charts/metabase`
- `kubeconform -strict -summary -ignore-missing-schemas` for default and all CI values
- `kubescape scan framework nsa` (overall compliance-score: 73)

## k3d validation
Cluster: `k3d-helmforge-tests-wsl`

- Default deployment with HelmForge PostgreSQL subchart: Metabase and PostgreSQL pods Ready, 0 restarts.
- `/api/health` returned `HTTP 200`.
- Root UI returned `HTTP 200`.
- No non-normal Kubernetes events.
- No operational error/fatal log matches in Metabase or PostgreSQL logs. Liquibase `error(text)` was verified as a column name in a normal migration log line, not an error.
- Namespace cleaned after validation.