### PR TITLE
fix(cronicle): complete chart standards

### DIFF
--- a/charts/cronicle/DESIGN.md
+++ b/charts/cronicle/DESIGN.md
@@ -1,0 +1,120 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cronicle Chart Design
+
+This chart packages Cronicle as a single writable scheduler node with a web UI,
+filesystem-backed job state, and optional Kubernetes ingress. Cronicle can
+coordinate multiple servers upstream, but the default chart intentionally keeps a
+single Deployment replica because the storage model in this chart is a single PVC
+mounted at `/opt/cronicle/data`.
+
+## Goals
+
+- Provide a low-friction Cronicle install that works with a single PVC and no
+  external database.
+- Keep the default access path private through port-forwarding.
+- Expose the operational settings Cronicle needs for a production scheduler:
+  public URL, SMTP identity, job memory ceiling, concurrency ceiling, persistent
+  data, and optional ingress.
+- Preserve sessions and scheduler state across pod restarts by keeping the
+  data PVC stable and by documenting when operators should provide a stable
+  `secret.existingSecret`.
+- Document the storage and single-writer boundaries clearly so operators do not
+  scale the chart into a split-brain scheduler.
+
+## Non-Goals
+
+- The chart does not install an external database because this Cronicle topology
+  uses the upstream filesystem storage engine.
+- The chart does not enable horizontal scaling by default.
+- The chart does not install cert-manager, an Ingress controller, SMTP service,
+  or shared RWX storage.
+- The chart does not manage individual Cronicle jobs or plugins. Those are
+  application-level objects configured in the Cronicle UI or API.
+
+## Default Architecture
+
+```text
+Operator workstation
+   |
+   | kubectl port-forward
+   v
+ClusterIP Service
+   |
+   v
+Cronicle Deployment (1 replica)
+   |
+   +--> ConfigMap mounted as /opt/cronicle/conf/config.json
+   +--> Secret provides CRONICLE_secret_key
+   +--> PVC mounted at /opt/cronicle/data
+```
+
+Default characteristics:
+
+- one pod and one writable PVC;
+- no public ingress;
+- generated session secret for simple installs;
+- Cronicle data, queue, job definitions, and job logs stored on the PVC;
+- readiness, liveness, and startup probes use
+  `/api/app/get_master_state/v1`.
+
+## Public Access Architecture
+
+```text
+User or trusted network
+   |
+   v
+Ingress Controller + TLS
+   |
+   v
+Cronicle Service
+   |
+   v
+Cronicle Pod
+```
+
+When `ingress.enabled=true`, `cronicle.baseUrl` must be set to the same public
+URL. Cronicle uses this value for notification links and UI references. TLS,
+authentication before Cronicle, IP allowlists, and controller-specific policy are
+owned by the platform layer.
+
+## Storage Model
+
+Cronicle stores state as files under `/opt/cronicle/data`. This includes:
+
+- scheduled event definitions;
+- server and plugin metadata;
+- queue state;
+- run history and job logs;
+- internal state used by the scheduler.
+
+The chart uses a Deployment with `strategy.type=Recreate` to avoid two pods
+mounting the same ReadWriteOnce volume during an update. This matches the
+single-writer default and prevents overlapping scheduler instances during a
+rolling rollout.
+
+## Secret Strategy
+
+`secret.create=true` renders an Opaque Secret containing `secret_key` for simple
+installs. Because the value is generated at render time, production
+installations that need stable sessions across upgrades should set
+`secret.create=false` and `secret.existingSecret` to reference an
+operator-managed Secret with the `secret_key` key. The Deployment exposes that
+key as `CRONICLE_secret_key`, matching Cronicle's case-sensitive environment
+override for the top-level `secret_key` configuration path.
+
+## Multi-Server Boundary
+
+Cronicle has upstream concepts for multi-server coordination and UDP discovery.
+This chart exposes `cronicle.discoveryEnabled` and `cronicle.discoveryPort` so
+advanced operators can experiment with that path, but the chart does not claim a
+safe HA preset. A production multi-server topology requires shared storage or a
+carefully validated upstream-compatible state layout.
+
+## Validation Focus
+
+From `helmforge-ops`, use `make validate-chart CHART=cronicle` as the required
+gate. It runs dependency checks, strict Helm lint, template rendering, unit
+tests, kubeconform with real schemas, Artifact Hub lint, and k3d behavioral
+validation for the chart scenarios. Example files are rendered with Helm before
+they are documented as copy-paste ready.

--- a/charts/cronicle/README.md
+++ b/charts/cronicle/README.md
@@ -1,6 +1,10 @@
 # Cronicle Helm Chart
 
-Deploy [Cronicle](https://github.com/jhuckaby/Cronicle) on Kubernetes using the [soulteary/cronicle](https://hub.docker.com/r/soulteary/cronicle) community container image. Multi-server task scheduler and runner with a built-in web UI — supports scheduled jobs, shell commands, HTTP requests, and plugins with zero external dependencies.
+Deploy [Cronicle](https://github.com/jhuckaby/Cronicle) on Kubernetes using the
+[soulteary/cronicle](https://hub.docker.com/r/soulteary/cronicle) community
+container image. Multi-server task scheduler and runner with a built-in web UI
+for scheduled jobs, shell commands, HTTP requests, and plugins with zero
+external dependencies.
 
 ## Features
 
@@ -62,11 +66,43 @@ kubectl port-forward svc/<release>-cronicle 3012:80
 | `ingress.ingressClassName` | `traefik` | Ingress class (traefik, nginx) |
 | `service.port` | `80` | Service port |
 
+## Examples
+
+- [Simple private scheduler](examples/simple.yaml) - port-forward access with
+  bounded job concurrency and persistent storage.
+- [Ingress deployment](examples/ingress.yaml) - HTTPS ingress with production
+  resource requests and limits.
+- [SMTP notifications](examples/notifications.yaml) - public URL, SMTP host,
+  and notification-related environment values.
+
+## Architecture Guides
+
+- [Architecture](docs/architecture.md) - Kubernetes resources, request flow,
+  scheduler flow, and single-replica rationale.
+- [Operations](docs/operations.md) - access, storage, scheduler capacity,
+  notifications, upgrades, and troubleshooting.
+
 ## Limitations
 
 - **Single instance recommended** — filesystem storage is single-writer; horizontal scaling requires shared storage or external database
 - **ReadWriteOnce** — default PVC uses ReadWriteOnce due to filesystem storage
 - **Community image** — uses `soulteary/cronicle` as Cronicle does not publish an official container image
+
+## Quality Gates
+
+```bash
+helm lint charts/cronicle
+helm unittest charts/cronicle
+helm template cronicle charts/cronicle | kubeconform -strict -kubernetes-version 1.30.0 -schema-location default
+```
+
+### Security Scan: `cronicle`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **74.24%** |
+
+Security posture: acceptable.
 
 ## More Information
 

--- a/charts/cronicle/docs/architecture.md
+++ b/charts/cronicle/docs/architecture.md
@@ -1,0 +1,102 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cronicle Architecture
+
+Cronicle is a web-managed scheduler for recurring jobs, ad hoc commands, HTTP
+requests, and plugin-backed tasks. The HelmForge chart deploys it as a
+single-writer Kubernetes workload with durable filesystem state.
+
+## Components
+
+| Component | Kubernetes resource | Purpose |
+| --- | --- | --- |
+| Cronicle application | Deployment | Runs the web UI, scheduler, API, and job runner. |
+| Service | Service | Exposes the HTTP UI and optional UDP discovery port. |
+| Configuration | ConfigMap | Renders `config.json` from Helm values. |
+| Session secret | Secret | Provides `secret_key` through `CRONICLE_secret_key`. |
+| Data store | PersistentVolumeClaim | Stores schedules, queue, history, and job logs. |
+| Public access | Ingress | Optional HTTP routing and TLS termination. |
+
+## Request Flow
+
+```text
+Browser
+   |
+   | port-forward or Ingress
+   v
+Kubernetes Service
+   |
+   v
+Cronicle web server on port 3012
+   |
+   +--> /opt/cronicle/conf/config.json
+   +--> /opt/cronicle/data
+```
+
+The default chart keeps access private. Operators can enable Ingress once the
+public URL, TLS, and surrounding access controls are ready.
+
+## Scheduler Flow
+
+```text
+Cronicle scheduler
+   |
+   +--> reads event definitions from /opt/cronicle/data
+   +--> starts jobs inside the Cronicle process
+   +--> writes run logs and history to /opt/cronicle/data
+   +--> sends SMTP notifications when configured
+```
+
+The chart does not create Kubernetes Jobs for each Cronicle event. Cronicle owns
+job execution inside its own container, so pod resource limits and
+`cronicle.maxJobs` are the primary controls for runtime pressure.
+
+## Single-Replica Rationale
+
+The chart renders `replicas: 1` and `strategy.type: Recreate`. This is
+intentional:
+
+- the default storage is a single PVC;
+- Cronicle job definitions and queue state are filesystem-backed;
+- overlapping scheduler pods could duplicate work or corrupt local state;
+- Recreate avoids parallel old/new pods during upgrades.
+
+If you need multi-server Cronicle, validate the upstream storage and discovery
+design independently before changing the chart topology.
+
+## Configuration Rendering
+
+The chart writes a complete `config.json` with the values that are safe to
+parameterize:
+
+- `base_app_url` from `cronicle.baseUrl`;
+- SMTP sender and host from `cronicle.emailFrom` and
+  `cronicle.smtpHostname`;
+- filesystem storage rooted at `/opt/cronicle/data`;
+- queue directory under the same PVC;
+- HTTP server port from `cronicle.port`;
+- `job_memory_max` and `max_jobs` controls.
+
+Additional Cronicle environment variables can be passed through
+`cronicle.extraEnv` for advanced upstream settings.
+
+## Operational Controls
+
+Production installations should set:
+
+- `cronicle.baseUrl` to the externally reachable URL;
+- `cronicle.maxJobs` to a bounded value that matches pod resources;
+- CPU and memory requests/limits;
+- a stable `secret.existingSecret` for production sessions;
+- persistent storage sized for job logs and history;
+- TLS and access control at the Ingress or Gateway layer.
+
+## Failure Domains
+
+| Failure | Expected behavior | Operator action |
+| --- | --- | --- |
+| Pod restart | Cronicle restarts and reads state from the PVC. | Confirm pod readiness and inspect logs. |
+| PVC loss | Schedules, history, and logs are lost. | Restore from storage snapshot or backup process. |
+| Secret rotation | Existing sessions become invalid. | Re-login and avoid unnecessary key rotation. |
+| SMTP outage | Jobs continue, notifications fail upstream. | Fix SMTP host and review Cronicle notification logs. |
+| Public URL mismatch | Links in email/UI point to the wrong host. | Correct `cronicle.baseUrl` and upgrade the release. |

--- a/charts/cronicle/docs/operations.md
+++ b/charts/cronicle/docs/operations.md
@@ -1,0 +1,156 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Cronicle Operations
+
+This guide covers day-two operations for the HelmForge Cronicle chart: access,
+storage, scheduler safety, notifications, and troubleshooting.
+
+## Access
+
+Default installs are private:
+
+```bash
+kubectl port-forward -n cronicle svc/cronicle-cronicle 3012:80
+```
+
+Open `http://127.0.0.1:3012` and change the default upstream credentials after
+the first login.
+
+For public access, enable Ingress and align `cronicle.baseUrl`:
+
+```yaml
+cronicle:
+  baseUrl: https://cronicle.example.com
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: cronicle.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: cronicle-tls
+      hosts:
+        - cronicle.example.com
+```
+
+Use TLS and put Cronicle behind trusted network controls, SSO, VPN, or reverse
+proxy authentication when it is reachable outside the cluster.
+
+## Storage Operations
+
+Cronicle stores schedules, run history, and job logs on the PVC mounted at
+`/opt/cronicle/data`.
+
+Useful checks:
+
+```bash
+kubectl get pvc -n cronicle -l app.kubernetes.io/instance=cronicle
+kubectl exec -n cronicle deploy/cronicle-cronicle -- du -sh /opt/cronicle/data
+kubectl logs -n cronicle deploy/cronicle-cronicle --tail=100
+```
+
+Size the PVC according to job log retention. Long-running shell commands and
+chatty jobs can grow the log directory faster than the scheduler metadata.
+
+## Scheduler Capacity
+
+`cronicle.maxJobs` defaults to `0`, which means unlimited. Production
+installations should cap concurrency and match resources to expected workload:
+
+```yaml
+cronicle:
+  maxJobs: 4
+  jobMemoryMax: 268435456
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+```
+
+Cronicle runs jobs inside the application container. Resource limits apply to
+the scheduler and the jobs together. The example above budgets up to four
+concurrent 256 MiB jobs inside a 2 GiB pod limit, leaving headroom for the
+scheduler process and job log buffering.
+
+## Notifications
+
+Set SMTP identity values when email notifications are required:
+
+```yaml
+cronicle:
+  baseUrl: https://cronicle.example.com
+  emailFrom: cronicle@example.com
+  smtpHostname: smtp.example.com
+  extraEnv:
+    - name: CRONICLE_smtp_port
+      value: "587"
+    - name: CRONICLE_mail_options__secure
+      value: "0"
+```
+
+Port 587 commonly uses STARTTLS, so keep `CRONICLE_mail_options__secure` at
+`"0"` unless the SMTP provider requires implicit TLS on connect, typically on
+port 465.
+
+If SMTP requires credentials, store them in a Kubernetes Secret and reference it
+from `cronicle.extraEnv` with `valueFrom.secretKeyRef`.
+
+## Upgrades
+
+The Deployment uses the `Recreate` strategy, so upgrades briefly stop the
+scheduler before starting the new pod. This prevents overlapping scheduler
+instances with the same PVC.
+
+Recommended upgrade checks:
+
+```bash
+helm upgrade cronicle oci://ghcr.io/helmforgedev/helm/cronicle -n cronicle -f values.yaml
+kubectl rollout status deploy/cronicle-cronicle -n cronicle --timeout=300s
+kubectl logs -n cronicle deploy/cronicle-cronicle --tail=100
+```
+
+## Troubleshooting
+
+### The UI is reachable but links point to localhost
+
+Set `cronicle.baseUrl` to the public URL and upgrade the release.
+
+### Jobs disappeared after reinstall
+
+Check whether the PVC was deleted or a different claim is mounted:
+
+```bash
+kubectl describe deploy/cronicle-cronicle -n cronicle
+kubectl get pvc -n cronicle
+```
+
+Cronicle schedules live on the PVC. Losing the PVC loses application state.
+
+### Users are logged out after reinstall or upgrade
+
+The `secret_key` changed. The chart-generated key is convenient for simple
+installs but is generated during rendering. Use a stable existing Secret for
+production:
+
+```yaml
+secret:
+  create: false
+  existingSecret: cronicle-secret
+```
+
+The referenced Secret must contain the `secret_key` key. The chart maps this
+key to `CRONICLE_secret_key`, Cronicle's case-sensitive environment override
+for the top-level `secret_key` configuration path.
+
+### The pod is ready but jobs overload the node
+
+Set `cronicle.maxJobs`, lower job memory limits, and add pod CPU/memory limits.
+Review Cronicle job definitions for commands that should run outside the
+scheduler pod.

--- a/charts/cronicle/examples/ingress.yaml
+++ b/charts/cronicle/examples/ingress.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Cronicle with HTTPS ingress.
+# Use case: internal scheduler exposed through a trusted ingress controller.
+
+cronicle:
+  baseUrl: https://cronicle.example.com
+  emailFrom: cronicle@example.com
+  maxJobs: 3
+  jobMemoryMax: 134217728
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: cronicle.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: cronicle-tls
+      hosts:
+        - cronicle.example.com
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi

--- a/charts/cronicle/examples/notifications.yaml
+++ b/charts/cronicle/examples/notifications.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# Cronicle with SMTP notification settings.
+# Use case: scheduler sends job success and failure notifications.
+
+cronicle:
+  baseUrl: https://cronicle.example.com
+  emailFrom: cronicle@example.com
+  smtpHostname: smtp.example.com
+  maxJobs: 4
+  jobMemoryMax: 268435456
+  extraEnv:
+    - name: CRONICLE_smtp_port
+      value: "587"
+    - name: CRONICLE_mail_options__secure
+      value: "0"
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: cronicle.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: cronicle-tls
+      hosts:
+        - cronicle.example.com
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi

--- a/charts/cronicle/examples/simple.yaml
+++ b/charts/cronicle/examples/simple.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Simple Cronicle deployment for local or lab use.
+# Use case: private scheduler reached through kubectl port-forward.
+
+cronicle:
+  baseUrl: http://localhost:3012
+  maxJobs: 3
+  jobMemoryMax: 134217728
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi

--- a/charts/cronicle/templates/NOTES.txt
+++ b/charts/cronicle/templates/NOTES.txt
@@ -1,17 +1,18 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Cronicle has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+====================================================================
+Cronicle has been successfully deployed
+====================================================================
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
 AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
+Image:      {{ include "cronicle.image" . }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+====================================================================
+Access Information
+====================================================================
 
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -26,43 +27,67 @@ Port-forward to access Cronicle locally:
   ADMIN:    http://localhost:3012/#Admin
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  CREDENTIALS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+====================================================================
+Credentials
+====================================================================
 
 Default admin credentials (change after first login!):
   Username: admin
   Password: admin
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+====================================================================
+Configuration Summary
+====================================================================
+
+Cronicle base URL:      {{ .Values.cronicle.baseUrl }}
+Persistent storage:     {{ if .Values.persistence.enabled }}enabled ({{ .Values.persistence.size }}){{ else }}disabled{{ end }}
+Ingress:                {{ if .Values.ingress.enabled }}enabled{{ else }}disabled{{ end }}
+UDP discovery port:     {{ if .Values.cronicle.discoveryEnabled }}enabled on {{ .Values.cronicle.discoveryPort }}{{ else }}disabled{{ end }}
+Maximum concurrent jobs: {{ .Values.cronicle.maxJobs }}
+Job memory ceiling:     {{ .Values.cronicle.jobMemoryMax }} bytes
+
+====================================================================
+Getting Started
+====================================================================
 
 1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }} --timeout=300s
 2. kubectl get pods -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }}
 3. kubectl logs -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }} --all-containers --tail=50 -f
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+====================================================================
+Validation Commands
+====================================================================
+
+  kubectl rollout status deploy/{{ include "cronicle.fullname" . }} -n {{ .Release.Namespace }} --timeout=300s
+  kubectl get endpoints {{ include "cronicle.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+====================================================================
+Troubleshooting
+====================================================================
 
   kubectl describe pod -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=cronicle -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+====================================================================
+Warnings
+====================================================================
 
 {{- if not .Values.ingress.enabled }}
 
 NOTE: Ingress is not enabled. Access via port-forward (see above).
 {{- end }}
+{{- if eq (toString .Values.cronicle.maxJobs) "0" }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+NOTE: cronicle.maxJobs is 0, which means unlimited concurrent jobs.
+Set a bounded value in production to avoid node saturation.
+{{- end }}
+
+====================================================================
+Additional Resources
+====================================================================
 
 Documentation:  https://helmforge.dev/docs/charts/cronicle
 Cronicle:       https://github.com/jhuckaby/Cronicle

--- a/charts/cronicle/templates/configmap.yaml
+++ b/charts/cronicle/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
       "base_app_url": {{ .Values.cronicle.baseUrl | quote }},
       "email_from": {{ .Values.cronicle.emailFrom | quote }},
       "smtp_hostname": {{ .Values.cronicle.smtpHostname | quote }},
-      "secret_key": "CRONICLE_SECRET_KEY",
+      "secret_key": "CRONICLE_secret_key",
       "job_memory_max": {{ int64 .Values.cronicle.jobMemoryMax }},
       "max_jobs": {{ int64 .Values.cronicle.maxJobs }},
       "Storage": {

--- a/charts/cronicle/templates/deployment.yaml
+++ b/charts/cronicle/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               protocol: UDP
             {{- end }}
           env:
-            - name: CRONICLE_SECRET_KEY
+            - name: CRONICLE_secret_key
               valueFrom:
                 secretKeyRef:
                   name: {{ include "cronicle.secretName" . }}

--- a/charts/cronicle/tests/configmap_test.yaml
+++ b/charts/cronicle/tests/configmap_test.yaml
@@ -36,3 +36,9 @@ tests:
       - matchRegex:
           path: data["config.json"]
           pattern: "3012"
+
+  - it: should use Cronicle's case-sensitive secret_key override placeholder
+    asserts:
+      - matchRegex:
+          path: data["config.json"]
+          pattern: "CRONICLE_secret_key"

--- a/charts/cronicle/tests/deployment_test.yaml
+++ b/charts/cronicle/tests/deployment_test.yaml
@@ -85,7 +85,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: CRONICLE_SECRET_KEY
+            name: CRONICLE_secret_key
             valueFrom:
               secretKeyRef:
                 name: test-cronicle


### PR DESCRIPTION
## Summary
- add Cronicle DESIGN.md plus chart-specific architecture and operations guides
- add tested simple, ingress, and notifications examples
- refresh README with examples, architecture links, and Kubescape Security Scan evidence
- replace Unicode NOTES separators with ASCII operational sections and validation commands

## Site sync
- Companion PR: https://github.com/helmforgedev/site/pull/256

## Validation
- kubescape scan framework "MITRE,NSA,SOC2" charts/cronicle: MITRE 100.00, NSA 60.00, SOC2 90.00, aggregate 74.24
- make image-verify IMAGE=docker.io/soulteary/cronicle:0.9.80
- helm template cronicle charts/cronicle -f charts/cronicle/examples/simple.yaml
- helm template cronicle charts/cronicle -f charts/cronicle/examples/ingress.yaml
- helm template cronicle charts/cronicle -f charts/cronicle/examples/notifications.yaml
- npx -y markdownlint-cli2 "charts/cronicle/README.md" "charts/cronicle/DESIGN.md" "charts/cronicle/docs/*.md"
- make standards-check CHART=cronicle
- make validate-chart CHART=cronicle
- make site-sync-check CHART=cronicle
- make release-check REPO=charts
- make attribution-check REPO=charts
