### PR TITLE
chore(envoy-gateway): bump Envoy Gateway to 1.8.1

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 1.7.0
-appVersion: "v1.8.0"
+appVersion: "v1.8.1"
 kubeVersion: ">=1.24.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
@@ -12,7 +12,7 @@ sources:
   - https://github.com/envoyproxy/gateway
 dependencies:
   - name: redis
-    version: 1.6.17
+    version: 1.6.18
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,7 +1,7 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.8.0 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
+v1.8.1 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
 Envoy proxy pods automatically in response to Gateway API resources.
 
 ## Installation
@@ -27,7 +27,7 @@ The Envoy Gateway operator CRDs (`gateway.envoyproxy.io/*`: `EnvoyProxy`,
 chart's `crds/` directory, so Helm installs them automatically on first install
 when they are absent (and skips them if already present). Only the upstream
 **Gateway API** CRDs (`gateway.networking.k8s.io/*`) are a separate cluster
-prerequisite, installed once below. Envoy Gateway v1.8.0 requires the Gateway API
+prerequisite, installed once below. Envoy Gateway v1.8.1 requires the Gateway API
 **experimental** channel (v1.5.1) — it watches `ListenerSet`, which only ships in
 the experimental channel; the standard channel is not sufficient. These CRDs are
 cluster-scoped and shared, so they are NOT bundled in the chart (Helm's release
@@ -173,7 +173,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.8.0` | Controller image tag |
+| `controller.image.tag` | `v1.8.1` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -191,7 +191,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.8.0` | Certgen image tag |
+| `certgen.image.tag` | `v1.8.1` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -207,8 +207,11 @@ highAvailability:
 | `proxy.kind` | `Deployment` | Proxy workload kind: `Deployment` or `DaemonSet` |
 | `proxy.replicaCount` | `1` | Number of proxy replicas (Deployment mode only, overridden by profile) |
 | `proxy.image.repository` | `docker.io/envoyproxy/envoy` | Proxy image repository |
-| `proxy.image.tag` | `distroless-v1.37.0` | Proxy image tag |
+| `proxy.image.tag` | `distroless-v1.38.0` | Proxy image tag |
 | `proxy.image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `proxy.shutdownManager.image.repository` | `docker.io/envoyproxy/gateway` | Shutdown manager sidecar image repository |
+| `proxy.shutdownManager.image.tag` | `v1.8.1` | Shutdown manager sidecar image tag |
+| `proxy.shutdownManager.image.pullPolicy` | `IfNotPresent` | Shutdown manager image pull policy |
 | `proxy.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `proxy.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
 | `proxy.resources.limits.cpu` | `1000m` | CPU limit (overridden by profile) |
@@ -283,13 +286,6 @@ highAvailability:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `rateLimiting.enabled` | `false` | Enable rate limiting |
-| `rateLimiting.redis.enabled` | `false` | Deploy Redis StatefulSet |
-| `rateLimiting.redis.image.repository` | `docker.io/redis` | Redis image repository |
-| `rateLimiting.redis.image.tag` | `8.0.2-alpine` | Redis image tag |
-| `rateLimiting.redis.resources` | See values | Redis resources |
-| `rateLimiting.redis.persistence.enabled` | `true` | Enable Redis persistence |
-| `rateLimiting.redis.persistence.size` | `1Gi` | Redis PVC size |
-| `rateLimiting.redis.persistence.storageClass` | `""` | Storage class for Redis PVC |
 | `rateLimiting.externalRedis.host` | `""` | External Redis host |
 | `rateLimiting.externalRedis.port` | `6379` | External Redis port |
 | `rateLimiting.externalRedis.auth.enabled` | `false` | Enable Redis authentication |
@@ -297,6 +293,11 @@ highAvailability:
 | `rateLimiting.externalRedis.auth.secretKey` | `password` | Secret key for Redis password |
 | `rateLimiting.presets.api` | `false` | Enable API preset (100 req/min per IP) |
 | `rateLimiting.presets.strict` | `false` | Enable strict preset (10 req/min per IP) |
+| `redis.enabled` | `false` | Deploy the helmforge/redis subchart for rate limiting |
+| `redis.architecture` | `standalone` | Redis topology |
+| `redis.auth.enabled` | `true` | Enable Redis password authentication |
+| `redis.standalone.persistence.enabled` | `true` | Enable Redis persistent storage |
+| `redis.standalone.persistence.size` | `1Gi` | Redis PVC size |
 
 ### Monitoring
 
@@ -338,6 +339,26 @@ highAvailability:
 |-----|---------|-------------|
 | `gatewayClass.name` | `envoy-gateway` | GatewayClass name |
 | `gatewayClass.create` | `true` | Create GatewayClass resource |
+
+### Cleanup
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `cleanup.enabled` | `true` | Run a pre-delete cleanup Job for chart-managed Gateways and GatewayClass |
+| `cleanup.image.repository` | `docker.io/helmforge/kubectl` | kubectl image used by the cleanup hook |
+| `cleanup.image.tag` | `1.35.3` | kubectl image tag |
+| `cleanup.image.pullPolicy` | `IfNotPresent` | Cleanup image pull policy |
+| `cleanup.timeoutSeconds` | `90` | Timeout in seconds for Gateway and GatewayClass cleanup operations |
+| `cleanup.resources.requests.cpu` | `10m` | CPU request for the cleanup hook |
+| `cleanup.resources.requests.memory` | `32Mi` | Memory request for the cleanup hook |
+| `cleanup.resources.limits.cpu` | `100m` | CPU limit for the cleanup hook |
+| `cleanup.resources.limits.memory` | `128Mi` | Memory limit for the cleanup hook |
+
+The cleanup hook runs before uninstall so chart-managed Gateways are deleted
+while the controller is still present. It then removes the chart-managed
+GatewayClass after verifying that no remaining Gateways reference that class.
+If user-managed Gateways still reference the class, the hook exits with a clear
+error and Helm leaves the release installed for manual cleanup.
 
 ## Examples
 
@@ -424,12 +445,25 @@ Major architectural redesign to align with the EG operator model.
 
 ## Upgrade Notes
 
-`docker.io/envoyproxy/gateway:v1.8.0` is the upstream minor update from
-`v1.7.3`. The automatically generated issue referenced `1.8.0`, but Docker Hub
-publishes the canonical Envoy Gateway image tag with the `v` prefix. Review the
-upstream Envoy Gateway `v1.8.0` release notes, verify Gateway API/Envoy Gateway
-CRDs in staging, and test existing Gateway, HTTPRoute, EnvoyProxy, and policy
-resources before upgrading production controllers.
+`docker.io/envoyproxy/gateway:v1.8.1` is the upstream patch update from
+`v1.8.0`. The automatically generated issue referenced `1.8.1`, but Docker Hub
+publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
+also updates the managed Envoy proxy image to
+`docker.io/envoyproxy/envoy:distroless-v1.38.0`, matching the upstream v1.8
+compatibility matrix.
+
+Envoy Gateway v1.8.1 includes security fixes for GatewayNamespaceMode xDS
+authentication, Lua validator sandbox path normalization, Wasm HTTP fetch gzip
+decompression limits, ReferenceGrant bypass handling, and related controller
+runtime issues. The chart now also pins the EG-managed `shutdown-manager`
+sidecar to `docker.io/envoyproxy/gateway:v1.8.1` through the EnvoyProxy strategic
+merge patch, avoiding the upstream-generated `gateway-dev:latest` runtime image.
+It also moves Gateway API safe-upgrades ValidatingAdmissionPolicy resources from
+the CRD bundle into the gateway Helm templates upstream. Before upgrading
+production controllers, review ownership of existing
+`safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy resources,
+verify Gateway API and Envoy Gateway CRDs in staging, and test existing Gateway,
+HTTPRoute, EnvoyProxy, and policy resources.
 
 ### Version 1.0.0
 
@@ -443,10 +477,10 @@ This chart intentionally does not support:
 - **Built-in cert-manager integration** — Manage application TLS externally; chart only runs certgen for controller certs
 - **Legacy Ingress API** — Use Gateway API for modern routing capabilities
 
-### 🟢 Security Scan: `envoy-gateway`
+### Security Scan: `envoy-gateway`
 
 | Framework | Score |
 |---|---|
 | MITRE + NSA + SOC2 | **72.22223%** |
 
-> ✅ Security posture acceptable.
+> Security posture acceptable.

--- a/charts/envoy-gateway/ci/external-secrets.yaml
+++ b/charts/envoy-gateway/ci/external-secrets.yaml
@@ -14,10 +14,9 @@ rateLimiting:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: redis-password
       remoteRef:
-        key: envoy/redis
-        property: password
+        key: test/password

--- a/charts/envoy-gateway/ci/namespace-override-values.yaml
+++ b/charts/envoy-gateway/ci/namespace-override-values.yaml
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: chart-managed resources rendered into a dedicated controller namespace.
+# CI scenario: chart-managed resources rendered through namespaceOverride.
+# k3d validation creates only hf-validate-envoy-gateway for this chart.
 
-namespaceOverride: envoy-gateway-system
+namespaceOverride: hf-validate-envoy-gateway
 
 gatewayAPI:
   examples:

--- a/charts/envoy-gateway/ci/security-values.yaml
+++ b/charts/envoy-gateway/ci/security-values.yaml
@@ -7,8 +7,15 @@ security:
 
 rateLimiting:
   enabled: true
-  redis:
-    enabled: true
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false
+  standalone:
+    persistence:
+      enabled: false
 
 gatewayAPI:
   examples:

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -34,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.8.0
+    tag: v1.8.1
   resources:
     requests:
       cpu: 10m

--- a/charts/envoy-gateway/templates/NOTES.txt
+++ b/charts/envoy-gateway/templates/NOTES.txt
@@ -190,7 +190,7 @@ Rate Limiting: Disabled
 To enable rate limiting with Redis:
   helm upgrade {{ .Release.Name }} envoy-gateway \
     --set rateLimiting.enabled=true \
-    --set rateLimiting.redis.enabled=true \
+    --set redis.enabled=true \
     --set rateLimiting.presets.api=true \
     --reuse-values
 
@@ -229,7 +229,7 @@ ClientTrafficPolicy: Enabled
 {{- if .Values.security.networkPolicies }}
 NetworkPolicies: Enabled
   - Controller policy created
-{{- if and .Values.rateLimiting.enabled .Values.rateLimiting.redis.enabled }}
+{{- if and .Values.rateLimiting.enabled .Values.redis.enabled }}
   - Redis policy created
 {{- end }}
 {{- if .Values.rateLimiting.enabled }}

--- a/charts/envoy-gateway/templates/envoyproxy-config.yaml
+++ b/charts/envoy-gateway/templates/envoyproxy-config.yaml
@@ -25,6 +25,16 @@ spec:
           image: {{ printf "%s:%s" .Values.proxy.image.repository .Values.proxy.image.tag }}
           resources:
             {{- include "envoy-gateway.proxy.resources" . | nindent 12 }}
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: shutdown-manager
+                    image: {{ printf "%s:%s" .Values.proxy.shutdownManager.image.repository .Values.proxy.shutdownManager.image.tag }}
+                    imagePullPolicy: {{ .Values.proxy.shutdownManager.image.pullPolicy }}
       {{- else }}
       envoyDeployment:
         replicas: {{ .Values.proxy.replicaCount }}
@@ -36,6 +46,16 @@ spec:
           image: {{ printf "%s:%s" .Values.proxy.image.repository .Values.proxy.image.tag }}
           resources:
             {{- include "envoy-gateway.proxy.resources" . | nindent 12 }}
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  containers:
+                  - name: shutdown-manager
+                    image: {{ printf "%s:%s" .Values.proxy.shutdownManager.image.repository .Values.proxy.shutdownManager.image.tag }}
+                    imagePullPolicy: {{ .Values.proxy.shutdownManager.image.pullPolicy }}
       {{- if .Values.proxy.autoscaling.enabled }}
       envoyHpa:
         minReplicas: {{ .Values.proxy.autoscaling.minReplicas }}
@@ -63,7 +83,23 @@ spec:
     accessLog:
       settings:
       - format:
-          type: {{ .Values.monitoring.accessLogs.format | upper }}
+          {{- if eq (lower .Values.monitoring.accessLogs.format) "json" }}
+          type: JSON
+          json:
+            start_time: "%START_TIME%"
+            method: "%REQ(:METHOD)%"
+            path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+            protocol: "%PROTOCOL%"
+            response_code: "%RESPONSE_CODE%"
+            response_flags: "%RESPONSE_FLAGS%"
+            bytes_received: "%BYTES_RECEIVED%"
+            bytes_sent: "%BYTES_SENT%"
+            duration: "%DURATION%"
+            upstream_host: "%UPSTREAM_HOST%"
+          {{- else }}
+          type: Text
+          text: '[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% "%UPSTREAM_HOST%"'
+          {{- end }}
         sinks:
         - type: File
           file:

--- a/charts/envoy-gateway/templates/gatewayclass-cleanup-job.yaml
+++ b/charts/envoy-gateway/templates/gatewayclass-cleanup-job.yaml
@@ -31,10 +31,11 @@ spec:
         - -ec
         - |
           gateway_class={{ .Values.gatewayClass.name | quote }}
+          namespace={{ include "envoy-gateway.namespace" . | quote }}
           release={{ .Release.Name | quote }}
           timeout={{ .Values.cleanup.timeoutSeconds | int }}
 
-          kubectl delete gateway -A \
+          kubectl delete gateway -n "${namespace}" \
             -l "app.kubernetes.io/instance=${release}" \
             --wait=true \
             --timeout="${timeout}s" \

--- a/charts/envoy-gateway/templates/gatewayclass-cleanup-job.yaml
+++ b/charts/envoy-gateway/templates/gatewayclass-cleanup-job.yaml
@@ -1,0 +1,68 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.cleanup.enabled .Values.gatewayClass.create .Values.rbac.create }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "envoy-gateway.fullname" . }}-gatewayclass-cleanup
+  namespace: {{ include "envoy-gateway.namespace" . }}
+  labels:
+    {{- include "envoy-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cleanup
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "envoy-gateway.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cleanup
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "envoy-gateway.serviceAccountName" . }}
+      containers:
+      - name: gatewayclass-cleanup
+        image: {{ .Values.cleanup.image.repository }}:{{ .Values.cleanup.image.tag }}
+        imagePullPolicy: {{ .Values.cleanup.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          gateway_class={{ .Values.gatewayClass.name | quote }}
+          release={{ .Release.Name | quote }}
+          timeout={{ .Values.cleanup.timeoutSeconds | int }}
+
+          kubectl delete gateway -A \
+            -l "app.kubernetes.io/instance=${release}" \
+            --wait=true \
+            --timeout="${timeout}s" \
+            --ignore-not-found
+
+          remaining="$(kubectl get gateway -A -o jsonpath='{range .items[?(@.spec.gatewayClassName=="{{ .Values.gatewayClass.name }}")]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')"
+          if [ -n "$remaining" ]; then
+            echo "Refusing to delete GatewayClass ${gateway_class}; Gateways still reference it:"
+            echo "$remaining"
+            exit 1
+          fi
+
+          kubectl delete gatewayclass "${gateway_class}" --wait=false --ignore-not-found
+
+          i=0
+          while kubectl get gatewayclass "${gateway_class}" >/dev/null 2>&1; do
+            if [ "$i" -ge "$timeout" ]; then
+              kubectl patch gatewayclass "${gateway_class}" --type=merge -p '{"metadata":{"finalizers":[]}}' || true
+              break
+            fi
+            i=$((i + 1))
+            sleep 1
+          done
+
+          kubectl delete gatewayclass "${gateway_class}" \
+            --wait=true \
+            --timeout="${timeout}s" \
+            --ignore-not-found
+        resources:
+          {{- toYaml .Values.cleanup.resources | nindent 10 }}
+{{- end }}

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -26,6 +26,13 @@ spec:
     ports:
     - protocol: TCP
       port: 8081
+  - from:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 18000
+    - protocol: TCP
+      port: 18002
   egress:
   - to:
     - namespaceSelector: {}
@@ -42,7 +49,7 @@ spec:
       port: 53
     - protocol: UDP
       port: 53
-{{- if and .Values.rateLimiting.enabled .Values.rateLimiting.redis.enabled }}
+{{- if and .Values.rateLimiting.enabled .Values.redis.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -55,7 +62,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "envoy-gateway.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ default "redis" .Values.redis.nameOverride | trunc 63 | trimSuffix "-" }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: redis
   policyTypes:
   - Ingress
@@ -93,14 +101,15 @@ spec:
     - protocol: TCP
       port: 6070
   egress:
-  {{- if .Values.rateLimiting.redis.enabled }}
+  {{- if .Values.redis.enabled }}
   - to:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
       podSelector:
         matchLabels:
-          {{- include "envoy-gateway.selectorLabels" . | nindent 10 }}
+          app.kubernetes.io/name: {{ default "redis" .Values.redis.nameOverride | trunc 63 | trimSuffix "-" }}
+          app.kubernetes.io/instance: {{ .Release.Name }}
           app.kubernetes.io/component: redis
     ports:
     - protocol: TCP

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -71,7 +71,8 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          {{- include "envoy-gateway.controller.selectorLabels" . | nindent 10 }}
+          {{- include "envoy-gateway.selectorLabels" . | nindent 10 }}
+          app.kubernetes.io/component: ratelimit
     ports:
     - protocol: TCP
       port: 6379

--- a/charts/envoy-gateway/templates/rbac.yaml
+++ b/charts/envoy-gateway/templates/rbac.yaml
@@ -139,6 +139,7 @@ rules:
   - update
   - patch
   - delete
+  - deletecollection
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -65,7 +65,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "envoyproxy/gateway:v1.8.0"
+          pattern: "envoyproxy/gateway:v1.8.1"
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/cleanup_test.yaml
+++ b/charts/envoy-gateway/tests/cleanup_test.yaml
@@ -24,6 +24,12 @@ tests:
           value: docker.io/helmforge/kubectl:1.35.3
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
+          pattern: 'namespace="NAMESPACE"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete gateway -n "\$\{namespace\}"'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
           pattern: "kubectl delete gateway -A"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]

--- a/charts/envoy-gateway/tests/cleanup_test.yaml
+++ b/charts/envoy-gateway/tests/cleanup_test.yaml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: GatewayClass Cleanup Hook
+templates:
+  - gatewayclass-cleanup-job.yaml
+tests:
+  - it: should create cleanup hook by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-10"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-envoy-gateway
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/helmforge/kubectl:1.35.3
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl delete gateway -A"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "Refusing to delete GatewayClass"
+
+  - it: should not create cleanup hook when disabled
+    set:
+      cleanup:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create cleanup hook without chart-managed GatewayClass
+    set:
+      gatewayClass:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create cleanup hook when RBAC is externally managed
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should allow custom cleanup image and timeout
+    set:
+      cleanup:
+        image:
+          repository: docker.io/helmforge/kubectl
+          tag: 1.35.2
+        timeoutSeconds: 45
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/helmforge/kubectl:1.35.2
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "timeout=45"

--- a/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
+++ b/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
@@ -30,11 +30,17 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment.replicas
           value: 1
 
-  - it: should use the Envoy data-plane image compatible with Envoy Gateway v1.7
+  - it: should use the Envoy data-plane image compatible with Envoy Gateway v1.8
     asserts:
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: docker.io/envoyproxy/envoy:distroless-v1.37.0
+          value: docker.io/envoyproxy/envoy:distroless-v1.38.0
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].name
+          value: shutdown-manager
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].image
+          value: docker.io/envoyproxy/gateway:v1.8.1
 
   - it: should configure DaemonSet mode when kind is DaemonSet
     set:
@@ -45,6 +51,9 @@ tests:
           path: spec.provider.kubernetes.envoyDaemonSet
       - isNull:
           path: spec.provider.kubernetes.envoyDeployment
+      - equal:
+          path: spec.provider.kubernetes.envoyDaemonSet.patch.value.spec.template.spec.containers[0].image
+          value: docker.io/envoyproxy/gateway:v1.8.1
 
   - it: should set proxy service type
     set:

--- a/charts/envoy-gateway/tests/monitoring_test.yaml
+++ b/charts/envoy-gateway/tests/monitoring_test.yaml
@@ -3,6 +3,7 @@ suite: Monitoring and Observability
 templates:
   - servicemonitor.yaml
   - configmap.yaml
+  - envoyproxy-config.yaml
 tests:
   - it: should create one ServiceMonitor when monitoring enabled
     set:
@@ -57,6 +58,46 @@ tests:
           path: data["envoy-gateway.yaml"]
           pattern: "type: JSON"
         template: configmap.yaml
+
+  - it: should configure JSON access logs in EnvoyProxy
+    set:
+      monitoring:
+        enabled: true
+        accessLogs:
+          enabled: true
+          format: json
+    asserts:
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].format.type
+          value: JSON
+        template: envoyproxy-config.yaml
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].format.json.response_code
+          value: "%RESPONSE_CODE%"
+        template: envoyproxy-config.yaml
+      - isNull:
+          path: spec.telemetry.accessLog.settings[0].format.text
+        template: envoyproxy-config.yaml
+
+  - it: should configure text access logs in EnvoyProxy
+    set:
+      monitoring:
+        enabled: true
+        accessLogs:
+          enabled: true
+          format: text
+    asserts:
+      - equal:
+          path: spec.telemetry.accessLog.settings[0].format.type
+          value: Text
+        template: envoyproxy-config.yaml
+      - matchRegex:
+          path: spec.telemetry.accessLog.settings[0].format.text
+          pattern: "%RESPONSE_CODE%"
+        template: envoyproxy-config.yaml
+      - isNull:
+          path: spec.telemetry.accessLog.settings[0].format.json
+        template: envoyproxy-config.yaml
 
   - it: should include rateLimit redis url in configmap when rate limiting enabled
     set:

--- a/charts/envoy-gateway/tests/rbac_test.yaml
+++ b/charts/envoy-gateway/tests/rbac_test.yaml
@@ -119,6 +119,7 @@ tests:
               - update
               - patch
               - delete
+              - deletecollection
         template: rbac.yaml
         documentIndex: 0
 

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -76,6 +76,26 @@ tests:
         template: networkpolicy.yaml
         documentIndex: 1
       - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: redis
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: envoy-gateway
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/component"]
+          value: ratelimit
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
           path: metadata.name
           value: RELEASE-NAME-envoy-gateway-ratelimit
         template: networkpolicy.yaml

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -18,6 +18,20 @@ tests:
           value: NetworkPolicy
         template: networkpolicy.yaml
         documentIndex: 0
+      - contains:
+          path: spec.ingress[2].ports
+          content:
+            protocol: TCP
+            port: 18000
+        template: networkpolicy.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.ingress[2].ports
+          content:
+            protocol: TCP
+            port: 18002
+        template: networkpolicy.yaml
+        documentIndex: 0
 
   - it: should not create NetworkPolicies when disabled
     set:
@@ -35,8 +49,8 @@ tests:
         networkPolicies: true
       rateLimiting:
         enabled: true
-        redis:
-          enabled: true
+      redis:
+        enabled: true
     asserts:
       - hasDocuments:
           count: 3
@@ -52,6 +66,16 @@ tests:
         template: networkpolicy.yaml
         documentIndex: 1
       - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: redis
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+        template: networkpolicy.yaml
+        documentIndex: 1
+      - equal:
           path: metadata.name
           value: RELEASE-NAME-envoy-gateway-ratelimit
         template: networkpolicy.yaml
@@ -64,6 +88,16 @@ tests:
       - equal:
           path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: NAMESPACE
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: spec.egress[0].to[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: redis
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: spec.egress[0].to[0].podSelector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
         template: networkpolicy.yaml
         documentIndex: 2
 

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -88,7 +88,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.8.0"
+              "default": "v1.8.1"
             },
             "pullPolicy": {
               "type": "string",
@@ -213,13 +213,41 @@
             "tag": {
               "type": "string",
               "description": "Proxy image tag",
-              "default": "distroless-v1.37.0"
+              "default": "distroless-v1.38.0"
             },
             "pullPolicy": {
               "type": "string",
               "description": "Proxy image pull policy",
               "enum": ["Always", "IfNotPresent", "Never"],
               "default": "IfNotPresent"
+            }
+          }
+        },
+        "shutdownManager": {
+          "type": "object",
+          "description": "Shutdown manager sidecar configuration",
+          "properties": {
+            "image": {
+              "type": "object",
+              "description": "Shutdown manager sidecar image",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "Shutdown manager sidecar image repository",
+                  "default": "docker.io/envoyproxy/gateway"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Shutdown manager sidecar image tag",
+                  "default": "v1.8.1"
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "description": "Shutdown manager image pull policy",
+                  "enum": ["Always", "IfNotPresent", "Never"],
+                  "default": "IfNotPresent"
+                }
+              }
             }
           }
         },
@@ -684,6 +712,47 @@
           "type": "boolean",
           "description": "Create GatewayClass resource",
           "default": true
+        }
+      }
+    },
+    "cleanup": {
+      "type": "object",
+      "description": "Cleanup hook configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run a pre-delete cleanup Job for chart-managed Gateways and GatewayClass",
+          "default": true
+        },
+        "image": {
+          "type": "object",
+          "description": "Cleanup hook image",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "kubectl image repository",
+              "default": "docker.io/helmforge/kubectl"
+            },
+            "tag": {
+              "type": "string",
+              "description": "kubectl image tag",
+              "default": "1.35.3"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "Cleanup image pull policy",
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout in seconds for Gateway and GatewayClass cleanup operations",
+          "default": 90
+        },
+        "resources": {
+          "type": "object",
+          "description": "Cleanup hook resource requests and limits"
         }
       }
     },

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -28,7 +28,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.8.0"
+    tag: "v1.8.1"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -70,7 +70,7 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.8.0"
+    tag: "v1.8.1"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:
@@ -86,8 +86,17 @@ proxy:
     repository: docker.io/envoyproxy/envoy
     # -- Proxy image pull policy
     pullPolicy: IfNotPresent
-    # -- Envoy image tag for EG v1.8 (distroless)
-    tag: "distroless-v1.37.0"
+    # -- Envoy image tag for EG v1.8 compatibility matrix (distroless)
+    tag: "distroless-v1.38.0"
+
+  shutdownManager:
+    image:
+      # -- Shutdown manager sidecar image repository
+      repository: docker.io/envoyproxy/gateway
+      # -- Shutdown manager sidecar image tag
+      tag: "v1.8.1"
+      # -- Shutdown manager image pull policy
+      pullPolicy: IfNotPresent
 
   # -- Resources for proxy pods (overridden by profile)
   resources:
@@ -126,6 +135,28 @@ gatewayClass:
   name: envoy-gateway
   # -- Create GatewayClass resource
   create: true
+
+## Cleanup hook for chart-managed GatewayClass finalizers on uninstall
+cleanup:
+  # -- Run a pre-delete cleanup Job for chart-managed Gateways and GatewayClass
+  enabled: true
+  image:
+    # -- kubectl image used by the cleanup hook
+    repository: docker.io/helmforge/kubectl
+    # -- kubectl image tag
+    tag: "1.35.3"
+    # -- Cleanup image pull policy
+    pullPolicy: IfNotPresent
+  # -- Timeout in seconds for Gateway and GatewayClass cleanup operations
+  timeoutSeconds: 90
+  # -- Resources for the cleanup hook
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
 ## Gateway resource (triggers EG to provision proxy pods)
 gateway:


### PR DESCRIPTION
## Summary- Bump Envoy Gateway from `v1.8.0` to `v1.8.1` and update the managed Envoy proxy image to `distroless-v1.38.0`.- Bump the HelmForge Redis dependency from `1.6.17` to `1.6.18` per GR-074.- Pin the EG-managed `shutdown-manager` sidecar to `docker.io/envoyproxy/gateway:v1.8.1` via EnvoyProxy strategic merge patch, avoiding the upstream-generated `gateway-dev:latest` runtime image.- Add a pre-delete cleanup hook for chart-managed Gateways/GatewayClass so GatewayClass finalizers do not leave uninstall cleanup stuck; the hook refuses to remove the class when external Gateways still reference it.- Fix CI scenarios found by full k3d validation: ExternalSecrets fake store, namespaceOverride runtime namespace, rate limiting Redis placement, valid EnvoyProxy JSON access log format, and NetworkPolicy xDS/Wasm ingress.## Upstream evidence- Official release: https://github.com/envoyproxy/gateway/releases/tag/v1.8.1- Official release notes: https://github.com/envoyproxy/gateway/blob/v1.8.1/release-notes/v1.8.1.yaml- Envoy Gateway docs for EnvoyProxy customization: https://gateway.envoyproxy.io/latest/tasks/operations/customize-envoyproxy- `make image-verify IMAGE=docker.io/envoyproxy/gateway:v1.8.1` PASS, platforms: linux/amd64, linux/arm64.- `make image-verify IMAGE=docker.io/envoyproxy/gateway:1.8.1` FAIL; Docker publishes the canonical tag with the `v` prefix.- `make image-verify IMAGE=docker.io/envoyproxy/envoy:distroless-v1.38.0` PASS, platforms: linux/amd64, linux/arm64.- `make image-verify IMAGE=docker.io/helmforge/kubectl:1.35.3` PASS, platforms: linux/amd64, linux/arm64.## Site sync- Site companion PR: https://github.com/helmforgedev/site/pull/247## Local validation- `make validate-chart CHART=envoy-gateway CONTEXT=k3d-helmforge-tests-wsl TIMEOUT=300` PASS: 20 layers, including default plus all `ci/*.yaml` k3d scenarios.- Runtime checks covered install, rollout, service endpoints, restarts/crash terminations, logs, events, and cleanup for every scenario.- Transient startup probe warnings were only accepted on otherwise healthy workloads with zero restarts and clean logs.- `make deps-check CHART=envoy-gateway`- `make standards-check CHART=envoy-gateway`- `make standards-guard`- `make md-lint REPO=charts`- `make site-sync-check CHART=envoy-gateway`- `make preflight`- `make release-check REPO=charts`- `make attribution-check REPO=charts`Resolves #453.