### PR TITLE
chore(ntfy): bump ntfy to v2.24.0

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -4,7 +4,7 @@ name: ntfy
 description: ntfy self-hosted push notification service with HTTP-based pub-sub
 type: application
 version: 1.1.9
-appVersion: "v2.23.0"
+appVersion: "v2.24.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v2.23.0 (#301)"
+      description: "update image to v2.24.0 (#459)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ntfy/DESIGN.md
+++ b/charts/ntfy/DESIGN.md
@@ -1,0 +1,77 @@
+# ntfy Chart Design
+
+## Scope
+
+This chart deploys ntfy, a self-hosted HTTP pub-sub notification service.
+
+Supported use cases:
+
+- personal or team notification endpoints
+- script-driven push notifications
+- single-instance deployments backed by persistent SQLite storage
+- ingress or Gateway API exposure for public HTTPS access
+- optional Prometheus scraping through the ntfy metrics endpoint
+
+## Architecture
+
+```mermaid
+flowchart LR
+  user[User or script] --> route[Ingress or HTTPRoute]
+  route --> svc[Service]
+  svc --> pod[ntfy pod]
+  pod --> cfg[ConfigMap server.yml]
+  pod --> pvc[(PVC /var/cache/ntfy)]
+  prom[Prometheus] -. optional .-> svc
+```
+
+## Design Choices
+
+- Use the upstream `binwiederhier/ntfy` image.
+- Keep the workload single-replica because ntfy stores cache and auth data in local SQLite files.
+- Keep persistence enabled by default so message cache, attachments, and auth data survive restarts.
+- Render Gateway API HTTPRoutes as an opt-in exposure path alongside Ingress.
+- Keep Service dual-stack fields opt-in so clusters without dual-stack support use their defaults.
+- Keep authentication user lifecycle out of the chart; ntfy users are managed with the upstream CLI.
+
+## Production Boundary
+
+Recommended production controls:
+
+- set `ntfy.baseUrl` to the public HTTPS URL clients will use
+- enable authentication and set `ntfy.authDefaultAccess: deny-all` for private deployments
+- keep persistence enabled with a durable storage class
+- back up the PVC before upgrades
+- expose the service only through trusted ingress or Gateway policy
+- set explicit resources for shared clusters
+
+## Non-Goals
+
+- multi-replica SQLite coordination
+- user account reconciliation
+- installing Gateway API CRDs or controllers
+- installing Prometheus Operator CRDs
+
+## Validation
+
+The chart is expected to pass:
+
+- Helm lint and strict lint
+- Helm template rendering for default and CI values
+- helm-unittest coverage for deployment, service, persistence, ingress, Gateway API, and metrics
+- kubeconform validation for Kubernetes-native default manifests
+- local k3d deployment smoke tests with pod logs and namespace events checked
+
+<!-- @AI-METADATA
+type: design
+title: ntfy Chart Design
+description: Design document for the ntfy Helm chart covering single-instance SQLite storage, exposure paths, metrics, and validation.
+keywords: ntfy, notifications, helm, sqlite, gateway-api, prometheus
+purpose: Document chart architecture, boundaries, and operational decisions.
+scope: Chart Design
+relations:
+  - charts/ntfy/README.md
+  - charts/ntfy/docs/configuration.md
+path: charts/ntfy/DESIGN.md
+version: 1.0
+date: 2026-06-10
+-->

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -132,5 +132,15 @@ service:
 
 ## More Information
 
+- [Chart design](DESIGN.md)
+- [Configuration guide](docs/configuration.md)
 - [ntfy documentation](https://docs.ntfy.sh)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/ntfy)
+
+### Security Scan: `ntfy`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **72.72727%** |
+
+> Security posture acceptable.

--- a/charts/ntfy/ci/dual-stack.yaml
+++ b/charts/ntfy/ci/dual-stack.yaml
@@ -5,6 +5,3 @@ persistence:
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/ntfy/docs/configuration.md
+++ b/charts/ntfy/docs/configuration.md
@@ -1,0 +1,62 @@
+# ntfy Configuration
+
+ntfy needs a stable public URL when clients connect through Ingress or Gateway API.
+
+## Public URL
+
+```yaml
+ntfy:
+  baseUrl: "https://ntfy.example.com"
+```
+
+This value should match the URL used by browsers, mobile apps, and scripts.
+
+## Authentication
+
+For private deployments, deny unauthenticated access and create users with the ntfy CLI:
+
+```yaml
+ntfy:
+  authDefaultAccess: "deny-all"
+```
+
+After deployment:
+
+```bash
+kubectl exec -it deploy/<release>-ntfy -- ntfy user add --role=admin admin
+```
+
+## Metrics
+
+```yaml
+ntfy:
+  enableMetrics: true
+
+metrics:
+  serviceMonitor:
+    enabled: true
+```
+
+`ServiceMonitor` requires Prometheus Operator CRDs to exist in the cluster.
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  hostnames:
+    - ntfy.example.com
+```
+
+## Dual Stack Service
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+```

--- a/charts/ntfy/examples/simple.yaml
+++ b/charts/ntfy/examples/simple.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+ntfy:
+  baseUrl: "https://ntfy.example.com"
+  authDefaultAccess: "deny-all"
+
+persistence:
+  enabled: true
+  size: 2Gi

--- a/charts/ntfy/templates/NOTES.txt
+++ b/charts/ntfy/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ntfy has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
+ntfy has been successfully deployed!
+--------------------------------------------------------------------
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
@@ -9,9 +9,9 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
+ACCESS INFORMATION
+--------------------------------------------------------------------
 
 {{- if .Values.gateway.enabled }}
 {{- with .Values.gateway.hostnames }}
@@ -34,9 +34,9 @@ Port-forward to access ntfy locally:
   API:      http://localhost:2586/<topic>
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
+GETTING STARTED
+--------------------------------------------------------------------
 
 1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }} --timeout=300s
 2. kubectl get pods -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }}
@@ -45,18 +45,18 @@ Port-forward to access ntfy locally:
 Send your first notification:
   curl -d "Hello World" http://localhost:2586/my-topic
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
+TROUBLESHOOTING
+--------------------------------------------------------------------
 
   kubectl describe pod -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
+WARNINGS
+--------------------------------------------------------------------
 
 {{- if not .Values.ingress.enabled }}
 
@@ -64,9 +64,9 @@ NOTE: Ingress is not enabled. Access via port-forward (see above).
 For push notifications to mobile apps, ntfy needs a public HTTPS endpoint.
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
+ADDITIONAL RESOURCES
+--------------------------------------------------------------------
 
 Documentation:  https://helmforge.dev/docs/charts/ntfy
 ntfy:           https://ntfy.sh | https://github.com/binwiederhier/ntfy

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/binwiederhier/ntfy:v2.23.0"
+          value: "docker.io/binwiederhier/ntfy:v2.24.0"
 
   - it: should pass serve argument
     template: templates/deployment.yaml

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
   # -- Image tag
-  tag: "v2.23.0"
+  tag: "v2.24.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump ntfy image/appVersion to v2.24.0.
- Add required chart design/configuration/example structure and Security Scan section.
- Adjust the dual-stack CI fixture to validate `PreferDualStack` without requiring IPv6 on single-stack clusters.

Closes #459

## Validation
- `make image-verify IMAGE=docker.io/binwiederhier/ntfy:v2.24.0 JSON=1`
- `make deps-check CHART=ntfy JSON=1`
- `make standards-check CHART=ntfy JSON=1`
- `make md-lint REPO=charts JSON=1`
- `make validate-chart CHART=ntfy TIMEOUT=600` -> FULLY VALIDATED (14 layers)
- `make release-check REPO=charts JSON=1`
- `make attribution-check REPO=charts JSON=1`


## Site sync
- Site PR: helmforgedev/site#250
