### PR TITLE
chore(mariadb): bump MariaDB to 12.3.2

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ name: mariadb
 description: MariaDB for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.0.1
-appVersion: "12.2.2"
+appVersion: "12.3.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "make subpath preparation opt-in (#466)"
+    - kind: changed
+      description: "bump appVersion to 12.3.2"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -82,7 +82,7 @@ replication:
 |-----|---------|-------------|
 | `architecture` | `standalone` | Deployment mode: standalone or replication |
 | `image.repository` | `mariadb` | MariaDB image |
-| `image.tag` | `12.2.2` | MariaDB version |
+| `image.tag` | `12.3.2` | MariaDB version |
 | `auth.rootPassword` | `""` | Root password (auto-generated if empty) |
 | `auth.database` | `app` | Application database |
 | `auth.username` | `app` | Application user |

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mariadb:12.2.2"
+          value: "docker.io/library/mariadb:12.3.2"
 
   - it: should always have 1 replica
     template: templates/statefulset-source.yaml

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- MariaDB image repository
   repository: docker.io/library/mariadb
   # -- MariaDB image tag
-  tag: "12.2.2"
+  tag: "12.3.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -289,7 +289,7 @@ backup:
       pullPolicy: IfNotPresent
     mariadb:
       repository: docker.io/library/mariadb
-      tag: "12.2.2"
+      tag: "12.3.2"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary
- Bump MariaDB version to 12.3.2 due to 12.2 release became unmaintained (cf. https://endoflife.date/mariadb)

## Type Of Change
- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/mariadb --strict` passed
- [x] `helm unittest charts/mariadb` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO