### PR TITLE
feat(umami): support extra init containers

### DIFF
--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -4,7 +4,7 @@ name: umami
 description: Umami privacy-first web analytics with PostgreSQL, Gateway API, External Secrets, backups, and production controls
 type: application
 version: 2.1.1
-appVersion: "3.1.0"
+appVersion: "3.0.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,8 +26,10 @@ sources:
 icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "support user-defined extra init containers for shared volume preparation (#441)"
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#449)"
+      description: "use Umami 3.0.3 after 3.1.0 exited with code 139 during k3d runtime validation"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -4,7 +4,7 @@ name: umami
 description: Umami privacy-first web analytics with PostgreSQL, Gateway API, External Secrets, backups, and production controls
 type: application
 version: 2.1.1
-appVersion: "3.0.3"
+appVersion: "3.1.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -29,7 +29,7 @@ annotations:
     - kind: added
       description: "support user-defined extra init containers for shared volume preparation (#441)"
     - kind: changed
-      description: "use Umami 3.0.3 after 3.1.0 exited with code 139 during k3d runtime validation"
+      description: "use Umami 3.1.0 after renewed runtime validation on k3d and Raspberry Pi nodes"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/umami/DESIGN.md
+++ b/charts/umami/DESIGN.md
@@ -74,15 +74,15 @@ second case.
 │ postgres-password     │
 └──────────┬───────────┘
            │ valueFrom
+┌──────────▼───────────┐
+│ wait-for-db          │
+└──────────┬───────────┘
+           │ ready
 ┌──────────▼───────────┐       CREATE EXTENSION       ┌──────────────────┐
 │ prepare-external-db  ├─────────────────────────────►│ External Postgres │
 │ postgres client      │                              │ umami database    │
 └──────────┬───────────┘                              └──────────────────┘
            │ success
-┌──────────▼───────────┐
-│ wait-for-db          │
-└──────────┬───────────┘
-           │
 ┌──────────▼───────────┐
 │ Umami container      │
 └──────────────────────┘
@@ -138,6 +138,9 @@ The chart maps common Umami environment variables to structured values. This mak
 - `FORCE_SSL`, `CLIENT_IP_HEADER`, `COLLECT_API_ENDPOINT`, `TRACKER_SCRIPT_NAME`, `ALLOWED_FRAME_URLS`, and related settings are optional structured values.
 
 `extraEnv` remains available for upstream settings that are not modeled yet.
+`extraInitContainers` can prepare shared volumes before Umami starts, and pairs
+with `extraVolumes` and `extraVolumeMounts` for cases such as GeoIP databases or
+organization-owned assets.
 `BASE_PATH` is intentionally not modeled because Umami v3 treats it as a build-time setting for the stock image.
 
 ## Security Posture

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -252,7 +252,7 @@ For production, test restore procedures outside Helm. Backups without restore va
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of Umami pods. |
 | `image.repository` | `ghcr.io/umami-software/umami` | Umami image repository. |
-| `image.tag` | `3.0.3` | Umami image tag. |
+| `image.tag` | `3.1.0` | Umami image tag. |
 | `service.type` | `ClusterIP` | Kubernetes service type. |
 | `service.ipFamilyPolicy` | `""` | Optional service IP family policy. |
 | `service.ipFamilies` | `[]` | Optional service IP families. |

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -252,7 +252,7 @@ For production, test restore procedures outside Helm. Backups without restore va
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of Umami pods. |
 | `image.repository` | `ghcr.io/umami-software/umami` | Umami image repository. |
-| `image.tag` | `3.1.0` | Umami image tag. |
+| `image.tag` | `3.0.3` | Umami image tag. |
 | `service.type` | `ClusterIP` | Kubernetes service type. |
 | `service.ipFamilyPolicy` | `""` | Optional service IP family policy. |
 | `service.ipFamilies` | `[]` | Optional service IP families. |
@@ -266,6 +266,8 @@ For production, test restore procedures outside Helm. Backups without restore va
 | `pdb.enabled` | `false` | Render PodDisruptionBudget. |
 | `backup.enabled` | `false` | Enable S3-compatible backup CronJob. |
 | `serviceAccount.automountServiceAccountToken` | `false` | Control service account token mounting. |
+| `extraInitContainers` | `[]` | Additional init containers for preparing shared volumes before Umami starts. |
+| `extraVolumes` / `extraVolumeMounts` | `[]` | Additional pod volumes and Umami container mounts, such as GeoIP databases or custom assets. |
 
 ## Examples
 

--- a/charts/umami/ci/dual-stack-values.yaml
+++ b/charts/umami/ci/dual-stack-values.yaml
@@ -1,6 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/umami/ci/external-db-values.yaml
+++ b/charts/umami/ci/external-db-values.yaml
@@ -5,11 +5,60 @@ postgresql:
 
 database:
   external:
-    host: db.example.com
+    host: umami-external-postgresql
     port: "5432"
     name: umami
     username: umami_user
     password: "ci-password"
     init:
       enabled: true
+      adminUsername: umami_user
       adminExistingSecret: postgres-admin
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: postgres-admin
+    type: Opaque
+    stringData:
+      postgres-password: ci-password
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: umami-external-postgresql
+    spec:
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+      selector:
+        app.kubernetes.io/name: umami-external-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: umami-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: umami-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: umami-external-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.4-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: umami
+                - name: POSTGRES_USER
+                  value: umami_user
+                - name: POSTGRES_PASSWORD
+                  value: ci-password

--- a/charts/umami/ci/external-secrets-values.yaml
+++ b/charts/umami/ci/external-secrets-values.yaml
@@ -4,36 +4,73 @@ postgresql:
 
 database:
   external:
-    host: postgres.example.internal
+    host: umami-external-postgresql
     name: umami
     username: umami
 
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: platform-secrets
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   app:
     enabled: true
     appSecretRemoteRef:
-      key: prod/umami
-      property: app-secret
+      key: test/token
   database:
     enabled: true
     passwordRemoteRef:
-      key: prod/umami
-      property: database-password
+      key: test/password
   backup:
     enabled: true
     accessKeyRemoteRef:
-      key: prod/umami/s3
-      property: access-key
+      key: test/username
     secretKeyRemoteRef:
-      key: prod/umami/s3
-      property: secret-key
+      key: test/token
 
 backup:
   enabled: true
   s3:
     endpoint: https://s3.example.com
     bucket: umami-backups
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: umami-external-postgresql
+    spec:
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+      selector:
+        app.kubernetes.io/name: umami-external-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: umami-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: umami-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: umami-external-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.4-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: umami
+                - name: POSTGRES_USER
+                  value: umami
+                - name: POSTGRES_PASSWORD
+                  value: helmforge-test-password

--- a/charts/umami/ci/production-values.yaml
+++ b/charts/umami/ci/production-values.yaml
@@ -13,13 +13,14 @@ postgresql:
 
 database:
   external:
-    host: postgres-primary.database.svc.cluster.local
+    host: umami-external-postgresql
     name: umami
     username: umami
     existingSecret: umami-db
     existingSecretPasswordKey: database-password
     init:
       enabled: true
+      adminUsername: umami
       adminExistingSecret: postgres-admin
 
 gatewayAPI:
@@ -56,3 +57,65 @@ resources:
     memory: 512Mi
   limits:
     memory: 1Gi
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: umami-app
+    type: Opaque
+    stringData:
+      app-secret: ci-app-secret
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: umami-db
+    type: Opaque
+    stringData:
+      database-password: ci-password
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: postgres-admin
+    type: Opaque
+    stringData:
+      postgres-password: ci-password
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: umami-external-postgresql
+    spec:
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+      selector:
+        app.kubernetes.io/name: umami-external-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: umami-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: umami-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: umami-external-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.4-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: umami
+                - name: POSTGRES_USER
+                  value: umami
+                - name: POSTGRES_PASSWORD
+                  value: ci-password

--- a/charts/umami/docs/configuration.md
+++ b/charts/umami/docs/configuration.md
@@ -44,6 +44,37 @@ Change the default admin password immediately after first login.
 - `backup.enabled=true` schedules `pg_dump` of the analytics DB — the only
   durable state — to S3-compatible storage.
 
+## Custom initialization
+
+Use `extraInitContainers` with `extraVolumes` and `extraVolumeMounts` when Umami
+needs files prepared before the application starts, such as a GeoIP database,
+custom tracker assets, or organization-owned configuration mounted from a
+shared volume:
+
+```yaml
+extraVolumes:
+  - name: geoip
+    emptyDir: {}
+
+extraInitContainers:
+  - name: download-geoip
+    image: docker.io/library/busybox:1.37
+    command: ["sh", "-ec"]
+    args:
+      - wget -O /geoip/GeoLite2-City.mmdb https://example.com/GeoLite2-City.mmdb
+    volumeMounts:
+      - name: geoip
+        mountPath: /geoip
+
+extraVolumeMounts:
+  - name: geoip
+    mountPath: /app/geoip
+```
+
+The chart renders custom init containers after the built-in database readiness
+check and optional external database preparation. Keep external downloads pinned
+to trusted URLs or use an internal artifact mirror for reproducible installs.
+
 ## Scaling
 
 Umami's app tier is stateless (state lives in PostgreSQL), so it can scale behind

--- a/charts/umami/templates/deployment.yaml
+++ b/charts/umami/templates/deployment.yaml
@@ -42,6 +42,22 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
+        - name: wait-for-db
+          image: docker.io/library/busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for database at {{ include "umami.dbHost" . }}:{{ include "umami.dbPort" . }}..."
+              until nc -z -w2 {{ include "umami.dbHost" . }} {{ include "umami.dbPort" . }}; do
+                echo "Database not ready, retrying in 2s..."
+                sleep 2
+              done
+              echo "Database is ready."
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- if .Values.database.external.init.enabled }}
         - name: prepare-external-db
           image: {{ .Values.database.external.init.image | quote }}
@@ -61,34 +77,29 @@ spec:
           args:
             - |
               echo "Preparing external PostgreSQL database {{ include "umami.dbName" . }} at {{ include "umami.dbHost" . }}:{{ include "umami.dbPort" . }}..."
-              printf '%s\n' "${DATABASE_INIT_SQL}" | PGPASSWORD="${DATABASE_ADMIN_PASSWORD}" psql \
-                -h {{ include "umami.dbHost" . | quote }} \
-                -p {{ include "umami.dbPort" . | quote }} \
-                -U {{ .Values.database.external.init.adminUsername | quote }} \
-                -d {{ include "umami.dbName" . | quote }} \
-                -v ON_ERROR_STOP=1
-              echo "External PostgreSQL database is prepared."
+              for attempt in $(seq 1 60); do
+                if printf '%s\n' "${DATABASE_INIT_SQL}" | PGPASSWORD="${DATABASE_ADMIN_PASSWORD}" psql \
+                  -h {{ include "umami.dbHost" . | quote }} \
+                  -p {{ include "umami.dbPort" . | quote }} \
+                  -U {{ .Values.database.external.init.adminUsername | quote }} \
+                  -d {{ include "umami.dbName" . | quote }} \
+                  -v ON_ERROR_STOP=1; then
+                  echo "External PostgreSQL database is prepared."
+                  exit 0
+                fi
+                echo "External PostgreSQL database is not ready for SQL yet, retrying in 2s (${attempt}/60)..."
+                sleep 2
+              done
+              echo "External PostgreSQL database preparation did not complete in time."
+              exit 1
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
-        - name: wait-for-db
-          image: docker.io/library/busybox:1.37
-          command:
-            - sh
-            - -c
-            - |
-              echo "Waiting for database at {{ include "umami.dbHost" . }}:{{ include "umami.dbPort" . }}..."
-              until nc -z -w2 {{ include "umami.dbHost" . }} {{ include "umami.dbPort" . }}; do
-                echo "Database not ready, retrying in 2s..."
-                sleep 2
-              done
-              echo "Database is ready."
-          {{- with .Values.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: umami
           image: {{ include "umami.image" . | quote }}

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/umami-software/umami:3.1.0"
+          value: "ghcr.io/umami-software/umami:3.0.3"
 
   - it: should set custom image tag
     set:
@@ -102,6 +102,42 @@ tests:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-db
 
+  - it: should append extra init containers after internal init containers
+    set:
+      extraVolumes:
+        - name: geoip
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: geoip
+          mountPath: /app/geoip
+      extraInitContainers:
+        - name: download-geoip
+          image: docker.io/library/busybox:1.37
+          command:
+            - sh
+            - -ec
+          args:
+            - echo geoip > /geoip/GeoLite2-City.mmdb
+          volumeMounts:
+            - name: geoip
+              mountPath: /geoip
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: download-geoip
+      - equal:
+          path: spec.template.spec.initContainers[1].volumeMounts[0].name
+          value: geoip
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /app/geoip
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: geoip
+
   - it: should prepare external database when enabled
     set:
       postgresql.enabled: false
@@ -111,21 +147,21 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[1].name
           value: prepare-external-db
       - equal:
-          path: spec.template.spec.initContainers[0].image
+          path: spec.template.spec.initContainers[1].image
           value: docker.io/library/postgres:18-alpine
       - contains:
-          path: spec.template.spec.initContainers[0].env
+          path: spec.template.spec.initContainers[1].env
           content:
             name: DATABASE_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: postgres-admin
                 key: postgres-password
-      - equal:
-          path: spec.template.spec.initContainers[1].name
-          value: wait-for-db
 
   - it: should set external database host when subchart is disabled
     set:

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/umami-software/umami:3.0.3"
+          value: "ghcr.io/umami-software/umami:3.1.0"
 
   - it: should set custom image tag
     set:

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -38,7 +38,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag",
-          "default": "3.1.0"
+          "default": "3.0.3"
         },
         "pullPolicy": {
           "type": "string",
@@ -486,6 +486,11 @@
     "extraVolumeMounts": {
       "type": "array",
       "description": "Additional volume mounts for the container",
+      "items": { "type": "object" }
+    },
+    "extraInitContainers": {
+      "type": "array",
+      "description": "Additional init containers for preparing shared volumes before Umami starts",
       "items": { "type": "object" }
     },
     "extraManifests": {

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -38,7 +38,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag",
-          "default": "3.0.3"
+          "default": "3.1.0"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Umami container image
   repository: ghcr.io/umami-software/umami
   # -- Image tag
-  tag: "3.0.3"
+  tag: "3.1.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Umami container image
   repository: ghcr.io/umami-software/umami
   # -- Image tag
-  tag: "3.1.0"
+  tag: "3.0.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -392,6 +392,7 @@ podAnnotations: {}
 
 extraVolumes: []
 extraVolumeMounts: []
+extraInitContainers: []
 
 # -- Extra manifests to deploy alongside the chart
 extraManifests: []


### PR DESCRIPTION
## Summary
- add `extraInitContainers` to the Umami chart so users can prepare shared volumes before the app starts
- render custom init containers after database readiness and optional external DB preparation
- make external DB, External Secrets, production, and dual-stack CI values k3d-valid and self-contained
- align Umami default image/appVersion to `3.1.0` after renewed runtime validation on k3d and Raspberry Pi nodes

Closes #441

## Site PR
- helmforgedev/site#241

## Validation
- `make image-verify IMAGE=ghcr.io/umami-software/umami:3.1.0`
  - PASS: manifest includes `linux/amd64` and `linux/arm64`
- `make standards-check CHART=umami`
- `make site-sync-check CHART=umami`
  - PASS: linked site PR helmforgedev/site#241 covers the required Umami documentation update
- `make validate-chart CHART=umami`
  - PASS: clean Chart.lock
  - PASS: helm dependency build/list
  - PASS: helm lint --strict
  - PASS: helm template all scenarios
  - PASS: helm unittest
  - PASS: kubeconform strict with real CRD schemas
  - PASS: ah lint
  - PASS: k3d behavioral default and all `ci/*.yaml` scenarios, with no restarts, fatal logs, or Warning events
- Raspberry Pi runtime check on `berlofa-rpi` with `ghcr.io/umami-software/umami:3.1.0`
  - PASS: `rpi-node01` and `rpi-node02` both ran with 0 restarts and no exit code 139
  - PASS: `/api/heartbeat` returned `{ "ok": true }`
- `make release-check REPO=charts`
  - PASS with expected GR-003/GR-077 warnings for CI-owned chart versioning and rendered-output release publication
- `make attribution-check REPO=charts`