### PR TITLE
fix(ddns-updater): complete chart standards

### DIFF
--- a/charts/ddns-updater/DESIGN.md
+++ b/charts/ddns-updater/DESIGN.md
@@ -1,0 +1,74 @@
+# DDNS Updater Chart Design
+
+This chart packages `ddns-updater` as a single-replica dynamic DNS controller
+with a web status UI and optional persistent update history.
+
+## Architecture
+
+```text
+Public IP checkers
+  |
+  v
+ddns-updater pod
+  |
+  +-- reads config.json from a Kubernetes Secret
+  +-- writes update history to /updater/data
+  +-- calls configured DNS provider APIs
+  +-- serves status UI on the ClusterIP Service
+```
+
+The application is intentionally deployed with `Recreate` strategy and one
+replica. Multiple replicas can race provider API updates and write conflicting
+history. Availability comes from quick restarts and persistent state, not
+horizontal scaling.
+
+## Design Choices
+
+- DNS provider credentials are rendered into a chart-managed Secret only for
+  simple starts. Production deployments should prefer `config.existingSecret`
+  with a pre-created `config.json`.
+- Persistence is enabled by default because `updates.json` is small and useful
+  for debugging provider update history.
+- The web UI is private by default. Operators can use port-forwarding or enable
+  Ingress explicitly.
+- Default resources are intentionally small, matching the lightweight polling
+  workload while satisfying resource governance.
+- The pod runs as the upstream image user `1000:1000`, disables service account
+  token automount, drops Linux capabilities, blocks privilege escalation, uses a
+  read-only root filesystem, and relies on `RuntimeDefault` seccomp.
+
+## Security Model
+
+The workload does not need Kubernetes API access after its Secret and PVC are
+mounted, so `serviceAccount.automountServiceAccountToken=false` is the default.
+Provider API tokens are sensitive credentials. Use `config.existingSecret` for
+production so tokens are not exposed in Helm release values.
+
+NetworkPolicy is not rendered by this chart because DNS provider access and
+public IP detection endpoints vary by deployment. Platform policy should define
+egress boundaries for the namespaces where this chart runs.
+
+## Non-Goals
+
+- The chart does not create DNS provider API tokens.
+- The chart does not validate provider-specific `config.settings` schemas.
+- The chart does not scale beyond one replica by default.
+- The chart does not render NetworkPolicy because required egress differs by
+  provider and IP detection strategy.
+
+## Validation Focus
+
+- Default chart-managed empty settings Secret.
+- Cloudflare settings rendering.
+- Existing Secret consumption for `config.json`.
+- Persistence and no-persistence runtime paths.
+- Ingress rendering for web UI exposure.
+- Restricted pod and ServiceAccount token defaults.
+
+## Related Files
+
+- `charts/ddns-updater/README.md`
+- `charts/ddns-updater/docs/providers.md`
+- `charts/ddns-updater/examples/simple/values.yaml`
+- `charts/ddns-updater/examples/production/values.yaml`
+- `charts/ddns-updater/examples/multi-provider/values.yaml`

--- a/charts/ddns-updater/README.md
+++ b/charts/ddns-updater/README.md
@@ -14,6 +14,7 @@ This chart currently deploys `qmcgaw/ddns-updater:2.10.0`.
 - **Persistent history** — update history stored in a PVC
 - **Existing secrets** — bring your own Secret for credentials
 - **Ingress support** — expose the web UI with TLS
+- **Restricted runtime** — non-root container, read-only root filesystem, dropped capabilities, and ServiceAccount token automount disabled
 
 ## Installation
 
@@ -106,8 +107,15 @@ config:
 | `ddns.rootUrl` | `/` | Web UI root URL path |
 | `persistence.enabled` | `true` | Persist update history |
 | `persistence.size` | `256Mi` | PVC size |
+| `resources.requests.cpu` | `10m` | Default CPU request |
+| `resources.requests.memory` | `32Mi` | Default memory request |
+| `resources.limits.cpu` | `100m` | Default CPU limit |
+| `resources.limits.memory` | `128Mi` | Default memory limit |
+| `serviceAccount.automountServiceAccountToken` | `false` | Mount Kubernetes API token into pods |
 | `service.port` | `80` | Web UI service port |
 | `ingress.enabled` | `false` | Enable ingress |
+| `podSecurityContext.runAsUser` | `1000` | Upstream image user |
+| `securityContext.readOnlyRootFilesystem` | `true` | Keep the container root filesystem read-only |
 
 ## Operations
 
@@ -118,19 +126,31 @@ Before upgrading, confirm the provider-specific configuration format against the
 kubectl logs -l app.kubernetes.io/name=ddns-updater --all-containers --tail=100
 ```
 
+## Security Scan
+
+🟢 Security Scan: `ddns-updater`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **93.94%** |
+
+> ✅ Security posture acceptable.
+
+Local details:
+
+| Framework | Score |
+|---|---|
+| MITRE | 100.00% |
+| NSA | 95.00% |
+| SOC2 | 80.00% |
+
+The remaining local scan findings are expected for raw chart scanning and
+platform-level controls: NetworkPolicy and egress firewall policy are supplied
+by the platform layer because DNS provider APIs and public IP detection
+endpoints vary by deployment.
+
 ## More Information
 
 - [Supported providers](docs/providers.md)
 - [Upstream documentation](https://github.com/qdm12/ddns-updater)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/ddns-updater)
-
-<!-- @AI-METADATA
-@description: README for the ddns-updater Helm chart
-@type: chart-readme
-@chart: ddns-updater
-@path: charts/ddns-updater/README.md
-@date: 2026-05-05
-@relations:
-  - charts/ddns-updater/values.yaml
-  - charts/ddns-updater/docs/providers.md
--->

--- a/charts/ddns-updater/docs/providers.md
+++ b/charts/ddns-updater/docs/providers.md
@@ -74,14 +74,3 @@ For all providers and their fields, see the
 
 Supported providers include Cloudflare, AWS Route53, Google, DuckDNS, Namecheap, GoDaddy, DigitalOcean, Hetzner, OVH,
 Linode, Porkbun, Gandi, Dynu, NoIP, FreeDNS, Infomaniak, IONOS, Strato, Netcup, and many more.
-
-<!-- @AI-METADATA
-@description: Supported DNS providers reference for the ddns-updater Helm chart
-@type: chart-docs
-@chart: ddns-updater
-@path: charts/ddns-updater/docs/providers.md
-@date: 2026-05-05
-@relations:
-  - charts/ddns-updater/README.md
-  - charts/ddns-updater/values.yaml
--->

--- a/charts/ddns-updater/templates/NOTES.txt
+++ b/charts/ddns-updater/templates/NOTES.txt
@@ -1,54 +1,58 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  DDNS Updater has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+DDNS Updater has been deployed.
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
-AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+Release:
+  Chart:      {{ .Chart.Name }}
+  Version:    {{ .Chart.Version }}
+  AppVersion: {{ .Chart.AppVersion }}
+  Release:    {{ .Release.Name }}
+  Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-DDNS Updater runs as a background service — no inbound web UI by default.
+Access:
+  DDNS Updater runs as a background service. The web UI is not exposed outside
+  the cluster unless ingress is enabled.
 
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-WEB UI:   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else }}
-Port-forward to access the status UI:
+  Port-forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ddns-updater.fullname" . }} 8000:{{ .Values.service.port }}
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ddns-updater.fullname" . }} 8000:{{ .Values.service.port }}
-
-  WEB UI:   http://localhost:8000/
+  Web UI:
+    http://localhost:8000/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Configuration:
+{{- if .Values.config.existingSecret }}
+  Config source: existing Secret {{ .Values.config.existingSecret }}
+  Config key:    {{ .Values.config.existingSecretKey }}
+{{- else }}
+  Config source: chart-managed Secret {{ include "ddns-updater.configSecretName" . }}
+  Records:       {{ len (.Values.config.settings | default list) }}
+{{- end }}
+  Data path:     /updater/data
+  Persistence:   {{ ternary "enabled" "disabled" .Values.persistence.enabled }}
 
-1. kubectl get pods -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
-2. kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-3. Check that your DNS provider credentials are configured correctly
+Security:
+  ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
+  Run as non-root:                {{ .Values.podSecurityContext.runAsNonRoot }}
+  Read-only root filesystem:      {{ .Values.securityContext.readOnlyRootFilesystem }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Next Steps:
+  1. Check pod status:
+       kubectl get pods -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
+  2. Follow logs:
+       kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+  3. Confirm provider credentials and DNS records in the web UI or logs.
 
+Troubleshooting:
   kubectl describe pod -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=100
-  kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
-  kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get all,pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-Documentation:   https://helmforge.dev/docs/charts/ddns-updater
-ddns-updater GH: https://github.com/qdm12/ddns-updater
+Documentation:
+  https://helmforge.dev/docs/charts/ddns-updater
 
 Happy Helmforging :)

--- a/charts/ddns-updater/templates/deployment.yaml
+++ b/charts/ddns-updater/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "ddns-updater.serviceAccountName" . }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/ddns-updater/templates/serviceaccount.yaml
+++ b/charts/ddns-updater/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/ddns-updater/tests/deployment_test.yaml
+++ b/charts/ddns-updater/tests/deployment_test.yaml
@@ -30,6 +30,13 @@ tests:
           path: spec.replicas
           value: 1
 
+  - it: should disable service account token automount by default
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
   - it: should set the correct image with v prefix
     template: templates/deployment.yaml
     asserts:
@@ -170,6 +177,47 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
           value: 10m
+
+  - it: should set secure default pod and container contexts
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: should set default resource requests and limits
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 32Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
 
   - it: should include config checksum annotation
     template: templates/deployment.yaml

--- a/charts/ddns-updater/tests/serviceaccount_test.yaml
+++ b/charts/ddns-updater/tests/serviceaccount_test.yaml
@@ -20,3 +20,15 @@ tests:
       - equal:
           path: metadata.name
           value: test-ddns-updater
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should allow automount token when explicitly enabled
+    set:
+      serviceAccount.create: true
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/ddns-updater/values.schema.json
+++ b/charts/ddns-updater/values.schema.json
@@ -169,6 +169,11 @@
           "description": "Create a ServiceAccount",
           "default": false
         },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Mount Kubernetes API token into pods",
+          "default": false
+        },
         "name": {
           "type": "string",
           "description": "ServiceAccount name",

--- a/charts/ddns-updater/values.yaml
+++ b/charts/ddns-updater/values.yaml
@@ -100,6 +100,8 @@ persistence:
 serviceAccount:
   # -- Create a ServiceAccount
   create: false
+  # -- Mount Kubernetes API token into pods
+  automountServiceAccountToken: false
   # -- ServiceAccount name
   name: ""
   # -- Annotations for the ServiceAccount
@@ -171,16 +173,31 @@ probes:
 # Resources and Security
 # =============================================================================
 
-resources: {}
-  # requests:
-  #   cpu: 10m
-  #   memory: 16Mi
-  # limits:
-  #   memory: 64Mi
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
 # =============================================================================
 # Scheduling


### PR DESCRIPTION
## Summary
- Add the ddns-updater DESIGN.md architecture record and replace NOTES.txt with plain HelmForge text output.
- Backfill README standards, security scan evidence, and remove prohibited metadata from chart docs.
- Harden default runtime settings with explicit resources, non-root contexts, read-only root filesystem, and disabled service account token automount.
- Add unit coverage for the new security/resource/service account defaults.

## Site Sync
- helmforgedev/site#263

## Validation
- helm lint charts/ddns-updater --strict
- helm unittest charts/ddns-updater (36 passed)
- node scripts/charts/standards-check.js --chart ddns-updater --json
- make standards-check CHART=ddns-updater JSON=1
- make standards-guard JSON=1
- make md-lint REPO=charts
- make validate-chart CHART=ddns-updater
  - FULLY VALIDATED, 14 layers
  - k3d cluster: k3d-helmforge-tests-wsl
  - scenarios: default, ci/cloudflare-values, ci/default-values, ci/ingress-values, ci/no-persistence-values
- make release-check REPO=charts
- make attribution-check REPO=charts

## Security Evidence
- Kubescape MITRE: 100.00%
- Kubescape NSA: 95.00%
- Kubescape SOC2: 80.00%
- Combined chart score: 93.94%
- Remaining findings are expected platform NetworkPolicy/firewall controls.