### PR TITLE
chore(openreel-video): bump image to v0.5.0

### DIFF
--- a/charts/openreel-video/Chart.yaml
+++ b/charts/openreel-video/Chart.yaml
@@ -4,7 +4,7 @@ name: openreel-video
 description: OpenReel Video browser-based video editor with WebCodecs-ready static hosting
 type: application
 version: 1.0.1
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,8 +24,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/openreel-video.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add OpenReel Video chart (#378)"
+    - kind: changed
+      description: "update image to v0.5.0 (#460)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/openreel-video/README.md
+++ b/charts/openreel-video/README.md
@@ -6,7 +6,7 @@ defaults tuned for WebCodecs and WASM workloads.
 
 ## Highlights
 
-- HelmForge-maintained `docker.io/helmforge/openreel-video:v0.4.0` image.
+- HelmForge-maintained `docker.io/helmforge/openreel-video:v0.5.0` image.
 - Non-root NGINX runtime on port `8080`.
 - `/healthz` endpoint for probes and Helm tests.
 - COOP/COEP headers are included in the image for SharedArrayBuffer, WebCodecs,
@@ -62,3 +62,11 @@ helm template openreel-video charts/openreel-video -f charts/openreel-video/ci/c
 helm unittest charts/openreel-video
 kubeconform -strict -summary rendered.yaml
 ```
+
+### Security Scan: `openreel-video`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **86.580086%** |
+
+> Security posture acceptable.

--- a/charts/openreel-video/ci/ci-values.yaml
+++ b/charts/openreel-video/ci/ci-values.yaml
@@ -3,9 +3,6 @@ replicaCount: 2
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6
 
 ingress:
   enabled: true

--- a/charts/openreel-video/templates/NOTES.txt
+++ b/charts/openreel-video/templates/NOTES.txt
@@ -45,4 +45,4 @@ DOCUMENTATION:
    Source: https://github.com/helmforgedev/charts/tree/main/charts/openreel-video
    OpenReel Video: https://github.com/Augani/openreel-video
 
-=============================================================================
+Happy Helmforging :)

--- a/charts/openreel-video/tests/deployment_test.yaml
+++ b/charts/openreel-video/tests/deployment_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/helmforge/openreel-video:v0.4.0
+          value: docker.io/helmforge/openreel-video:v0.5.0
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false

--- a/charts/openreel-video/values.yaml
+++ b/charts/openreel-video/values.yaml
@@ -22,7 +22,7 @@ image:
   # -- OpenReel Video image repository maintained by HelmForge.
   repository: docker.io/helmforge/openreel-video
   # -- OpenReel Video image tag. Do not use latest.
-  tag: "v0.4.0"
+  tag: "v0.5.0"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bump OpenReel Video appVersion to 0.5.0 and image tag to v0.5.0.
- Update README/test expectations for the new image.
- Keep CI dual-stack coverage compatible with single-stack k3d by validating `PreferDualStack` without forcing IPv6.
- Add the local Security Scan section and normalize the NOTES footer.

Closes #460

## Upstream evidence
- `docker.io/helmforge/openreel-video:v0.5.0` exists for linux/amd64 and linux/arm64.
- `docker.io/helmforge/openreel-video:0.5.0` was checked and does not exist; the chart keeps the existing `v` tag convention.

## Validation
- `make image-verify IMAGE=docker.io/helmforge/openreel-video:v0.5.0 JSON=1`
- `make deps-check CHART=openreel-video JSON=1`
- `make standards-check CHART=openreel-video JSON=1`
- `make site-sync-check CHART=openreel-video JSON=1`
- `make md-lint REPO=charts JSON=1`
- `make validate-chart CHART=openreel-video TIMEOUT=600` -> FULLY VALIDATED (12 layers)
- `make release-check REPO=charts JSON=1`
- `make attribution-check REPO=charts JSON=1`