### PR TITLE
chore(n8n): update to 2.23.2

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
-version: 1.5.9
-appVersion: "2.22.3"
+version: 1.5.10
+appVersion: "2.23.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 2.22.3 (#330)"
+      description: "update image to 2.23.2 and refresh HelmForge subcharts (#400)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -51,14 +51,14 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.9.1
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.14
+    version: 1.6.16
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/n8n/DESIGN.md
+++ b/charts/n8n/DESIGN.md
@@ -37,6 +37,8 @@ flowchart LR
   subcharts, while still allowing explicit `database.mode` overrides.
 - Keep the encryption key in a Kubernetes Secret and support External Secrets as
   the single source of truth when `encryptionKey.existingSecret` is set.
+- Disable anonymous diagnostics by default for privacy-focused self-hosted
+  clusters, while allowing operators to opt in explicitly.
 - Run n8n containers as the upstream non-root node user with dropped Linux
   capabilities, RuntimeDefault seccomp, and resource requests/limits by default.
 - Model queue mode as a separate worker Deployment so the main UI/webhook pod
@@ -49,8 +51,8 @@ flowchart LR
   sidecar on the main pod and each queue worker. The chart generates a shared
   token and wires the broker port so Code and Python task runner execution does
   not depend on the Python runtime inside the main `n8nio/n8n` image.
-- Retain the deprecated `gateway` block only as a backward-compatible alias for
-  existing releases; new configuration should use `gatewayAPI`.
+- Use a single `gateway` block with Gateway API `parentRefs`, matching the
+  consolidated HelmForge routing pattern and avoiding competing aliases.
 - Include database-aware backup scripts for SQLite, PostgreSQL, and MySQL.
 
 ## Production Boundary

--- a/charts/n8n/DESIGN.md
+++ b/charts/n8n/DESIGN.md
@@ -1,0 +1,95 @@
+# n8n Chart Design
+
+## Scope
+
+This chart deploys n8n for self-hosted workflow automation. It supports the
+zero-configuration SQLite path, HelmForge-managed PostgreSQL or MySQL, external
+databases, Redis-backed queue mode, worker replicas, persistent data, ingress,
+Gateway API, External Secrets, and S3-compatible backup jobs.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[Users and webhooks] --> route[Ingress or HTTPRoute]
+  route --> svc[n8n Service]
+  svc --> main[n8n main Deployment]
+  main --> data[(n8n PVC)]
+  main --> db[(SQLite, PostgreSQL, or MySQL)]
+  main --> redis[(Redis queue)]
+  worker[n8n worker Deployment] --> redis
+  worker --> db
+  backup[Backup CronJob] --> data
+  backup --> db
+  backup --> s3[S3-compatible storage]
+  eso[ExternalSecret] --> secrets[Encryption and credential Secrets]
+  secrets --> main
+  secrets --> worker
+```
+
+## Main Design Choices
+
+- Use the upstream `docker.io/n8nio/n8n` image and pin explicit release tags.
+- Keep SQLite as the default so small installations can start without subcharts.
+- Use HelmForge PostgreSQL, MySQL, and Redis subcharts when operators enable
+  managed dependencies.
+- Auto-detect database mode from external database settings and enabled
+  subcharts, while still allowing explicit `database.mode` overrides.
+- Keep the encryption key in a Kubernetes Secret and support External Secrets as
+  the single source of truth when `encryptionKey.existingSecret` is set.
+- Run n8n containers as the upstream non-root node user with dropped Linux
+  capabilities, RuntimeDefault seccomp, and resource requests/limits by default.
+- Model queue mode as a separate worker Deployment so the main UI/webhook pod
+  and background execution workers can be scaled independently.
+- Use `emptyDir` for worker data by default so queue mode does not contend for a
+  `ReadWriteOnce` main data PVC during scheduling.
+- Make workers wait for main readiness before starting so fresh installs do not
+  race n8n database migrations.
+- Use external task runner mode with a generated shared token by default so n8n
+  does not try to launch the unavailable internal Python runner from the base
+  image.
+- Retain the deprecated `gateway` block only as a backward-compatible alias for
+  existing releases; new configuration should use `gatewayAPI`.
+- Include database-aware backup scripts for SQLite, PostgreSQL, and MySQL.
+
+## Production Boundary
+
+For production, operators should define:
+
+- a stable `n8n.encryptionKey` or existing Secret before first workflow use
+- PostgreSQL or MySQL instead of SQLite for larger or multi-pod deployments
+- Redis and worker sizing when queue mode is enabled
+- webhook/editor URLs that match the public ingress or Gateway endpoint
+- resource requests and limits for main, worker, backup, database, and Redis pods
+- persistent storage classes and backup retention
+- External Secrets integration for encryption, database, Redis, and S3 credentials
+- staging validation for migrations before reusing production PVCs
+
+## Explicit Non-Goals
+
+- provisioning external databases, object storage, secret stores, or ingress
+  controllers
+- managing n8n Cloud features or licensing
+- running Python task runners inside the base n8n application image
+- guaranteeing compatibility for every third-party node package or custom node
+- replacing upstream n8n migration and upgrade guidance
+
+<!-- @AI-METADATA
+type: design
+title: n8n Chart Design
+description: Design document for the n8n Helm chart architecture, database modes, queue mode, backups, and production boundaries
+
+keywords: n8n, design, workflow, automation, queue, redis, postgresql, mysql, sqlite, backup, helm, kubernetes
+
+purpose: Document chart architecture, operational choices, production boundaries, and non-goals
+scope: Chart Design
+
+relations:
+  - charts/n8n/README.md
+  - charts/n8n/docs/database.md
+  - charts/n8n/docs/queue-mode.md
+  - charts/n8n/docs/backup.md
+path: charts/n8n/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/n8n/DESIGN.md
+++ b/charts/n8n/DESIGN.md
@@ -45,9 +45,10 @@ flowchart LR
   `ReadWriteOnce` main data PVC during scheduling.
 - Make workers wait for main readiness before starting so fresh installs do not
   race n8n database migrations.
-- Use external task runner mode with a generated shared token by default so n8n
-  does not try to launch the unavailable internal Python runner from the base
-  image.
+- Use external task runner mode by default with a dedicated `n8nio/runners`
+  sidecar on the main pod and each queue worker. The chart generates a shared
+  token and wires the broker port so Code and Python task runner execution does
+  not depend on the Python runtime inside the main `n8nio/n8n` image.
 - Retain the deprecated `gateway` block only as a backward-compatible alias for
   existing releases; new configuration should use `gatewayAPI`.
 - Include database-aware backup scripts for SQLite, PostgreSQL, and MySQL.

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -103,15 +103,16 @@ service:
 Requires Gateway API CRDs and a compatible controller (e.g. Envoy Gateway).
 
 ```yaml
-gatewayAPI:
+gateway:
   enabled: true
-  gatewayName: envoy-gateway
-  gatewayNamespace: envoy-gateway-system
+  parentRefs:
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
   hostnames:
     - n8n.example.com
 ```
 
-> **Note:** `gatewayAPI.gatewayName` is required when `gatewayAPI.enabled=true`.
+> **Note:** `gateway.parentRefs` is required when `gateway.enabled=true`.
 
 ## External Secrets Operator (ESO)
 
@@ -144,6 +145,7 @@ externalSecrets:
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
+| `n8n.diagnosticsEnabled` | `false` | Share anonymous diagnostics with n8n |
 | `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
 | `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
@@ -167,11 +169,9 @@ externalSecrets:
 | `backup.enabled` | `false` | Enable S3 backups |
 | `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
 | `service.ipFamilies` | `[]` | IP families override (`IPv4`, `IPv6`) |
-| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
-| `gatewayAPI.gatewayName` | `""` | Gateway name (required when `gatewayAPI.enabled=true`) |
-| `gatewayAPI.gatewayNamespace` | `""` | Gateway namespace |
-| `gatewayAPI.hostnames` | `[]` | HTTPRoute hostnames |
-| `gateway.enabled` | `false` | Deprecated legacy alias for `gatewayAPI.enabled` |
+| `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
+| `gateway.parentRefs` | `[]` | Gateway parentRefs (required when `gateway.enabled=true`) |
+| `gateway.hostnames` | `[]` | HTTPRoute hostnames |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret resource |
 | `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
 | `externalSecrets.refreshInterval` | `"0"` | Refresh interval (`"0"` = one-time sync) |
@@ -192,12 +192,17 @@ when it resolves to SQLite or when Redis is not configured, because workers must
 share the same PostgreSQL, MySQL, or external database as the main pod. Validate
 database and queue mode in a staging namespace before reusing production PVCs.
 
-The chart keeps `N8N_RUNNERS_ENABLED=true` and defaults to
-`N8N_RUNNERS_MODE=external`. It creates a shared auth token, opens the broker
-port, and runs a `docker.io/n8nio/runners` sidecar next to the main pod and each
-queue worker. This avoids the missing-Python warning produced by internal runner
-mode in the upstream `n8nio/n8n` image and gives each queue worker its own
-runner, as required by n8n external task runner architecture.
+The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth
+token, opens the broker port, and runs a `docker.io/n8nio/runners` sidecar next
+to the main pod and each queue worker. This avoids the missing-Python warning
+produced by internal runner mode in the upstream `n8nio/n8n` image and gives
+each queue worker its own runner, as required by n8n external task runner
+architecture.
+
+Anonymous diagnostics are disabled by default with
+`N8N_DIAGNOSTICS_ENABLED=false`, which keeps self-hosted clusters private and
+reduces startup log noise. Operators can opt in with
+`n8n.diagnosticsEnabled=true`.
 
 ## Resources Generated
 
@@ -212,7 +217,7 @@ runner, as required by n8n external task runner architecture.
 | Secret (backup) | `backup.enabled` and no `backup.s3.existingSecret` |
 | PVC | `persistence.enabled` and no `persistence.existingClaim` |
 | Ingress | `ingress.enabled` |
-| HTTPRoute | `gatewayAPI.enabled` |
+| HTTPRoute | `gateway.enabled` |
 | ExternalSecret | `externalSecrets.enabled` |
 | ServiceAccount | `serviceAccount.create` |
 | CronJob (backup) | `backup.enabled` |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -113,6 +113,9 @@ gateway:
 ```
 
 > **Note:** `gateway.parentRefs` is required when `gateway.enabled=true`.
+> Existing releases that still carry `gatewayAPI.enabled`, `gatewayAPI.gatewayName`,
+> and `gatewayAPI.gatewayNamespace` from older chart values remain supported as a
+> deprecated upgrade alias. New configuration should use `gateway.parentRefs`.
 
 ## External Secrets Operator (ESO)
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -148,7 +148,7 @@ externalSecrets:
 | `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
 | `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.0`) |
-| `queue.enabled` | `false` | Enable queue mode (requires Redis) |
+| `queue.enabled` | `false` | Enable queue mode (requires Redis and a non-SQLite database) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
 | `queue.persistence.shareMainVolume` | `false` | Mount the main n8n data PVC into worker pods |
@@ -184,8 +184,10 @@ and licensed Insights page rendering. Review the upstream release notes before
 upgrading, back up the database, and keep the encryption key stable before
 upgrading live deployments. This chart also refreshes the bundled HelmForge
 PostgreSQL, MySQL, and Redis subchart versions and enables hardened non-root
-container defaults with resource requests and limits; validate database and
-queue mode in a staging namespace before reusing production PVCs.
+container defaults with resource requests and limits. Queue mode now fails fast
+when it resolves to SQLite or when Redis is not configured, because workers must
+share the same PostgreSQL, MySQL, or external database as the main pod. Validate
+database and queue mode in a staging namespace before reusing production PVCs.
 
 The chart sets `N8N_RUNNERS_MODE=external` with a generated auth token and
 `N8N_NATIVE_PYTHON_RUNNER=false` by default because the upstream `n8nio/n8n`

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -154,6 +154,9 @@ externalSecrets:
 | `queue.persistence.shareMainVolume` | `false` | Mount the main n8n data PVC into worker pods |
 | `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.16`) |
 | `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
+| `taskRunners.image.repository` | `docker.io/n8nio/runners` | External task runner sidecar image repository |
+| `taskRunners.image.tag` | `""` | External task runner sidecar tag (defaults to `image.tag`) |
+| `taskRunners.autoShutdownTimeout` | `15` | External runner launcher idle shutdown timeout |
 | `taskRunners.authToken` | `""` | External runner auth token, auto-generated when empty |
 | `taskRunners.nativePython.enabled` | `false` | Enable native Python runner integration |
 | `persistence.enabled` | `true` | Enable persistent storage |
@@ -189,16 +192,12 @@ when it resolves to SQLite or when Redis is not configured, because workers must
 share the same PostgreSQL, MySQL, or external database as the main pod. Validate
 database and queue mode in a staging namespace before reusing production PVCs.
 
-The chart sets `N8N_RUNNERS_MODE=external` with a generated auth token and
-`N8N_NATIVE_PYTHON_RUNNER=false` by default because the upstream `n8nio/n8n`
-image does not include the separate Python runner runtime. Configure external
-`n8nio/runners` or a compatible custom runner image before enabling native
-Python execution.
-
-Self-hosted n8n `2.x` starts an internal JavaScript task runner by default. The
-base `n8nio/n8n` image may also log a Python runner warning when Python is not
-present; use n8n external task runners when running Python Code nodes in
-production.
+The chart keeps `N8N_RUNNERS_ENABLED=true` and defaults to
+`N8N_RUNNERS_MODE=external`. It creates a shared auth token, opens the broker
+port, and runs a `docker.io/n8nio/runners` sidecar next to the main pod and each
+queue worker. This avoids the missing-Python warning produced by internal runner
+mode in the upstream `n8nio/n8n` image and gives each queue worker its own
+runner, as required by n8n external task runner architecture.
 
 ## Resources Generated
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -10,6 +10,7 @@ Deploy [n8n](https://n8n.io/) on Kubernetes — a workflow automation platform f
 - **External database** — connect to existing PostgreSQL or MySQL
 - **Queue mode** — Redis-backed horizontal scaling with worker pods
 - **Redis subchart** — bundled via HelmForge dependency for queue mode
+- **Worker-safe persistence** — queue workers use ephemeral data by default to avoid RWO PVC contention
 - **Scheduled backups** — database-aware CronJob with S3 upload
 - **Ingress support** — TLS with cert-manager, auto-detected webhook URL
 - **Encryption key** — auto-generated and persisted across upgrades
@@ -139,20 +140,26 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.22.3` | n8n container image tag |
+| `image.tag` | `2.23.2` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
 | `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
-| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
-| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `1.9.1`) |
+| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.0`) |
 | `queue.enabled` | `false` | Enable queue mode (requires Redis) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
-| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.14`) |
+| `queue.persistence.shareMainVolume` | `false` | Mount the main n8n data PVC into worker pods |
+| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.16`) |
+| `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
+| `taskRunners.authToken` | `""` | External runner auth token, auto-generated when empty |
+| `taskRunners.nativePython.enabled` | `false` | Enable native Python runner integration |
 | `persistence.enabled` | `true` | Enable persistent storage |
 | `persistence.size` | `5Gi` | PVC size |
+| `resources.requests.memory` | `512Mi` | Default memory request for the main pod |
+| `securityContext.runAsNonRoot` | `true` | Run n8n containers as the upstream non-root node user |
 | `ingress.enabled` | `false` | Enable ingress |
 | `backup.enabled` | `false` | Enable S3 backups |
 | `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
@@ -171,11 +178,20 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.22.3` is an upstream bugfix release. Review the upstream release
-notes before upgrading, back up the database, and keep the encryption key
-stable before upgrading live deployments. When using the bundled PostgreSQL
-subchart on a fresh data directory, the chart bootstraps the `uuid-ossp`
-extension before n8n migrations run.
+n8n `2.23.2` is an upstream bugfix release. It includes fixes for MCP registry
+server identifiers, data-table timestamp columns, production execution pin data,
+and licensed Insights page rendering. Review the upstream release notes before
+upgrading, back up the database, and keep the encryption key stable before
+upgrading live deployments. This chart also refreshes the bundled HelmForge
+PostgreSQL, MySQL, and Redis subchart versions and enables hardened non-root
+container defaults with resource requests and limits; validate database and
+queue mode in a staging namespace before reusing production PVCs.
+
+The chart sets `N8N_RUNNERS_MODE=external` with a generated auth token and
+`N8N_NATIVE_PYTHON_RUNNER=false` by default because the upstream `n8nio/n8n`
+image does not include the separate Python runner runtime. Configure external
+`n8nio/runners` or a compatible custom runner image before enabling native
+Python execution.
 
 Self-hosted n8n `2.x` starts an internal JavaScript task runner by default. The
 base `n8nio/n8n` image may also log a Python runner warning when Python is not
@@ -206,6 +222,7 @@ production.
 - [Database configuration](docs/database.md)
 - [Queue mode](docs/queue-mode.md)
 - [Backup and restore](docs/backup.md)
+- [Chart design](DESIGN.md)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/n8n)
 
 <!-- @AI-METADATA
@@ -219,11 +236,12 @@ purpose: User-facing chart documentation with install, features, examples, and v
 scope: Chart
 
 relations:
+  - charts/n8n/DESIGN.md
   - charts/n8n/values.yaml
   - charts/n8n/docs/database.md
   - charts/n8n/docs/queue-mode.md
   - charts/n8n/docs/backup.md
 path: charts/n8n/README.md
-version: 1.1
-date: 2026-04-30
+version: 1.2
+date: 2026-06-02
 -->

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -10,7 +10,7 @@ Deploy [n8n](https://n8n.io/) on Kubernetes — a workflow automation platform f
 - **External database** — connect to existing PostgreSQL or MySQL
 - **Queue mode** — Redis-backed horizontal scaling with worker pods
 - **Redis subchart** — bundled via HelmForge dependency for queue mode
-- **Worker-safe persistence** — queue workers use ephemeral data by default to avoid RWO PVC contention
+- **Worker-aware persistence** — queue workers keep the main data PVC by default for upgrade compatibility, with an opt-out for RWO scheduling
 - **Scheduled backups** — database-aware CronJob with S3 upload
 - **Ingress support** — TLS with cert-manager, auto-detected webhook URL
 - **Encryption key** — auto-generated and persisted across upgrades
@@ -149,6 +149,7 @@ externalSecrets:
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
 | `n8n.diagnosticsEnabled` | `false` | Share anonymous diagnostics with n8n |
+| `n8n.gracefulShutdownTimeout` | `60` | Graceful shutdown timeout in seconds for main and workers |
 | `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
 | `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
@@ -156,7 +157,8 @@ externalSecrets:
 | `queue.enabled` | `false` | Enable queue mode (requires Redis and a non-SQLite database) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
-| `queue.persistence.shareMainVolume` | `false` | Mount the main n8n data PVC into worker pods |
+| `queue.persistence.shareMainVolume` | `true` | Mount the main n8n data PVC into worker pods |
+| `terminationGracePeriodSeconds` | `75` | Kubernetes pod shutdown grace period |
 | `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.16`) |
 | `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
 | `taskRunners.image.repository` | `docker.io/n8nio/runners` | External task runner sidecar image repository |

--- a/charts/n8n/ci/gateway-api.yaml
+++ b/charts/n8n/ci/gateway-api.yaml
@@ -3,10 +3,11 @@
 persistence:
   enabled: false
 
-gatewayAPI:
+gateway:
   enabled: true
-  gatewayName: my-gateway
-  gatewayNamespace: default
+  parentRefs:
+    - name: my-gateway
+      namespace: default
   hostnames:
     - n8n.example.com
   path: /

--- a/charts/n8n/docs/queue-mode.md
+++ b/charts/n8n/docs/queue-mode.md
@@ -51,6 +51,10 @@ queue:
 Worker pods wait for the main n8n readiness endpoint before starting. This keeps
 database migrations serialized on fresh PostgreSQL or MySQL subchart installs.
 
+Queue mode uses external task runners by default. The chart renders a dedicated
+`n8nio/runners` sidecar next to the main pod and each worker so every queue
+worker has its own runner, matching upstream n8n external runner guidance.
+
 ### With External Redis
 
 ```yaml

--- a/charts/n8n/docs/queue-mode.md
+++ b/charts/n8n/docs/queue-mode.md
@@ -38,18 +38,23 @@ postgresql:
     password: "db-password"
 ```
 
-Workers use `emptyDir` for `/home/node/.n8n` by default. This avoids scheduling
-contention when the main pod uses a `ReadWriteOnce` PVC. If your deployment
-requires workers to share the main data PVC, enable it explicitly:
+Workers mount the main `/home/node/.n8n` PVC by default. This preserves persisted
+community nodes and files for existing queue-mode releases. If your cluster uses
+multi-node `ReadWriteOnce` storage and workers must avoid the main PVC, disable
+the shared worker volume explicitly:
 
 ```yaml
 queue:
   persistence:
-    shareMainVolume: true
+    shareMainVolume: false
 ```
 
 Worker pods wait for the main n8n readiness endpoint before starting. This keeps
 database migrations serialized on fresh PostgreSQL or MySQL subchart installs.
+
+The chart sets `N8N_GRACEFUL_SHUTDOWN_TIMEOUT=60` and keeps the pod
+`terminationGracePeriodSeconds` above that value so workers can stop cleanly
+during queue-mode upgrades.
 
 Queue mode uses external task runners by default. The chart renders a dedicated
 `n8nio/runners` sidecar next to the main pod and each worker so every queue
@@ -97,7 +102,8 @@ database:
 |-----|---------|-------------|
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
-| `queue.persistence.shareMainVolume` | `false` | Mount the main data PVC into workers |
+| `queue.persistence.shareMainVolume` | `true` | Mount the main data PVC into workers |
+| `n8n.gracefulShutdownTimeout` | `60` | n8n graceful shutdown timeout in seconds |
 | `queue.resources.requests.memory` | `512Mi` | Default worker memory request |
 
 <!-- @AI-METADATA

--- a/charts/n8n/docs/queue-mode.md
+++ b/charts/n8n/docs/queue-mode.md
@@ -1,10 +1,14 @@
 # Queue Mode
 
-n8n supports a **queue mode** that uses Redis as a message broker, enabling horizontal scaling with separate worker processes.
+n8n supports a **queue mode** that uses Redis as a message broker, enabling
+horizontal scaling with separate worker processes.
 
 ## How It Works
 
-In queue mode, the main n8n instance acts as the web UI and workflow trigger handler. Workflow executions are pushed to a Redis queue and picked up by worker pods. This allows scaling execution capacity independently from the web interface.
+In queue mode, the main n8n instance acts as the web UI and workflow trigger
+handler. Workflow executions are pushed to a Redis queue and picked up by worker
+pods. This allows scaling execution capacity independently from the web
+interface.
 
 ## Enable Queue Mode
 
@@ -29,6 +33,19 @@ postgresql:
     password: "db-password"
 ```
 
+Workers use `emptyDir` for `/home/node/.n8n` by default. This avoids scheduling
+contention when the main pod uses a `ReadWriteOnce` PVC. If your deployment
+requires workers to share the main data PVC, enable it explicitly:
+
+```yaml
+queue:
+  persistence:
+    shareMainVolume: true
+```
+
+Worker pods wait for the main n8n readiness endpoint before starting. This keeps
+database migrations serialized on fresh PostgreSQL or MySQL subchart installs.
+
 ### With External Redis
 
 ```yaml
@@ -43,7 +60,7 @@ queue:
 
 ## Architecture
 
-```
+```text
 ┌──────────┐     ┌───────┐     ┌──────────┐
 │  n8n UI  │────▶│ Redis │◀────│ Worker 1 │
 │ (main)   │     │       │     └──────────┘
@@ -63,7 +80,8 @@ queue:
 |-----|---------|-------------|
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
-| `queue.resources` | `{}` | Resources for worker pods |
+| `queue.persistence.shareMainVolume` | `false` | Mount the main data PVC into workers |
+| `queue.resources.requests.memory` | `512Mi` | Default worker memory request |
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/n8n/docs/queue-mode.md
+++ b/charts/n8n/docs/queue-mode.md
@@ -1,7 +1,7 @@
 # Queue Mode
 
-n8n supports a **queue mode** that uses Redis as a message broker, enabling
-horizontal scaling with separate worker processes.
+n8n supports a **queue mode** that uses Redis as a message broker and a shared
+non-SQLite database, enabling horizontal scaling with separate worker processes.
 
 ## How It Works
 
@@ -9,6 +9,11 @@ In queue mode, the main n8n instance acts as the web UI and workflow trigger
 handler. Workflow executions are pushed to a Redis queue and picked up by worker
 pods. This allows scaling execution capacity independently from the web
 interface.
+
+Queue mode is intentionally rejected when the chart resolves to SQLite. SQLite
+stores state on the main pod volume and cannot safely back multiple worker pods.
+Use the PostgreSQL subchart, the MySQL subchart, or an external PostgreSQL/MySQL
+database before enabling `queue.enabled`.
 
 ## Enable Queue Mode
 
@@ -56,6 +61,14 @@ queue:
     host: redis.example.com
     port: 6379
     password: "redis-password"
+
+database:
+  external:
+    vendor: postgres
+    host: postgres.example.com
+    name: n8n
+    username: n8n
+    password: "db-password"
 ```
 
 ## Architecture

--- a/charts/n8n/examples/production/values.yaml
+++ b/charts/n8n/examples/production/values.yaml
@@ -1,4 +1,4 @@
-# Production setup — PostgreSQL + Redis queue + ingress + backup
+# Production setup - PostgreSQL + Redis queue + ingress + backup
 n8n:
   webhookUrl: "https://n8n.example.com/"
   logLevel: warn

--- a/charts/n8n/examples/production/values.yaml
+++ b/charts/n8n/examples/production/values.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Production setup - PostgreSQL + Redis queue + ingress + backup
 n8n:
   webhookUrl: "https://n8n.example.com/"

--- a/charts/n8n/examples/production/values.yaml
+++ b/charts/n8n/examples/production/values.yaml
@@ -9,7 +9,7 @@ postgresql:
     database: n8n
     username: n8n
     password: "strong-db-password"
-  primary:
+  standalone:
     persistence:
       size: 20Gi
 

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -221,7 +221,7 @@ Common checks:
 - If workflows fail to execute, verify the encryption key secret is present and not rotated.
 - If webhook triggers do not fire, verify WEBHOOK_URL is set to the public-facing URL with the correct scheme.
 - If queue workers are not picking up jobs, verify Redis connectivity and that EXECUTIONS_MODE=queue is set on both main and workers.
-- If Python Code nodes are required, deploy n8n external task runners; the base n8n image may log a Python runner warning in internal mode.
+- External task runner sidecars are enabled by default. If you switch to taskRunners.mode=internal, verify logs because the upstream image may report missing Python for internal Python runners.
 - If the SQLite database is lost on restart, verify persistence is enabled and the PVC is bound.
 - If backup jobs fail, inspect the backup pod logs and verify S3 credentials and bucket configuration.
 

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -210,7 +210,7 @@ Inspect n8n logs:
 
 Inspect worker logs:
 
-  kubectl logs deploy/{{ include "n8n.fullname" . }}-worker -n {{ .Release.Namespace }} -c n8n --tail=200
+  kubectl logs deploy/{{ include "n8n.fullname" . }}-worker -n {{ .Release.Namespace }} -c worker --tail=200
 {{- end }}
 
 {{- $dbModeTs := include "n8n.databaseMode" . }}

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -49,13 +49,23 @@ Ingress is enabled.
 Ingress is disabled.
 {{- end }}
 
-{{- if .Values.gateway.enabled }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $legacyGateway := default dict .Values.gatewayAPI }}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
 Gateway API HTTPRoute is enabled.
+{{- if $useLegacyGateway }}
+- ParentRef: {{ $legacyGateway.gatewayName }}{{ with $legacyGateway.gatewayNamespace }}.{{ . }}{{ end }}
+{{- range $legacyGateway.hostnames }}
+- Hostname: {{ . }}
+{{- end }}
+{{- else }}
 {{- range .Values.gateway.parentRefs }}
 - ParentRef: {{ .name }}{{ with .namespace }}.{{ . }}{{ end }}
 {{- end }}
 {{- range .Values.gateway.hostnames }}
 - Hostname: {{ . }}
+{{- end }}
 {{- end }}
 {{- else }}
 Gateway API HTTPRoute is disabled.

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -49,16 +49,12 @@ Ingress is enabled.
 Ingress is disabled.
 {{- end }}
 
-{{- $gatewayAPI := default dict .Values.gatewayAPI }}
-{{- $legacyGateway := default dict .Values.gateway }}
-{{- $gatewayEnabled := or (default false $gatewayAPI.enabled) (default false $legacyGateway.enabled) }}
-{{- $gatewayName := default (default "" $legacyGateway.gatewayName) $gatewayAPI.gatewayName }}
-{{- $gatewayNamespace := default (default "" $legacyGateway.gatewayNamespace) $gatewayAPI.gatewayNamespace }}
-{{- $gatewayHostnames := default (default list $legacyGateway.hostnames) $gatewayAPI.hostnames }}
-{{- if $gatewayEnabled }}
+{{- if .Values.gateway.enabled }}
 Gateway API HTTPRoute is enabled.
-  Gateway: {{ $gatewayName }}{{ with $gatewayNamespace }}.{{ . }}{{ end }}
-{{- range $gatewayHostnames }}
+{{- range .Values.gateway.parentRefs }}
+- ParentRef: {{ .name }}{{ with .namespace }}.{{ . }}{{ end }}
+{{- end }}
+{{- range .Values.gateway.hostnames }}
 - Hostname: {{ . }}
 {{- end }}
 {{- else }}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -48,8 +48,19 @@ app.kubernetes.io/component: worker
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "n8n.runnerImage" -}}
+{{- printf "%s:%s" .Values.taskRunners.image.repository (.Values.taskRunners.image.tag | default .Values.image.tag) -}}
+{{- end -}}
+
 {{- define "n8n.validate" -}}
 {{- $mode := include "n8n.databaseMode" . -}}
+{{- $taskRunnerMode := .Values.taskRunners.mode | default "external" -}}
+{{- if not (has $taskRunnerMode (list "internal" "external")) -}}
+{{- fail (printf "taskRunners.mode must be one of: internal, external (got %s)" $taskRunnerMode) -}}
+{{- end -}}
+{{- if and .Values.taskRunners.nativePython.enabled (ne $taskRunnerMode "external") -}}
+{{- fail "taskRunners.nativePython.enabled=true requires taskRunners.mode=external" -}}
+{{- end -}}
 {{- end -}}
 
 # =============================================================================

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -48,6 +48,10 @@ app.kubernetes.io/component: worker
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "n8n.validate" -}}
+{{- $mode := include "n8n.databaseMode" . -}}
+{{- end -}}
+
 # =============================================================================
 # Database Mode Detection
 # =============================================================================
@@ -60,9 +64,19 @@ app.kubernetes.io/component: worker
 {{- $hasExternal := or (ne (.Values.database.external.host | default "") "") (ne (.Values.database.external.existingSecret | default "") "") -}}
 {{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
 {{- $hasMysql := .Values.mysql.enabled | default false -}}
+{{- $hasRedis := or (.Values.redis.enabled | default false) (ne (.Values.queue.external.host | default "") "") -}}
 {{- $vendor := .Values.database.external.vendor | default "postgres" -}}
 {{- if not (has $vendor (list "postgres" "mysql")) -}}
 {{- fail (printf "database.external.vendor must be one of: postgres, mysql (got %s)" $vendor) -}}
+{{- end -}}
+{{- if and .Values.queue.enabled (not $hasRedis) -}}
+{{- fail "queue.enabled=true requires redis.enabled=true or queue.external.host to be set" -}}
+{{- end -}}
+{{- if and .Values.queue.enabled (eq $mode "sqlite") -}}
+{{- fail "queue.enabled=true is not supported with SQLite; configure PostgreSQL, MySQL, or an external database" -}}
+{{- end -}}
+{{- if and .Values.queue.enabled (eq $mode "auto") (not (or $hasExternal $hasPostgresql $hasMysql)) -}}
+{{- fail "queue.enabled=true is not supported with SQLite; configure PostgreSQL, MySQL, or an external database" -}}
 {{- end -}}
 {{- if eq $mode "auto" -}}
   {{- $count := 0 -}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -234,6 +234,22 @@ database-password
 {{- end -}}
 {{- end -}}
 
+{{- define "n8n.taskRunnerSecretName" -}}
+{{- if .Values.taskRunners.existingSecret -}}
+{{- .Values.taskRunners.existingSecret -}}
+{{- else -}}
+{{- printf "%s-task-runners" (include "n8n.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "n8n.taskRunnerSecretKey" -}}
+{{- if .Values.taskRunners.existingSecret -}}
+{{- .Values.taskRunners.existingSecretKey -}}
+{{- else -}}
+auth-token
+{{- end -}}
+{{- end -}}
+
 # =============================================================================
 # Redis / Queue
 # =============================================================================

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "n8n.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -153,6 +153,8 @@ spec:
               value: {{ .Values.n8n.logLevel | quote }}
             - name: N8N_LOG_OUTPUT
               value: {{ .Values.n8n.logOutput | quote }}
+            - name: N8N_RUNNERS_ENABLED
+              value: "true"
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -106,6 +106,11 @@ spec:
             - name: http
               containerPort: 5678
               protocol: TCP
+            {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+            - name: runners
+              containerPort: 5679
+              protocol: TCP
+            {{- end }}
           env:
             - name: DB_TYPE
               value: {{ include "n8n.dbType" . | quote }}
@@ -159,6 +164,8 @@ spec:
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+            - name: N8N_RUNNERS_BROKER_LISTEN_ADDRESS
+              value: "0.0.0.0"
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -227,6 +234,37 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+        - name: task-runners
+          image: {{ include "n8n.runnerImage" . | quote }}
+          imagePullPolicy: {{ .Values.taskRunners.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: runner-health
+              containerPort: 5680
+              protocol: TCP
+          env:
+            - name: N8N_RUNNERS_TASK_BROKER_URI
+              value: "http://127.0.0.1:5679"
+            - name: N8N_RUNNERS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "n8n.taskRunnerSecretName" . }}
+                  key: {{ include "n8n.taskRunnerSecretKey" . }}
+            - name: N8N_RUNNERS_LAUNCHER_LOG_LEVEL
+              value: {{ .Values.n8n.logLevel | quote }}
+            - name: N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT
+              value: {{ .Values.taskRunners.autoShutdownTimeout | quote }}
+            - name: N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT
+              value: "5680"
+          {{- with .Values.taskRunners.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -159,8 +159,8 @@ spec:
               value: {{ .Values.n8n.logLevel | quote }}
             - name: N8N_LOG_OUTPUT
               value: {{ .Values.n8n.logOutput | quote }}
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
+            - name: N8N_DIAGNOSTICS_ENABLED
+              value: {{ .Values.n8n.diagnosticsEnabled | quote }}
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -161,6 +161,8 @@ spec:
               value: {{ .Values.n8n.logOutput | quote }}
             - name: N8N_DIAGNOSTICS_ENABLED
               value: {{ .Values.n8n.diagnosticsEnabled | quote }}
+            - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
+              value: {{ .Values.n8n.gracefulShutdownTimeout | quote }}
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
         {{- if ne $dbMode "sqlite" }}
         - name: wait-for-db
           image: docker.io/library/busybox:1.37
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -74,6 +78,10 @@ spec:
         {{- if .Values.queue.enabled }}
         - name: wait-for-redis
           image: docker.io/library/busybox:1.37
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -145,9 +153,22 @@ spec:
               value: {{ .Values.n8n.logLevel | quote }}
             - name: N8N_LOG_OUTPUT
               value: {{ .Values.n8n.logOutput | quote }}
+            - name: N8N_RUNNERS_MODE
+              value: {{ .Values.taskRunners.mode | quote }}
+            {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+            - name: N8N_RUNNERS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "n8n.taskRunnerSecretName" . }}
+                  key: {{ include "n8n.taskRunnerSecretKey" . }}
+            {{- end }}
+            - name: N8N_NATIVE_PYTHON_RUNNER
+              value: {{ .Values.taskRunners.nativePython.enabled | quote }}
             {{- if .Values.queue.enabled }}
             - name: EXECUTIONS_MODE
               value: queue
+            - name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
+              value: "true"
             - name: QUEUE_BULL_REDIS_HOST
               value: {{ include "n8n.redisHost" . | quote }}
             - name: QUEUE_BULL_REDIS_PORT

--- a/charts/n8n/templates/httproute.yaml
+++ b/charts/n8n/templates/httproute.yaml
@@ -1,16 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- $gatewayAPI := default dict .Values.gatewayAPI }}
-{{- $legacyGateway := default dict .Values.gateway }}
-{{- if or .Values.gatewayAPI.enabled .Values.gateway.enabled }}
-{{- $activeGateway := ternary $gatewayAPI $legacyGateway .Values.gatewayAPI.enabled }}
-{{- $gatewayName := default "" $activeGateway.gatewayName }}
-{{- $gatewayNamespace := default "" $activeGateway.gatewayNamespace }}
-{{- $gatewayAnnotations := default dict $activeGateway.annotations }}
-{{- $gatewayHostnames := default list $activeGateway.hostnames }}
-{{- $gatewayPath := default "/" $activeGateway.path }}
-{{- $gatewayPathType := default "PathPrefix" $activeGateway.pathType }}
-{{- if not $gatewayName }}
-  {{- fail "gatewayAPI.gatewayName is required when gatewayAPI.enabled=true" }}
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+  {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
+{{- end }}
+{{- range .Values.gateway.parentRefs }}
+  {{- if not .name }}
+    {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
+  {{- end }}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -18,25 +14,22 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
-  {{- with $gatewayAnnotations }}
+  {{- with .Values.gateway.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    - name: {{ $gatewayName }}
-      {{- with $gatewayNamespace }}
-      namespace: {{ . }}
-      {{- end }}
-  {{- with $gatewayHostnames }}
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ $gatewayPathType }}
-            value: {{ $gatewayPath }}
+            type: {{ .Values.gateway.pathType }}
+            value: {{ .Values.gateway.path | quote }}
       backendRefs:
         - name: {{ include "n8n.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/n8n/templates/httproute.yaml
+++ b/charts/n8n/templates/httproute.yaml
@@ -1,9 +1,31 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.gateway.enabled }}
-{{- if not .Values.gateway.parentRefs }}
+{{- $gateway := default dict .Values.gateway }}
+{{- $legacyGateway := default dict .Values.gatewayAPI }}
+{{- $useLegacyGateway := and (not (default false $gateway.enabled)) (default false $legacyGateway.enabled) }}
+{{- if or (default false $gateway.enabled) $useLegacyGateway }}
+{{- $parentRefs := default list $gateway.parentRefs }}
+{{- $annotations := default dict $gateway.annotations }}
+{{- $hostnames := default list $gateway.hostnames }}
+{{- $path := default "/" $gateway.path }}
+{{- $pathType := default "PathPrefix" $gateway.pathType }}
+{{- if $useLegacyGateway }}
+  {{- if not $legacyGateway.gatewayName }}
+    {{- fail "gatewayAPI.gatewayName is required when legacy gatewayAPI.enabled=true" }}
+  {{- end }}
+  {{- $legacyParentRef := dict "name" $legacyGateway.gatewayName }}
+  {{- with $legacyGateway.gatewayNamespace }}
+    {{- $_ := set $legacyParentRef "namespace" . }}
+  {{- end }}
+  {{- $parentRefs = list $legacyParentRef }}
+  {{- $annotations = default dict $legacyGateway.annotations }}
+  {{- $hostnames = default list $legacyGateway.hostnames }}
+  {{- $path = default "/" $legacyGateway.path }}
+  {{- $pathType = default "PathPrefix" $legacyGateway.pathType }}
+{{- end }}
+{{- if not $parentRefs }}
   {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." }}
 {{- end }}
-{{- range .Values.gateway.parentRefs }}
+{{- range $parentRefs }}
   {{- if not .name }}
     {{- fail "Each gateway.parentRefs entry must define a 'name' field" }}
   {{- end }}
@@ -14,22 +36,22 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
-  {{- with .Values.gateway.annotations }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:
-    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
-  {{- with .Values.gateway.hostnames }}
+    {{- toYaml $parentRefs | nindent 4 }}
+  {{- with $hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - matches:
         - path:
-            type: {{ .Values.gateway.pathType }}
-            value: {{ .Values.gateway.path | quote }}
+            type: {{ $pathType }}
+            value: {{ $path | quote }}
       backendRefs:
         - name: {{ include "n8n.fullname" . }}
           port: {{ .Values.service.port }}

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -19,6 +19,26 @@ data:
   {{- end }}
 {{- end }}
 ---
+{{- if and (eq (.Values.taskRunners.mode | default "external") "external") (not .Values.taskRunners.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "n8n.fullname" . }}-task-runners
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- $taskRunnerSecretName := printf "%s-task-runners" (include "n8n.fullname" .) }}
+  {{- $existingTaskRunnerSecret := lookup "v1" "Secret" .Release.Namespace $taskRunnerSecretName }}
+  {{- if and $existingTaskRunnerSecret (not .Values.taskRunners.authToken) }}
+  auth-token: {{ index $existingTaskRunnerSecret.data "auth-token" }}
+  {{- else if .Values.taskRunners.authToken }}
+  auth-token: {{ .Values.taskRunners.authToken | b64enc | quote }}
+  {{- else }}
+  auth-token: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}
+{{- end }}
+---
 {{- $mode := include "n8n.databaseMode" . }}
 {{- if and (ne $mode "sqlite") (not (and (eq $mode "external") .Values.database.external.existingSecret)) }}
 apiVersion: v1

--- a/charts/n8n/templates/service.yaml
+++ b/charts/n8n/templates/service.yaml
@@ -23,5 +23,11 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+    - name: runners
+      port: 5679
+      targetPort: runners
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "n8n.selectorLabels" . | nindent 4 }}

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -129,6 +129,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "n8n.encryptionKeySecretName" . }}
                   key: {{ include "n8n.encryptionKeySecretKey" . }}
+            - name: N8N_RUNNERS_ENABLED
+              value: "true"
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         {{- if ne (include "n8n.databaseMode" .) "sqlite" }}
         - name: wait-for-db
           image: docker.io/library/busybox:1.37
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -59,6 +63,10 @@ spec:
         {{- end }}
         - name: wait-for-redis
           image: docker.io/library/busybox:1.37
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -68,11 +76,30 @@ spec:
                 sleep 2
               done
               echo "Redis is reachable."
+        - name: wait-for-main
+          image: docker.io/library/busybox:1.37
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for n8n main readiness..."
+              until wget -qO- http://{{ include "n8n.fullname" . }}:{{ .Values.service.port }}/healthz/readiness >/dev/null 2>&1; do
+                sleep 2
+              done
+              echo "n8n main is ready."
       containers:
         - name: worker
           image: {{ include "n8n.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["n8n", "worker", "--concurrency={{ .Values.queue.concurrency }}"]
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: DB_TYPE
               value: {{ include "n8n.dbType" . | quote }}
@@ -102,6 +129,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "n8n.encryptionKeySecretName" . }}
                   key: {{ include "n8n.encryptionKeySecretKey" . }}
+            - name: N8N_RUNNERS_MODE
+              value: {{ .Values.taskRunners.mode | quote }}
+            {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+            - name: N8N_RUNNERS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "n8n.taskRunnerSecretName" . }}
+                  key: {{ include "n8n.taskRunnerSecretKey" . }}
+            {{- end }}
+            - name: N8N_NATIVE_PYTHON_RUNNER
+              value: {{ .Values.taskRunners.nativePython.enabled | quote }}
             - name: EXECUTIONS_MODE
               value: queue
             - name: QUEUE_BULL_REDIS_HOST
@@ -127,7 +165,7 @@ spec:
               mountPath: /home/node/.n8n
       volumes:
         - name: data
-          {{- if .Values.persistence.enabled }}
+          {{- if and .Values.queue.persistence.shareMainVolume .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "n8n.fullname" .)) }}
           {{- else }}

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "n8n.validate" . }}
 {{- if .Values.queue.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -132,6 +132,8 @@ spec:
                   key: {{ include "n8n.encryptionKeySecretKey" . }}
             - name: N8N_DIAGNOSTICS_ENABLED
               value: {{ .Values.n8n.diagnosticsEnabled | quote }}
+            - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
+              value: {{ .Values.n8n.gracefulShutdownTimeout | quote }}
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -130,8 +130,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "n8n.encryptionKeySecretName" . }}
                   key: {{ include "n8n.encryptionKeySecretKey" . }}
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
+            - name: N8N_DIAGNOSTICS_ENABLED
+              value: {{ .Values.n8n.diagnosticsEnabled | quote }}
             - name: N8N_RUNNERS_MODE
               value: {{ .Values.taskRunners.mode | quote }}
             {{- if eq (.Values.taskRunners.mode | default "external") "external" }}

--- a/charts/n8n/templates/worker-deployment.yaml
+++ b/charts/n8n/templates/worker-deployment.yaml
@@ -166,6 +166,37 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n
+        {{- if eq (.Values.taskRunners.mode | default "external") "external" }}
+        - name: task-runners
+          image: {{ include "n8n.runnerImage" . | quote }}
+          imagePullPolicy: {{ .Values.taskRunners.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: runner-health
+              containerPort: 5680
+              protocol: TCP
+          env:
+            - name: N8N_RUNNERS_TASK_BROKER_URI
+              value: "http://127.0.0.1:5679"
+            - name: N8N_RUNNERS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "n8n.taskRunnerSecretName" . }}
+                  key: {{ include "n8n.taskRunnerSecretKey" . }}
+            - name: N8N_RUNNERS_LAUNCHER_LOG_LEVEL
+              value: {{ .Values.n8n.logLevel | quote }}
+            - name: N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT
+              value: {{ .Values.taskRunners.autoShutdownTimeout | quote }}
+            - name: N8N_RUNNERS_LAUNCHER_HEALTH_CHECK_PORT
+              value: "5680"
+          {{- with .Values.taskRunners.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: data
           {{- if and .Values.queue.persistence.shareMainVolume .Values.persistence.enabled }}

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -174,6 +174,8 @@ tests:
       queue.enabled: true
       redis.enabled: true
       redis.auth.password: redispass
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -191,6 +193,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.initContainers
@@ -250,6 +254,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -222,6 +222,15 @@ tests:
             name: N8N_LOG_LEVEL
             value: debug
 
+  - it: should disable diagnostics by default
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_DIAGNOSTICS_ENABLED
+            value: "false"
+
   - it: should configure external task runner sidecar by default
     template: templates/deployment.yaml
     asserts:
@@ -244,11 +253,6 @@ tests:
               secretKeyRef:
                 name: test-n8n-task-runners
                 key: auth-token
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: N8N_RUNNERS_ENABLED
-            value: "true"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.22.3"
+          value: "docker.io/n8nio/n8n:2.23.2"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -32,6 +32,35 @@ tests:
             name: http
             containerPort: 5678
             protocol: TCP
+
+  - it: should render hardened pod and container security defaults
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: should render resource defaults
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
 
   - it: should mount data volume at /home/node/.n8n
     template: templates/deployment.yaml
@@ -188,6 +217,40 @@ tests:
           content:
             name: N8N_LOG_LEVEL
             value: debug
+
+  - it: should disable native Python runner by default
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_RUNNERS_MODE
+            value: external
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_RUNNERS_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: test-n8n-task-runners
+                key: auth-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_NATIVE_PYTHON_RUNNER
+            value: "false"
+
+  - it: should offload manual executions to workers in queue mode
+    template: templates/deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS
+            value: "true"
 
   - it: should use PVC when persistence enabled
     template: templates/deployment.yaml

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -222,9 +222,28 @@ tests:
             name: N8N_LOG_LEVEL
             value: debug
 
-  - it: should disable native Python runner by default
+  - it: should configure external task runner sidecar by default
     template: templates/deployment.yaml
     asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: task-runners
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: "docker.io/n8nio/runners:2.23.2"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: N8N_RUNNERS_TASK_BROKER_URI
+            value: "http://127.0.0.1:5679"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: N8N_RUNNERS_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: test-n8n-task-runners
+                key: auth-token
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -238,6 +257,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: N8N_RUNNERS_BROKER_LISTEN_ADDRESS
+            value: "0.0.0.0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: N8N_RUNNERS_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
@@ -248,6 +272,30 @@ tests:
           content:
             name: N8N_NATIVE_PYTHON_RUNNER
             value: "false"
+
+  - it: should disable external task runner sidecar in internal mode
+    template: templates/deployment.yaml
+    set:
+      taskRunners.mode: internal
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_RUNNERS_MODE
+            value: internal
+      - notExists:
+          path: spec.template.spec.containers[1]
+
+  - it: should reject native Python runner outside external mode
+    template: templates/deployment.yaml
+    set:
+      taskRunners.mode: internal
+      taskRunners.nativePython.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "taskRunners.nativePython.enabled=true requires taskRunners.mode=external"
 
   - it: should offload manual executions to workers in queue mode
     template: templates/deployment.yaml

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -343,6 +343,25 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
           value: /healthz
 
+  - it: should delay readiness while n8n finishes database bootstrap
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 30
+
+  - it: should allow graceful shutdown during upgrades
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 75
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
+            value: "60"
+
   - it: should add extra env vars
     template: templates/deployment.yaml
     set:

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -224,6 +224,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: N8N_RUNNERS_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: N8N_RUNNERS_MODE
             value: external
       - contains:

--- a/charts/n8n/tests/gateway_api_test.yaml
+++ b/charts/n8n/tests/gateway_api_test.yaml
@@ -67,3 +67,30 @@ tests:
       - equal:
           path: spec.rules[0].matches[0].path.value
           value: /automation
+
+  - it: should preserve legacy gatewayAPI values during upgrades
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.gatewayName: legacy-gateway
+      gatewayAPI.gatewayNamespace: gateway-system
+      gatewayAPI.hostnames:
+        - legacy.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: legacy-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - contains:
+          path: spec.hostnames
+          content: legacy.example.com
+
+  - it: should fail legacy gatewayAPI when gatewayName is missing
+    set:
+      gatewayAPI.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.gatewayName is required when legacy gatewayAPI.enabled=true"

--- a/charts/n8n/tests/gateway_api_test.yaml
+++ b/charts/n8n/tests/gateway_api_test.yaml
@@ -13,10 +13,11 @@ tests:
 
   - it: should render an HTTPRoute when Gateway API is enabled
     set:
-      gatewayAPI.enabled: true
-      gatewayAPI.gatewayName: my-gateway
-      gatewayAPI.gatewayNamespace: gateway-system
-      gatewayAPI.hostnames:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: my-gateway
+          namespace: gateway-system
+      gateway.hostnames:
         - n8n.example.com
     asserts:
       - isKind:
@@ -31,33 +32,38 @@ tests:
           path: spec.hostnames
           content: n8n.example.com
 
-  - it: should keep the legacy gateway values compatible
+  - it: should fail when Gateway API is enabled without parentRefs
     set:
       gateway.enabled: true
-      gateway.gatewayName: legacy-gateway
-    asserts:
-      - isKind:
-          of: HTTPRoute
-      - equal:
-          path: spec.parentRefs[0].name
-          value: legacy-gateway
-
-  - it: should not reuse legacy gatewayName when Gateway API block is enabled
-    set:
-      gateway.enabled: true
-      gateway.gatewayName: legacy-gateway
-      gatewayAPI.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: "gatewayAPI.gatewayName is required when gatewayAPI.enabled=true"
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."
 
-  - it: should prefer Gateway API values over legacy values when enabled
+  - it: should fail when a parentRef does not define a name
     set:
       gateway.enabled: true
-      gateway.gatewayName: legacy-gateway
-      gatewayAPI.enabled: true
-      gatewayAPI.gatewayName: api-gateway
+      gateway.parentRefs:
+        - namespace: gateway-system
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each gateway.parentRefs entry must define a 'name' field"
+
+  - it: should render path and annotations from gateway values
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: api-gateway
+      gateway.annotations:
+        example.com/route: n8n
+      gateway.path: /automation
+      gateway.pathType: PathPrefix
     asserts:
       - equal:
           path: spec.parentRefs[0].name
           value: api-gateway
+      - equal:
+          path: metadata.annotations["example.com/route"]
+          value: n8n
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /automation

--- a/charts/n8n/tests/secret_test.yaml
+++ b/charts/n8n/tests/secret_test.yaml
@@ -26,23 +26,34 @@ tests:
           path: data["encryption-key"]
           value: bXktc2VjcmV0LWtleQ==
 
+  - it: should render task runner secret by default
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: test-n8n-task-runners
+      - exists:
+          path: data["auth-token"]
+
   - it: should not render encryption secret when existingSecret set
     set:
       encryptionKey.existingSecret: my-secret
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
 
   - it: should not render database secret in sqlite mode
     asserts:
       - hasDocuments:
-          count: 1
+          count: 2
 
   - it: should render database secret for postgresql
     set:
       postgresql.enabled: true
       postgresql.auth.password: dbpass
-    documentIndex: 1
+    documentIndex: 2
     asserts:
       - isKind:
           of: Secret

--- a/charts/n8n/tests/service_test.yaml
+++ b/charts/n8n/tests/service_test.yaml
@@ -30,6 +30,26 @@ tests:
             targetPort: http
             protocol: TCP
 
+  - it: should expose task runner broker port by default
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: runners
+            port: 5679
+            targetPort: runners
+            protocol: TCP
+
+  - it: should hide task runner broker port in internal mode
+    set:
+      taskRunners.mode: internal
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: runners
+          any: true
+
   - it: should use selector labels
     asserts:
       - equal:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -165,25 +165,10 @@ tests:
             name: N8N_DIAGNOSTICS_ENABLED
             value: "false"
 
-  - it: should use emptyDir for worker data by default
+  - it: should mount the main PVC for worker data by default
     template: templates/worker-deployment.yaml
     set:
       queue.enabled: true
-      redis.enabled: true
-      postgresql.enabled: true
-      postgresql.auth.password: pgpass
-    asserts:
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: data
-            emptyDir: {}
-
-  - it: should allow sharing the main PVC with workers when explicitly enabled
-    template: templates/worker-deployment.yaml
-    set:
-      queue.enabled: true
-      queue.persistence.shareMainVolume: true
       redis.enabled: true
       postgresql.enabled: true
       postgresql.auth.password: pgpass
@@ -194,6 +179,38 @@ tests:
             name: data
             persistentVolumeClaim:
               claimName: test-n8n-data
+
+  - it: should allow graceful worker shutdown during upgrades
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 75
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
+            value: "60"
+
+  - it: should allow worker emptyDir when shared persistence is explicitly disabled
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      queue.persistence.shareMainVolume: false
+      redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
 
   - it: should use worker-specific labels
     template: templates/worker-deployment.yaml

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -121,7 +121,7 @@ tests:
             name: wait-for-main
           any: true
 
-  - it: should disable native Python runner by default
+  - it: should configure external task runner sidecar by default
     template: templates/worker-deployment.yaml
     set:
       queue.enabled: true
@@ -129,6 +129,17 @@ tests:
       postgresql.enabled: true
       postgresql.auth.password: pgpass
     asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: task-runners
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: "docker.io/n8nio/runners:2.23.2"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: N8N_RUNNERS_TASK_BROKER_URI
+            value: "http://127.0.0.1:5679"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -139,14 +150,6 @@ tests:
           content:
             name: N8N_RUNNERS_MODE
             value: external
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: N8N_RUNNERS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: test-n8n-task-runners
-                key: auth-token
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -18,6 +18,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - isKind:
           of: Deployment
@@ -31,6 +33,8 @@ tests:
       queue.enabled: true
       queue.workers: 3
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - equal:
           path: spec.replicas
@@ -41,6 +45,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - equal:
           path: spec.template.spec.containers[0].command
@@ -51,6 +57,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
@@ -71,6 +79,8 @@ tests:
       queue.enabled: true
       redis.enabled: true
       redis.auth.password: pass
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -88,6 +98,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.initContainers
@@ -100,6 +112,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.initContainers
@@ -112,6 +126,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
@@ -142,6 +158,8 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -155,6 +173,8 @@ tests:
       queue.enabled: true
       queue.persistence.shareMainVolume: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -168,7 +188,28 @@ tests:
     set:
       queue.enabled: true
       redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
     asserts:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/component"]
           value: worker
+
+  - it: should reject queue mode with SQLite
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "queue.enabled=true is not supported with SQLite"
+
+  - it: should reject queue mode without Redis
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
+    asserts:
+      - failedTemplate:
+          errorPattern: "queue.enabled=true requires redis.enabled=true or queue.external.host"

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -116,6 +116,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: N8N_RUNNERS_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: N8N_RUNNERS_MODE
             value: external
       - contains:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -46,6 +46,25 @@ tests:
           path: spec.template.spec.containers[0].command
           value: ["n8n", "worker", "--concurrency=10"]
 
+  - it: should render hardened worker security defaults and resources
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+
   - it: should set queue env vars
     template: templates/worker-deployment.yaml
     set:
@@ -75,6 +94,69 @@ tests:
           content:
             name: wait-for-redis
           any: true
+
+  - it: should wait for the main pod before starting workers
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-main
+          any: true
+
+  - it: should disable native Python runner by default
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_RUNNERS_MODE
+            value: external
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_RUNNERS_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: test-n8n-task-runners
+                key: auth-token
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_NATIVE_PYTHON_RUNNER
+            value: "false"
+
+  - it: should use emptyDir for worker data by default
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: should allow sharing the main PVC with workers when explicitly enabled
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      queue.persistence.shareMainVolume: true
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: test-n8n-data
 
   - it: should use worker-specific labels
     template: templates/worker-deployment.yaml

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -143,17 +143,26 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: N8N_RUNNERS_ENABLED
-            value: "true"
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
             name: N8N_RUNNERS_MODE
             value: external
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: N8N_NATIVE_PYTHON_RUNNER
+            value: "false"
+
+  - it: should disable diagnostics by default on workers
+    template: templates/worker-deployment.yaml
+    set:
+      queue.enabled: true
+      redis.enabled: true
+      postgresql.enabled: true
+      postgresql.auth.password: pgpass
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: N8N_DIAGNOSTICS_ENABLED
             value: "false"
 
   - it: should use emptyDir for worker data by default

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -70,6 +70,10 @@
           "description": "Log output: console, file",
           "enum": ["console", "file"]
         },
+        "diagnosticsEnabled": {
+          "type": "boolean",
+          "description": "Share anonymous diagnostics with n8n"
+        },
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables for the n8n container",
@@ -664,29 +668,25 @@
       "description": "Extra Kubernetes manifests to deploy alongside the chart",
       "items": { "type": "object" }
     },
-    "gatewayAPI": {
+    "gateway": {
       "type": "object",
       "description": "Gateway API HTTPRoute configuration (GR-060)",
       "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean", "default": false },
         "annotations": { "type": "object" },
-        "gatewayName": { "type": "string", "default": "" },
-        "gatewayNamespace": { "type": "string", "default": "" },
-        "hostnames": { "type": "array", "items": { "type": "string" } },
-        "path": { "type": "string", "default": "/" },
-        "pathType": { "type": "string", "default": "PathPrefix" }
-      }
-    },
-    "gateway": {
-      "type": "object",
-      "description": "Deprecated Gateway API HTTPRoute configuration. Use gatewayAPI instead.",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": { "type": "boolean", "default": false },
-        "annotations": { "type": "object" },
-        "gatewayName": { "type": "string", "default": "" },
-        "gatewayNamespace": { "type": "string", "default": "" },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "sectionName": { "type": "string" }
+            }
+          }
+        },
         "hostnames": { "type": "array", "items": { "type": "string" } },
         "path": { "type": "string", "default": "/" },
         "pathType": { "type": "string", "default": "PathPrefix" }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -74,6 +74,11 @@
           "type": "boolean",
           "description": "Share anonymous diagnostics with n8n"
         },
+        "gracefulShutdownTimeout": {
+          "type": "integer",
+          "description": "Graceful shutdown timeout in seconds for main and worker processes",
+          "default": 60
+        },
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables for the n8n container",
@@ -138,7 +143,8 @@
           "properties": {
             "shareMainVolume": {
               "type": "boolean",
-              "description": "Mount the main n8n data PVC in worker pods"
+              "description": "Mount the main n8n data PVC in worker pods",
+              "default": true
             }
           }
         },
@@ -418,7 +424,7 @@
       "properties": {
         "enabled": { "type": "boolean", "description": "Enable startup probe" },
         "path": { "type": "string", "description": "Path for HTTP GET probe" },
-        "initialDelaySeconds": { "type": "integer" },
+        "initialDelaySeconds": { "type": "integer", "default": 10 },
         "periodSeconds": { "type": "integer" },
         "timeoutSeconds": { "type": "integer" },
         "failureThreshold": { "type": "integer" }
@@ -430,7 +436,7 @@
       "properties": {
         "enabled": { "type": "boolean", "description": "Enable liveness probe" },
         "path": { "type": "string", "description": "Path for HTTP GET probe" },
-        "initialDelaySeconds": { "type": "integer" },
+        "initialDelaySeconds": { "type": "integer", "default": 0 },
         "periodSeconds": { "type": "integer" },
         "timeoutSeconds": { "type": "integer" },
         "failureThreshold": { "type": "integer" }
@@ -442,7 +448,7 @@
       "properties": {
         "enabled": { "type": "boolean", "description": "Enable readiness probe" },
         "path": { "type": "string", "description": "Path for HTTP GET probe" },
-        "initialDelaySeconds": { "type": "integer" },
+        "initialDelaySeconds": { "type": "integer", "default": 30 },
         "periodSeconds": { "type": "integer" },
         "timeoutSeconds": { "type": "integer" },
         "failureThreshold": { "type": "integer" }
@@ -643,7 +649,8 @@
     },
     "terminationGracePeriodSeconds": {
       "type": "integer",
-      "description": "Grace period for shutdown (seconds)"
+      "description": "Grace period for shutdown (seconds)",
+      "default": 75
     },
     "podLabels": {
       "type": "object",

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.22.3"
+          "default": "2.23.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -79,6 +79,39 @@
         }
       }
     },
+    "taskRunners": {
+      "type": "object",
+      "description": "n8n task runner configuration",
+      "properties": {
+        "nativePython": {
+          "type": "object",
+          "description": "Native Python task runner integration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable native Python runner integration"
+            }
+          }
+        },
+        "mode": {
+          "type": "string",
+          "description": "Task runner mode",
+          "enum": ["internal", "external"]
+        },
+        "authToken": {
+          "type": "string",
+          "description": "Shared auth token for external task runners"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing secret containing the task runner auth token"
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "description": "Key in the task runner auth token secret"
+        }
+      }
+    },
     "queue": {
       "type": "object",
       "description": "Queue mode configuration (Redis-backed horizontal scaling)",
@@ -94,6 +127,16 @@
         "concurrency": {
           "type": "integer",
           "description": "Worker concurrency (workflows per worker)"
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Worker data volume configuration",
+          "properties": {
+            "shareMainVolume": {
+              "type": "boolean",
+              "description": "Mount the main n8n data PVC in worker pods"
+            }
+          }
         },
         "resources": {
           "type": "object",
@@ -221,7 +264,7 @@
             "rootPassword": { "type": "string", "description": "Root password (auto-generated if empty)" }
           }
         },
-        "primary": {
+        "standalone": {
           "type": "object",
           "properties": {
             "persistence": {
@@ -266,7 +309,7 @@
             "rootPassword": { "type": "string", "description": "Root password (auto-generated if empty)" }
           }
         },
-        "primary": {
+        "standalone": {
           "type": "object",
           "properties": {
             "persistence": {
@@ -275,6 +318,16 @@
                 "enabled": { "type": "boolean", "description": "Enable persistence for MySQL data" },
                 "size": { "type": "string", "description": "PVC size for MySQL" }
               }
+            }
+          }
+        },
+        "startupProbe": {
+          "type": "object",
+          "description": "MySQL startup probe overrides",
+          "properties": {
+            "initialDelaySeconds": {
+              "type": "integer",
+              "description": "Initial delay before MySQL startup probe checks"
             }
           }
         }
@@ -298,7 +351,7 @@
             "password": { "type": "string", "description": "Redis password (auto-generated if empty)" }
           }
         },
-        "primary": {
+        "standalone": {
           "type": "object",
           "properties": {
             "persistence": {

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.22.3"
+  tag: "2.23.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -61,6 +61,26 @@ n8n:
   extraEnv: []
 
 # =============================================================================
+# Task Runners
+# =============================================================================
+
+taskRunners:
+  # -- Task runner mode: internal or external.
+  # external avoids starting unavailable internal Python runners in the base image.
+  mode: external
+  # -- Shared auth token for external task runners. Auto-generated if empty.
+  authToken: ""
+  # -- Existing secret containing the task runner auth token.
+  existingSecret: ""
+  # -- Key in the task runner auth token secret.
+  existingSecretKey: auth-token
+  nativePython:
+    # -- Enable n8n native Python runner integration.
+    # The upstream n8nio/n8n image does not include the Python runner runtime;
+    # enable this only when using external n8nio/runners or a compatible image.
+    enabled: false
+
+# =============================================================================
 # Queue Mode (Redis)
 # =============================================================================
 # When enabled, n8n runs in queue mode using Redis as the message broker.
@@ -77,8 +97,19 @@ queue:
   # -- Worker concurrency (workflows per worker)
   concurrency: 10
 
+  persistence:
+    # -- Mount the main n8n data PVC in worker pods.
+    # Keep disabled for RWO storage classes; workers use emptyDir by default.
+    shareMainVolume: false
+
   # -- Resources for worker pods
-  resources: {}
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
 
   external:
     # -- Use an external Redis instead of the subchart
@@ -166,7 +197,7 @@ postgresql:
     # -- Database password (auto-generated if empty)
     password: ""
 
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for PostgreSQL data
       enabled: true
@@ -203,12 +234,16 @@ mysql:
     # -- Root password (auto-generated if empty)
     rootPassword: ""
 
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for MySQL data
       enabled: true
       # -- PVC size for MySQL
       size: 8Gi
+
+  startupProbe:
+    # -- Delay startup checks until the initial MySQL bootstrap has opened port 3306
+    initialDelaySeconds: 30
 
 # =============================================================================
 # Redis Subchart (for queue mode)
@@ -225,7 +260,7 @@ redis:
     # -- Redis password (auto-generated if empty)
     password: ""
 
-  primary:
+  standalone:
     persistence:
       # -- Enable persistence for Redis data
       enabled: true
@@ -260,21 +295,40 @@ persistence:
 # =============================================================================
 
 # -- CPU and memory requests/limits for the n8n container
-resources: {}
-  # requests:
-  #   cpu: 250m
-  #   memory: 256Mi
-  # limits:
-  #   cpu: "1"
-  #   memory: 1Gi
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
 
 # =============================================================================
 # Security Context
 # =============================================================================
 
-podSecurityContext: {}
+podSecurityContext:
+  # -- Group ID used for writable application storage
+  fsGroup: 1000
+  # -- Avoid recursive ownership changes when the volume already matches
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    # -- Use the Kubernetes RuntimeDefault seccomp profile
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  # -- Run the upstream image as the node user
+  runAsUser: 1000
+  # -- Run the upstream image as the node group
+  runAsGroup: 1000
+  # -- Require a non-root container user
+  runAsNonRoot: true
+  # -- Prevent privilege escalation
+  allowPrivilegeEscalation: false
+  capabilities:
+    # -- Drop all Linux capabilities by default
+    drop:
+      - ALL
 
 # =============================================================================
 # Probes
@@ -408,7 +462,7 @@ backup:
     # -- Image used for SQLite backup (must have tar)
     sqlite: docker.io/library/alpine:3.22
     # -- Image used for PostgreSQL backup (must have pg_dump)
-    postgresql: docker.io/library/postgres:18.3-alpine
+    postgresql: docker.io/library/postgres:18.4-alpine
     # -- Image used for MySQL backup (must have mysqldump)
     mysql: docker.io/library/mysql:8.4
     # -- Image used for S3 upload (MinIO client)

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -52,6 +52,9 @@ n8n:
   # -- Log output: console, file
   logOutput: console
 
+  # -- Share anonymous diagnostics with n8n. Disabled by default for private clusters.
+  diagnosticsEnabled: false
+
   # -- Additional environment variables for the n8n container
   # extraEnv:
   #   - name: GENERIC_TIMEZONE
@@ -577,31 +580,21 @@ extraManifests: []
 # Gateway API
 # =============================================================================
 
-gatewayAPI:
+gateway:
   # -- Enable Gateway API HTTPRoute (alternative to Ingress; requires Gateway API CRDs)
   enabled: false
   # -- Annotations to add to the HTTPRoute resource
   annotations: {}
-  # -- Gateway name to attach the HTTPRoute to
-  gatewayName: ""
-  # -- Namespace of the gateway
-  gatewayNamespace: ""
+  # -- parentRefs pointing to Gateway resources. Required when gateway.enabled=true.
+  parentRefs: []
+    # - name: n8n-gateway
+    #   namespace: gateway-system
   # -- Hostnames the HTTPRoute matches
   hostnames: []
     # - n8n.example.com
   # -- Path prefix for the HTTPRoute
   path: /
   # -- Path match type
-  pathType: PathPrefix
-
-# -- Deprecated: use gatewayAPI instead. Kept for backward compatibility.
-gateway:
-  enabled: false
-  annotations: {}
-  gatewayName: ""
-  gatewayNamespace: ""
-  hostnames: []
-  path: /
   pathType: PathPrefix
 
 # =============================================================================

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -66,8 +66,25 @@ n8n:
 
 taskRunners:
   # -- Task runner mode: internal or external.
-  # external avoids starting unavailable internal Python runners in the base image.
+  # external runs the dedicated n8nio/runners sidecar next to main and worker pods.
   mode: external
+  image:
+    # -- External task runner image repository
+    repository: docker.io/n8nio/runners
+    # -- External task runner image tag. Empty defaults to image.tag.
+    tag: ""
+    # -- External task runner image pull policy
+    pullPolicy: IfNotPresent
+  # -- External runner launcher auto-shutdown timeout in seconds (0 disables idle shutdown)
+  autoShutdownTimeout: 15
+  # -- Resources for external task runner sidecars
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
   # -- Shared auth token for external task runners. Auto-generated if empty.
   authToken: ""
   # -- Existing secret containing the task runner auth token.

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -83,12 +83,13 @@ taskRunners:
 # =============================================================================
 # Queue Mode (Redis)
 # =============================================================================
-# When enabled, n8n runs in queue mode using Redis as the message broker.
+# When enabled, n8n runs in queue mode using Redis as the message broker and a
+# shared non-SQLite database (PostgreSQL, MySQL, or external database).
 # This allows horizontal scaling with separate worker processes.
 # =============================================================================
 
 queue:
-  # -- Enable queue mode (requires Redis)
+  # -- Enable queue mode (requires Redis and a non-SQLite database)
   enabled: false
 
   # -- Number of worker replicas

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -55,6 +55,9 @@ n8n:
   # -- Share anonymous diagnostics with n8n. Disabled by default for private clusters.
   diagnosticsEnabled: false
 
+  # -- Graceful shutdown timeout in seconds for main and worker processes
+  gracefulShutdownTimeout: 60
+
   # -- Additional environment variables for the n8n container
   # extraEnv:
   #   - name: GENERIC_TIMEZONE
@@ -120,8 +123,9 @@ queue:
 
   persistence:
     # -- Mount the main n8n data PVC in worker pods.
-    # Keep disabled for RWO storage classes; workers use emptyDir by default.
-    shareMainVolume: false
+    # Keep enabled to preserve persisted community nodes and files on upgrades.
+    # Set false for multi-node RWO scheduling when workers should use emptyDir.
+    shareMainVolume: true
 
   # -- Resources for worker pods
   resources:
@@ -380,7 +384,7 @@ readinessProbe:
   enabled: true
   # -- Path for HTTP GET probe. /healthz/readiness checks database connectivity and migrations.
   path: /healthz/readiness
-  initialDelaySeconds: 0
+  initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
@@ -551,8 +555,8 @@ topologySpreadConstraints: []
 # -- Priority class name
 priorityClassName: ""
 
-# -- Grace period for shutdown (seconds)
-terminationGracePeriodSeconds: 30
+# -- Grace period for shutdown (seconds). Keep higher than n8n.gracefulShutdownTimeout.
+terminationGracePeriodSeconds: 75
 
 # =============================================================================
 # Pod-Level Metadata


### PR DESCRIPTION
Closes #400

## Summary
- Update n8n to `docker.io/n8nio/n8n:2.23.2` and bump the chart to `1.5.10`.
- Refresh HelmForge subcharts to PostgreSQL `2.0.2`, MySQL `2.0.0`, and Redis `1.6.16`.
- Align subchart values with the new `standalone.persistence` schema and tune MySQL startup probing.
- Add hardened pod/container defaults, generated task-runner auth token support, worker wait-for-main sequencing, and queue worker `emptyDir` by default to avoid RWO PVC contention.
- Add `DESIGN.md` and expand queue mode documentation.

## Upstream evidence
- Reviewed `n8n@2.23.2` release notes published on 2026-06-01.
- Verified `docker.io/n8nio/n8n:2.23.2` publishes Linux `amd64` and `arm64` manifests.

## Validation
- `npx -y markdownlint-cli2 charts/n8n/README.md charts/n8n/DESIGN.md charts/n8n/docs/*.md`
- `helm dependency build charts/n8n`
- `helm lint charts/n8n`
- `helm lint charts/n8n --strict`
- `helm template n8n-test charts/n8n`
- Rendered every `charts/n8n/ci/*.yaml` values file and validated with kubeconform strict.
- `helm unittest charts/n8n` (65 tests, 9 suites)
- `ah lint -p charts/n8n`
- `kubescape scan framework nsa` on rendered manifests (score 90)

## k3d validation
- Cluster/context: `k3d-helmforge-tests-wsl`
- Scenarios: SQLite default, PostgreSQL subchart, MySQL subchart, queue mode with PostgreSQL + Redis subcharts
- Smoke tests: `/healthz` or `/healthz/readiness` returned `status: ok`
- All pods reached Ready with 0 restarts
- Checked all pod/init container logs and Kubernetes events; no errors or non-normal events
- Removed all validation namespaces after testing