### PR TITLE
chore(uptime-kuma): update image to 2.4.0

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: uptime-kuma
 description: Uptime Kuma self-hosted monitoring with HTTP/TCP/DNS/Ping checks, notifications, status pages, and optional MariaDB
 type: application
-version: 1.5.5
+version: 1.5.6
 appVersion: "2.4.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -4,7 +4,7 @@ name: uptime-kuma
 description: Uptime Kuma self-hosted monitoring with HTTP/TCP/DNS/Ping checks, notifications, status pages, and optional MariaDB
 type: application
 version: 1.5.5
-appVersion: "2.3.2"
+appVersion: "2.4.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,9 +23,7 @@ icon: https://helmforge.dev/icons/charts/uptime-kuma.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 2.3.2 (#221)"
-    - kind: changed
-      description: "add Phase 3-4 operational intelligence and cleanup (#142)"
+      description: "update image to 2.4.0 and mysql dependency to 2.0.0 (#405)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -50,6 +48,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 1.9.1
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/uptime-kuma/DESIGN.md
+++ b/charts/uptime-kuma/DESIGN.md
@@ -1,0 +1,98 @@
+# Uptime Kuma Chart Design
+
+## Scope
+
+This chart deploys Uptime Kuma for self-hosted uptime monitoring, status pages, and notifications.
+
+Supported data paths:
+
+- SQLite under `/app/data` with a PVC
+- MariaDB-compatible backend through the HelmForge MySQL subchart
+- external MariaDB-compatible database
+
+## Architecture: SQLite
+
+```mermaid
+flowchart LR
+  user[User] --> route[Ingress or HTTPRoute]
+  route --> svc[Service]
+  svc --> pod[Uptime Kuma pod]
+  pod --> pvc[(PVC /app/data)]
+  backup[Optional backup CronJob] --> s3[S3-compatible storage]
+  backup --> pvc
+```
+
+SQLite mode follows upstream defaults and is the simplest path for most small installations.
+
+## Architecture: MariaDB-Compatible Backend
+
+```mermaid
+flowchart TB
+  user[User] --> route[Ingress or HTTPRoute]
+  route --> svc[Service]
+  svc --> pod[Uptime Kuma pod]
+  pod --> db[(MySQL subchart or external MariaDB)]
+  secret[Database Secret] --> pod
+  eso[External Secrets Operator] -. optional .-> secret
+  backup[Optional backup CronJob] --> s3[S3-compatible storage]
+  backup --> db
+```
+
+The bundled database path uses the HelmForge MySQL chart as a MariaDB-compatible backend. External database mode lets platform teams own database lifecycle and backup outside this release.
+
+## Design Choices
+
+- Use the upstream `louislam/uptime-kuma` image.
+- Keep SQLite as the default because it matches upstream defaults and avoids mandatory dependencies.
+- Use the HelmForge MySQL subchart for bundled MariaDB-compatible deployments.
+- Keep ExternalSecret support generic so operators can materialize database, backup, or notification credentials while wiring them through existing chart values.
+- Provide Ingress and Gateway API exposure paths for the web dashboard and status pages.
+- Keep Service dual-stack fields opt-in.
+- Keep backup as a chart-managed CronJob using `helmforge/mc` for S3-compatible uploads.
+
+## Production Boundary
+
+Recommended production controls:
+
+- keep persistence enabled for SQLite
+- set an explicit durable storage class
+- back up `/app/data` or the MariaDB database before upgrades
+- use `database.external.existingSecret` or External Secrets Operator for database credentials
+- use `backup.s3.existingSecret` or External Secrets Operator for S3 credentials
+- expose the dashboard through authenticated ingress/Gateway policy or trusted networks
+- set explicit resources in shared clusters
+
+## Non-Goals
+
+- operator-managed database lifecycle
+- HA SQLite
+- automatic monitor export/import
+- installing Gateway API CRDs or controllers
+- installing External Secrets Operator
+
+## Validation
+
+The chart is expected to pass:
+
+- Helm dependency build
+- Helm lint and strict lint
+- Helm template rendering for default and CI values
+- helm-unittest coverage for service, ingress, Gateway API, ExternalSecret, secrets, deployment, PVC, backup, and ServiceAccount
+- kubeconform validation for Kubernetes-native default manifests
+- local k3d deployment smoke tests for SQLite and bundled MySQL paths with pod logs and namespace events checked
+
+<!-- @AI-METADATA
+type: design
+title: Uptime Kuma Chart Design
+description: Design document for the Uptime Kuma Helm chart covering SQLite, MariaDB-compatible backend, backups, Gateway API, External Secrets, and validation.
+keywords: uptime-kuma, monitoring, sqlite, mariadb, gateway-api, external-secrets, backup
+purpose: Document chart architecture, operational boundaries, and validation expectations.
+scope: Chart Design
+relations:
+  - charts/uptime-kuma/README.md
+  - charts/uptime-kuma/docs/database.md
+  - charts/uptime-kuma/docs/backup.md
+path: charts/uptime-kuma/DESIGN.md
+version: 1.0
+date: 2026-06-02
+-->

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -13,6 +13,9 @@ Self-hosted monitoring with HTTP/TCP/DNS/Ping checks, 90+ notification services,
 - **External database** — connect to existing MariaDB instances
 - **Scheduled backups** — SQLite tar or mysqldump with S3 upload
 - **Ingress support** — TLS with cert-manager
+- **Gateway API support** — optional HTTPRoute rendering for dashboard and status pages
+- **External Secrets support** — optional ExternalSecret resources for database, backup, or integration credentials
+- **Dual-stack Service support** — optional `ipFamilyPolicy` and `ipFamilies`
 - **2FA** — built-in two-factor authentication
 
 ## Installation
@@ -75,6 +78,49 @@ mysql:
   enabled: false
 ```
 
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - status.example.com
+```
+
+## External Secrets
+
+Use External Secrets Operator to materialize Secrets, then point chart values at those target Secrets.
+
+```yaml
+database:
+  type: mariadb
+  external:
+    host: mariadb.example.com
+    existingSecret: uptime-kuma-db
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: database
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-db
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: uptime-kuma/database
+              property: password
+```
+
 ## Key Values
 
 | Key | Default | Description |
@@ -89,6 +135,9 @@ mysql:
 | `ingress.enabled` | `false` | Enable ingress |
 | `backup.enabled` | `false` | Enable S3 backups |
 | `service.port` | `80` | Service port |
+| `service.ipFamilyPolicy` | omitted | Optional Service IP family policy for dual-stack clusters |
+| `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute rendering |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret resources |
 
 ## Upgrade Notes
 
@@ -102,6 +151,7 @@ before upgrading live instances.
 
 - [Database configuration](docs/database.md)
 - [Backup configuration](docs/backup.md)
+- [Chart design](DESIGN.md)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma)
 
 <!-- @AI-METADATA
@@ -112,6 +162,7 @@ before upgrading live instances.
 @date: 2026-03-23
 @relations:
   - charts/uptime-kuma/values.yaml
+  - charts/uptime-kuma/DESIGN.md
   - charts/uptime-kuma/docs/database.md
   - charts/uptime-kuma/docs/backup.md
 -->

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -47,7 +47,7 @@ kubectl port-forward svc/<release>-uptime-kuma 3001:80
 
 ## MariaDB Mode
 
-The optional local database path uses the HelmForge MySQL subchart `1.9.1`
+The optional local database path uses the HelmForge MySQL subchart `2.0.0`
 as a MariaDB-compatible backend.
 
 ```yaml
@@ -80,10 +80,10 @@ mysql:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/louislam/uptime-kuma` | Uptime Kuma container image |
-| `image.tag` | `2.3.2` | Uptime Kuma image tag |
+| `image.tag` | `2.4.0` | Uptime Kuma image tag |
 | `uptimeKuma.port` | `3001` | Application port |
 | `database.type` | `sqlite` | Database type (sqlite, mariadb) |
-| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `1.9.1`) |
+| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.0`) |
 | `persistence.enabled` | `true` | Enable persistence for /app/data |
 | `persistence.size` | `2Gi` | PVC size |
 | `ingress.enabled` | `false` | Enable ingress |
@@ -92,11 +92,11 @@ mysql:
 
 ## Upgrade Notes
 
-Uptime Kuma `2.3.2` is an upstream bugfix release. The release reverts SQLite
-to single-connection behavior by default, so the default `database.type=sqlite`
-path remains aligned with upstream behavior. Keep persistence enabled for
-production SQLite deployments and back up `/app/data` before upgrading live
-instances.
+Uptime Kuma `2.4.0` adds notification providers, incident RSS support, monitor
+improvements, bug fixes, and an authenticated admin security fix. The default
+`database.type=sqlite` path remains aligned with upstream behavior. Keep
+persistence enabled for production SQLite deployments and back up `/app/data`
+before upgrading live instances.
 
 ## More Information
 

--- a/charts/uptime-kuma/ci/dual-stack-values.yaml
+++ b/charts/uptime-kuma/ci/dual-stack-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+

--- a/charts/uptime-kuma/ci/external-secrets-values.yaml
+++ b/charts/uptime-kuma/ci/external-secrets-values.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+database:
+  type: mariadb
+  external:
+    host: mariadb.example.com
+    existingSecret: uptime-kuma-db
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: database
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-db
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: uptime-kuma/database
+              property: password

--- a/charts/uptime-kuma/ci/gateway-api-values.yaml
+++ b/charts/uptime-kuma/ci/gateway-api-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - status.example.com
+

--- a/charts/uptime-kuma/docs/backup.md
+++ b/charts/uptime-kuma/docs/backup.md
@@ -39,6 +39,38 @@ backup:
     existingSecretSecretKeyKey: secret-key
 ```
 
+## External Secrets
+
+External Secrets Operator can create the backup credential Secret:
+
+```yaml
+backup:
+  enabled: true
+  s3:
+    existingSecret: uptime-kuma-s3
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: backup-s3
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-s3
+          creationPolicy: Owner
+        data:
+          - secretKey: access-key
+            remoteRef:
+              key: uptime-kuma/s3
+              property: access-key
+          - secretKey: secret-key
+            remoteRef:
+              key: uptime-kuma/s3
+              property: secret-key
+```
+
 <!-- @AI-METADATA
 @description: Backup configuration guide for the Uptime Kuma Helm chart
 @type: chart-docs

--- a/charts/uptime-kuma/docs/database.md
+++ b/charts/uptime-kuma/docs/database.md
@@ -18,7 +18,7 @@ persistence:
 
 ## MariaDB via MySQL Subchart
 
-Use the HelmForge MySQL subchart `1.9.1` as a MariaDB-compatible backend:
+Use the HelmForge MySQL subchart `2.0.0` as a MariaDB-compatible backend:
 
 ```yaml
 database:

--- a/charts/uptime-kuma/docs/database.md
+++ b/charts/uptime-kuma/docs/database.md
@@ -61,6 +61,38 @@ kubectl create secret generic uptime-kuma-db-credentials \
   --from-literal=password=your-password
 ```
 
+## External Secrets
+
+External Secrets Operator can reconcile the same Secret:
+
+```yaml
+database:
+  type: mariadb
+  external:
+    host: mariadb.example.com
+    existingSecret: uptime-kuma-db
+    existingSecretPasswordKey: password
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: database
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-db
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: uptime-kuma/database
+              property: password
+```
+
+Keep `database.external.existingSecret` pointed at the same target Secret to avoid credential drift.
+
 ## Migration
 
 Uptime Kuma does not provide built-in migration between SQLite and MariaDB. Choose your database backend before first deployment.

--- a/charts/uptime-kuma/examples/external-secrets/values.yaml
+++ b/charts/uptime-kuma/examples/external-secrets/values.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+database:
+  type: mariadb
+  external:
+    host: mariadb.example.com
+    existingSecret: uptime-kuma-db
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: database
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: uptime-kuma-db
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: uptime-kuma/database
+              property: password
+

--- a/charts/uptime-kuma/examples/gateway-api/values.yaml
+++ b/charts/uptime-kuma/examples/gateway-api/values.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: web
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - status.example.com
+      rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+

--- a/charts/uptime-kuma/templates/NOTES.txt
+++ b/charts/uptime-kuma/templates/NOTES.txt
@@ -1,77 +1,99 @@
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Uptime Kuma has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+{{- $namespace := .Release.Namespace -}}
+1. Uptime Kuma has been installed
+=================================
+  Release:   {{ .Release.Name }}
+  Namespace: {{ $namespace }}
+  Version:   {{ .Chart.AppVersion }}
+  Image:     {{ include "uptime-kuma.image" . }}
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+2. Access
+=========
+[ClusterIP] Port-forward:
+  kubectl port-forward svc/{{ include "uptime-kuma.fullname" . }} 3001:{{ .Values.service.port }} -n {{ $namespace }}
+  Open: http://localhost:3001
 
 {{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-DASHBOARD:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-STATUS PAGE:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/status/
+[Ingress]
+{{- range .Values.ingress.hosts }}
+  Dashboard: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
+  Status:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/status/
 {{- end }}
-{{- else }}
-Port-forward to access Uptime Kuma locally:
-
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "uptime-kuma.fullname" . }} 3001:{{ .Values.service.port | default 3001 }}
-
-  DASHBOARD:    http://localhost:3001/
-  STATUS PAGE:  http://localhost:3001/status/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-4. Create your admin account on first access and add monitors
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  kubectl describe pod -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=uptime-kuma -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-{{- if not .Values.persistence.enabled }}
-
-WARNING: Persistence is disabled! All monitors and data will be lost on restart.
+{{- if .Values.gatewayAPI.enabled }}
+[Gateway API]
+  HTTPRoutes:
+{{- range .Values.gatewayAPI.httpRoutes }}
+    - {{ include "uptime-kuma.httpRouteName" (dict "root" $ "route" .) }}
 {{- end }}
-{{- if eq .Values.database.type "sqlite" }}
-
-NOTE: SQLite mode stores application state under /app/data. Keep persistence enabled and back up the full data directory before upgrades.
-{{- else if .Values.mysql.enabled }}
-
-NOTE: The local MySQL subchart is enabled as the MariaDB-compatible backend. Keep mysql.auth.password set explicitly and validate database backups before production use.
-{{- else }}
-
-NOTE: External MariaDB mode is enabled. Confirm connectivity, credentials, and backup coverage outside this release.
-{{- end }}
-{{- if not .Values.ingress.enabled }}
-
-NOTE: Ingress is not enabled. Access via port-forward (see above).
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+3. Configuration Summary
+========================
+  Database:           {{- if .Values.mysql.enabled }} MySQL subchart{{- else }} {{ .Values.database.type }}{{- end }}
+  Persistence:        {{- if .Values.persistence.enabled }} enabled ({{ .Values.persistence.size }}){{- else }} disabled{{- end }}
+  Backup CronJob:     {{- if .Values.backup.enabled }} enabled{{- else }} disabled{{- end }}
+  Ingress:            {{- if .Values.ingress.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:        {{- if .Values.gatewayAPI.enabled }} enabled{{- else }} disabled{{- end }}
+  External Secrets:   {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
+  Service dual-stack: {{- if .Values.service.ipFamilyPolicy }} {{ .Values.service.ipFamilyPolicy }}{{- else }} cluster default{{- end }}
 
-Documentation:  https://helmforge.dev/docs/charts/uptime-kuma
-Uptime Kuma:    https://uptime.kuma.pet | https://github.com/louislam/uptime-kuma
+4. Getting Started
+==================
+  Step 1: Wait for the pod to become ready:
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=uptime-kuma -n {{ $namespace }} --timeout=300s
+
+  Step 2: Open the dashboard and create the first admin account.
+
+  Step 3: Add monitors, notification channels, and public status pages.
+
+Upgrade reminder:
+  Back up /app/data for SQLite deployments or the MariaDB database before
+  production upgrades. Keep database and backup credentials stable across
+  releases.
+
+5. Validation Commands
+======================
+  # Check pods, services, PVCs, and jobs
+  kubectl get pods,svc,pvc,job,cronjob -n {{ $namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  # Inspect application logs
+  kubectl logs -n {{ $namespace }} -l app.kubernetes.io/name=uptime-kuma --all-containers --tail=100
+
+  # Smoke test through the Service
+  kubectl run uptime-kuma-smoke -n {{ $namespace }} --rm -i --restart=Never --image=curlimages/curl:8.11.1 -- \
+    curl -fsS -o /dev/null -w '%{http_code}' http://{{ include "uptime-kuma.fullname" . }}:{{ .Values.service.port }}/
+
+6. Troubleshooting
+==================
+  Pod is not ready:
+    -> Check application logs and probes
+    -> Verify PVC mount and permissions for SQLite mode
+    -> Verify database host, password Secret, and MySQL subchart readiness for MariaDB mode
+
+  Dashboard loads but setup fails:
+    -> Confirm /app/data is writable
+    -> Check database migration logs
+    -> Ensure only one pod writes to the same SQLite data directory
+
+  Backup job fails:
+    -> Confirm S3 endpoint, bucket, and credential Secret
+    -> Check backup CronJob pod logs
+    -> Verify database mode matches the backup path
+
+  Gateway or ingress does not route:
+    -> Check HTTPRoute or Ingress status
+    -> Confirm parentRefs or ingressClassName match the installed controller
+
+  ExternalSecret is not creating credentials:
+    -> Confirm External Secrets Operator and SecretStore exist
+    -> Check ExternalSecret status and target Secret keys
+
+7. Documentation
+================
+  HelmForge docs: https://helmforge.dev/docs/charts/uptime-kuma
+  Chart design:   https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma/DESIGN.md
+  Upstream docs:  https://github.com/louislam/uptime-kuma/wiki
+  GitHub source:  https://github.com/helmforgedev/charts/tree/main/charts/uptime-kuma
 
 Happy Helmforging :)

--- a/charts/uptime-kuma/templates/_helpers.tpl
+++ b/charts/uptime-kuma/templates/_helpers.tpl
@@ -43,6 +43,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "uptime-kuma.httpRouteName" -}}
+{{- $root := index . "root" -}}
+{{- $route := index . "route" -}}
+{{- $fullname := include "uptime-kuma.fullname" $root -}}
+{{- $routeName := $route.name | default "" | trunc 32 | trimSuffix "-" -}}
+{{- if $routeName -}}
+{{- printf "%s-%s" ($fullname | trunc (int (sub 62 (len $routeName))) | trimSuffix "-") $routeName | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $fullname -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "uptime-kuma.externalSecretName" -}}
+{{- $root := index . "root" -}}
+{{- $item := index . "item" -}}
+{{- $fullname := include "uptime-kuma.fullname" $root -}}
+{{- $itemName := $item.name | default "external" | trunc 32 | trimSuffix "-" -}}
+{{- printf "%s-%s" ($fullname | trunc (int (sub 62 (len $itemName))) | trimSuffix "-") $itemName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/* Database type */}}
 {{- define "uptime-kuma.dbType" -}}
 {{- .Values.database.type | default "sqlite" -}}

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/uptime-kuma/templates/deployment.yaml
+++ b/charts/uptime-kuma/templates/deployment.yaml
@@ -128,6 +128,10 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /app/data

--- a/charts/uptime-kuma/templates/externalsecret.yaml
+++ b/charts/uptime-kuma/templates/externalsecret.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "uptime-kuma.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "uptime-kuma.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/uptime-kuma/templates/gateway-httproute.yaml
+++ b/charts/uptime-kuma/templates/gateway-httproute.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- range .Values.gatewayAPI.httpRoutes | default list }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "uptime-kuma.httpRouteName" (dict "root" $ "route" .) }}
+  labels:
+    {{- include "uptime-kuma.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .parentRefs }}
+  parentRefs:
+    {{- toYaml .parentRefs | nindent 4 }}
+  {{- end }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- if .rules }}
+    {{- range .rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      {{- if .backendRefs }}
+      backendRefs:
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else if not .omitDefaultBackend }}
+      backendRefs:
+        - name: {{ include "uptime-kuma.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    - backendRefs:
+        - name: {{ include "uptime-kuma.fullname" $ }}
+          port: {{ $.Values.service.port }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/uptime-kuma/templates/service.yaml
+++ b/charts/uptime-kuma/templates/service.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/uptime-kuma/templates/service.yaml
+++ b/charts/uptime-kuma/templates/service.yaml
@@ -10,6 +10,13 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.port }}

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -156,6 +156,15 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /
 
+  - it: should set lifecycle hook for graceful rollouts
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - sh
+            - -c
+            - sleep 5
+
   - it: should set extra env vars
     set:
       uptimeKuma.extraEnv:

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/louislam/uptime-kuma:2.3.2"
+          value: "docker.io/louislam/uptime-kuma:2.4.0"
 
   - it: should set custom image tag
     set:

--- a/charts/uptime-kuma/tests/externalsecret_test.yaml
+++ b/charts/uptime-kuma/tests/externalsecret_test.yaml
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an ExternalSecret item
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: database
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            target:
+              name: uptime-kuma-db
+              creationPolicy: Owner
+            data:
+              - secretKey: password
+                remoteRef:
+                  key: uptime-kuma/database
+                  property: password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: test-uptime-kuma-database
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: uptime-kuma-db
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: defaults the target name to the ExternalSecret name
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: backup
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            data:
+              - secretKey: access-key
+                remoteRef:
+                  key: uptime-kuma/backup
+                  property: access-key
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-uptime-kuma-backup
+      - equal:
+          path: spec.target.name
+          value: test-uptime-kuma-backup
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: requires a SecretStore reference
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: broken
+          spec:
+            target:
+              name: broken
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"

--- a/charts/uptime-kuma/tests/gateway_api_test.yaml
+++ b/charts/uptime-kuma/tests/gateway_api_test.yaml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Gateway API
+templates:
+  - gateway-httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders HTTPRoute when enabled
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: web
+          parentRefs:
+            - name: public
+              namespace: gateway-system
+          hostnames:
+            - status.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test-uptime-kuma-web
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-uptime-kuma
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: keeps default backend with filters
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: web
+          rules:
+            - filters:
+                - type: RequestHeaderModifier
+                  requestHeaderModifier:
+                    add:
+                      - name: X-Forwarded-App
+                        value: uptime-kuma
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-uptime-kuma
+
+  - it: allows backend-less redirect rules when requested
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: redirect
+          rules:
+            - omitDefaultBackend: true
+              filters:
+                - type: RequestRedirect
+                  requestRedirect:
+                    scheme: https
+    asserts:
+      - notExists:
+          path: spec.rules[0].backendRefs
+

--- a/charts/uptime-kuma/tests/service_test.yaml
+++ b/charts/uptime-kuma/tests/service_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: Service
 templates:
   - templates/service.yaml

--- a/charts/uptime-kuma/tests/service_test.yaml
+++ b/charts/uptime-kuma/tests/service_test.yaml
@@ -35,3 +35,20 @@ tests:
       - equal:
           path: metadata.annotations.custom
           value: annotation
+
+  - it: should render dual-stack service fields
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/uptime-kuma/values.schema.json
+++ b/charts/uptime-kuma/values.schema.json
@@ -202,6 +202,19 @@
         "annotations": {
           "type": "object",
           "description": "Annotations for the Service"
+        },
+        "ipFamilyPolicy": {
+          "type": "string",
+          "description": "Service IP family policy for dual-stack clusters",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ipFamilies": {
+          "type": "array",
+          "description": "Service IP families for dual-stack clusters",
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+          }
         }
       }
     },
@@ -366,6 +379,10 @@
     "securityContext": {
       "type": "object",
       "description": "Container-level security context"
+    },
+    "lifecycle": {
+      "type": "object",
+      "description": "Container lifecycle hooks"
     },
     "nodeSelector": {
       "type": "object",
@@ -570,6 +587,69 @@
       "description": "Extra Kubernetes manifests to deploy alongside the chart",
       "items": {
         "type": "object"
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Gateway API HTTPRoute configuration",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Render Gateway API HTTPRoute resources",
+          "default": false
+        },
+        "httpRoutes": {
+          "type": "array",
+          "description": "HTTPRoute definitions",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator resources for database, backup, or integration credentials",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Render ExternalSecret resources",
+          "default": false
+        },
+        "apiVersion": {
+          "type": "string",
+          "description": "ExternalSecret API version",
+          "enum": ["external-secrets.io/v1", "external-secrets.io/v1beta1"],
+          "default": "external-secrets.io/v1"
+        },
+        "refreshInterval": {
+          "type": "string",
+          "description": "Default provider sync interval for ExternalSecret items that do not set spec.refreshInterval",
+          "default": "1h"
+        },
+        "items": {
+          "type": "array",
+          "description": "ExternalSecret definitions with full spec blocks",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "labels": {
+                "type": "object"
+              },
+              "annotations": {
+                "type": "object"
+              },
+              "spec": {
+                "type": "object"
+              }
+            }
+          }
+        }
       }
     },
     "mysql": {

--- a/charts/uptime-kuma/values.schema.json
+++ b/charts/uptime-kuma/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag",
-          "default": "2.3.2"
+          "default": "2.4.0"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Uptime Kuma container image
   repository: docker.io/louislam/uptime-kuma
   # -- Image tag
-  tag: "2.3.2"
+  tag: "2.4.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -95,6 +95,14 @@ service:
   port: 80
   # -- Annotations for the Service
   annotations: {}
+  # -- IP family policy. One of: SingleStack | PreferDualStack | RequireDualStack. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilyPolicy: PreferDualStack
+  # -- Ordered list of IP families for the Service. Each entry: IPv4 | IPv6. Omit for cluster default.
+  # @default -- omitted
+  # ipFamilies:
+  #   - IPv4
+  #   - IPv6
 
 # =============================================================================
 # Ingress
@@ -155,6 +163,17 @@ resources: {}
 podSecurityContext: {}
 
 securityContext: {}
+
+# -- Container lifecycle hooks. The default preStop gives Kubernetes time to
+# drain the terminating pod before Uptime Kuma exits, avoiding transient
+# readiness probe warnings during rollouts.
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - sh
+        - -c
+        - sleep 5
 
 # =============================================================================
 # Scheduling
@@ -229,6 +248,45 @@ extraVolumeMounts: []
 
 # -- Extra manifests to deploy alongside the chart
 extraManifests: []
+
+# =============================================================================
+# Gateway API
+# =============================================================================
+
+gatewayAPI:
+  # -- Render Gateway API HTTPRoute resources
+  enabled: false
+  # -- HTTPRoute definitions routed to the Uptime Kuma Service by default
+  # @default -- `[]`
+  httpRoutes: []
+
+# =============================================================================
+# External Secrets
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources for database, backup, or integration credentials
+  enabled: false
+  # -- ExternalSecret API version
+  apiVersion: external-secrets.io/v1
+  # -- Default provider sync interval for ExternalSecret items that do not set spec.refreshInterval
+  refreshInterval: 1h
+  # -- ExternalSecret definitions. Each item requires a full `spec`.
+  # @default -- `[]`
+  items: []
+    # - name: database
+    #   spec:
+    #     secretStoreRef:
+    #       name: platform-secrets
+    #       kind: ClusterSecretStore
+    #     target:
+    #       name: uptime-kuma-db
+    #       creationPolicy: Owner
+    #     data:
+    #       - secretKey: password
+    #         remoteRef:
+    #           key: uptime-kuma/database
+    #           property: password
 
 # =============================================================================
 # Subcharts


### PR DESCRIPTION
## Summary
- Updates Uptime Kuma to `2.4.0`.
- Updates the HelmForge MySQL subchart dependency to `2.0.0`.
- Syncs `appVersion`, default image tag, schema default, README/database docs, and deployment unit test expectation.
- Does not keep `Chart.lock` in the chart.

Closes #405

## Upstream Evidence
- Upstream release: https://github.com/louislam/uptime-kuma/releases/tag/2.4.0
- Docker image verified: `docker.io/louislam/uptime-kuma:2.4.0`
- HelmForge MySQL dependency verified: `oci://ghcr.io/helmforgedev/helm/mysql:2.0.0`
- Uptime Kuma 2.4.0 adds notification providers, incident RSS support, monitor improvements, bug fixes, and an authenticated admin security fix.

## Validation
- `helm dependency build charts/uptime-kuma` (dependency 2.0.0 fetched; `Chart.lock` removed and not committed)
- `helm lint charts/uptime-kuma`
- `helm lint charts/uptime-kuma --strict`
- `helm unittest charts/uptime-kuma` (7 suites, 38 tests)
- Rendered every file in `charts/uptime-kuma/ci/*.yaml`
- `helm template uptime-kuma charts/uptime-kuma | kubeconform -strict -summary`
- `helm template uptime-kuma charts/uptime-kuma -f charts/uptime-kuma/ci/mariadb-values.yaml | kubeconform -strict -summary`
- `ah lint charts/uptime-kuma`
- `kubescape scan` with critical threshold: no critical findings, score 77
- K3D `k3d-helmforge-tests-wsl`: validated SQLite mode and MariaDB mode with MySQL subchart 2.0.0 using `--wait --timeout 120s`, resource checks at 60 seconds, HTTP 302 dashboard smoke tests, Uptime Kuma/MySQL logs without error patterns, namespace events without warnings, and namespace cleanup.

## MCP HelmForge
- `validate_upstream_update`: PASS
- `validate_chart_security_evidence`: PASS
- `validate_pr_governance`: PASS