### PR TITLE
fix(listmonk): complete chart standards

### DIFF
--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -51,6 +51,6 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/listmonk/DESIGN.md
+++ b/charts/listmonk/DESIGN.md
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Listmonk Design
+
+## Purpose
+
+The Listmonk chart deploys the newsletter application with the infrastructure
+pieces it needs to start safely on Kubernetes: PostgreSQL connectivity, uploads
+storage, database bootstrap and upgrade init containers, HTTP Service, optional
+Ingress, and optional S3-compatible database backups.
+
+## Default Architecture
+
+```text
+Browser
+   |
+   | port-forward or Ingress
+   v
+Listmonk Service
+   |
+   v
+Listmonk Deployment
+   |
+   +--> wait-for-postgresql init container
+   +--> db-init init container
+   +--> listmonk container on port 9000
+   +--> uploads PVC mounted at /listmonk/uploads
+   +--> PostgreSQL subchart or external PostgreSQL
+```
+
+Default characteristics:
+
+- one Listmonk replica;
+- bundled PostgreSQL subchart enabled;
+- persistent uploads PVC enabled;
+- no public ingress by default;
+- SMTP configured after install through the UI or through extra environment
+  variables;
+- database install and upgrade commands run before the main container starts.
+
+## Database Strategy
+
+`database.mode=auto` selects the bundled PostgreSQL subchart unless external
+database settings are present. Explicit modes fail fast when values conflict:
+
+- `postgresql` requires `postgresql.enabled=true`;
+- `external` requires external host or Secret configuration and forbids the
+  bundled subchart;
+- `auto` rejects ambiguous configurations where both bundled and external
+  database settings are active.
+
+The chart uses PostgreSQL Secret keys from either the subchart or an external
+Secret. Inline external passwords render into a chart-managed Secret, but
+production installs should prefer `database.external.existingSecret`.
+
+## Bootstrap and Upgrade
+
+The Listmonk container starts only after two init containers complete:
+
+- `wait-for-postgresql` uses `pg_isready` against the configured database host,
+  port, user, and database;
+- `db-init` runs `./listmonk --install --idempotent --yes --config=""` and then
+  `./listmonk --upgrade --yes --config=""` with the same database and app
+  address environment required by the Listmonk binary.
+
+This keeps fresh installs and upgrades deterministic while avoiding manual SQL
+steps for the bundled PostgreSQL path.
+
+## Storage Model
+
+Uploaded media is mounted at `/listmonk/uploads`. The PVC is independent from the
+PostgreSQL data volume managed by the subchart. Database backup does not back up
+uploaded media; operators need a separate PVC backup or object-store strategy for
+uploads.
+
+## Backup Model
+
+When `backup.enabled=true`, the chart renders:
+
+- a backup script ConfigMap;
+- a backup Secret when inline S3 credentials are used;
+- a CronJob with a `pg_dump` init container and an upload container.
+
+The backup path is intentionally database-only. It is useful for PostgreSQL
+restore points, but it is not a complete Listmonk disaster recovery plan unless
+uploads storage is backed up separately.
+
+## Security Posture
+
+The chart exposes resource, service account, pod security, and container security
+settings without hardcoding a single platform baseline. Production values should
+set resource requests and limits for Listmonk, PostgreSQL, and backup jobs, use
+Secrets for credentials, and add namespace NetworkPolicies or equivalent
+platform policy.
+
+## Validation
+
+The HelmForge gate for this chart is:
+
+```bash
+make validate-chart CHART=listmonk
+```
+
+This includes the bundled PostgreSQL path, external database templates, ingress,
+unit tests, kubeconform with real schemas, Artifact Hub lint, and k3d behavioral
+validation.

--- a/charts/listmonk/README.md
+++ b/charts/listmonk/README.md
@@ -1,103 +1,142 @@
 # Listmonk Helm Chart
 
-Self-hosted newsletter and mailing list manager for Kubernetes.
+Deploy [Listmonk](https://listmonk.app), a self-hosted newsletter and mailing
+list manager, on Kubernetes with a PostgreSQL backend, persistent uploads,
+idempotent database bootstrap, optional ingress, and optional S3-compatible
+database backups.
 
-[Listmonk](https://listmonk.app) is a high-performance, self-hosted newsletter and mailing list manager. It comes as a single binary with a built-in web UI for managing subscribers, campaigns, templates, and transactional emails.
+Current application version: `6.1.0`.
 
 ## Features
 
-- Bundled PostgreSQL via HelmForge subchart or external database support
-- Automatic database initialization and migration on startup
-- Persistent storage for media uploads
-- Configurable ingress with TLS support
-- Built-in PostgreSQL backup CronJob with S3 upload
-- First-access setup wizard for Super Admin account creation
-- SMTP configuration through the admin UI after installation
+- Official `docker.io/listmonk/listmonk:v6.1.0` image
+- HelmForge PostgreSQL subchart or external PostgreSQL mode
+- Init containers for `listmonk --install --idempotent` and `--upgrade`
+- Persistent upload storage mounted at `/listmonk/uploads`
+- Ingress with TLS support
+- Optional PostgreSQL backup CronJob using `pg_dump` and S3-compatible upload
+- Existing Secret support for external database and backup credentials
+- Extra environment variables for SMTP and application automation
 
-## Install
+## Installation
+
+HTTPS repository:
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
 helm repo update
-helm install listmonk helmforge/listmonk
+helm install listmonk helmforge/listmonk -f values.yaml
 ```
+
+OCI registry:
+
+```bash
+helm install listmonk oci://ghcr.io/helmforgedev/helm/listmonk -f values.yaml
+```
+
+## Examples
+
+The chart includes example values under `examples/`:
+
+- `examples/simple.yaml` - bundled PostgreSQL with persistent uploads.
+- `examples/ingress.yaml` - TLS ingress and explicit resources.
+- `examples/external-db.yaml` - managed external PostgreSQL.
+- `examples/backup.yaml` - S3-compatible PostgreSQL backup CronJob.
+
+Render an example before adapting it:
+
+```bash
+helm template listmonk charts/listmonk -f charts/listmonk/examples/ingress.yaml
+```
+
+## Architecture Guides
+
+- [Design rationale](DESIGN.md)
+- [Architecture guide](docs/architecture.md)
+- [Operations guide](docs/operations.md)
 
 ## Quick Start
 
-### Default install (bundled PostgreSQL)
+Install with bundled PostgreSQL:
 
 ```bash
 helm install listmonk helmforge/listmonk
+kubectl port-forward svc/listmonk 9000:80
 ```
 
-### External PostgreSQL
+Open `http://localhost:9000`, create the first Super Admin user in the setup
+wizard, and configure SMTP from the Listmonk UI under Settings > SMTP.
 
-```bash
-helm install listmonk helmforge/listmonk \
-  --set postgresql.enabled=false \
-  --set database.mode=external \
-  --set database.external.host=pg.example.com \
-  --set database.external.password=changeme
+## Database Modes
+
+Default mode deploys the HelmForge PostgreSQL subchart:
+
+```yaml
+postgresql:
+  enabled: true
+database:
+  mode: auto
 ```
 
-### With ingress
+External PostgreSQL disables the subchart and reads the password from either an
+inline value or an existing Secret:
 
-```bash
-helm install listmonk helmforge/listmonk \
-  --set ingress.enabled=true \
-  --set ingress.ingressClassName=traefik \
-  --set "ingress.hosts[0].host=listmonk.example.com" \
-  --set "ingress.hosts[0].paths[0].path=/" \
-  --set "ingress.hosts[0].paths[0].pathType=Prefix"
+```yaml
+postgresql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: listmonk
+    username: listmonk
+    existingSecret: listmonk-db
+    existingSecretPasswordKey: database-password
+    sslMode: require
 ```
 
-## Configuration
+External databases must already allow Listmonk to create required objects and
+must provide the PostgreSQL extensions Listmonk expects.
 
-SMTP and most application settings are configured through the Listmonk admin UI after installation at **Settings > SMTP**. The Helm chart handles infrastructure-level configuration (database, storage, ingress, probes).
+## Key Values
 
-### Admin Setup
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of Listmonk replicas |
+| `image.repository` | `docker.io/listmonk/listmonk` | Listmonk image |
+| `image.tag` | `"v6.1.0"` | Listmonk image tag |
+| `database.mode` | `auto` | Database mode: `auto`, `external`, or `postgresql` |
+| `postgresql.enabled` | `true` | Deploy the PostgreSQL subchart |
+| `storage.enabled` | `true` | Persist uploaded media |
+| `storage.size` | `5Gi` | Uploads PVC size |
+| `backup.enabled` | `false` | Enable PostgreSQL backup CronJob |
+| `backup.schedule` | `"0 3 * * *"` | Backup cron schedule |
+| `backup.s3.existingSecret` | `""` | Existing S3 credential Secret |
+| `ingress.enabled` | `false` | Enable Ingress |
+| `listmonk.extraEnv` | `[]` | Extra Listmonk environment variables |
 
-On first access, Listmonk displays a setup wizard where you create a Super Admin account. This is handled entirely through the web UI — the chart does not manage admin credentials.
+## Security Scan
 
-### Database Initialization
+Security Scan: Kubescape on rendered default manifests.
 
-The chart automatically runs `--install --idempotent --yes` and `--upgrade --yes` as init containers before the main application starts. This handles both fresh installs and upgrades.
+| Framework | Score |
+| --- | --- |
+| MITRE | 100.00% |
+| NSA | 70.00% |
+| SOC2 | 90.00% |
+| Aggregate | 86.67% |
 
-## Values
+Default findings are driven by intentionally unset platform-specific controls:
+resource limits, container hardening context, service account token mounting, and
+NetworkPolicy boundaries. Set `resources`, `securityContext`,
+`podSecurityContext`, and platform NetworkPolicies according to your cluster
+baseline.
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `replicaCount` | int | `1` | Number of replicas |
-| `image.repository` | string | `docker.io/listmonk/listmonk` | Image repository |
-| `image.tag` | string | `""` | Image tag (defaults to appVersion) |
-| `image.pullPolicy` | string | `IfNotPresent` | Pull policy |
-| `listmonk.extraEnv` | list | `[]` | Additional environment variables |
-| `database.mode` | string | `auto` | Database mode: `auto`, `external`, `postgresql` |
-| `database.external.host` | string | `""` | External PostgreSQL hostname |
-| `database.external.port` | int | `5432` | External PostgreSQL port |
-| `database.external.name` | string | `listmonk` | External database name |
-| `database.external.username` | string | `listmonk` | External database username |
-| `database.external.password` | string | `""` | External database password |
-| `database.external.sslMode` | string | `disable` | PostgreSQL SSL mode |
-| `database.external.existingSecret` | string | `""` | Existing secret for database password |
-| `postgresql.enabled` | bool | `true` | Deploy PostgreSQL subchart |
-| `postgresql.auth.database` | string | `listmonk` | PostgreSQL database name |
-| `postgresql.auth.username` | string | `listmonk` | PostgreSQL username |
-| `storage.enabled` | bool | `true` | Enable persistent uploads storage |
-| `storage.size` | string | `5Gi` | Uploads PVC size |
-| `storage.existingClaim` | string | `""` | Use existing PVC |
-| `backup.enabled` | bool | `false` | Enable backup CronJob |
-| `backup.schedule` | string | `0 3 * * *` | Backup cron schedule |
-| `service.type` | string | `ClusterIP` | Service type |
-| `service.port` | int | `80` | Service port |
-| `ingress.enabled` | bool | `false` | Enable ingress |
-| `ingress.ingressClassName` | string | `""` | Ingress class (`traefik`, `nginx`, etc.) |
-| `ingress.hosts` | list | `[]` | Ingress hosts |
-| `ingress.tls` | list | `[]` | Ingress TLS configuration |
+## Backups
 
-## Backup
-
-Enable PostgreSQL backups to S3-compatible storage:
+Backups are opt-in. Use an existing Secret for S3 credentials in production:
 
 ```yaml
 backup:
@@ -105,37 +144,36 @@ backup:
   schedule: "0 3 * * *"
   s3:
     endpoint: https://s3.amazonaws.com
-    bucket: my-backups
+    bucket: listmonk-backups
     prefix: listmonk
-    accessKey: AKIAIOSFODNN7EXAMPLE
-    secretKey: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    existingSecret: listmonk-s3-credentials
 ```
 
-Or use an existing secret:
+The backup CronJob dumps the configured PostgreSQL database and uploads the
+archive with the configured object prefix.
 
-```yaml
-backup:
-  enabled: true
-  s3:
-    endpoint: https://s3.amazonaws.com
-    bucket: my-backups
-    existingSecret: my-s3-credentials
+## Quality Gates
+
+Before proposing a merge for this chart, run:
+
+```bash
+make deps-check CHART=listmonk
+make standards-check CHART=listmonk
+make validate-chart CHART=listmonk
+make site-sync-check CHART=listmonk
 ```
 
-<!-- @AI-METADATA
-type: chart-readme
-title: Listmonk Helm Chart
-description: Helm chart for deploying Listmonk newsletter and mailing list manager on Kubernetes
+## Limitations
 
-keywords: listmonk, newsletter, mailing-list, email, helm, kubernetes
+- Keep `replicaCount=1` unless the database, uploads storage, sessions, and
+  operational model have been validated for concurrent Listmonk pods.
+- The chart does not manage SMTP credentials as first-class values; use the UI or
+  `listmonk.extraEnv` with Secrets.
+- Built-in backups cover PostgreSQL. Uploaded media on the uploads PVC needs a
+  separate storage backup plan.
 
-purpose: Installation and configuration guide for the Listmonk Helm chart
-scope: Chart Documentation
+## More Information
 
-relations:
-  - charts/listmonk/values.yaml
-  - charts/listmonk/Chart.yaml
-path: charts/listmonk/README.md
-version: 1.0
-date: 2026-04-03
--->
+- [Listmonk documentation](https://listmonk.app/docs)
+- [Listmonk source](https://github.com/knadh/listmonk)
+- [HelmForge chart source](https://github.com/helmforgedev/charts/tree/main/charts/listmonk)

--- a/charts/listmonk/ci/external-db-values.yaml
+++ b/charts/listmonk/ci/external-db-values.yaml
@@ -6,9 +6,63 @@ postgresql:
 database:
   mode: external
   external:
-    host: postgres.example.com
+    host: listmonk-external-postgres
     port: 5432
     name: listmonk
     username: listmonk
     password: changeme
-    sslMode: require
+    sslMode: disable
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: listmonk-external-postgres
+      labels:
+        app.kubernetes.io/name: listmonk-external-postgres
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: listmonk-external-postgres
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: listmonk-external-postgres
+        spec:
+          containers:
+            - name: postgres
+              image: docker.io/library/postgres:17-alpine
+              ports:
+                - name: postgres
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: listmonk
+                - name: POSTGRES_USER
+                  value: listmonk
+                - name: POSTGRES_PASSWORD
+                  value: changeme
+              readinessProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - listmonk
+                    - -d
+                    - listmonk
+                initialDelaySeconds: 5
+                periodSeconds: 5
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: listmonk-external-postgres
+      labels:
+        app.kubernetes.io/name: listmonk-external-postgres
+    spec:
+      ports:
+        - name: postgres
+          port: 5432
+          targetPort: postgres
+      selector:
+        app.kubernetes.io/name: listmonk-external-postgres

--- a/charts/listmonk/docs/architecture.md
+++ b/charts/listmonk/docs/architecture.md
@@ -1,0 +1,77 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Listmonk Architecture
+
+Listmonk is a web application for newsletters, mailing lists, campaigns, and
+transactional email. The HelmForge chart runs the application with PostgreSQL and
+upload storage as the durable state layers.
+
+## Components
+
+| Component | Kubernetes resource | Purpose |
+| --- | --- | --- |
+| Listmonk | Deployment | Runs the web UI, API, campaign worker, and SMTP sender. |
+| Database init | Init containers | Waits for PostgreSQL, installs schema, and applies upgrades. |
+| PostgreSQL | Subchart or external service | Stores subscribers, lists, campaigns, settings, and SMTP config. |
+| Uploads | PersistentVolumeClaim | Stores uploaded media and campaign assets. |
+| Service | Service | Exposes Listmonk HTTP on port 80 inside the cluster. |
+| Ingress | Ingress | Optional external HTTP/TLS route. |
+| Backup | ConfigMap, Secret, CronJob | Optional PostgreSQL dump and S3-compatible upload flow. |
+
+## Request Flow
+
+```text
+User
+   |
+   | HTTP request
+   v
+Ingress or port-forward
+   |
+   v
+Service port 80
+   |
+   v
+Listmonk container port 9000
+```
+
+Listmonk stores application settings, including SMTP settings configured through
+the UI, in PostgreSQL. Uploaded assets are stored on the uploads PVC.
+
+## Database Flow
+
+With bundled PostgreSQL, the application points at the release-scoped
+PostgreSQL Service and reads the generated application user Secret. With external
+PostgreSQL, the chart points Listmonk at the configured host and reads the
+password from an existing Secret or chart-managed Secret.
+
+For external databases, create the database, user, privileges, and required
+extensions before installing the chart. The Listmonk init container still runs
+the idempotent schema install and upgrade commands.
+
+## Backup Flow
+
+```text
+CronJob schedule
+   |
+   v
+postgres-backup init container
+   |
+   | writes dump archive
+   v
+emptyDir work directory
+   |
+   v
+upload container
+   |
+   v
+S3-compatible bucket
+```
+
+Backups read the same database Secret as Listmonk and read S3 credentials from
+`backup.s3.existingSecret` or the chart-managed backup Secret.
+
+## Scaling Boundary
+
+The chart defaults to one replica. Before increasing `replicaCount`, validate
+session behavior, uploads storage semantics, database connection limits, and
+campaign scheduling behavior for multiple Listmonk pods.

--- a/charts/listmonk/docs/operations.md
+++ b/charts/listmonk/docs/operations.md
@@ -1,0 +1,122 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Listmonk Operations
+
+## Preflight
+
+Render the target values and run the chart gate:
+
+```bash
+helm template listmonk charts/listmonk -f values.yaml
+make validate-chart CHART=listmonk
+```
+
+Verify the pinned images:
+
+```bash
+make image-verify IMAGE=docker.io/listmonk/listmonk:v6.1.0
+make image-verify IMAGE=docker.io/library/postgres:17-alpine
+make image-verify IMAGE=docker.io/helmforge/mc:1.0.0
+```
+
+## Installation
+
+Bundled PostgreSQL:
+
+```bash
+helm install listmonk helmforge/listmonk
+kubectl port-forward svc/listmonk 9000:80
+```
+
+Open `http://localhost:9000`, create the first Super Admin account, then
+configure SMTP in Settings > SMTP.
+
+## Production Checklist
+
+- Decide between bundled PostgreSQL and an external managed PostgreSQL service.
+- Use existing Secrets for external database and backup credentials.
+- Set resource requests and limits for Listmonk, PostgreSQL, and backup jobs.
+- Set ingress TLS or provide an equivalent edge proxy.
+- Back up both PostgreSQL and the uploads PVC.
+- Configure DNS records required for email deliverability outside the chart.
+
+## Health Checks
+
+Check rollout and init container status:
+
+```bash
+kubectl rollout status deploy/listmonk
+kubectl get pods -l app.kubernetes.io/name=listmonk
+kubectl logs deploy/listmonk -c listmonk --tail=100
+```
+
+If startup stalls, inspect init containers:
+
+```bash
+kubectl logs deploy/listmonk -c wait-for-postgresql --tail=100
+kubectl logs deploy/listmonk -c db-init --tail=100
+```
+
+## Backup and Restore
+
+Enable database backups with an existing S3 credential Secret:
+
+```yaml
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: listmonk-backups
+    existingSecret: listmonk-s3-credentials
+```
+
+Restore testing should verify:
+
+- PostgreSQL database dump imports successfully;
+- the Super Admin account can log in;
+- lists, subscribers, and campaigns are present;
+- uploaded media still exists after restoring the uploads PVC.
+
+## Common Issues
+
+### Init container waits forever
+
+The database host or port is unreachable. Check the selected database mode:
+
+```bash
+helm get values listmonk
+kubectl logs deploy/listmonk -c wait-for-postgresql --tail=100
+```
+
+### Database migration fails
+
+Inspect the `db-init` logs and verify database privileges:
+
+```bash
+kubectl logs deploy/listmonk -c db-init --tail=200
+```
+
+For external PostgreSQL, ensure the user can create required objects in the
+configured database.
+
+### Uploaded images disappear
+
+Check whether `storage.enabled=false`, a different existing PVC was configured,
+or the uploads PVC was deleted:
+
+```bash
+kubectl get pvc
+kubectl describe deploy/listmonk
+```
+
+### Backups do not run
+
+Check the CronJob and last Job:
+
+```bash
+kubectl get cronjob listmonk-backup
+kubectl describe cronjob listmonk-backup
+kubectl logs job/<job-name> --all-containers
+```
+
+Backups require database credentials plus S3 endpoint, bucket, and credentials.

--- a/charts/listmonk/examples/backup.yaml
+++ b/charts/listmonk/examples/backup.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# PostgreSQL backup CronJob using existing S3-compatible credentials.
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  archivePrefix: listmonk
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: listmonk-backups
+    prefix: listmonk
+    existingSecret: listmonk-s3-credentials
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/charts/listmonk/examples/external-db.yaml
+++ b/charts/listmonk/examples/external-db.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Listmonk connected to an externally managed PostgreSQL database.
+
+postgresql:
+  enabled: false
+
+database:
+  mode: external
+  external:
+    host: postgres.example.com
+    port: 5432
+    name: listmonk
+    username: listmonk
+    existingSecret: listmonk-db-credentials
+    existingSecretPasswordKey: database-password
+    sslMode: require
+
+storage:
+  enabled: true
+  size: 10Gi

--- a/charts/listmonk/examples/ingress.yaml
+++ b/charts/listmonk/examples/ingress.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# TLS ingress with bundled PostgreSQL and explicit Listmonk resources.
+
+replicaCount: 1
+
+storage:
+  enabled: true
+  size: 10Gi
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: listmonk.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: listmonk-tls
+      hosts:
+        - listmonk.example.com

--- a/charts/listmonk/examples/simple.yaml
+++ b/charts/listmonk/examples/simple.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Bundled PostgreSQL with persistent uploads for a private Listmonk install.
+
+replicaCount: 1
+
+storage:
+  enabled: true
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+postgresql:
+  enabled: true
+  standalone:
+    persistence:
+      enabled: true
+      size: 8Gi

--- a/charts/listmonk/templates/NOTES.txt
+++ b/charts/listmonk/templates/NOTES.txt
@@ -1,18 +1,67 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 Listmonk has been deployed.
 
+Release:
+  Chart:      {{ .Chart.Name }}
+  Version:    {{ .Chart.Version }}
+  AppVersion: {{ .Chart.AppVersion }}
+  Release:    {{ .Release.Name }}
+  Namespace:  {{ .Release.Namespace }}
+
+Access:
 {{- if .Values.ingress.enabled }}
-Access Listmonk at:
 {{- range .Values.ingress.hosts }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+  Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
 {{- end }}
 {{- else }}
-To access the Listmonk admin UI, run:
+  Port-forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "listmonk.fullname" . }} 9000:{{ .Values.service.port }}
 
-  kubectl port-forward svc/{{ include "listmonk.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
-
-Then open http://localhost:{{ .Values.service.port }} in your browser.
+  Web UI: http://localhost:9000/
 {{- end }}
 
-On first access, Listmonk will prompt you to create a Super Admin account.
-Configure SMTP and other settings through the admin UI at Settings > SMTP.
+Configuration:
+  Listmonk image: {{ include "listmonk.image" . }}
+  Replicas: {{ .Values.replicaCount }}
+  Database mode: {{ include "listmonk.databaseMode" . | trim }}
+  Database host: {{ include "listmonk.databaseHost" . }}
+  Upload storage enabled: {{ .Values.storage.enabled }}
+  Backup enabled: {{ .Values.backup.enabled }}
+{{- if .Values.backup.enabled }}
+  Backup schedule: {{ .Values.backup.schedule }}
+  Backup bucket: {{ .Values.backup.s3.bucket }}
+{{- end }}
+
+Validation:
+  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }} --timeout=300s
+  kubectl get pods -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }} -c listmonk --tail=50
+
+Getting started:
+  1. Open the Listmonk web UI.
+  2. Create the first Super Admin account in the setup wizard.
+  3. Configure SMTP in Settings > SMTP before sending campaigns.
+
+Troubleshooting:
+  kubectl describe pod -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }} -c wait-for-postgresql --tail=100
+  kubectl logs -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }} -c db-init --tail=100
+  kubectl logs -l app.kubernetes.io/name=listmonk -n {{ .Release.Namespace }} -c listmonk --tail=100
+  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Warnings:
+{{- if gt (int .Values.replicaCount) 1 }}
+  - replicaCount is greater than 1. Validate uploads storage, sessions, and campaign scheduling before production use.
+{{- end }}
+{{- if not .Values.resources }}
+  - resources is empty. Set Listmonk CPU and memory requests/limits for production.
+{{- end }}
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+  - backup.s3.existingSecret is empty. Prefer existing Secrets for backup credentials in production.
+{{- end }}
+
+Documentation:
+  https://helmforge.dev/docs/charts/listmonk
+  https://listmonk.app/docs
+
+Happy Helmforging :)

--- a/charts/listmonk/templates/deployment.yaml
+++ b/charts/listmonk/templates/deployment.yaml
@@ -38,16 +38,16 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-postgresql
-          image: docker.io/library/busybox:1.37
+          image: docker.io/library/postgres:17-alpine
           command:
             - sh
             - -c
             - |
-              echo "Waiting for {{ include "listmonk.databaseHost" . }}:{{ include "listmonk.databasePort" . }} ..."
-              until nc -z -w2 {{ include "listmonk.databaseHost" . }} {{ include "listmonk.databasePort" . }}; do
+              echo "Waiting for PostgreSQL readiness at {{ include "listmonk.databaseHost" . }}:{{ include "listmonk.databasePort" . }} ..."
+              until pg_isready -h {{ include "listmonk.databaseHost" . | quote }} -p {{ include "listmonk.databasePort" . | quote }} -U {{ include "listmonk.databaseUsername" . | quote }} -d {{ include "listmonk.databaseName" . | quote }}; do
                 sleep 2
               done
-              echo "PostgreSQL is reachable."
+              echo "PostgreSQL is accepting connections."
         - name: db-init
           image: {{ include "listmonk.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -58,6 +58,8 @@ spec:
               ./listmonk --install --idempotent --yes --config="" && \
               ./listmonk --upgrade --yes --config=""
           env:
+            - name: LISTMONK_app__address
+              value: "0.0.0.0:9000"
             - name: LISTMONK_db__host
               value: {{ include "listmonk.databaseHost" . | quote }}
             - name: LISTMONK_db__port

--- a/charts/listmonk/tests/deployment_test.yaml
+++ b/charts/listmonk/tests/deployment_test.yaml
@@ -36,6 +36,12 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-postgresql
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/postgres:17-alpine
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: pg_isready
 
   - it: includes db-init init container
     template: templates/deployment.yaml
@@ -43,6 +49,11 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[1].name
           value: db-init
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: LISTMONK_app__address
+            value: "0.0.0.0:9000"
 
   - it: sets database env vars
     template: templates/deployment.yaml


### PR DESCRIPTION
## Summary
- Backfill Listmonk chart standards with DESIGN.md, docs, examples, README Security Scan, and operational NOTES.
- Bump the HelmForge PostgreSQL subchart dependency from 1.9.11 to 2.0.3.
- Fix Listmonk init behavior for PostgreSQL 2.0.3 by using pg_isready and providing LISTMONK_app__address to db-init.
- Make the external database CI scenario k3d-valid with an in-namespace external PostgreSQL fixture.

## Validation
- make image-verify IMAGE=docker.io/listmonk/listmonk:v6.1.0
- make image-verify IMAGE=docker.io/library/postgres:17-alpine
- make image-verify IMAGE=docker.io/helmforge/mc:1.0.0
- helm template listmonk charts/listmonk -f charts/listmonk/examples/simple.yaml
- helm template listmonk charts/listmonk -f charts/listmonk/examples/ingress.yaml
- helm template listmonk charts/listmonk -f charts/listmonk/examples/external-db.yaml
- helm template listmonk charts/listmonk -f charts/listmonk/examples/backup.yaml
- npx -y markdownlint-cli2 "charts/listmonk/README.md" "charts/listmonk/DESIGN.md" "charts/listmonk/docs/*.md"
- make deps-check CHART=listmonk
- make standards-check CHART=listmonk
- helm template listmonk charts/listmonk -f charts/listmonk/ci/external-db-values.yaml | kubeconform -strict -summary -schema-location default -schema-location "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
- make k3d-validate CHART=listmonk VALUES=ci/external-db-values.yaml
- make validate-chart CHART=listmonk
- make site-sync-check CHART=listmonk
- make release-check REPO=charts
- make attribution-check REPO=charts

## Security Scan
- MITRE: 100.00%
- NSA: 70.00%
- SOC2: 90.00%
- Aggregate: 86.67%

## Site Sync
- Site PR: helmforgedev/site#258