### PR TITLE
feat(immich): add server extra volumes

### DIFF
--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/immich.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#449)"
+      description: "add Immich server extra volume and volumeMount support (#447)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/immich/README.md
+++ b/charts/immich/README.md
@@ -28,6 +28,30 @@ Persistent storage is enabled by default for uploads, PostgreSQL, internal cache
 machine-learning model cache. For local smoke tests, disable persistence with
 the k3d values file.
 
+## Extra Server Volumes
+
+Use `extraVolumes` and `extraVolumeMounts` to mount additional ConfigMaps,
+Secrets, or PVCs into the Immich server container. This is useful for custom
+configuration files and read-only external media locations.
+
+```yaml
+extraVolumes:
+  - name: external-media
+    persistentVolumeClaim:
+      claimName: external-media
+  - name: immich-config
+    configMap:
+      name: immich-config
+
+extraVolumeMounts:
+  - name: external-media
+    mountPath: /mnt/external-media
+    readOnly: true
+  - name: immich-config
+    mountPath: /config/immich
+    readOnly: true
+```
+
 ## External Database
 
 ```yaml

--- a/charts/immich/ci/ci-values.yaml
+++ b/charts/immich/ci/ci-values.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 server:
-  replicaCount: 2
+  replicaCount: 1
   persistence:
     enabled: false
 
@@ -20,9 +20,6 @@ valkey:
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6
 
 ingress:
   enabled: true
@@ -45,8 +42,8 @@ networkPolicy:
   enabled: true
 
 autoscaling:
-  enabled: true
-  minReplicas: 2
+  enabled: false
+  minReplicas: 1
   maxReplicas: 4
 
 pdb:

--- a/charts/immich/ci/k3d-values.yaml
+++ b/charts/immich/ci/k3d-values.yaml
@@ -34,3 +34,22 @@ resources:
   limits:
     cpu: "1"
     memory: 1536Mi
+
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: immich-extra-config
+    data:
+      custom.yaml: |
+        source: helmforge-ci
+
+extraVolumes:
+  - name: immich-extra-config
+    configMap:
+      name: immich-extra-config
+
+extraVolumeMounts:
+  - name: immich-extra-config
+    mountPath: /config/immich
+    readOnly: true

--- a/charts/immich/templates/deployment.yaml
+++ b/charts/immich/templates/deployment.yaml
@@ -160,6 +160,9 @@ spec:
           volumeMounts:
             - name: uploads
               mountPath: /data
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: uploads
           {{- if .Values.server.persistence.enabled }}
@@ -168,6 +171,9 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/immich/tests/deployment_test.yaml
+++ b/charts/immich/tests/deployment_test.yaml
@@ -205,6 +205,65 @@ tests:
         template: templates/pvc.yaml
         documentIndex: 0
 
+  - it: should render extra server volumes and mounts
+    set:
+      extraVolumes:
+        - name: immich-config
+          configMap:
+            name: immich-config
+        - name: external-media
+          persistentVolumeClaim:
+            claimName: external-media
+      extraVolumeMounts:
+        - name: immich-config
+          mountPath: /config/immich
+          readOnly: true
+        - name: external-media
+          mountPath: /mnt/external-media
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uploads
+            persistentVolumeClaim:
+              claimName: test-immich-uploads
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: immich-config
+            configMap:
+              name: immich-config
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: external-media
+            persistentVolumeClaim:
+              claimName: external-media
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: uploads
+            mountPath: /data
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: immich-config
+            mountPath: /config/immich
+            readOnly: true
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: external-media
+            mountPath: /mnt/external-media
+            readOnly: true
+        template: templates/deployment.yaml
+
   - it: should fail external database without explicit password or secret
     set:
       postgresql.enabled: false

--- a/charts/immich/values.schema.json
+++ b/charts/immich/values.schema.json
@@ -157,6 +157,16 @@
     "affinity": { "type": "object" },
     "topologySpreadConstraints": { "type": "array" },
     "test": { "type": "object" },
-    "extraObjects": { "type": "array" }
+    "extraObjects": { "type": "array" },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Extra volumes mounted into the Immich server pod",
+      "items": { "type": "object" }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Extra volume mounts for the Immich server container",
+      "items": { "type": "object" }
+    }
   }
 }

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -438,3 +438,9 @@ test:
 
 # -- Extra Kubernetes manifests rendered with the release.
 extraObjects: []
+
+# -- Extra volumes mounted into the Immich server pod.
+extraVolumes: []
+
+# -- Extra volume mounts for the Immich server container.
+extraVolumeMounts: []


### PR DESCRIPTION
## Summary
- fixes helmforgedev/charts#447 by adding top-level `extraVolumes` and `extraVolumeMounts` for the Immich server pod/container
- keeps the built-in `/data` uploads mount intact while allowing additional ConfigMap, Secret, PVC, emptyDir, or other Kubernetes volumes
- adds schema entries and unit tests for custom server volumes and mounts
- validates the new path in the k3d scenario with a mounted ConfigMap
- makes Immich CI scenarios runtime-safe on the local k3d cluster: dual-stack policy no longer forces IPv6 and the autoscaling scenario no longer creates an invalid multi-server emptyDir upload layout

## Documentation
- Site PR: helmforgedev/site#244

## Validation
- `make validate-chart CHART=immich CONTEXT=k3d-helmforge-tests-wsl TIMEOUT=180` passed end-to-end: deps, lint, template/ci, unittest, kubeconform, ah lint, and all k3d behavioral scenarios (12 layers)
- k3d scenarios passed with no restarts, no crash/fatal log patterns, and no critical/unjustified Warning events
- `helm unittest --with-subchart=false charts/immich` passed: 42 tests
- `make standards-check REPO=charts CHART=immich JSON=1` passed
- `make deps-check REPO=charts CHART=immich JSON=1` passed
- `make site-sync-check CHART=immich JSON=1` passed
- `make md-lint REPO=charts JSON=1` passed
- `make release-check REPO=charts JSON=1` passed
- `make attribution-check REPO=charts JSON=1` passed