### PR TITLE
fix(karakeep): complete chart standards

### DIFF
--- a/charts/karakeep/DESIGN.md
+++ b/charts/karakeep/DESIGN.md
@@ -1,0 +1,107 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Karakeep Design
+
+## Purpose
+
+The Karakeep chart packages the official Karakeep application with the two
+sidecars that complete the default product experience: Meilisearch for full-text
+search and browserless Chromium for screenshots and archived page capture. The
+chart keeps the runtime simple and explicit: one application pod, one writable
+PVC, one Service, and optional edge routing.
+
+## Default Architecture
+
+```text
+Browser or API client
+   |
+   | port-forward, Ingress, or HTTPRoute
+   v
+ClusterIP Service
+   |
+   v
+Karakeep Deployment (1 replica, Recreate)
+   |
+   +--> karakeep container on port 3000
+   +--> optional Meilisearch sidecar on localhost:7700
+   +--> optional Chromium sidecar on localhost:9222
+   +--> Secret for NEXTAUTH_SECRET and MEILI_MASTER_KEY
+   +--> PVC mounted at /data
+```
+
+Default characteristics:
+
+- one pod and one writable PVC;
+- Meilisearch and Chromium enabled for the full bookmark/search/archive
+  experience;
+- generated credentials reused through Helm `lookup` during upgrades;
+- no public ingress by default;
+- TCP probes on the Karakeep HTTP port.
+
+## Storage Model
+
+Karakeep stores SQLite data, uploaded content, and application state under
+`/data`. The Meilisearch sidecar stores its index under `/data/meilisearch`
+through a subPath mount. This keeps backup and restore centered on a single PVC.
+
+The Deployment uses `strategy.type=Recreate` because the default storage model is
+single-writer. Running multiple replicas against the same SQLite database and PVC
+is outside this chart's supported contract.
+
+## Secret Strategy
+
+When `karakeep.existingSecret` is empty, the chart creates an Opaque Secret with
+the keys configured by `karakeep.existingSecretNextAuthKey` and
+`karakeep.existingSecretMeiliMasterKey`. The helper templates use `lookup` to
+reuse existing Secret data during Helm upgrades.
+
+Production operators can set `karakeep.existingSecret` to use a platform-managed
+Secret. External Secrets Operator support intentionally requires that existing
+Secret path so the chart-managed Secret and ExternalSecret do not compete as
+credential writers.
+
+## Sidecar Boundary
+
+Meilisearch and Chromium are sidecars rather than external dependencies by
+default. This makes the chart self-contained and easy to validate, but it also
+means one pod carries application, search, and browser resource pressure.
+
+Operators that need independent scaling, stricter isolation, or separate backup
+policies should disable the sidecars and point Karakeep at externally managed
+services through `karakeep.extraEnv` only after validating the upstream
+configuration variables for their target version.
+
+## Routing Model
+
+The chart supports three access paths:
+
+- no edge resource, using `kubectl port-forward` for local or private testing;
+- Kubernetes Ingress for controller-managed HTTP/TLS routing;
+- Gateway API HTTPRoute for clusters standardized on Gateway API.
+
+`karakeep.nextAuthUrl` must match the user-facing URL. Authentication callback
+URLs are sensitive to scheme, host, and trailing slash differences.
+
+## Security Posture
+
+The chart exposes `resources`, `securityContext`, `podSecurityContext`,
+`serviceAccount`, and scheduling controls without forcing a single cluster
+baseline. This keeps the default portable across local clusters and managed
+platforms, while production values should set:
+
+- resource requests and limits for all three containers;
+- non-root and privilege escalation restrictions where supported by the images;
+- service account and token mounting policy appropriate for the namespace;
+- NetworkPolicies or equivalent platform policy for ingress and egress.
+
+## Validation
+
+The HelmForge gate for this chart is:
+
+```bash
+make validate-chart CHART=karakeep
+```
+
+This runs dependency, lint, template, unittest, kubeconform, Artifact Hub lint,
+and k3d behavioral validation. Site documentation must also remain synchronized
+with chart-facing examples and value contracts.

--- a/charts/karakeep/README.md
+++ b/charts/karakeep/README.md
@@ -1,26 +1,26 @@
 # Karakeep Helm Chart
 
-Deploy [Karakeep](https://karakeep.app) (formerly Hoarder) on Kubernetes using the official
-[karakeep-app/karakeep](https://github.com/karakeep-app/karakeep) container image. An AI-powered bookmark manager with
-full-text search, web archiving, and automatic tagging.
+Deploy [Karakeep](https://karakeep.app), formerly Hoarder, on Kubernetes using
+the official `ghcr.io/karakeep-app/karakeep` container image. Karakeep provides
+bookmark management, full-text archive search, web page capture, and optional AI
+tagging in a single-writer application pod.
 
 Current application version: `0.32.0`.
 
 ## Features
 
-- **AI-powered tagging** — automatic categorization of bookmarks using AI
-- **Full-text search** — optional Meilisearch sidecar for fast search across all bookmarks
-- **Web archiving** — optional Chromium sidecar for page screenshots and content preservation
-- **SQLite storage** — no external database required, data stored on PVC
-- **Auto-generated secrets** — NEXTAUTH_SECRET and MEILI_MASTER_KEY are generated automatically and preserved across upgrades
-- **Ingress support** — TLS with cert-manager, supports traefik and nginx
-- **Gateway API support** — optional HTTPRoute for native Kubernetes routing
-- **Dual-stack ready Service** — optional `ipFamilyPolicy` and `ipFamilies`
-- **External Secrets Operator** — optional projection for NEXTAUTH_SECRET and MEILI_MASTER_KEY
+- Official Karakeep image pinned to `0.32.0`
+- Optional Meilisearch sidecar for full-text search
+- Optional browserless Chromium sidecar for screenshots and page archiving
+- SQLite and uploaded content stored on a PersistentVolumeClaim
+- Generated `NEXTAUTH_SECRET` and `MEILI_MASTER_KEY` with lookup-based reuse on
+  upgrades
+- Existing Secret and External Secrets Operator paths for production credentials
+- Ingress, Gateway API, dual-stack Service, scheduling, and resource controls
 
 ## Installation
 
-**HTTPS repository:**
+HTTPS repository:
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
@@ -28,71 +28,94 @@ helm repo update
 helm install karakeep helmforge/karakeep -f values.yaml
 ```
 
-**OCI registry:**
+OCI registry:
 
 ```bash
 helm install karakeep oci://ghcr.io/helmforgedev/helm/karakeep -f values.yaml
 ```
 
-## Basic Example
+## Examples
 
-```yaml
-# values.yaml
-karakeep:
-  nextAuthUrl: "https://karakeep.example.com"
-```
+The chart includes example values under `examples/`:
 
-After deploying:
+- `examples/simple.yaml` - local or private-network deployment with explicit
+  resources.
+- `examples/ingress.yaml` - TLS ingress with sidecars enabled.
+- `examples/ai-tagging.yaml` - AI tagging through Secret-backed environment
+  variables.
+- `examples/external-secrets.yaml` - External Secrets Operator projection for
+  auth and search credentials.
+
+Render an example before adapting it:
 
 ```bash
-# Port-forward to test
-kubectl port-forward svc/<release>-karakeep 8080:80
-
-# Access the web UI at http://localhost:8080
+helm template karakeep charts/karakeep -f charts/karakeep/examples/ingress.yaml
 ```
+
+## Architecture Guides
+
+- [Design rationale](DESIGN.md)
+- [Architecture guide](docs/architecture.md)
+- [Operations guide](docs/operations.md)
+
+## Basic Configuration
+
+For local testing through port-forwarding:
+
+```yaml
+karakeep:
+  nextAuthUrl: "http://localhost:3000"
+```
+
+Then access the web UI:
+
+```bash
+kubectl port-forward svc/<release>-karakeep 3000:80
+```
+
+For production, `karakeep.nextAuthUrl` must match the exact external URL users
+open in the browser, including `https://` when TLS is enabled.
 
 ## Sidecars
 
-### Meilisearch (Full-Text Search)
-
-Enabled by default. Provides fast full-text search across all bookmarks.
+Meilisearch and Chromium are enabled by default because they provide Karakeep's
+search and archive capture experience. They also increase pod memory needs. Set
+resources for each container in production:
 
 ```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
 meilisearch:
-  enabled: true  # default
-  image:
-    repository: docker.io/getmeili/meilisearch
-    tag: "v1.41.0"
   resources:
     requests:
+      cpu: 100m
       memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+chromium:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
 ```
 
-To disable:
+Disable sidecars only when the workload can operate without their features:
 
 ```yaml
 meilisearch:
   enabled: false
-```
 
-### Chromium (Screenshots)
-
-Enabled by default. Takes screenshots and archives web pages.
-
-```yaml
-chromium:
-  enabled: true  # default
-  image:
-    repository: ghcr.io/browserless/chromium
-    tag: "v2.46.0"
-  resources:
-    requests:
-      memory: 512Mi
-```
-
-To disable:
-
-```yaml
 chromium:
   enabled: false
 ```
@@ -100,73 +123,67 @@ chromium:
 ## Key Values
 
 | Key | Default | Description |
-|-----|---------|-------------|
+| --- | --- | --- |
 | `image.repository` | `ghcr.io/karakeep-app/karakeep` | Main Karakeep image |
 | `image.tag` | `"0.32.0"` | Main Karakeep image tag |
 | `karakeep.nextAuthUrl` | `""` | Public URL of the Karakeep instance |
 | `karakeep.browserConnectOnDemand` | `true` | Connect to Chromium only when crawling needs it |
-| `karakeep.existingSecret` | `""` | Existing secret with `nextauth-secret` and `meili-master-key` |
-| `meilisearch.enabled` | `true` | Enable Meilisearch sidecar for full-text search |
-| `chromium.enabled` | `true` | Enable Chromium sidecar for web page screenshots |
-| `chromium.port` | `9222` | Internal Chromium sidecar HTTP port |
-| `persistence.enabled` | `true` | Enable persistence for application data |
+| `karakeep.existingSecret` | `""` | Existing secret with auth and Meilisearch keys |
+| `karakeep.extraEnv` | `[]` | Extra environment variables for AI and advanced configuration |
+| `meilisearch.enabled` | `true` | Enable the Meilisearch sidecar |
+| `chromium.enabled` | `true` | Enable the Chromium sidecar |
+| `persistence.enabled` | `true` | Enable persistence for SQLite, uploads, and Meilisearch data |
 | `persistence.size` | `10Gi` | PVC size |
-| `ingress.enabled` | `false` | Enable ingress |
-| `ingress.ingressClassName` | `traefik` | Ingress class (traefik, nginx, etc.) |
-| `service.port` | `80` | Service port |
-| `service.ipFamilyPolicy` | `null` | Service IP family policy |
-| `service.ipFamilies` | `[]` | Ordered Service IP families |
+| `ingress.enabled` | `false` | Enable Ingress |
 | `gatewayAPI.enabled` | `false` | Enable Gateway API HTTPRoute |
-| `externalSecrets.enabled` | `false` | Render ExternalSecret for app secrets |
+| `externalSecrets.enabled` | `false` | Render ExternalSecret for app credentials |
 
-## Ingress Example
+## Security Scan
 
-```yaml
-karakeep:
-  nextAuthUrl: "https://karakeep.example.com"
+Security Scan: Kubescape on rendered default manifests.
 
-ingress:
-  enabled: true
-  ingressClassName: traefik  # or nginx
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-  hosts:
-    - host: karakeep.example.com
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - hosts:
-        - karakeep.example.com
-      secretName: karakeep-tls
+| Framework | Score |
+| --- | --- |
+| MITRE | 100.00% |
+| NSA | 60.00% |
+| SOC2 | 80.00% |
+| Aggregate | 80.00% |
+
+Default findings are driven by intentionally unset platform-specific controls:
+resource limits, container hardening context, service account token mounting, and
+NetworkPolicy boundaries. Set `resources`, `securityContext`,
+`podSecurityContext`, and platform NetworkPolicies according to your cluster
+baseline.
+
+## Quality Gates
+
+Before proposing a merge for this chart, run:
+
+```bash
+make validate-chart CHART=karakeep
+make standards-check CHART=karakeep
+make deps-check CHART=karakeep
+make site-sync-check CHART=karakeep
 ```
 
-## Gateway API
+## Persistence
+
+Karakeep stores SQLite, uploads, queue state, and optional sidecar data on the
+PVC mounted at `/data`. The Deployment uses `strategy.type=Recreate` because the
+default storage model is single-writer.
+
+Use an existing PVC when migrating from another release:
 
 ```yaml
-gatewayAPI:
-  enabled: true
-  parentRefs:
-    - name: shared-gateway
-      namespace: gateway-system
-      sectionName: https
-  hostnames:
-    - karakeep.example.com
-  paths:
-    - type: PathPrefix
-      value: /
+persistence:
+  existingClaim: my-karakeep-pvc
 ```
-
-## Dual-Stack Networking
-
-```yaml
-service:
-  ipFamilyPolicy: PreferDualStack
-```
-
-Set `service.ipFamilies` only when the target cluster advertises the requested IP families.
 
 ## External Secrets
+
+Use `externalSecrets.enabled=true` only with `karakeep.existingSecret`. The
+ExternalSecret must populate both `nextauth-secret` and `meili-master-key` when
+Meilisearch is enabled.
 
 ```yaml
 karakeep:
@@ -188,40 +205,17 @@ externalSecrets:
         property: meili-master-key
 ```
 
-The External Secrets Operator and SecretStore are managed outside this chart. `externalSecrets.data` must populate both
-`nextauth-secret` and `meili-master-key`, or the chart fails during template rendering.
-
-## Upgrade Notes
-
-This update moves the default Karakeep image from `0.31.0` to `0.32.0`. Upstream release notes describe mobile app design
-work and application fixes; no breaking chart value changes were identified.
-
-## Persistence
-
-SQLite database and uploaded content are stored under `/data`. A PVC is created by default.
-
-To use an existing PVC:
-
-```yaml
-persistence:
-  existingClaim: my-karakeep-pvc
-```
-
 ## Limitations
 
-- **Single instance** — SQLite does not support concurrent writers
-- **No clustering** — designed as a single-node deployment
+- Single replica by default; SQLite and the shared PVC are not a concurrent
+  writer architecture.
+- Ingress and Gateway API expose HTTP routing only; authentication and network
+  boundaries outside Karakeep are platform responsibilities.
+- AI providers are configured through `karakeep.extraEnv`; this chart does not
+  create provider-specific API key Secrets.
 
 ## More Information
 
 - [Karakeep documentation](https://docs.karakeep.app)
-- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/karakeep)
-
-<!-- @AI-METADATA
-type: chart-readme
-path: charts/karakeep/README.md
-date: 2026-04-03
-relations:
-  - charts/karakeep/values.yaml
-  - charts/karakeep/Chart.yaml
--->
+- [Karakeep source](https://github.com/karakeep-app/karakeep)
+- [HelmForge chart source](https://github.com/helmforgedev/charts/tree/main/charts/karakeep)

--- a/charts/karakeep/docs/architecture.md
+++ b/charts/karakeep/docs/architecture.md
@@ -1,0 +1,86 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Karakeep Architecture
+
+Karakeep is a bookmark and read-later application with optional full-text search,
+screenshots, archive capture, and AI tagging. The HelmForge chart deploys it as a
+single-writer workload with colocated search and browser sidecars.
+
+## Components
+
+| Component | Kubernetes resource | Purpose |
+| --- | --- | --- |
+| Karakeep | Deployment container | Runs the web UI, API, auth flow, and bookmark processing. |
+| Meilisearch | Deployment sidecar | Provides local full-text search when enabled. |
+| Chromium | Deployment sidecar | Provides screenshot and archive capture when enabled. |
+| Service | Service | Exposes the Karakeep HTTP port inside the cluster. |
+| Credentials | Secret or ExternalSecret | Provides `NEXTAUTH_SECRET` and `MEILI_MASTER_KEY`. |
+| Data store | PersistentVolumeClaim | Stores SQLite, uploads, queue data, and optional search index. |
+| Edge routing | Ingress or HTTPRoute | Optional public or private HTTP entrypoint. |
+
+## Request Flow
+
+```text
+User
+   |
+   | browser request
+   v
+Ingress, HTTPRoute, or port-forward
+   |
+   v
+Service port 80
+   |
+   v
+karakeep container port 3000
+```
+
+If Meilisearch is enabled, Karakeep uses `http://localhost:7700` inside the pod.
+If Chromium is enabled, Karakeep uses `http://localhost:<chromium.port>` inside
+the pod and can defer browser connection until a crawl needs it.
+
+## Data Layout
+
+All durable state is rooted at `/data`:
+
+- SQLite application database;
+- uploaded or archived bookmark content;
+- Meilisearch index data under `/data/meilisearch`;
+- operational state created by Karakeep at runtime.
+
+Backups should snapshot the PVC consistently. Because SQLite and Meilisearch live
+on the same volume by default, restore testing should include search reindexing
+and bookmark access checks.
+
+## Credential Flow
+
+The main container reads `NEXTAUTH_SECRET` from the configured Secret. When
+Meilisearch is enabled, both the main container and the Meilisearch sidecar read
+the same `MEILI_MASTER_KEY` key.
+
+With chart-managed credentials, Helm `lookup` preserves existing Secret data
+during upgrades. With External Secrets Operator, the chart renders only the
+ExternalSecret path and expects the operator to own the target Secret.
+
+## Public URL Contract
+
+`karakeep.nextAuthUrl` renders `NEXTAUTH_URL`. It must match the actual external
+URL used by clients. For example, an HTTPS ingress should use:
+
+```yaml
+karakeep:
+  nextAuthUrl: "https://karakeep.example.com"
+```
+
+For local port-forward tests, use the URL users open locally:
+
+```yaml
+karakeep:
+  nextAuthUrl: "http://localhost:3000"
+```
+
+## Scaling Boundary
+
+The chart is intentionally single-replica. SQLite and the default shared PVC are
+not a horizontal application architecture. Resource tuning should happen within
+the pod first; independent scaling of search or browser services requires moving
+those services outside this chart's default topology.

--- a/charts/karakeep/docs/operations.md
+++ b/charts/karakeep/docs/operations.md
@@ -1,0 +1,138 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Karakeep Operations
+
+## Preflight
+
+Render the chart before installing production values:
+
+```bash
+helm template karakeep charts/karakeep -f values.yaml
+make validate-chart CHART=karakeep
+```
+
+Verify that every image tag is pinned:
+
+```bash
+make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.32.0
+make image-verify IMAGE=docker.io/getmeili/meilisearch:v1.41.0
+make image-verify IMAGE=ghcr.io/browserless/chromium:v2.46.0
+```
+
+## Installation
+
+Local port-forward values:
+
+```yaml
+karakeep:
+  nextAuthUrl: "http://localhost:3000"
+```
+
+Install and open the UI:
+
+```bash
+helm install karakeep helmforge/karakeep -f values.yaml
+kubectl port-forward svc/karakeep-karakeep 3000:80
+```
+
+## Production Checklist
+
+- Set `karakeep.nextAuthUrl` to the exact external URL.
+- Use TLS at the Ingress, Gateway, or upstream edge proxy.
+- Set resource requests and limits for Karakeep, Meilisearch, and Chromium.
+- Use `karakeep.existingSecret` or External Secrets Operator for managed
+  credentials.
+- Define a PVC backup and restore procedure.
+- Add namespace NetworkPolicies or equivalent platform policy.
+
+## Health Checks
+
+Check rollout and container status:
+
+```bash
+kubectl rollout status deploy/karakeep-karakeep
+kubectl get pods -l app.kubernetes.io/name=karakeep
+kubectl logs deploy/karakeep-karakeep -c karakeep --tail=100
+```
+
+Inspect sidecars:
+
+```bash
+kubectl logs deploy/karakeep-karakeep -c meilisearch --tail=100
+kubectl logs deploy/karakeep-karakeep -c chromium --tail=100
+```
+
+## Backup and Restore
+
+Back up the PVC that backs `/data`. A restore should verify:
+
+- login succeeds with the restored `NEXTAUTH_SECRET`;
+- bookmarks and uploaded content are present;
+- Meilisearch starts and can search restored content;
+- Chromium capture still works for a new bookmark.
+
+If restoring into a new release name, either restore the Secret keys with the PVC
+or set `karakeep.existingSecret` to a Secret that contains the original
+`nextauth-secret` and `meili-master-key` values.
+
+## Common Issues
+
+### Login redirects fail
+
+Check `karakeep.nextAuthUrl`. It must match the public URL exactly, including
+scheme and host. A port-forward setup commonly needs:
+
+```yaml
+karakeep:
+  nextAuthUrl: "http://localhost:3000"
+```
+
+### Pod is OOMKilled
+
+The default sidecars are useful but memory intensive. Add limits and inspect the
+container that was killed:
+
+```bash
+kubectl describe pod -l app.kubernetes.io/name=karakeep
+kubectl logs -l app.kubernetes.io/name=karakeep -c chromium --tail=100
+```
+
+For small nodes, disable one or both sidecars:
+
+```yaml
+meilisearch:
+  enabled: false
+
+chromium:
+  enabled: false
+```
+
+### Search is unavailable
+
+Confirm Meilisearch is enabled and receiving the same master key as the main
+container:
+
+```bash
+kubectl get secret <secret-name> -o jsonpath='{.data.meili-master-key}'
+kubectl logs deploy/karakeep-karakeep -c meilisearch --tail=100
+```
+
+### Screenshots are not created
+
+Confirm Chromium is enabled and the configured port matches the sidecar:
+
+```bash
+kubectl get deploy karakeep-karakeep -o jsonpath='{.spec.template.spec.containers[*].name}'
+kubectl logs deploy/karakeep-karakeep -c chromium --tail=100
+```
+
+### ExternalSecret renders but pod cannot start
+
+The target Secret must exist before the Deployment can consume it. Check the
+ExternalSecret status and target Secret keys:
+
+```bash
+kubectl get externalsecret
+kubectl describe externalsecret karakeep-karakeep-secret
+kubectl get secret karakeep-app-secret
+```

--- a/charts/karakeep/examples/ai-tagging.yaml
+++ b/charts/karakeep/examples/ai-tagging.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# AI tagging example using a Secret-backed OpenAI API key.
+
+karakeep:
+  nextAuthUrl: "https://karakeep.example.com"
+  extraEnv:
+    - name: OPENAI_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: karakeep-ai-secret
+          key: openai-api-key
+    - name: OPENAI_BASE_URL
+      value: "https://api.openai.com/v1"
+
+meilisearch:
+  enabled: true
+
+chromium:
+  enabled: true
+
+persistence:
+  enabled: true
+  size: 20Gi

--- a/charts/karakeep/examples/external-secrets.yaml
+++ b/charts/karakeep/examples/external-secrets.yaml
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
+# External Secrets Operator example for Karakeep credentials.
+
 karakeep:
   existingSecret: karakeep-app-secret
+  nextAuthUrl: "https://karakeep.example.com"
 
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: helmforge-fake-store
+    name: platform-secrets
     kind: ClusterSecretStore
   data:
     - secretKey: nextauth-secret
       remoteRef:
-        key: test/token
+        key: karakeep/credentials
+        property: nextauth-secret
     - secretKey: meili-master-key
       remoteRef:
-        key: test/password
+        key: karakeep/credentials
+        property: meili-master-key

--- a/charts/karakeep/examples/ingress.yaml
+++ b/charts/karakeep/examples/ingress.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# TLS ingress example for Karakeep with search and capture sidecars enabled.
+
+karakeep:
+  nextAuthUrl: "https://karakeep.example.com"
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+meilisearch:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+chromium:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: karakeep.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - karakeep.example.com
+      secretName: karakeep-tls

--- a/charts/karakeep/examples/simple.yaml
+++ b/charts/karakeep/examples/simple.yaml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Local or private-network Karakeep with default search and browser sidecars.
+
+karakeep:
+  nextAuthUrl: "http://localhost:3000"
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+meilisearch:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+chromium:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi

--- a/charts/karakeep/templates/NOTES.txt
+++ b/charts/karakeep/templates/NOTES.txt
@@ -1,61 +1,67 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Karakeep has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Karakeep has been deployed.
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+Release:
+  Chart:      {{ .Chart.Name }}
+  Version:    {{ .Chart.Version }}
+  AppVersion: {{ .Chart.AppVersion }}
+  Release:    {{ .Release.Name }}
+  Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
+Access:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else if .Values.gatewayAPI.enabled }}
-Gateway API HTTPRoute has been rendered for Karakeep.
+  Gateway API HTTPRoute has been rendered for Karakeep.
 {{- with .Values.gatewayAPI.hostnames }}
-WEB UI:   http://{{ index . 0 }}/
+  Web UI: http://{{ index . 0 }}/
 {{- end }}
 {{- else }}
-Port-forward to access Karakeep locally:
+  Port-forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "karakeep.fullname" . }} 3000:{{ .Values.service.port }}
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "karakeep.fullname" . }} 3000:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:3000/
+  Web UI: http://localhost:3000/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-
+Configuration:
+  Karakeep image: {{ include "karakeep.image" . }}
+  Meilisearch enabled: {{ .Values.meilisearch.enabled }}
+  Chromium enabled: {{ .Values.chromium.enabled }}
+  Persistence enabled: {{ .Values.persistence.enabled }}
+{{- with .Values.karakeep.nextAuthUrl }}
+  NEXTAUTH_URL: {{ . }}
+{{- else }}
+  NEXTAUTH_URL: not set
+{{- end }}
 {{- with .Values.service.ipFamilyPolicy }}
-Service IP family policy:
-  {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
+  Service IP family policy: {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Validation:
+  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --timeout=300s
+  kubectl get pods -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=50
 
+Troubleshooting:
   kubectl describe pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Warnings:
+{{- if not .Values.karakeep.nextAuthUrl }}
+  - karakeep.nextAuthUrl is not set. Set it to the exact URL users open in the browser before production use.
+{{- end }}
+{{- if and .Values.meilisearch.enabled (not .Values.meilisearch.resources) }}
+  - meilisearch.resources is empty. Set resource requests and limits for production.
+{{- end }}
+{{- if and .Values.chromium.enabled (not .Values.chromium.resources) }}
+  - chromium.resources is empty. Set resource requests and limits for production.
+{{- end }}
 
-Documentation:  https://helmforge.dev/docs/charts/karakeep
-Karakeep:       https://karakeep.app | https://github.com/karakeep-app/karakeep
+Documentation:
+  https://helmforge.dev/docs/charts/karakeep
+  https://karakeep.app
 
 Happy Helmforging :)


### PR DESCRIPTION
## Summary
- Backfill Karakeep chart standards with DESIGN.md, docs, renderable examples, and plain-text NOTES.
- Add README Security Scan evidence and quality gates.
- Align the ExternalSecrets CI scenario with the HelmForge k3d fake store so runtime validation exercises ESO end to end.

## Validation
- make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.32.0
- make image-verify IMAGE=docker.io/getmeili/meilisearch:v1.41.0
- make image-verify IMAGE=ghcr.io/browserless/chromium:v2.46.0
- helm template karakeep charts/karakeep -f charts/karakeep/examples/simple.yaml
- helm template karakeep charts/karakeep -f charts/karakeep/examples/ingress.yaml
- helm template karakeep charts/karakeep -f charts/karakeep/examples/ai-tagging.yaml
- helm template karakeep charts/karakeep -f charts/karakeep/examples/external-secrets.yaml
- npx -y markdownlint-cli2 "charts/karakeep/README.md" "charts/karakeep/DESIGN.md" "charts/karakeep/docs/*.md"
- make deps-check CHART=karakeep
- make standards-check CHART=karakeep
- helm template karakeep charts/karakeep -f charts/karakeep/ci/external-secrets.yaml | kubeconform -strict -summary -schema-location default -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
- make k3d-validate CHART=karakeep VALUES=ci/external-secrets.yaml
- make validate-chart CHART=karakeep
- make site-sync-check CHART=karakeep
- make release-check REPO=charts
- make attribution-check REPO=charts

## Security Scan
- MITRE: 100.00%
- NSA: 60.00%
- SOC2: 80.00%
- Aggregate: 80.00%

## Site Sync
- Site PR: helmforgedev/site#257