### PR TITLE
feat(mariadb)!: isolate datadir from volume root

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB for Kubernetes with explicit standalone and replication modes
 type: application
-version: 1.1.9
+version: 2.0.0
 appVersion: "12.2.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "repair mysqld exporter authentication (#325)"
+    - kind: changed
+      description: "BREAKING: mount the MariaDB datadir from persistence.subPath by default to keep ext4 lost+found outside the datadir (#420)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mariadb/DESIGN.md
+++ b/charts/mariadb/DESIGN.md
@@ -1,0 +1,115 @@
+# MariaDB Chart Design
+
+## Scope
+
+This chart provides MariaDB deployments for Kubernetes using the official
+MariaDB image. It supports two operating modes:
+
+- `standalone`: one writable MariaDB pod backed by one PVC
+- `replication`: one fixed writable source plus asynchronous read replicas
+
+The chart focuses on practical Helm-native operation. It does not implement
+operator-style failover, promotion, fencing, or automated data migration.
+
+## Architecture: Standalone
+
+```mermaid
+flowchart LR
+  app[Application pods] --> svc[Client Service]
+  svc --> db[MariaDB StatefulSet pod-0]
+  db --> pvc[(PVC)]
+  db --> cfg[Generated my.cnf]
+  db --> secret[Password Secret]
+  eso[External Secrets Operator optional] -. materializes .-> secret
+```
+
+Standalone mode is intended for development, internal services, and production
+workloads where restore-based recovery is acceptable.
+
+## Architecture: Replication
+
+```mermaid
+flowchart TB
+  write[Write clients] --> sourceSvc[Source Service]
+  read[Read clients] --> replicaSvc[Replicas Service]
+
+  sourceSvc --> source[Source StatefulSet pod-0]
+  replicaSvc --> replica0[Replica StatefulSet pod-0]
+  replicaSvc --> replica1[Replica StatefulSet pod-1]
+
+  source -. GTID async replication .-> replica0
+  source -. GTID async replication .-> replica1
+
+  source --> sourcePVC[(Source PVC)]
+  replica0 --> replicaPVC0[(Replica PVC 0)]
+  replica1 --> replicaPVC1[(Replica PVC 1)]
+```
+
+Replication mode is read scaling and recovery assistance, not automatic HA. The
+source is fixed and promotion remains an operational procedure outside this
+chart.
+
+## Datadir Mount Strategy
+
+The chart mounts the MariaDB datadir at `/var/lib/mysql` from
+`persistence.subPath` by default. This keeps ext4 `lost+found` out of the
+datadir on new PVCs.
+
+Default:
+
+```yaml
+persistence:
+  subPath: mysql
+```
+
+Legacy behavior for existing installations:
+
+```yaml
+persistence:
+  subPath: ""
+```
+
+This is intentionally global instead of per-role. A single setting keeps
+standalone, source, and replica data paths consistent and avoids unnecessary API
+surface.
+
+## Production Controls
+
+Production installations should explicitly configure:
+
+- `auth.existingSecret`
+- `externalSecrets.enabled`
+- `tls.enabled`
+- `networkPolicy.enabled`
+- `backup.enabled`
+- `metrics.enabled`
+- `resources` or resource presets
+- scheduling constraints and disruption budgets
+
+## Non-Goals
+
+- automatic source promotion
+- failover orchestration
+- fencing or split-brain prevention
+- online data migration between datadir layouts
+- bundled proxy/router layer
+- installing External Secrets Operator or Prometheus Operator
+
+<!-- @AI-METADATA
+type: design
+title: MariaDB Chart Design
+description: Design document for the MariaDB Helm chart with standalone, replication, and datadir subPath decisions
+
+keywords: mariadb, design, replication, datadir, subPath, lost+found
+
+purpose: Document architecture, design choices, production controls, and non-goals for the MariaDB chart
+scope: Chart
+
+relations:
+  - charts/mariadb/values.yaml
+  - charts/mariadb/templates/statefulset-source.yaml
+  - charts/mariadb/templates/statefulset-replicas.yaml
+path: charts/mariadb/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -4,6 +4,24 @@
 
 Helm chart for deploying [MariaDB](https://mariadb.org/) on Kubernetes using the official [`mariadb`](https://hub.docker.com/_/mariadb) Docker image. Supports standalone and GTID-based replication architectures.
 
+## Breaking Change in 2.0.0
+
+MariaDB now mounts `/var/lib/mysql` from the data volume subdirectory configured
+by `persistence.subPath` instead of the volume root. The default is `mysql`.
+This prevents ext4-backed PVCs from exposing the filesystem-created
+`lost+found` directory to MariaDB as a candidate database.
+
+Existing installations whose data already lives at the volume root must set the
+legacy value during upgrade:
+
+```yaml
+persistence:
+  subPath: ""
+```
+
+Alternatively, migrate the existing volume-root data into the `mysql`
+subdirectory before upgrading.
+
 ## Supported Architectures
 
 | Architecture | Description |
@@ -24,6 +42,7 @@ Helm chart for deploying [MariaDB](https://mariadb.org/) on Kubernetes using the
 - **S3-compatible backup** CronJob with mariadb-dump and minio/mc upload
 - **NetworkPolicy** for ingress traffic control
 - **PodDisruptionBudget** for availability during maintenance
+- **Datadir subPath isolation** to keep ext4 `lost+found` out of MariaDB logs
 - **Password management** auto-generated or from existing Secret
 - **Dual-stack networking** — IPv4/IPv6 service support across all 6 Service objects
 - **External Secrets Operator** — ExternalSecret for Vault, AWS Secrets Manager, and more
@@ -63,7 +82,7 @@ replication:
 |-----|---------|-------------|
 | `architecture` | `standalone` | Deployment mode: standalone or replication |
 | `image.repository` | `mariadb` | MariaDB image |
-| `image.tag` | `11.4` | MariaDB version (LTS) |
+| `image.tag` | `12.2.2` | MariaDB version |
 | `auth.rootPassword` | `""` | Root password (auto-generated if empty) |
 | `auth.database` | `app` | Application database |
 | `auth.username` | `app` | Application user |
@@ -72,9 +91,13 @@ replication:
 | `auth.existingSecret` | `""` | Existing secret with passwords |
 | `config.preset` | `none` | Configuration preset |
 | `config.myCnf` | `""` | Extra my.cnf content |
+| `persistence.subPath` | `mysql` | Data volume subdirectory mounted as `/var/lib/mysql`; set `""` for legacy volume-root installs |
+| `standalone.resourcesPreset` | `small` | Default standalone resource requests and limits |
 | `standalone.persistence.size` | `8Gi` | Standalone PVC size |
+| `replication.source.resourcesPreset` | `small` | Default source resource requests and limits |
 | `replication.source.persistence.size` | `20Gi` | Source PVC size |
 | `replication.readReplicas.replicaCount` | `2` | Number of read replicas |
+| `replication.readReplicas.resourcesPreset` | `small` | Default replica resource requests and limits |
 | `replication.readReplicas.persistence.size` | `20Gi` | Replica PVC size |
 | `replication.binlog.format` | `ROW` | Binlog format |
 | `service.type` | `ClusterIP` | Service type |
@@ -106,6 +129,34 @@ service:
     - IPv4
     - IPv6
 ```
+
+## Datadir SubPath and lost+found
+
+Kubernetes storage classes often format PVCs as ext4. ext4 creates
+`lost+found` at the filesystem root, and MariaDB scans every datadir
+subdirectory as a database. Mounting the PVC root at `/var/lib/mysql` can
+therefore produce this non-fatal but noisy log line:
+
+```text
+Invalid (old?) table or database name 'lost+found'
+```
+
+The chart avoids that on new installs by mounting the `mysql` subdirectory as
+the datadir:
+
+```yaml
+persistence:
+  subPath: mysql
+```
+
+For existing installations with data at the PVC root, keep the legacy behavior:
+
+```yaml
+persistence:
+  subPath: ""
+```
+
+See [docs/datadir-subpath.md](docs/datadir-subpath.md) for upgrade guidance.
 
 ## External Secrets Operator (ESO)
 
@@ -154,6 +205,7 @@ This chart uses MariaDB-native features:
 | `replication-metrics.yaml` | Replication with metrics |
 | `config-preset.yaml` | OLTP config preset |
 | `resources-preset.yaml` | Resource presets for replication |
+| `legacy-volume-root.yaml` | Legacy datadir mount for existing volume-root installs |
 | `tls.yaml` | TLS with existingSecret |
 | `tls-networkpolicy.yaml` | TLS + replication + NetworkPolicy |
 | `backup.yaml` | Backup with S3 |
@@ -164,6 +216,7 @@ This chart uses MariaDB-native features:
 
 - [MariaDB documentation](https://mariadb.com/kb/en/)
 - [Chart source](https://github.com/helmforgedev/charts/tree/main/charts/mariadb)
+- [Datadir subPath migration](docs/datadir-subpath.md)
 
 <!-- @AI-METADATA
 type: chart-readme
@@ -179,6 +232,6 @@ relations:
   - charts/mariadb/values.yaml
   - charts/mysql/README.md
 path: charts/mariadb/README.md
-version: 1.0
-date: 2026-04-30
+version: 2.0
+date: 2026-06-02
 -->

--- a/charts/mariadb/ci/legacy-volume-root.yaml
+++ b/charts/mariadb/ci/legacy-volume-root.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI scenario: legacy volume-root datadir for existing installs upgrading from 1.x.
+architecture: standalone
+persistence:
+  subPath: ""

--- a/charts/mariadb/docs/datadir-subpath.md
+++ b/charts/mariadb/docs/datadir-subpath.md
@@ -1,0 +1,101 @@
+# MariaDB Datadir SubPath
+
+## Summary
+
+MariaDB 2.0.0 changes the default datadir mount to use a data volume
+subdirectory:
+
+```yaml
+persistence:
+  subPath: mysql
+```
+
+This keeps ext4 `lost+found` out of `/var/lib/mysql`.
+
+## Why This Changed
+
+Many Kubernetes storage classes format PVCs as ext4. ext4 creates a
+`lost+found` directory at the filesystem root. When the PVC root is mounted
+directly as `/var/lib/mysql`, MariaDB scans `lost+found` as if it were a
+database directory and logs:
+
+```text
+Invalid (old?) table or database name 'lost+found'
+```
+
+The database can still start, but the log entry repeats on restarts and hides
+real operational signal.
+
+## New Installs
+
+Use the default:
+
+```yaml
+persistence:
+  subPath: mysql
+```
+
+The chart mounts the `mysql` subdirectory as `/var/lib/mysql`, so the
+filesystem root and its `lost+found` directory remain outside the MariaDB
+datadir.
+
+## Existing Installs
+
+If the existing data lives at the volume root, set:
+
+```yaml
+persistence:
+  subPath: ""
+```
+
+This preserves the previous mount layout. Without this override, MariaDB will
+look in the new `mysql` subdirectory and the database can appear empty.
+
+## Migration Option
+
+To adopt the new default for an existing install, migrate the PVC contents from
+the volume root into the configured subdirectory before upgrading. The exact
+procedure depends on the storage class, backup policy, and maintenance window.
+
+Recommended approach:
+
+1. Take and verify a backup.
+2. Stop application writes.
+3. Stop MariaDB.
+4. Move existing datadir contents into the `mysql` subdirectory, excluding
+   filesystem-managed entries such as `lost+found`.
+5. Upgrade with `persistence.subPath: mysql`.
+6. Validate pod readiness, application connectivity, and logs.
+
+## Validation
+
+After upgrade, check:
+
+```bash
+kubectl get pods -n <namespace> -l app.kubernetes.io/instance=<release>
+kubectl logs -n <namespace> <statefulset-name>-0 -c mariadb --tail=100
+```
+
+Expected result:
+
+- no `Invalid (old?) table or database name 'lost+found'` log entry
+- MariaDB readiness succeeds
+- application tables are present
+
+<!-- @AI-METADATA
+type: chart-docs
+title: MariaDB Datadir SubPath
+description: Migration and operations guidance for the MariaDB persistence.subPath breaking change
+
+keywords: mariadb, datadir, subPath, lost+found, migration, upgrade
+
+purpose: Explain the MariaDB 2.0.0 datadir subPath behavior and migration options
+scope: Chart
+
+relations:
+  - charts/mariadb/values.yaml
+  - charts/mariadb/DESIGN.md
+path: charts/mariadb/docs/datadir-subpath.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/mariadb/examples/legacy-volume-root-upgrade.yaml
+++ b/charts/mariadb/examples/legacy-volume-root-upgrade.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Use this only for existing installs whose MariaDB data already lives at the PVC root.
+persistence:
+  subPath: ""

--- a/charts/mariadb/templates/NOTES.txt
+++ b/charts/mariadb/templates/NOTES.txt
@@ -1,72 +1,132 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-MariaDB has been installed.
+{{- $namespace := .Release.Namespace -}}
+{{- $datadirSubPath := .Values.persistence.subPath -}}
+1. MariaDB has been installed
+=============================
+  Release:         {{ .Release.Name }}
+  Namespace:       {{ $namespace }}
+  Architecture:    {{ .Values.architecture }}
+  Chart Version:   {{ .Chart.Version }}
+  App Version:     {{ .Chart.AppVersion }}
+  Datadir subPath: {{- if $datadirSubPath }} {{ $datadirSubPath }}{{- else }} volume root (legacy){{- end }}
 
-Useful Services:
-
-- Client Service: {{ include "mariadb.clientServiceName" . }}
-{{- if .Values.metrics.enabled }}
-- Metrics Service: {{ include "mariadb.metricsServiceName" . }}
-{{- end }}
+2. Services
+===========
+  Client Service: {{ include "mariadb.clientServiceName" . }}:{{ .Values.service.port }}
 {{- if eq .Values.architecture "replication" }}
-- Source Service: {{ include "mariadb.sourceServiceName" . }}
-- Replicas Service: {{ include "mariadb.replicasServiceName" . }}
+  Source Service: {{ include "mariadb.sourceServiceName" . }}:{{ .Values.service.port }}
+  Read Service:   {{ include "mariadb.replicasServiceName" . }}:{{ .Values.service.port }}
+{{- end }}
 {{- if .Values.metrics.enabled }}
-- Source Metrics Service: {{ include "mariadb.sourceMetricsServiceName" . }}
-- Replicas Metrics Service: {{ include "mariadb.replicasMetricsServiceName" . }}
+  Metrics Service: {{ include "mariadb.metricsServiceName" . }}:{{ .Values.service.metricsPort }}
+{{- if eq .Values.architecture "replication" }}
+  Source Metrics:  {{ include "mariadb.sourceMetricsServiceName" . }}:{{ .Values.service.metricsPort }}
+  Replica Metrics: {{ include "mariadb.replicasMetricsServiceName" . }}:{{ .Values.service.metricsPort }}
 {{- end }}
 {{- end }}
 
+3. Credentials
+==============
 Root password:
+  kubectl get secret {{ include "mariadb.secretName" . }} -n {{ $namespace }} \
+    -o jsonpath="{.data.{{ .Values.auth.existingSecretRootPasswordKey }}}" | base64 -d
 
-  kubectl get secret {{ include "mariadb.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.existingSecretRootPasswordKey }}}" | base64 -d
+Application password:
+  kubectl get secret {{ include "mariadb.secretName" . }} -n {{ $namespace }} \
+    -o jsonpath="{.data.{{ .Values.auth.existingSecretUserPasswordKey }}}" | base64 -d
+
+4. Connect
+==========
+Port-forward:
+  kubectl port-forward -n {{ $namespace }} svc/{{ include "mariadb.clientServiceName" . }} 3306:{{ .Values.service.port }}
+
+Connect as application user:
+  mariadb -h 127.0.0.1 -P 3306 -u {{ .Values.auth.username }} -p {{ .Values.auth.database }}
+
+Connect as root:
+  mariadb -h 127.0.0.1 -P 3306 -uroot -p
+
+{{- if eq .Values.architecture "replication" }}
+Read-only workloads should use:
+  mariadb -h {{ include "mariadb.replicasServiceName" . }} -P {{ .Values.service.port }} -u {{ .Values.auth.username }} -p {{ .Values.auth.database }}
+
+Writable workloads should use:
+  mariadb -h {{ include "mariadb.sourceServiceName" . }} -P {{ .Values.service.port }} -u {{ .Values.auth.username }} -p {{ .Values.auth.database }}
+{{- end }}
+
+5. Configuration Summary
+========================
+  TLS:              {{- if .Values.tls.enabled }} enabled{{- else }} disabled{{- end }}
+  Metrics:          {{- if .Values.metrics.enabled }} enabled{{- else }} disabled{{- end }}
+  Backup:           {{- if .Values.backup.enabled }} enabled{{- else }} disabled{{- end }}
+  NetworkPolicy:    {{- if .Values.networkPolicy.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets: {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+  PDB:              {{- if include "mariadb.pdbEnabled" . }} enabled{{- else }} disabled{{- end }}
+
+{{- if .Values.externalSecrets.enabled }}
+ExternalSecret:
+  SecretStore:   {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
+  Target Secret: {{ include "mariadb.secretName" . }}
+  Refresh:       {{ .Values.externalSecrets.refreshInterval }}
+{{- end }}
+
 {{- if .Values.tls.enabled }}
-
 TLS secret:
-
   {{ include "mariadb.tlsSecretName" . }}
 {{- end }}
 
-Connection examples:
+6. Breaking Change: Datadir subPath
+===================================
+MariaDB now mounts the data volume subdirectory configured by
+`persistence.subPath` as `/var/lib/mysql`. The default is `mysql`, which keeps
+ext4 `lost+found` out of the MariaDB datadir on new installs.
 
-  mariadb -h {{ include "mariadb.clientServiceName" . }} -P {{ .Values.service.port }} -u {{ .Values.auth.username }} -p
+Existing installs whose data already lives at the volume root must set:
+  persistence.subPath: ""
+
+Alternatively, migrate the existing volume-root data into the configured
+subdirectory before upgrading.
+
+7. Validation Commands
+======================
+Check pods:
+  kubectl get pods -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Check logs:
+  kubectl logs -n {{ $namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0 -c mariadb --tail=100
 {{- if eq .Values.architecture "replication" }}
-
-Read-only workloads should use:
-
-  mariadb -h {{ include "mariadb.replicasServiceName" . }} -P {{ .Values.service.port }} -u {{ .Values.auth.username }} -p
-
-Writable workloads should use:
-
-  mariadb -h {{ include "mariadb.sourceServiceName" . }} -P {{ .Values.service.port }} -u {{ .Values.auth.username }} -p
+  kubectl logs -n {{ $namespace }} {{ include "mariadb.replicaStatefulSetName" . }}-0 -c mariadb --tail=100
 {{- end }}
-
-Initial troubleshooting:
-
-  kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
-  kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0
 {{- if .Values.metrics.enabled }}
-  kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0 -c mysqld-exporter
-{{- end }}
-{{- if eq .Values.architecture "replication" }}
-  kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.replicaStatefulSetName" . }}-0
-{{- if .Values.metrics.enabled }}
-  kubectl logs -n {{ .Release.Namespace }} {{ include "mariadb.replicaStatefulSetName" . }}-0 -c mysqld-exporter
-{{- end }}
+  kubectl logs -n {{ $namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0 -c mysqld-exporter --tail=100
 {{- end }}
 
-{{- if .Values.externalSecrets.enabled }}
+Check readiness from inside the source pod:
+  kubectl exec -n {{ $namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0 -c mariadb -- \
+    sh -ec 'mariadb-admin ping -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="$MARIADB_ROOT_PASSWORD"'
 
-ExternalSecrets:
+8. Troubleshooting
+==================
+  lost+found log entry:
+    -> New installs should use persistence.subPath=mysql (default).
+    -> Existing installs should set persistence.subPath="" until data is migrated.
 
-  SecretStore: {{ .Values.externalSecrets.secretStoreRef.name }} ({{ .Values.externalSecrets.secretStoreRef.kind }})
-  Target Secret: {{ include "mariadb.secretName" . }}
-  Refresh: {{ .Values.externalSecrets.refreshInterval }}
-{{- end }}
+  Database appears empty after upgrade:
+    -> The data probably remains at the PVC root while persistence.subPath=mysql is active.
+    -> Roll back or set persistence.subPath="" before investigating migration.
 
-Important:
+  Pod not ready:
+    -> Check MariaDB logs and events:
+       kubectl describe pod -n {{ $namespace }} {{ include "mariadb.sourceStatefulSetName" . }}-0
 
-- replication mode provides one fixed source and asynchronous read replicas
-- the chart does not implement automatic source promotion or operator-style HA
-- default values are suitable for development; production installs should provide external credentials, persistence, TLS, NetworkPolicy, resources, backups, and operational runbooks
+  Replication not catching up:
+    -> Check source and replica logs.
+    -> Verify the replication user password is stable across upgrades.
+
+9. Documentation
+================
+  HelmForge docs: https://helmforge.dev/docs/charts/mariadb
+  Chart source:   https://github.com/helmforgedev/charts/tree/main/charts/mariadb
+  MariaDB docs:   https://mariadb.com/kb/en/
 
 Happy Helmforging :)

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -186,7 +186,7 @@ mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="${MARIADB_
 
 {{- define "mariadb.replicaReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") (or .Values.replication.readReplicas.probes.requireReadOnly .Values.replication.readReplicas.probes.requireRunningReplication) -}}
-mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(CAST(@@global.read_only AS CHAR) IN ('ON', '1'){{- if .Values.replication.readReplicas.probes.requireRunningReplication }} AND EXISTS (SELECT 1 FROM information_schema.processlist WHERE command = 'Binlog Dump') IS NOT NULL{{- end }}, 1, 0)" | grep -qx 1
+test -f /tmp/helmforge-replication-started && mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(CAST(@@global.read_only AS CHAR) IN ('ON', '1'){{- if .Values.replication.readReplicas.probes.requireRunningReplication }} AND EXISTS (SELECT 1 FROM information_schema.processlist WHERE command = 'Binlog Dump') IS NOT NULL{{- end }}, 1, 0)" | grep -qx 1
 {{- else -}}
 {{ include "mariadb.replicaProbeCommandString" . }}
 {{- end -}}

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -262,6 +262,9 @@ test -f /tmp/helmforge-replication-started && mariadb --socket=/run/mysqld/mysql
 
 {{- define "mariadb.prepareDataSubPathInitContainer" -}}
 {{- with .Values.persistence.subPath }}
+{{- $runAsUser := int (default 999 $.Values.securityContext.runAsUser) }}
+{{- $runAsGroup := int (default $runAsUser $.Values.securityContext.runAsGroup) }}
+{{- $fsGroup := int (default $runAsGroup $.Values.podSecurityContext.fsGroup) }}
 - name: prepare-datadir-subpath
   image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
   imagePullPolicy: {{ $.Values.image.pullPolicy }}
@@ -270,7 +273,8 @@ test -f /tmp/helmforge-replication-started && mariadb --socket=/run/mysqld/mysql
     - -ec
     - |
       mkdir -p "/mnt/data/{{ . }}"
-      chown 999:999 "/mnt/data/{{ . }}"
+      chmod 2770 "/mnt/data/{{ . }}"
+      chown {{ $runAsUser }}:{{ $fsGroup }} "/mnt/data/{{ . }}"
   securityContext:
     runAsUser: 0
     runAsGroup: 0
@@ -280,6 +284,7 @@ test -f /tmp/helmforge-replication-started && mariadb --socket=/run/mysqld/mysql
     capabilities:
       add:
         - CHOWN
+        - FOWNER
       drop:
         - ALL
   volumeMounts:

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -178,7 +178,7 @@ mariadb-admin ping --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB
 
 {{- define "mariadb.sourceReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") .Values.replication.source.probes.requireWritable -}}
-mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(@@global.read_only IN ('OFF', '0'), 1, 0)" | grep -qx 1
+mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(CAST(@@global.read_only AS CHAR) IN ('OFF', '0'), 1, 0)" | grep -qx 1
 {{- else -}}
 {{ include "mariadb.probeCommandString" . }}
 {{- end -}}
@@ -186,7 +186,7 @@ mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="${MARIADB_
 
 {{- define "mariadb.replicaReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") (or .Values.replication.readReplicas.probes.requireReadOnly .Values.replication.readReplicas.probes.requireRunningReplication) -}}
-mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(@@global.read_only IN ('ON', '1'){{- if .Values.replication.readReplicas.probes.requireRunningReplication }} AND EXISTS (SELECT 1 FROM information_schema.processlist WHERE command = 'Binlog Dump') IS NOT NULL{{- end }}, 1, 0)" | grep -qx 1
+mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(CAST(@@global.read_only AS CHAR) IN ('ON', '1'){{- if .Values.replication.readReplicas.probes.requireRunningReplication }} AND EXISTS (SELECT 1 FROM information_schema.processlist WHERE command = 'Binlog Dump') IS NOT NULL{{- end }}, 1, 0)" | grep -qx 1
 {{- else -}}
 {{ include "mariadb.replicaProbeCommandString" . }}
 {{- end -}}

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -169,12 +169,16 @@ app.kubernetes.io/role: {{ .role }}
 {{- end -}}
 
 {{- define "mariadb.probeCommandString" -}}
-MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb-admin ping -h 127.0.0.1 -P {{ .Values.service.port }} -uroot
+mariadb-admin ping -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}"
+{{- end -}}
+
+{{- define "mariadb.replicaProbeCommandString" -}}
+mariadb-admin ping --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}"
 {{- end -}}
 
 {{- define "mariadb.sourceReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") .Values.replication.source.probes.requireWritable -}}
-MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot -Nse "SELECT IF(@@global.read_only = 0, 1, 0)" | grep -qx 1
+mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(@@global.read_only IN ('OFF', '0'), 1, 0)" | grep -qx 1
 {{- else -}}
 {{ include "mariadb.probeCommandString" . }}
 {{- end -}}
@@ -182,9 +186,9 @@ MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb -h 127.0.0.1 -P {{ .Values.service.
 
 {{- define "mariadb.replicaReadinessCommandString" -}}
 {{- if and (eq .Values.architecture "replication") (or .Values.replication.readReplicas.probes.requireReadOnly .Values.replication.readReplicas.probes.requireRunningReplication) -}}
-MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb -h 127.0.0.1 -P {{ .Values.service.port }} -uroot -Nse "SELECT IF(@@global.read_only = 1{{- if .Values.replication.readReplicas.probes.requireRunningReplication }} AND EXISTS (SELECT 1 FROM information_schema.processlist WHERE command = 'Binlog Dump') IS NOT NULL{{- end }}, 1, 0)" | grep -qx 1
+mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT IF(@@global.read_only IN ('ON', '1'){{- if .Values.replication.readReplicas.probes.requireRunningReplication }} AND EXISTS (SELECT 1 FROM information_schema.processlist WHERE command = 'Binlog Dump') IS NOT NULL{{- end }}, 1, 0)" | grep -qx 1
 {{- else -}}
-{{ include "mariadb.probeCommandString" . }}
+{{ include "mariadb.replicaProbeCommandString" . }}
 {{- end -}}
 {{- end -}}
 
@@ -246,6 +250,14 @@ MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb -h 127.0.0.1 -P {{ .Values.service.
   mountPath: /tls
   readOnly: true
 {{- end }}
+{{- end -}}
+
+{{- define "mariadb.dataVolumeMount" -}}
+- name: data
+  mountPath: /var/lib/mysql
+  {{- with .Values.persistence.subPath }}
+  subPath: {{ . | quote }}
+  {{- end }}
 {{- end -}}
 
 {{- define "mariadb.tlsClientEnabled" -}}

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -260,6 +260,34 @@ test -f /tmp/helmforge-replication-started && mariadb --socket=/run/mysqld/mysql
   {{- end }}
 {{- end -}}
 
+{{- define "mariadb.prepareDataSubPathInitContainer" -}}
+{{- with .Values.persistence.subPath }}
+- name: prepare-datadir-subpath
+  image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+  imagePullPolicy: {{ $.Values.image.pullPolicy }}
+  command:
+    - sh
+    - -ec
+    - |
+      mkdir -p "/mnt/data/{{ . }}"
+      chown 999:999 "/mnt/data/{{ . }}"
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    runAsNonRoot: false
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      add:
+        - CHOWN
+      drop:
+        - ALL
+  volumeMounts:
+    - name: data
+      mountPath: /mnt/data
+{{- end }}
+{{- end -}}
+
 {{- define "mariadb.tlsClientEnabled" -}}
 {{- if or .Values.tls.client.enabled .Values.tls.requireSecureTransport -}}true{{- end -}}
 {{- end -}}

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
       {{- include "mariadb.podSpecCommon" . | nindent 6 }}
       initContainers:
+        {{- include "mariadb.prepareDataSubPathInitContainer" . | nindent 8 }}
         - name: clone-source
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -56,13 +56,17 @@ spec:
                   mariadb-admin --socket=/tmp/mysql.sock -uroot shutdown
                 fi
               }
+              wait_local_socket() {
+                until [ -S /tmp/mysql.sock ]; do
+                  sleep 2
+                done
+                sleep 2
+              }
               if [ -d "${DATA_DIR}/mysql" ]; then
                 mariadbd --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking --read-only=OFF &
                 LOCAL_SERVER_STARTED=true
 
-                until mariadb-admin --socket=/tmp/mysql.sock ping --silent; do
-                  sleep 2
-                done
+                wait_local_socket
 
                 if mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT 1" >/dev/null 2>&1; then
                   LOCAL_ROOT_PASSWORD_REQUIRED=true
@@ -105,9 +109,7 @@ spec:
               if [ "${LOCAL_SERVER_STARTED}" = "false" ]; then
                 mariadbd --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking --read-only=OFF &
 
-                until mariadb-admin --socket=/tmp/mysql.sock ping --silent; do
-                  sleep 2
-                done
+                wait_local_socket
               fi
 
               local_mariadb <<EOSQL
@@ -119,46 +121,37 @@ spec:
               DELETE FROM mysql.global_priv WHERE User = '';
               DELETE FROM mysql.proxies_priv WHERE User = '' OR Proxied_user = '';
               DROP USER IF EXISTS 'root'@'${HOSTNAME}';
-              CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              CREATE OR REPLACE USER 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
-              CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              CREATE OR REPLACE USER 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
               FLUSH PRIVILEGES;
               EOSQL
               LOCAL_ROOT_PASSWORD_REQUIRED=true
 
-              DATABASES="$(mariadb \
+              GTID_SQL=""
+
+              mariadb-dump \
                 -h {{ include "mariadb.sourceServiceName" . }} \
                 -P {{ .Values.service.port }} \
                 -uroot \
                 --password="${MARIADB_ROOT_PASSWORD}" \
                 {{ include "mariadb.cliTlsArgs" . }} \
-                -Nse "SHOW DATABASES WHERE \`Database\` NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')")"
-              GTID_SQL=""
+                --single-transaction \
+                --gtid \
+                --master-data=2 \
+                --all-databases \
+                --triggers \
+                --routines \
+                --events \
+                > /tmp/source.sql
 
-              if [ -n "${DATABASES}" ]; then
-                mariadb-dump \
-                  -h {{ include "mariadb.sourceServiceName" . }} \
-                  -P {{ .Values.service.port }} \
-                  -uroot \
-                  --password="${MARIADB_ROOT_PASSWORD}" \
-                  {{ include "mariadb.cliTlsArgs" . }} \
-                  --single-transaction \
-                  --gtid \
-                  --master-data=2 \
-                  --databases ${DATABASES} \
-                  --triggers \
-                  --routines \
-                  --events \
-                  > /tmp/source.sql
-
-                SOURCE_GTID="$(sed -n "s/^-- SET GLOBAL gtid_slave_pos='\([^']*\)'.*/\1/p; s/^SET GLOBAL gtid_slave_pos='\([^']*\)'.*/\1/p" /tmp/source.sql | tail -n 1)"
-                if [ -n "${SOURCE_GTID}" ]; then
-                  GTID_SQL="SET GLOBAL gtid_slave_pos='${SOURCE_GTID}';"
-                fi
-
-                local_mariadb < /tmp/source.sql
+              SOURCE_GTID="$(sed -n "s/^-- SET GLOBAL gtid_slave_pos='\([^']*\)'.*/\1/p; s/^SET GLOBAL gtid_slave_pos='\([^']*\)'.*/\1/p" /tmp/source.sql | tail -n 1)"
+              if [ -n "${SOURCE_GTID}" ]; then
+                GTID_SQL="SET GLOBAL gtid_slave_pos='${SOURCE_GTID}';"
               fi
+
+              local_mariadb < /tmp/source.sql
 
               local_mariadb <<EOSQL
               SET GLOBAL read_only = OFF;
@@ -169,9 +162,9 @@ spec:
               DELETE FROM mysql.global_priv WHERE User = '';
               DELETE FROM mysql.proxies_priv WHERE User = '' OR Proxied_user = '';
               DROP USER IF EXISTS 'root'@'${HOSTNAME}';
-              CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              CREATE OR REPLACE USER 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
-              CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              CREATE OR REPLACE USER 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
               CREATE DATABASE IF NOT EXISTS \`${MARIADB_DATABASE}\`;
               CREATE USER IF NOT EXISTS '${MARIADB_USER}'@'%' IDENTIFIED BY '${MARIADB_PASSWORD}';
@@ -233,6 +226,8 @@ spec:
             - sh
             - -ec
             - |
+              REPLICATION_READY_MARKER="/tmp/helmforge-replication-started"
+              rm -f "${REPLICATION_READY_MARKER}"
               ordinal="${HOSTNAME##*-}"
               server_id=$(( {{ .Values.replication.readReplicas.serverIdBase }} + ordinal + 1 ))
               cat /config/my.cnf > /etc/mysql/conf.d/zz-chart.cnf
@@ -261,6 +256,7 @@ spec:
               if ! printf "%s\n" "${status}" | grep -q "Slave_SQL_Running: Yes"; then
                 mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -e "START SLAVE;"
               fi
+              touch "${REPLICATION_READY_MARKER}"
               wait "${pid}"
           ports:
             - name: mariadb
@@ -293,7 +289,7 @@ spec:
                 - sh
                 - -ec
                 - {{ include "mariadb.replicaReadinessCommandString" . | quote }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            initialDelaySeconds: {{ max 60 (int .Values.readinessProbe.initialDelaySeconds) }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -134,17 +134,7 @@ spec:
                 --password="${MARIADB_ROOT_PASSWORD}" \
                 {{ include "mariadb.cliTlsArgs" . }} \
                 -Nse "SHOW DATABASES WHERE \`Database\` NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')")"
-              SOURCE_GTID="$(mariadb \
-                -h {{ include "mariadb.sourceServiceName" . }} \
-                -P {{ .Values.service.port }} \
-                -uroot \
-                --password="${MARIADB_ROOT_PASSWORD}" \
-                {{ include "mariadb.cliTlsArgs" . }} \
-                -Nse "SELECT @@global.gtid_binlog_pos")"
               GTID_SQL=""
-              if [ -n "${SOURCE_GTID}" ]; then
-                GTID_SQL="SET GLOBAL gtid_slave_pos='${SOURCE_GTID}';"
-              fi
 
               if [ -n "${DATABASES}" ]; then
                 mariadb-dump \
@@ -155,11 +145,17 @@ spec:
                   {{ include "mariadb.cliTlsArgs" . }} \
                   --single-transaction \
                   --gtid \
+                  --master-data=2 \
                   --databases ${DATABASES} \
                   --triggers \
                   --routines \
                   --events \
                   > /tmp/source.sql
+
+                SOURCE_GTID="$(sed -n "s/^-- SET GLOBAL gtid_slave_pos='\([^']*\)'.*/\1/p; s/^SET GLOBAL gtid_slave_pos='\([^']*\)'.*/\1/p" /tmp/source.sql | tail -n 1)"
+                if [ -n "${SOURCE_GTID}" ]; then
+                  GTID_SQL="SET GLOBAL gtid_slave_pos='${SOURCE_GTID}';"
+                fi
 
                 local_mariadb < /tmp/source.sql
               fi

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -40,6 +40,10 @@ spec:
               if [ -f "${CLONE_MARKER}" ]; then
                 exit 0
               fi
+              if [ -d "${DATA_DIR}/mysql" ]; then
+                touch "${CLONE_MARKER}"
+                exit 0
+              fi
 
               ordinal="${HOSTNAME##*-}"
               server_id=$(( {{ .Values.replication.readReplicas.serverIdBase }} + ordinal + 1 ))

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -40,9 +40,40 @@ spec:
               if [ -f "${CLONE_MARKER}" ]; then
                 exit 0
               fi
+              LOCAL_SERVER_STARTED=false
+              LOCAL_ROOT_PASSWORD_REQUIRED=false
+              local_mariadb() {
+                if [ "${LOCAL_ROOT_PASSWORD_REQUIRED}" = "true" ]; then
+                  mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" "$@"
+                else
+                  mariadb --socket=/tmp/mysql.sock -uroot "$@"
+                fi
+              }
+              local_admin_shutdown() {
+                if [ "${LOCAL_ROOT_PASSWORD_REQUIRED}" = "true" ]; then
+                  mariadb-admin --socket=/tmp/mysql.sock -uroot -p"${MARIADB_ROOT_PASSWORD}" shutdown
+                else
+                  mariadb-admin --socket=/tmp/mysql.sock -uroot shutdown
+                fi
+              }
               if [ -d "${DATA_DIR}/mysql" ]; then
-                touch "${CLONE_MARKER}"
-                exit 0
+                mariadbd --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking --read-only=OFF &
+                LOCAL_SERVER_STARTED=true
+
+                until mariadb-admin --socket=/tmp/mysql.sock ping --silent; do
+                  sleep 2
+                done
+
+                if mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SELECT 1" >/dev/null 2>&1; then
+                  LOCAL_ROOT_PASSWORD_REQUIRED=true
+                fi
+
+                status="$(local_mariadb -Nse "SHOW SLAVE STATUS\\G" 2>/dev/null || true)"
+                if printf "%s\n" "${status}" | grep -Eq "Master_Host: .+"; then
+                  touch "${CLONE_MARKER}"
+                  local_admin_shutdown
+                  exit 0
+                fi
               fi
 
               ordinal="${HOSTNAME##*-}"
@@ -55,6 +86,7 @@ spec:
               read_only = ON
               relay_log = mariadb-relay-bin
               log_slave_updates = ON
+              skip_slave_start = ON
               slave_parallel_workers = {{ .Values.replication.replicaTuning.parallelWorkers }}
               EOF
 
@@ -70,13 +102,15 @@ spec:
                 mariadb-install-db --datadir="${DATA_DIR}" --auth-root-authentication-method=normal
               fi
 
-              mariadbd --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking --read-only=OFF &
+              if [ "${LOCAL_SERVER_STARTED}" = "false" ]; then
+                mariadbd --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking --read-only=OFF &
 
-              until mariadb-admin --socket=/tmp/mysql.sock ping --silent; do
-                sleep 2
-              done
+                until mariadb-admin --socket=/tmp/mysql.sock ping --silent; do
+                  sleep 2
+                done
+              fi
 
-              mariadb --socket=/tmp/mysql.sock -uroot <<EOSQL
+              local_mariadb <<EOSQL
               SET GLOBAL read_only = OFF;
               ALTER USER 'root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               DROP USER IF EXISTS ''@'localhost';
@@ -84,12 +118,14 @@ spec:
               DROP USER IF EXISTS ''@'%';
               DELETE FROM mysql.global_priv WHERE User = '';
               DELETE FROM mysql.proxies_priv WHERE User = '' OR Proxied_user = '';
+              DROP USER IF EXISTS 'root'@'${HOSTNAME}';
               CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
               CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
               FLUSH PRIVILEGES;
               EOSQL
+              LOCAL_ROOT_PASSWORD_REQUIRED=true
 
               DATABASES="$(mariadb \
                 -h {{ include "mariadb.sourceServiceName" . }} \
@@ -98,6 +134,17 @@ spec:
                 --password="${MARIADB_ROOT_PASSWORD}" \
                 {{ include "mariadb.cliTlsArgs" . }} \
                 -Nse "SHOW DATABASES WHERE \`Database\` NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')")"
+              SOURCE_GTID="$(mariadb \
+                -h {{ include "mariadb.sourceServiceName" . }} \
+                -P {{ .Values.service.port }} \
+                -uroot \
+                --password="${MARIADB_ROOT_PASSWORD}" \
+                {{ include "mariadb.cliTlsArgs" . }} \
+                -Nse "SELECT @@global.gtid_binlog_pos")"
+              GTID_SQL=""
+              if [ -n "${SOURCE_GTID}" ]; then
+                GTID_SQL="SET GLOBAL gtid_slave_pos='${SOURCE_GTID}';"
+              fi
 
               if [ -n "${DATABASES}" ]; then
                 mariadb-dump \
@@ -114,10 +161,10 @@ spec:
                   --events \
                   > /tmp/source.sql
 
-                mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" < /tmp/source.sql
+                local_mariadb < /tmp/source.sql
               fi
 
-              mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" <<EOSQL
+              local_mariadb <<EOSQL
               SET GLOBAL read_only = OFF;
               ALTER USER 'root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               DROP USER IF EXISTS ''@'localhost';
@@ -125,10 +172,16 @@ spec:
               DROP USER IF EXISTS ''@'%';
               DELETE FROM mysql.global_priv WHERE User = '';
               DELETE FROM mysql.proxies_priv WHERE User = '' OR Proxied_user = '';
+              DROP USER IF EXISTS 'root'@'${HOSTNAME}';
               CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
               CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
               GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
+              CREATE DATABASE IF NOT EXISTS \`${MARIADB_DATABASE}\`;
+              CREATE USER IF NOT EXISTS '${MARIADB_USER}'@'%' IDENTIFIED BY '${MARIADB_PASSWORD}';
+              ALTER USER '${MARIADB_USER}'@'%' IDENTIFIED BY '${MARIADB_PASSWORD}';
+              GRANT ALL PRIVILEGES ON \`${MARIADB_DATABASE}\`.* TO '${MARIADB_USER}'@'%';
+              ${GTID_SQL}
               CHANGE MASTER TO
                 MASTER_HOST='{{ include "mariadb.sourceServiceName" . }}',
                 MASTER_PORT={{ .Values.service.port }},
@@ -139,7 +192,7 @@ spec:
               EOSQL
 
               touch "${CLONE_MARKER}"
-              mariadb-admin --socket=/tmp/mysql.sock -uroot -p"${MARIADB_ROOT_PASSWORD}" shutdown
+              local_admin_shutdown
           env:
             - name: MARIADB_ROOT_PASSWORD
               valueFrom:
@@ -153,6 +206,13 @@ spec:
                   key: {{ .Values.auth.existingSecretReplicationPasswordKey }}
             - name: MARIADB_DATABASE
               value: {{ .Values.auth.database | quote }}
+            - name: MARIADB_USER
+              value: {{ .Values.auth.username | quote }}
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mariadb.secretName" . }}
+                  key: {{ .Values.auth.existingSecretUserPasswordKey }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
@@ -186,6 +246,7 @@ spec:
               read_only = ON
               relay_log = mariadb-relay-bin
               log_slave_updates = ON
+              skip_slave_start = ON
               slave_parallel_workers = {{ .Values.replication.replicaTuning.parallelWorkers }}
               EOF
               docker-entrypoint.sh mariadbd &
@@ -194,6 +255,10 @@ spec:
 
               until mariadb-admin ping --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" --silent; do
                 sleep 2
+              done
+
+              until mariadb-admin ping -h {{ include "mariadb.sourceServiceName" . }} -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}" {{ include "mariadb.cliTlsArgs" . }} --silent; do
+                sleep 5
               done
 
               status="$(mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SHOW SLAVE STATUS\\G" 2>/dev/null || true)"

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -36,7 +36,8 @@ spec:
             - -ec
             - |
               DATA_DIR="/var/lib/mysql"
-              if [ -d "${DATA_DIR}/mysql" ]; then
+              CLONE_MARKER="${DATA_DIR}/.helmforge-cloned"
+              if [ -f "${CLONE_MARKER}" ]; then
                 exit 0
               fi
 
@@ -53,38 +54,77 @@ spec:
               slave_parallel_workers = {{ .Values.replication.replicaTuning.parallelWorkers }}
               EOF
 
-              until MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb-admin ping -h {{ include "mariadb.sourceServiceName" . }} -P {{ .Values.service.port }} -uroot {{ include "mariadb.cliTlsArgs" . }} --silent; do
+              until mariadb-admin ping -h {{ include "mariadb.sourceServiceName" . }} -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}" {{ include "mariadb.cliTlsArgs" . }} --silent; do
                 sleep 5
               done
 
-              mariadb-install-db --user=mysql --datadir="${DATA_DIR}"
-              mariadbd --user=mysql --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking &
+              until mariadb -h {{ include "mariadb.sourceServiceName" . }} -P {{ .Values.service.port }} -uroot --password="${MARIADB_ROOT_PASSWORD}" {{ include "mariadb.cliTlsArgs" . }} -Nse "SHOW DATABASES LIKE '${MARIADB_DATABASE}'" | grep -qx "${MARIADB_DATABASE}"; do
+                sleep 5
+              done
+
+              if [ ! -d "${DATA_DIR}/mysql" ]; then
+                mariadb-install-db --datadir="${DATA_DIR}" --auth-root-authentication-method=normal
+              fi
+
+              mariadbd --datadir="${DATA_DIR}" --socket=/tmp/mysql.sock --pid-file=/tmp/mariadb.pid --skip-networking --read-only=OFF &
 
               until mariadb-admin --socket=/tmp/mysql.sock ping --silent; do
                 sleep 2
               done
 
               mariadb --socket=/tmp/mysql.sock -uroot <<EOSQL
+              SET GLOBAL read_only = OFF;
               ALTER USER 'root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              DROP USER IF EXISTS ''@'localhost';
+              DROP USER IF EXISTS ''@'${HOSTNAME}';
+              DROP USER IF EXISTS ''@'%';
+              DELETE FROM mysql.global_priv WHERE User = '';
+              DELETE FROM mysql.proxies_priv WHERE User = '' OR Proxied_user = '';
+              CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+              CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
               FLUSH PRIVILEGES;
               EOSQL
 
-              MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb-dump \
+              DATABASES="$(mariadb \
                 -h {{ include "mariadb.sourceServiceName" . }} \
                 -P {{ .Values.service.port }} \
                 -uroot \
+                --password="${MARIADB_ROOT_PASSWORD}" \
                 {{ include "mariadb.cliTlsArgs" . }} \
-                --single-transaction \
-                --gtid \
-                --all-databases \
-                --triggers \
-                --routines \
-                --events \
-                > /tmp/source.sql
+                -Nse "SHOW DATABASES WHERE \`Database\` NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')")"
 
-              MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb --socket=/tmp/mysql.sock -uroot < /tmp/source.sql
+              if [ -n "${DATABASES}" ]; then
+                mariadb-dump \
+                  -h {{ include "mariadb.sourceServiceName" . }} \
+                  -P {{ .Values.service.port }} \
+                  -uroot \
+                  --password="${MARIADB_ROOT_PASSWORD}" \
+                  {{ include "mariadb.cliTlsArgs" . }} \
+                  --single-transaction \
+                  --gtid \
+                  --databases ${DATABASES} \
+                  --triggers \
+                  --routines \
+                  --events \
+                  > /tmp/source.sql
 
-              MYSQL_PWD="${MARIADB_ROOT_PASSWORD}" mariadb --socket=/tmp/mysql.sock -uroot <<EOSQL
+                mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" < /tmp/source.sql
+              fi
+
+              mariadb --socket=/tmp/mysql.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" <<EOSQL
+              SET GLOBAL read_only = OFF;
+              ALTER USER 'root'@'localhost' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              DROP USER IF EXISTS ''@'localhost';
+              DROP USER IF EXISTS ''@'${HOSTNAME}';
+              DROP USER IF EXISTS ''@'%';
+              DELETE FROM mysql.global_priv WHERE User = '';
+              DELETE FROM mysql.proxies_priv WHERE User = '' OR Proxied_user = '';
+              CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+              CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY '${MARIADB_ROOT_PASSWORD}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
               CHANGE MASTER TO
                 MASTER_HOST='{{ include "mariadb.sourceServiceName" . }}',
                 MASTER_PORT={{ .Values.service.port }},
@@ -92,9 +132,9 @@ spec:
                 MASTER_PASSWORD='${REPLICATION_PASSWORD}',
                 {{ include "mariadb.replicationTlsClause" . | nindent 16 }}
                 MASTER_USE_GTID=slave_pos;
-              START SLAVE;
               EOSQL
 
+              touch "${CLONE_MARKER}"
               mariadb-admin --socket=/tmp/mysql.sock -uroot -p"${MARIADB_ROOT_PASSWORD}" shutdown
           env:
             - name: MARIADB_ROOT_PASSWORD
@@ -107,11 +147,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "mariadb.secretName" . }}
                   key: {{ .Values.auth.existingSecretReplicationPasswordKey }}
+            - name: MARIADB_DATABASE
+              value: {{ .Values.auth.database | quote }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
-            - name: data
-              mountPath: /var/lib/mysql
+            {{- include "mariadb.dataVolumeMount" . | nindent 12 }}
             - name: config
               mountPath: /config
             - name: mariadb-conf
@@ -143,7 +184,19 @@ spec:
               log_slave_updates = ON
               slave_parallel_workers = {{ .Values.replication.replicaTuning.parallelWorkers }}
               EOF
-              exec docker-entrypoint.sh mariadbd
+              docker-entrypoint.sh mariadbd &
+              pid="$!"
+              trap 'kill -TERM "${pid}"; wait "${pid}"' TERM INT
+
+              until mariadb-admin ping --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" --silent; do
+                sleep 2
+              done
+
+              status="$(mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -Nse "SHOW SLAVE STATUS\\G" 2>/dev/null || true)"
+              if ! printf "%s\n" "${status}" | grep -q "Slave_SQL_Running: Yes"; then
+                mariadb --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}" -e "START SLAVE;"
+              fi
+              wait "${pid}"
           ports:
             - name: mariadb
               containerPort: {{ .Values.service.port }}
@@ -162,7 +215,7 @@ spec:
               command:
                 - sh
                 - -ec
-                - {{ include "mariadb.probeCommandString" . | quote }}
+                - {{ include "mariadb.replicaProbeCommandString" . | quote }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -186,7 +239,7 @@ spec:
               command:
                 - sh
                 - -ec
-                - {{ include "mariadb.probeCommandString" . | quote }}
+                - {{ include "mariadb.replicaProbeCommandString" . | quote }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
@@ -201,8 +254,7 @@ spec:
             {{- include "mariadb.resourcesPreset" (dict "preset" .Values.replication.readReplicas.resourcesPreset) | nindent 12 }}
             {{- end }}
           volumeMounts:
-            - name: data
-              mountPath: /var/lib/mysql
+            {{- include "mariadb.dataVolumeMount" . | nindent 12 }}
             - name: config
               mountPath: /config
             - name: mariadb-conf

--- a/charts/mariadb/templates/statefulset-source.yaml
+++ b/charts/mariadb/templates/statefulset-source.yaml
@@ -25,9 +25,12 @@ spec:
         {{- end }}
     spec:
       {{- include "mariadb.podSpecCommon" . | nindent 6 }}
-      {{- if .Values.metrics.enabled }}
+      {{- if or .Values.persistence.subPath .Values.metrics.enabled }}
       initContainers:
+        {{- include "mariadb.prepareDataSubPathInitContainer" . | nindent 8 }}
+        {{- if .Values.metrics.enabled }}
         {{- include "mariadb.metricsConfigInitContainer" . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: mariadb

--- a/charts/mariadb/templates/statefulset-source.yaml
+++ b/charts/mariadb/templates/statefulset-source.yaml
@@ -134,8 +134,7 @@ spec:
             {{- end }}
             {{- end }}
           volumeMounts:
-            - name: data
-              mountPath: /var/lib/mysql
+            {{- include "mariadb.dataVolumeMount" . | nindent 12 }}
             - name: config
               mountPath: /config
             - name: mariadb-conf

--- a/charts/mariadb/tests/notes_test.yaml
+++ b/charts/mariadb/tests/notes_test.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notes
+templates:
+  - templates/NOTES.txt
+tests:
+  - it: should describe the default datadir subPath
+    asserts:
+      - matchRegexRaw:
+          pattern: "Datadir subPath:[[:space:]]+mysql"
+      - matchRegexRaw:
+          pattern: "persistence.subPath: \"\""
+
+  - it: should describe legacy volume-root mounts when subPath is empty
+    set:
+      persistence:
+        subPath: ""
+    asserts:
+      - matchRegexRaw:
+          pattern: "Datadir subPath:[[:space:]]+volume root"

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -27,11 +27,28 @@ tests:
       architecture: replication
     asserts:
       - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-datadir-subpath
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "mkdir -p \"/mnt/data/mysql\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 999:999 \"/mnt/data/mysql\""
+      - equal:
           path: spec.template.spec.initContainers[0].volumeMounts[0]
+          value:
+            name: data
+            mountPath: /mnt/data
+      - equal:
+          path: spec.template.spec.initContainers[1].volumeMounts[0]
           value:
             name: data
             mountPath: /var/lib/mysql
             subPath: mysql
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: clone-source
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0]
           value:
@@ -46,20 +63,20 @@ tests:
     asserts:
       - not: true
         matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--user=mysql"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--read-only=OFF"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--auth-root-authentication-method=normal"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "wait_local_socket\\(\\)"
       - not: true
         matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "mariadb-admin --socket=/tmp/mysql\\.sock ping --silent"
 
   - it: should preserve root local access for replica probes after cloning
@@ -68,31 +85,31 @@ tests:
       architecture: replication
     asserts:
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "CREATE OR REPLACE USER 'root'@'127\\.0\\.0\\.1'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "GRANT ALL PRIVILEGES ON \\*\\.\\* TO 'root'@'127\\.0\\.0\\.1' WITH GRANT OPTION"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "CREATE OR REPLACE USER 'root'@'%'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "DELETE FROM mysql\\.global_priv WHERE User = ''"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "DROP USER IF EXISTS ''@'\\$\\{HOSTNAME\\}'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "DROP USER IF EXISTS 'root'@'\\$\\{HOSTNAME\\}'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "DELETE FROM mysql\\.proxies_priv WHERE User = '' OR Proxied_user = ''"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "CLONE_MARKER="
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "touch \"\\$\\{CLONE_MARKER\\}\""
 
   - it: should preserve already initialized replica datadirs during upgrade
@@ -101,19 +118,19 @@ tests:
       architecture: replication
     asserts:
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "if \\[ -d \"\\$\\{DATA_DIR\\}/mysql\" \\]; then"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "SHOW SLAVE STATUS"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "grep -Eq \"Master_Host: .\\+\""
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "touch \"\\$\\{CLONE_MARKER\\}\""
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "local_admin_shutdown\\n\\s+exit 0"
 
   - it: should continue clone completion when an unmarked datadir lacks replication metadata
@@ -122,19 +139,19 @@ tests:
       architecture: replication
     asserts:
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "LOCAL_SERVER_STARTED=false"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "LOCAL_ROOT_PASSWORD_REQUIRED=false"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "local_mariadb\\(\\)"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "if \\[ \"\\$\\{LOCAL_SERVER_STARTED\\}\" = \"false\" \\]; then"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "CHANGE MASTER TO"
 
   - it: should clone all source databases including grant tables from one GTID snapshot
@@ -143,28 +160,28 @@ tests:
       architecture: replication
     asserts:
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--all-databases"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--master-data=2"
       - not: true
         matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "START SLAVE"
       - not: true
         matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "SHOW DATABASES WHERE"
       - not: true
         matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--databases \\$\\{DATABASES\\}"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "SHOW DATABASES LIKE '\\$\\{MARIADB_DATABASE\\}'"
       - equal:
-          path: spec.template.spec.initContainers[0].env[2]
+          path: spec.template.spec.initContainers[1].env[2]
           value:
             name: MARIADB_DATABASE
             value: app
@@ -175,34 +192,34 @@ tests:
       architecture: replication
     asserts:
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "CREATE DATABASE IF NOT EXISTS \\\\`\\$\\{MARIADB_DATABASE\\}\\\\`"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "CREATE USER IF NOT EXISTS '\\$\\{MARIADB_USER\\}'@'%' IDENTIFIED BY '\\$\\{MARIADB_PASSWORD\\}'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "ALTER USER '\\$\\{MARIADB_USER\\}'@'%' IDENTIFIED BY '\\$\\{MARIADB_PASSWORD\\}'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "GRANT ALL PRIVILEGES ON \\\\`\\$\\{MARIADB_DATABASE\\}\\\\`\\.\\* TO '\\$\\{MARIADB_USER\\}'@'%'"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "--master-data=2"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "sed -n \"s/\\^-- SET GLOBAL gtid_slave_pos="
       - not: true
         matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "SELECT @@global\\.gtid_binlog_pos"
       - equal:
-          path: spec.template.spec.initContainers[0].env[3]
+          path: spec.template.spec.initContainers[1].env[3]
           value:
             name: MARIADB_USER
             value: app
       - equal:
-          path: spec.template.spec.initContainers[0].env[4]
+          path: spec.template.spec.initContainers[1].env[4]
           value:
             name: MARIADB_PASSWORD
             valueFrom:
@@ -237,7 +254,7 @@ tests:
           path: spec.template.spec.containers[0].command[2]
           pattern: "skip_slave_start = ON"
       - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
+          path: spec.template.spec.initContainers[1].command[2]
           pattern: "skip_slave_start = ON"
 
   - it: should use local socket probes for replicas

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -85,6 +85,21 @@ tests:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "touch \"\\$\\{CLONE_MARKER\\}\""
 
+  - it: should preserve already initialized replica datadirs during upgrade
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "if \\[ -d \"\\$\\{DATA_DIR\\}/mysql\" \\]; then"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "touch \"\\$\\{CLONE_MARKER\\}\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "touch \"\\$\\{CLONE_MARKER\\}\"\\n\\s+exit 0"
+
   - it: should clone user databases without overwriting local grant tables
     template: templates/statefulset-replicas.yaml
     set:

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -34,7 +34,16 @@ tests:
           pattern: "mkdir -p \"/mnt/data/mysql\""
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 2770 \"/mnt/data/mysql\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
           pattern: "chown 999:999 \"/mnt/data/mysql\""
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add[0]
+          value: CHOWN
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add[1]
+          value: FOWNER
       - equal:
           path: spec.template.spec.initContainers[0].volumeMounts[0]
           value:
@@ -46,6 +55,23 @@ tests:
             name: data
             mountPath: /var/lib/mysql
             subPath: mysql
+
+  - it: should prepare replica subPath with custom runtime ownership
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1002
+      podSecurityContext:
+        fsGroup: 1003
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 2770 \"/mnt/data/mysql\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 1001:1003 \"/mnt/data/mysql\""
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: clone-source

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -54,6 +54,13 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "--auth-root-authentication-method=normal"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "wait_local_socket\\(\\)"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "mariadb-admin --socket=/tmp/mysql\\.sock ping --silent"
 
   - it: should preserve root local access for replica probes after cloning
     template: templates/statefulset-replicas.yaml
@@ -62,13 +69,13 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "CREATE USER IF NOT EXISTS 'root'@'127\\.0\\.0\\.1'"
+          pattern: "CREATE OR REPLACE USER 'root'@'127\\.0\\.0\\.1'"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "GRANT ALL PRIVILEGES ON \\*\\.\\* TO 'root'@'127\\.0\\.0\\.1' WITH GRANT OPTION"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "CREATE USER IF NOT EXISTS 'root'@'%'"
+          pattern: "CREATE OR REPLACE USER 'root'@'%'"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "DELETE FROM mysql\\.global_priv WHERE User = ''"
@@ -130,28 +137,29 @@ tests:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "CHANGE MASTER TO"
 
-  - it: should clone user databases without overwriting local grant tables
+  - it: should clone all source databases including grant tables from one GTID snapshot
     template: templates/statefulset-replicas.yaml
     set:
       architecture: replication
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "SHOW DATABASES WHERE"
-      - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
-          pattern: "'mysql'"
-      - matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
-          pattern: "--databases \\$\\{DATABASES\\}"
-      - not: true
-        matchRegex:
-          path: spec.template.spec.initContainers[0].command[2]
           pattern: "--all-databases"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--master-data=2"
       - not: true
         matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "START SLAVE"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SHOW DATABASES WHERE"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--databases \\$\\{DATABASES\\}"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "SHOW DATABASES LIKE '\\$\\{MARIADB_DATABASE\\}'"
@@ -212,6 +220,15 @@ tests:
           pattern: "START SLAVE"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
+          pattern: "REPLICATION_READY_MARKER=\"/tmp/helmforge-replication-started\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "rm -f \"\\$\\{REPLICATION_READY_MARKER\\}\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "touch \"\\$\\{REPLICATION_READY_MARKER\\}\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
           pattern: "until mariadb-admin ping -h RELEASE-NAME-mariadb-source"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
@@ -233,6 +250,9 @@ tests:
           value: mariadb-admin ping --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}"
       - matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "test -f /tmp/helmforge-replication-started"
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
           pattern: "--socket=/run/mysqld/mysqld\\.sock"
       - matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
@@ -243,6 +263,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
           pattern: "CAST\\(@@global\\.read_only AS CHAR\\) IN \\('ON', '1'\\)"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 60
       - not: true
         matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -77,6 +77,9 @@ tests:
           pattern: "DROP USER IF EXISTS ''@'\\$\\{HOSTNAME\\}'"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
+          pattern: "DROP USER IF EXISTS 'root'@'\\$\\{HOSTNAME\\}'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
           pattern: "DELETE FROM mysql\\.proxies_priv WHERE User = '' OR Proxied_user = ''"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
@@ -95,10 +98,37 @@ tests:
           pattern: "if \\[ -d \"\\$\\{DATA_DIR\\}/mysql\" \\]; then"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SHOW SLAVE STATUS"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "grep -Eq \"Master_Host: .\\+\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
           pattern: "touch \"\\$\\{CLONE_MARKER\\}\""
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "touch \"\\$\\{CLONE_MARKER\\}\"\\n\\s+exit 0"
+          pattern: "local_admin_shutdown\\n\\s+exit 0"
+
+  - it: should continue clone completion when an unmarked datadir lacks replication metadata
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "LOCAL_SERVER_STARTED=false"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "LOCAL_ROOT_PASSWORD_REQUIRED=false"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "local_mariadb\\(\\)"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "if \\[ \"\\$\\{LOCAL_SERVER_STARTED\\}\" = \"false\" \\]; then"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "CHANGE MASTER TO"
 
   - it: should clone user databases without overwriting local grant tables
     template: templates/statefulset-replicas.yaml
@@ -131,6 +161,43 @@ tests:
             name: MARIADB_DATABASE
             value: app
 
+  - it: should recreate chart-managed application grants on cloned replicas
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "CREATE DATABASE IF NOT EXISTS \\\\`\\$\\{MARIADB_DATABASE\\}\\\\`"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "CREATE USER IF NOT EXISTS '\\$\\{MARIADB_USER\\}'@'%' IDENTIFIED BY '\\$\\{MARIADB_PASSWORD\\}'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "ALTER USER '\\$\\{MARIADB_USER\\}'@'%' IDENTIFIED BY '\\$\\{MARIADB_PASSWORD\\}'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "GRANT ALL PRIVILEGES ON \\\\`\\$\\{MARIADB_DATABASE\\}\\\\`\\.\\* TO '\\$\\{MARIADB_USER\\}'@'%'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SELECT @@global\\.gtid_binlog_pos"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SET GLOBAL gtid_slave_pos='\\$\\{SOURCE_GTID\\}'"
+      - equal:
+          path: spec.template.spec.initContainers[0].env[3]
+          value:
+            name: MARIADB_USER
+            value: app
+      - equal:
+          path: spec.template.spec.initContainers[0].env[4]
+          value:
+            name: MARIADB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-mariadb-auth
+                key: mariadb-user-password
+
   - it: should start replication in the main replica container
     template: templates/statefulset-replicas.yaml
     set:
@@ -141,7 +208,16 @@ tests:
           pattern: "START SLAVE"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
+          pattern: "until mariadb-admin ping -h RELEASE-NAME-mariadb-source"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
           pattern: "docker-entrypoint\\.sh mariadbd &"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "skip_slave_start = ON"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "skip_slave_start = ON"
 
   - it: should use local socket probes for replicas
     template: templates/statefulset-replicas.yaml

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -180,10 +180,14 @@ tests:
           pattern: "GRANT ALL PRIVILEGES ON \\\\`\\$\\{MARIADB_DATABASE\\}\\\\`\\.\\* TO '\\$\\{MARIADB_USER\\}'@'%'"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "SELECT @@global\\.gtid_binlog_pos"
+          pattern: "--master-data=2"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "SET GLOBAL gtid_slave_pos='\\$\\{SOURCE_GTID\\}'"
+          pattern: "sed -n \"s/\\^-- SET GLOBAL gtid_slave_pos="
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SELECT @@global\\.gtid_binlog_pos"
       - equal:
           path: spec.template.spec.initContainers[0].env[3]
           value:

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: statefulset-replicas
+templates:
+  - templates/statefulset-replicas.yaml
+  - templates/configmap.yaml
+tests:
+  - it: should not render replicas in standalone mode
+    template: templates/statefulset-replicas.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render replicas in replication mode
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mariadb-replicas
+
+  - it: should mount replica datadirs from the safe default subPath
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].volumeMounts[0]
+          value:
+            name: data
+            mountPath: /var/lib/mysql
+            subPath: mysql
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          value:
+            name: data
+            mountPath: /var/lib/mysql
+            subPath: mysql
+
+  - it: should not request mariadbd ownership changes in the non-root clone init container
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--user=mysql"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--read-only=OFF"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--auth-root-authentication-method=normal"
+
+  - it: should preserve root local access for replica probes after cloning
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "CREATE USER IF NOT EXISTS 'root'@'127\\.0\\.0\\.1'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "GRANT ALL PRIVILEGES ON \\*\\.\\* TO 'root'@'127\\.0\\.0\\.1' WITH GRANT OPTION"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "CREATE USER IF NOT EXISTS 'root'@'%'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "DELETE FROM mysql\\.global_priv WHERE User = ''"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "DROP USER IF EXISTS ''@'\\$\\{HOSTNAME\\}'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "DELETE FROM mysql\\.proxies_priv WHERE User = '' OR Proxied_user = ''"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "CLONE_MARKER="
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "touch \"\\$\\{CLONE_MARKER\\}\""
+
+  - it: should clone user databases without overwriting local grant tables
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SHOW DATABASES WHERE"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "'mysql'"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--databases \\$\\{DATABASES\\}"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--all-databases"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "START SLAVE"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "SHOW DATABASES LIKE '\\$\\{MARIADB_DATABASE\\}'"
+      - equal:
+          path: spec.template.spec.initContainers[0].env[2]
+          value:
+            name: MARIADB_DATABASE
+            value: app
+
+  - it: should start replication in the main replica container
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "START SLAVE"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "docker-entrypoint\\.sh mariadbd &"
+
+  - it: should use local socket probes for replicas
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
+          value: mariadb-admin ping --socket=/run/mysqld/mysqld.sock -uroot --password="${MARIADB_ROOT_PASSWORD}"
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "--socket=/run/mysqld/mysqld\\.sock"
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "-uroot"
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "--password=\"\\$\\{MARIADB_ROOT_PASSWORD\\}\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "@@global\\.read_only IN \\('ON', '1'\\)"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[2]
+          pattern: "127\\.0\\.0\\.1"
+
+  - it: should allow legacy volume-root datadir mounts for replicas
+    template: templates/statefulset-replicas.yaml
+    set:
+      architecture: replication
+      persistence:
+        subPath: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].volumeMounts[0].mountPath
+          value: /var/lib/mysql
+      - notExists:
+          path: spec.template.spec.initContainers[0].volumeMounts[0].subPath
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /var/lib/mysql
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath

--- a/charts/mariadb/tests/statefulset_replicas_test.yaml
+++ b/charts/mariadb/tests/statefulset_replicas_test.yaml
@@ -242,7 +242,11 @@ tests:
           pattern: "--password=\"\\$\\{MARIADB_ROOT_PASSWORD\\}\""
       - matchRegex:
           path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
-          pattern: "@@global\\.read_only IN \\('ON', '1'\\)"
+          pattern: "CAST\\(@@global\\.read_only AS CHAR\\) IN \\('ON', '1'\\)"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "IF\\(@@global\\.read_only IN"
       - not: true
         matchRegex:
           path: spec.template.spec.containers[0].startupProbe.exec.command[2]

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -74,6 +74,28 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
           value: 8Gi
 
+  - it: should mount the datadir from the safe default subPath
+    template: templates/statefulset-source.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+          value:
+            name: data
+            mountPath: /var/lib/mysql
+            subPath: mysql
+
+  - it: should allow legacy volume-root datadir mounts for existing installs
+    template: templates/statefulset-source.yaml
+    set:
+      persistence:
+        subPath: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /var/lib/mysql
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+
   - it: should render metrics sidecar when enabled
     template: templates/statefulset-source.yaml
     set:

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -104,6 +104,9 @@ tests:
           pattern: "mkdir -p \"/mnt/data/mysql\""
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 2770 \"/mnt/data/mysql\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
           pattern: "chown 999:999 \"/mnt/data/mysql\""
       - equal:
           path: spec.template.spec.initContainers[0].securityContext.runAsUser
@@ -115,10 +118,29 @@ tests:
           path: spec.template.spec.initContainers[0].securityContext.capabilities.add[0]
           value: CHOWN
       - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add[1]
+          value: FOWNER
+      - equal:
           path: spec.template.spec.initContainers[0].volumeMounts[0]
           value:
             name: data
             mountPath: /mnt/data
+
+  - it: should prepare default subPath with custom runtime ownership
+    template: templates/statefulset-source.yaml
+    set:
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1002
+      podSecurityContext:
+        fsGroup: 1003
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chmod 2770 \"/mnt/data/mysql\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 1001:1003 \"/mnt/data/mysql\""
 
   - it: should allow legacy volume-root datadir mounts for existing installs
     template: templates/statefulset-source.yaml

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -67,6 +67,19 @@ tests:
       - isNotNull:
           path: spec.template.spec.containers[0].startupProbe
 
+  - it: should use explicit textual read_only checks in replication readiness
+    template: templates/statefulset-source.yaml
+    set:
+      architecture: replication
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "CAST\\(@@global\\.read_only AS CHAR\\) IN \\('OFF', '0'\\)"
+      - not: true
+        matchRegex:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[2]
+          pattern: "IF\\(@@global\\.read_only IN"
+
   - it: should have VolumeClaimTemplate with 8Gi default
     template: templates/statefulset-source.yaml
     asserts:

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -96,6 +96,29 @@ tests:
             name: data
             mountPath: /var/lib/mysql
             subPath: mysql
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-datadir-subpath
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "mkdir -p \"/mnt/data/mysql\""
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "chown 999:999 \"/mnt/data/mysql\""
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add[0]
+          value: CHOWN
+      - equal:
+          path: spec.template.spec.initContainers[0].volumeMounts[0]
+          value:
+            name: data
+            mountPath: /mnt/data
 
   - it: should allow legacy volume-root datadir mounts for existing installs
     template: templates/statefulset-source.yaml
@@ -130,10 +153,10 @@ tests:
             mountPath: /etc/mysqld-exporter
             readOnly: true
       - equal:
-          path: spec.template.spec.initContainers[0].name
+          path: spec.template.spec.initContainers[1].name
           value: mysqld-exporter-config
       - contains:
-          path: spec.template.spec.initContainers[0].env
+          path: spec.template.spec.initContainers[1].env
           content:
             name: MARIADB_ROOT_PASSWORD
           any: true

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -71,6 +71,16 @@
         "existingConfigMap": { "type": "string" }
       }
     },
+    "persistence": {
+      "type": "object",
+      "description": "Global persistence settings applied to MariaDB datadir mounts",
+      "properties": {
+        "subPath": {
+          "type": "string",
+          "description": "Subdirectory of the data volume mounted as /var/lib/mysql. Empty string preserves legacy volume-root behavior."
+        }
+      }
+    },
     "standalone": {
       "type": "object",
       "description": "Standalone mode settings"

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -82,6 +82,17 @@ initdb:
   existingConfigMap: ""
 
 # =============================================================================
+# Persistence
+# =============================================================================
+
+persistence:
+  # -- Subdirectory of the data volume mounted as the MariaDB datadir.
+  # Keeps ext4 lost+found out of /var/lib/mysql on new installs.
+  # BREAKING: existing installs with data at the volume root must set this to "" on upgrade
+  # unless they migrate data into the configured subdirectory first.
+  subPath: mysql
+
+# =============================================================================
 # Standalone
 # =============================================================================
 
@@ -89,7 +100,7 @@ standalone:
   # -- Server ID used in standalone mode
   serverId: 1
   # -- Optional resource preset: none | small | medium | large
-  resourcesPreset: none
+  resourcesPreset: small
   persistence:
     # -- Enable PVC for standalone mode
     enabled: true
@@ -112,7 +123,7 @@ replication:
     # -- Server ID used by the source pod
     serverId: 1
     # -- Optional resource preset: none | small | medium | large
-    resourcesPreset: none
+    resourcesPreset: small
     persistence:
       # -- Enable PVC for the source StatefulSet
       enabled: true
@@ -132,7 +143,7 @@ replication:
     # -- Base server ID used to derive replica server IDs from pod ordinal
     serverIdBase: 100
     # -- Optional resource preset: none | small | medium | large
-    resourcesPreset: none
+    resourcesPreset: small
     # -- Number of read replica pods
     replicaCount: 2
     persistence:


### PR DESCRIPTION
## Summary
- Fixes the ext4 `lost+found` log noise by mounting the MariaDB datadir from `persistence.subPath` by default.
- Adds the legacy opt-out `persistence.subPath: ""` for existing installs that still store data at the PVC root.
- Hardens and validates the replication bootstrap so replicas clone user databases, preserve local credentials, start replication idempotently, and use clean socket-based probes.
- Expands MariaDB docs with `DESIGN.md`, datadir migration guidance, legacy values example, README updates, and a detailed `NOTES.txt`.

## Breaking Change
`persistence.subPath` now defaults to `mysql`, so new installs mount the PVC subdirectory as `/var/lib/mysql` and keep ext4 `lost+found` outside the datadir.

Existing installs with data already written at the PVC root must set:

```yaml
persistence:
  subPath: ""
```

or migrate data into the configured subdirectory before upgrading.

## Validation
- `helm dependency build charts/mariadb`
- `helm lint charts/mariadb`
- `helm lint --strict charts/mariadb`
- `helm unittest charts/mariadb` (`35` tests)
- `ah lint charts/mariadb` (`78` packages, `0` errors)
- `values.schema.json` parsed with `ConvertFrom-Json`
- `kubeconform -strict` default render
- `kubeconform -strict -schema-location default -schema-location https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json` for every `charts/mariadb/ci/*.yaml`
- Installed and kept CRDs in local k3d for validation: `external-secrets` and `prometheus-operator-crds`
- `kubescape scan framework nsa` on rendered manifests: score `90`, Critical `0`, High `0`, Action Required `0`
- `markdownlint charts/mariadb/README.md charts/mariadb/DESIGN.md charts/mariadb/docs/datadir-subpath.md`

## k3d Runtime Validation
Cluster: `k3d-helmforge-tests-wsl`

Standalone:
- Deployed `hf-mariadb-420-default` with `helm upgrade --install ... --wait --timeout 3m`.
- Pod Ready `1/1`, restarts `0`.
- `/var/lib/mysql/lost+found` absent.
- Root ping and `app` database query succeeded.
- Logs and events checked; no error, `lost+found`, access-denied, failed, or warning events.

Replication:
- Deployed `hf-mariadb-420-repl` with source + one read replica and `--wait --timeout 3m`.
- Source and replica Ready `1/1`, restarts `0`.
- Source is writable, replica is read-only.
- `app` database cloned to replica and application user can access it.
- A new row written on source replicated to replica.
- `/var/lib/mysql/lost+found` absent on source and replica.
- Logs and events checked across source, replica, and clone init container; no error, `lost+found`, access-denied, failed, or warning events.

Closes #420