### PR TITLE
chore(minecraft): update minecraft-server to 2026.5.4

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: minecraft
 type: application
-version: 1.4.10
-appVersion: "2026.5.2"
+version: 1.4.11
+appVersion: "2026.5.4"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 2026.5.2 (#266)"
+      description: "update minecraft-server image to 2026.5.4 (#399)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/DESIGN.md
+++ b/charts/minecraft/DESIGN.md
@@ -1,0 +1,76 @@
+# Minecraft Chart Design
+
+## Scope
+
+This chart deploys Minecraft Java Edition servers using the official community-standard
+`docker.io/itzg/minecraft-server` image. It supports vanilla, Paper, Forge, Fabric, Quilt, Geyser/Floodgate cross-play,
+RCON operations, persistent worlds, metrics, External Secrets, and S3-compatible backups.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  player[Java players] --> svc[Minecraft Service]
+  bedrock[Bedrock players] -. optional .-> svc
+  svc --> pod[Minecraft Deployment]
+  pod --> data[(World PVC)]
+  rcon[RCON Service] --> pod
+  secret[RCON Secret or ExternalSecret] --> pod
+  backup[Backup CronJob] --> data
+  backup --> s3[S3-compatible storage]
+```
+
+The workload intentionally uses a single replica with `Recreate` strategy because one Minecraft server process owns the
+world data at a time.
+
+## Main Design Choices
+
+- Use `itzg/minecraft-server` because it handles server type selection, modloader bootstrap, version pinning, and startup
+  automation.
+- Require explicit `server.eula=true` before a server can run.
+- Keep persistent world storage enabled by default.
+- Expose the game service as `LoadBalancer` by default, with dual-stack service controls available.
+- Keep RCON enabled for operational automation, backups, and graceful save coordination.
+- Use External Secrets only when explicitly enabled and require an existing RCON secret to avoid credential drift.
+- Use the same `itzg/minecraft-server` image for backup worker jobs so RCON tooling stays aligned with the server image.
+
+## Production Boundary
+
+For production, operators should define:
+
+- `server.version`, `server.type`, and mod/plugin versions
+- storage class, PVC size, and restore runbook
+- service exposure, firewall rules, and optional DNS
+- RCON secret management
+- backup schedule, object storage credentials, and retention policy
+- resource requests and memory/JVM settings appropriate for player count and modpack size
+- staging validation for plugins, mods, datapacks, and resource packs before reusing production PVCs
+
+## Explicit Non-Goals
+
+- managing Bedrock Dedicated Server as a separate product
+- running multiple Minecraft server replicas against one world
+- provisioning object storage or external secret stores
+- validating third-party mod/plugin compatibility
+- bypassing the Minecraft EULA acceptance requirement
+
+<!-- @AI-METADATA
+type: design
+title: Minecraft Chart Design
+description: Design document for the Minecraft Helm chart architecture, persistence, backup, RCON, and production boundaries
+
+keywords: minecraft, design, architecture, game-server, rcon, backup, geyser, forge, fabric, paper, helm, kubernetes
+
+purpose: Document chart architecture, operational choices, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/minecraft/README.md
+  - charts/minecraft/docs/vanilla-and-paper.md
+  - charts/minecraft/docs/modded.md
+  - charts/minecraft/docs/crossplay.md
+  - charts/minecraft/docs/backup.md
+path: charts/minecraft/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -248,10 +248,13 @@ mods:
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.5.2` is an upstream image update from
-`2026.4.2`. Review the upstream release notes before upgrading production
-servers, take a world backup, and verify plugins, mods, datapacks, and pinned
-`server.version` values in a staging environment before reusing existing PVCs.
+`docker.io/itzg/minecraft-server:2026.5.4` updates the upstream server image from
+`2026.5.2`. The upstream releases include env-file loading at startup, server
+library cleanup on Paper installs, helper/monitor/RCON dependency updates, and a
+fix for deriving `MC_IMAGE_HELPER_OPTS` from `PROXY_*` variables. Review the
+upstream release notes before upgrading production servers, take a world backup,
+and verify plugins, mods, datapacks, proxy settings, and pinned `server.version`
+values in a staging environment before reusing existing PVCs.
 
 ### Mods & Plugins
 
@@ -356,6 +359,7 @@ externalSecrets:
 - [Production](examples/production.yaml) — Paper with whitelist, metrics, backup, and affinity
 - [Modded](examples/modded.yaml) — Forge server for mods
 - [Cross-play](examples/crossplay.yaml) — Paper with GeyserMC for Bedrock clients
+- [Chart design](DESIGN.md)
 
 ## Architecture Guides
 
@@ -393,6 +397,7 @@ keywords: minecraft, helm, kubernetes, paper, forge, fabric, geyser, bedrock, ga
 purpose: Installation guide, configuration reference, and operational documentation for the minecraft Helm chart
 scope: Chart
 relations:
+  - charts/minecraft/DESIGN.md
   - charts/minecraft/docs/vanilla-and-paper.md
   - charts/minecraft/docs/modded.md
   - charts/minecraft/docs/crossplay.md

--- a/charts/minecraft/templates/NOTES.txt
+++ b/charts/minecraft/templates/NOTES.txt
@@ -1,88 +1,172 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-Minecraft Server has been deployed!
+{{- $fullname := include "minecraft.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
 
-Server Type: {{ .Values.server.type }}
-Version:     {{ .Values.server.version }}
-Game Mode:   {{ .Values.server.gameMode }}
-Difficulty:  {{ .Values.server.difficulty }}
-Max Players: {{ .Values.server.maxPlayers }}
+1. Minecraft server has been installed
+--------------------------------------
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ $namespace }}
+  Image:          {{ include "minecraft.image" . }}
+  Server Type:    {{ .Values.server.type }}
+  Version:        {{ .Values.server.version }}
+  Game Mode:      {{ .Values.server.gameMode }}
+  Difficulty:     {{ .Values.server.difficulty }}
+  Max Players:    {{ .Values.server.maxPlayers }}
+  Java Port:      {{ .Values.service.port }}
+  RCON:           {{ .Values.rcon.enabled }}
+  Persistence:    {{ .Values.persistence.enabled }}
 
+2. Connect
+----------
 {{- if eq .Values.service.type "LoadBalancer" }}
-
-To get the server address, run:
-
-  export SERVER_IP=$(kubectl get svc {{ include "minecraft.fullname" . }} \
-    --namespace {{ .Release.Namespace }} \
-    -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo "Connect to: ${SERVER_IP}:{{ .Values.service.port }}"
-
+  Get the LoadBalancer address:
+    export SERVER_IP=$(kubectl get svc {{ $fullname }} -n {{ $namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "Connect to: ${SERVER_IP}:{{ .Values.service.port }}"
 {{- else if eq .Values.service.type "NodePort" }}
-
-To get the server address, run:
-
-  export NODE_PORT=$(kubectl get svc {{ include "minecraft.fullname" . }} \
-    --namespace {{ .Release.Namespace }} \
-    -o jsonpath='{.spec.ports[?(@.name=="minecraft")].nodePort}')
-  export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
-  echo "Connect to: ${NODE_IP}:${NODE_PORT}"
-
+  Get the NodePort address:
+    export NODE_PORT=$(kubectl get svc {{ $fullname }} -n {{ $namespace }} -o jsonpath='{.spec.ports[?(@.name=="minecraft")].nodePort}')
+    export NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+    echo "Connect to: ${NODE_IP}:${NODE_PORT}"
 {{- else }}
-
-The server is available within the cluster at:
-
-  {{ include "minecraft.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
-
+  In-cluster endpoint:
+    {{ $fullname }}.{{ $namespace }}.svc.cluster.local:{{ .Values.service.port }}
 {{- end }}
-
 {{- if .Values.geyser.enabled }}
 
-GeyserMC Cross-Play (Bedrock):
-
-  Bedrock clients can connect on UDP port {{ .Values.geyser.port }}.
+  GeyserMC Bedrock cross-play:
+    UDP port: {{ .Values.geyser.port }}
 {{- end }}
 
+3. First-time Setup
+-------------------
+  - EULA accepted: {{ .Values.server.eula }}
+  - World name: {{ .Values.server.worldSaveName }}
+  - MOTD: {{ .Values.server.motd }}
+  - Online mode: {{ .Values.auth.onlineMode }}
+  - Whitelist enforced: {{ .Values.auth.enforceWhitelist }}
+  - Operators configured: {{ if .Values.auth.ops }}yes{{ else }}no{{ end }}
+
+4. Configuration Summary
+------------------------
+  Service type:       {{ .Values.service.type }}
+  JVM memory:         {{ .Values.jvm.memory }}
+  Aikar flags:        {{ .Values.jvm.useAikarFlags }}
+  View distance:      {{ .Values.server.viewDistance }}
+  Simulation distance: {{ .Values.server.simulationDistance }}
+  Geyser:             {{ .Values.geyser.enabled }}
+  Metrics:            {{ .Values.metrics.enabled }}
+  Backup:             {{ .Values.backup.enabled }}
+  External Secrets:   {{ .Values.externalSecrets.enabled }}
+{{- with .Values.service.ipFamilyPolicy }}
+  IP family policy:   {{ . }}{{ with $.Values.service.ipFamilies }} ({{ join ", " . }}){{ end }}
+{{- end }}
+
+5. Validation Commands
+----------------------
+  Wait for the server pod:
+    kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=minecraft -n {{ $namespace }} --timeout=600s
+
+  Check pod and service:
+    kubectl get pods,svc,pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ $namespace }} -o wide
+
+  Check recent events:
+    kubectl get events -n {{ $namespace }} --sort-by=.lastTimestamp
+
+  Check server logs:
+    kubectl logs -l app.kubernetes.io/name=minecraft -n {{ $namespace }} --tail=200
+
+  Confirm Minecraft health checks are running:
+    kubectl describe pod -l app.kubernetes.io/name=minecraft -n {{ $namespace }} | grep -A5 -E 'Startup|Liveness|Readiness'
+
+6. RCON
+-------
 {{- if .Values.rcon.enabled }}
+  Read the RCON password:
+    export RCON_PASSWORD=$(kubectl get secret {{ include "minecraft.secretName" . }} -n {{ $namespace }} -o jsonpath='{.data.{{ include "minecraft.secretKey" . }}}' | base64 -d)
 
-RCON:
-
-  To retrieve the RCON password:
-
-    kubectl get secret {{ include "minecraft.secretName" . }} \
-      --namespace {{ .Release.Namespace }} \
-      -o jsonpath='{.data.{{ include "minecraft.secretKey" . }}}' | base64 -d
-
-  To connect via RCON from inside the cluster:
-
-    kubectl run rcon-cli --rm -it --restart=Never \
-      --image=itzg/rcon-cli -- \
-      --host {{ include "minecraft.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local \
+  Run a console command from inside the cluster:
+    kubectl run rcon-cli -n {{ $namespace }} --rm -it --restart=Never --image=docker.io/itzg/rcon-cli -- \
+      --host {{ $fullname }}.{{ $namespace }}.svc.cluster.local \
       --port {{ .Values.rcon.port }} \
-      --password <RCON_PASSWORD>
+      --password "${RCON_PASSWORD}" list
+{{- if .Values.rcon.serviceEnabled }}
+
+  Dedicated RCON Service:
+    {{ $fullname }}-rcon.{{ $namespace }}.svc.cluster.local:{{ .Values.rcon.port }}
+{{- end }}
+{{- else }}
+  RCON is disabled. Enable `rcon.enabled=true` for remote console access and coordinated backups.
 {{- end }}
 
+7. Metrics
+----------
 {{- if .Values.metrics.enabled }}
-
-Metrics:
-
-  Prometheus metrics are available on port {{ .Values.metrics.port }} at /metrics.
-  {{- if .Values.metrics.serviceMonitor.enabled }}
-  A ServiceMonitor has been created for Prometheus Operator auto-discovery.
-  {{- end }}
+  Prometheus metrics are exposed on port {{ .Values.metrics.port }} at `/metrics`.
+  ServiceMonitor: {{ .Values.metrics.serviceMonitor.enabled }}
+{{- else }}
+  Metrics are disabled. Enable `metrics.enabled=true` to run mc-monitor.
 {{- end }}
 
+8. Backup
+---------
 {{- if .Values.backup.enabled }}
+  S3 backup is enabled:
+    Schedule: {{ .Values.backup.schedule }}
+    Bucket:   {{ .Values.backup.s3.bucket }}
+    Prefix:   {{ .Values.backup.s3.prefix }}
 
-Backup:
+  Backups use RCON to run save-all/save-off before archive creation and save-on afterwards.
 
-  Backups are scheduled via CronJob: {{ .Values.backup.schedule }}
-  Target: s3://{{ .Values.backup.s3.bucket }}/{{ .Values.backup.s3.prefix }}/
+  Check backup jobs:
+    kubectl get cronjob,jobs -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  Trigger a manual backup:
+    kubectl create job --from=cronjob/{{ $fullname }}-backup minecraft-backup-$(date +%s) -n {{ $namespace }}
+{{- else }}
+  Backup is disabled. For production worlds, enable `backup.enabled=true` with S3 credentials.
+  Backup requires `persistence.enabled=true` and `rcon.enabled=true`.
 {{- end }}
 
-{{- if .Values.externalSecrets.enabled }}
+9. Troubleshooting
+------------------
+  Server does not become ready:
+    kubectl describe pod -l app.kubernetes.io/name=minecraft -n {{ $namespace }}
+    kubectl logs -l app.kubernetes.io/name=minecraft -n {{ $namespace }} --tail=300
 
-ExternalSecrets:
-
-  SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
-  Target Secret: {{ default (include "minecraft.fullname" .) .Values.rcon.existingSecret }}
-  Refresh: {{ .Values.externalSecrets.refreshInterval }}
+  Players cannot connect:
+    kubectl get svc {{ $fullname }} -n {{ $namespace }} -o wide
+    # Confirm firewall/load balancer rules allow TCP {{ .Values.service.port }}.
+{{- if .Values.geyser.enabled }}
+    # For Bedrock, also confirm UDP {{ .Values.geyser.port }} is reachable.
 {{- end }}
+
+  World data is missing after restart:
+    kubectl get pvc {{ default $fullname .Values.persistence.existingClaim }} -n {{ $namespace }}
+    # Use persistence.enabled=true for production worlds.
+
+  RCON password mismatch:
+    kubectl get secret {{ include "minecraft.secretName" . }} -n {{ $namespace }}
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+
+  Modpack or plugin startup issue:
+    kubectl logs -l app.kubernetes.io/name=minecraft -n {{ $namespace }} --tail=500
+    # Check server.type, mods.*, and resourcePack.* values.
+
+10. Documentation
+-----------------
+  Helm values:
+    helm get values {{ .Release.Name }} -n {{ $namespace }}
+
+  Helm manifest:
+    helm get manifest {{ .Release.Name }} -n {{ $namespace }}
+
+  HelmForge docs:
+    https://helmforge.dev/docs/charts/minecraft
+
+  Chart source:
+    https://github.com/helmforgedev/charts/tree/main/charts/minecraft
+
+  Upstream image docs:
+    https://docker-minecraft-server.readthedocs.io/
+
+Happy Helmforging :)

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.5.2
+          value: docker.io/itzg/minecraft-server:2026.5.4
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.5.2
+          value: docker.io/itzg/minecraft-server:2026.5.4
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.5.2
+          value: docker.io/itzg/minecraft-server:2026.5.4
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.5.2
+          value: docker.io/itzg/minecraft-server:2026.5.4
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.5.2"
+          "default": "2026.5.4"
         },
         "pullPolicy": {
           "type": "string",
@@ -634,7 +634,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.5.2"
+              "default": "docker.io/itzg/minecraft-server:2026.5.4"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.5.2"
+  tag: "2026.5.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -380,9 +380,8 @@ backup:
   excludes: "*.jar cache logs"
 
   images:
-    # -- Image used for RCON commands and tar archiving
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.5.2
+    worker: docker.io/itzg/minecraft-server:2026.5.4
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
Closes #399

## Summary
- Update the Minecraft server image and backup worker image to `docker.io/itzg/minecraft-server:2026.5.4`.
- Bump the chart to `1.4.11` and appVersion to `2026.5.4`.
- Add a chart `DESIGN.md` to document workload scope, architecture, production boundaries, and non-goals.
- Refresh README upgrade notes for the 2026.5.3 and 2026.5.4 upstream changes.

## Upstream evidence
- Reviewed upstream releases `2026.5.3` and `2026.5.4`.
- Verified `docker.io/itzg/minecraft-server:2026.5.4` publishes Linux `amd64` and `arm64` manifests.

## Validation
- `npx -y markdownlint-cli2 charts/minecraft/README.md charts/minecraft/DESIGN.md charts/minecraft/docs/*.md`
- `helm dependency build charts/minecraft`
- `helm lint charts/minecraft`
- `helm lint charts/minecraft --strict`
- `helm template minecraft-ci charts/minecraft`
- Rendered every `charts/minecraft/ci/*.yaml` values file explicitly.
- `helm unittest charts/minecraft` (71 tests, 7 suites)
- `ah lint -p charts/minecraft`
- `kubeconform -strict -summary -ignore-missing-schemas` for default and CI renders
- `kubescape scan framework nsa` (score 75)

## k3d validation
- Cluster/context: `k3d-helmforge-tests-wsl`
- Scenario: default chart deployment with `server.eula=true` and `service.type=ClusterIP`
- Pod reached Ready 1/1 with 0 restarts
- In-cluster smoke test confirmed TCP 25565 is reachable
- Checked pod logs and Kubernetes events; no errors or non-normal events
- Removed the validation namespace after testing