### PR TITLE
chore(adguard-home): bump adguard home to 0.107.77

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -4,7 +4,7 @@ name: adguard-home
 description: AdGuard Home network-wide ad and tracker blocking DNS server with sync and S3 backup
 type: application
 version: 1.4.10
-appVersion: "0.107.76"
+appVersion: "0.107.77"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/adguard-home/DESIGN.md
+++ b/charts/adguard-home/DESIGN.md
@@ -1,0 +1,83 @@
+# AdGuard Home Chart Design
+
+## Scope
+
+This chart deploys AdGuard Home as a single-instance DNS filtering service with
+an optional web setup wizard, pre-seeded configuration, synchronization helper,
+Gateway API or Ingress routing, External Secrets integration, and S3 backup.
+
+The chart is intended for home labs, small networks, and production Kubernetes
+clusters that want DNS-level ad and tracker blocking with explicit persistence
+and operational controls.
+
+## Architecture
+
+```mermaid
+flowchart TB
+  clients[DNS clients] --> dns[DNS Service]
+  users[Administrators] --> route[Ingress or HTTPRoute]
+  route --> web[Web Service]
+  dns --> app[AdGuard Home Deployment]
+  web --> app
+  app --> conf[(Configuration PVC)]
+  app --> work[(Work data PVC)]
+  eso[External Secrets Operator] -. optional .-> configSecret[AdGuardHome.yaml Secret]
+  configSecret --> app
+  sync[adguardhome-sync Deployment] -. optional .-> app
+  backup[Backup CronJob] --> s3[S3-compatible storage]
+```
+
+## Main Design Choices
+
+- Keep the default in setup-wizard mode so first-time users can deploy without
+  writing an `AdGuardHome.yaml` file.
+- Use `config.adGuardHome` or `config.existingSecret` to bypass the wizard and
+  seed a managed configuration for repeatable deployments.
+- Keep the workload single-replica with `Recreate` strategy because AdGuard Home
+  stores mutable DNS configuration and runtime data on local volumes.
+- Expose web and DNS services separately so users can route the admin UI
+  independently from DNS traffic.
+- Support optional `adguardhome-sync` for users who run multiple AdGuard Home
+  instances outside the scope of this chart's primary pod.
+- Render ExternalSecret resources only when explicitly enabled; the chart does
+  not install External Secrets Operator or manage provider-side stores.
+- Keep S3 backup opt-in and use the HelmForge `mc` utility image for uploads.
+
+## Production Boundary
+
+Production users should set explicit values for:
+
+- `config.adGuardHome` or `config.existingSecret`
+- `service.dns.type` and any external load balancer address
+- `persistence.conf.size`, `persistence.work.size`, and storage classes
+- `resources`
+- `ingress` or `gateway` routing for the admin UI
+- backup S3 credentials via existing Kubernetes Secrets or External Secrets
+- network policy and egress rules suitable for upstream DNS providers
+
+## Non-Goals
+
+- Installing or configuring External Secrets Operator
+- Managing DNS provider or router configuration outside Kubernetes
+- Multi-replica AdGuard Home from one Stateful workload
+- Automatic filter list curation beyond what AdGuard Home itself manages
+- Provisioning S3 buckets or cloud load balancers
+
+<!-- @AI-METADATA
+type: design
+title: AdGuard Home Chart Design
+description: Design document for the AdGuard Home Helm chart
+
+keywords: adguard-home, dns, design, gateway-api, external-secrets, backup
+
+purpose: Document architecture, chart boundaries, and production choices for AdGuard Home
+scope: Chart Design
+
+relations:
+  - charts/adguard-home/README.md
+  - charts/adguard-home/docs/sync.md
+  - charts/adguard-home/docs/backup.md
+path: charts/adguard-home/DESIGN.md
+version: 1.0
+date: 2026-06-09
+-->

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -35,9 +35,14 @@ To skip the wizard and deploy a pre-configured instance, provide `config.adGuard
 
 ## Upstream Version Notes
 
-AdGuard Home `0.107.76` is an upstream hotfix release for cache behavior after the previous update.
-The release notes also state that YAML duration values now support `d` day units. If you roll back to
-a version below `v0.107.76`, convert any `d` duration values in `config.adGuardHome` back to hours first.
+AdGuard Home `0.107.77` is an upstream security and bugfix release. It fixes a
+GLiNET-mode authorization path traversal issue (CVE-2026-41448), adds the
+`reason` query parameter for query log filtering, and deprecates the older
+`response_status` query parameter.
+
+The `0.107.76` release notes also state that YAML duration values now support
+`d` day units. If you roll back to a version below `v0.107.76`, convert any `d`
+duration values in `config.adGuardHome` back to hours first.
 
 ## Features
 
@@ -183,7 +188,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/adguard/adguardhome` | Container image |
-| `image.tag` | `v0.107.76` | Image tag |
+| `image.tag` | `v0.107.77` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### General Configuration
@@ -382,7 +387,6 @@ externalSecrets:
     - secretKey: AdGuardHome.yaml
       remoteRef:
         key: adguard-home/config
-        property: AdGuardHome.yaml
 ```
 
 ## Examples
@@ -420,6 +424,14 @@ This chart intentionally does not support:
 - **Multi-replica DNS** - AdGuard Home is designed as a single instance; use sync for multi-site setups
 - **Built-in DNS-over-HTTPS proxy** - use a dedicated reverse proxy or ingress controller for TLS termination
 - **Automatic filter list management** - filter lists are managed through the AdGuard Home web UI or config
+
+### Security Scan: `adguard-home`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **72.72727%** |
+
+> Security posture acceptable.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/adguard-home/ci/dual-stack.yaml
+++ b/charts/adguard-home/ci/dual-stack.yaml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: dual-stack IPv6 service (GR-058)
+# CI scenario: dual-stack networking via service ipFamilyPolicy.
+#
+# Uses PreferDualStack policy without explicit ipFamilies so this scenario
+# works on both single-stack and dual-stack clusters. The Kubernetes API rejects
+# an explicit ipFamilies entry that the cluster does not advertise, so explicit
+# families should be tested only on a dual-stack cluster.
 persistence:
   conf:
     enabled: false
@@ -9,12 +14,6 @@ persistence:
 service:
   web:
     ipFamilyPolicy: PreferDualStack
-    ipFamilies:
-      - IPv4
-      - IPv6
   dns:
     type: ClusterIP
     ipFamilyPolicy: PreferDualStack
-    ipFamilies:
-      - IPv4
-      - IPv6

--- a/charts/adguard-home/ci/external-secrets.yaml
+++ b/charts/adguard-home/ci/external-secrets.yaml
@@ -13,10 +13,9 @@ config:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: AdGuardHome.yaml
       remoteRef:
         key: adguard-home/config
-        property: AdGuardHome.yaml

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/adguard/adguardhome:v0.107.76"
+          value: "docker.io/adguard/adguardhome:v0.107.77"
 
   - it: should expose setup wizard port 3000 by default (no config)
     template: templates/deployment.yaml

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- AdGuard Home container image
   repository: docker.io/adguard/adguardhome
   # -- Image tag
-  tag: "v0.107.76"
+  tag: "v0.107.77"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update AdGuard Home from `0.107.76` to `0.107.77` using the verified upstream image tag `docker.io/adguard/adguardhome:v0.107.77`
- refresh chart tests, README upstream notes, Security Scan evidence, and chart design documentation
- fix the dual-stack CI scenario so it works on single-stack k3d by using `PreferDualStack` without explicit `ipFamilies`
- fix the External Secrets CI scenario to use the HelmForge fake store and a whole-secret `AdGuardHome.yaml` payload

## Issue

Resolves #451.

## Site sync

- Companion docs PR: helmforgedev/site#245

## Upstream evidence

- `make image-verify IMAGE=docker.io/adguard/adguardhome:v0.107.77` passed with linux/386, linux/amd64, linux/arm, linux/arm64, and linux/ppc64le manifests.
- `make image-verify IMAGE=docker.io/adguard/adguardhome:0.107.77` failed because the non-`v` tag has no manifest, so the chart keeps the official `v0.107.77` tag format.
- AdGuard Home `v0.107.77` release notes identify this as a security and bugfix release, including CVE-2026-41448, the new `reason` query log filter, and the `response_status` query parameter deprecation.

## Local validation

- `make deps-check CHART=adguard-home`
- `make validate-chart CHART=adguard-home` passed end-to-end, including k3d behavioral validation for default and all CI values
- `make standards-check CHART=adguard-home`
- `make standards-guard`
- `make md-lint REPO=charts`
- `make preflight`
- `make site-sync-check CHART=adguard-home`