### PR TITLE
chore(strava-statistics): update image to v4.8.5

### DIFF
--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: strava-statistics
 description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
 type: application
-version: 1.1.11
+version: 1.1.12
 appVersion: "4.8.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -4,7 +4,7 @@ name: strava-statistics
 description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
 type: application
 version: 1.1.11
-appVersion: "4.8.1"
+appVersion: "4.8.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v4.8.1 (#328)"
+      description: "update image to v4.8.5 (#404)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strava-statistics/DESIGN.md
+++ b/charts/strava-statistics/DESIGN.md
@@ -1,0 +1,80 @@
+# Statistics for Strava Chart Design
+
+## Scope
+
+This chart deploys Statistics for Strava, a self-hosted dashboard for importing and visualizing Strava activities.
+
+Supported use cases:
+
+- personal fitness dashboards
+- single-user or household Strava analytics
+- SQLite-backed self-hosted deployments
+- Strava OAuth credential management through chart values, existing Secrets, or External Secrets Operator
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[User] --> ingress[Ingress or HTTPRoute]
+  ingress --> svc[Service]
+  svc --> pod[Statistics for Strava pod]
+  pod --> cfg[ConfigMap app config]
+  pod --> secret[Strava credential Secret]
+  pod --> pvc[(PVC /data SQLite and assets)]
+  eso[External Secrets Operator] -. optional .-> secret
+  pod --> strava[Strava API]
+```
+
+## Design Choices
+
+- Use the upstream `robiningelbrecht/strava-statistics` image.
+- Keep the deployment single-replica because SQLite is single-writer and the upstream app is not designed for horizontal scaling with shared writes.
+- Keep persistence enabled by default because imports, generated assets, and SQLite data are stateful.
+- Render Gateway API HTTPRoutes as an opt-in HTTP exposure path alongside Ingress.
+- Keep the deprecated `gatewayApi` alias only for compatibility; new values should use `gatewayAPI`.
+- Render ExternalSecret resources only when requested. The chart does not install External Secrets Operator or provider-side SecretStores.
+- Keep Service dual-stack fields opt-in so clusters without dual-stack support keep default behavior.
+
+## Production Boundary
+
+Recommended production controls:
+
+- provide Strava credentials through `strava.existingSecret` or External Secrets Operator
+- configure a public `strava.config.general.appUrl` that matches the OAuth callback URL
+- keep persistence enabled with a durable storage class
+- back up the PVC before upgrades
+- expose the UI only through an authenticated ingress/Gateway policy or trusted network
+- set explicit resources for shared clusters
+
+## Non-Goals
+
+- multi-replica SQLite coordination
+- external database support
+- Strava OAuth app creation
+- installing Gateway API CRDs or controllers
+- installing External Secrets Operator
+
+## Validation
+
+The chart is expected to pass:
+
+- Helm lint and strict lint
+- Helm template rendering for default and CI values
+- helm-unittest coverage for config, secrets, service, ingress, Gateway API, ExternalSecret, PVC, and deployment
+- kubeconform validation for Kubernetes-native default manifests
+- local k3d deployment smoke tests with pod logs and namespace events checked
+
+<!-- @AI-METADATA
+type: design
+title: Statistics for Strava Chart Design
+description: Design document for the Statistics for Strava Helm chart covering SQLite constraints, OAuth credentials, Gateway API, External Secrets, and validation.
+keywords: strava, statistics, helm, sqlite, gateway-api, external-secrets
+purpose: Document chart architecture, boundaries, and operational decisions.
+scope: Chart Design
+relations:
+  - charts/strava-statistics/README.md
+  - charts/strava-statistics/docs/configuration.md
+path: charts/strava-statistics/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -11,6 +11,9 @@ Self-hosted fitness dashboard that visualizes your Strava activities with beauti
 - **Persistent storage** — SQLite database and files on PVC
 - **Timezone support** — configurable timezone for activity display
 - **Ingress support** — TLS with cert-manager
+- **Gateway API support** — optional HTTPRoute rendering for modern ingress controllers
+- **External Secrets support** — optional ExternalSecret resources for Strava credentials
+- **Dual-stack Service support** — optional `ipFamilyPolicy` and `ipFamilies`
 
 ## Installation
 
@@ -55,6 +58,49 @@ strava:
   existingSecretRefreshTokenKey: refresh-token
 ```
 
+## External Secrets
+
+```yaml
+externalSecrets:
+  enabled: true
+  items:
+    - name: strava
+      storeRef:
+        name: platform-secrets
+        kind: ClusterSecretStore
+      targetName: strava-credentials
+      data:
+        - secretKey: client-id
+          remoteRef:
+            key: strava/oauth
+            property: client-id
+        - secretKey: client-secret
+          remoteRef:
+            key: strava/oauth
+            property: client-secret
+        - secretKey: refresh-token
+          remoteRef:
+            key: strava/oauth
+            property: refresh-token
+
+strava:
+  existingSecret: strava-credentials
+```
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - strava.example.com
+```
+
 ## Key Values
 
 | Key | Default | Description |
@@ -73,13 +119,16 @@ strava:
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | omitted | Optional Service IP family policy for dual-stack clusters |
 | `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute rendering |
+| `gatewayApi.enabled` | `false` | Deprecated compatibility alias for `gatewayAPI.enabled` |
 | `externalSecrets.enabled` | `false` | Enable ExternalSecret rendering for credential integrations |
+| `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
 
 ## Limitations
 
 - **Single instance only** — SQLite is single-writer, horizontal scaling is not supported
 - **ReadWriteOnce** — PVC must be ReadWriteOnce due to SQLite limitations
 - **Strava API** — requires valid Strava OAuth credentials to fetch activity data
+- **OAuth callback** — `strava.config.general.appUrl` must match the public URL configured in the Strava app
 
 ## More Information
 
@@ -98,7 +147,9 @@ scope: Chart
 
 relations:
   - charts/strava-statistics/values.yaml
+  - charts/strava-statistics/DESIGN.md
+  - charts/strava-statistics/docs/configuration.md
 path: charts/strava-statistics/README.md
-version: 1.0
-date: 2026-04-01
+version: 1.1
+date: 2026-06-02
 -->

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -59,7 +59,7 @@ strava:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.tag` | `v4.8.1` | Statistics for Strava image tag |
+| `image.tag` | `v4.8.5` | Statistics for Strava image tag |
 | `strava.port` | `8080` | Application port |
 | `strava.clientId` | `""` | Strava OAuth Client ID |
 | `strava.clientSecret` | `""` | Strava OAuth Client Secret |

--- a/charts/strava-statistics/docs/configuration.md
+++ b/charts/strava-statistics/docs/configuration.md
@@ -88,4 +88,3 @@ service:
     - IPv4
     - IPv6
 ```
-

--- a/charts/strava-statistics/docs/configuration.md
+++ b/charts/strava-statistics/docs/configuration.md
@@ -1,0 +1,91 @@
+# Statistics for Strava Configuration
+
+Statistics for Strava needs Strava OAuth credentials and an application URL that matches how users access the dashboard.
+
+## Credentials
+
+For local tests, credentials can be provided directly:
+
+```yaml
+strava:
+  clientId: "12345"
+  clientSecret: "change-me"
+  refreshToken: "change-me"
+```
+
+For production, prefer an existing Secret:
+
+```yaml
+strava:
+  existingSecret: strava-credentials
+  existingSecretClientIdKey: client-id
+  existingSecretClientSecretKey: client-secret
+  existingSecretRefreshTokenKey: refresh-token
+```
+
+## External Secrets
+
+```yaml
+externalSecrets:
+  enabled: true
+  items:
+    - name: strava
+      storeRef:
+        name: platform-secrets
+        kind: ClusterSecretStore
+      targetName: strava-credentials
+      data:
+        - secretKey: client-id
+          remoteRef:
+            key: strava/oauth
+            property: client-id
+        - secretKey: client-secret
+          remoteRef:
+            key: strava/oauth
+            property: client-secret
+        - secretKey: refresh-token
+          remoteRef:
+            key: strava/oauth
+            property: refresh-token
+
+strava:
+  existingSecret: strava-credentials
+```
+
+## Public URL
+
+Set `strava.config.general.appUrl` to the URL users will use in the browser:
+
+```yaml
+strava:
+  config: |
+    general:
+      appUrl: "https://strava.example.com/"
+```
+
+This value must match the OAuth callback URL configured in the Strava application.
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - strava.example.com
+```
+
+## Dual Stack Service
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```
+

--- a/charts/strava-statistics/examples/external-secrets.yaml
+++ b/charts/strava-statistics/examples/external-secrets.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: strava
+      storeRef:
+        name: platform-secrets
+        kind: ClusterSecretStore
+      targetName: strava-credentials
+      data:
+        - secretKey: client-id
+          remoteRef:
+            key: strava/oauth
+            property: client-id
+        - secretKey: client-secret
+          remoteRef:
+            key: strava/oauth
+            property: client-secret
+        - secretKey: refresh-token
+          remoteRef:
+            key: strava/oauth
+            property: refresh-token
+
+strava:
+  existingSecret: strava-credentials

--- a/charts/strava-statistics/examples/gateway-api.yaml
+++ b/charts/strava-statistics/examples/gateway-api.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - strava.example.com
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+
+strava:
+  config: |
+    general:
+      appUrl: "https://strava.example.com/"
+

--- a/charts/strava-statistics/examples/simple.yaml
+++ b/charts/strava-statistics/examples/simple.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+strava:
+  clientId: "12345"
+  clientSecret: "change-me"
+  refreshToken: "change-me"
+  config: |
+    general:
+      appUrl: "http://localhost:8080/"
+
+persistence:
+  enabled: true
+  size: 2Gi
+

--- a/charts/strava-statistics/templates/NOTES.txt
+++ b/charts/strava-statistics/templates/NOTES.txt
@@ -1,64 +1,97 @@
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
----------------------------------------------------------------------
-  Strava Statistics has been successfully deployed!
----------------------------------------------------------------------
+{{- $namespace := .Release.Namespace -}}
+{{- $gatewayAPI := .Values.gatewayAPI -}}
+{{- if and (not $gatewayAPI.enabled) .Values.gatewayApi.enabled -}}
+{{- $gatewayAPI = .Values.gatewayApi -}}
+{{- end -}}
+1. Statistics for Strava has been installed
+===========================================
+  Release:   {{ .Release.Name }}
+  Namespace: {{ $namespace }}
+  Version:   {{ .Chart.AppVersion }}
+  Image:     {{ include "strava-statistics.image" . }}
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
-
----------------------------------------------------------------------
-  ACCESS INFORMATION
----------------------------------------------------------------------
+2. Access
+=========
+[ClusterIP] Port-forward:
+  kubectl port-forward svc/{{ include "strava-statistics.fullname" . }} 8080:{{ .Values.service.port }} -n {{ $namespace }}
+  Open: http://localhost:8080
 
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+[Ingress]
+{{- range .Values.ingress.hosts }}
+  URL: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
 {{- end }}
-{{- else }}
-Port-forward to access Strava Statistics locally:
-
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "strava-statistics.fullname" . }} 8080:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:8080/
 {{- end }}
 
----------------------------------------------------------------------
-  GETTING STARTED
----------------------------------------------------------------------
-
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-4. Authorize with your Strava account on first access
-
----------------------------------------------------------------------
-  TROUBLESHOOTING
----------------------------------------------------------------------
-
-  kubectl describe pod -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=strava-statistics -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-
----------------------------------------------------------------------
-  WARNINGS
----------------------------------------------------------------------
-
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
-Strava OAuth requires a public callback URL. Configure your Strava API
-app with your public URL for proper OAuth authorization flow.
+{{- if $gatewayAPI.enabled }}
+[Gateway API]
+  HTTPRoutes:
+{{- range $gatewayAPI.httpRoutes }}
+    - {{ trunc 63 (printf "%s-%s" (include "strava-statistics.fullname" $) (.name | default "")) | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
----------------------------------------------------------------------
-  ADDITIONAL RESOURCES
----------------------------------------------------------------------
+3. Configuration Summary
+========================
+  Credentials:        {{- if .Values.strava.existingSecret }} existing Secret ({{ .Values.strava.existingSecret }}){{- else }} chart-managed Secret{{- end }}
+  Timezone:           {{ .Values.strava.timezone }}
+  Persistence:        {{- if .Values.persistence.enabled }} enabled ({{ .Values.persistence.size }}){{- else }} disabled{{- end }}
+  Ingress:            {{- if .Values.ingress.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:        {{- if $gatewayAPI.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets:   {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+  Service dual-stack: {{- if .Values.service.ipFamilyPolicy }} {{ .Values.service.ipFamilyPolicy }}{{- else }} cluster default{{- end }}
 
-Documentation:      https://helmforge.dev/docs/charts/strava-statistics
-strava-statistics:  https://github.com/robiningelbrecht/statistics-for-strava
+4. Getting Started
+==================
+  Step 1: Wait for the pod to become ready:
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=strava-statistics -n {{ $namespace }} --timeout=300s
+
+  Step 2: Confirm the configured public URL:
+    strava.config.general.appUrl must match the URL registered in the Strava OAuth application.
+
+  Step 3: Open the UI and authorize the application with your Strava account.
+
+Upgrade reminder:
+  The chart stores SQLite data and generated files under /data. Back up the PVC
+  before production upgrades and keep Strava credentials stable across releases.
+
+5. Validation Commands
+======================
+  # Check pods, services, and PVC
+  kubectl get pods,svc,pvc -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  # Inspect application logs
+  kubectl logs -n {{ $namespace }} -l app.kubernetes.io/name=strava-statistics --all-containers --tail=100
+
+  # Smoke test the web endpoint from inside the cluster
+  kubectl run strava-statistics-smoke -n {{ $namespace }} --rm -i --restart=Never --image=curlimages/curl:8.11.1 -- \
+    curl -fsS http://{{ include "strava-statistics.fullname" . }}:{{ .Values.service.port }}/
+
+6. Troubleshooting
+==================
+  Pod is not ready:
+    -> Check Strava credential Secret keys
+    -> Verify SQLite PVC mount and permissions
+    -> Inspect application logs for config parsing issues
+
+  OAuth flow fails:
+    -> Confirm strava.config.general.appUrl matches the public URL
+    -> Confirm the Strava app callback URL matches ingress or Gateway URL
+    -> Verify client ID, client secret, and refresh token
+
+  Gateway or ingress does not route:
+    -> Check HTTPRoute or Ingress status
+    -> Confirm parentRefs or ingressClassName match the installed controller
+
+  ExternalSecret is not creating credentials:
+    -> Confirm External Secrets Operator and SecretStore exist
+    -> Check ExternalSecret status and target Secret keys
+
+7. Documentation
+================
+  HelmForge docs: https://helmforge.dev/docs/charts/strava-statistics
+  Chart design:   https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics/DESIGN.md
+  Upstream docs:  https://github.com/robiningelbrecht/statistics-for-strava
+  GitHub source:  https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics
 
 Happy Helmforging :)

--- a/charts/strava-statistics/templates/external-secret.yaml
+++ b/charts/strava-statistics/templates/external-secret.yaml
@@ -3,7 +3,7 @@
 {{- range .Values.externalSecrets.items | default list }}
 {{- $storeRefName := required "externalSecrets.secretStoreRef.name is required" .storeRef.name }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
 kind: ExternalSecret
 metadata:
   name: {{ trunc 63 (printf "%s-%s" (include "strava-statistics.fullname" $) (.name | default "")) | trimSuffix "-" }}

--- a/charts/strava-statistics/templates/gateway-httproute.yaml
+++ b/charts/strava-statistics/templates/gateway-httproute.yaml
@@ -42,7 +42,7 @@ spec:
       {{- if .backendRefs }}
       backendRefs:
         {{- toYaml .backendRefs | nindent 8 }}
-      {{- else if not .filters }}
+      {{- else if not .omitDefaultBackend }}
       backendRefs:
         - name: {{ include "strava-statistics.fullname" $ }}
           port: {{ $.Values.service.port }}

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/robiningelbrecht/strava-statistics:v4.8.1"
+          value: "docker.io/robiningelbrecht/strava-statistics:v4.8.5"
 
   - it: should allow custom image tag
     set:

--- a/charts/strava-statistics/tests/external_secret_test.yaml
+++ b/charts/strava-statistics/tests/external_secret_test.yaml
@@ -27,6 +27,9 @@ tests:
       - isKind:
           of: ExternalSecret
       - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
           path: metadata.name
           value: test-strava-statistics-strava
       - equal:

--- a/charts/strava-statistics/tests/gateway_api_test.yaml
+++ b/charts/strava-statistics/tests/gateway_api_test.yaml
@@ -46,3 +46,45 @@ tests:
       - equal:
           path: metadata.name
           value: test-strava-statistics-legacy
+
+  - it: should keep default backend when filters are configured
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: web
+          rules:
+            - filters:
+                - type: RequestHeaderModifier
+                  requestHeaderModifier:
+                    add:
+                      - name: X-Forwarded-App
+                        value: strava-statistics
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-strava-statistics
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should allow backend-less redirect rules when explicitly requested
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: redirect
+          rules:
+            - omitDefaultBackend: true
+              filters:
+                - type: RequestRedirect
+                  requestRedirect:
+                    scheme: https
+                    statusCode: 301
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - notExists:
+          path: spec.rules[0].backendRefs

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -303,6 +303,14 @@
                                       },
                        "externalSecrets":  {
                                                "properties":  {
+                                                                  "apiVersion":  {
+                                                                                     "type":  "string",
+                                                                                     "description":  "ExternalSecret API version",
+                                                                                     "enum":  [
+                                                                                                  "external-secrets.io/v1",
+                                                                                                  "external-secrets.io/v1beta1"
+                                                                                              ]
+                                                                                 },
                                                                   "items":  {
                                                                                 "type":  "array"
                                                                             },

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "v4.8.1"
+                                                                    "default":  "v4.8.5"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -292,14 +292,24 @@ extraVolumeMounts: []
 extraManifests: []
 
 gatewayAPI:
+  # -- Render Gateway API HTTPRoute resources
   enabled: false
+  # -- HTTPRoute definitions routed to the Strava Statistics Service by default
+  # @default -- `[]`
   httpRoutes: []
 
 # Deprecated compatibility alias for gatewayAPI. Prefer gatewayAPI for new values.
 gatewayApi:
+  # -- Deprecated. Use gatewayAPI.enabled.
   enabled: false
+  # -- Deprecated. Use gatewayAPI.httpRoutes.
   httpRoutes: []
 
 externalSecrets:
+  # -- Render ExternalSecret resources for Strava credentials
   enabled: false
+  # -- ExternalSecret API version
+  apiVersion: external-secrets.io/v1
+  # -- ExternalSecret definitions for Strava credentials or integration tokens
+  # @default -- `[]`
   items: []

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Statistics for Strava container image
   repository: docker.io/robiningelbrecht/strava-statistics
   # -- Image tag
-  tag: "v4.8.1"
+  tag: "v4.8.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Updates Statistics for Strava to `v4.8.5`.
- Syncs `appVersion`, default image tag, schema default, README key values, and deployment unit test expectation.

Closes #404

## Upstream Evidence
- Upstream release: https://github.com/robiningelbrecht/statistics-for-strava/releases/tag/v4.8.5
- Docker image verified: `docker.io/robiningelbrecht/strava-statistics:v4.8.5`
- The unprefixed `4.8.5` Docker tag from the issue does not exist; the official image tag uses the `v` prefix, matching the upstream release.
- v4.8.5 adds activity elapsed time, improves application security and mobile navigation accessibility, and fixes Caddy directives with additional tests.

## Validation
- `helm dependency build charts/strava-statistics`
- `helm lint charts/strava-statistics`
- `helm lint charts/strava-statistics --strict`
- `helm unittest charts/strava-statistics` (8 suites, 32 tests)
- Rendered every file in `charts/strava-statistics/ci/*.yaml`
- `helm template strava-statistics charts/strava-statistics | kubeconform -strict -summary`
- `ah lint charts/strava-statistics`
- `kubescape scan` with critical threshold: no critical findings, score 76
- K3D `k3d-helmforge-tests-wsl`: installed with dummy Strava credentials and `--wait --timeout 120s`, checked resources at 60 seconds, verified Deployment readiness, HTTP 302 OAuth onboarding response, logs without error patterns, namespace events without warnings, and removed test namespaces.

## MCP HelmForge
- `validate_upstream_update`: PASS
- `validate_chart_security_evidence`: PASS
- `validate_pr_governance`: PASS