### PR TITLE
fix(vaultwarden): bind Rocket to non-root port

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -21,8 +21,10 @@ sources:
 icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "set Vaultwarden Rocket to a non-privileged container port for non-root deployments"
     - kind: changed
-      description: "upgrade to 1.36.0 (#220)"
+      description: "refresh bundled HelmForge PostgreSQL and MySQL dependency versions"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -47,10 +49,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.9.1
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/vaultwarden/DESIGN.md
+++ b/charts/vaultwarden/DESIGN.md
@@ -114,7 +114,12 @@ Reasoning:
 
 Set `ROCKET_ADDRESS=0.0.0.0` and derive `ROCKET_PORT` from `service.targetPort`.
 
-The upstream container is commonly configured for port 80, but this chart runs Vaultwarden as UID 1000, requires `runAsNonRoot`, and drops all Linux capabilities. Binding Rocket to a privileged port inside that container causes a runtime `PermissionDenied` bind failure. Keeping the Service on port 80 while binding the container to non-privileged port 8085 preserves the public Kubernetes contract and keeps the pod security defaults intact.
+The upstream container is commonly configured for port 80, but this chart runs Vaultwarden as UID 1000,
+requires `runAsNonRoot`, and drops all Linux capabilities.
+
+Binding Rocket to a privileged port inside that container causes a runtime `PermissionDenied` bind failure.
+Keeping the Service on port 80 while binding the container to non-privileged port 8085 preserves the public
+Kubernetes contract and keeps the pod security defaults intact.
 
 ### SMTP
 

--- a/charts/vaultwarden/DESIGN.md
+++ b/charts/vaultwarden/DESIGN.md
@@ -29,6 +29,7 @@ For the v1 scope in this repository:
 - the default database model is SQLite
 - WebSocket notifications ride through the same HTTP service
 - TLS termination is expected at ingress or reverse proxy level
+- Rocket binds to a non-privileged container port so the default non-root security posture works without extra Linux capabilities
 
 ## v1 Scope
 
@@ -42,15 +43,15 @@ For the v1 scope in this repository:
 - optional admin token with `existingSecret`
 - security-focused defaults for container and pod context
 - explicit docs for SQLite limitations
+- optional local HelmForge PostgreSQL and MySQL subcharts
+- optional backup CronJob for SQLite archives and database dumps
 
 ### Excluded
 
 - HA claims
 - multi-replica scaling
 - automatic failover
-- embedded backup job
 - operator-like lifecycle control
-- external database mode unless later implementation proves it can stay small and clear
 - split websocket Service unless a real product need appears
 
 ## Architecture Decision
@@ -109,6 +110,12 @@ Reasoning:
 - aligns with common reverse-proxy setups
 - avoids extra manifests unless the product truly needs them
 
+### Rocket bind port
+
+Set `ROCKET_ADDRESS=0.0.0.0` and derive `ROCKET_PORT` from `service.targetPort`.
+
+The upstream container is commonly configured for port 80, but this chart runs Vaultwarden as UID 1000, requires `runAsNonRoot`, and drops all Linux capabilities. Binding Rocket to a privileged port inside that container causes a runtime `PermissionDenied` bind failure. Keeping the Service on port 80 while binding the container to non-privileged port 8085 preserves the public Kubernetes contract and keeps the pod security defaults intact.
+
 ### SMTP
 
 SMTP should be fully optional.
@@ -157,6 +164,7 @@ data:
 service:
   type: ClusterIP
   port: 80
+  targetPort: 8085
   annotations: {}
 
 ingress:
@@ -212,6 +220,11 @@ The chart should validate at least these scenarios:
 - `ci/smtp.yaml`
 - `ci/existing-secret.yaml`
 - `ci/ingress.yaml`
+- `ci/database-postgresql.yaml`
+- `ci/database-mysql.yaml`
+- `ci/backup-sqlite.yaml`
+- `ci/gateway-api.yaml`
+- `ci/external-secrets.yaml`
 
 ## Documentation Set
 
@@ -227,6 +240,7 @@ The docs must explain:
 - why multi-replica is out of scope
 - why `/data` persistence is essential
 - how websocket traffic behaves behind ingress
+- why Rocket binds to a non-privileged container port
 - how to secure the admin interface
 
 ## Security Direction

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -27,6 +27,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 - optional SMTP configuration
 - optional admin token through inline value or `existingSecret`
 - websocket notifications on the same HTTP service
+- explicit Rocket bind settings for secure non-root containers
 
 ## Architecture guides
 
@@ -52,6 +53,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 - built-in backup can archive `/data` for SQLite or run database dumps for DB-backed modes
 - ingress and `domain` should be aligned for attachment links and client behavior
 - websocket traffic uses the same HTTP service and ingress path as the web vault
+- the pod binds Vaultwarden/Rocket to non-privileged container port `8085` by default while keeping the Kubernetes Service on port `80`
 
 ## Official product references
 
@@ -81,7 +83,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 ### Database selection
 
 - for production, prefer `database.external` or one of the optional subcharts
-- optional local database subcharts are vendored from HelmForge dependencies: PostgreSQL chart `1.10.0` and MySQL chart `1.9.1`
+- optional local database subcharts are vendored from HelmForge dependencies: PostgreSQL chart `2.0.2` and MySQL chart `2.0.0`
 - `database.mode=auto` uses this precedence:
 - `database.external.host` or `database.external.existingSecret`
 - `postgresql.enabled=true`
@@ -100,6 +102,16 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 - if Vaultwarden is exposed behind a path or non-default HTTPS port, keep that full external URL in `domain`
 - keep `vaultwarden.proxy.ipHeader` aligned with your ingress controller or reverse proxy behavior
 - review ingress/controller timeouts if websocket notifications are important for your users
+
+### Runtime port and websocket notifications
+
+- Vaultwarden is built on Rocket and reads bind settings from `ROCKET_ADDRESS` and `ROCKET_PORT`
+- the upstream container defaults to port `80`, but this chart runs the container as non-root and drops Linux capabilities
+- binding to port `80` inside a non-root container can fail with `PermissionDenied`
+- the chart therefore sets `ROCKET_ADDRESS=0.0.0.0` and `ROCKET_PORT` from `service.targetPort`
+- keep `service.targetPort` at the default `8085` unless your platform has a concrete reason to use another non-privileged port
+- `service.port` remains `80`, so in-cluster clients and ingress backends do not need to target `8085` directly
+- websocket notifications use the same HTTP listener and Service; no separate websocket Service is required
 
 ### SQLite and runtime database settings
 
@@ -140,6 +152,8 @@ This chart intentionally maps the most important operational settings from the o
 - `PASSWORD_HINTS_ALLOWED`
 - `SHOW_PASSWORD_HINT`
 - `ENABLE_WEBSOCKET`
+- `ROCKET_ADDRESS`
+- `ROCKET_PORT`
 - `IP_HEADER`
 - `ENABLE_DB_WAL`
 - `DB_CONNECTION_RETRIES`
@@ -207,8 +221,8 @@ Official reference:
 | `database.external.username` | External database username | `vaultwarden` |
 | `database.external.existingSecret` | Existing secret containing a complete `DATABASE_URL` | `""` |
 | `database.external.existingSecretUrlKey` | Secret key containing the `DATABASE_URL` value | `database-url` |
-| `postgresql.enabled` | Enable the local PostgreSQL subchart (`helmforge/postgresql` `1.10.0`) | `false` |
-| `mysql.enabled` | Enable the local MySQL subchart (`helmforge/mysql` `1.9.1`) | `false` |
+| `postgresql.enabled` | Enable the local PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) | `false` |
+| `mysql.enabled` | Enable the local MySQL subchart (`helmforge/mysql` `2.0.0`) | `false` |
 | `vaultwarden.signupsAllowed` | Allow new user signups | `false` |
 | `vaultwarden.signupsVerify` | Require email verification for new signups | `false` |
 | `vaultwarden.signupsVerifyResendTime` | Seconds before another verification email can be sent | `3600` |
@@ -241,6 +255,8 @@ Official reference:
 | `data.persistence.existingClaim` | Existing PVC for `/data` | `""` |
 | `data.persistence.selectorLabels` | PVC selector labels for restore or pre-bound PV flows | `{}` |
 | `data.persistence.size` | PVC size | `5Gi` |
+| `service.port` | Kubernetes Service HTTP port | `80` |
+| `service.targetPort` | Non-privileged Vaultwarden/Rocket container port and `ROCKET_PORT` value | `8085` |
 | `backup.enabled` | Enable built-in backup CronJob | `false` |
 | `backup.schedule` | Backup schedule | `"0 0 * * *"` |
 | `backup.s3.endpoint` | S3-compatible endpoint URL | `""` |

--- a/charts/vaultwarden/docs/ingress-and-domain.md
+++ b/charts/vaultwarden/docs/ingress-and-domain.md
@@ -54,9 +54,17 @@ ingress:
 
 ## WebSocket note
 
-WebSocket notifications use the same HTTP service and ingress path in this chart. No separate websocket service is required in v1.
+WebSocket notifications use the same HTTP service and ingress path in this chart. No separate websocket service is required.
 
 For most ingress controllers, the normal HTTP ingress path is enough. If operators use aggressive idle timeouts or proxy buffering defaults, they should validate websocket behavior explicitly after deployment.
+
+The pod binds Vaultwarden/Rocket to `service.targetPort` and the Service exposes it through `service.port`. By default that means:
+
+- `ROCKET_ADDRESS=0.0.0.0`
+- `ROCKET_PORT=8085`
+- Service port `80`
+
+This keeps the container compatible with `runAsNonRoot` and dropped Linux capabilities while preserving the normal Service and ingress backend port.
 
 ## Reverse proxy note
 

--- a/charts/vaultwarden/templates/NOTES.txt
+++ b/charts/vaultwarden/templates/NOTES.txt
@@ -1,35 +1,132 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-Vaultwarden has been deployed.
+{{- $name := include "vaultwarden.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+1. Vaultwarden has been installed
+==================================
+  Release:        {{ .Release.Name }}
+  Namespace:      {{ $namespace }}
+  Version:        {{ .Chart.AppVersion }}
+  Database Mode:  {{ include "vaultwarden.databaseMode" . }}
+
+2. Access
+=========
+[ClusterIP] Port-forward:
+  kubectl port-forward svc/{{ $name }} 8080:{{ .Values.service.port }} -n {{ $namespace }}
+  Open: http://localhost:8080
 
 {{- if .Values.ingress.enabled }}
-Access URL(s):
+[Ingress]
 {{- range .Values.ingress.hosts }}
-- https://{{ .host }}
+  URL: {{ include "vaultwarden.domain" $ | default (printf "https://%s" .host) }}
 {{- end }}
-{{- else }}
-Service:
-- kubectl port-forward svc/{{ include "vaultwarden.fullname" . }} 8080:{{ .Values.service.port }}
-- http://127.0.0.1:8080
+{{- else if include "vaultwarden.domain" . }}
+[Configured Domain]
+  URL: {{ include "vaultwarden.domain" . }}
 {{- end }}
 
-Operational notes:
-- Vaultwarden v1 in this repository is designed for a single replica with persistent `/data`
-- database mode selected for this release: {{ include "vaultwarden.databaseMode" . }}
-{{- if .Values.postgresql.enabled }}
-- local PostgreSQL subchart is enabled; keep `postgresql.auth.password` set explicitly and validate migrations before moving live data
-{{- else if .Values.mysql.enabled }}
-- local MySQL subchart is enabled; keep `mysql.auth.password` set explicitly and validate migrations before moving live data
-{{- else if .Values.database.external.existingSecret }}
-- external database mode uses an existing secret; confirm the configured key contains a complete `DATABASE_URL`
-{{- else if .Values.database.external.host }}
-- external database mode is enabled; confirm connectivity, TLS requirements, and backup credentials outside this release
+NOTE: WebSocket notifications use the same HTTP Service and ingress route.
+If clients do not receive live updates, verify that your ingress controller
+allows WebSocket connection upgrades and uses suitable idle timeouts.
+
+3. First-time Setup
+===================
+  - Create the first user only if signups are allowed or invite users through the admin flow.
+  - Keep `vaultwarden.signupsAllowed=false` for public instances unless self-service signup is intended.
+{{- if include "vaultwarden.adminEnabled" . }}
+  - Admin panel: {{ include "vaultwarden.domain" . | default "http://localhost:8080" }}/admin
+  - Use the configured ADMIN_TOKEN and rotate it if it was created only for bootstrap.
 {{- else }}
-- SQLite is selected; treat the full `/data` directory as the backup and restore boundary
+  - Admin panel is disabled because no admin token or admin existingSecret is configured.
 {{- end }}
-- if you enable SMTP, verify mail delivery from the admin settings and invitation flows
-- if you use the admin panel, prefer an Argon2-based `ADMIN_TOKEN`
-- if backup is enabled, validate that the S3 endpoint, bucket, and storage mode match the generated backup behavior for this release
-- if you use an existing PVC, validate restore procedures before treating the instance as production-ready
-- if you reattach restored storage, confirm whether the release is using `existingClaim` or PVC selector labels and validate the `/data` contents before reopening traffic
-- back up the full `/data` set, including `db.sqlite3`, `config.json`, `rsa_key*`, `attachments/`, and `sends/`
-- remember that admin-interface changes may persist effective runtime configuration in `/data/config.json`
+  - Configure SMTP before relying on invitations, verification, password reset, or emergency access email flows.
+
+4. Configuration Summary
+========================
+  Service:          {{ .Values.service.type }} {{ .Values.service.port }} -> container {{ .Values.service.targetPort }}
+  Rocket Bind:      0.0.0.0:{{ .Values.service.targetPort }}
+  WebSocket:        {{- if .Values.vaultwarden.websocket.enabled }} enabled{{- else }} disabled{{- end }}
+  Persistence:      {{- if .Values.data.persistence.enabled }} enabled{{- else }} disabled{{- end }}
+  SMTP:             {{- if .Values.smtp.enabled }} enabled{{- else }} disabled{{- end }}
+  Admin Panel:      {{- if include "vaultwarden.adminEnabled" . }} enabled{{- else }} disabled{{- end }}
+  Network Policy:   {{- if .Values.networkPolicy.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:      {{- if .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets: {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+{{- if .Values.postgresql.enabled }}
+  Database Detail:  HelmForge PostgreSQL subchart
+{{- else if .Values.mysql.enabled }}
+  Database Detail:  HelmForge MySQL subchart
+{{- else if .Values.database.external.existingSecret }}
+  Database Detail:  External database from existing DATABASE_URL secret
+{{- else if .Values.database.external.host }}
+  Database Detail:  External {{ .Values.database.external.vendor }} database
+{{- else }}
+  Database Detail:  SQLite stored under /data
+{{- end }}
+
+5. Validation Commands
+======================
+  # Check pods are ready
+  kubectl get pods -n {{ $namespace }} -l app.kubernetes.io/name=vaultwarden
+
+  # Check rendered runtime port
+  kubectl exec -n {{ $namespace }} deploy/{{ $name }} -- \
+    sh -c 'echo "ROCKET_ADDRESS=$ROCKET_ADDRESS ROCKET_PORT=$ROCKET_PORT"'
+
+  # Check health endpoint through the Service
+  kubectl run {{ $name }}-health --rm -i --restart=Never -n {{ $namespace }} \
+    --image=docker.io/curlimages/curl:8.11.1 --command -- \
+    sh -c 'curl -fsS -o /dev/null -w "%{http_code}\n" http://{{ $name }}/alive'
+
+  # Review recent application logs
+  kubectl logs -n {{ $namespace }} deploy/{{ $name }} -c vaultwarden --tail=100
+
+  # Review namespace events
+  kubectl get events -n {{ $namespace }} --sort-by=.lastTimestamp
+
+6. Backup and Restore
+=====================
+  - Back up the full /data directory for SQLite mode.
+  - Include db.sqlite3, config.json, rsa_key*, attachments/, sends/, and icon cache state.
+  - For PostgreSQL/MySQL modes, back up the database and still preserve Vaultwarden runtime files under /data.
+  - If `backup.enabled=true`, validate the object storage destination after the first scheduled run.
+  - When restoring, use an existing PVC or selector labels deliberately and validate data before reopening traffic.
+
+7. Troubleshooting
+==================
+  Rocket bind permission denied:
+    -> The container runs as non-root and cannot bind privileged port 80.
+    -> Keep service.targetPort at 8085 or another port >= 1024.
+    -> Do not override ROCKET_PORT to 80 unless you also change security settings intentionally.
+
+  WebSocket not connecting:
+    -> Confirm vaultwarden.websocket.enabled=true.
+    -> Check ingress support for WebSocket upgrade.
+    -> Validate proxy idle timeouts and buffering behavior.
+
+  Login or attachment URLs are wrong:
+    -> Set domain to the exact external HTTPS URL.
+    -> Keep ingress host/path aligned with domain.
+
+  Invitations or verification emails fail:
+    -> Enable smtp.enabled and validate host, port, sender, credentials, and TLS mode.
+    -> Check logs for SMTP provider errors.
+
+  Database connection refused:
+    -> Check the selected database mode in section 4.
+    -> For bundled databases, check the subchart pod and Secret values.
+    -> For external databases, verify host, port, TLS, credentials, and DATABASE_URL content.
+
+8. Upgrading
+============
+  - Back up /data and the selected database before upgrading production.
+  - Keep ADMIN_TOKEN, database credentials, and SMTP secrets stable across upgrades.
+  - Review upstream Vaultwarden release notes when changing image.tag.
+  - If switching database modes, follow the chart migration documentation first.
+
+9. Documentation
+================
+  HelmForge docs: https://helmforge.dev/docs/charts/vaultwarden
+  Upstream app:   https://github.com/dani-garcia/vaultwarden
+  Chart source:   https://github.com/helmforgedev/charts/tree/main/charts/vaultwarden
+
+Happy Helmforging :)

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: ROCKET_ADDRESS
+              value: "0.0.0.0"
+            - name: ROCKET_PORT
+              value: {{ .Values.service.targetPort | quote }}
             {{- with (include "vaultwarden.domain" .) }}
             - name: DOMAIN
               value: {{ . | quote }}

--- a/charts/vaultwarden/tests/deployment_test.yaml
+++ b/charts/vaultwarden/tests/deployment_test.yaml
@@ -93,3 +93,34 @@ tests:
           content:
             name: ENABLE_WEBSOCKET
             value: "true"
+
+  - it: should bind Rocket to a non-privileged port by default
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8085
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROCKET_ADDRESS
+            value: "0.0.0.0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROCKET_PORT
+            value: "8085"
+
+  - it: should use service.targetPort as the Rocket port
+    template: deployment.yaml
+    set:
+      service.targetPort: 8080
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8080
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ROCKET_PORT
+            value: "8080"

--- a/charts/vaultwarden/tests/networkpolicy_test.yaml
+++ b/charts/vaultwarden/tests/networkpolicy_test.yaml
@@ -17,3 +17,6 @@ tests:
     asserts:
       - isKind:
           of: NetworkPolicy
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 8085

--- a/charts/vaultwarden/values.schema.json
+++ b/charts/vaultwarden/values.schema.json
@@ -392,7 +392,9 @@
         },
         "targetPort": {
           "type": "integer",
-          "description": "Container port exposed by Vaultwarden"
+          "description": "Non-privileged Vaultwarden/Rocket container port. This value is also exported as ROCKET_PORT.",
+          "minimum": 1024,
+          "maximum": 65535
         },
         "annotations": {
           "type": "object",

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -196,8 +196,8 @@ service:
   type: ClusterIP
   # -- HTTP service port
   port: 80
-  # -- Container port exposed by Vaultwarden
-  targetPort: 80
+  # -- Non-privileged Vaultwarden/Rocket container port. This value is also exported as ROCKET_PORT.
+  targetPort: 8085
   # -- Set the ipFamilyPolicy for dual-stack (GR-058)
   ipFamilyPolicy: ''
   # -- Set the ipFamilies for dual-stack


### PR DESCRIPTION
Closes #422

## Summary

- Set `ROCKET_ADDRESS=0.0.0.0` and derive `ROCKET_PORT` from `service.targetPort` so Vaultwarden can run with the chart's non-root security defaults.
- Keep `service.port=80` while changing the default container/Rocket port to non-privileged `8085`.
- Reject privileged `service.targetPort` values through the values schema.
- Refresh Vaultwarden dependencies to HelmForge PostgreSQL `2.0.2` and MySQL `2.0.0`.
- Expand deployment/network policy unit coverage and replace the basic `NOTES.txt` with a chart-specific operational guide.
- Update README, DESIGN, and ingress docs to document Rocket/websocket behavior.

## Root Cause

The upstream Vaultwarden container can default Rocket to port 80. This chart runs the container as UID 1000 with `runAsNonRoot=true` and drops all Linux capabilities, so binding to the privileged container port can fail with `PermissionDenied` before the app becomes healthy.

## Validation

- `helm dependency update charts/vaultwarden` then removed generated `Chart.lock` per HelmForge policy.
- `helm dependency list charts/vaultwarden` shows PostgreSQL `2.0.2` and MySQL `2.0.0` OK.
- `helm lint charts/vaultwarden`
- `helm lint --strict charts/vaultwarden`
- `helm template vaultwarden-test charts/vaultwarden`
- Rendered all `charts/vaultwarden/ci/*.yaml` successfully.
- `helm template vaultwarden-test charts/vaultwarden | kubeconform -strict -summary`
- `helm unittest charts/vaultwarden` passed 6 suites / 29 tests.
- `ah lint charts/vaultwarden` passed for Vaultwarden.
- `kubescape scan` against rendered minimal manifest passed with critical threshold, score 81.
- Negative schema test: `service.targetPort=80` is rejected before deploy.

## K3D Validation

Cluster: `k3d-helmforge-tests-wsl`

Validated with `helm --wait --timeout 120s` and status inspection at 60 seconds:

- User-reported values without the workaround: pod ready, `ROCKET_ADDRESS=0.0.0.0`, `ROCKET_PORT=8085`, `/alive` returned HTTP 200 through the Service, logs showed `Rocket has launched from http://0.0.0.0:8085`, no Kubernetes Warning events.
- Custom `service.targetPort=8080`: pod ready, `ROCKET_PORT=8080`, `/alive` returned HTTP 200 through the Service, logs showed `Rocket has launched from http://0.0.0.0:8080`, no Kubernetes Warning events.
- PostgreSQL subchart: Vaultwarden and PostgreSQL ready, `/alive` returned HTTP 200 through the Service, app logs clean, PostgreSQL logs had normal bootstrap output only, no Kubernetes Warning events.
- MySQL subchart: Vaultwarden and MySQL ready, `/alive` returned HTTP 200 through the Service, app logs clean, MySQL logs had normal upstream bootstrap warnings only and no `ERROR`/`FATAL`, no Kubernetes Warning events.

Namespaces cleaned after validation: `hf-vaultwarden-rocket`, `hf-vaultwarden-pg`, `hf-vaultwarden-mysql`.