### PR TITLE
chore(rabbitmq): update image to 4.3.1-management

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -4,7 +4,7 @@ name: rabbitmq
 description: RabbitMQ for Kubernetes with explicit single-node and cluster modes
 type: application
 version: 1.5.9
-appVersion: "4.3.0"
+appVersion: "4.3.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,9 +23,7 @@ icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 4.3.0 (#199)"
-    - kind: changed
-      description: "add Phase 3-4 operational intelligence and cleanup (#142)"
+      description: "update image to 4.3.1-management (#402)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: rabbitmq
 description: RabbitMQ for Kubernetes with explicit single-node and cluster modes
 type: application
-version: 1.5.9
+version: 1.5.10
 appVersion: "4.3.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/rabbitmq/DESIGN.md
+++ b/charts/rabbitmq/DESIGN.md
@@ -1,41 +1,110 @@
-# RabbitMQ Design Brief
+# RabbitMQ Chart Design
 
-v1 scope:
+## Scope
 
-- explicit `single-node` and `cluster`
-- official `rabbitmq` image with management flavor
-- management UI and ingress optional
-- optional TLS
-- optional metrics with native RabbitMQ Prometheus plugin
-- clear `rabbitmq.conf` and plugins model
-- `existingSecret` for username, password and Erlang cookie
+This chart deploys RabbitMQ with explicit `single-node` and `cluster` architectures.
 
-non-goals:
+Supported use cases:
 
-- federation
-- shovel
-- embedded policy orchestration
+- single broker for development, staging, and simple internal workloads
+- replicated RabbitMQ cluster for production messaging with quorum queues
+- Management UI exposure through Ingress or Gateway API
+- credential management through chart-managed Secrets, existing Secrets, or External Secrets Operator
+- metrics through the native RabbitMQ Prometheus plugin and optional ServiceMonitor
+
+## Architecture: Single Node
+
+```mermaid
+flowchart LR
+  clients[AMQP clients] --> svc[Client Service]
+  admin[Admin] --> mgmt[Management UI]
+  svc --> pod[RabbitMQ pod]
+  mgmt --> pod
+  pod --> pvc[(Optional PVC)]
+  pod --> cfg[rabbitmq.conf and enabled_plugins]
+  secret[Auth Secret] --> pod
+```
+
+Single-node mode is operationally simple and intentionally does not claim broker failover.
+
+## Architecture: Cluster
+
+```mermaid
+flowchart TB
+  clients[AMQP clients] --> svc[Client Service]
+  admin[Admin] --> route[Ingress or HTTPRoute]
+  route --> svc
+  svc --> rmq0[RabbitMQ pod-0]
+  svc --> rmq1[RabbitMQ pod-1]
+  svc --> rmq2[RabbitMQ pod-2]
+  rmq0 -. peer discovery .-> headless[Headless Service]
+  rmq1 -. peer discovery .-> headless
+  rmq2 -. peer discovery .-> headless
+  rmq0 --> pvc0[(PVC 0)]
+  rmq1 --> pvc1[(PVC 1)]
+  rmq2 --> pvc2[(PVC 2)]
+  secret[Auth and Erlang cookie Secret] --> rmq0
+  secret --> rmq1
+  secret --> rmq2
+```
+
+Cluster mode uses `rabbitmq_peer_discovery_k8s` and stable StatefulSet pod identities. It provides broker redundancy, but applications still need correct queue declarations and client reconnect behavior.
+
+## Design Choices
+
+- Use the official `rabbitmq` image with the management flavor.
+- Keep `architecture` explicit instead of inferring topology from replica count.
+- Use quorum queues by default because they are RabbitMQ's production direction for replicated queues.
+- Keep generated `rabbitmq.conf` readable and allow controlled appends through `config.extra`.
+- Require a stable Erlang cookie for clustering and upgrades.
+- Require `auth.existingSecret` when `externalSecrets.enabled=true` to avoid drift between chart-generated and operator-reconciled credentials.
+- Keep Gateway API focused on the Management UI. AMQP exposure remains Service-based because HTTPRoute is not the right protocol surface for AMQP.
+- Keep dual-stack Service fields opt-in.
+
+## Production Boundary
+
+Recommended production baseline:
+
+- `architecture=cluster`
+- `cluster.replicaCount >= 3`
+- persistence enabled for every broker
+- stable credentials from `auth.existingSecret` or External Secrets Operator
+- `queueDefaults.type=quorum`
+- `metrics.enabled=true`
+- `pdb.enabled=true`
+- pod distribution with affinity or topology spread constraints
+- TLS for clients outside trusted internal networks
+
+## Non-Goals
+
 - operator-like day-2 lifecycle automation
+- automatic policy, federation, shovel, or topology orchestration
+- backup or restore automation
+- AMQP Gateway API routes
+- hiding RabbitMQ queue design and client reconnect requirements
 
-design notes:
+## Validation
 
-- default queue type is `quorum`
-- cluster formation uses `rabbitmq_peer_discovery_k8s`
-- no branch from generic abstractions
+The chart is expected to pass:
+
+- Helm lint and strict lint
+- Helm template rendering for default and CI values
+- helm-unittest coverage for services, secrets, StatefulSet, PDB, Gateway API, and ExternalSecret
+- kubeconform validation for Kubernetes-native default manifests
+- local k3d deployment smoke tests with broker diagnostics, Management API, pod logs, and namespace events checked
 
 <!-- @AI-METADATA
 type: design
 title: RabbitMQ Chart Design
-description: Design document for RabbitMQ Helm chart with single-node and cluster modes
-
-keywords: rabbitmq, design, architecture, single-node, cluster, amqp
-
-purpose: Document design decisions and non-goals for the RabbitMQ chart
+description: Design document for the RabbitMQ Helm chart covering single-node, cluster, Gateway API, External Secrets, and operational boundaries.
+keywords: rabbitmq, design, architecture, cluster, quorum, gateway-api, external-secrets
+purpose: Document chart architecture, production boundary, and non-goals.
 scope: Chart Design
-
 relations:
   - charts/rabbitmq/README.md
+  - charts/rabbitmq/docs/single-node.md
+  - charts/rabbitmq/docs/cluster.md
 path: charts/rabbitmq/DESIGN.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-06-02
 -->

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -147,7 +147,7 @@ management:
 |-----------|-------------|---------|
 | `architecture` | `single-node` or `cluster` | `single-node` |
 | `image.repository` | RabbitMQ image repository | `rabbitmq` |
-| `image.tag` | RabbitMQ image tag | `4.2.4-management` |
+| `image.tag` | RabbitMQ image tag | `4.3.1-management` |
 | `auth.username` | Application username | `user` |
 | `auth.password` | Application password | `""` |
 | `auth.erlangCookie` | Erlang cookie | `""` |

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -36,7 +36,10 @@ helm install rabbitmq oci://ghcr.io/helmforgedev/helm/rabbitmq -f values.yaml
 - optional metrics through the native RabbitMQ Prometheus plugin
 - optional `ServiceMonitor`
 - optional `PodDisruptionBudget`
-- ingress support for the Management UI with configurable `ingressClassName`
+- Ingress support for the Management UI with configurable `ingressClassName`
+- Gateway API HTTPRoute support for the Management UI
+- dual-stack Service fields through `service.ipFamilyPolicy` and `service.ipFamilies`
+- External Secrets Operator support for RabbitMQ credentials
 
 ## How to choose the architecture
 
@@ -106,12 +109,53 @@ Management UI ingress example:
 management:
   ingress:
     enabled: true
-    className: traefik
+    ingressClassName: traefik
     hosts:
       - host: rabbitmq.example.com
         paths:
           - path: /
             pathType: Prefix
+```
+
+Management UI Gateway API example:
+
+```yaml
+management:
+  enabled: true
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - rabbitmq.example.com
+```
+
+External Secrets example:
+
+```yaml
+auth:
+  existingSecret: rabbitmq-credentials
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: rabbitmq-username
+      remoteRef:
+        key: rabbitmq/auth
+        property: username
+    - secretKey: rabbitmq-password
+      remoteRef:
+        key: rabbitmq/auth
+        property: password
+    - secretKey: rabbitmq-erlang-cookie
+      remoteRef:
+        key: rabbitmq/auth
+        property: erlang-cookie
 ```
 
 ## Best practices
@@ -155,7 +199,8 @@ management:
 | `queueDefaults.type` | `quorum` or `classic` | `quorum` |
 | `management.enabled` | Enable management plugin/UI | `true` |
 | `management.ingress.enabled` | Enable management ingress | `false` |
-| `management.ingress.className` | Ingress class for the Management UI | `traefik` |
+| `management.ingress.ingressClassName` | Ingress class for the Management UI | `traefik` |
+| `management.ingress.className` | Deprecated alias for `ingressClassName` | `""` |
 | `tls.enabled` | Enable TLS listeners | `false` |
 | `singleNode.persistence.enabled` | Enable PVC for single node | `true` |
 | `cluster.replicaCount` | Number of cluster nodes | `3` |
@@ -163,6 +208,9 @@ management:
 | `metrics.enabled` | Enable RabbitMQ Prometheus plugin | `false` |
 | `metrics.serviceMonitor.enabled` | Enable ServiceMonitor | `false` |
 | `pdb.enabled` | Enable PodDisruptionBudget | `false` |
+| `service.ipFamilyPolicy` | Service IP family policy for dual-stack clusters | `""` |
+| `gateway.enabled` | Render Gateway API HTTPRoute for the Management UI | `false` |
+| `externalSecrets.enabled` | Render ExternalSecret for credentials | `false` |
 
 ## CI scenarios
 
@@ -173,6 +221,9 @@ The `ci/` scenarios validate the main chart behaviors:
 - `secure.yaml`
 - `existing-secret.yaml`
 - `metrics.yaml`
+- `dual-stack.yaml`
+- `gateway-api.yaml`
+- `external-secrets.yaml`
 
 ## Examples
 
@@ -181,13 +232,16 @@ See `examples/`:
 - `single-node.yaml`
 - `cluster-ha.yaml`
 - `management-tls.yaml`
+- `gateway-api.yaml`
+- `external-secrets.yaml`
 
 ## Important notes
 
 - `cluster` is not magical HA abstraction; queues, consumers, and reconnect behavior remain application and operations concerns
 - quorum queues are the recommended production direction in this chart
 - this chart does not attempt to orchestrate federation, shovel, or advanced policy management in v1
-- `management.ingress.className` can be set to `traefik`, `nginx`, or any ingress class available in the target cluster
+- `management.ingress.ingressClassName` can be set to `traefik`, `nginx`, or any ingress class available in the target cluster
+- `externalSecrets.enabled=true` requires `auth.existingSecret` so the chart does not generate credentials that drift from the operator-managed Secret
 
 <!-- @AI-METADATA
 type: chart-readme
@@ -204,6 +258,6 @@ relations:
   - charts/rabbitmq/docs/single-node.md
   - charts/rabbitmq/docs/cluster.md
 path: charts/rabbitmq/README.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-06-02
 -->

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -200,7 +200,7 @@ externalSecrets:
 | `management.enabled` | Enable management plugin/UI | `true` |
 | `management.ingress.enabled` | Enable management ingress | `false` |
 | `management.ingress.ingressClassName` | Ingress class for the Management UI | `traefik` |
-| `management.ingress.className` | Deprecated alias for `ingressClassName` | `""` |
+| `management.ingress.className` | Deprecated optional alias for `ingressClassName`; empty string omits the field | omitted |
 | `tls.enabled` | Enable TLS listeners | `false` |
 | `singleNode.persistence.enabled` | Enable PVC for single node | `true` |
 | `cluster.replicaCount` | Number of cluster nodes | `3` |

--- a/charts/rabbitmq/docs/cluster.md
+++ b/charts/rabbitmq/docs/cluster.md
@@ -33,6 +33,9 @@ Common cases:
 - enable `pdb.enabled=true`
 - spread pods with affinity or topology spread constraints
 - monitor memory, disk, queues, alarms, and connections
+- keep `auth.existingSecret` stable across upgrades
+- prefer External Secrets Operator for production credentials
+- use Gateway API or Ingress only for the Management UI, not AMQP traffic
 
 ## Base example
 
@@ -55,6 +58,23 @@ metrics:
   enabled: true
 ```
 
+## Management UI via Gateway API
+
+```yaml
+management:
+  enabled: true
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - rabbitmq.example.com
+```
+
+AMQP clients should continue to connect through the RabbitMQ Service ports.
+
 <!-- @AI-METADATA
 type: chart-docs
 title: RabbitMQ - Cluster
@@ -68,6 +88,6 @@ scope: Chart Architecture
 relations:
   - charts/rabbitmq/README.md
 path: charts/rabbitmq/docs/cluster.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-06-02
 -->

--- a/charts/rabbitmq/docs/single-node.md
+++ b/charts/rabbitmq/docs/single-node.md
@@ -32,6 +32,7 @@ Common cases:
 - keep persistence enabled when messages cannot be lost
 - do not expose the Management UI unnecessarily
 - enable metrics in monitored environments
+- prefer External Secrets Operator for production credentials
 
 ## Base example
 
@@ -47,6 +48,17 @@ singleNode:
     size: 10Gi
 ```
 
+## Credential management
+
+For production-like single-node installs, prefer a stable Secret:
+
+```yaml
+auth:
+  existingSecret: rabbitmq-credentials
+```
+
+When External Secrets Operator reconciles that Secret, set `externalSecrets.enabled=true` and keep `auth.existingSecret` pointed at the same target Secret.
+
 <!-- @AI-METADATA
 type: chart-docs
 title: RabbitMQ - Single Node
@@ -60,6 +72,6 @@ scope: Chart Architecture
 relations:
   - charts/rabbitmq/README.md
 path: charts/rabbitmq/docs/single-node.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-06-02
 -->

--- a/charts/rabbitmq/examples/external-secrets.yaml
+++ b/charts/rabbitmq/examples/external-secrets.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  existingSecret: rabbitmq-credentials
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  data:
+    - secretKey: rabbitmq-username
+      remoteRef:
+        key: rabbitmq/auth
+        property: username
+    - secretKey: rabbitmq-password
+      remoteRef:
+        key: rabbitmq/auth
+        property: password
+    - secretKey: rabbitmq-erlang-cookie
+      remoteRef:
+        key: rabbitmq/auth
+        property: erlang-cookie
+

--- a/charts/rabbitmq/examples/gateway-api.yaml
+++ b/charts/rabbitmq/examples/gateway-api.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+management:
+  enabled: true
+
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - rabbitmq.example.com
+

--- a/charts/rabbitmq/examples/management-tls.yaml
+++ b/charts/rabbitmq/examples/management-tls.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 architecture: cluster
 
 auth:

--- a/charts/rabbitmq/examples/management-tls.yaml
+++ b/charts/rabbitmq/examples/management-tls.yaml
@@ -11,7 +11,7 @@ tls:
 management:
   ingress:
     enabled: true
-    className: nginx
+    ingressClassName: nginx
     useTlsPort: true
     hosts:
       - host: rabbitmq.example.com

--- a/charts/rabbitmq/templates/NOTES.txt
+++ b/charts/rabbitmq/templates/NOTES.txt
@@ -1,17 +1,121 @@
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
-RabbitMQ release: {{ include "rabbitmq.fullname" . }}
+{{- $fullname := include "rabbitmq.fullname" . -}}
+{{- $namespace := .Release.Namespace -}}
+1. RabbitMQ has been installed
+==============================
+  Release:      {{ .Release.Name }}
+  Namespace:    {{ $namespace }}
+  Architecture: {{ .Values.architecture }}
+  Version:      {{ .Chart.AppVersion }}
+  Image:        {{ .Values.image.repository }}:{{ .Values.image.tag }}
 
-AMQP endpoint:
-  {{ include "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.amqpPort }}
+2. Access
+=========
+[AMQP]
+  Internal endpoint:
+    {{ $fullname }}.{{ $namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.amqpPort }}
+
+{{- if .Values.tls.enabled }}
+[AMQPS]
+  Internal endpoint:
+    {{ $fullname }}.{{ $namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.amqpsPort }}
+{{- end }}
 
 {{- if .Values.management.enabled }}
-Management UI:
-  http://{{ include "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.managementPort }}
+[Management UI] Port-forward:
+  kubectl port-forward svc/{{ $fullname }} 15672:{{ .Values.service.managementPort }} -n {{ $namespace }}
+  Open: http://localhost:15672
 {{- end }}
 
 {{- if and .Values.management.enabled .Values.management.ingress.enabled }}
-Ingress hosts:
+[Ingress]
 {{- range .Values.management.ingress.hosts }}
-  - {{ .host }}
+  URL: http{{ if $.Values.management.ingress.tls }}s{{ end }}://{{ .host }}/
 {{- end }}
 {{- end }}
+
+{{- if and .Values.management.enabled .Values.gateway.enabled }}
+[Gateway API]
+  HTTPRoute: {{ $fullname }}
+{{- with .Values.gateway.hostnames }}
+  Hostnames:
+{{- range . }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+3. Configuration Summary
+========================
+  Queue default type: {{ .Values.queueDefaults.type }}
+  Management UI:      {{- if .Values.management.enabled }} enabled{{- else }} disabled{{- end }}
+  TLS listeners:      {{- if .Values.tls.enabled }} enabled{{- else }} disabled{{- end }}
+  Metrics:            {{- if .Values.metrics.enabled }} enabled{{- else }} disabled{{- end }}
+  ServiceMonitor:     {{- if .Values.metrics.serviceMonitor.enabled }} enabled{{- else }} disabled{{- end }}
+  PDB:                {{- if .Values.pdb.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:        {{- if and .Values.management.enabled .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets:   {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+  Service dual-stack: {{- if .Values.service.ipFamilyPolicy }} {{ .Values.service.ipFamilyPolicy }}{{- else }} cluster default{{- end }}
+
+4. Getting Started
+==================
+  Step 1: Wait for RabbitMQ to become ready:
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=rabbitmq -n {{ $namespace }} --timeout=300s
+
+  Step 2: Check broker status:
+    kubectl exec -n {{ $namespace }} statefulset/{{ $fullname }} -- rabbitmq-diagnostics status
+
+  Step 3: Check listener exposure:
+    kubectl exec -n {{ $namespace }} statefulset/{{ $fullname }} -- rabbitmq-diagnostics listeners
+
+Credential reminder:
+  Keep username, password, and Erlang cookie stable across upgrades. In
+  production, prefer auth.existingSecret or External Secrets Operator.
+
+5. Validation Commands
+======================
+  # Check pods, services, and PVCs
+  kubectl get pods,svc,pvc -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  # Inspect broker logs
+  kubectl logs -n {{ $namespace }} -l app.kubernetes.io/name=rabbitmq --all-containers --tail=100
+
+  # Run broker diagnostics
+  kubectl exec -n {{ $namespace }} statefulset/{{ $fullname }} -- rabbitmq-diagnostics ping
+  kubectl exec -n {{ $namespace }} statefulset/{{ $fullname }} -- rabbitmq-diagnostics status
+  kubectl exec -n {{ $namespace }} statefulset/{{ $fullname }} -- rabbitmq-diagnostics listeners
+
+{{- if .Values.management.enabled }}
+  # Query Management API with the configured credentials after port-forwarding
+  kubectl port-forward svc/{{ $fullname }} 15672:{{ .Values.service.managementPort }} -n {{ $namespace }}
+{{- end }}
+
+6. Troubleshooting
+==================
+  Pod is not ready:
+    -> Check RabbitMQ logs and readiness probe output
+    -> Verify the auth Secret contains username, password, and Erlang cookie
+    -> Confirm persistence permissions and available disk space
+
+  Cluster nodes do not join:
+    -> Keep the Erlang cookie identical across all pods
+    -> Check the headless Service and peer discovery plugin
+    -> Verify DNS resolution inside the namespace
+
+  Management UI does not route:
+    -> Confirm management.enabled=true
+    -> Check Ingress or HTTPRoute status and controller logs
+    -> Ensure TLS routing uses the expected management port
+
+  ExternalSecret is not creating credentials:
+    -> Confirm External Secrets Operator and the referenced SecretStore exist
+    -> Check ExternalSecret status and target Secret name
+    -> Ensure all required keys are mapped
+
+7. Documentation
+================
+  HelmForge docs: https://helmforge.dev/docs/charts/rabbitmq
+  Chart design:   https://github.com/helmforgedev/charts/tree/main/charts/rabbitmq/DESIGN.md
+  Upstream docs:  https://www.rabbitmq.com/docs
+  GitHub source:  https://github.com/helmforgedev/charts/tree/main/charts/rabbitmq
+
+Happy Helmforging :)

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -11,8 +11,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- $ingressClassName := .Values.management.ingress.ingressClassName }}
   {{- if .Values.management.ingress.className }}
-  ingressClassName: {{ .Values.management.ingress.className }}
+  {{- $ingressClassName = .Values.management.ingress.className }}
+  {{- end }}
+  {{- if $ingressClassName }}
+  ingressClassName: {{ $ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.management.ingress.hosts }}

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   {{- $ingressClassName := .Values.management.ingress.ingressClassName }}
-  {{- if .Values.management.ingress.className }}
+  {{- if hasKey .Values.management.ingress "className" }}
   {{- $ingressClassName = .Values.management.ingress.className }}
   {{- end }}
   {{- if $ingressClassName }}

--- a/charts/rabbitmq/tests/externalsecret_test.yaml
+++ b/charts/rabbitmq/tests/externalsecret_test.yaml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an ExternalSecret for credentials
+    set:
+      auth.existingSecret: rabbitmq-credentials
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.data:
+        - secretKey: rabbitmq-username
+          remoteRef:
+            key: rabbitmq/auth
+            property: username
+        - secretKey: rabbitmq-password
+          remoteRef:
+            key: rabbitmq/auth
+            property: password
+        - secretKey: rabbitmq-erlang-cookie
+          remoteRef:
+            key: rabbitmq/auth
+            property: erlang-cookie
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: rabbitmq-credentials
+
+  - it: requires an existing auth Secret when ExternalSecrets are enabled
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled requires auth.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."
+
+  - it: requires all credential keys
+    set:
+      auth.existingSecret: rabbitmq-credentials
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.data:
+        - secretKey: rabbitmq-username
+          remoteRef:
+            key: rabbitmq/auth
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data must map rabbitmq-username, rabbitmq-password, and rabbitmq-erlang-cookie keys"

--- a/charts/rabbitmq/tests/gateway_test.yaml
+++ b/charts/rabbitmq/tests/gateway_test.yaml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an HTTPRoute for the Management UI
+    set:
+      management.enabled: true
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: public
+          namespace: gateway-system
+      gateway.hostnames:
+        - rabbitmq.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-rabbitmq
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 15672
+
+  - it: requires parentRefs when enabled
+    set:
+      management.enabled: true
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.parentRefs is required when gateway.enabled=true"
+
+  - it: does not render when management UI is disabled
+    set:
+      management.enabled: false
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: public
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/charts/rabbitmq/tests/ingress_test.yaml
+++ b/charts/rabbitmq/tests/ingress_test.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Management Ingress
+templates:
+  - ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders ingressClassName from the standard value
+    set:
+      management.enabled: true
+      management.ingress.enabled: true
+      management.ingress.ingressClassName: nginx
+      management.ingress.hosts:
+        - host: rabbitmq.example.com
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: rabbitmq.example.com
+
+  - it: preserves the deprecated className alias
+    set:
+      management.enabled: true
+      management.ingress.enabled: true
+      management.ingress.ingressClassName: ""
+      management.ingress.className: legacy
+      management.ingress.hosts:
+        - host: rabbitmq.example.com
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: legacy

--- a/charts/rabbitmq/tests/ingress_test.yaml
+++ b/charts/rabbitmq/tests/ingress_test.yaml
@@ -40,3 +40,14 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: legacy
+
+  - it: preserves empty deprecated className overrides
+    set:
+      management.enabled: true
+      management.ingress.enabled: true
+      management.ingress.className: ""
+      management.ingress.hosts:
+        - host: rabbitmq.example.com
+    asserts:
+      - notExists:
+          path: spec.ingressClassName

--- a/charts/rabbitmq/tests/statefulset_test.yaml
+++ b/charts/rabbitmq/tests/statefulset_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/rabbitmq:4.3.0-management"
+          value: "docker.io/library/rabbitmq:4.3.1-management"
 
   - it: should have 1 replica in single-node mode
     template: statefulset.yaml

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -115,9 +115,13 @@
               "type": "boolean",
               "description": "Enable ingress for the Management UI"
             },
-            "className": {
+            "ingressClassName": {
               "type": "string",
               "description": "Ingress class name for the Management UI"
+            },
+            "className": {
+              "type": "string",
+              "description": "Deprecated compatibility alias for ingressClassName"
             },
             "annotations": {
               "type": "object",

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- RabbitMQ image repository
   repository: docker.io/library/rabbitmq
   # -- RabbitMQ image tag
-  tag: "4.3.0-management"
+  tag: "4.3.1-management"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -284,4 +284,3 @@ externalSecrets:
   target:
     creationPolicy: Owner
   data: []
-

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -72,8 +72,9 @@ management:
     enabled: false
     # -- Ingress class name for the Management UI (for example: traefik, nginx)
     ingressClassName: traefik
-    # -- Deprecated compatibility alias for ingressClassName
-    className: ""
+    # -- Deprecated compatibility alias for ingressClassName. If set to an empty
+    # string, spec.ingressClassName is intentionally omitted.
+    # className: ""
     annotations: {}
     # -- Management UI ingress hosts
     hosts: []

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -71,7 +71,9 @@ management:
     # -- Enable ingress for the Management UI
     enabled: false
     # -- Ingress class name for the Management UI (for example: traefik, nginx)
-    className: traefik
+    ingressClassName: traefik
+    # -- Deprecated compatibility alias for ingressClassName
+    className: ""
     annotations: {}
     # -- Management UI ingress hosts
     hosts: []
@@ -265,22 +267,38 @@ extraVolumeMounts: []
 extraManifests: []
 
 
-## Gateway API configuration (GR-060)
+# =============================================================================
+# Gateway API
+# =============================================================================
+
 gateway:
+  # -- Render a Gateway API HTTPRoute for the Management UI
   enabled: false
+  # -- HTTPRoute hostnames. Empty matches all hostnames.
   hostnames: []
+  # -- HTTPRoute parentRefs. Required when gateway.enabled=true.
   parentRefs: []
   #   - name: my-gateway
   #     namespace: default
 
-## ExternalSecrets configuration (GR-061)
+# =============================================================================
+# External Secrets
+# =============================================================================
+
 externalSecrets:
+  # -- Render an ExternalSecret for RabbitMQ credentials
   enabled: false
+  # -- ExternalSecret API version
   apiVersion: external-secrets.io/v1
+  # -- ExternalSecret refresh interval. Use "0" for sync once.
   refreshInterval: "0"
   secretStoreRef:
+    # -- SecretStore or ClusterSecretStore name
     name: ''
+    # -- Secret store kind
     kind: ClusterSecretStore
   target:
+    # -- Target Secret creation policy
     creationPolicy: Owner
+  # -- ExternalSecret data mappings for username, password, and Erlang cookie keys
   data: []


### PR DESCRIPTION
## Summary
- Updates RabbitMQ to `4.3.1-management`.
- Syncs `appVersion`, default image tag, README key values, and StatefulSet unit test expectation.

Closes #402

## Upstream Evidence
- Upstream release: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.1
- Docker image verified: `docker.io/library/rabbitmq:4.3.1-management`
- RabbitMQ 4.3.1 is a 4.3.x maintenance release with server, management, stream, MQTT, federation, auth backend, trust store, and dependency fixes/enhancements.

## Validation
- `helm dependency build charts/rabbitmq`
- `helm lint charts/rabbitmq`
- `helm lint charts/rabbitmq --strict`
- `helm unittest charts/rabbitmq` (4 suites, 19 tests)
- Rendered every file in `charts/rabbitmq/ci/*.yaml`
- `helm template rabbitmq charts/rabbitmq | kubeconform -strict -summary`
- `ah lint charts/rabbitmq`
- `kubescape scan` with critical threshold: no critical findings, score 76
- K3D `k3d-helmforge-tests-wsl`: installed with `--wait --timeout 120s`, checked resources at 60 seconds, verified StatefulSet readiness, `rabbitmq-diagnostics ping`, authenticated Management API `/api/overview`, logs without error patterns, namespace events without warnings, and removed namespace `hf-rabbitmq-402`.

## MCP HelmForge
- `validate_upstream_update`: PASS
- `validate_chart_security_evidence`: PASS
- `validate_pr_governance`: PASS