### PR TITLE
chore(charts): untrack committed Chart.lock files (GR-062)

### DIFF
--- a/charts/alfio/Chart.lock
+++ b/charts/alfio/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.4
-digest: sha256:b16f01cd2c62fe194daa1544dd0056121b9cd38160923139b8298689c3534d11
-generated: "2026-04-03T02:37:11.8908223-03:00"

--- a/charts/appwrite/Chart.lock
+++ b/charts/appwrite/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.1.6
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.6.9
-digest: sha256:1446d90e003a0bfcd68464a3fd8f9046777c524932a9f9db42e88d2ec56ca741
-generated: "2026-04-29T11:40:15.7413825-03:00"

--- a/charts/automatisch/Chart.lock
+++ b/charts/automatisch/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.4
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.5
-digest: sha256:ab948ba00ffb21671dc14c2506bdeb90cffbb799ec3c5e30e37d2440ecc06efc
-generated: "2026-04-03T02:46:37.7367482-03:00"

--- a/charts/castopod/Chart.lock
+++ b/charts/castopod/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: mariadb
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.0.5
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.5
-digest: sha256:ce25a743fe77666f55bb2ce30b4b49885b9d9637884f541b10dc3422dfa83aff
-generated: "2026-04-03T02:36:57.0795375-03:00"

--- a/charts/chiefonboarding/Chart.lock
+++ b/charts/chiefonboarding/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.4
-digest: sha256:b16f01cd2c62fe194daa1544dd0056121b9cd38160923139b8298689c3534d11
-generated: "2026-04-03T02:37:06.882053-03:00"

--- a/charts/flowise/Chart.lock
+++ b/charts/flowise/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.6.9
-digest: sha256:9e1865ee4ab8182a1d3fb04c2b45db3ee7b1d5253fb8132bef8764654c129e18
-generated: "2026-04-29T04:48:01.9426269-03:00"

--- a/charts/guacamole/Chart.lock
+++ b/charts/guacamole/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.1
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.7.1
-digest: sha256:d94183dfbee1c25301bf105f76ceafb872e3e3a678c780f1e1aef8272d8b98e0
-generated: "2026-04-01T09:04:27.0859717-03:00"

--- a/charts/listmonk/Chart.lock
+++ b/charts/listmonk/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.1
-digest: sha256:a7bb45c41c1b64493c1e09a08e99dd8f741d7f7e3e78da1b73bedc7e45d45ae3
-generated: "2026-04-03T21:03:36.835227-03:00"

--- a/charts/middleware/Chart.lock
+++ b/charts/middleware/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.3
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.4
-digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
-generated: "2026-04-01T18:57:51.5823596-03:00"

--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.3
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.4
-digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
-generated: "2026-04-02T18:57:43.0566722-03:00"

--- a/charts/strapi/Chart.lock
+++ b/charts/strapi/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.9.11
-- name: mysql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.5
-digest: sha256:09bc7509b3ebe455bb1651e160c72df3c47cbfbff5f321103fbcd0c12c8045bd
-generated: "2026-04-29T13:58:44.0425992-03:00"

--- a/charts/superset/Chart.lock
+++ b/charts/superset/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.3
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.4
-digest: sha256:e2bad04b59832ae470409f9027d956c7577d838715e63db37864b9e30ddbac2e
-generated: "2026-04-01T19:51:30.2642924-03:00"

--- a/charts/wallabag/Chart.lock
+++ b/charts/wallabag/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.8.2
-- name: redis
-  repository: oci://ghcr.io/helmforgedev/helm
-  version: 1.5.3
-digest: sha256:f2ecff13c4e28f73f395cb457a45c1649fa79c31819bda1d2c35d07e6d4cf0ad
-generated: "2026-04-01T16:29:11.0797922-03:00"


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- alfio: untracked Chart.lock
- appwrite: untracked Chart.lock
- automatisch: untracked Chart.lock
- castopod: untracked Chart.lock
- chiefonboarding: untracked Chart.lock
- flowise: untracked Chart.lock
- guacamole: untracked Chart.lock
- listmonk: untracked Chart.lock
- middleware: untracked Chart.lock
- open-webui: untracked Chart.lock
- strapi: untracked Chart.lock
- superset: untracked Chart.lock
- wallabag: untracked Chart.lock

Major/manual items remain tracked in #436.

Related to #436

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._