### PR TITLE
feat(generic): template externalSecrets backend keys via tpl

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 maintainers:
   - name: helmforgedev
   - name: mberlofa
-version: 3.0.0
+version: 3.1.0
 appVersion: "1.31.1"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
@@ -14,7 +14,7 @@ kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: render env values and ingress hosts/tls through tpl (#471)"
+      description: "render externalSecrets item spec through tpl so backend keys can be templated (e.g. .Release.Namespace)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -6,15 +6,15 @@ type: application
 maintainers:
   - name: helmforgedev
   - name: mberlofa
-version: 3.1.0
+version: 3.0.0
 appVersion: "1.31.1"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "render externalSecrets item spec through tpl so backend keys can be templated (e.g. .Release.Namespace)"
+    - kind: added
+      description: "template externalSecrets backend keys (remoteRef.key, dataFrom.extract.key) so they can derive per-environment paths (e.g. .Release.Namespace)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -276,16 +276,19 @@ Secrets Operator behavior and avoiding duplicated names in values.
 externalSecrets:
   enabled: true
   items:
-    - fullnameOverride: beesense-gateway-env
+    - fullnameOverride: app-env
       spec:
         refreshInterval: 1m
         secretStoreRef:
-          name: vault-qa
+          name: vault
           kind: ClusterSecretStore
         dataFrom:
           - extract:
-              key: qa/deskbee/beesense-gateway/v2
+              key: secret/data/{{ .Release.Namespace }}/app-env
 ```
+
+The `spec` of each item is rendered through `tpl`, so values such as backend keys can be
+templated (e.g. `{{ .Release.Namespace }}`) to derive per-environment paths from a single definition.
 
 ### Breaking-change migration notes
 

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -35,6 +35,17 @@
 {{- if dig "secretStoreRef" "name" "" $spec }}
 {{- $secretStoreName := required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .spec.secretStoreRef.name }}
 {{- end }}
+{{/* Template only backend reference keys; leave ESO target.template expressions untouched. */}}
+{{- range ($spec.data | default list) }}
+{{- if and (hasKey . "remoteRef") (hasKey (.remoteRef | default dict) "key") }}
+{{- $_ := set .remoteRef "key" (tpl (.remoteRef.key | toString) $) }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if and (hasKey . "extract") (hasKey (.extract | default dict) "key") }}
+{{- $_ := set .extract "key" (tpl (.extract.key | toString) $) }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -43,6 +54,6 @@ metadata:
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
-  {{- tpl (toYaml $spec) $ | nindent 2 }}
+  {{- toYaml $spec | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/generic/templates/external-secret.yaml
+++ b/charts/generic/templates/external-secret.yaml
@@ -43,6 +43,6 @@ metadata:
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
-  {{- toYaml $spec | nindent 2 }}
+  {{- tpl (toYaml $spec) $ | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -135,16 +135,16 @@ tests:
 
   - it: should render tpl in env values and preserve valueFrom
     release:
-      namespace: deskbia
+      namespace: staging
     set:
       env:
         - name: GLOBAL_URL
-          value: "https://app-{{ .Release.Namespace }}.deskbee.dev"
+          value: "https://app-{{ .Release.Namespace }}.example.com"
       containers:
         - name: app
           env:
             - name: APP_URL
-              value: "https://api-{{ .Release.Namespace }}.deskbee.dev"
+              value: "https://api-{{ .Release.Namespace }}.example.com"
             - name: PLAIN
               value: keepme
             - name: FROM_SECRET
@@ -155,10 +155,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
-          value: https://app-deskbia.deskbee.dev
+          value: https://app-staging.example.com
       - equal:
           path: spec.template.spec.containers[0].env[1].value
-          value: https://api-deskbia.deskbee.dev
+          value: https://api-staging.example.com
       - equal:
           path: spec.template.spec.containers[0].env[2].value
           value: keepme

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -173,3 +173,29 @@ tests:
       - equal:
           path: spec.data[0].remoteRef.key
           value: secret/data/default/app-db
+
+  - it: should template backend keys but preserve ESO target.template expressions
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: app
+            spec:
+              secretStoreRef:
+                name: vault
+                kind: ClusterSecretStore
+              target:
+                template:
+                  data:
+                    config.yml: 'password: "{{ .password }}"'
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: 'secret/data/{{ .Release.Namespace }}/app'
+    asserts:
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: secret/data/default/app
+      - equal:
+          path: spec.target.template.data["config.yml"]
+          value: 'password: "{{ .password }}"'

--- a/charts/generic/tests/externalsecret_test.yaml
+++ b/charts/generic/tests/externalsecret_test.yaml
@@ -148,3 +148,28 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "externalSecrets.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"
+
+  - it: should template Release.Namespace in dataFrom and remoteRef keys
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: app
+            spec:
+              secretStoreRef:
+                name: vault
+                kind: ClusterSecretStore
+              dataFrom:
+                - extract:
+                    key: 'secret/data/{{ .Release.Namespace }}/app-env'
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: 'secret/data/{{ .Release.Namespace }}/app-db'
+    asserts:
+      - equal:
+          path: spec.dataFrom[0].extract.key
+          value: secret/data/default/app-env
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: secret/data/default/app-db

--- a/charts/generic/tests/ingress_test.yaml
+++ b/charts/generic/tests/ingress_test.yaml
@@ -28,25 +28,25 @@ tests:
 
   - it: should render tpl in host, tls hosts and secretName from .Release.Namespace
     release:
-      namespace: deskbia
+      namespace: staging
     set:
       ingress.enabled: true
       ingress.hosts:
-        - host: "api-{{ .Release.Namespace }}.deskbee.dev"
+        - host: "api-{{ .Release.Namespace }}.example.com"
           paths:
             - path: /
               pathType: Prefix
       ingress.tls:
         - hosts:
-            - "api-{{ .Release.Namespace }}.deskbee.dev"
+            - "api-{{ .Release.Namespace }}.example.com"
           secretName: "api-{{ .Release.Namespace }}-tls"
     asserts:
       - equal:
           path: spec.rules[0].host
-          value: api-deskbia.deskbee.dev
+          value: api-staging.example.com
       - equal:
           path: spec.tls[0].hosts[0]
-          value: api-deskbia.deskbee.dev
+          value: api-staging.example.com
       - equal:
           path: spec.tls[0].secretName
-          value: api-deskbia-tls
+          value: api-staging-tls


### PR DESCRIPTION
## What

Render each `externalSecrets.items[].spec` through `tpl`, so backend reference keys can be templated.

## Why

Brings `externalSecrets` in line with the chart's existing `tpl` support on `env` and `ingress` values. A single chart definition can now derive per-environment backend paths (e.g. `secret/data/{{ .Release.Namespace }}/app`) instead of duplicating values per environment or relying on fragile index-based `--set` overrides.

## Changes

- `templates/external-secret.yaml`: `toYaml $spec` → `tpl (toYaml $spec) $`
- Unit test covering templated `dataFrom` / `remoteRef` keys
- README example updated to show a templated key
- Chart bumped to `3.1.0`

## Compatibility

Backward compatible for specs without Go-template syntax in their values (the common case) — existing static keys render unchanged.

## Tests

- `helm unittest charts/generic` → 18 suites / 71 tests passing
- `helm lint charts/generic` → clean
