### PR TITLE
chore(redis): update image to 8.8.0

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
-version: 1.6.16
+version: 1.6.17
 appVersion: "8.8.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -4,7 +4,7 @@ name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 1.6.16
-appVersion: "8.6.3"
+appVersion: "8.8.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,8 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "deduplicate ServiceMonitor targets (#388)"
+    - kind: changed
+      description: "update image to 8.8.0 (#403)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -221,7 +221,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Redis topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Redis image repository | `docker.io/library/redis` |
-| `image.tag` | Redis image tag | `8.6.3` |
+| `image.tag` | Redis image tag | `8.8.0` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Redis password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Redis password | `""` |

--- a/charts/redis/tests/externalsecret_test.yaml
+++ b/charts/redis/tests/externalsecret_test.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an ExternalSecret for Redis auth
+    set:
+      auth.existingSecret: redis-auth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+      externalSecrets.secretStoreRef.kind: ClusterSecretStore
+      externalSecrets.data:
+        - secretKey: redis-password
+          remoteRef:
+            key: redis/auth
+            property: password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: test-redis-auth
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: redis-auth
+
+  - it: requires an existing auth Secret when enabled
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled requires auth.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."
+
+  - it: requires ExternalSecret data mappings
+    set:
+      auth.existingSecret: redis-auth
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: platform-secrets
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data must not be empty when externalSecrets.enabled=true"

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/redis:8.6.3"
+          value: "docker.io/library/redis:8.8.0"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -28,7 +28,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/redis
-  tag: "8.6.3"
+  tag: "8.8.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Updates Redis to `8.8.0`.
- Syncs `appVersion`, default image tag, README key values, and standalone StatefulSet unit test expectation.

Closes #403

## Upstream Evidence
- Upstream release: https://github.com/redis/redis/releases/tag/8.8.0
- Docker image verified: `docker.io/library/redis:8.8.0`
- Redis 8.8.0 is the GA release of Redis Open Source 8.8 with the new Array data structure, INCREX, XNACK, new aggregators, performance improvements, and bug fixes.

## Validation
- `helm dependency build charts/redis`
- `helm lint charts/redis`
- `helm lint charts/redis --strict`
- `helm unittest charts/redis` (6 suites, 30 tests)
- Rendered every file in `charts/redis/ci/*.yaml`
- `helm template redis charts/redis | kubeconform -strict -summary`
- `ah lint charts/redis`
- `kubescape scan` with critical threshold: no critical findings, score 80
- K3D `k3d-helmforge-tests-wsl`: installed standalone with `--wait --timeout 120s`, checked resources at 60 seconds, verified StatefulSet readiness, authenticated `redis-cli PING`, `SET`, `GET`, logs without error patterns, namespace events without warnings, and removed namespace `hf-redis-403`.

## MCP HelmForge
- `validate_upstream_update`: PASS
- `validate_chart_security_evidence`: PASS
- `validate_pr_governance`: PASS