### PR TITLE
chore(n8n): bump n8n to 2.25.6

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.1
-appVersion: "2.23.2"
+appVersion: "2.25.6"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.17
+    version: 1.6.18
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.23.2` | n8n container image tag |
+| `image.tag` | `2.25.6` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -159,7 +159,7 @@ externalSecrets:
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
 | `queue.persistence.shareMainVolume` | `true` | Mount the main n8n data PVC into worker pods |
 | `terminationGracePeriodSeconds` | `75` | Kubernetes pod shutdown grace period |
-| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.16`) |
+| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.18`) |
 | `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
 | `taskRunners.image.repository` | `docker.io/n8nio/runners` | External task runner sidecar image repository |
 | `taskRunners.image.tag` | `""` | External task runner sidecar tag (defaults to `image.tag`) |
@@ -186,15 +186,13 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.23.2` is an upstream bugfix release. It includes fixes for MCP registry
-server identifiers, data-table timestamp columns, production execution pin data,
-and licensed Insights page rendering. Review the upstream release notes before
-upgrading, back up the database, and keep the encryption key stable before
-upgrading live deployments. This chart also refreshes the bundled HelmForge
-PostgreSQL, MySQL, and Redis subchart versions and enables hardened non-root
-container defaults with resource requests and limits. Queue mode now fails fast
-when it resolves to SQLite or when Redis is not configured, because workers must
-share the same PostgreSQL, MySQL, or external database as the main pod. Validate
+n8n `2.25.6` is an upstream bugfix release. It includes an editor fix for
+copying only the selected markdown editor text. Review the upstream release
+notes before upgrading, back up the database, and keep the encryption key stable
+before upgrading live deployments. This chart keeps the hardened non-root
+container defaults with resource requests and limits. Queue mode fails fast when
+it resolves to SQLite or when Redis is not configured, because workers must share
+the same PostgreSQL, MySQL, or external database as the main pod. Validate
 database and queue mode in a staging namespace before reusing production PVCs.
 
 The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth

--- a/charts/n8n/ci/dual-stack.yaml
+++ b/charts/n8n/ci/dual-stack.yaml
@@ -5,6 +5,3 @@ persistence:
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/n8n/ci/external-db-values.yaml
+++ b/charts/n8n/ci/external-db-values.yaml
@@ -1,9 +1,67 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI: External PostgreSQL database
+persistence:
+  enabled: false
+
 database:
   external:
     vendor: postgres
-    host: postgresql.example.svc
+    host: n8n-external-postgresql
     name: n8n
     username: n8n
     password: external-password
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: n8n-external-postgresql
+      labels:
+        app.kubernetes.io/name: n8n-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: n8n-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: n8n-external-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.4-alpine
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: POSTGRES_DB
+                  value: n8n
+                - name: POSTGRES_USER
+                  value: n8n
+                - name: POSTGRES_PASSWORD
+                  value: external-password
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+                  protocol: TCP
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: n8n-external-postgresql
+      labels:
+        app.kubernetes.io/name: n8n-external-postgresql
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: n8n-external-postgresql

--- a/charts/n8n/ci/external-secrets.yaml
+++ b/charts/n8n/ci/external-secrets.yaml
@@ -10,10 +10,9 @@ encryptionKey:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: encryption-key
       remoteRef:
-        key: n8n/credentials
-        property: encryption-key
+        key: test/token

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.23.2"
+          value: "docker.io/n8nio/n8n:2.25.6"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.23.2"
+          value: "docker.io/n8nio/runners:2.25.6"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.23.2"
+          value: "docker.io/n8nio/runners:2.25.6"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.23.2"
+          "default": "2.25.6"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.23.2"
+  tag: "2.25.6"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bump n8n image from 2.23.2 to 2.25.6.
- Bump HelmForge Redis subchart dependency to 1.6.18 per GR-074.
- Make n8n runtime fixtures k3d-safe for dual-stack, external database, and External Secrets validation.

## Upstream
- Release: https://github.com/n8n-io/n8n/releases/tag/n8n%402.25.6
- Published: 2026-06-08
- Image verified: `docker.io/n8nio/n8n:2.25.6` (`linux/amd64`, `linux/arm64`)

## Validation
- `make image-verify IMAGE=docker.io/n8nio/n8n:2.25.6 JSON=1`
- `make deps-check CHART=n8n JSON=1`
- `make standards-check CHART=n8n JSON=1`
- `make site-sync-check CHART=n8n JSON=1`
- `make validate-chart CHART=n8n` - PASS, FULLY VALIDATED (20 layers), including all k3d scenarios
- `make release-check REPO=charts JSON=1`
- `make attribution-check REPO=charts JSON=1`

Closes #458