### PR TITLE
docs(repo): refresh local validation workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,17 @@
 
 Thanks for contributing to HelmForge Charts.
 
-This repository has a few workflow rules that are stricter than a typical Helm charts repo because chart publishing, versioning, and release notes are automated.
+This repository has stricter rules than a typical Helm charts repo because chart publishing, semantic versioning, security checks, and release notes are automated.
 
 ## Before You Start
 
-- write all repository documentation in English
-- use `main` as the only PR target
-- never edit `version` in `Chart.yaml` manually
-- use [Conventional Commits](https://www.conventionalcommits.org/) for commits and PR titles
-- for chart changes, use the exact chart directory name as the scope, for example:
-  - `feat(redis): add replication topology`
-  - `fix(mongodb): correct readiness probe`
-  - `docs(repo): refine contribution guidance`
+- Write all repository documentation in English.
+- Use `main` as the only PR target.
+- Create or link a GitHub issue for every PR.
+- Never edit `version` in `Chart.yaml` manually.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commits and PR titles.
+- For chart changes, use the exact chart directory name as the scope.
+  Good examples are `feat(redis): add replication topology`, `fix(mongodb): correct readiness probe`, and `docs(repo): refine contribution guidance`.
 
 ## Branch And PR Flow
 
@@ -21,18 +20,23 @@ Always follow this sequence:
 
 1. `git checkout main`
 2. `git pull --ff-only origin main`
-3. create a new branch from the updated `main`
-4. make the change
-5. validate locally
-6. commit with a Conventional Commit
-7. push the branch
-8. open a PR to `main`
+3. Create a new branch from the updated `main`.
+4. Make the change.
+5. Validate locally.
+6. Commit with a Conventional Commit.
+7. Push the branch.
+8. Open a PR to `main` and link the required issue.
+9. Wait for CI to finish.
+10. Resolve or reply to every review comment.
+11. Rerun local validation after every correction that changes chart behavior.
 
 Rules:
 
-- never open branch-to-branch PRs
-- do not continue new work from an old merged feature branch
-- after a PR is merged, return to `main` and start a fresh branch
+- Never open branch-to-branch PRs.
+- Do not continue new work from an old merged feature branch.
+- After a PR is merged, return to `main` and start a fresh branch.
+- Do not leave unresolved review comments or unanswered requested changes.
+- Do not use `kubeconform --ignore-missing-schema`; install missing CRDs or provide schema coverage instead.
 
 Recommended branch names:
 
@@ -46,75 +50,83 @@ Recommended branch names:
 
 When adding a new chart:
 
-1. research official product docs and mature public charts
-2. confirm the latest release in both official GitHub Releases and official Docker Hub tags
-3. only pin a version when both sources match
-4. create:
-   - `Chart.yaml`
-   - `values.yaml`
-   - `values.schema.json`
-   - `templates/`
-   - `tests/`
-   - `ci/`
-   - `examples/`
-   - `docs/`
-   - `README.md`
-5. update the root [README.md](README.md) charts table
-6. update the `site/` repository in the same workstream
-7. validate locally on `k3d` before pushing the PR
+1. Research official product docs and mature public charts.
+2. Confirm the latest release in both official GitHub Releases and official image registry tags.
+3. Only pin a version when both sources match.
+4. Create `Chart.yaml`, `values.yaml`, `values.schema.json`, `templates/`, `tests/`, `ci/`, `examples/`, `docs/`, `README.md`, and `DESIGN.md`.
+5. Add official chart icons using the repository icon standard.
+6. Update the root [README.md](README.md) when the catalog overview changes.
+7. Update the `site/` repository in the same workstream when public docs, listings, icons, or maturity change.
+8. Validate locally on `k3d` before pushing the PR.
 
 ## Modifying An Existing Chart
 
 When changing an existing chart:
 
-- run `helm lint --strict`
-- run `helm unittest`
-- render all `ci/*.yaml` scenarios
-- update tests when template behavior changes
-- update `values.schema.json` when values change
-- update chart docs when behavior or defaults change
-- update the `site/` repository when the change affects public docs, chart listing, or maturity
+- Run the current local validation helper: `./test.sh <chart-name>`.
+- Update tests when template behavior changes.
+- Update `values.schema.json` when values change.
+- Update chart docs when behavior or defaults change.
+- Update the `site/` repository when the change affects public docs, chart listing, icon, or maturity.
+- Keep `README.md`, `DESIGN.md`, `docs/`, `examples/`, `ci/`, `tests/`, and `templates/NOTES.txt` aligned with the established chart standard.
+- Prefer HelmForge subcharts for databases, caches, queues, and coordination services when the catalog already provides that dependency.
+- Use the latest compatible HelmForge dependency versions in `Chart.yaml`.
 
 ## Required Local Validation
 
 Before any local runtime validation:
 
-- run `kubectl config current-context`
-- confirm the active context is the intended local `k3d` cluster
-- never install, upgrade, or uninstall against a non-local or unclear context
+- Run `kubectl config current-context`.
+- Confirm the active context is the intended local `k3d-helmforge-tests-wsl` cluster or another clearly local `k3d-` context.
+- Never install, upgrade, or uninstall against a non-local or unclear context.
 
-Required commands for chart work:
-
-```bash
-helm lint charts/<chart-name> --strict
-helm template test-release charts/<chart-name>
-helm unittest charts/<chart-name>
-for f in charts/<chart-name>/ci/*.yaml; do helm template test-release charts/<chart-name> -f "$f"; done
-```
-
-Shortcut script (runs the same checks and prints a PR checklist snippet):
+Required command for chart work:
 
 ```bash
 ./test.sh <chart-name>
-./test.sh --all
 ```
+
+The helper runs the current local equivalent of the PR gates:
+
+- `helm dependency build`
+- `helm lint --strict`
+- `helm template` with default values
+- `helm template` for every `ci/*.yaml` scenario
+- `kubeconform -strict` with Kubernetes schemas and CRD schemas from the Datree CRDs catalog
+- `helm unittest --with-subchart=false` when `tests/` exists
+- `ah lint -p`
+- `kubescape scan framework "MITRE,NSA,SOC2"`
+
+Optional runtime validation:
+
+```bash
+kubectl config current-context
+./test.sh <chart-name> --runtime -f charts/<chart-name>/ci/<scenario>.yaml
+```
+
+Runtime validation installs with `helm upgrade --install --wait --timeout 120s`, checks Kubernetes resources, recent events, and pod logs, then removes the namespace unless `--keep-namespace` is used.
 
 For every new chart and every release update:
 
-- local `k3d` validation is mandatory before pushing the PR
-- validate the default install
-- validate at least one main non-default supported scenario
-- if the chart includes backup behavior, validate it end-to-end against local MinIO
+- Local `k3d` validation is mandatory before pushing the PR.
+- Validate the default install.
+- Validate at least one main non-default supported scenario.
+- Restart relevant Deployments or StatefulSets when the change affects startup behavior, persistence, probes, or application configuration.
+- Verify logs and namespace events do not contain warnings, startup failures, permission errors, probe failures, crash loops, or image pull failures.
+- If the chart includes backup behavior, validate it end-to-end against local MinIO.
 
 ## Chart Standards
 
 Every chart must:
 
-- include Artifact Hub annotations in `Chart.yaml`
-- include `helmforge.dev/maturity` in `Chart.yaml`
-- include `values.schema.json` using JSON Schema draft-07
-- document `values.yaml` keys using `# --` comments
-- use product-oriented values and templates rather than generic abstraction
+- Include Artifact Hub annotations in `Chart.yaml`.
+- Include `helmforge.dev/maturity` in `Chart.yaml`.
+- Include `values.schema.json` using JSON Schema draft-07.
+- Document `values.yaml` keys using `# --` comments.
+- Use product-oriented values and templates rather than generic abstraction.
+- Use `ingress.ingressClassName`, Gateway API HTTPRoute values, service dual-stack values, and External Secrets patterns consistently with established charts when those features make sense for the workload.
+- Keep `templates/NOTES.txt` useful for operators, including access paths, credentials guidance, health checks, and next steps adapted to the chart.
+- Avoid committing `Chart.lock` for charts that use dependencies; dependency resolution is handled during validation and release.
 
 ## Site Sync
 
@@ -122,10 +134,12 @@ If you add a new chart, you must also update the `site/` repository.
 
 If you change public chart metadata or user-visible behavior, update the `site/` repository when the website should reflect that change, including:
 
-- new chart pages
-- chart cards / listings
-- sidebar entries
-- maturity changes
+- New chart pages
+- Chart cards or listings
+- Sidebar entries
+- Maturity changes
+- Icons and hosted logo assets
+- Documentation examples
 
 ## Releases
 
@@ -133,15 +147,29 @@ Releases are automated by GitHub Actions.
 
 Do not:
 
-- create git tags manually
-- create GitHub Releases manually
-- edit `version` in `Chart.yaml`
+- Create git tags manually.
+- Create GitHub Releases manually.
+- Edit `version` in `Chart.yaml`.
 
 Conventional Commits drive semantic versioning and release notes.
+
+## PR Review And CI Completion
+
+Before considering a PR complete:
+
+- The PR title must pass the semantic PR title workflow.
+- All CI, code quality, security, and governance checks must be green.
+- Every review comment must be fixed or answered.
+- Every requested change must be resolved in the PR conversation.
+- The linked issue must be referenced in the PR body.
+- Local validation evidence must be listed in the PR body or a follow-up comment.
+- Runtime namespaces created during validation must be removed from the local cluster.
 
 ## Related Docs
 
 - [README.md](README.md)
+- [Local Testing with k3d](docs/local-testing-k3d.md)
+- [Testing Strategy](docs/testing-strategy.md)
 - [SECURITY.md](SECURITY.md)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - [GOVERNANCE.md](GOVERNANCE.md)
@@ -151,15 +179,17 @@ Conventional Commits drive semantic versioning and release notes.
 <!-- @AI-METADATA
 type: guide
 title: Contributing
-description: Contribution guide for HelmForge Charts covering git flow, validation, and chart-specific standards
+description: Contribution guide for HelmForge Charts covering git flow, validation, PR review, and chart-specific standards
 
-keywords: contributing, pull requests, git flow, helm, charts, validation
+keywords: contributing, pull requests, git flow, helm, charts, validation, k3d, kubeconform, kubescape
 
-purpose: Explain how humans should contribute to the HelmForge Charts repository
+purpose: Explain how humans and agents should contribute to the HelmForge Charts repository
 scope: Repository
 
 relations:
   - README.md
+  - docs/local-testing-k3d.md
+  - docs/testing-strategy.md
   - .claude/AGENTS.md
   - SECURITY.md
   - CODE_OF_CONDUCT.md
@@ -167,6 +197,6 @@ relations:
   - MAINTAINERS.md
   - ADOPTERS.md
 path: CONTRIBUTING.md
-version: 1.2
-date: 2026-04-27
+version: 1.3
+date: 2026-06-02
 -->

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Check each chart's README and [git tags](../../tags) for available versions.
 
 ### Verify a packaged chart
 
-Every published chart package is signed with GPG provenance, and OCI artifacts are signed with Cosign by the release workflow. Import the HelmForge public key before using Helm provenance verification.
+Every published chart package is signed with GPG provenance, and OCI artifacts are signed with Cosign by the release workflow.
+Import the HelmForge public key before using Helm provenance verification.
 
 ```bash
 # HTTPS repository provenance verification
@@ -91,10 +92,11 @@ HelmForge is built on a simple principle: **use what upstream ships, make the Ku
 - **Official upstream images** — charts prefer images published by the application maintainers. No proprietary rebuild layer or vendor-specific runtime wrapper.
 - **Pinned version tags** — charts reference explicit, immutable image tags. No `:latest`, no floating tags, no surprises after a pull.
 - **Apache-2.0 licensed** — the charts, tests, and docs use a CNCF-aligned permissive license. No open-core, no paid tiers, no license traps.
-- **GPG + Cosign signed** — every release includes GPG provenance files for Helm verification and [Sigstore Cosign](https://www.sigstore.dev/) keyless signatures on OCI artifacts via GitHub Actions OIDC.
+- **GPG + Cosign signed** — every release includes GPG provenance files for Helm verification and [Sigstore Cosign](https://www.sigstore.dev/) keyless signatures on OCI artifacts.
 - **No vendor lock-in** — standard Helm, standard Kubernetes APIs, standard images. If you stop using HelmForge tomorrow, nothing breaks.
 - **Explicit values contracts** — product-oriented `values.yaml` files map directly to application and Kubernetes configuration, with schemas and validations where they prevent bad releases.
-- **HelmForge-native dependencies** — charts that need databases, caches, queues, or coordination services use HelmForge subcharts when available, keeping dependency behavior consistent across the catalog.
+- **HelmForge-native dependencies** — charts that need databases, caches, queues, or coordination services use HelmForge subcharts when available.
+  This keeps dependency behavior consistent across the catalog.
 - **Operator-first docs** — chart READMEs, site docs, examples, and test values are kept close to the release surface.
 
 ## Support and Star Tracking
@@ -153,7 +155,7 @@ The repository is governed by a comprehensive suite of GitHub Actions workflows 
 
 | Workflow | Trigger | Purpose |
 |----------|---------|----------|
-| **[ci.yml](../../actions/workflows/ci.yml)** | PR | Dependency build, lint, template, unit test, kubeconform, ArtifactHub lint |
+| **[ci.yml](../../actions/workflows/ci.yml)** | PR | Dependency build, strict lint, default and CI scenario rendering, unit tests, kubeconform, Artifact Hub lint |
 | **[publish.yml](../../actions/workflows/publish.yml)** | Push to main | Semver bump, package, sign, publish to GHCR + Pages |
 | **[code-quality.yml](../../actions/workflows/code-quality.yml)** | PR | Markdown lint, values quality checks, SPDX license headers |
 | **[security-scan.yml](../../actions/workflows/security-scan.yml)** | PR | Kubescape MITRE + NSA + SOC2 compliance scanning |
@@ -162,15 +164,15 @@ The repository is governed by a comprehensive suite of GitHub Actions workflows 
 | **[community.yml](../../actions/workflows/community.yml)** | Daily | Stale issue/PR management |
 | **[repo-health.yml](../../actions/workflows/repo-health.yml)** | Daily | Helm index, OCI registry, and badge endpoint monitoring |
 
-## Tests and Publishing
+## Validation and Publishing
 
 Charts are automatically tested and published via GitHub Actions.
 
 ```text
-PR        --> ci.yml           --> [Lint] [Template] [Unit Test] [Kubeconform] [ArtifactHub Lint]
+PR        --> ci.yml            --> [Dependency Build] [Strict Lint] [Template] [Unit Test] [Kubeconform] [Artifact Hub Lint]
           --> code-quality.yml --> [Markdown Lint] [Values Quality] [License Headers]
           --> security-scan.yml --> [Kubescape MITRE+NSA+SOC2]
-          --> pr-governance.yml --> [Conventional Commits] [Auto Labels]
+          --> pr-governance.yml --> [Conventional PR Title] [Scope Labels]
 Push main --> publish.yml      --> Detect --> Semver --> Package --> Sign --> Publish --> Git tag
 Weekly    --> upstream-watch.yml --> Scan all charts --> Create issues for outdated images
 ```
@@ -187,15 +189,34 @@ from chart tests and release publishing.
 
 Quality gates include:
 
-- `helm dependency build` for charts with subcharts.
-- `helm lint` and `helm lint --strict`.
+- `helm dependency build` for every changed chart, including HelmForge OCI subcharts.
+- `helm lint --strict`.
 - `helm template` with default values and every `ci/*.yaml` scenario.
 - `helm unittest` when a chart has a test suite.
 - `kubeconform` against Kubernetes schemas and CRD schemas from the Datree CRDs catalog.
+- `ah lint -p` for Artifact Hub metadata.
 - Kubescape security compliance scanning (MITRE, NSA, SOC2 frameworks).
-- Markdown linting and SPDX license header enforcement on changed files.
-- Artifact Hub package lint before release metadata is published.
+- Markdown linting, values quality checks, and SPDX license header enforcement on changed YAML, template, and shell files.
 - Signed package publishing to GHCR and the HTTPS Helm repository.
+
+Local validation should use the repository helper:
+
+```bash
+# Static validation matching the current PR gates
+./test.sh <chart-name>
+
+# Validate a runtime scenario on the local k3d cluster
+kubectl config current-context
+./test.sh <chart-name> --runtime -f charts/<chart-name>/ci/<scenario>.yaml
+
+# Validate every chart without runtime installs
+./test.sh --all --skip-runtime
+```
+
+`test.sh` intentionally does not use `kubeconform --ignore-missing-schema`.
+If a chart renders a CRD-backed resource, install the CRD locally and make sure schema validation can resolve the API.
+
+Every chart PR should have a linked GitHub issue, complete PR checklist evidence, passing CI, and no unresolved review comments before merge.
 
 ### Versioning
 
@@ -220,7 +241,7 @@ Every chart release automatically creates a [GitHub Release](https://github.com/
 
 Each release includes install instructions for both OCI and Helm repository.
 
-### Testing
+### Chart Testing
 
 Each chart can include a `ci/` directory with test values files. The pipeline runs `helm template`
 and kubeconform against every `ci/*.yaml` file automatically, in addition to default values, lint,
@@ -229,22 +250,15 @@ Artifact Hub lint, and chart unit tests when present.
 For local chart work:
 
 ```bash
-# For charts with HelmForge OCI subcharts, authenticate to GHCR if your environment is not already logged in.
+# For charts with HelmForge OCI subcharts, authenticate to GHCR if your environment is not already logged in
 echo "$GHCR_TOKEN" | helm registry login ghcr.io -u "$GHCR_USERNAME" --password-stdin
-helm dependency build charts/<chart-name>
-helm lint charts/<chart-name> --strict
-helm template test-release charts/<chart-name>
-helm unittest charts/<chart-name>
-helm template test-release charts/<chart-name> \
-  | kubeconform -strict -summary \
-      -schema-location default \
-      -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-      -exit-on-error
-ah lint -p charts/<chart-name>
-kubescape scan framework "MITRE,NSA,SOC2" charts/<chart-name>
+
+./test.sh <chart-name>
 ```
 
-For runtime validation, use a local k3d cluster instead of a production Kubernetes context.
+For runtime validation, use the local `k3d-helmforge-tests-wsl` cluster instead of any production Kubernetes context.
+Helm installs should use `--wait --timeout 120s`.
+Validation must check pod readiness, recent namespace events, and pod logs before the namespace is removed.
 
 ### Kubernetes Compatibility
 
@@ -293,11 +307,11 @@ Apache License 2.0
 <!-- @AI-METADATA
 type: overview
 title: HelmForge Charts
-description: Helm chart repository overview, installation, charts list, tests, and publishing
+description: Helm chart repository overview, installation, charts list, validation, and publishing
 
 keywords: helm, charts, oci, ghcr, repository, install
 
-purpose: Repository overview with charts list, installation, tests, publishing, and contributing guide
+purpose: Repository overview with charts list, installation, validation, publishing, and contributing guide
 scope: Repository
 
 relations:
@@ -310,7 +324,7 @@ relations:
   - ADOPTERS.md
   - SECURITY.md
 path: README.md
-version: 1.2
+version: 1.3
 date: 2026-04-01
-updated: 2026-04-29
+updated: 2026-06-02
 -->

--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ kubectl config current-context
 
 `test.sh` intentionally does not use `kubeconform --ignore-missing-schema`.
 If a chart renders a CRD-backed resource, install the CRD locally and make sure schema validation can resolve the API.
+The helper checks the tools needed by the selected gates before running.
+Missing `helm`, `kubectl`, `kubeconform`, `ah`, and `kubescape` binaries are
+installed into `~/.local/bin` by default, and the `helm-unittest` plugin is
+installed when selected charts include tests. Set `HELMFORGE_TOOLS_DIR` to use a
+different tool directory, or pass `--no-install` to fail fast on missing tools.
 
 Every chart PR should have a linked GitHub issue, complete PR checklist evidence, passing CI, and no unresolved review comments before merge.
 

--- a/docs/local-testing-k3d.md
+++ b/docs/local-testing-k3d.md
@@ -32,8 +32,15 @@ Runtime validation is mandatory for new charts, release updates, startup fixes, 
 | kubescape | current CLI | security scanning |
 | jq | current CLI | local score parsing and JSON inspection |
 
-The local helper expects these tools to be installed permanently on the workstation.
-Do not download them ad hoc for each PR.
+The local helper verifies the tools it will use before running validation.
+When a selected gate needs a missing CLI, `test.sh` installs it into
+`~/.local/bin` by default, or into `HELMFORGE_TOOLS_DIR` when that variable is set.
+This bootstrap covers `helm`, `kubectl`, `kubeconform`, `ah`, `kubescape`, and the
+`helm-unittest` plugin when selected charts include tests.
+
+Use `--no-install` when you want the helper to fail fast instead of preparing a
+clean workstation. Docker, k3d, network access, and the local cluster remain
+external prerequisites for runtime validation.
 
 ## Cluster Standard
 

--- a/docs/local-testing-k3d.md
+++ b/docs/local-testing-k3d.md
@@ -1,53 +1,52 @@
 # Local Testing with k3d
 
-This guide covers how to run Helm charts locally using [k3d](https://k3d.io), a lightweight Kubernetes distribution
-that runs k3s inside Docker containers. Use this for integration testing beyond what `helm template` and `helm-unittest` can validate.
+Use local k3d validation when a chart change needs proof beyond static rendering.
+Static validation catches template and schema issues.
+k3d validation proves that the chart installs, workloads become ready, services work, events are clean, and logs do not show runtime problems.
 
 ## When to Use Local Testing
 
-| Scenario | Tool |
-|----------|------|
+| Scenario | Required tool |
+|----------|---------------|
 | YAML syntax and template rendering | `helm lint`, `helm template` |
-| Assert template output | `helm-unittest` |
-| Validate against K8s schemas | `kubeconform` |
-| **Verify pods start and become ready** | **k3d** |
-| **Test persistence, networking, ingress** | **k3d** |
-| **Validate init containers, probes, env vars** | **k3d** |
-| **End-to-end chart behavior** | **k3d** |
+| Template output assertions | `helm-unittest` |
+| Kubernetes API schema validation | `kubeconform` |
+| Artifact Hub metadata validation | `ah` |
+| Security compliance scan | `kubescape` |
+| Pod readiness, probes, init containers, env vars, and persistence | `k3d`, `helm`, `kubectl` |
+| Service, ingress, Gateway API, and application smoke tests | `k3d`, `curl`, chart-specific clients |
 
-Static validation (lint, template, unittest, kubeconform) catches most issues. Use k3d when you need to verify runtime behavior.
+Runtime validation is mandatory for new charts, release updates, startup fixes, dependency changes, persistence changes, networking changes, and fixes that previously failed only after installation.
 
 ## Prerequisites
 
-| Tool | Minimum Version | Install |
-|------|----------------|---------|
-| Docker | 20.10+ | [docs.docker.com](https://docs.docker.com/get-docker/) |
-| k3d | 5.x | `choco install k3d` or `brew install k3d` |
-| kubectl | 1.28+ | `choco install kubernetes-cli` or `brew install kubectl` |
-| Helm | 3.14+ | `choco install kubernetes-helm` or `brew install helm` |
+| Tool | Expected baseline | Purpose |
+|------|-------------------|---------|
+| Docker | 20.10+ | k3d runtime |
+| k3d | 5.x | local Kubernetes cluster |
+| kubectl | 1.28+ | Kubernetes inspection |
+| Helm | 4.x | chart validation and install |
+| helm-unittest | current plugin | chart unit tests |
+| kubeconform | current CLI | rendered manifest schema validation |
+| ah | current CLI | Artifact Hub lint |
+| kubescape | current CLI | security scanning |
+| jq | current CLI | local score parsing and JSON inspection |
 
-## Cluster Management
+The local helper expects these tools to be installed permanently on the workstation.
+Do not download them ad hoc for each PR.
 
-### Create a Cluster
+## Cluster Standard
 
-```bash
-# Standard single-node cluster for chart testing
-k3d cluster create helmforge-test \
-  --agents 0 \
-  --servers 1 \
-  --port "8080:80@loadbalancer" \
-  --port "8443:443@loadbalancer" \
-  --wait
+The default local cluster used by HelmForge validation is:
+
+```text
+k3d-helmforge-tests-wsl
 ```
 
-Port mapping exposes the traefik ingress at `localhost:8080` (HTTP) and `localhost:8443` (HTTPS).
-
-### Multi-node Cluster
-
-For testing anti-affinity, PDBs, and replication:
+Create it when needed:
 
 ```bash
-k3d cluster create helmforge-test \
+k3d cluster create helmforge-tests-wsl \
   --agents 2 \
   --servers 1 \
   --port "8080:80@loadbalancer" \
@@ -55,229 +54,192 @@ k3d cluster create helmforge-test \
   --wait
 ```
 
-### Delete a Cluster
+Confirm context before every install, upgrade, or uninstall:
 
 ```bash
-k3d cluster delete helmforge-test
+kubectl config current-context
 ```
 
-### List Clusters
+The context must be clearly local and should start with `k3d-`.
+Never run runtime validation against production, staging, shared development clusters, or unclear contexts.
+
+## CRDs
+
+Install required CRDs before validating charts that render CRD-backed resources.
+Do not bypass validation with `kubeconform --ignore-missing-schema`.
+
+Common examples:
 
 ```bash
-k3d cluster list
+# Gateway API
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+
+# External Secrets Operator CRDs
+kubectl apply -f https://raw.githubusercontent.com/external-secrets/external-secrets/main/deploy/crds/bundle.yaml
 ```
 
-## Testing Workflow
+Use the current official CRD release when validating a specific chart.
+The commands above are examples for common local setup.
 
-### 1. Create Cluster
+## Standard Workflow
+
+Run static validation first:
 
 ```bash
-k3d cluster create helmforge-test --wait
+./test.sh <chart-name>
 ```
 
-### 2. Verify Connectivity
+Run runtime validation with a representative scenario:
 
 ```bash
-kubectl cluster-info
-kubectl get nodes
+kubectl config current-context
+./test.sh <chart-name> --runtime -f charts/<chart-name>/ci/<scenario>.yaml
 ```
 
-### 3. Install Chart
+The helper installs with:
 
 ```bash
-# From local source
-helm install test-release charts/<chart-name> -f charts/<chart-name>/ci/<values-file>.yaml
-
-# From OCI registry (to test published charts)
-helm install test-release oci://ghcr.io/helmforgedev/helm/<chart-name>
+helm upgrade --install hf-test charts/<chart-name> \
+  --namespace hf-test-<chart-name> \
+  --wait \
+  --timeout 120s
 ```
 
-### 4. Verify Deployment
+If rollout is not progressing, inspect status after roughly 60 seconds.
+Do not wait for long-running broken installs when events or logs already show the cause.
+
+## Manual Runtime Checks
+
+When you need to inspect a chart manually:
 
 ```bash
-# Wait for pods to become ready
-kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=test-release --timeout=120s
+ns=hf-test-<chart-name>
+release=hf-test
 
-# Check all resources
-kubectl get all -l app.kubernetes.io/instance=test-release
-
-# Check pod logs
-kubectl logs -l app.kubernetes.io/instance=test-release --tail=50
-
-# Describe pod (useful for debugging startup failures)
-kubectl describe pod -l app.kubernetes.io/instance=test-release
+kubectl get all,pvc,ingress -n "$ns"
+kubectl get events -n "$ns" --sort-by=.lastTimestamp
+kubectl get pods -n "$ns" -o wide
+kubectl logs -n "$ns" -l app.kubernetes.io/instance="$release" --all-containers --tail=120
 ```
 
-### 5. Validate Functionality
+For Deployments:
 
 ```bash
-# Port-forward to test the application directly
-kubectl port-forward svc/test-release-<chart-name> 8080:<service-port>
-
-# Test with curl
-curl -s http://localhost:8080/
+kubectl rollout status deployment -n "$ns" -l app.kubernetes.io/instance="$release" --timeout=120s
+kubectl rollout restart deployment -n "$ns" -l app.kubernetes.io/instance="$release"
+kubectl rollout status deployment -n "$ns" -l app.kubernetes.io/instance="$release" --timeout=120s
 ```
 
-### 6. Cleanup
+For StatefulSets:
 
 ```bash
-helm uninstall test-release
-# Or delete the entire cluster
-k3d cluster delete helmforge-test
+kubectl rollout status statefulset -n "$ns" -l app.kubernetes.io/instance="$release" --timeout=120s
+kubectl rollout restart statefulset -n "$ns" -l app.kubernetes.io/instance="$release"
+kubectl rollout status statefulset -n "$ns" -l app.kubernetes.io/instance="$release" --timeout=120s
 ```
 
-## Chart-Specific Testing
+## Functional Smoke Tests
 
-### Databases (PostgreSQL, MySQL, MongoDB, Redis)
+Use chart-specific checks after readiness passes.
 
-Databases need persistence and readiness probes to pass:
+HTTP applications:
 
 ```bash
-# Install with standalone ci values
-helm install test-db charts/postgresql -f charts/postgresql/ci/standalone.yaml
-
-# Wait for StatefulSet to be ready
-kubectl rollout status statefulset/test-db-postgresql --timeout=120s
-
-# Test connectivity
-kubectl exec -it test-db-postgresql-0 -- pg_isready
+kubectl port-forward -n "$ns" svc/<service-name> 8080:<service-port>
+curl -fsS http://127.0.0.1:8080/
 ```
 
-### Stateful Applications (Vaultwarden, Keycloak)
-
-These require persistence and may need specific environment variables:
+Databases:
 
 ```bash
-# Install with minimal ci values
-helm install test-vault charts/vaultwarden -f charts/vaultwarden/ci/minimal.yaml
-
-# Wait and verify
-kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=test-vault --timeout=180s
-kubectl logs -l app.kubernetes.io/instance=test-vault --tail=20
+kubectl exec -n "$ns" <pod-name> -- <native-readiness-command>
 ```
 
-### Replication and Clustering (Redis, RabbitMQ, PostgreSQL, MySQL)
-
-Test with multi-node cluster and replication values:
+Queues, caches, and coordinators:
 
 ```bash
-# Create multi-node cluster
-k3d cluster create helmforge-test --agents 2 --wait
-
-# Install replication config
-helm install test-redis charts/redis -f charts/redis/ci/replication.yaml
-
-# Wait for all replicas
-kubectl rollout status statefulset/test-redis-primary --timeout=120s
-kubectl rollout status statefulset/test-redis-replicas --timeout=120s
-
-# Verify replication
-kubectl exec test-redis-primary-0 -- redis-cli INFO replication | grep connected_slaves
+kubectl exec -n "$ns" <pod-name> -- <native-cli> <health-or-info-command>
 ```
 
-### Ingress Testing
+## Required Evidence
 
-k3d ships with traefik by default:
+A PR that includes runtime validation should record:
+
+- Current Kubernetes context.
+- Exact `./test.sh` command.
+- Values scenario used.
+- Workload rollout result.
+- Functional smoke test performed.
+- Confirmation that events and logs were clean.
+- Confirmation that the namespace was removed.
+
+## Cleanup
+
+The helper removes the runtime namespace by default.
+If you used `--keep-namespace` or manual commands, clean up explicitly:
 
 ```bash
-# Create cluster with port mapping
-k3d cluster create helmforge-test --port "8080:80@loadbalancer" --wait
-
-# Install chart with ingress enabled
-helm install test-vault charts/vaultwarden \
-  --set domain="http://vault.localhost:8080" \
-  --set ingress.enabled=true \
-  --set ingress.ingressClassName=traefik \
-  --set "ingress.hosts[0].host=vault.localhost" \
-  --set "ingress.hosts[0].paths[0].path=/" \
-  --set "ingress.hosts[0].paths[0].pathType=Prefix"
-
-# Test (vault.localhost resolves to 127.0.0.1 on most systems)
-curl -s http://vault.localhost:8080/
+helm uninstall hf-test -n hf-test-<chart-name>
+kubectl delete namespace hf-test-<chart-name>
 ```
 
-## Using CI Values for Testing
-
-Every chart has `ci/*.yaml` files designed for template validation. These files also work as starting points for local testing:
+Verify no leftover namespaces:
 
 ```bash
-# List available CI values for a chart
-ls charts/<chart-name>/ci/
-
-# Install with a specific CI values file
-helm install test charts/<chart-name> -f charts/<chart-name>/ci/<values>.yaml
+kubectl get ns | grep hf-test || true
 ```
-
-CI values files cover different configurations (standalone, replication, TLS, metrics, etc.) and are a good baseline for integration tests.
 
 ## Troubleshooting
 
-### Pod stuck in CrashLoopBackOff
+CrashLoopBackOff:
 
 ```bash
-kubectl logs <pod-name> --previous   # logs from the crashed container
-kubectl describe pod <pod-name>       # events and conditions
+kubectl logs -n "$ns" <pod-name> --all-containers --previous
+kubectl describe pod -n "$ns" <pod-name>
+kubectl get events -n "$ns" --sort-by=.lastTimestamp
 ```
 
-### Pod stuck in Pending
+Pending pods:
 
 ```bash
-kubectl describe pod <pod-name>       # check for scheduling issues
-kubectl get pvc                       # check if PVC is bound
-kubectl get events --sort-by=.lastTimestamp
+kubectl describe pod -n "$ns" <pod-name>
+kubectl get pvc -n "$ns"
+kubectl get events -n "$ns" --sort-by=.lastTimestamp
 ```
 
-### Service not reachable
+Service not reachable:
 
 ```bash
-kubectl get svc                       # verify service exists and has endpoints
-kubectl get endpoints <svc-name>      # verify endpoints are populated
-kubectl port-forward svc/<svc-name> <local-port>:<svc-port>  # bypass ingress
+kubectl get svc,endpoints,endpointslice -n "$ns"
+kubectl port-forward -n "$ns" svc/<service-name> 8080:<service-port>
+curl -v http://127.0.0.1:8080/
 ```
 
-### Ingress not routing
+Permission denied at startup:
 
 ```bash
-kubectl get ingress                   # check ingress resource
-kubectl get pods -n kube-system       # check traefik is running
-kubectl logs -n kube-system -l app.kubernetes.io/name=traefik --tail=20
+kubectl get pod -n "$ns" <pod-name> -o yaml
+kubectl logs -n "$ns" <pod-name> --all-containers --tail=120
+kubectl describe pod -n "$ns" <pod-name>
 ```
 
-## Standard Validation Checklist
-
-Before pushing changes, after local testing passes:
-
-```bash
-# Static validation (always required)
-helm lint charts/<name> --strict
-helm template test charts/<name>
-helm unittest charts/<name>
-for f in charts/<name>/ci/*.yaml; do helm template test charts/<name> -f "$f"; done
-
-# Local integration test (when testing runtime behavior)
-k3d cluster create helmforge-test --wait
-helm install test charts/<name> -f charts/<name>/ci/<values>.yaml
-kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=test --timeout=120s
-kubectl get all -l app.kubernetes.io/instance=test
-helm uninstall test
-k3d cluster delete helmforge-test
-```
+Check container user, security context, service target ports, environment variables, mounted volume ownership, and upstream application bind addresses.
 
 <!-- @AI-METADATA
 type: guide
 title: Local Testing with k3d
-description: Guide for local integration testing of Helm charts using k3d (k3s in Docker)
+description: Local k3d validation guide for HelmForge charts covering cluster setup, CRDs, runtime checks, logs, events, and cleanup
 
-keywords: k3d, k3s, local-testing, integration, kubernetes, docker, validation
+keywords: k3d, kubernetes, helm, runtime validation, logs, events, kubeconform, crds
 
-purpose: Document local integration testing workflow using k3d for Helm chart validation
+purpose: Explain how to validate HelmForge charts locally before opening or updating a PR
 scope: Testing
 
 relations:
-  - docs/testing-strategy.md
-  - .claude/CLAUDE.md
-  - .claude/AGENTS.md
+  - testing-strategy.md
+  - ../CONTRIBUTING.md
+  - ../test.sh
 path: docs/local-testing-k3d.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-06-02
 -->

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -42,6 +42,13 @@ The helper mirrors the active PR gates:
 - Runs Kubescape and applies the minimum score gate.
 - Prints a PR checklist snippet with the evidence expected in review.
 
+Before running those gates, the helper verifies the tools required by the
+selected options. Missing `helm`, `kubectl`, `kubeconform`, `ah`, and
+`kubescape` binaries are installed into `~/.local/bin` by default, or into
+`HELMFORGE_TOOLS_DIR` when set. If selected charts include `tests/`, the helper
+also verifies and installs the `helm-unittest` plugin. Use `--no-install` to
+disable this bootstrap and fail fast on missing tools.
+
 To validate all charts without runtime installs:
 
 ```bash

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,22 +1,91 @@
 # Testing Strategy
 
-This repository uses a layered testing approach for Helm charts, combining static analysis, unit testing, and schema validation.
+HelmForge uses layered validation for Helm charts.
+Static checks catch template, schema, metadata, and security regressions before review.
+Runtime checks on the local k3d cluster prove that workloads start, become ready, and do not produce bad events or logs.
+
+For runtime testing details, see [Local Testing with k3d](local-testing-k3d.md).
 
 ## Testing Layers
 
-| Layer | Tool | Purpose | When |
-|-------|------|---------|------|
-| Lint | `helm lint --strict` | Catch YAML/template syntax errors | Every PR, local dev |
-| Template | `helm template` | Verify templates render without errors | Every PR, local dev |
-| Unit Test | `helm-unittest` | Assert template output matches expectations | Every PR, local dev |
-| Schema Validation | `kubeconform` | Validate rendered manifests against K8s API schemas | Every PR |
-| Integration | `k3d` + `helm install` | Verify pods start, probes pass, networking works | Local dev, major changes |
+| Layer | Tool | Purpose | Required |
+|-------|------|---------|----------|
+| Dependency build | `helm dependency build` | Resolve HelmForge subcharts and upstream dependencies | Every chart PR |
+| Strict lint | `helm lint --strict` | Catch chart metadata, values, and template issues | Every chart PR |
+| Default rendering | `helm template` | Verify default values render cleanly | Every chart PR |
+| Scenario rendering | `helm template -f ci/*.yaml` | Verify supported modes and feature combinations | Every chart PR |
+| Unit tests | `helm unittest --with-subchart=false` | Assert expected rendered resources and values | Charts with `tests/` |
+| Schema validation | `kubeconform -strict` | Validate rendered manifests against Kubernetes and CRD schemas | Every chart PR |
+| Artifact Hub lint | `ah lint -p` | Validate package metadata consumed by Artifact Hub | Every chart PR |
+| Values quality | Custom CI checks | Detect floating image tags, missing schemas, and weak values contracts | Every PR |
+| License headers | Custom CI checks | Enforce SPDX headers on changed YAML, template, and shell files | Every PR |
+| Security scan | `kubescape` | Scan rendered chart output against MITRE, NSA, and SOC2 frameworks | Every chart PR |
+| Runtime validation | `k3d`, `helm`, `kubectl` | Prove install, readiness, events, logs, and cleanup | New charts and risky fixes |
 
-For integration testing details, see [Local Testing with k3d](local-testing-k3d.md).
+## Local Helper
+
+Use the repository helper for normal local chart validation:
+
+```bash
+./test.sh <chart-name>
+```
+
+The helper mirrors the active PR gates:
+
+- Builds dependencies.
+- Runs `helm lint --strict`.
+- Renders default values.
+- Renders every `charts/<chart>/ci/*.yaml` scenario.
+- Runs kubeconform on default and CI scenario renders.
+- Runs helm-unittest when `tests/` exists.
+- Runs Artifact Hub lint.
+- Runs Kubescape and applies the minimum score gate.
+- Prints a PR checklist snippet with the evidence expected in review.
+
+To validate all charts without runtime installs:
+
+```bash
+./test.sh --all --skip-runtime
+```
+
+To validate a runtime scenario:
+
+```bash
+kubectl config current-context
+./test.sh <chart-name> --runtime -f charts/<chart-name>/ci/<scenario>.yaml
+```
+
+Runtime mode must run against a local `k3d-` context.
+The default expected cluster is `k3d-helmforge-tests-wsl`.
+
+## kubeconform Policy
+
+Never use `kubeconform --ignore-missing-schema`.
+
+The repository validates rendered manifests with:
+
+```bash
+kubeconform -strict -summary \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+  -exit-on-error
+```
+
+If a chart renders a CRD-backed resource, make schema validation work.
+For runtime tests, install the CRD in the local cluster before installing the chart.
+
+Common CRD-backed features include:
+
+- Gateway API HTTPRoutes
+- External Secrets
+- ServiceMonitor, PodMonitor, and PrometheusRule
+- KEDA ScaledObjects
+- VerticalPodAutoscalers
 
 ## helm-unittest
 
-[helm-unittest](https://github.com/helm-unittest/helm-unittest) is a BDD-style unit test framework for Helm charts, installed as a Helm plugin.
+[helm-unittest](https://github.com/helm-unittest/helm-unittest) is a BDD-style unit test framework for Helm charts.
+It is installed as a Helm plugin.
 
 ### Installation
 
@@ -27,14 +96,8 @@ helm plugin install https://github.com/helm-unittest/helm-unittest
 ### Running Tests
 
 ```bash
-# Single chart
-helm unittest charts/<chart-name>
-
-# All charts
-helm unittest charts/*
+helm unittest --with-subchart=false charts/<chart-name>
 ```
-
-### Test File Location
 
 Test files live under `charts/<chart-name>/tests/` with the naming convention `<template-name>_test.yaml`.
 
@@ -54,13 +117,13 @@ charts/<chart-name>/
 suite: <Suite Name>
 templates:
   - <primary-template>.yaml
-  - <dependency-template>.yaml   # if primary includes other templates
+  - <dependency-template>.yaml
 release:
   name: test
   namespace: default
 tests:
   - it: should <expected behavior>
-    template: <primary-template>.yaml  # required when multiple templates listed
+    template: <primary-template>.yaml
     set:
       key: value
     asserts:
@@ -68,90 +131,28 @@ tests:
           <assertion-params>
 ```
 
-### Key Patterns
+## Unit Test Patterns
 
-#### Multi-template dependencies
+Multi-template dependencies:
 
-When a template uses `include` to reference another template (e.g., for checksum annotations),
-both templates must be listed in the suite's `templates` array.
-Use the `template` field at the test level to target assertions at the correct template:
+Templates that use `include` for checksums or helper-rendered manifests need the referenced templates listed in the suite.
+Use `template` at the test level to target assertions at the correct resource.
 
-```yaml
-templates:
-  - statefulset-primary.yaml
-  - configmap.yaml          # needed because statefulset includes configmap checksum
-tests:
-  - it: should be a StatefulSet
-    template: statefulset-primary.yaml   # target only the statefulset
-    asserts:
-      - isKind:
-          of: StatefulSet
-```
+Multi-document templates:
 
-#### Multi-document templates
+Use `documentSelector` when one template emits more than one resource.
+It is more stable than relying on document order.
 
-When a single template renders multiple YAML documents (separated by `---`), use `documentIndex` or `documentSelector` at the test level:
+Conditional resources:
 
-```yaml
-# By index
-- it: should have headless service
-  documentIndex: 0
-  asserts:
-    - equal:
-        path: metadata.name
-        value: test-redis-headless
+Test both enabled and disabled states for optional resources such as NetworkPolicy, Ingress, HTTPRoute, ServiceMonitor, ExternalSecret, and PodDisruptionBudget.
 
-# By content (preferred when order is not guaranteed)
-- it: should target the StatefulSet
-  documentSelector:
-    path: kind
-    value: StatefulSet
-  asserts:
-    - equal:
-        path: spec.replicas
-        value: 1
-```
+Edge conditions:
 
-#### Conditional resources
+PDBs, autoscalers, clustering, and backup resources often require multiple enabling conditions.
+Test the negative edge case where only one condition is true.
 
-Test both the enabled and disabled states of optional resources:
-
-```yaml
-- it: should not create NetworkPolicy by default
-  asserts:
-    - hasDocuments:
-        count: 0
-
-- it: should create NetworkPolicy when enabled
-  set:
-    networkPolicy.enabled: true
-  asserts:
-    - isKind:
-        of: NetworkPolicy
-```
-
-#### Complex conditional PDBs
-
-Some PDBs require multiple conditions (e.g., `pdb.enabled` AND `replicaCount > 1`). Always test the edge case where only one condition is met:
-
-```yaml
-- it: should not create PDB with single replica even when enabled
-  set:
-    pdb.enabled: true
-  asserts:
-    - hasDocuments:
-        count: 0
-
-- it: should create PDB with multiple replicas when enabled
-  set:
-    pdb.enabled: true
-    replicaCount: 3
-  asserts:
-    - isKind:
-        of: PodDisruptionBudget
-```
-
-### Common Assertion Types
+## Common Assertion Types
 
 | Assertion | Purpose |
 |-----------|---------|
@@ -165,60 +166,80 @@ Some PDBs require multiple conditions (e.g., `pdb.enabled` AND `replicaCount > 1
 | `lengthEqual` | Assert array length |
 | `matchRegex` | Value matches a regex pattern |
 
-### Pitfalls
-
-1. **`protocol: TCP`** — Kubernetes adds `protocol: TCP` by default when the template does not specify it.
-   If the rendered output includes `protocol: TCP`, the `contains` assertion must include it too, or it will fail.
-
-2. **`documentIndex` scope** — `documentIndex` is scoped per-template, not across all rendered templates.
-   When using suite-level `documentIndex`, it only works reliably if the suite targets a single template file.
-
-3. **`template` filter** — When multiple templates are listed in the suite, always use `template: <file>.yaml`
-   at the test level to avoid assertions running against all rendered templates.
-
-4. **`stringData` vs `data`** — Some secrets use `stringData` (plain text) instead of `data` (base64). Check the actual template output before writing assertions.
-
-5. **Include dependencies** — Templates that use `include (print $.Template.BasePath "/secret.yaml")` will fail rendering if `secret.yaml` is not in the `templates` list.
-
 ## CI Pipeline
 
-The CI workflow (`.github/workflows/ci.yml`) runs these jobs for every PR:
+The CI workflow (`.github/workflows/ci.yml`) runs these jobs for every relevant PR:
 
 ```text
-detect → lint (parallel)
-       → template (parallel)
-       → unittest (parallel)
-       → kubeconform (after template)
-       → ci (gate)
+detect
+  -> lint
+  -> template
+  -> unittest
+  -> artifacthub-lint
+  -> kubeconform
+  -> ci gate
 ```
 
-The `unittest` job skips charts without a `tests/` directory, allowing incremental adoption.
+Other required PR workflows include:
 
-## Local Validation Checklist
+- `code-quality.yml` for Markdown lint, values quality, and SPDX license headers.
+- `security-scan.yml` for Kubescape MITRE, NSA, and SOC2 scanning.
+- `pr-governance.yml` for semantic PR title checks and labels.
 
-Before pushing chart changes:
+Documentation-only changes are intentionally excluded from chart rendering jobs when they do not affect chart behavior.
+
+## Runtime Evidence
+
+For new charts, release updates, and fixes that affect startup or configuration, collect runtime evidence from the local k3d cluster:
 
 ```bash
-helm lint charts/<name> --strict
-helm template test charts/<name>
-helm unittest charts/<name>
-for f in charts/<name>/ci/*.yaml; do helm template test charts/<name> -f "$f"; done
+kubectl config current-context
+./test.sh <chart-name> --runtime -f charts/<chart-name>/ci/<scenario>.yaml
 ```
+
+The install must use `--wait --timeout 120s`.
+Do not wait for long-running failed installs without checking resource status.
+Inspect pods, events, and logs after roughly 60 seconds if rollout is not progressing.
+
+Runtime evidence must confirm:
+
+- Workloads are Ready or Complete as expected.
+- Services and endpoints exist when the chart exposes traffic.
+- PVCs are Bound when persistence is enabled.
+- Namespace events do not contain warnings or failures.
+- Pod logs do not contain startup errors, permission errors, crash loops, or probe failures.
+- The test namespace was removed after validation.
+
+## Pitfalls
+
+- Kubernetes defaults `protocol: TCP` when a Service port omits it.
+  Include `protocol: TCP` in `contains` assertions when the rendered output includes it.
+- `documentIndex` is scoped per template.
+  Prefer `documentSelector` when order is not important.
+- Templates that reference other templates through `include (print $.Template.BasePath "/secret.yaml")` must list those files in the test suite.
+- Some Secrets use `stringData` instead of base64 encoded `data`.
+  Render the chart before writing assertions.
+- Charts with dependencies should not commit `Chart.lock`.
+  Dependency build is part of validation and release.
 
 <!-- @AI-METADATA
 type: guide
 title: Testing Strategy
-description: Helm chart testing strategy using helm-unittest, helm lint, kubeconform, and CI automation
+description: Helm chart testing strategy using test.sh, helm-unittest, helm lint, kubeconform, Artifact Hub lint, Kubescape, and k3d validation
 
-keywords: helm-unittest, testing, unit-test, ci, kubeconform, lint, validation, bdd, yaml
+keywords: helm-unittest, testing, unit-test, ci, kubeconform, lint, validation, kubescape, artifacthub, k3d
 
-purpose: Testing strategy documentation covering helm-unittest, helm lint, kubeconform, and CI
+purpose: Testing strategy documentation covering local and CI validation for HelmForge charts
 scope: Testing
 
 relations:
-  - .claude/AGENTS.md
-  - .claude/CLAUDE.md
+  - ../CONTRIBUTING.md
+  - local-testing-k3d.md
+  - ../test.sh
+  - ../.github/workflows/ci.yml
+  - ../.github/workflows/code-quality.yml
+  - ../.github/workflows/security-scan.yml
 path: docs/testing-strategy.md
-version: 1.0
-date: 2026-03-20
+version: 1.1
+date: 2026-06-02
 -->

--- a/test.sh
+++ b/test.sh
@@ -226,6 +226,17 @@ runtime_namespace_for_chart() {
   fi
 }
 
+cleanup_runtime_namespace() {
+  local ns="$1"
+
+  if [[ "$KEEP_NAMESPACE" -eq 0 ]]; then
+    helm uninstall "$RELEASE_NAME" --namespace "$ns" >/dev/null 2>&1 || true
+    kubectl delete namespace "$ns" --wait=false >/dev/null 2>&1 || true
+  else
+    warn "Keeping namespace '$ns' because --keep-namespace was set"
+  fi
+}
+
 current_context() {
   kubectl config current-context 2>/dev/null || true
 }
@@ -268,19 +279,22 @@ runtime_install() {
     --wait \
     --timeout "$RUNTIME_TIMEOUT"; then
     collect_runtime_evidence "$ns"
+    cleanup_runtime_namespace "$ns"
     return 1
   fi
 
   collect_runtime_evidence "$ns"
-  validate_runtime_events "$ns" || return 1
-  validate_runtime_logs "$ns" || return 1
-
-  if [[ "$KEEP_NAMESPACE" -eq 0 ]]; then
-    helm uninstall "$RELEASE_NAME" --namespace "$ns" >/dev/null 2>&1 || true
-    kubectl delete namespace "$ns" --wait=false >/dev/null 2>&1 || true
-  else
-    warn "Keeping namespace '$ns' because --keep-namespace was set"
+  if ! validate_runtime_events "$ns"; then
+    cleanup_runtime_namespace "$ns"
+    return 1
   fi
+
+  if ! validate_runtime_logs "$ns"; then
+    cleanup_runtime_namespace "$ns"
+    return 1
+  fi
+
+  cleanup_runtime_namespace "$ns"
 }
 
 collect_runtime_evidence() {

--- a/test.sh
+++ b/test.sh
@@ -771,7 +771,6 @@ main() {
 
   ensure_tool_path
   ensure_command helm
-  ensure_command kubectl
   [[ "$RUN_KUBECONFORM" -eq 0 ]] || ensure_command kubeconform
   [[ "$RUN_ARTIFACTHUB" -eq 0 ]] || ensure_command ah
   [[ "$RUN_KUBESCAPE" -eq 0 ]] || ensure_command kubescape
@@ -780,9 +779,12 @@ main() {
     ensure_helm_unittest
   fi
 
+  # kubectl is only required for runtime validation; static-only runs (lint,
+  # template, kubeconform, ...) must work on a workstation without it.
   if [[ "$RUN_RUNTIME" -eq 1 ]]; then
+    ensure_command kubectl
     require_runtime_context || exit 1
-  else
+  elif command -v kubectl >/dev/null 2>&1; then
     local context
     context="$(current_context)"
     if [[ -n "$context" ]]; then

--- a/test.sh
+++ b/test.sh
@@ -16,12 +16,19 @@ RUN_KUBESCAPE=1
 RUN_UNITTEST=1
 RUN_RUNTIME=0
 KEEP_NAMESPACE=0
+AUTO_INSTALL_TOOLS=1
 
 RELEASE_NAME="hf-test"
 NAMESPACE=""
 EXPECTED_CONTEXT_PREFIX="k3d-"
 RUNTIME_TIMEOUT="120s"
 KUBESCAPE_MIN_SCORE=50
+TOOL_BIN_DIR="${HELMFORGE_TOOLS_DIR:-$HOME/.local/bin}"
+HELM_VERSION="${HELM_VERSION:-v4.1.4}"
+KUBECONFORM_VERSION="${KUBECONFORM_VERSION:-v0.7.0}"
+AH_VERSION="${AH_VERSION:-1.22.0}"
+KUBESCAPE_VERSION="${KUBESCAPE_VERSION:-4.0.9}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-stable}"
 VALUES_FILES=()
 CHARTS_TO_CHECK=()
 
@@ -33,6 +40,7 @@ ARTIFACTHUB_OK=1
 KUBESCAPE_OK=1
 RUNTIME_OK=1
 CONTEXT_OK=0
+UNITTEST_RAN=0
 
 usage() {
   cat <<'EOF'
@@ -76,6 +84,13 @@ Options:
   --skip-kubescape            Skip Kubescape scan
   --skip-unittest             Skip helm-unittest
   --keep-namespace            Keep runtime namespace after validation
+  --no-install                Fail when a required tool is missing instead of installing it
+
+Tool bootstrap:
+  Missing helm, kubectl, kubeconform, ah, kubescape, and helm-unittest are installed
+  before validation when the selected gates need them. CLI tools are installed into
+  ${HELMFORGE_TOOLS_DIR:-$HOME/.local/bin} by default. Override versions with
+  HELM_VERSION, KUBECTL_VERSION, KUBECONFORM_VERSION, AH_VERSION, and KUBESCAPE_VERSION.
 EOF
 }
 
@@ -90,6 +105,181 @@ require_command() {
     fail "Required command not found: $cmd"
     exit 1
   fi
+}
+
+ensure_tool_path() {
+  mkdir -p "$TOOL_BIN_DIR"
+  case ":$PATH:" in
+    *":$TOOL_BIN_DIR:"*) ;;
+    *) export PATH="$TOOL_BIN_DIR:$PATH" ;;
+  esac
+}
+
+require_bootstrap_command() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail "Cannot install missing tools because '$cmd' is not available"
+    exit 1
+  fi
+}
+
+platform_os() {
+  local os
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  case "$os" in
+    linux|darwin) printf '%s\n' "$os" ;;
+    msys*|mingw*|cygwin*) printf 'windows\n' ;;
+    *) fail "Unsupported OS for tool bootstrap: $os"; exit 1 ;;
+  esac
+}
+
+platform_arch() {
+  local arch
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) printf 'amd64\n' ;;
+    aarch64|arm64) printf 'arm64\n' ;;
+    *) fail "Unsupported architecture for tool bootstrap: $arch"; exit 1 ;;
+  esac
+}
+
+download_file() {
+  local url="$1"
+  local output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$output"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$url" -O "$output"
+  else
+    fail "Cannot download tools because neither curl nor wget is available"
+    exit 1
+  fi
+}
+
+install_binary_from_archive() {
+  local url="$1"
+  local binary_name="$2"
+  local archive
+  local extract_dir
+  archive="$(mktemp)"
+  extract_dir="$(mktemp -d)"
+
+  require_bootstrap_command tar
+  info "Downloading $binary_name from $url"
+  download_file "$url" "$archive"
+  tar -xzf "$archive" -C "$extract_dir"
+
+  local found
+  found="$(find "$extract_dir" -type f -name "$binary_name" -o -name "$binary_name.exe" | head -1)"
+  if [[ -z "$found" ]]; then
+    rm -rf "$archive" "$extract_dir"
+    fail "Could not find $binary_name in downloaded archive"
+    exit 1
+  fi
+
+  cp "$found" "$TOOL_BIN_DIR/$binary_name"
+  chmod +x "$TOOL_BIN_DIR/$binary_name"
+  rm -rf "$archive" "$extract_dir"
+}
+
+install_kubectl() {
+  local os
+  local arch
+  local version
+  os="$(platform_os)"
+  arch="$(platform_arch)"
+  version="$KUBECTL_VERSION"
+
+  if [[ "$version" == "stable" ]]; then
+    local version_file
+    version_file="$(mktemp)"
+    download_file "https://dl.k8s.io/release/stable.txt" "$version_file"
+    version="$(tr -d '\r\n' < "$version_file")"
+    rm -f "$version_file"
+  fi
+
+  local suffix=""
+  [[ "$os" == "windows" ]] && suffix=".exe"
+  info "Downloading kubectl $version"
+  download_file "https://dl.k8s.io/release/$version/bin/$os/$arch/kubectl$suffix" "$TOOL_BIN_DIR/kubectl"
+  chmod +x "$TOOL_BIN_DIR/kubectl"
+}
+
+install_tool() {
+  local cmd="$1"
+  local os
+  local arch
+  os="$(platform_os)"
+  arch="$(platform_arch)"
+
+  ensure_tool_path
+  case "$cmd" in
+    helm)
+      install_binary_from_archive "https://get.helm.sh/helm-${HELM_VERSION}-${os}-${arch}.tar.gz" helm
+      ;;
+    kubectl)
+      install_kubectl
+      ;;
+    kubeconform)
+      install_binary_from_archive "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-${os}-${arch}.tar.gz" kubeconform
+      ;;
+    ah)
+      local ah_os="$os"
+      [[ "$ah_os" == "darwin" ]] && ah_os="macos"
+      install_binary_from_archive "https://github.com/artifacthub/hub/releases/download/v${AH_VERSION}/ah_${AH_VERSION}_${ah_os}_${arch}.tar.gz" ah
+      ;;
+    kubescape)
+      install_binary_from_archive "https://github.com/kubescape/kubescape/releases/download/v${KUBESCAPE_VERSION}/kubescape_${KUBESCAPE_VERSION}_${os}_${arch}.tar.gz" kubescape
+      ;;
+    *)
+      fail "No bootstrap recipe is defined for: $cmd"
+      exit 1
+      ;;
+  esac
+}
+
+ensure_command() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ "$AUTO_INSTALL_TOOLS" -eq 0 ]]; then
+    fail "Required command not found: $cmd"
+    exit 1
+  fi
+
+  warn "Required command not found: $cmd; installing into $TOOL_BIN_DIR"
+  install_tool "$cmd"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    fail "Installed $cmd, but it is still not available in PATH"
+    exit 1
+  fi
+}
+
+selected_charts_have_tests() {
+  local chart
+  for chart in "${CHARTS_TO_CHECK[@]}"; do
+    if [[ -d "$CHARTS_DIR/$chart/tests" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_helm_unittest() {
+  if helm plugin list 2>/dev/null | awk 'NR > 1 {print $1}' | grep -qx "unittest"; then
+    return 0
+  fi
+
+  if [[ "$AUTO_INSTALL_TOOLS" -eq 0 ]]; then
+    fail "helm-unittest plugin is missing. Install with: helm plugin install https://github.com/helm-unittest/helm-unittest"
+    exit 1
+  fi
+
+  info "Installing helm-unittest plugin"
+  helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
 }
 
 run_check() {
@@ -372,6 +562,7 @@ validate_chart() {
 
   if [[ "$RUN_UNITTEST" -eq 1 ]]; then
     if [[ -d "$chart_path/tests" ]]; then
+      UNITTEST_RAN=1
       if ! run_check "[$chart] helm unittest --with-subchart=false" run_quiet helm_unittest "$chart_path"; then
         UNITTEST_OK=0
       fi
@@ -408,6 +599,12 @@ print_checklist_snippet() {
   local kubescape_box="[x]"
   local runtime_box="[x]"
   local context_box="[x]"
+  local context_note=""
+  local unittest_note=""
+  local kubeconform_note=""
+  local artifacthub_note=""
+  local kubescape_note=""
+  local runtime_note=""
 
   [[ "$LINT_OK" -eq 1 ]] || lint_box="[ ]"
   [[ "$TEMPLATE_OK" -eq 1 ]] || template_box="[ ]"
@@ -418,16 +615,49 @@ print_checklist_snippet() {
   [[ "$RUNTIME_OK" -eq 1 ]] || runtime_box="[ ]"
   [[ "$CONTEXT_OK" -eq 1 || "$RUN_RUNTIME" -eq 0 ]] || context_box="[ ]"
 
+  if [[ "$RUN_RUNTIME" -eq 0 ]]; then
+    runtime_box="[ ]"
+    runtime_note=" (not run; add --runtime when runtime validation is required)"
+  fi
+
+  if [[ "$RUN_UNITTEST" -eq 0 ]]; then
+    unittest_box="[ ]"
+    unittest_note=" (skipped by --skip-unittest)"
+  elif [[ "$UNITTEST_RAN" -eq 0 ]]; then
+    unittest_box="[ ]"
+    unittest_note=" (not applicable: no tests/ directory)"
+  fi
+
+  if [[ "$RUN_KUBECONFORM" -eq 0 ]]; then
+    kubeconform_box="[ ]"
+    kubeconform_note=" (skipped by --skip-kubeconform)"
+  fi
+
+  if [[ "$RUN_ARTIFACTHUB" -eq 0 ]]; then
+    artifacthub_box="[ ]"
+    artifacthub_note=" (skipped by --skip-artifacthub)"
+  fi
+
+  if [[ "$RUN_KUBESCAPE" -eq 0 ]]; then
+    kubescape_box="[ ]"
+    kubescape_note=" (skipped by --skip-kubescape)"
+  fi
+
+  if [[ "$RUN_RUNTIME" -eq 0 ]]; then
+    context_box="[ ]"
+    context_note=" (not required without --runtime)"
+  fi
+
   echo
   echo "PR checklist snippet:"
-  echo "- $context_box I confirmed \`kubectl config current-context\` before local installs/upgrades/uninstalls"
+  echo "- $context_box I confirmed \`kubectl config current-context\` before local installs/upgrades/uninstalls$context_note"
   echo "- $lint_box \`helm lint charts/<chart-name> --strict\` passed"
   echo "- $template_box \`helm template\` passed for default values and relevant \`ci/*.yaml\` scenarios"
-  echo "- $unittest_box \`helm unittest --with-subchart=false charts/<chart-name>\` passed when tests exist"
-  echo "- $kubeconform_box \`kubeconform -strict\` passed without \`--ignore-missing-schema\`"
-  echo "- $artifacthub_box \`ah lint -p charts/<chart-name>\` passed"
-  echo "- $kubescape_box \`kubescape scan framework \"MITRE,NSA,SOC2\"\` passed the minimum score gate"
-  echo "- $runtime_box local k3d runtime validation passed when required, including pod status, events, and logs"
+  echo "- $unittest_box \`helm unittest --with-subchart=false charts/<chart-name>\` passed when tests exist$unittest_note"
+  echo "- $kubeconform_box \`kubeconform -strict\` passed without \`--ignore-missing-schema\`$kubeconform_note"
+  echo "- $artifacthub_box \`ah lint -p charts/<chart-name>\` passed$artifacthub_note"
+  echo "- $kubescape_box \`kubescape scan framework \"MITRE,NSA,SOC2\"\` passed the minimum score gate$kubescape_note"
+  echo "- $runtime_box local k3d runtime validation passed when required, including pod status, events, and logs$runtime_note"
   echo "- [ ] I updated chart docs and the site repo when public behavior changed"
   echo "- [ ] I linked or created the required GitHub issue for this PR"
 }
@@ -462,6 +692,9 @@ parse_args() {
         ;;
       --keep-namespace)
         KEEP_NAMESPACE=1
+        ;;
+      --no-install)
+        AUTO_INSTALL_TOOLS=0
         ;;
       --values|-f)
         shift
@@ -536,15 +769,15 @@ main() {
   parse_args "$@"
   validate_args
 
-  require_command helm
-  require_command kubectl
-  [[ "$RUN_KUBECONFORM" -eq 0 ]] || require_command kubeconform
-  [[ "$RUN_ARTIFACTHUB" -eq 0 ]] || require_command ah
-  [[ "$RUN_KUBESCAPE" -eq 0 ]] || require_command kubescape
+  ensure_tool_path
+  ensure_command helm
+  ensure_command kubectl
+  [[ "$RUN_KUBECONFORM" -eq 0 ]] || ensure_command kubeconform
+  [[ "$RUN_ARTIFACTHUB" -eq 0 ]] || ensure_command ah
+  [[ "$RUN_KUBESCAPE" -eq 0 ]] || ensure_command kubescape
 
-  if [[ "$RUN_UNITTEST" -eq 1 ]] && ! helm plugin list 2>/dev/null | awk 'NR > 1 {print $1}' | grep -qx "unittest"; then
-    fail "helm-unittest plugin is missing. Install with: helm plugin install https://github.com/helm-unittest/helm-unittest"
-    exit 1
+  if [[ "$RUN_UNITTEST" -eq 1 ]] && selected_charts_have_tests; then
+    ensure_helm_unittest
   fi
 
   if [[ "$RUN_RUNTIME" -eq 1 ]]; then

--- a/test.sh
+++ b/test.sh
@@ -1,60 +1,88 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 
-set -u
+set -uo pipefail
 
-SCRIPT_NAME="$(basename "$0")"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHARTS_DIR="$ROOT_DIR/charts"
 
 TOTAL_CHECKS=0
 FAILED_CHECKS=0
 
-KUBECTL_CONTEXT_OK=0
-LINT_OK=1
-UNITTEST_OK=1
-CI_TEMPLATE_OK=1
+RUN_ALL=0
+RUN_KUBECONFORM=1
+RUN_ARTIFACTHUB=1
+RUN_KUBESCAPE=1
+RUN_UNITTEST=1
+RUN_RUNTIME=0
+KEEP_NAMESPACE=0
 
-HAS_UNITTEST_PLUGIN=0
+RELEASE_NAME="hf-test"
+NAMESPACE=""
+EXPECTED_CONTEXT_PREFIX="k3d-"
+RUNTIME_TIMEOUT="120s"
+KUBESCAPE_MIN_SCORE=50
+VALUES_FILES=()
+CHARTS_TO_CHECK=()
+
+LINT_OK=1
+TEMPLATE_OK=1
+UNITTEST_OK=1
+KUBECONFORM_OK=1
+ARTIFACTHUB_OK=1
+KUBESCAPE_OK=1
+RUNTIME_OK=1
+CONTEXT_OK=0
 
 usage() {
   cat <<'EOF'
 HelmForge charts validation helper.
 
 Usage:
-  ./test.sh <chart-name>
-  ./test.sh --all
+  ./test.sh <chart-name> [options]
+  ./test.sh --all [options]
   ./test.sh --help
 
-Examples:
-  ./test.sh mosquitto
-  ./test.sh --all
+Common examples:
+  ./test.sh redis
+  ./test.sh uptime-kuma --values charts/uptime-kuma/ci/mysql-values.yaml --runtime
+  ./test.sh generic --skip-kubescape
+  ./test.sh --all --skip-runtime
 
-What it checks per chart:
+What it checks by default:
   1) helm dependency build
   2) helm lint --strict
-  3) helm template (default values)
+  3) helm template with default values
   4) helm template for every charts/<chart>/ci/*.yaml file
-  5) helm unittest (requires helm-unittest plugin)
+  5) kubeconform for default values and every ci/*.yaml file
+  6) helm unittest --with-subchart=false when tests/ exists
+  7) Artifact Hub lint
+  8) Kubescape MITRE, NSA, and SOC2 scan with a minimum score gate
 
-It also prints the current kubectl context and a PR checklist snippet at the end.
+Runtime validation:
+  --runtime installs the chart into the current k3d context with helm --wait --timeout 120s,
+  checks workloads, events, and pod logs, then removes the namespace unless --keep-namespace is set.
+
+Options:
+  --all                       Validate all charts under charts/
+  --values <file>             Extra values file for runtime install. Can be repeated.
+  --release <name>            Runtime Helm release name. Default: hf-test
+  --namespace <name>          Runtime namespace. Default: hf-test-<chart>
+  --kube-context <prefix>     Required context prefix for runtime checks. Default: k3d-
+  --runtime                   Run local k3d install validation
+  --skip-runtime              Do not run runtime validation (default)
+  --skip-kubeconform          Skip kubeconform validation
+  --skip-artifacthub          Skip Artifact Hub lint
+  --skip-kubescape            Skip Kubescape scan
+  --skip-unittest             Skip helm-unittest
+  --keep-namespace            Keep runtime namespace after validation
 EOF
 }
 
-info() {
-  echo "[INFO] $*"
-}
-
-ok() {
-  echo "[PASS] $*"
-}
-
-warn() {
-  echo "[WARN] $*"
-}
-
-fail() {
-  echo "[FAIL] $*"
-}
+info() { echo "[INFO] $*"; }
+ok() { echo "[PASS] $*"; }
+warn() { echo "[WARN] $*"; }
+fail() { echo "[FAIL] $*"; }
 
 require_command() {
   local cmd="$1"
@@ -97,7 +125,17 @@ discover_all_charts() {
   done
 }
 
-run_ci_templates() {
+helm_dependency_build() {
+  local chart_path="$1"
+  helm dependency build "$chart_path"
+}
+
+template_default() {
+  local chart_path="$1"
+  helm template test-release "$chart_path"
+}
+
+template_ci_values() {
   local chart="$1"
   local chart_path="$CHARTS_DIR/$chart"
   local ci_file
@@ -106,9 +144,8 @@ run_ci_templates() {
   shopt -s nullglob
   for ci_file in "$chart_path"/ci/*.yaml; do
     ci_found=1
-    if ! helm template test-release "$chart_path" -f "$ci_file" >/dev/null; then
-      return 1
-    fi
+    info "Rendering $chart with $ci_file"
+    helm template test-release "$chart_path" -f "$ci_file" >/dev/null || return 1
   done
   shopt -u nullglob
 
@@ -119,6 +156,176 @@ run_ci_templates() {
   return 0
 }
 
+kubeconform_render() {
+  kubeconform -strict -summary \
+    -schema-location default \
+    -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+    -exit-on-error
+}
+
+kubeconform_default() {
+  local chart_path="$1"
+  helm template test-release "$chart_path" | kubeconform_render
+}
+
+kubeconform_ci_values() {
+  local chart="$1"
+  local chart_path="$CHARTS_DIR/$chart"
+  local ci_file
+  local ci_found=0
+
+  shopt -s nullglob
+  for ci_file in "$chart_path"/ci/*.yaml; do
+    ci_found=1
+    info "Kubeconform validating $chart with $ci_file"
+    helm template test-release "$chart_path" -f "$ci_file" | kubeconform_render || return 1
+  done
+  shopt -u nullglob
+
+  if [[ "$ci_found" -eq 0 ]]; then
+    warn "No ci/*.yaml files found for '$chart' (skipping scenario kubeconform)"
+  fi
+
+  return 0
+}
+
+helm_unittest() {
+  local chart_path="$1"
+  helm unittest --with-subchart=false "$chart_path"
+}
+
+artifacthub_lint() {
+  local chart="$1"
+  (cd "$ROOT_DIR" && ah lint -p "charts/$chart")
+}
+
+kubescape_scan() {
+  local chart="$1"
+  local report
+  report="$(mktemp)"
+
+  (cd "$ROOT_DIR" && kubescape scan framework "MITRE,NSA,SOC2" "charts/$chart") 2>&1 | tee "$report"
+
+  local score
+  local score_int
+  score="$(grep -E 'Overall compliance-score|Resource Summary' "$report" | grep -Eo '[0-9]+([.][0-9]+)?%' | tail -1 | tr -d '%' || true)"
+  score="${score:-0}"
+  score_int="$(printf '%s\n' "$score" | awk '{print int($1)}')"
+  rm -f "$report"
+
+  info "Kubescape score for $chart: $score%"
+  [[ "$score_int" -ge "$KUBESCAPE_MIN_SCORE" ]]
+}
+
+runtime_namespace_for_chart() {
+  local chart="$1"
+  if [[ -n "$NAMESPACE" ]]; then
+    printf '%s\n' "$NAMESPACE"
+  else
+    printf 'hf-test-%s\n' "$chart"
+  fi
+}
+
+current_context() {
+  kubectl config current-context 2>/dev/null || true
+}
+
+require_runtime_context() {
+  local context
+  context="$(current_context)"
+  if [[ -z "$context" ]]; then
+    fail "Cannot read kubectl context"
+    return 1
+  fi
+
+  info "kubectl context: $context"
+  if [[ "$context" != "$EXPECTED_CONTEXT_PREFIX"* ]]; then
+    fail "Runtime validation requires a local context matching '$EXPECTED_CONTEXT_PREFIX*'"
+    return 1
+  fi
+
+  CONTEXT_OK=1
+}
+
+runtime_install() {
+  local chart="$1"
+  local chart_path="$CHARTS_DIR/$chart"
+  local ns
+  ns="$(runtime_namespace_for_chart "$chart")"
+  local -a value_args=()
+  local value_file
+
+  for value_file in "${VALUES_FILES[@]}"; do
+    value_args+=(--values "$value_file")
+  done
+
+  kubectl create namespace "$ns" >/dev/null 2>&1 || true
+  info "Installing $chart as release '$RELEASE_NAME' in namespace '$ns'"
+
+  if ! helm upgrade --install "$RELEASE_NAME" "$chart_path" \
+    --namespace "$ns" \
+    "${value_args[@]}" \
+    --wait \
+    --timeout "$RUNTIME_TIMEOUT"; then
+    collect_runtime_evidence "$ns"
+    return 1
+  fi
+
+  collect_runtime_evidence "$ns"
+  validate_runtime_events "$ns" || return 1
+  validate_runtime_logs "$ns" || return 1
+
+  if [[ "$KEEP_NAMESPACE" -eq 0 ]]; then
+    helm uninstall "$RELEASE_NAME" --namespace "$ns" >/dev/null 2>&1 || true
+    kubectl delete namespace "$ns" --wait=false >/dev/null 2>&1 || true
+  else
+    warn "Keeping namespace '$ns' because --keep-namespace was set"
+  fi
+}
+
+collect_runtime_evidence() {
+  local ns="$1"
+  echo
+  info "Runtime resources in namespace $ns"
+  kubectl get all,pvc,ingress,httproute,externalsecret -n "$ns" 2>/dev/null || kubectl get all,pvc,ingress -n "$ns" 2>/dev/null || true
+  echo
+  info "Recent namespace events"
+  kubectl get events -n "$ns" --sort-by=.lastTimestamp 2>/dev/null | tail -40 || true
+}
+
+validate_runtime_events() {
+  local ns="$1"
+  local events
+  events="$(kubectl get events -n "$ns" --sort-by=.lastTimestamp 2>/dev/null || true)"
+  if printf '%s\n' "$events" | grep -Eiq 'Warning|Failed|BackOff|Unhealthy|FailedMount|FailedScheduling|ImagePullBackOff|ErrImagePull|CrashLoopBackOff'; then
+    fail "Runtime events contain warnings or failures"
+    return 1
+  fi
+
+  return 0
+}
+
+validate_runtime_logs() {
+  local ns="$1"
+  local pods
+  pods="$(kubectl get pods -n "$ns" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)"
+  local pod
+  local bad=0
+
+  while IFS= read -r pod; do
+    [[ -n "$pod" ]] || continue
+    info "Checking logs for pod $pod"
+    local logs
+    logs="$(kubectl logs -n "$ns" "$pod" --all-containers --tail=120 2>&1 || true)"
+    if printf '%s\n' "$logs" | grep -Eiq 'panic|fatal|traceback|permission denied|CrashLoopBackOff|Error:|ERROR'; then
+      printf '%s\n' "$logs" | tail -80
+      bad=1
+    fi
+  done <<< "$pods"
+
+  [[ "$bad" -eq 0 ]]
+}
+
 validate_chart() {
   local chart="$1"
   local chart_path="$CHARTS_DIR/$chart"
@@ -126,113 +333,222 @@ validate_chart() {
   echo
   info "Validating chart: $chart"
 
-  run_check "[$chart] helm dependency build" run_quiet helm dependency build "$chart_path"
+  run_check "[$chart] helm dependency build" run_quiet helm_dependency_build "$chart_path"
 
   if ! run_check "[$chart] helm lint --strict" run_quiet helm lint "$chart_path" --strict; then
     LINT_OK=0
   fi
 
-  run_check "[$chart] helm template (default values)" run_quiet helm template test-release "$chart_path"
-
-  if ! run_check "[$chart] helm template for ci/*.yaml scenarios" run_ci_templates "$chart"; then
-    CI_TEMPLATE_OK=0
+  if ! run_check "[$chart] helm template (default values)" run_quiet template_default "$chart_path"; then
+    TEMPLATE_OK=0
   fi
 
-  if [[ "$HAS_UNITTEST_PLUGIN" -eq 1 ]]; then
-    if ! run_check "[$chart] helm unittest" run_quiet helm unittest "$chart_path"; then
-      UNITTEST_OK=0
+  if ! run_check "[$chart] helm template for ci/*.yaml scenarios" template_ci_values "$chart"; then
+    TEMPLATE_OK=0
+  fi
+
+  if [[ "$RUN_KUBECONFORM" -eq 1 ]]; then
+    if ! run_check "[$chart] kubeconform (default values)" run_quiet kubeconform_default "$chart_path"; then
+      KUBECONFORM_OK=0
     fi
-  else
-    TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
-    FAILED_CHECKS=$((FAILED_CHECKS + 1))
-    UNITTEST_OK=0
-    fail "[$chart] helm unittest (helm-unittest plugin not installed)"
+    if ! run_check "[$chart] kubeconform for ci/*.yaml scenarios" kubeconform_ci_values "$chart"; then
+      KUBECONFORM_OK=0
+    fi
+  fi
+
+  if [[ "$RUN_UNITTEST" -eq 1 ]]; then
+    if [[ -d "$chart_path/tests" ]]; then
+      if ! run_check "[$chart] helm unittest --with-subchart=false" run_quiet helm_unittest "$chart_path"; then
+        UNITTEST_OK=0
+      fi
+    else
+      warn "[$chart] no tests/ directory found (helm unittest skipped)"
+    fi
+  fi
+
+  if [[ "$RUN_ARTIFACTHUB" -eq 1 ]]; then
+    if ! run_check "[$chart] Artifact Hub lint" artifacthub_lint "$chart"; then
+      ARTIFACTHUB_OK=0
+    fi
+  fi
+
+  if [[ "$RUN_KUBESCAPE" -eq 1 ]]; then
+    if ! run_check "[$chart] Kubescape MITRE,NSA,SOC2" kubescape_scan "$chart"; then
+      KUBESCAPE_OK=0
+    fi
+  fi
+
+  if [[ "$RUN_RUNTIME" -eq 1 ]]; then
+    if ! run_check "[$chart] k3d runtime install and log/event validation" runtime_install "$chart"; then
+      RUNTIME_OK=0
+    fi
   fi
 }
 
 print_checklist_snippet() {
   local lint_box="[x]"
+  local template_box="[x]"
   local unittest_box="[x]"
-  local ci_box="[x]"
+  local kubeconform_box="[x]"
+  local artifacthub_box="[x]"
+  local kubescape_box="[x]"
+  local runtime_box="[x]"
   local context_box="[x]"
 
   [[ "$LINT_OK" -eq 1 ]] || lint_box="[ ]"
+  [[ "$TEMPLATE_OK" -eq 1 ]] || template_box="[ ]"
   [[ "$UNITTEST_OK" -eq 1 ]] || unittest_box="[ ]"
-  [[ "$CI_TEMPLATE_OK" -eq 1 ]] || ci_box="[ ]"
-  [[ "$KUBECTL_CONTEXT_OK" -eq 1 ]] || context_box="[ ]"
+  [[ "$KUBECONFORM_OK" -eq 1 ]] || kubeconform_box="[ ]"
+  [[ "$ARTIFACTHUB_OK" -eq 1 ]] || artifacthub_box="[ ]"
+  [[ "$KUBESCAPE_OK" -eq 1 ]] || kubescape_box="[ ]"
+  [[ "$RUNTIME_OK" -eq 1 ]] || runtime_box="[ ]"
+  [[ "$CONTEXT_OK" -eq 1 || "$RUN_RUNTIME" -eq 0 ]] || context_box="[ ]"
 
   echo
   echo "PR checklist snippet:"
   echo "- $context_box I confirmed \`kubectl config current-context\` before local installs/upgrades/uninstalls"
   echo "- $lint_box \`helm lint charts/<chart-name> --strict\` passed"
-  echo "- $unittest_box \`helm unittest charts/<chart-name>\` passed"
-  echo "- $ci_box All relevant \`ci/*.yaml\` scenarios rendered successfully"
-  echo "- [ ] I validated this change on a local \`k3d\` cluster when required"
-  echo "- [ ] I validated the default install"
-  echo "- [ ] I validated at least one main non-default scenario for this change"
+  echo "- $template_box \`helm template\` passed for default values and relevant \`ci/*.yaml\` scenarios"
+  echo "- $unittest_box \`helm unittest --with-subchart=false charts/<chart-name>\` passed when tests exist"
+  echo "- $kubeconform_box \`kubeconform -strict\` passed without \`--ignore-missing-schema\`"
+  echo "- $artifacthub_box \`ah lint -p charts/<chart-name>\` passed"
+  echo "- $kubescape_box \`kubescape scan framework \"MITRE,NSA,SOC2\"\` passed the minimum score gate"
+  echo "- $runtime_box local k3d runtime validation passed when required, including pod status, events, and logs"
+  echo "- [ ] I updated chart docs and the site repo when public behavior changed"
+  echo "- [ ] I linked or created the required GitHub issue for this PR"
+}
+
+parse_args() {
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      --all)
+        RUN_ALL=1
+        ;;
+      --runtime)
+        RUN_RUNTIME=1
+        ;;
+      --skip-runtime)
+        RUN_RUNTIME=0
+        ;;
+      --skip-kubeconform)
+        RUN_KUBECONFORM=0
+        ;;
+      --skip-artifacthub)
+        RUN_ARTIFACTHUB=0
+        ;;
+      --skip-kubescape)
+        RUN_KUBESCAPE=0
+        ;;
+      --skip-unittest)
+        RUN_UNITTEST=0
+        ;;
+      --keep-namespace)
+        KEEP_NAMESPACE=1
+        ;;
+      --values|-f)
+        shift
+        [[ "${1:-}" ]] || { fail "--values requires a file path"; exit 1; }
+        VALUES_FILES+=("$1")
+        ;;
+      --release)
+        shift
+        [[ "${1:-}" ]] || { fail "--release requires a name"; exit 1; }
+        RELEASE_NAME="$1"
+        ;;
+      --namespace|-n)
+        shift
+        [[ "${1:-}" ]] || { fail "--namespace requires a name"; exit 1; }
+        NAMESPACE="$1"
+        ;;
+      --kube-context)
+        shift
+        [[ "${1:-}" ]] || { fail "--kube-context requires a context prefix"; exit 1; }
+        EXPECTED_CONTEXT_PREFIX="$1"
+        ;;
+      --*)
+        fail "Unknown option: $1"
+        usage
+        exit 1
+        ;;
+      *)
+        CHARTS_TO_CHECK+=("$1")
+        ;;
+    esac
+    shift
+  done
+}
+
+validate_args() {
+  if [[ "$RUN_ALL" -eq 1 && "${#CHARTS_TO_CHECK[@]}" -gt 0 ]]; then
+    fail "Use either --all or explicit chart names, not both."
+    exit 1
+  fi
+
+  if [[ "$RUN_ALL" -eq 1 ]]; then
+    mapfile -t CHARTS_TO_CHECK < <(discover_all_charts)
+  fi
+
+  if [[ "${#CHARTS_TO_CHECK[@]}" -eq 0 ]]; then
+    usage
+    exit 0
+  fi
+
+  local chart
+  for chart in "${CHARTS_TO_CHECK[@]}"; do
+    if ! chart_exists "$chart"; then
+      fail "Chart '$chart' not found in '$CHARTS_DIR'."
+      exit 1
+    fi
+  done
+
+  local value_file
+  for value_file in "${VALUES_FILES[@]}"; do
+    if [[ ! -f "$value_file" ]]; then
+      fail "Values file not found: $value_file"
+      exit 1
+    fi
+  done
+
+  if [[ "$RUN_RUNTIME" -eq 1 && "$RUN_ALL" -eq 1 ]]; then
+    warn "--runtime with --all can be slow and destructive. Use explicit chart names for runtime validation when possible."
+  fi
 }
 
 main() {
-  local -a charts_to_check=()
-  case "${1:-}" in
-    "")
-      usage
-      exit 0
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    --all)
-      if [[ "$#" -ne 1 ]]; then
-        fail "Use only --all, without extra arguments."
-        usage
-        exit 1
-      fi
-      mapfile -t charts_to_check < <(discover_all_charts)
-      if [[ "${#charts_to_check[@]}" -eq 0 ]]; then
-        fail "No charts found under '$CHARTS_DIR'."
-        exit 1
-      fi
-      ;;
-    *)
-      if [[ "$#" -ne 1 ]]; then
-        fail "Expected exactly one chart name, or --all."
-        usage
-        exit 1
-      fi
-
-      if ! chart_exists "$1"; then
-        fail "Chart '$1' not found in '$CHARTS_DIR'."
-        exit 1
-      fi
-      charts_to_check=("$1")
-      ;;
-  esac
+  parse_args "$@"
+  validate_args
 
   require_command helm
   require_command kubectl
+  [[ "$RUN_KUBECONFORM" -eq 0 ]] || require_command kubeconform
+  [[ "$RUN_ARTIFACTHUB" -eq 0 ]] || require_command ah
+  [[ "$RUN_KUBESCAPE" -eq 0 ]] || require_command kubescape
 
-  local context
-  context="$(kubectl config current-context 2>/dev/null || true)"
-  if [[ -n "$context" ]]; then
-    KUBECTL_CONTEXT_OK=1
-    info "kubectl context: $context"
-  else
-    warn "Could not read kubectl context"
+  if [[ "$RUN_UNITTEST" -eq 1 ]] && ! helm plugin list 2>/dev/null | awk 'NR > 1 {print $1}' | grep -qx "unittest"; then
+    fail "helm-unittest plugin is missing. Install with: helm plugin install https://github.com/helm-unittest/helm-unittest"
+    exit 1
   fi
 
-  if helm plugin list 2>/dev/null | awk 'NR > 1 {print $1}' | grep -qx "unittest"; then
-    HAS_UNITTEST_PLUGIN=1
+  if [[ "$RUN_RUNTIME" -eq 1 ]]; then
+    require_runtime_context || exit 1
   else
-    warn "helm-unittest plugin is missing. Install with:"
-    warn "  helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false"
+    local context
+    context="$(current_context)"
+    if [[ -n "$context" ]]; then
+      info "kubectl context: $context"
+    else
+      warn "Could not read kubectl context"
+    fi
   fi
 
-  info "Charts selected: ${charts_to_check[*]}"
+  info "Charts selected: ${CHARTS_TO_CHECK[*]}"
 
   local chart
-  for chart in "${charts_to_check[@]}"; do
+  for chart in "${CHARTS_TO_CHECK[@]}"; do
     validate_chart "$chart"
   done
 


### PR DESCRIPTION
## Summary

Closes #432.

This updates the repository-level validation workflow and root docs so they match the current HelmForge PR environment.

## Changes

- Reworked 	est.sh to cover dependency build, strict lint, default and CI scenario rendering, kubeconform without missing-schema ignores, helm-unittest, Artifact Hub lint, Kubescape score gating, and optional k3d runtime validation.
- Updated README.md, CONTRIBUTING.md, docs/testing-strategy.md, and docs/local-testing-k3d.md with the current PR, CI, review, issue, and k3d validation expectations.
- Documented the local k3d-helmforge-tests-wsl workflow, CRD policy, 120s runtime timeout, log/event checks, and cleanup requirements.

## Validation

- [x] MCP HelmForge nalyze_change_set passed with no CI-relevant chart changes detected.
- [x] 
px markdownlint-cli2 README.md CONTRIBUTING.md docs/testing-strategy.md docs/local-testing-k3d.md
- [x] ash -n test.sh
- [x] git diff --check -- test.sh README.md CONTRIBUTING.md docs/testing-strategy.md docs/local-testing-k3d.md
- [x] ./test.sh generic --skip-runtime passed 9/9 checks.

## Notes

Runtime k3d installation was not run because this PR changes repository documentation and the local validation helper, not chart templates or runtime behavior.