### PR TITLE
fix(alfio): complete chart standards

### DIFF
--- a/charts/alfio/DESIGN.md
+++ b/charts/alfio/DESIGN.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# alf.io Chart Design
+
+The alf.io chart packages the official `docker.io/alfio/alf.io` image with a
+PostgreSQL backend. It is intended for event organizers that need a
+self-hosted ticketing system with attendee management, check-in, invoicing, and
+public ticket sales.
+
+## Architecture
+
+The chart deploys a single Spring Boot application `Deployment`, one HTTP
+`Service`, an optional `Ingress`, a credentials `Secret`, and optional extra
+manifests. PostgreSQL is provided by the HelmForge PostgreSQL subchart by
+default and can be replaced by an external PostgreSQL service for production
+teams that operate databases separately.
+
+alf.io itself is stateful through PostgreSQL. The application pod does not
+mount application data by default, so the durable boundary is the database. The
+chart keeps the web tier single-replica because the upstream application and
+session behavior are not validated here for horizontal scaling.
+
+## Database Modes
+
+- Bundled PostgreSQL is the default and is useful for development, demos, and
+  small installations that accept chart-managed database lifecycle.
+- External PostgreSQL is the production ownership model. Set
+  `postgresql.enabled=false` and provide `database.external.*` values, preferably
+  through `database.external.existingSecret`.
+- The init container waits for the configured database endpoint before the
+  application starts, which makes startup ordering deterministic in k3d and CI.
+
+## Exposure Model
+
+The chart exposes alf.io over HTTP through a ClusterIP Service. Ingress is
+optional and should be enabled only after `alfio.baseUrl` is set to the public
+URL that users will use for ticket purchase and admin access. TLS termination is
+delegated to the Ingress controller and certificate automation used by the
+cluster.
+
+## Security Boundaries
+
+- The chart uses the official upstream image and a pinned tag.
+- Database credentials are rendered into a Kubernetes Secret or consumed from an
+  operator-managed existing Secret.
+- `serviceAccount.create` defaults to `false` because the application does not
+  require Kubernetes API access.
+- Resource and pod/container security contexts are intentionally user-tunable;
+  production installs should set CPU/memory limits and a non-root-compatible
+  security posture after validating image behavior in their environment.
+
+## Operational Notes
+
+Set `alfio.profiles=spring-boot` and a non-empty `alfio.baseUrl` for production.
+The default `dev` profile is convenient for local validation but should not be
+treated as a production posture. Use external PostgreSQL when database backup,
+replication, or compliance requirements are owned outside the Helm release.
+
+## Validation
+
+From `helmforge-ops`, use `make validate-chart CHART=alfio` as the required
+gate before a chart PR is considered ready. From the `charts` repository, use
+`./test.sh alfio` as the repo-local CI parity helper. The full HelmForge gate
+adds strict kubeconform, Artifact Hub lint, and k3d behavioral validation for
+the default, external database, and ingress scenarios.

--- a/charts/alfio/README.md
+++ b/charts/alfio/README.md
@@ -57,6 +57,16 @@ database:
     existingSecret: alfio-db-credentials
 ```
 
+## Architecture Guides
+
+- [Architecture](docs/architecture.md)
+- [Database Configuration](docs/database.md)
+
+## Examples
+
+- [Simple self-contained deployment](examples/simple.yaml)
+- [External PostgreSQL deployment](examples/external-postgresql.yaml)
+
 ## Ingress
 
 ```yaml
@@ -86,6 +96,14 @@ ingress:
 | `ingress.enabled` | `false` | Enable ingress |
 | `service.port` | `80` | Service port |
 | `probes.startup.initialDelaySeconds` | `15` | Startup probe initial delay (JVM warm-up) |
+
+### 🟢 Security Scan: `alfio`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **78.79%** |
+
+> ✅ Security posture acceptable.
 
 ## Limitations
 

--- a/charts/alfio/README.md
+++ b/charts/alfio/README.md
@@ -1,6 +1,9 @@
 # alf.io Helm Chart
 
-Deploy [alf.io](https://alf.io) on Kubernetes using the official [alfio/alf.io](https://hub.docker.com/r/alfio/alf.io) container image. Open-source event management and ticketing platform for conferences, meetups, and exhibitions.
+Deploy [alf.io](https://alf.io) on Kubernetes using the official
+[alfio/alf.io](https://hub.docker.com/r/alfio/alf.io) container image.
+Open-source event management and ticketing platform for conferences, meetups,
+and exhibitions.
 
 ## Features
 

--- a/charts/alfio/ci/external-db-values.yaml
+++ b/charts/alfio/ci/external-db-values.yaml
@@ -1,12 +1,72 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external PostgreSQL database
+# CI: external PostgreSQL database backed by a local disposable PostgreSQL pod
 postgresql:
   enabled: false
 
+alfio:
+  baseUrl: "http://alfio.example.test"
+
 database:
   external:
-    host: db.example.com
+    host: postgresql
     port: "5432"
     name: alfio
-    username: alfio_user
+    username: alfio
     password: "ci-password"
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: postgresql
+      labels:
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+      selector:
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/component: external-db-ci
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: postgresql
+      labels:
+        app.kubernetes.io/name: postgresql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: postgresql
+          app.kubernetes.io/component: external-db-ci
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: postgresql
+            app.kubernetes.io/component: external-db-ci
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:17-alpine
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: POSTGRES_DB
+                  value: alfio
+                - name: POSTGRES_USER
+                  value: alfio
+                - name: POSTGRES_PASSWORD
+                  value: ci-password
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/postgresql/data
+          volumes:
+            - name: data
+              emptyDir: {}

--- a/charts/alfio/docs/architecture.md
+++ b/charts/alfio/docs/architecture.md
@@ -47,4 +47,3 @@ administrative workflows. Run one pod and scale the database independently.
 5. Set CPU and memory requests and limits after load testing expected ticket
    sale traffic.
 6. Store database credentials in an existing Secret for GitOps workflows.
-

--- a/charts/alfio/docs/architecture.md
+++ b/charts/alfio/docs/architecture.md
@@ -1,0 +1,50 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# alf.io Architecture
+
+alf.io is a Spring Boot ticketing platform backed by PostgreSQL. This chart
+keeps that topology explicit: one application pod handles the public ticketing
+UI, admin UI, and API, while PostgreSQL owns all durable event, ticket, attendee,
+invoice, and configuration data.
+
+## Components
+
+- `Deployment`: runs the official alf.io container image.
+- `Secret`: stores generated or supplied database credentials.
+- `Service`: exposes HTTP traffic inside the cluster.
+- `Ingress`: optional edge route for public ticketing and admin access.
+- PostgreSQL subchart: optional database for self-contained deployments.
+- Init container: waits for PostgreSQL before starting the application.
+
+## Request Flow
+
+Users reach the application through either an Ingress or a port-forwarded
+ClusterIP Service. alf.io serves public event pages, checkout flows, admin
+screens, and API endpoints from the same HTTP port. The application then uses a
+JDBC connection to PostgreSQL for all persistent state.
+
+## Database Ownership
+
+The bundled PostgreSQL mode is useful when the Helm release should own the
+database lifecycle. Production teams commonly disable the subchart and point
+alf.io at an externally managed PostgreSQL service so backup, retention,
+replication, and maintenance windows are handled by the platform database team.
+
+## Scaling Boundary
+
+This chart intentionally keeps `replicaCount` out of the public values surface.
+alf.io is deployed as a single application replica because the chart does not
+validate clustered sessions, concurrent scheduler behavior, or multi-pod
+administrative workflows. Run one pod and scale the database independently.
+
+## Production Checklist
+
+1. Set `alfio.baseUrl` to the externally reachable HTTPS URL.
+2. Use `alfio.profiles=spring-boot`.
+3. Use an external PostgreSQL instance or define a backup plan for the bundled
+   PostgreSQL volume.
+4. Enable Ingress with TLS through the cluster standard.
+5. Set CPU and memory requests and limits after load testing expected ticket
+   sale traffic.
+6. Store database credentials in an existing Secret for GitOps workflows.
+

--- a/charts/alfio/docs/database.md
+++ b/charts/alfio/docs/database.md
@@ -62,4 +62,3 @@ alf.io stores durable business data in PostgreSQL. The chart does not render an
 application-level backup job. Use the PostgreSQL subchart backup pattern if the
 database is chart-managed, or the platform database backup process when using an
 external PostgreSQL service.
-

--- a/charts/alfio/docs/database.md
+++ b/charts/alfio/docs/database.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Database Configuration
+
+alf.io requires PostgreSQL. The chart supports a bundled HelmForge PostgreSQL
+subchart and an external PostgreSQL endpoint.
+
+## Bundled PostgreSQL
+
+Bundled PostgreSQL is enabled by default:
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    database: alfio
+    username: alfio
+```
+
+Use this mode for local validation, demos, and small installations where the
+Helm release can own the database lifecycle.
+
+## External PostgreSQL
+
+Disable the subchart and configure the external endpoint:
+
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: "5432"
+    name: alfio
+    username: alfio
+    existingSecret: alfio-db
+    existingSecretPasswordKey: password
+```
+
+The referenced Secret must exist in the release namespace:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alfio-db
+type: Opaque
+stringData:
+  password: change-me
+```
+
+## Startup Behavior
+
+The chart renders an init container that waits for the PostgreSQL host and port.
+This prevents the main application container from starting before DNS and the
+database listener are ready.
+
+## Backup Responsibility
+
+alf.io stores durable business data in PostgreSQL. The chart does not render an
+application-level backup job. Use the PostgreSQL subchart backup pattern if the
+database is chart-managed, or the platform database backup process when using an
+external PostgreSQL service.
+

--- a/charts/alfio/examples/external-postgresql.yaml
+++ b/charts/alfio/examples/external-postgresql.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-style alf.io deployment using platform-owned PostgreSQL.
+
+alfio:
+  baseUrl: "https://tickets.example.com"
+  profiles: "spring-boot"
+
+postgresql:
+  enabled: false
+
+database:
+  external:
+    host: postgres.example.com
+    port: "5432"
+    name: alfio
+    username: alfio
+    existingSecret: alfio-db
+    existingSecretPasswordKey: password
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: tickets.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - tickets.example.com
+      secretName: alfio-tls
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 1024Mi
+  limits:
+    cpu: "2"
+    memory: 2048Mi
+

--- a/charts/alfio/examples/simple.yaml
+++ b/charts/alfio/examples/simple.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Simple self-contained alf.io deployment for local validation.
+
+alfio:
+  baseUrl: "http://localhost:8080"
+  profiles: "dev"
+
+postgresql:
+  enabled: true
+  auth:
+    database: alfio
+    username: alfio
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 768Mi
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+

--- a/charts/alfio/templates/NOTES.txt
+++ b/charts/alfio/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   alf.io has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
@@ -9,9 +9,9 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -33,9 +33,9 @@ Port-forward to access alf.io locally:
 Internal cluster endpoint:
   http://{{ include "alfio.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   CREDENTIALS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Default admin credentials (first launch):
   Username: admin
@@ -43,9 +43,9 @@ Default admin credentials (first launch):
 
 IMPORTANT: Complete the setup wizard on first access to configure admin credentials.
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   CONFIGURATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Deployment:
   Image:           {{ include "alfio.image" . }}
@@ -70,9 +70,9 @@ Database:
 {{- end }}
   JDBC URL:        {{ include "alfio.jdbcUrl" . }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 1. Wait for alf.io to be ready:
    kubectl wait --for=condition=ready pod \
@@ -96,9 +96,9 @@ Database:
      --set alfio.profiles=spring-boot \
      --reuse-values
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Check pod status:
   kubectl get pods -l app.kubernetes.io/name=alfio -n {{ .Release.Namespace }}
@@ -134,9 +134,9 @@ Health check endpoint:
     deploy/{{ include "alfio.fullname" . }} -- \
     wget -qO- http://localhost:8080/healthz
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 {{- if and (eq (.Values.alfio.profiles) "dev") (not .Values.alfio.baseUrl) }}
 
@@ -159,9 +159,9 @@ NOTE: Ingress is not enabled. To expose alf.io externally:
     --reuse-values
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
   ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+--------------------------------------------------------------------
 
 Documentation:     https://helmforge.dev/docs/charts/alfio
 Chart Repository:  https://github.com/helmforgedev/charts/tree/main/charts/alfio


### PR DESCRIPTION
## Summary

- Adds alf.io chart design documentation, architecture/database guides, and copy-paste examples.
- Adds the local Kubescape security scan result to the README.
- Replaces decorative Unicode separators in NOTES.txt with ASCII-safe headers.
- Makes the external PostgreSQL CI scenario self-contained with a pinned official PostgreSQL image so k3d validation can exercise the path.

## Validation

- `kubescape scan framework "MITRE,NSA,SOC2" charts/alfio` — 78.79%
- `make standards-check CHART=alfio`
- `make md-lint REPO=charts`
- `make validate-chart CHART=alfio` — fully validated, 13 layers
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=alfio`

## GR-007 Site Sync

Companion site PR: helmforgedev/site#253

`make site-sync-check CHART=alfio` exits successfully with the companion site branch checked out and records the standard site review requirements for architecture/default/install-path changes.

## Release Note

`make release-check REPO=charts` passes with the expected GR-077 warning to confirm the chart release/tag after merge because rendered output changed.