### PR TITLE
feat(generic)!: render env values and ingress hosts/tls through tpl

### DIFF
--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -371,7 +371,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `containers` | List of container specs | 1 container on port 80 |
 | `initContainers` | Init container specs | `[]` |
 | **Environment** | | |
-| `env` | Global env vars for all containers | `[]` |
+| `env` | Global env vars for all containers (`value` supports tpl, e.g. `{{ .Release.Namespace }}`) | `[]` |
 | `envFrom` | Global envFrom for all containers | `[]` |
 | **Service Account** | | |
 | `serviceAccount.create` | Create a ServiceAccount | `false` |
@@ -398,7 +398,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | `services` | Additional Service resources | `[]` |
 | `ingress.enabled` | Enable Ingress | `false` |
 | `ingress.ingressClassName` | Ingress class | `traefik` |
-| `ingress.hosts` | Ingress host rules; paths require explicit `backend` when `service.enabled=false` | `[]` |
+| `ingress.hosts` | Ingress host rules; `host` supports tpl (e.g. `{{ .Release.Namespace }}`); paths require explicit `backend` when `service.enabled=false` | `[]` |
 | `ingress.defaultBackend` | Ingress default backend | `{}` |
 | `ingress.tls` | TLS configuration | `[]` |
 | `gatewayApi.enabled` | Enable Gateway API HTTPRoutes | `false` |

--- a/charts/generic/templates/_helpers.tpl
+++ b/charts/generic/templates/_helpers.tpl
@@ -172,13 +172,17 @@ Used by deployment, job, and cronjob templates to avoid duplication.
   {{- with .container.workingDir }}
   workingDir: {{ . }}
   {{- end }}
-  {{- if or .root.Values.env .container.env }}
+  {{- $allEnv := concat (.root.Values.env | default list) (.container.env | default list) }}
+  {{- if $allEnv }}
   env:
-    {{- with .root.Values.env }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .container.env }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $allEnv }}
+    - name: {{ .name }}
+      {{- if hasKey . "value" }}
+      value: {{ tpl (.value | toString) $.root | quote }}
+      {{- else if .valueFrom }}
+      valueFrom:
+        {{- toYaml .valueFrom | nindent 8 }}
+      {{- end }}
     {{- end }}
   {{- end }}
   {{- if or .root.Values.envFrom .container.envFrom }}

--- a/charts/generic/templates/ingress.yaml
+++ b/charts/generic/templates/ingress.yaml
@@ -23,16 +23,16 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       {{- with .secretName }}
-      secretName: {{ . }}
+      secretName: {{ tpl . $ }}
       {{- end }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths | default (list "/") }}

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -132,3 +132,36 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["helmforge.dev/restartedAt"]
           value: "2026-04-27T00:00:00Z"
+
+  - it: should render tpl in env values and preserve valueFrom
+    release:
+      namespace: deskbia
+    set:
+      env:
+        - name: GLOBAL_URL
+          value: "https://app-{{ .Release.Namespace }}.deskbee.dev"
+      containers:
+        - name: app
+          env:
+            - name: APP_URL
+              value: "https://api-{{ .Release.Namespace }}.deskbee.dev"
+            - name: PLAIN
+              value: keepme
+            - name: FROM_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: s
+                  key: k
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: https://app-deskbia.deskbee.dev
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: https://api-deskbia.deskbee.dev
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: keepme
+      - equal:
+          path: spec.template.spec.containers[0].env[3].valueFrom.secretKeyRef.name
+          value: s

--- a/charts/generic/tests/ingress_test.yaml
+++ b/charts/generic/tests/ingress_test.yaml
@@ -25,3 +25,28 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: traefik
+
+  - it: should render tpl in host, tls hosts and secretName from .Release.Namespace
+    release:
+      namespace: deskbia
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: "api-{{ .Release.Namespace }}.deskbee.dev"
+          paths:
+            - path: /
+              pathType: Prefix
+      ingress.tls:
+        - hosts:
+            - "api-{{ .Release.Namespace }}.deskbee.dev"
+          secretName: "api-{{ .Release.Namespace }}-tls"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: api-deskbia.deskbee.dev
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: api-deskbia.deskbee.dev
+      - equal:
+          path: spec.tls[0].secretName
+          value: api-deskbia-tls


### PR DESCRIPTION
## What

Render the following through Helm's `tpl` so values can reference the release context (notably `{{ .Release.Namespace }}`):

- `env[].value` (global and per-container)
- `ingress.hosts[].host`
- `ingress.tls[].hosts[]`
- `ingress.tls[].secretName`

`valueFrom` and `envFrom` are untouched; global+container env ordering is preserved.

## Why

Lets shared/workload value files stay **environment-agnostic** and resolve per environment from the namespace, e.g.:

```yaml
env:
  - name: APP_URL
    value: "https://api-{{ .Release.Namespace }}.deskbee.dev"
ingress:
  hosts:
    - host: "api-{{ .Release.Namespace }}.deskbee.dev"
```

No more hardcoding the environment name in every workload/values file.

## Breaking change

`env[].value` (and the ingress host/tls fields) are now evaluated as Go templates. Values containing literal `{{ }}` will be interpreted and will fail to render if they are not valid chart template expressions. Quote/escape such values or move them to `envFrom`.

Hostnames and Secret names cannot contain `{{`, so the ingress part is effectively non-breaking; the env part is the breaking surface.

## Tests

- `helm unittest`: 70 passed (added cases for tpl-rendered env values, `valueFrom` preservation, and tpl-rendered ingress host/tls/secretName).
- `helm lint`: clean.
- README parameter table updated for `env` and `ingress.hosts`.

Version bump intentionally omitted — handled by CI via semver from the `feat!` commit.