### PR TITLE
fix(liwan): complete chart standards

### DIFF
--- a/charts/liwan/DESIGN.md
+++ b/charts/liwan/DESIGN.md
@@ -1,0 +1,86 @@
+# Liwan Chart Design
+
+This chart deploys Liwan as a single-instance web analytics service using the official `ghcr.io/explodingcamera/liwan:1.5.0` image.
+
+## Product Model
+
+Liwan is a compact Rust service for privacy-focused web analytics. It serves the UI, receives tracking events, and
+stores analytics data through an embedded DuckDB database. The runtime data directory is mounted at `/data`.
+
+The chart does not model an external database because the upstream application is designed around local embedded storage.
+The Kubernetes contract is therefore a single pod with durable storage, predictable networking, and explicit public URL
+configuration.
+
+## Default Topology
+
+Defaults target a production-safe single instance:
+
+- `replicas: 1`
+- `strategy.type: Recreate`
+- `persistence.enabled: true`
+- one PVC mounted at `/data`
+- Service on port `80` targeting container port `9042`
+- ServiceAccount token automount disabled
+- non-root UID/GID `1000`
+- `RuntimeDefault` seccomp profile
+- dropped Linux capabilities
+
+`Recreate` is intentional. DuckDB is embedded and single-writer oriented, so the chart avoids overlapping pods during rollout.
+
+## Persistence
+
+The `/data` volume stores the DuckDB analytics database and runtime data such as GeoIP assets. The default PVC size is
+`2Gi`, which is enough for small installations and test environments. Production installations should size the PVC based
+on traffic volume and retention expectations.
+
+When `persistence.enabled=false`, the chart uses `emptyDir`. That mode is only appropriate for demos and CI because analytics history is lost when the pod is replaced.
+
+## Public URL
+
+`liwan.baseUrl` renders `LIWAN_BASE_URL`. Set it to the external URL before installing tracking snippets. Without a
+public base URL, the UI can still run, but generated tracker URLs can point at an internal or incomplete endpoint.
+
+## Exposure
+
+The chart supports three exposure paths:
+
+- ClusterIP Service for internal or port-forward access
+- Kubernetes Ingress with class, hosts, paths, and TLS
+- Gateway API HTTPRoute for clusters using Gateway controllers
+
+Ingress and Gateway API are independent. Operators should enable one public routing path per release unless they intentionally need both during migration.
+
+## Security Choices
+
+Liwan does not need Kubernetes API access, so `serviceAccount.automountServiceAccountToken` defaults to `false`.
+
+The pod and container security contexts default to:
+
+- non-root UID/GID `1000`
+- `fsGroup: 1000`
+- `fsGroupChangePolicy: OnRootMismatch`
+- `seccompProfile.type: RuntimeDefault`
+- `allowPrivilegeEscalation: false`
+- `capabilities.drop: [ALL]`
+
+`readOnlyRootFilesystem` is not forced by default because the upstream image behavior around temporary files is not a stable chart contract. Persistent application data remains isolated to `/data`.
+
+## Scaling
+
+The chart intentionally renders one replica and does not expose `replicaCount`. Horizontal scaling would require a
+different storage model than embedded DuckDB. Run separate Liwan releases for isolated sites or environments.
+
+## Validation Scope
+
+The chart has unit tests for:
+
+- Deployment strategy and image selection
+- non-root and hardened security contexts
+- ServiceAccount token automount
+- PVC and `emptyDir` behavior
+- base URL environment wiring
+- Ingress rendering
+- Gateway API HTTPRoute rendering
+- dual-stack Service fields
+
+Behavioral validation uses the default persistent single-pod topology in k3d.

--- a/charts/liwan/README.md
+++ b/charts/liwan/README.md
@@ -2,24 +2,25 @@
 
 # Liwan Helm Chart
 
-Deploy [Liwan](https://liwan.dev) on Kubernetes using the official
-[ghcr.io/explodingcamera/liwan](https://github.com/explodingcamera/liwan/pkgs/container/liwan)
-container image. Ultra-lightweight privacy-first web analytics written in Rust with embedded DuckDB.
+Deploy [Liwan](https://liwan.dev) on Kubernetes with the official
+`ghcr.io/explodingcamera/liwan:1.5.0` image.
+
+Liwan is a lightweight, privacy-focused web analytics application. It runs as a single Rust service and stores analytics
+data in embedded DuckDB under `/data`.
 
 ## Features
 
-- **Ultra-lightweight** — single Rust binary, minimal CPU and memory usage
-- **Zero dependencies** — DuckDB embedded, no external database needed
-- **Privacy-first** — no cookies, no personal data collection
-- **Non-root** — runs as UID 1000 by default
-- **Persistent storage** — DuckDB database and GeoIP data on PVC
-- **Ingress support** — TLS with cert-manager
-- **Gateway API support** — optional HTTPRoute for native Kubernetes routing
-- **Dual-stack ready Service** — optional `ipFamilyPolicy` and `ipFamilies`
+- Official upstream image pinned by tag
+- Single-instance topology aligned with embedded DuckDB
+- Persistent `/data` volume for analytics and runtime assets
+- `Recreate` rollout strategy to avoid overlapping DuckDB writers
+- Public URL wiring through `LIWAN_BASE_URL`
+- Ingress and Gateway API exposure options
+- Dual-stack Service support
+- Non-root security context with token automount disabled
+- Extra manifests, volumes, mounts, labels, and annotations for platform integration
 
-## Installation
-
-**HTTPS repository:**
+## Install
 
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
@@ -27,94 +28,147 @@ helm repo update
 helm install liwan helmforge/liwan -f values.yaml
 ```
 
-**OCI registry:**
+OCI registry:
 
 ```bash
 helm install liwan oci://ghcr.io/helmforgedev/helm/liwan -f values.yaml
 ```
 
-## Basic Example
+## Production Example
 
 ```yaml
-# values.yaml - default values are sufficient
-# DuckDB embedded, no database needed
+liwan:
+  baseUrl: https://analytics.example.com
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: analytics.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: liwan-tls
+      hosts:
+        - analytics.example.com
 ```
 
-After deploying:
+## Architecture
 
-```bash
-kubectl port-forward svc/<release>-liwan 9042:80
-# Open http://localhost:9042
+The chart renders one Deployment, one Service, and a PVC by default. Liwan listens on container port `9042`; the Service
+exposes port `80`.
+
+The Deployment uses `strategy.type: Recreate` because the application stores data in embedded DuckDB. A rolling update
+could briefly run two writers against the same data volume, so the chart prefers a short outage during upgrades over a
+risky overlapping write window.
+
+Set `liwan.baseUrl` to the public URL used by browsers and tracking scripts:
+
+```yaml
+liwan:
+  baseUrl: https://analytics.example.com
 ```
+
+## Tracking Script
+
+After installing Liwan, create a site in the UI and use the generated tracking snippet. A typical snippet looks like:
+
+```html
+<script defer src="https://analytics.example.com/script.js" data-site-name="my-site"></script>
+```
+
+Keep `liwan.baseUrl`, Ingress hostnames, Gateway API hostnames, and TLS hosts aligned so generated URLs match the public
+endpoint.
+
+## Examples
+
+- [Simple internal deployment](examples/simple.yaml)
+- [Ingress with TLS](examples/ingress.yaml)
+- [Gateway API](examples/gateway-api.yaml)
+- [Dual-stack Service](examples/dual-stack.yaml)
 
 ## Key Values
 
 | Key | Default | Description |
-|-----|---------|-------------|
-| `image.repository` | `ghcr.io/explodingcamera/liwan` | Liwan image repository |
-| `image.tag` | `"1.5.0"` | Liwan image tag |
-| `liwan.port` | `9042` | Application port |
-| `liwan.baseUrl` | `""` | Public base URL |
-| `persistence.enabled` | `true` | Enable persistence for /data |
-| `persistence.size` | `2Gi` | PVC size |
-| `ingress.enabled` | `false` | Enable ingress |
-| `service.port` | `80` | Service port |
-| `service.ipFamilyPolicy` | `null` | Service IP family policy |
-| `service.ipFamilies` | `[]` | Ordered Service IP families |
-| `gatewayAPI.enabled` | `false` | Render a Gateway API HTTPRoute |
+| --- | --- | --- |
+| `image.repository` | `ghcr.io/explodingcamera/liwan` | Liwan image repository. |
+| `image.tag` | `"1.5.0"` | Liwan image tag. |
+| `liwan.port` | `9042` | Application HTTP port. |
+| `liwan.baseUrl` | `""` | Public base URL for UI and tracking scripts. |
+| `liwan.extraEnv` | `[]` | Extra environment variables for advanced upstream settings. |
+| `persistence.enabled` | `true` | Persist `/data`. |
+| `persistence.size` | `2Gi` | PVC size. |
+| `service.port` | `80` | Kubernetes Service port. |
+| `service.ipFamilyPolicy` | `null` | Optional Service IP family policy. |
+| `service.ipFamilies` | `[]` | Optional ordered IP families. |
+| `ingress.enabled` | `false` | Render an Ingress. |
+| `gatewayAPI.enabled` | `false` | Render a Gateway API HTTPRoute. |
+| `serviceAccount.automountServiceAccountToken` | `false` | Mount a Kubernetes API token into the pod. |
+| `extraManifests` | `[]` | Additional Kubernetes resources to render with the release. |
 
-## Gateway API Example
+## Operations
 
-```yaml
-gatewayAPI:
-  enabled: true
-  parentRefs:
-    - name: shared-gateway
-      namespace: gateway-system
-      sectionName: https
-  hostnames:
-    - analytics.example.com
+Check rollout:
+
+```bash
+kubectl rollout status deployment/liwan-liwan
+kubectl get deployment,svc,pvc -l app.kubernetes.io/name=liwan,app.kubernetes.io/instance=liwan
 ```
 
-## Dual-Stack Service Example
+Port-forward for local access:
 
-```yaml
-service:
-  ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6
+```bash
+kubectl port-forward svc/liwan-liwan 9042:80
 ```
 
-## Upgrade Notes
+Back up the PVC mounted at `/data`. For consistent snapshots, pause writes or scale the Deployment to zero before taking
+a storage-level snapshot.
 
-Liwan `1.5.0` is published in GHCR and includes the unreleased upstream changelog entries after `v1.4.0`,
-including additional trusted proxy/header options, new dimensions, DuckDB updates, and startup locking fixes.
-The chart keeps the single-replica `Recreate` strategy because DuckDB remains single-writer storage.
+## Security
 
-## Limitations
+Default security posture:
 
-- **Single instance only** — DuckDB is single-writer, horizontal scaling is not supported
-- **ReadWriteOnce** — PVC must be ReadWriteOnce due to DuckDB limitations
+- ServiceAccount token automount disabled
+- non-root UID/GID `1000`
+- `fsGroup: 1000`
+- `fsGroupChangePolicy: OnRootMismatch`
+- `seccompProfile.type: RuntimeDefault`
+- `allowPrivilegeEscalation: false`
+- `capabilities.drop: [ALL]`
 
-## More Information
+Resource requests and limits are intentionally user-defined because Liwan traffic profiles vary by site. Set them for
+production to satisfy cluster policy and capacity planning.
 
-- [Liwan documentation](https://liwan.dev)
-- [Source code](https://github.com/helmforgedev/charts/tree/main/charts/liwan)
+## Security Scan: `liwan`
 
-<!-- @AI-METADATA
-type: chart-readme
-title: Liwan Helm Chart
-description: README for the Liwan ultra-lightweight web analytics Helm chart
+| Framework | Score |
+| --- | --- |
+| Overall | **84.85%** |
+| MITRE | **100.00%** |
+| NSA | **80.00%** |
+| SOC2 | **80.00%** |
 
-keywords: liwan, analytics, privacy, duckdb, lightweight, rust
+Security posture acceptable. Remaining findings are resource limits, network policy, and immutable root filesystem,
+which are environment-specific choices for this chart.
 
-purpose: Chart installation, configuration, and usage documentation
-scope: Chart
+## Documentation
 
-relations:
-  - charts/liwan/values.yaml
-path: charts/liwan/README.md
-version: 1.0
-date: 2026-04-01
--->
+- [Architecture](docs/architecture.md)
+- [Operations](docs/operations.md)
+- [Liwan official documentation](https://liwan.dev)
+- [Upstream source](https://github.com/explodingcamera/liwan)

--- a/charts/liwan/ci/ip-family-policy.yaml
+++ b/charts/liwan/ci/ip-family-policy.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: explicit single-stack Service settings supported by the k3d validation cluster.
+service:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4

--- a/charts/liwan/docs/architecture.md
+++ b/charts/liwan/docs/architecture.md
@@ -1,0 +1,61 @@
+# Liwan Architecture
+
+Liwan runs as one HTTP application process backed by embedded DuckDB storage.
+
+## Runtime Components
+
+The Helm chart renders:
+
+- a Deployment named after the release
+- a ClusterIP Service
+- a PersistentVolumeClaim when persistence is enabled
+- optional Ingress
+- optional Gateway API HTTPRoute
+- optional extra manifests supplied through `extraManifests`
+
+The container listens on `liwan.port`, which defaults to `9042`. The Service exposes port `80` and forwards to the named `http` container port.
+
+## Storage Layout
+
+The pod mounts a volume named `data` at `/data`.
+
+With default values, that volume is a chart-managed PVC named `<release>-liwan-data`. If `persistence.existingClaim` is
+set, the chart mounts the existing claim instead. If persistence is disabled, the chart uses `emptyDir`.
+
+DuckDB files and runtime assets live on this mounted volume. Treat the PVC as the source of truth for backup and restore.
+
+## Rollout Model
+
+The Deployment uses `strategy.type: Recreate`.
+
+This prevents old and new pods from writing to the same DuckDB-backed data directory at the same time during upgrades.
+The tradeoff is a short outage during rollout, which is preferable to overlapping writers for this application model.
+
+## Public Endpoint
+
+`liwan.baseUrl` sets `LIWAN_BASE_URL`.
+
+Set this value to the same URL users and tracking scripts will use, for example:
+
+```yaml
+liwan:
+  baseUrl: https://analytics.example.com
+```
+
+For public deployments, keep `liwan.baseUrl`, Ingress hostnames, Gateway API hostnames, and TLS hosts aligned.
+
+## Network Entry Points
+
+For local or internal access, use the Service directly:
+
+```bash
+kubectl port-forward svc/liwan-liwan 9042:80
+```
+
+For public access, use either Ingress or Gateway API. Both route to the same Service backend and do not change the application runtime.
+
+## Security Boundary
+
+Liwan does not need Kubernetes API access. The chart disables ServiceAccount token automount and uses non-root security
+defaults. Restrict network ingress at the cluster, namespace, or Ingress controller level when Liwan should only receive
+traffic from trusted front doors.

--- a/charts/liwan/docs/operations.md
+++ b/charts/liwan/docs/operations.md
@@ -1,0 +1,90 @@
+# Liwan Operations
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install liwan helmforge/liwan -f values.yaml
+```
+
+## Runtime Checks
+
+Check the rollout:
+
+```bash
+kubectl rollout status deployment/liwan-liwan
+kubectl get deployment,svc,pvc -l app.kubernetes.io/name=liwan,app.kubernetes.io/instance=liwan
+```
+
+Inspect logs:
+
+```bash
+kubectl logs -l app.kubernetes.io/name=liwan,app.kubernetes.io/instance=liwan --tail=100
+```
+
+Open a local tunnel:
+
+```bash
+kubectl port-forward svc/liwan-liwan 9042:80
+```
+
+Then open `http://127.0.0.1:9042`.
+
+## Public URL
+
+Set `liwan.baseUrl` before using tracking snippets:
+
+```yaml
+liwan:
+  baseUrl: https://analytics.example.com
+```
+
+If the UI loads but tracking scripts fail, verify that the public URL, Ingress host, TLS host, and browser URL all match.
+
+## Backups
+
+Back up the PVC mounted at `/data`.
+
+Recommended order:
+
+1. Stop writes by scaling the Deployment to zero or pausing traffic.
+2. Snapshot the PVC with the cluster storage provider.
+3. Restore traffic after the snapshot completes.
+4. Test restore into a separate namespace before relying on the backup.
+
+For small installations, a storage-level snapshot is simpler and safer than copying files from a live DuckDB process.
+
+## Upgrades
+
+Before upgrading:
+
+1. Back up the PVC.
+2. Review upstream Liwan release notes for storage changes.
+3. Run `helm upgrade`.
+4. Watch the Deployment rollout.
+5. Check logs for startup or DuckDB migration messages.
+
+```bash
+helm upgrade liwan helmforge/liwan -f values.yaml
+kubectl rollout status deployment/liwan-liwan
+kubectl logs -l app.kubernetes.io/name=liwan,app.kubernetes.io/instance=liwan --tail=100
+```
+
+## Common Failures
+
+`The pod is pending`
+
+Check whether the PVC is bound and whether the requested StorageClass exists.
+
+`The UI works but tracking scripts use the wrong URL`
+
+Set `liwan.baseUrl` to the public URL and align it with the routing hostname.
+
+`Data disappeared after restart`
+
+Verify `persistence.enabled=true` and that the Deployment is mounting the expected PVC. `emptyDir` mode is ephemeral.
+
+`Ingress returns 404`
+
+Verify the host, path, Ingress class, and controller logs. The Service backend should be `<release>-liwan` on port `80`.

--- a/charts/liwan/examples/dual-stack.yaml
+++ b/charts/liwan/examples/dual-stack.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Prefer a dual-stack Service when the cluster supports IPv4 and IPv6.
 service:
   ipFamilyPolicy: PreferDualStack
   ipFamilies:

--- a/charts/liwan/examples/gateway-api.yaml
+++ b/charts/liwan/examples/gateway-api.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# Public Liwan deployment through Gateway API.
+liwan:
+  baseUrl: https://analytics.example.com
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - analytics.example.com
+  paths:
+    - type: PathPrefix
+      value: /

--- a/charts/liwan/examples/ingress.yaml
+++ b/charts/liwan/examples/ingress.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Public Liwan deployment through Kubernetes Ingress and TLS.
+liwan:
+  baseUrl: https://analytics.example.com
+
+persistence:
+  enabled: true
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: analytics.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: liwan-tls
+      hosts:
+        - analytics.example.com

--- a/charts/liwan/examples/simple.yaml
+++ b/charts/liwan/examples/simple.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Minimal persistent Liwan deployment for port-forward or private routing.
+
+persistence:
+  enabled: true
+  size: 2Gi

--- a/charts/liwan/templates/NOTES.txt
+++ b/charts/liwan/templates/NOTES.txt
@@ -1,84 +1,77 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Liwan has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Liwan deployment summary
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
+Chart: {{ .Chart.Name }}
+Version: {{ .Chart.Version }}
 AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Access
 
 {{- if .Values.ingress.enabled }}
+Ingress is enabled.
 {{- range $host := .Values.ingress.hosts }}
-WEB UI:    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
-TRACKER:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}:9042/
+- Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+- Tracker: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/script.js
 {{- end }}
 {{- else }}
-Port-forward to access Liwan locally:
+Run this command to access Liwan locally:
 
   kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "liwan.fullname" . }} 9042:{{ .Values.service.port }}
 
-  WEB UI:   http://localhost:9042/
+Then open:
+
+  http://localhost:9042/
 {{- end }}
 {{- if .Values.gatewayAPI.enabled }}
 
-Gateway API HTTPRoute rendered.
+Gateway API
+
+An HTTPRoute was rendered.
 {{- with .Values.gatewayAPI.hostnames }}
 Hostnames:
 {{- range . }}
-  - {{ . }}
+- {{ . }}
 {{- end }}
 {{- end }}
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  CONFIGURATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Configuration
 
-Base URL:
 {{- if .Values.liwan.baseUrl }}
-  {{ .Values.liwan.baseUrl }}
+Base URL: {{ .Values.liwan.baseUrl }}
 {{- else }}
-  Not configured. Set liwan.baseUrl to the public URL before enabling tracking scripts.
+Base URL: not configured. Set liwan.baseUrl to the public URL before installing tracking snippets.
 {{- end }}
-Persistence:
 {{- if .Values.persistence.enabled }}
-  enabled, claim {{ include "liwan.dataClaimName" . }}
+Persistence: enabled, claim {{ include "liwan.dataClaimName" . }}
 {{- else }}
-  disabled, data is stored on an emptyDir volume and is lost on pod restart
+Persistence: disabled. Analytics data is stored on emptyDir and is lost when the pod restarts.
 {{- end }}
 {{- with .Values.service.ipFamilyPolicy }}
-Service IP family policy:
-  {{ . }}
+Service IP family policy: {{ . }}
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Next steps
 
-1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --timeout=300s
-2. kubectl get pods -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }}
-3. kubectl logs -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+1. Wait for the pod:
+   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --timeout=300s
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+2. Check recent logs:
+   kubectl logs -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --all-containers --tail=50
 
+3. Create a site in the Liwan UI and install the generated tracking snippet.
+
+Troubleshooting
+
+Describe the pod:
   kubectl describe pod -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=liwan -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Inspect release resources:
+  kubectl get all,pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-Documentation:  https://helmforge.dev/docs/charts/liwan
-Liwan:          https://liwan.dev | https://github.com/explodingcamera/liwan
+Documentation: https://helmforge.dev/docs/charts/liwan
+Upstream: https://liwan.dev
 
 Happy Helmforging :)

--- a/charts/liwan/templates/deployment.yaml
+++ b/charts/liwan/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "liwan.serviceAccountName" . }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/liwan/tests/deployment_test.yaml
+++ b/charts/liwan/tests/deployment_test.yaml
@@ -32,11 +32,26 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 1000
       - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1000
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: should not automount a service account token by default
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
 
   - it: should mount data volume
     asserts:

--- a/charts/liwan/values.schema.json
+++ b/charts/liwan/values.schema.json
@@ -42,7 +42,8 @@
       "properties": {
         "create": { "type": "boolean", "default": false },
         "name": { "type": "string", "default": "" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean", "default": false }
       }
     },
     "service": {

--- a/charts/liwan/values.yaml
+++ b/charts/liwan/values.yaml
@@ -62,6 +62,8 @@ serviceAccount:
   name: ""
   # -- Annotations for the ServiceAccount
   annotations: {}
+  # -- Automount the Kubernetes API token into the pod
+  automountServiceAccountToken: false
 
 # =============================================================================
 # Service
@@ -156,11 +158,18 @@ resources: {}
 
 podSecurityContext:
   fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   runAsUser: 1000
   runAsGroup: 1000
   runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # =============================================================================
 # Scheduling


### PR DESCRIPTION
## Summary
- add Liwan design, architecture, operations, and example values documentation
- remove README metadata block and add local Security Scan results
- harden the default pod security context and disable ServiceAccount token automount
- replace the k3d-incompatible dual-stack CI values file with an IPv4 SingleStack CI scenario while keeping dual-stack coverage in tests and examples

## Validation
- make standards-check CHART=liwan
- make deps-check CHART=liwan
- make image-verify IMAGE=ghcr.io/explodingcamera/liwan:1.5.0
- helm lint --strict charts/liwan
- helm unittest charts/liwan
- kubescape scan framework "MITRE,NSA,SOC2" "charts/liwan"
- make validate-chart CHART=liwan

## Site
- helmforgedev/site#259