### PR TITLE
feat(rabbitmq): optimize idle cpu defaults

### DIFF
--- a/charts/rabbitmq/DESIGN.md
+++ b/charts/rabbitmq/DESIGN.md
@@ -52,13 +52,16 @@ Cluster mode uses `rabbitmq_peer_discovery_k8s` and stable StatefulSet pod ident
 
 ## Design Choices
 
-- Use the official `rabbitmq` image with the management flavor.
+- Use the official `rabbitmq` Alpine image and let chart values control enabled plugins.
 - Keep `architecture` explicit instead of inferring topology from replica count.
 - Use quorum queues by default because they are RabbitMQ's production direction for replicated queues.
+- Disable Erlang scheduler busy-wait by default to keep idle CPU low in containerized environments.
+- Use TCP probes against the active AMQP listener by default to avoid recurring `rabbitmq-diagnostics` VM startup cost.
 - Keep generated `rabbitmq.conf` readable and allow controlled appends through `config.extra`.
 - Require a stable Erlang cookie for clustering and upgrades.
 - Require `auth.existingSecret` when `externalSecrets.enabled=true` to avoid drift between chart-generated and operator-reconciled credentials.
 - Keep Gateway API focused on the Management UI. AMQP exposure remains Service-based because HTTPRoute is not the right protocol surface for AMQP.
+- Do not switch image tags based on `management.enabled`; the default Alpine image already contains the management plugin, and `enabled_plugins` is the authoritative plugin surface.
 - Keep dual-stack Service fields opt-in.
 
 ## Production Boundary

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -40,6 +40,7 @@ helm install rabbitmq oci://ghcr.io/helmforgedev/helm/rabbitmq -f values.yaml
 - Gateway API HTTPRoute support for the Management UI
 - dual-stack Service fields through `service.ipFamilyPolicy` and `service.ipFamilies`
 - External Secrets Operator support for RabbitMQ credentials
+- official Alpine RabbitMQ image by default; plugins are controlled by chart values
 
 ## How to choose the architecture
 
@@ -122,14 +123,13 @@ Management UI Gateway API example:
 ```yaml
 management:
   enabled: true
-
-gateway:
-  enabled: true
-  parentRefs:
-    - name: public
-      namespace: gateway-system
-  hostnames:
-    - rabbitmq.example.com
+  gateway:
+    enabled: true
+    parentRefs:
+      - name: public
+        namespace: gateway-system
+    hostnames:
+      - rabbitmq.example.com
 ```
 
 External Secrets example:
@@ -185,13 +185,20 @@ externalSecrets:
 - use `metrics.serviceMonitor.enabled=true` with Prometheus Operator
 - monitor memory, disk, connections, queues, consumers, and node-local alarms
 
+### Runtime efficiency
+
+- the default image is `docker.io/library/rabbitmq:4.3.1-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
+- `runtime.disableSchedulerBusyWait=true` is enabled by default to reduce idle CPU from Erlang scheduler spin-wait in containers
+- default Kubernetes probes use lightweight TCP checks against the active AMQP listener instead of recurring `rabbitmq-diagnostics` commands
+- use `runtime.additionalErlArgs` for extra Erlang VM flags and reserve `extraEnv` for explicit upstream environment variables or full overrides
+
 ## Main values
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `architecture` | `single-node` or `cluster` | `single-node` |
 | `image.repository` | RabbitMQ image repository | `rabbitmq` |
-| `image.tag` | RabbitMQ image tag | `4.3.1-management` |
+| `image.tag` | RabbitMQ image tag | `4.3.1-alpine` |
 | `auth.username` | Application username | `user` |
 | `auth.password` | Application password | `""` |
 | `auth.erlangCookie` | Erlang cookie | `""` |
@@ -200,16 +207,20 @@ externalSecrets:
 | `management.enabled` | Enable management plugin/UI | `true` |
 | `management.ingress.enabled` | Enable management ingress | `false` |
 | `management.ingress.ingressClassName` | Ingress class for the Management UI | `traefik` |
-| `management.ingress.className` | Deprecated optional alias for `ingressClassName`; empty string omits the field | omitted |
 | `tls.enabled` | Enable TLS listeners | `false` |
 | `singleNode.persistence.enabled` | Enable PVC for single node | `true` |
 | `cluster.replicaCount` | Number of cluster nodes | `3` |
 | `cluster.partitionHandling` | Cluster partition handling | `pause_minority` |
 | `metrics.enabled` | Enable RabbitMQ Prometheus plugin | `false` |
 | `metrics.serviceMonitor.enabled` | Enable ServiceMonitor | `false` |
+| `runtime.disableSchedulerBusyWait` | Disable Erlang scheduler busy-wait for lower idle CPU | `true` |
+| `runtime.additionalErlArgs` | Additional Erlang VM arguments appended to chart defaults | `""` |
+| `startupProbe.enabled` | Enable TCP startup probe | `true` |
+| `livenessProbe.enabled` | Enable TCP liveness probe | `true` |
+| `readinessProbe.enabled` | Enable TCP readiness probe | `true` |
 | `pdb.enabled` | Enable PodDisruptionBudget | `false` |
 | `service.ipFamilyPolicy` | Service IP family policy for dual-stack clusters | `""` |
-| `gateway.enabled` | Render Gateway API HTTPRoute for the Management UI | `false` |
+| `management.gateway.enabled` | Render Gateway API HTTPRoute for the Management UI | `false` |
 | `externalSecrets.enabled` | Render ExternalSecret for credentials | `false` |
 
 ## CI scenarios
@@ -242,6 +253,14 @@ See `examples/`:
 - this chart does not attempt to orchestrate federation, shovel, or advanced policy management in v1
 - `management.ingress.ingressClassName` can be set to `traefik`, `nginx`, or any ingress class available in the target cluster
 - `externalSecrets.enabled=true` requires `auth.existingSecret` so the chart does not generate credentials that drift from the operator-managed Secret
+
+### Security Scan: `rabbitmq`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **74.24%** |
+
+> Security posture acceptable.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/rabbitmq/ci/gateway-api.yaml
+++ b/charts/rabbitmq/ci/gateway-api.yaml
@@ -3,11 +3,10 @@
 
 management:
   enabled: true
-
-gateway:
-  enabled: true
-  parentRefs:
-    - name: my-gateway
-      namespace: default
-  hostnames:
-    - rabbitmq.local
+  gateway:
+    enabled: true
+    parentRefs:
+      - name: my-gateway
+        namespace: default
+    hostnames:
+      - rabbitmq.local

--- a/charts/rabbitmq/docs/cluster.md
+++ b/charts/rabbitmq/docs/cluster.md
@@ -63,14 +63,13 @@ metrics:
 ```yaml
 management:
   enabled: true
-
-gateway:
-  enabled: true
-  parentRefs:
-    - name: public
-      namespace: gateway-system
-  hostnames:
-    - rabbitmq.example.com
+  gateway:
+    enabled: true
+    parentRefs:
+      - name: public
+        namespace: gateway-system
+    hostnames:
+      - rabbitmq.example.com
 ```
 
 AMQP clients should continue to connect through the RabbitMQ Service ports.

--- a/charts/rabbitmq/examples/gateway-api.yaml
+++ b/charts/rabbitmq/examples/gateway-api.yaml
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 management:
   enabled: true
-
-gateway:
-  enabled: true
-  parentRefs:
-    - name: public
-      namespace: gateway-system
-  hostnames:
-    - rabbitmq.example.com
-
+  gateway:
+    enabled: true
+    parentRefs:
+      - name: public
+        namespace: gateway-system
+    hostnames:
+      - rabbitmq.example.com

--- a/charts/rabbitmq/templates/NOTES.txt
+++ b/charts/rabbitmq/templates/NOTES.txt
@@ -34,10 +34,10 @@
 {{- end }}
 {{- end }}
 
-{{- if and .Values.management.enabled .Values.gateway.enabled }}
+{{- if and .Values.management.enabled .Values.management.gateway.enabled }}
 [Gateway API]
   HTTPRoute: {{ $fullname }}
-{{- with .Values.gateway.hostnames }}
+{{- with .Values.management.gateway.hostnames }}
   Hostnames:
 {{- range . }}
     - {{ . }}
@@ -53,7 +53,7 @@
   Metrics:            {{- if .Values.metrics.enabled }} enabled{{- else }} disabled{{- end }}
   ServiceMonitor:     {{- if .Values.metrics.serviceMonitor.enabled }} enabled{{- else }} disabled{{- end }}
   PDB:                {{- if .Values.pdb.enabled }} enabled{{- else }} disabled{{- end }}
-  Gateway API:        {{- if and .Values.management.enabled .Values.gateway.enabled }} enabled{{- else }} disabled{{- end }}
+  Gateway API:        {{- if and .Values.management.enabled .Values.management.gateway.enabled }} enabled{{- else }} disabled{{- end }}
   External Secrets:   {{- if .Values.externalSecrets.enabled }} enabled{{- else }} disabled{{- end }}
   Service dual-stack: {{- if .Values.service.ipFamilyPolicy }} {{ .Values.service.ipFamilyPolicy }}{{- else }} cluster default{{- end }}
 

--- a/charts/rabbitmq/templates/_helpers.tpl
+++ b/charts/rabbitmq/templates/_helpers.tpl
@@ -123,6 +123,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf ".%s.%s.svc.%s" (include "rabbitmq.headlessServiceName" .) .Release.Namespace .Values.clusterDomain -}}
 {{- end -}}
 
+{{- define "rabbitmq.serverAdditionalErlArgs" -}}
+{{- $args := list -}}
+{{- if .Values.runtime.disableSchedulerBusyWait -}}
+{{- $args = append $args "+sbwt none +sbwtdcpu none +sbwtdio none" -}}
+{{- end -}}
+{{- with .Values.runtime.additionalErlArgs -}}
+{{- $args = append $args . -}}
+{{- end -}}
+{{- join " " $args -}}
+{{- end -}}
+
+{{- define "rabbitmq.probePortName" -}}
+{{- if and .Values.tls.enabled .Values.tls.disableNonTLSListeners -}}
+amqps
+{{- else -}}
+amqp
+{{- end -}}
+{{- end -}}
+
 {{- define "rabbitmq.ingressPortName" -}}
 {{- if and .Values.tls.enabled .Values.management.ingress.useTlsPort -}}
 management-tls

--- a/charts/rabbitmq/templates/httproute.yaml
+++ b/charts/rabbitmq/templates/httproute.yaml
@@ -1,7 +1,10 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if and .Values.gateway.enabled .Values.management.enabled }}
-{{- if not .Values.gateway.parentRefs }}
-  {{- fail "gateway.parentRefs is required when gateway.enabled=true" }}
+{{- if hasKey .Values "gateway" }}
+  {{- fail "gateway.* was removed; use management.gateway.* for the Management UI HTTPRoute" }}
+{{- end }}
+{{- if and .Values.management.enabled .Values.management.gateway.enabled }}
+{{- if not .Values.management.gateway.parentRefs }}
+  {{- fail "management.gateway.parentRefs is required when management.gateway.enabled=true" }}
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -11,8 +14,8 @@ metadata:
     {{- include "rabbitmq.labels" . | nindent 4 }}
 spec:
   parentRefs:
-    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
-  {{- with .Values.gateway.hostnames }}
+    {{- toYaml .Values.management.gateway.parentRefs | nindent 4 }}
+  {{- with .Values.management.gateway.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -11,12 +11,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- $ingressClassName := .Values.management.ingress.ingressClassName }}
   {{- if hasKey .Values.management.ingress "className" }}
-  {{- $ingressClassName = .Values.management.ingress.className }}
+  {{- fail "management.ingress.className was removed; use management.ingress.ingressClassName" }}
   {{- end }}
-  {{- if $ingressClassName }}
-  ingressClassName: {{ $ingressClassName }}
+  {{- if .Values.management.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.management.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.management.ingress.hosts }}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -89,6 +89,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "rabbitmq.secretName" . }}
                   key: {{ .Values.auth.existingSecretErlangCookieKey }}
+            {{- $hasServerAdditionalErlArgs := false }}
+            {{- range .Values.extraEnv }}
+            {{- if eq .name "RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS" }}
+            {{- $hasServerAdditionalErlArgs = true }}
+            {{- end }}
+            {{- end }}
+            {{- $serverAdditionalErlArgs := include "rabbitmq.serverAdditionalErlArgs" . }}
+            {{- if and (not $hasServerAdditionalErlArgs) $serverAdditionalErlArgs }}
+            - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+              value: {{ $serverAdditionalErlArgs | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -115,36 +126,33 @@ spec:
             - name: metrics
               containerPort: {{ .Values.service.metricsPort }}
             {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            exec:
-              command:
-                - sh
-                - -ec
-                - rabbitmq-diagnostics -q ping
-            initialDelaySeconds: 30
-            timeoutSeconds: 10
-            periodSeconds: 20
-            failureThreshold: 6
+            tcpSocket:
+              port: {{ include "rabbitmq.probePortName" . }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            exec:
-              command:
-                - sh
-                - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
-            initialDelaySeconds: 20
-            timeoutSeconds: 10
-            periodSeconds: 10
-            failureThreshold: 6
+            tcpSocket:
+              port: {{ include "rabbitmq.probePortName" . }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
           startupProbe:
-            exec:
-              command:
-                - sh
-                - -ec
-                - rabbitmq-diagnostics -q ping
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
-            periodSeconds: 10
-            failureThreshold: 30
+            tcpSocket:
+              port: {{ include "rabbitmq.probePortName" . }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           {{- if and (eq .Values.architecture "cluster") .Values.cluster.gracefulShutdown.enabled }}
           lifecycle:
             preStop:

--- a/charts/rabbitmq/tests/configmap_test.yaml
+++ b/charts/rabbitmq/tests/configmap_test.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ConfigMap
+templates:
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should enable management plugin by default
+    asserts:
+      - equal:
+          path: data.enabled_plugins
+          value: |
+            [rabbitmq_management].
+
+  - it: should disable management plugin when management is disabled
+    set:
+      management.enabled: false
+    asserts:
+      - equal:
+          path: data.enabled_plugins
+          value: |
+            [].
+
+  - it: should enable metrics plugin when metrics are enabled
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: data.enabled_plugins
+          value: |
+            [rabbitmq_management,rabbitmq_prometheus].
+
+  - it: should enable Kubernetes peer discovery in cluster mode
+    set:
+      architecture: cluster
+    asserts:
+      - equal:
+          path: data.enabled_plugins
+          value: |
+            [rabbitmq_management,rabbitmq_peer_discovery_k8s].

--- a/charts/rabbitmq/tests/gateway_test.yaml
+++ b/charts/rabbitmq/tests/gateway_test.yaml
@@ -14,11 +14,11 @@ tests:
   - it: renders an HTTPRoute for the Management UI
     set:
       management.enabled: true
-      gateway.enabled: true
-      gateway.parentRefs:
+      management.gateway.enabled: true
+      management.gateway.parentRefs:
         - name: public
           namespace: gateway-system
-      gateway.hostnames:
+      management.gateway.hostnames:
         - rabbitmq.example.com
     asserts:
       - isKind:
@@ -36,21 +36,33 @@ tests:
           path: spec.rules[0].backendRefs[0].port
           value: 15672
 
-  - it: requires parentRefs when enabled
+  - it: fails when top-level gateway values are used
     set:
       management.enabled: true
       gateway.enabled: true
+      gateway.parentRefs:
+        - name: public
+          namespace: gateway-system
+      gateway.hostnames:
+        - rabbitmq.example.com
     asserts:
       - failedTemplate:
-          errorMessage: "gateway.parentRefs is required when gateway.enabled=true"
+          errorMessage: "gateway.* was removed; use management.gateway.* for the Management UI HTTPRoute"
+
+  - it: requires parentRefs when enabled
+    set:
+      management.enabled: true
+      management.gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "management.gateway.parentRefs is required when management.gateway.enabled=true"
 
   - it: does not render when management UI is disabled
     set:
       management.enabled: false
-      gateway.enabled: true
-      gateway.parentRefs:
+      management.gateway.enabled: true
+      management.gateway.parentRefs:
         - name: public
     asserts:
       - hasDocuments:
           count: 0
-

--- a/charts/rabbitmq/tests/ingress_test.yaml
+++ b/charts/rabbitmq/tests/ingress_test.yaml
@@ -28,24 +28,22 @@ tests:
           path: spec.rules[0].host
           value: rabbitmq.example.com
 
-  - it: preserves the deprecated className alias
+  - it: fails when removed ingress class alias is used
+    set:
+      management.enabled: true
+      management.ingress.enabled: true
+      management.ingress.className: nginx
+      management.ingress.hosts:
+        - host: rabbitmq.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "management.ingress.className was removed; use management.ingress.ingressClassName"
+
+  - it: omits ingressClassName when the standard value is empty
     set:
       management.enabled: true
       management.ingress.enabled: true
       management.ingress.ingressClassName: ""
-      management.ingress.className: legacy
-      management.ingress.hosts:
-        - host: rabbitmq.example.com
-    asserts:
-      - equal:
-          path: spec.ingressClassName
-          value: legacy
-
-  - it: preserves empty deprecated className overrides
-    set:
-      management.enabled: true
-      management.ingress.enabled: true
-      management.ingress.className: ""
       management.ingress.hosts:
         - host: rabbitmq.example.com
     asserts:

--- a/charts/rabbitmq/tests/statefulset_test.yaml
+++ b/charts/rabbitmq/tests/statefulset_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/rabbitmq:4.3.1-management"
+          value: "docker.io/library/rabbitmq:4.3.1-alpine"
 
   - it: should have 1 replica in single-node mode
     template: statefulset.yaml
@@ -56,10 +56,58 @@ tests:
   - it: should have probes
     template: statefulset.yaml
     asserts:
-      - isNotNull:
-          path: spec.template.spec.containers[0].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[0].readinessProbe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: amqp
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: amqp
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: amqp
+
+  - it: should probe the TLS AMQP listener when non-TLS listeners are disabled
+    template: statefulset.yaml
+    set:
+      tls.enabled: true
+      tls.disableNonTLSListeners: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: amqps
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: amqps
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: amqps
+
+  - it: should disable Erlang scheduler busy-wait by default
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+            value: "+sbwt none +sbwtdcpu none +sbwtdio none"
+
+  - it: should allow extraEnv to override chart-managed Erlang arguments
+    template: statefulset.yaml
+    set:
+      extraEnv:
+        - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+          value: "+S 2"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+            value: "+S 2"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+            value: "+sbwt none +sbwtdcpu none +sbwtdio none"
 
   - it: should create VolumeClaimTemplate with default 8Gi
     template: statefulset.yaml

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -107,10 +107,10 @@
           "type": "boolean",
           "description": "Enable the management plugin/UI"
         },
-        "ingress": {
-          "type": "object",
-          "description": "Ingress configuration for the Management UI",
-          "properties": {
+          "ingress": {
+            "type": "object",
+            "description": "Ingress configuration for the Management UI",
+            "properties": {
             "enabled": {
               "type": "boolean",
               "description": "Enable ingress for the Management UI"
@@ -118,10 +118,6 @@
             "ingressClassName": {
               "type": "string",
               "description": "Ingress class name for the Management UI"
-            },
-            "className": {
-              "type": "string",
-              "description": "Deprecated compatibility alias for ingressClassName"
             },
             "annotations": {
               "type": "object",
@@ -144,11 +140,40 @@
             "useTlsPort": {
               "type": "boolean",
               "description": "Route ingress to the TLS management port instead of the plain HTTP port"
+              }
+            }
+          },
+          "gateway": {
+            "type": "object",
+            "description": "Gateway API HTTPRoute configuration for the Management UI (GR-060)",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Create an HTTPRoute for the Management UI"
+              },
+              "hostnames": {
+                "type": "array",
+                "description": "Allowed hostnames for the HTTPRoute (empty = match all)",
+                "items": { "type": "string" }
+              },
+              "parentRefs": {
+                "type": "array",
+                "description": "Gateway parentRefs. Required when management.gateway.enabled=true",
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "namespace": { "type": "string" },
+                    "group": { "type": "string" },
+                    "kind": { "type": "string" }
+                  }
+                }
+              }
             }
           }
         }
-      }
-    },
+      },
     "tls": {
       "type": "object",
       "description": "TLS listener configuration",
@@ -361,6 +386,20 @@
         }
       }
     },
+    "runtime": {
+      "type": "object",
+      "description": "RabbitMQ runtime tuning",
+      "properties": {
+        "disableSchedulerBusyWait": {
+          "type": "boolean",
+          "description": "Disable Erlang scheduler busy-wait to reduce idle CPU in containerized deployments"
+        },
+        "additionalErlArgs": {
+          "type": "string",
+          "description": "Additional Erlang VM arguments appended to the chart-managed defaults"
+        }
+      }
+    },
     "serviceAccount": {
       "type": "object",
       "description": "ServiceAccount configuration",
@@ -423,6 +462,39 @@
             }
           }
         }
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "description": "Startup probe timing. The chart uses a TCP socket probe against the active AMQP listener.",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable startup probe" },
+        "initialDelaySeconds": { "type": "integer", "description": "Initial delay before startup probing starts" },
+        "timeoutSeconds": { "type": "integer", "description": "Startup probe timeout" },
+        "periodSeconds": { "type": "integer", "description": "Startup probe period" },
+        "failureThreshold": { "type": "integer", "description": "Startup probe failure threshold" }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Liveness probe timing. The chart uses a TCP socket probe against the active AMQP listener.",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable liveness probe" },
+        "initialDelaySeconds": { "type": "integer", "description": "Initial delay before liveness probing starts" },
+        "timeoutSeconds": { "type": "integer", "description": "Liveness probe timeout" },
+        "periodSeconds": { "type": "integer", "description": "Liveness probe period" },
+        "failureThreshold": { "type": "integer", "description": "Liveness probe failure threshold" }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe timing. The chart uses a TCP socket probe against the active AMQP listener.",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Enable readiness probe" },
+        "initialDelaySeconds": { "type": "integer", "description": "Initial delay before readiness probing starts" },
+        "timeoutSeconds": { "type": "integer", "description": "Readiness probe timeout" },
+        "periodSeconds": { "type": "integer", "description": "Readiness probe period" },
+        "failureThreshold": { "type": "integer", "description": "Readiness probe failure threshold" }
       }
     },
     "resources": {
@@ -494,35 +566,6 @@
       "type": "array",
       "description": "Extra manifests rendered with tpl",
       "items": { "type": "object" }
-    },
-    "gateway": {
-      "type": "object",
-      "description": "Gateway API HTTPRoute configuration (GR-060)",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Create an HTTPRoute for the management UI"
-        },
-        "hostnames": {
-          "type": "array",
-          "description": "Allowed hostnames for the HTTPRoute (empty = match all)",
-          "items": { "type": "string" }
-        },
-        "parentRefs": {
-          "type": "array",
-          "description": "Gateway parentRefs — required when gateway.enabled=true",
-          "items": {
-            "type": "object",
-            "required": ["name"],
-            "properties": {
-              "name": { "type": "string" },
-              "namespace": { "type": "string" },
-              "group": { "type": "string" },
-              "kind": { "type": "string" }
-            }
-          }
-        }
-      }
     },
     "externalSecrets": {
       "type": "object",

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- RabbitMQ image repository
   repository: docker.io/library/rabbitmq
   # -- RabbitMQ image tag
-  tag: "4.3.1-management"
+  tag: "4.3.1-alpine"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -72,9 +72,6 @@ management:
     enabled: false
     # -- Ingress class name for the Management UI (for example: traefik, nginx)
     ingressClassName: traefik
-    # -- Deprecated compatibility alias for ingressClassName. If set to an empty
-    # string, spec.ingressClassName is intentionally omitted.
-    # className: ""
     annotations: {}
     # -- Management UI ingress hosts
     hosts: []
@@ -86,6 +83,15 @@ management:
     tls: []
     # -- Route ingress to the TLS management port instead of the plain HTTP port
     useTlsPort: false
+  gateway:
+    # -- Render a Gateway API HTTPRoute for the Management UI
+    enabled: false
+    # -- HTTPRoute hostnames. Empty matches all hostnames.
+    hostnames: []
+    # -- HTTPRoute parentRefs. Required when management.gateway.enabled=true.
+    parentRefs: []
+    #   - name: my-gateway
+    #     namespace: default
 
 # =============================================================================
 # TLS
@@ -201,6 +207,16 @@ config:
   advancedConfig: ""
 
 # =============================================================================
+# Runtime
+# =============================================================================
+
+runtime:
+  # -- Disable Erlang scheduler busy-wait to reduce idle CPU in containerized deployments
+  disableSchedulerBusyWait: true
+  # -- Additional Erlang VM arguments appended to the chart-managed defaults
+  additionalErlArgs: ""
+
+# =============================================================================
 # Service Account
 # =============================================================================
 
@@ -236,6 +252,34 @@ metrics:
     labels: {}
 
 # =============================================================================
+# Health Probes
+# =============================================================================
+
+startupProbe:
+  # -- Enable startup probe
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 10
+  failureThreshold: 30
+
+livenessProbe:
+  # -- Enable liveness probe
+  enabled: true
+  initialDelaySeconds: 30
+  timeoutSeconds: 3
+  periodSeconds: 30
+  failureThreshold: 6
+
+readinessProbe:
+  # -- Enable readiness probe
+  enabled: true
+  initialDelaySeconds: 20
+  timeoutSeconds: 3
+  periodSeconds: 10
+  failureThreshold: 6
+
+# =============================================================================
 # Resources and Security
 # =============================================================================
 
@@ -266,21 +310,6 @@ extraEnv: []
 extraVolumes: []
 extraVolumeMounts: []
 extraManifests: []
-
-
-# =============================================================================
-# Gateway API
-# =============================================================================
-
-gateway:
-  # -- Render a Gateway API HTTPRoute for the Management UI
-  enabled: false
-  # -- HTTPRoute hostnames. Empty matches all hostnames.
-  hostnames: []
-  # -- HTTPRoute parentRefs. Required when gateway.enabled=true.
-  parentRefs: []
-  #   - name: my-gateway
-  #     namespace: default
 
 # =============================================================================
 # External Secrets


### PR DESCRIPTION
Related to #477

## Summary

- Changes the RabbitMQ default image to `docker.io/library/rabbitmq:4.3.1-alpine`.
- Adds chart-managed Erlang scheduler busy-wait defaults via `runtime.disableSchedulerBusyWait`.
- Replaces recurring `rabbitmq-diagnostics` probes with lightweight TCP probes against the active AMQP listener.
- Keeps plugin activation controlled by values through `enabled_plugins`; `management.enabled=false` disables the management plugin without switching images.
- Moves Gateway API Management UI exposure under `management.gateway.*`, matching the `management.ingress.*` model.
- Removes the deprecated `management.ingress.className` alias and updates schema, README, design notes, and unit tests.

## Why

The dedicated RabbitMQ deployment had high idle CPU. The cluster investigation showed the busy-wait env was useful, but recurring Kubernetes probes were still starting `rabbitmq-diagnostics` frequently. The new defaults reduce idle CPU and make the optimization chart-owned instead of requiring every consumer to remember `extraEnv`.

## Site sync

- Site PR: https://github.com/helmforgedev/site/pull/249

## Validation

- `helm unittest charts/rabbitmq`
- `helm lint charts/rabbitmq --strict`
- `node scripts/charts/validate-chart.js --chart rabbitmq --no-k3d`
- `node scripts/charts/standards-check.js --chart rabbitmq`
- `node scripts/charts/deps-check.js --chart rabbitmq`
- `node scripts/docs/md-lint.js --repo charts`
- `node scripts/charts/k3d-validate.js --chart rabbitmq --release rabbitmq-default --timeout 300s`
- `node scripts/charts/k3d-validate.js --chart rabbitmq --release rabbitmq-ci-cluster --values ci/cluster.yaml --timeout 300s`
- `node scripts/release/check.js --repo charts`
- `node scripts/release/check-attribution.js --repo charts`

## Notes

The full `validate-chart` k3d pass only failed on `ci/dual-stack.yaml` because the local `k3d-helmforge-tests-wsl` cluster does not have IPv6 configured: `spec.ipFamilies[1]: IPv6: not configured on this cluster`. Default and cluster behavioral validations passed sequentially.
