### PR TITLE
chore(homarr): bump homarr to 1.64.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.15
-appVersion: "1.63.0"
+appVersion: "1.64.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.63.0`.
+Current application version: `v1.64.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.63.0"` | Homarr image tag |
+| `image.tag` | `"v1.64.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,8 +265,9 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.62.0` to `v1.63.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.63.0` includes authentication, board, management UI, bug fix, and performance updates; no breaking
+This update moves the default image from `v1.63.0` to `v1.64.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.64.0` includes demo mode, PeaNUT UPS monitoring, Docker UI improvements, onboarding updates,
+media request search, widget editing, authentication fixes, and UI bug fixes; no breaking
 changes were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
@@ -304,7 +305,7 @@ kubectl logs -l app.kubernetes.io/name=homarr -n <namespace> --all-containers --
 - [Homarr documentation](https://homarr.dev/docs)
 - [Chart source](https://github.com/helmforgedev/charts/tree/main/charts/homarr)
 
-### 🟢 Security Scan: `homarr`
+### Security Scan: `homarr`
 
 | Framework | Score |
 |---|---|

--- a/charts/homarr/ci/external-db.yaml
+++ b/charts/homarr/ci/external-db.yaml
@@ -1,10 +1,78 @@
 # SPDX-License-Identifier: Apache-2.0
-# External PostgreSQL
+# External PostgreSQL.
+# The k3d behavioral gate needs a real endpoint, so this scenario keeps the
+# Homarr chart in external database mode and creates an in-namespace PostgreSQL
+# fixture through extraManifests.
 database:
   external:
     vendor: postgres
-    host: postgres.database.svc
+    host: homarr-ci-external-db-postgresql
     port: 5432
     name: homarr
     username: homarr
     password: testpassword
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: homarr-ci-external-db-postgresql
+      labels:
+        app.kubernetes.io/name: homarr-external-postgresql
+        app.kubernetes.io/instance: homarr-ci-external-db
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: homarr-external-postgresql
+          app.kubernetes.io/instance: homarr-ci-external-db
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: homarr-external-postgresql
+            app.kubernetes.io/instance: homarr-ci-external-db
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.3-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+                  protocol: TCP
+              env:
+                - name: POSTGRES_DB
+                  value: homarr
+                - name: POSTGRES_USER
+                  value: homarr
+                - name: POSTGRES_PASSWORD
+                  value: testpassword
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: homarr-ci-external-db-postgresql
+      labels:
+        app.kubernetes.io/name: homarr-external-postgresql
+        app.kubernetes.io/instance: homarr-ci-external-db
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: homarr-external-postgresql
+        app.kubernetes.io/instance: homarr-ci-external-db
+        app.kubernetes.io/component: external-database

--- a/charts/homarr/ci/external-secrets.yaml
+++ b/charts/homarr/ci/external-secrets.yaml
@@ -5,14 +5,26 @@ encryption:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: platform-secrets
-    kind: ClusterSecretStore
+    name: homarr-ci-fake-store
+    kind: SecretStore
   data:
     - secretKey: secret-encryption-key
       remoteRef:
-        key: homarr/credentials
-        property: secret-encryption-key
+        key: homarr/secret-encryption-key
     - secretKey: auth-secret
       remoteRef:
-        key: homarr/credentials
-        property: auth-secret
+        key: homarr/auth-secret
+
+extraManifests:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: homarr-ci-fake-store
+    spec:
+      provider:
+        fake:
+          data:
+            - key: homarr/secret-encryption-key
+              value: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            - key: homarr/auth-secret
+              value: "helmforge-homarr-auth-secret"

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.63.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.64.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.63.0"
+  tag: "v1.64.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary
- bump Homarr from v1.63.0 to v1.64.0
- update chart defaults, README, and unit test expectations
- harden Homarr CI scenarios used by the k3d behavioral gate

## Upstream evidence
- Issue: Closes #455
- Image manifest: ghcr.io/homarr-labs/homarr:v1.64.0 resolves for linux/amd64 and linux/arm64
- Release notes: https://github.com/homarr-labs/homarr/releases
- Notes reviewed: v1.64.0 includes demo mode, PeaNUT UPS monitoring, Docker UI improvements, onboarding updates, media request search, widget editing, authentication fixes, and UI bug fixes; no breaking changes identified in upstream release metadata.

## Validation
- make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.64.0 JSON=1
- make deps-check CHART=homarr JSON=1
- make standards-check CHART=homarr JSON=1
- make site-sync-check CHART=homarr JSON=1
- make validate-chart CHART=homarr: PASS, 19 layers including k3d behavioral validation on k3d-helmforge-tests-wsl
- make release-check REPO=charts JSON=1
- make attribution-check REPO=charts JSON=1