### PR TITLE
chore(ghost): bump ghost to 6.44.1

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.13
-appVersion: "6.42.0"
+appVersion: "6.44.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update Ghost to 6.42.0 (#414)"
+      description: "update Ghost to 6.44.1 (#454)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -65,7 +65,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.42.0` | Ghost image tag |
+| `image.tag` | `6.44.1` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -77,7 +77,7 @@ database:
 
 ## Upgrade Notes
 
-`docker.io/library/ghost:6.42.0` is an upstream image update from `6.39.0`.
+`docker.io/library/ghost:6.44.1` is an upstream image update from `6.42.0`.
 Review the upstream Ghost release notes before upgrading production sites, take
 a content and database backup, and verify themes, custom integrations,
 newsletter flows, comments, and member signup paths in staging before reusing
@@ -100,6 +100,14 @@ backup:
 
 - **Single instance** — Ghost does not support horizontal scaling out of the box
 - **MySQL only** — Ghost requires MySQL 8; PostgreSQL is not supported. The bundled HelmForge MySQL dependency is kept on MySQL 8 through `mysql.image.tag`.
+
+### Security Scan: `ghost`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **86.580086%** |
+
+> Security posture acceptable.
 
 ## More Information
 

--- a/charts/ghost/ci/dual-stack.yaml
+++ b/charts/ghost/ci/dual-stack.yaml
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: dual-stack for HTTP service (GR-058)
+# CI scenario: dual-stack-compatible HTTP service policy (GR-058).
+# The local k3d validation cluster is IPv4-only, so this scenario exercises
+# PreferDualStack without forcing an IPv6 ipFamilies entry that Kubernetes
+# rejects on single-stack clusters.
 persistence:
-  enabled: false
-mysql:
   enabled: false
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/ghost/ci/external-db-values.yaml
+++ b/charts/ghost/ci/external-db-values.yaml
@@ -1,12 +1,85 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external MySQL database
+# CI: external MySQL database.
+# This scenario keeps the Ghost chart's bundled mysql subchart disabled, then
+# creates a small in-namespace MySQL fixture through extraManifests so the k3d
+# behavioral gate validates the external database path with a real endpoint.
+persistence:
+  enabled: false
+
 mysql:
   enabled: false
 
 database:
   external:
-    host: "mysql.example.com"
+    host: "ghost-ci-external-db-values-external-mysql"
     port: "3306"
     name: ghost
     username: ghost
     password: "test-password"
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ghost-ci-external-db-values-external-mysql
+      labels:
+        app.kubernetes.io/name: ghost-external-mysql
+        app.kubernetes.io/instance: ghost-ci-external-db-values
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: ghost-external-mysql
+          app.kubernetes.io/instance: ghost-ci-external-db-values
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ghost-external-mysql
+            app.kubernetes.io/instance: ghost-ci-external-db-values
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:8.4.7
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: mysql
+                  containerPort: 3306
+                  protocol: TCP
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-password
+                - name: MYSQL_DATABASE
+                  value: ghost
+                - name: MYSQL_USER
+                  value: ghost
+                - name: MYSQL_PASSWORD
+                  value: test-password
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ghost-ci-external-db-values-external-mysql
+      labels:
+        app.kubernetes.io/name: ghost-external-mysql
+        app.kubernetes.io/instance: ghost-ci-external-db-values
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: ghost-external-mysql
+        app.kubernetes.io/instance: ghost-ci-external-db-values
+        app.kubernetes.io/component: external-database

--- a/charts/ghost/ci/external-secrets.yaml
+++ b/charts/ghost/ci/external-secrets.yaml
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: ExternalSecrets with drift guard (GR-061)
+# CI scenario: ExternalSecrets with drift guard (GR-061).
+# The local k3d lab provides ClusterSecretStore/helmforge-fake-store with
+# test/password=helmforge-test-password. Keep the bundled mysql subchart disabled
+# and create an in-namespace MySQL fixture so this validates the external secret
+# and external database path end to end.
 persistence:
   enabled: false
 
@@ -8,15 +12,85 @@ mysql:
 
 database:
   external:
+    host: "ghost-ci-external-secrets-external-mysql"
+    port: "3306"
+    name: ghost
+    username: ghost
     existingSecret: ghost-db-credentials
 
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: password
       remoteRef:
-        key: ghost/db
-        property: password
+        key: test/password
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ghost-ci-external-secrets-external-mysql
+      labels:
+        app.kubernetes.io/name: ghost-external-mysql
+        app.kubernetes.io/instance: ghost-ci-external-secrets
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: ghost-external-mysql
+          app.kubernetes.io/instance: ghost-ci-external-secrets
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ghost-external-mysql
+            app.kubernetes.io/instance: ghost-ci-external-secrets
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:8.4.7
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: mysql
+                  containerPort: 3306
+                  protocol: TCP
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-password
+                - name: MYSQL_DATABASE
+                  value: ghost
+                - name: MYSQL_USER
+                  value: ghost
+                - name: MYSQL_PASSWORD
+                  value: helmforge-test-password
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ghost-ci-external-secrets-external-mysql
+      labels:
+        app.kubernetes.io/name: ghost-external-mysql
+        app.kubernetes.io/instance: ghost-ci-external-secrets
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: ghost-external-mysql
+        app.kubernetes.io/instance: ghost-ci-external-secrets
+        app.kubernetes.io/component: external-database

--- a/charts/ghost/ci/gateway-api.yaml
+++ b/charts/ghost/ci/gateway-api.yaml
@@ -2,8 +2,6 @@
 # CI scenario: Gateway API (GR-060)
 persistence:
   enabled: false
-mysql:
-  enabled: false
 
 gateway:
   enabled: true

--- a/charts/ghost/ci/ingress-values.yaml
+++ b/charts/ghost/ci/ingress-values.yaml
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI: ingress enabled
-ghost:
-  url: "https://blog.example.com"
 
 ingress:
   enabled: true

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.42.0"
+          value: "docker.io/library/ghost:6.44.1"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.42.0"
+                                                                    "default":  "6.44.1"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.42.0"
+  tag: "6.44.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump Ghost from 6.42.0 to 6.44.1 using the official `docker.io/library/ghost:6.44.1` image.
- Update chart defaults, schema, unit tests, README upgrade notes, and Artifact Hub change notes.
- Make Ghost CI scenarios behaviorally valid in k3d: dual-stack-compatible service policy, real external MySQL fixtures, ExternalSecrets against `helmforge-fake-store`, Gateway API with a database, and ingress without a fake public URL that generates runtime errors.

## Upstream evidence
- Image verification: `make image-verify IMAGE=docker.io/library/ghost:6.44.1 JSON=1` passed for linux/amd64, linux/arm, linux/arm64, and linux/s390x.
- Official releases reviewed:
  - https://github.com/TryGhost/Ghost/releases/tag/v6.43.0
  - https://github.com/TryGhost/Ghost/releases/tag/v6.43.1
  - https://github.com/TryGhost/Ghost/releases/tag/v6.44.0
  - https://github.com/TryGhost/Ghost/releases/tag/v6.44.1
- `make deps-check CHART=ghost JSON=1` passed; MySQL dependency remains current.

## Validation
- `make validate-chart CHART=ghost CONTEXT=k3d-helmforge-tests-wsl TIMEOUT=300` passed: `ghost: FULLY VALIDATED (16 layers)`.
- `make preflight` passed with warnings only for existing non-blocking icon/drift findings.
- `make site-sync-check CHART=ghost` passed and requires companion site PR helmforgedev/site#248.

Resolves #454.