### PR TITLE
fix(gophish): validate external database scenario

### DIFF
--- a/charts/gophish/DESIGN.md
+++ b/charts/gophish/DESIGN.md
@@ -40,6 +40,8 @@ surface separation, TLS choices, persistence, and site sync notes.
 
 ## Validation Focus
 
-Use `make validate-chart CHART=gophish` as the required gate. It exercises Helm
-lint, template rendering, unit tests, kubeconform with real schemas, Artifact Hub
-lint, and k3d behavioral validation for every CI values file.
+From `helmforge-ops`, use `make validate-chart CHART=gophish` as the required
+gate. It exercises Helm lint, template rendering, unit tests, kubeconform with
+real schemas, Artifact Hub lint, and k3d behavioral validation for every CI
+values file. From the `charts` repository, `./test.sh gophish` remains the
+repo-local CI parity helper.

--- a/charts/gophish/DESIGN.md
+++ b/charts/gophish/DESIGN.md
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Gophish Chart Design
+
+This chart packages the official Gophish image for authorized security awareness
+training workflows. It keeps the default install private and single-replica,
+because upstream Gophish stores state locally by default and does not document a
+Kubernetes-native HA mode.
+
+## Differentiators
+
+- Separate admin and phishing Services, Ingresses, and Gateway API HTTPRoutes.
+- Safe SQLite defaults with explicit persistence boundaries.
+- External MySQL and HelmForge MySQL dependency paths for production database
+  lifecycle ownership.
+- Generated `config.json` stored as a Secret, with `existingSecret` support for
+  operator-managed configuration.
+- NetworkPolicy, dual-stack Service fields, ServiceAccount token control, and
+  backup support for SQLite mode.
+- CI scenarios covering default, ingress, Gateway API, backup, dual-stack,
+  NetworkPolicy, embedded MySQL, and external database render paths.
+
+## Architecture
+
+The detailed architecture record lives in [docs/architecture.md](docs/architecture.md).
+That document captures upstream image behavior, database mode decisions, network
+surface separation, TLS choices, persistence, and site sync notes.
+
+## Runtime Boundaries
+
+- Admin UI is privileged and should stay private behind port-forward, VPN, SSO,
+  reverse proxy auth, or an internal Gateway/Ingress.
+- The phishing listener is intentionally separate so campaign traffic can use a
+  different hostname, policy, and network path.
+- SQLite mode remains single-replica. Multi-replica experiments require
+  `database.mode=external` or `database.mode=mysql` and separate validation of
+  shared database behavior.
+- Chart-managed backup covers SQLite mode only. MySQL backup is delegated to the
+  MySQL dependency or external database tooling.
+
+## Validation Focus
+
+Use `make validate-chart CHART=gophish` as the required gate. It exercises Helm
+lint, template rendering, unit tests, kubeconform with real schemas, Artifact Hub
+lint, and k3d behavioral validation for every CI values file.

--- a/charts/gophish/README.md
+++ b/charts/gophish/README.md
@@ -170,3 +170,11 @@ helm unittest charts/gophish
 helm template gophish charts/gophish | kubeconform -strict -kubernetes-version 1.30.0 -schema-location default
 ct lint --target-branch main --charts charts/gophish
 ```
+
+### Security Scan: `gophish`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **88.38384%** |
+
+Security posture: acceptable.

--- a/charts/gophish/ci/external-db-values.yaml
+++ b/charts/gophish/ci/external-db-values.yaml
@@ -2,8 +2,86 @@
 database:
   mode: external
   external:
-    host: mysql.database.svc.cluster.local
+    host: mysql
     name: gophish
     username: gophish
     existingSecret: gophish-db
     existingSecretDsnKey: dsn
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: gophish-db
+    type: Opaque
+    stringData:
+      dsn: gophish:helmforge-test-password@(mysql:3306)/gophish?charset=utf8&parseTime=True&loc=UTC
+      mysql-root-password: helmforge-root-password
+      mysql-user-password: helmforge-test-password
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mysql
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+      selector:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mysql
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: mysql
+          app.kubernetes.io/component: external-db-ci
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: mysql
+            app.kubernetes.io/component: external-db-ci
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:9.7.0
+              imagePullPolicy: IfNotPresent
+              args:
+                - --sql-mode=NO_ENGINE_SUBSTITUTION
+                - --character-set-server=utf8mb4
+                - --collation-server=utf8mb4_unicode_ci
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: gophish-db
+                      key: mysql-root-password
+                - name: MYSQL_DATABASE
+                  value: gophish
+                - name: MYSQL_USER
+                  value: gophish
+                - name: MYSQL_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: gophish-db
+                      key: mysql-user-password
+              ports:
+                - name: mysql
+                  containerPort: 3306
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/mysql
+          volumes:
+            - name: data
+              emptyDir: {}

--- a/charts/gophish/docs/architecture.md
+++ b/charts/gophish/docs/architecture.md
@@ -173,7 +173,7 @@ HelmForge differentiation:
 
 ## Site Sync Notes
 
-HelmForge MCP site sync check for a new `gophish` chart requires:
+HelmForge site sync for a new `gophish` chart requires:
 
 - dedicated chart documentation page
 - chart card entry on the charts overview page
@@ -187,8 +187,8 @@ These are Phase 10 deliverables, but they are recorded here because architecture
 
 - Tavily was attempted first for this phase.
 - Tavily detailed research timed out, and a second query returned a plan usage limit error.
-- Context7 MCP was requested by policy during initial research; later implementation used local Helm and Kubernetes references plus HelmForge MCP guardrails.
-- Fallback research used official GitHub, Docker Hub, upstream user guide, and HelmForge MCP resources.
+- Context7 MCP was requested by policy during initial research; later implementation used local Helm and Kubernetes references plus HelmForge guardrails.
+- Fallback research used official GitHub, Docker Hub, upstream user guide, and local HelmForge knowledge.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Adds a dedicated design record for the Gophish chart.
- Makes the external database CI scenario self-contained with a pinned official MySQL image.
- Documents the current kubescape score in the chart README.
- Removes stale retired tooling references from the chart architecture notes.

## Validation

- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make standards-check CHART=gophish`
- `make md-lint REPO=charts`
- `make validate-chart CHART=gophish`
- `make site-sync-check REPO=charts`

## GR-007 Site Sync

`make site-sync-check REPO=charts` exited successfully and reported existing site artifacts for Gophish. It also flagged the standard review items for defaults/install path changes, so this PR records the site-sync review requirement for maintainer follow-up before merge.