### PR TITLE
feat(generic): support literal ExternalSecret names

### DIFF
--- a/charts/generic/DESIGN.md
+++ b/charts/generic/DESIGN.md
@@ -37,6 +37,8 @@ flowchart TB
 - Keep CRD-backed integrations opt-in. ExternalSecret, SealedSecret, ServiceMonitor, PodMonitor, PrometheusRule, KEDA,
   VPA, and Gateway API resources require their operators or CRDs to exist before users enable them.
 - Render ExternalSecret resources with `external-secrets.io/v1`, matching the current External Secrets Operator API.
+- Keep ExternalSecret naming backward compatible with suffix-based `name`, while allowing literal resource names through
+  `fullnameOverride`. When `spec.target.name` is omitted, default it to the rendered ExternalSecret name.
 - Validate unsafe combinations at render time, including HPA with DaemonSet, incomplete PDB configuration, and routes that would point to a disabled primary Service.
 - Avoid time-based pod annotations. Intentional rollouts use `rollout.restartAt` or checksum-driven ConfigMap and Secret changes.
 

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -265,6 +265,28 @@ The chart now includes opt-in primitives for common platform needs:
   ScaledObjects target the chart workload and require `workload.enabled=true`; use ScaledJobs for batch-only releases.
 - `persistence.persistentVolumeClaims[]` and explicit opt-in `persistence.persistentVolumes[]` for clearer storage ownership.
 
+### External Secrets
+
+`externalSecrets.items[].name` keeps the standard chart naming behavior and renders as `<releaseName>-<name>`.
+Use `externalSecrets.items[].fullnameOverride` when the ExternalSecret must use a literal Kubernetes name.
+When `spec.target.name` is omitted, the chart defaults it to the rendered ExternalSecret name, matching External
+Secrets Operator behavior and avoiding duplicated names in values.
+
+```yaml
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: beesense-gateway-env
+      spec:
+        refreshInterval: 1m
+        secretStoreRef:
+          name: vault-qa
+          kind: ClusterSecretStore
+        dataFrom:
+          - extract:
+              key: qa/deskbee/beesense-gateway/v2
+```
+
 ### Breaking-change migration notes
 
 - The default image is now pinned to `docker.io/library/nginx:1.27.5` with `IfNotPresent` instead of relying on `latest`.
@@ -433,6 +455,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Security** | | |
 | `secrets` | Declarative Secret resources | `[]` |
 | `externalSecrets.enabled` | Enable ExternalSecret resources | `false` |
+| `externalSecrets.items[].fullnameOverride` | Literal ExternalSecret metadata.name override | `""` |
 | `sealedSecrets.enabled` | Enable SealedSecret resources | `false` |
 | `rbac.create` | Create Role and RoleBinding | `false` |
 | `rbac.clusterRole.create` | Create ClusterRole and ClusterRoleBinding | `false` |

--- a/charts/generic/ci/external-secrets-values.yaml
+++ b/charts/generic/ci/external-secrets-values.yaml
@@ -2,11 +2,9 @@
 externalSecrets:
   enabled: true
   items:
-    - name: test-secret
+    - fullnameOverride: test-secret
       spec:
         refreshInterval: 1h
-        target:
-          name: test-secret
         secretStoreRef:
           name: test-store
           kind: ClusterSecretStore

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -3,7 +3,7 @@
 {{- range .Values.externalSecrets.items | default list }}
 {{- $resourceName := "" }}
 {{- if .fullnameOverride }}
-{{- $resourceName = tpl .fullnameOverride $ | trunc 63 | trimSuffix "-" }}
+{{- $resourceName = tpl .fullnameOverride $ }}
 {{- else if .name }}
 {{- $resourceName = include "chart.namedResource" (dict "root" $ "name" .name) }}
 {{- else }}

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -1,7 +1,20 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- range .Values.externalSecrets.items | default list }}
-{{- $spec := .spec | default dict }}
+{{- $resourceName := "" }}
+{{- if .fullnameOverride }}
+{{- $resourceName = tpl .fullnameOverride $ | trunc 63 | trimSuffix "-" }}
+{{- else if .name }}
+{{- $resourceName = include "chart.namedResource" (dict "root" $ "name" .name) }}
+{{- else }}
+{{- $resourceName = include "chart.fullname" $ }}
+{{- end }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $resourceName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
 {{- $hasStoreRef := false }}
 {{- if dig "secretStoreRef" "name" "" $spec }}
 {{- $hasStoreRef = true }}
@@ -26,10 +39,10 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{ include "chart.namedResource" (dict "root" $ "name" .name) }}
+  name: {{ $resourceName }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
-  {{- toYaml .spec | nindent 2 }}
+  {{- toYaml $spec | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -88,6 +88,29 @@ tests:
           path: spec.target.name
           value: app-env
 
+  - it: should preserve long literal fullnameOverride values
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - fullnameOverride: app-env-name-that-is-intentionally-longer-than-sixty-three-characters.example
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault
+                kind: ClusterSecretStore
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: app/password
+    asserts:
+      - equal:
+          path: metadata.name
+          value: app-env-name-that-is-intentionally-longer-than-sixty-three-characters.example
+      - equal:
+          path: spec.target.name
+          value: app-env-name-that-is-intentionally-longer-than-sixty-three-characters.example
+
   - it: should render ExternalSecret item with per-entry sourceRef storeRef
     set:
       externalSecrets:

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -41,6 +41,53 @@ tests:
           path: spec.secretStoreRef.name
           value: vault
 
+  - it: should default target name to the rendered ExternalSecret name
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: env
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault
+                kind: ClusterSecretStore
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: app/password
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-env
+      - equal:
+          path: spec.target.name
+          value: test-env
+
+  - it: should render an ExternalSecret item with a literal fullnameOverride
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: env
+            fullnameOverride: app-env
+            spec:
+              refreshInterval: 1h
+              secretStoreRef:
+                name: vault
+                kind: ClusterSecretStore
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: app/password
+    asserts:
+      - equal:
+          path: metadata.name
+          value: app-env
+      - equal:
+          path: spec.target.name
+          value: app-env
+
   - it: should render ExternalSecret item with per-entry sourceRef storeRef
     set:
       externalSecrets:

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -664,7 +664,26 @@
       "description": "ExternalSecret resources",
       "properties": {
         "enabled": { "type": "boolean", "default": false },
-        "items": { "type": "array", "items": { "type": "object" } }
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Resource name suffix appended to the chart fullname"
+              },
+              "fullnameOverride": {
+                "type": "string",
+                "description": "Literal ExternalSecret metadata.name override"
+              },
+              "spec": {
+                "type": "object",
+                "description": "ExternalSecret spec"
+              }
+            }
+          }
+        }
       }
     },
     "sealedSecrets": {


### PR DESCRIPTION
## Summary
- add `externalSecrets.items[].fullnameOverride` for literal ExternalSecret resource names
- default missing `spec.target.name` to the rendered ExternalSecret name
- document the new External Secrets naming behavior

Note: `Chart.yaml.version` and `artifacthub.io/changes` are intentionally untouched; HelmForge release automation owns chart versioning and release notes.

## Validation
- `helm lint charts/generic --strict`
- `helm unittest charts/generic`
- `helm template` default + ExternalSecret CI values through `kubeconform -strict` with CRDs-catalog schema