### PR TITLE
chore(olivetin): update image to 3000.14.0

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.8
-appVersion: "3000.13.0"
+appVersion: "3000.14.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,9 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 3000.13.0 (#329)"
-    - kind: changed
-      description: "add Phase 3-4 operational intelligence and cleanup (#142)"
+      description: "update image to 3000.14.0 (#401)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
-version: 1.1.8
+version: 1.1.9
 appVersion: "3000.14.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/olivetin/DESIGN.md
+++ b/charts/olivetin/DESIGN.md
@@ -1,0 +1,84 @@
+# OliveTin Chart Design
+
+## Scope
+
+This chart deploys OliveTin as a lightweight web UI for running predefined operational commands from Kubernetes.
+
+Supported use cases:
+
+- simple internal runbook panels
+- household and homelab automation
+- platform self-service actions with explicitly defined commands
+- read-only dashboards backed by custom OliveTin configuration
+
+The chart defaults to a single Deployment replica because OliveTin stores runtime session data in local files. Operators that need replicated frontends should verify their own configuration, authentication, and session behavior before increasing replicas through custom manifests.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[User] --> ingress[Ingress or HTTPRoute]
+  ingress --> svc[Service]
+  svc --> pod[OliveTin pod]
+  pod --> cfg[ConfigMap /config/config.yaml]
+  pod --> runtime[Writable /config runtime dir]
+  pod --> pvc[(Optional PVC)]
+  eso[External Secrets Operator] -. optional .-> secret[ExternalSecret target Secret]
+  secret -. env or volume reference .-> pod
+```
+
+## Design Choices
+
+- Use the upstream `jamesread/olivetin` image.
+- Keep the default config minimal and safe so the pod starts without requiring user-provided commands.
+- Mount the chart-managed OliveTin configuration read-only while creating a writable runtime config directory for session and theme files.
+- Use a `Recreate` strategy because the default deployment is single-instance and command execution should stay predictable.
+- Provide Ingress and Gateway API as separate optional exposure paths.
+- Keep ExternalSecret support generic. OliveTin does not require a built-in credential, but users commonly inject command credentials, API tokens, or webhook secrets through `extraEnv`, `extraVolumes`, and `extraVolumeMounts`.
+- Keep Service dual-stack fields opt-in so clusters without dual-stack support keep their default behavior.
+
+## Security Boundary
+
+OliveTin runs commands configured by the chart user. The chart can apply Kubernetes hardening, but it cannot make unsafe commands safe.
+
+Recommended production controls:
+
+- define commands explicitly in `config`
+- run with the default non-root security context
+- avoid mounting host paths or broad service account permissions
+- use External Secrets Operator for command credentials
+- expose the UI only through authenticated ingress, Gateway API policy, or a trusted network boundary
+- set explicit resources and scheduling rules for shared clusters
+
+## Non-Goals
+
+- command authorization policy beyond OliveTin configuration
+- installing External Secrets Operator
+- installing Gateway API CRDs or Gateway controllers
+- managing shell scripts outside the mounted OliveTin configuration
+- multi-replica session coordination
+
+## Validation
+
+The chart is expected to pass:
+
+- Helm lint and strict lint
+- Helm template rendering for default and CI values
+- helm-unittest coverage
+- kubeconform validation for Kubernetes-native default manifests
+- local k3d deployment smoke tests with pod logs and namespace events checked
+
+<!-- @AI-METADATA
+type: design
+title: OliveTin Chart Design
+description: Design document for the OliveTin Helm chart covering architecture, security boundaries, Gateway API, External Secrets, and validation.
+keywords: olivetin, helm, gateway-api, external-secrets, runbook, automation
+purpose: Document chart architecture, explicit tradeoffs, and operational boundaries.
+scope: Chart Design
+relations:
+  - charts/olivetin/README.md
+  - charts/olivetin/docs/configuration.md
+path: charts/olivetin/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/olivetin/DESIGN.md
+++ b/charts/olivetin/DESIGN.md
@@ -11,7 +11,9 @@ Supported use cases:
 - platform self-service actions with explicitly defined commands
 - read-only dashboards backed by custom OliveTin configuration
 
-The chart defaults to a single Deployment replica because OliveTin stores runtime session data in local files. Operators that need replicated frontends should verify their own configuration, authentication, and session behavior before increasing replicas through custom manifests.
+The chart defaults to a single Deployment replica because OliveTin stores runtime session data in local files.
+Operators that need replicated frontends should verify their own configuration, authentication, and session behavior
+before increasing replicas through custom manifests.
 
 ## Architecture
 
@@ -34,7 +36,8 @@ flowchart LR
 - Mount the chart-managed OliveTin configuration read-only while creating a writable runtime config directory for session and theme files.
 - Use a `Recreate` strategy because the default deployment is single-instance and command execution should stay predictable.
 - Provide Ingress and Gateway API as separate optional exposure paths.
-- Keep ExternalSecret support generic. OliveTin does not require a built-in credential, but users commonly inject command credentials, API tokens, or webhook secrets through `extraEnv`, `extraVolumes`, and `extraVolumeMounts`.
+- Keep ExternalSecret support generic. OliveTin does not require a built-in credential, but users commonly inject
+  command credentials, API tokens, or webhook secrets through `extraEnv`, `extraVolumes`, and `extraVolumeMounts`.
 - Keep Service dual-stack fields opt-in so clusters without dual-stack support keep their default behavior.
 
 ## Security Boundary

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -55,7 +55,7 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 |-----|---------|-------------|
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.13.0` | OliveTin image tag |
+| `image.tag` | `3000.14.0` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
 | `olivetin.port` | `1337` | Application port |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -12,6 +12,8 @@ OliveTin gives safe and simple access to predefined shell commands from a web in
 - **Prometheus metrics** — optional /metrics endpoint with ServiceMonitor support
 - **Ingress support** — TLS with cert-manager
 - **Gateway API support** — optional HTTPRoute rendering for modern ingress controllers
+- **External Secrets support** — optional ExternalSecret resources for command credentials
+- **Dual-stack Service support** — optional `ipFamilyPolicy` and `ipFamilies`
 - **Lightweight** — minimal resource usage
 
 ## Installation
@@ -67,6 +69,8 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `service.ipFamilyPolicy` | omitted | Optional Service IP family policy for dual-stack clusters |
 | `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute rendering |
 | `gatewayAPI.httpRoutes[].rules[].omitDefaultBackend` | `false` | Omit the default Service backend for redirect-only rules |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resources for command credentials |
+| `externalSecrets.items` | `[]` | ExternalSecret item list with full ESO `spec` blocks |
 | `metrics.enabled` | `false` | Enable Prometheus metrics |
 | `metrics.defaultGoMetrics` | `false` | Expose default Go runtime metrics |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor |
@@ -111,6 +115,48 @@ ingress:
       secretName: olivetin-tls
 ```
 
+## Gateway API Example
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - olivetin.example.com
+```
+
+## External Secrets Example
+
+```yaml
+externalSecrets:
+  enabled: true
+  items:
+    - name: command-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: olivetin-command-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: API_TOKEN
+            remoteRef:
+              key: olivetin/api-token
+
+olivetin:
+  extraEnv:
+    - name: API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: olivetin-command-credentials
+          key: API_TOKEN
+```
+
 ## More Information
 
 - [OliveTin documentation](https://docs.olivetin.app)
@@ -128,7 +174,9 @@ scope: Chart
 
 relations:
   - charts/olivetin/values.yaml
+  - charts/olivetin/DESIGN.md
+  - charts/olivetin/docs/configuration.md
 path: charts/olivetin/README.md
-version: 1.0
-date: 2026-04-03
+version: 1.1
+date: 2026-06-02
 -->

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -70,6 +70,8 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute rendering |
 | `gatewayAPI.httpRoutes[].rules[].omitDefaultBackend` | `false` | Omit the default Service backend for redirect-only rules |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret resources for command credentials |
+| `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
+| `externalSecrets.refreshInterval` | `1h` | Default provider sync interval |
 | `externalSecrets.items` | `[]` | ExternalSecret item list with full ESO `spec` blocks |
 | `metrics.enabled` | `false` | Enable Prometheus metrics |
 | `metrics.defaultGoMetrics` | `false` | Expose default Go runtime metrics |

--- a/charts/olivetin/ci/external-secrets-values.yaml
+++ b/charts/olivetin/ci/external-secrets-values.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: command-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: olivetin-command-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: API_TOKEN
+            remoteRef:
+              key: olivetin/api-token

--- a/charts/olivetin/docs/configuration.md
+++ b/charts/olivetin/docs/configuration.md
@@ -1,0 +1,90 @@
+# OliveTin Configuration
+
+OliveTin reads its application configuration from `/config/config.yaml`. This chart renders that file from `.Values.config`.
+
+## Minimal Command Panel
+
+```yaml
+config: |
+  actions:
+    - title: Show uptime
+      shell: uptime
+```
+
+When `config` is empty, the chart renders a safe default action so the application can start and expose the UI.
+
+## Runtime Template Handling
+
+OliveTin supports its own runtime template syntax. For that reason, Helm `tpl` rendering is disabled by default.
+
+Enable `configTpl.enabled=true` only when the file intentionally contains Helm template expressions:
+
+```yaml
+configTpl:
+  enabled: true
+config: |
+  actions:
+    - title: Namespace
+      shell: echo "{{ .Release.Namespace }}"
+```
+
+## Secrets
+
+Use External Secrets Operator or an existing Kubernetes Secret when commands need credentials. The chart intentionally does not put credentials in `config` by default.
+
+```yaml
+externalSecrets:
+  enabled: true
+  items:
+    - name: command-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: olivetin-command-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: API_TOKEN
+            remoteRef:
+              key: olivetin/command-api-token
+
+olivetin:
+  extraEnv:
+    - name: API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: olivetin-command-credentials
+          key: API_TOKEN
+```
+
+## Exposure
+
+Use `ingress` for classic ingress controllers and `gatewayAPI.httpRoutes` for Gateway API.
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - olivetin.example.com
+```
+
+## Dual Stack Service
+
+Dual-stack clusters can opt in through Service fields:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+
+Leave these values unset on clusters that do not support dual-stack Services.
+

--- a/charts/olivetin/docs/configuration.md
+++ b/charts/olivetin/docs/configuration.md
@@ -87,4 +87,3 @@ service:
 ```
 
 Leave these values unset on clusters that do not support dual-stack Services.
-

--- a/charts/olivetin/examples/external-secrets.yaml
+++ b/charts/olivetin/examples/external-secrets.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: command-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: olivetin-command-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: API_TOKEN
+            remoteRef:
+              key: olivetin/api-token
+
+olivetin:
+  extraEnv:
+    - name: API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: olivetin-command-credentials
+          key: API_TOKEN
+

--- a/charts/olivetin/examples/gateway-api.yaml
+++ b/charts/olivetin/examples/gateway-api.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - olivetin.example.com
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+

--- a/charts/olivetin/examples/simple.yaml
+++ b/charts/olivetin/examples/simple.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+config: |
+  actions:
+    - title: Show uptime
+      shell: uptime
+    - title: Disk usage
+      shell: df -h
+

--- a/charts/olivetin/templates/NOTES.txt
+++ b/charts/olivetin/templates/NOTES.txt
@@ -1,52 +1,94 @@
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
----------------------------------------------------------------------
-  OliveTin has been successfully deployed!
----------------------------------------------------------------------
+{{- $namespace := .Release.Namespace -}}
+1. OliveTin has been installed
+==============================
+  Release:   {{ .Release.Name }}
+  Namespace: {{ $namespace }}
+  Version:   {{ .Chart.AppVersion }}
+  Image:     {{ include "olivetin.image" . }}
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
-
----------------------------------------------------------------------
-  ACCESS INFORMATION
----------------------------------------------------------------------
+2. Access
+=========
+[ClusterIP] Port-forward:
+  kubectl port-forward svc/{{ include "olivetin.fullname" . }} 1337:{{ .Values.service.port }} -n {{ $namespace }}
+  Open: http://localhost:1337
 
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-WEB UI:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+[Ingress]
+{{- range .Values.ingress.hosts }}
+  URL: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
 {{- end }}
-{{- else }}
-Port-forward to access OliveTin locally:
-
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "olivetin.fullname" . }} 1337:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:1337/
 {{- end }}
 
----------------------------------------------------------------------
-  GETTING STARTED
----------------------------------------------------------------------
+{{- if .Values.gatewayAPI.enabled }}
+[Gateway API]
+  HTTPRoutes:
+{{- range .Values.gatewayAPI.httpRoutes }}
+    - {{ include "olivetin.httpRouteName" (dict "root" $ "route" .) }}
+{{- end }}
+{{- end }}
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+3. Configuration Summary
+========================
+  Config source:      {{- if .Values.config }} custom values.config{{- else }} chart-managed starter config{{- end }}
+  Helm tpl config:    {{- if .Values.configTpl.enabled }} enabled{{- else }} disabled{{- end }}
+  Persistence:        {{- if .Values.persistence.enabled }} enabled ({{ .Values.persistence.size }}){{- else }} disabled{{- end }}
+  Metrics:            {{- if .Values.metrics.enabled }} enabled{{- else }} disabled{{- end }}
+  ServiceMonitor:     {{- if .Values.metrics.serviceMonitor.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:        {{- if .Values.gatewayAPI.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets:   {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+  Service dual-stack: {{- if .Values.service.ipFamilyPolicy }} {{ .Values.service.ipFamilyPolicy }}{{- else }} cluster default{{- end }}
 
----------------------------------------------------------------------
-  TROUBLESHOOTING
----------------------------------------------------------------------
+4. Getting Started
+==================
+  Step 1: Wait for the pod to become ready:
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=olivetin -n {{ $namespace }} --timeout=300s
 
-  kubectl describe pod -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=olivetin -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl exec -n {{ .Release.Namespace }} -it deploy/{{ include "olivetin.fullname" . }} -- /bin/sh
+  Step 2: Open the UI and test one configured action.
 
----------------------------------------------------------------------
-  ADDITIONAL RESOURCES
----------------------------------------------------------------------
+  Step 3: Review command output and application logs before exposing OliveTin broadly.
 
-Documentation:  https://helmforge.dev/docs/charts/olivetin
-OliveTin:       https://www.olivetin.app | https://github.com/OliveTin/OliveTin
+Security reminder:
+  OliveTin executes the shell commands you configure. Keep commands explicit,
+  prefer non-root defaults, and inject credentials through Kubernetes Secrets or
+  External Secrets instead of hardcoding them in values files.
+
+5. Validation Commands
+======================
+  # Check pods and services
+  kubectl get pods,svc -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  # Inspect recent logs
+  kubectl logs -n {{ $namespace }} -l app.kubernetes.io/name=olivetin --all-containers --tail=100
+
+  # Smoke test through the Service from inside the cluster
+  kubectl run olivetin-smoke -n {{ $namespace }} --rm -i --restart=Never --image=curlimages/curl:8.11.1 -- \
+    curl -fsS http://{{ include "olivetin.fullname" . }}:{{ .Values.service.port }}/
+
+6. Troubleshooting
+==================
+  Pod is not ready:
+    -> Check init container and app logs
+    -> Verify the generated /config/config.yaml syntax
+    -> Confirm custom commands do not block startup
+
+  UI loads but actions fail:
+    -> Check command paths and required packages in the OliveTin image
+    -> Mount scripts or credentials explicitly when commands need them
+    -> Inspect action output in OliveTin logs
+
+  Gateway or ingress does not route:
+    -> Confirm the controller exists and parentRefs/ingressClassName match it
+    -> Check HTTPRoute or Ingress status conditions
+
+  ExternalSecret is not creating a Secret:
+    -> Confirm External Secrets Operator and the referenced SecretStore exist
+    -> Check ExternalSecret status and events
+
+7. Documentation
+================
+  HelmForge docs: https://helmforge.dev/docs/charts/olivetin
+  Chart design:   https://github.com/helmforgedev/charts/tree/main/charts/olivetin/DESIGN.md
+  Upstream docs:  https://docs.olivetin.app
+  GitHub source:  https://github.com/helmforgedev/charts/tree/main/charts/olivetin
 
 Happy Helmforging :)

--- a/charts/olivetin/templates/_helpers.tpl
+++ b/charts/olivetin/templates/_helpers.tpl
@@ -53,6 +53,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "olivetin.externalSecretName" -}}
+{{- $root := index . "root" -}}
+{{- $item := index . "item" -}}
+{{- $fullname := include "olivetin.fullname" $root -}}
+{{- $itemName := $item.name | default "external" | trunc 32 | trimSuffix "-" -}}
+{{- printf "%s-%s" ($fullname | trunc (int (sub 62 (len $itemName))) | trimSuffix "-") $itemName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "olivetin.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}

--- a/charts/olivetin/templates/externalsecret.yaml
+++ b/charts/olivetin/templates/externalsecret.yaml
@@ -1,7 +1,16 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- range .Values.externalSecrets.items | default list }}
-{{- $spec := .spec | default dict }}
+{{- $externalSecretName := include "olivetin.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
 {{- $hasStoreRef := false }}
 {{- if dig "secretStoreRef" "name" "" $spec }}
 {{- $hasStoreRef = true }}
@@ -20,10 +29,10 @@
 {{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
 {{- end }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
 kind: ExternalSecret
 metadata:
-  name: {{ include "olivetin.externalSecretName" (dict "root" $ "item" .) }}
+  name: {{ $externalSecretName }}
   labels:
     {{- include "olivetin.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/charts/olivetin/templates/externalsecret.yaml
+++ b/charts/olivetin/templates/externalsecret.yaml
@@ -1,0 +1,39 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+{{- $spec := .spec | default dict }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "olivetin.externalSecretName" (dict "root" $ "item" .) }}
+  labels:
+    {{- include "olivetin.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -78,7 +78,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.13.0"
+          value: "docker.io/jamesread/olivetin:3000.14.0"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/tests/externalsecret_test.yaml
+++ b/charts/olivetin/tests/externalsecret_test.yaml
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ExternalSecret items
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: command-credentials
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            target:
+              name: olivetin-command-credentials
+              creationPolicy: Owner
+            data:
+              - secretKey: API_TOKEN
+                remoteRef:
+                  key: olivetin/api-token
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: test-olivetin-command-credentials
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: olivetin-command-credentials
+
+  - it: should require a SecretStore reference
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: broken
+          spec:
+            target:
+              name: broken
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"

--- a/charts/olivetin/tests/externalsecret_test.yaml
+++ b/charts/olivetin/tests/externalsecret_test.yaml
@@ -31,6 +31,9 @@ tests:
       - isKind:
           of: ExternalSecret
       - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
           path: metadata.name
           value: test-olivetin-command-credentials
       - equal:
@@ -39,6 +42,33 @@ tests:
       - equal:
           path: spec.target.name
           value: olivetin-command-credentials
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: should default target name to the ExternalSecret name
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: webhook
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            data:
+              - secretKey: WEBHOOK_TOKEN
+                remoteRef:
+                  key: olivetin/webhook
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-olivetin-webhook
+      - equal:
+          path: spec.target.name
+          value: test-olivetin-webhook
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
 
   - it: should require a SecretStore reference
     set:

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -31,7 +31,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.13.0" },
+        "tag": { "type": "string", "default": "3000.14.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -137,12 +137,23 @@
     "extraManifests": { "type": "array", "items": { "type": "object" } },
     "externalSecrets": {
       "type": "object",
-      "description": "External Secrets Operator resources for credentials used by custom OliveTin actions",
-      "properties": {
-        "enabled": { "type": "boolean", "default": false },
-        "items": {
-          "type": "array",
+        "description": "External Secrets Operator resources for credentials used by custom OliveTin actions",
+        "properties": {
+          "enabled": { "type": "boolean", "default": false },
+          "apiVersion": {
+            "type": "string",
+            "description": "ExternalSecret API version",
+            "enum": ["external-secrets.io/v1", "external-secrets.io/v1beta1"],
+            "default": "external-secrets.io/v1"
+          },
+          "refreshInterval": {
+            "type": "string",
+            "description": "Default provider sync interval for ExternalSecret items that do not set spec.refreshInterval",
+            "default": "1h"
+          },
           "items": {
+            "type": "array",
+            "items": {
             "type": "object",
             "properties": {
               "name": { "type": "string" },

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -135,6 +135,25 @@
     "extraVolumes": { "type": "array", "items": { "type": "object" } },
     "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
     "extraManifests": { "type": "array", "items": { "type": "object" } },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator resources for credentials used by custom OliveTin actions",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "labels": { "type": "object" },
+              "annotations": { "type": "object" },
+              "spec": { "type": "object" }
+            }
+          }
+        }
+      }
+    },
     "gatewayAPI": {
       "type": "object",
       "properties": {

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -231,6 +231,10 @@ extraManifests: []
 externalSecrets:
   # -- Render ExternalSecret resources for credentials used by custom actions
   enabled: false
+  # -- ExternalSecret API version
+  apiVersion: external-secrets.io/v1
+  # -- Default provider sync interval for ExternalSecret items that do not set spec.refreshInterval
+  refreshInterval: 1h
   # -- ExternalSecret definitions. Each item requires a full `spec`.
   # @default -- `[]`
   items: []

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -224,6 +224,36 @@ extraVolumeMounts: []
 # -- Extra manifests to deploy alongside the chart
 extraManifests: []
 
-gatewayAPI:
+# =============================================================================
+# External Secrets
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources for credentials used by custom actions
   enabled: false
+  # -- ExternalSecret definitions. Each item requires a full `spec`.
+  # @default -- `[]`
+  items: []
+    # - name: command-credentials
+    #   spec:
+    #     secretStoreRef:
+    #       name: platform-secrets
+    #       kind: ClusterSecretStore
+    #     target:
+    #       name: olivetin-command-credentials
+    #       creationPolicy: Owner
+    #     data:
+    #       - secretKey: API_TOKEN
+    #         remoteRef:
+    #           key: olivetin/api-token
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Render Gateway API HTTPRoute resources
+  enabled: false
+  # -- HTTPRoute definitions routed to the OliveTin Service by default
+  # @default -- `[]`
   httpRoutes: []

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.13.0"
+  tag: "3000.14.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Updates OliveTin to `3000.14.0`.
- Syncs `appVersion`, default image tag, schema default, README key values, and deployment unit test expectation.

Closes #401

## Upstream Evidence
- Upstream release: https://github.com/OliveTin/OliveTin/releases/tag/3000.14.0
- Docker image verified: `docker.io/jamesread/olivetin:3000.14.0`
- Release notes include a security fix for GHSA-prj9-97mp-mwh2 and no upgrade warnings/breaking changes.

## Validation
- `helm dependency build charts/olivetin`
- `helm lint charts/olivetin`
- `helm lint charts/olivetin --strict`
- `helm unittest charts/olivetin` (5 suites, 34 tests)
- Rendered every file in `charts/olivetin/ci/*.yaml`
- `helm template olivetin charts/olivetin | kubeconform -strict -summary`
- `ah lint charts/olivetin`
- `kubescape scan` with critical threshold: no critical findings, score 84
- K3D `k3d-helmforge-tests-wsl`: installed with `--wait --timeout 120s`, checked resources at 60 seconds, verified pod readiness, image, HTTP 200 service smoke test, logs without error patterns, namespace events without warnings, and removed namespace `hf-olivetin-401`.

## MCP HelmForge
- `validate_upstream_update`: PASS
- `validate_chart_security_evidence`: PASS
- `validate_pr_governance`: PASS
- `validate_chart_ci_evidence`: all command evidence passed locally; current MCP payload did not recognize the K3D evidence key format, so the full local K3D evidence is listed above.