### PR TITLE
ci(automation): add Tier 1 drift-detection and auto-fix workflows

### DIFF
--- a/.github/workflows/automation-org-consistency.yml
+++ b/.github/workflows/automation-org-consistency.yml
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Automation - Org Consistency
+
+# Keeps the org profile counts and chart<->site parity correct.
+# Opens an auto-fix PR for the profile counts (in helmforgedev/.github) and a
+# tracking issue for parity gaps that need manual work. Manual merge.
+#
+# Requires repo/org secret OPS_AUTOMATION_TOKEN: a PAT (or GitHub App token)
+# with contents+issues+pull_requests write on helmforgedev/{.github,site} and
+# read on the private helmforgedev/helmforge-ops. See helmforge-ops README.
+
+on:
+  schedule:
+    - cron: '0 7 * * 1' # Monday 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  org-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout helmforge-ops (private)
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/helmforge-ops
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: ops
+
+      - name: Checkout charts
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/charts
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: charts
+
+      - name: Checkout site
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/site
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: site
+
+      - name: Checkout .github profile
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/.github
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: github-profile
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install ops dependencies
+        working-directory: ops
+        run: npm ci
+
+      - name: Configure git auth for pushes
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+
+      - name: Run org-consistency reporter
+        working-directory: ops
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          HELMFORGE_CHARTS_DIR: ${{ github.workspace }}/charts
+          HELMFORGE_SITE_DIR: ${{ github.workspace }}/site
+          HELMFORGE_GITHUB_DIR: ${{ github.workspace }}/github-profile
+        run: node scripts/ci/auto-report.js --check org-consistency

--- a/.github/workflows/automation-spdx-migrate.yml
+++ b/.github/workflows/automation-spdx-migrate.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Automation - SPDX Backfill (one-time)
+
+# One-time catalog-wide SPDX header backfill (GR-076). Manual dispatch only —
+# opens a single large auto-fix PR inserting SPDX headers into every chart
+# YAML/tpl/sh/NOTES.txt file that lacks one. Runs on Linux so line endings
+# stay LF (do not run this locally on Windows — it would rewrite CRLF).
+#
+# Requires secret OPS_AUTOMATION_TOKEN (see automation-org-consistency.yml).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  spdx-migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout helmforge-ops (private)
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/helmforge-ops
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: ops
+
+      - name: Checkout charts
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/charts
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: charts
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install ops dependencies
+        working-directory: ops
+        run: npm ci
+
+      - name: Configure git auth for pushes
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+
+      - name: Run SPDX backfill reporter
+        working-directory: ops
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          HELMFORGE_CHARTS_DIR: ${{ github.workspace }}/charts
+        run: node scripts/ci/auto-report.js --check spdx-migrate

--- a/.github/workflows/automation-standards-sweep.yml
+++ b/.github/workflows/automation-standards-sweep.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Automation - Standards Sweep
+
+# Sweeps all charts for standards drift (className, tracked Chart.lock, SPDX
+# headers, required structure). Opens an auto-fix PR for the mechanical fixes
+# (SPDX insertion, Chart.lock untracking) and a tracking issue for the rest
+# (structure, className). Manual merge.
+#
+# Requires secret OPS_AUTOMATION_TOKEN (see automation-org-consistency.yml).
+
+on:
+  schedule:
+    - cron: '0 8 * * 1' # Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  standards-sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout helmforge-ops (private)
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/helmforge-ops
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: ops
+
+      - name: Checkout charts
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/charts
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: charts
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install ops dependencies
+        working-directory: ops
+        run: npm ci
+
+      - name: Configure git auth for pushes
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+
+      - name: Run standards-sweep reporter
+        working-directory: ops
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          HELMFORGE_CHARTS_DIR: ${{ github.workspace }}/charts
+        run: node scripts/ci/auto-report.js --check standards-sweep

--- a/.github/workflows/automation-subchart-deps.yml
+++ b/.github/workflows/automation-subchart-deps.yml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Automation - Subchart Dependency Freshness
+
+# Detects HelmForge subchart dependencies behind the latest published version
+# (GR-074). Opens an auto-fix PR bumping minor/patch versions and a tracking
+# issue for major bumps (which need manual upgrade + k3d validation). Manual merge.
+#
+# Requires secret OPS_AUTOMATION_TOKEN (see automation-org-consistency.yml).
+
+on:
+  schedule:
+    - cron: '30 7 * * 1' # Monday 07:30 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  subchart-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout helmforge-ops (private)
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/helmforge-ops
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: ops
+
+      - name: Checkout charts
+        uses: actions/checkout@v4
+        with:
+          repository: helmforgedev/charts
+          token: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          path: charts
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install ops dependencies
+        working-directory: ops
+        run: npm ci
+
+      - name: Configure git auth for pushes
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+
+      - name: Run subchart-deps reporter
+        working-directory: ops
+        env:
+          GH_TOKEN: ${{ secrets.OPS_AUTOMATION_TOKEN }}
+          HELMFORGE_CHARTS_DIR: ${{ github.workspace }}/charts
+        run: node scripts/ci/auto-report.js --check subchart-deps


### PR DESCRIPTION
## Summary

Four scheduled/dispatch workflows that run the helmforge-ops checks and open **auto-fix PRs linked to tracking issues** (manual merge — nothing reaches main automatically). The detection/fix logic lives in the private `helmforge-ops` repo; these workflows just check it out and run a generic reporter.

| Workflow | Schedule | Auto-fix PR | Tracking issue |
|---|---|---|---|
| `automation-org-consistency` | Mon 07:00 | profile chart/stable/backup counts (in `.github`) | chart/site parity gaps |
| `automation-subchart-deps` | Mon 07:30 | HelmForge subchart **minor/patch** bumps (GR-074) | **major** bumps (need k3d) |
| `automation-standards-sweep` | Mon 08:00 | untrack committed `Chart.lock` (GR-062) | `className` usage (GR-072) |
| `automation-spdx-migrate` | manual dispatch | one-time SPDX backfill across the catalog (GR-076) | — |

## Prerequisite (required before these run)

Create an org/repo secret **`OPS_AUTOMATION_TOKEN`** — a PAT (or GitHub App token) with:
- `read` on the private `helmforgedev/helmforge-ops`
- `contents` + `issues` + `pull_requests` write on `helmforgedev/charts`, `helmforgedev/site`, `helmforgedev/.github`

PRs are created with this token (not GITHUB_TOKEN) so CI runs on the auto-fix PRs.

## Notes

- Runs on Linux so SPDX backfill keeps LF line endings (do not run that locally on Windows).
- Dry-run validated locally: org-consistency clean; subchart-deps found 42 stale deps (19 minor/patch auto-fixable, rest major); standards sweep found 13 tracked Chart.lock + 4 className.