### PR TITLE
fix(mariadb): improved application name generation

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "make subpath preparation opt-in (#466)"
+      description: "improved application name generation"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -1,15 +1,20 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- define "mariadb.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{- define "mariadb.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name (include "mariadb.name" .) | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{- define "mariadb.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}


### PR DESCRIPTION
## Summary
- Fix duplicated chart name in generated resource names. The previous `mariadb.fullname` helper unconditionally concatenated `.Release.Name` with the chart name, so a release named `myapp-mariadb` produced resources prefixed `myapp-mariadb-mariadb-*`.
- Adopt the standard Helm `fullname` helper, which skips re-appending the chart name when `.Release.Name` already contains it (`contains $name .Release.Name`). Resources now render as `myapp-mariadb-*`.

## Type Of Change
- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags
      <!-- N/A: no appVersion / image change in this PR -->

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/mariadb --strict` passed
- [x] `helm unittest charts/mariadb` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO
      <!-- N/A: backup behavior unchanged -->

## Notes
- Behavioral note for reviewers: the standard helper uses substring matching (`contains`). The chart name is therefore stripped whenever it appears anywhere inside the release name, not only as an exact match. This is the upstream Helm convention and matches every scaffolded chart, but reviewers should be aware that a short chart name could be matched incidentally inside an unrelated release name.
- No `values.yaml`, `values.schema.json`, `appVersion`, or image changes — this is a templating-only fix.

---
> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.