### PR TITLE
fix(discount-bandit): complete chart standards

### DIFF
--- a/charts/discount-bandit/DESIGN.md
+++ b/charts/discount-bandit/DESIGN.md
@@ -142,16 +142,25 @@ The chart separates storage concerns:
 
 ## Security
 
-Defaults avoid mounting the Kubernetes API token:
+Defaults avoid mounting the Kubernetes API token and apply conservative controls that are compatible with the current
+upstream image:
 
 ```yaml
 serviceAccount:
   automountServiceAccountToken: false
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
 ```
 
-The upstream image currently runs Supervisor and worker processes in a way that is not assumed to be non-root safe. For that
-reason the chart exposes `podSecurityContext` and `securityContext` but does not force a restrictive default that could break
-the application before K3D validation.
+The upstream image currently runs Supervisor and worker processes as root and listens on port 80. For that reason the chart
+does not force `runAsNonRoot`, `readOnlyRootFilesystem`, or dropped capabilities by default; those require upstream image
+changes or dedicated runtime validation for FrankenPHP, Supervisor, and Chromium crawlers.
+
+The chart also sets resource requests and limits for both Discount Bandit and the bundled MySQL subchart so the default
+install has explicit scheduler and quota behavior.
 
 ## Production Checklist
 

--- a/charts/discount-bandit/README.md
+++ b/charts/discount-bandit/README.md
@@ -19,6 +19,8 @@ Gotify.
 - Optional persistent logs volume mounted at `/logs`
 - Optional PodDisruptionBudget
 - Kubernetes-safe Supervisor base config that removes the upstream unauthenticated Supervisor HTTP endpoint
+- Conservative runtime defaults with service account token automount disabled, RuntimeDefault seccomp, privilege escalation
+  disabled, and explicit resources
 - Production example with MySQL, Gateway API, NetworkPolicy, and resources
 
 ## Installation
@@ -88,6 +90,7 @@ resources:
     cpu: 250m
     memory: 512Mi
   limits:
+    cpu: 1000m
     memory: 1Gi
 ```
 
@@ -213,6 +216,10 @@ networkPolicy:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `mysql.enabled` | `true` | Deploy HelmForge MySQL as the primary database. |
+| `mysql.standalone.resources.requests.cpu` | `250m` | Default CPU request for the bundled MySQL pod. |
+| `mysql.standalone.resources.requests.memory` | `512Mi` | Default memory request for the bundled MySQL pod. |
+| `mysql.standalone.resources.limits.cpu` | `1000m` | Default CPU limit for the bundled MySQL pod. |
+| `mysql.standalone.resources.limits.memory` | `1Gi` | Default memory limit for the bundled MySQL pod. |
 | `database.mode` | `auto` | Database mode: `auto`, `mysql`, `external`, or `sqlite`. |
 | `database.sqlite.enabled` | `false` | Enables explicit SQLite development mode. |
 | `discountBandit.appUrl` | `""` | Public application URL (`APP_URL`). |
@@ -226,9 +233,29 @@ networkPolicy:
 | `externalSecrets.enabled` | `false` | Enable External Secrets Operator resources. |
 | `networkPolicy.enabled` | `false` | Render NetworkPolicy. |
 | `serviceAccount.automountServiceAccountToken` | `false` | Disable Kubernetes API token mount by default. |
+| `resources.requests.cpu` | `250m` | Default CPU request for the Discount Bandit container. |
+| `resources.requests.memory` | `512Mi` | Default memory request for the Discount Bandit container. |
+| `resources.limits.cpu` | `1000m` | Default CPU limit for the Discount Bandit container. |
+| `resources.limits.memory` | `1Gi` | Default memory limit for the Discount Bandit container. |
+| `podSecurityContext.seccompProfile.type` | `RuntimeDefault` | Use the Kubernetes RuntimeDefault seccomp profile. |
+| `securityContext.allowPrivilegeEscalation` | `false` | Disable privilege escalation for the application container. |
 | `persistence.logs.enabled` | `false` | Persist `/logs` instead of using `emptyDir`. |
 | `supervisor.configMap.enabled` | `true` | Replace the upstream Supervisor base config with a Kubernetes-safe config. |
 | `pdb.enabled` | `false` | Render PodDisruptionBudget. |
+
+## Security Scan
+
+Security Scan: `discount-bandit`
+
+| Framework | Score |
+|-----------|-------|
+| MITRE + NSA + SOC2 | **91.21%** |
+| MITRE | **100.00%** |
+| NSA | **87.50%** |
+| SOC2 | **92.00%** |
+
+The remaining expected findings are tied to the upstream root runtime, writable application filesystem needs, and
+NetworkPolicy/firewall decisions that depend on crawler and notification destinations.
 
 ## Operational Notes
 
@@ -239,6 +266,7 @@ networkPolicy:
 - SQLite is suitable for development and small personal installs only.
 - Production deployments should use the MySQL subchart or external MySQL/MariaDB.
 - Enable NetworkPolicy carefully because product crawling and notifications need outbound internet access.
+- See `docs/operations.md` for runtime, database, crawler egress, routing, and validation guidance.
 
 ## More Information
 

--- a/charts/discount-bandit/ci/external-mysql-values.yaml
+++ b/charts/discount-bandit/ci/external-mysql-values.yaml
@@ -1,13 +1,82 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external MySQL with native Secret
+# CI: external MySQL with native Secret and an in-cluster MySQL fixture
 database:
   mode: external
   external:
     type: mysql
-    host: mysql.example.com
+    host: discount-bandit-external-mysql
     port: 3306
     name: discount_bandit
     username: discount_bandit
     password: change-me
 mysql:
   enabled: false
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: discount-bandit-external-mysql
+      labels:
+        app.kubernetes.io/name: discount-bandit-external-mysql
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+      selector:
+        app.kubernetes.io/name: discount-bandit-external-mysql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: discount-bandit-external-mysql
+      labels:
+        app.kubernetes.io/name: discount-bandit-external-mysql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: discount-bandit-external-mysql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: discount-bandit-external-mysql
+        spec:
+          automountServiceAccountToken: false
+          securityContext:
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:9.7.0
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: mysql
+                  containerPort: 3306
+              env:
+                - name: MYSQL_DATABASE
+                  value: discount_bandit
+                - name: MYSQL_USER
+                  value: discount_bandit
+                - name: MYSQL_PASSWORD
+                  value: change-me
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-change-me
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi

--- a/charts/discount-bandit/ci/external-secrets-values.yaml
+++ b/charts/discount-bandit/ci/external-secrets-values.yaml
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: External Secrets for app and external database credentials
+# CI: External Secrets for app and external database credentials with local fake store
 database:
   mode: external
   external:
-    host: mysql.example.com
+    host: discount-bandit-eso-mysql
     name: discount_bandit
     username: discount_bandit
 mysql:
@@ -11,17 +11,98 @@ mysql:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: cluster-secrets
+    name: discount-bandit-ci-fake-store
+    kind: SecretStore
   app:
     enabled: true
     appKeyRemoteRef:
-      key: discount-bandit/app
-      property: app-key
+      key: app-key
     exchangeRateApiKeyRemoteRef:
-      key: discount-bandit/app
-      property: exchange-rate-api-key
+      key: exchange-rate-api-key
   database:
     enabled: true
     passwordRemoteRef:
-      key: discount-bandit/mysql
-      property: password
+      key: database-password
+extraManifests:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: discount-bandit-ci-fake-store
+    spec:
+      provider:
+        fake:
+          data:
+            - key: app-key
+              value: base64:MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+            - key: exchange-rate-api-key
+              value: test-exchange-rate-key
+            - key: database-password
+              value: helmforge-test-password
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: discount-bandit-eso-mysql
+      labels:
+        app.kubernetes.io/name: discount-bandit-eso-mysql
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+      selector:
+        app.kubernetes.io/name: discount-bandit-eso-mysql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: discount-bandit-eso-mysql
+      labels:
+        app.kubernetes.io/name: discount-bandit-eso-mysql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: discount-bandit-eso-mysql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: discount-bandit-eso-mysql
+        spec:
+          automountServiceAccountToken: false
+          securityContext:
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:9.7.0
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: mysql
+                  containerPort: 3306
+              env:
+                - name: MYSQL_DATABASE
+                  value: discount_bandit
+                - name: MYSQL_USER
+                  value: discount_bandit
+                - name: MYSQL_PASSWORD
+                  value: helmforge-test-password
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-change-me
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+                runAsGroup: 999
+                runAsNonRoot: true
+                runAsUser: 999
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi

--- a/charts/discount-bandit/ci/production-values.yaml
+++ b/charts/discount-bandit/ci/production-values.yaml
@@ -37,4 +37,5 @@ resources:
     cpu: 250m
     memory: 512Mi
   limits:
+    cpu: 1000m
     memory: 1Gi

--- a/charts/discount-bandit/docs/operations.md
+++ b/charts/discount-bandit/docs/operations.md
@@ -1,0 +1,53 @@
+# Discount Bandit Operations
+
+## Runtime Profile
+
+Discount Bandit runs a Laravel application with FrankenPHP, a scheduler, queue workers, and Chromium-based crawlers in a
+single upstream container. The chart keeps one Deployment with `Recreate` strategy so SQLite development mode and log
+volumes are not mounted concurrently by multiple pods.
+
+The upstream image currently runs as root and listens on port 80. The chart therefore applies conservative hardening by
+default:
+
+- service account token automount disabled
+- RuntimeDefault seccomp profile
+- privilege escalation disabled
+- explicit CPU and memory requests and limits
+
+Do not force `runAsNonRoot`, `readOnlyRootFilesystem`, or dropped capabilities without validating the upstream image and
+Chromium crawler behavior in a real workload test.
+
+## Database Modes
+
+Use the default HelmForge MySQL subchart for production when the cluster should own the database lifecycle. Use
+`database.mode=external` when a platform MySQL or MariaDB service already exists. SQLite mode is intended for development
+and small personal installs only and should stay at `replicaCount=1`.
+
+Production database values should use Secrets or External Secrets for `APP_KEY`, database passwords, and optional
+exchange-rate credentials.
+
+## Crawling And Egress
+
+Discount Bandit crawls product pages and can send notifications through user-configured providers. NetworkPolicy should be
+enabled only after the required outbound destinations are understood. The production example allows DNS, HTTPS crawler
+traffic, and same-namespace MySQL egress.
+
+If product updates stop working after enabling NetworkPolicy, inspect:
+
+```bash
+kubectl logs -n discount-bandit -l app.kubernetes.io/name=discount-bandit --all-containers --tail=100
+kubectl describe networkpolicy -n discount-bandit
+```
+
+## Routing
+
+Set `discountBandit.appUrl` and `discountBandit.assetUrl` before exposing the application. Use Gateway API when the
+cluster has a platform-owned Gateway. Use classic Ingress for clusters that still standardize on an Ingress controller.
+
+## Validation Checklist
+
+- Confirm the first admin account can be created through the web UI.
+- Add one product and verify crawler logs show successful fetches.
+- Confirm MySQL or external database credentials are read from the intended Secret.
+- Review memory use after enabling Chromium-heavy stores and adjust `resources` for the workload.
+- Enable NetworkPolicy only after crawler and notification egress has been tested.

--- a/charts/discount-bandit/examples/production.yaml
+++ b/charts/discount-bandit/examples/production.yaml
@@ -56,4 +56,5 @@ resources:
     cpu: 250m
     memory: 512Mi
   limits:
+    cpu: 1000m
     memory: 1Gi

--- a/charts/discount-bandit/tests/deployment_test.yaml
+++ b/charts/discount-bandit/tests/deployment_test.yaml
@@ -152,6 +152,30 @@ tests:
           path: spec.template.spec.automountServiceAccountToken
           value: false
 
+  - it: should set default resource requests and limits
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1000m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 1Gi
+
+  - it: should set conservative default security controls
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
   - it: should use TCP probes
     asserts:
       - equal:

--- a/charts/discount-bandit/values.yaml
+++ b/charts/discount-bandit/values.yaml
@@ -103,6 +103,13 @@ mysql:
     persistence:
       enabled: true
       size: 8Gi
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
   serviceAccount:
     automountServiceAccountToken: false
   startupProbe:
@@ -286,11 +293,20 @@ supervisor:
 # Resources and Security
 # =============================================================================
 
-resources: {}
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
 
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 
 # =============================================================================
 # NetworkPolicy


### PR DESCRIPTION
## Summary
- Add Discount Bandit operational docs and the required README Security Scan section.
- Add conservative default resources for Discount Bandit and bundled MySQL.
- Add compatible runtime hardening with RuntimeDefault seccomp and privilege escalation disabled.
- Fix CI values for External MySQL and External Secrets so k3d validation uses real local fixtures instead of unreachable placeholder hosts/stores.
- Extend unit coverage for resource and security defaults.

## Site Sync
- helmforgedev/site#264

## Validation
- docker manifest inspect docker.io/cybrarist/discount-bandit:v4.0.4
- docker image inspect docker.io/cybrarist/discount-bandit:v4.0.4
- helm lint charts/discount-bandit --strict
- helm unittest charts/discount-bandit (38 passed)
- make standards-check CHART=discount-bandit JSON=1
- make standards-guard JSON=1
- make md-lint REPO=charts
- make k3d-validate CHART=discount-bandit VALUES=ci/external-mysql-values.yaml
- make k3d-validate CHART=discount-bandit VALUES=ci/external-secrets-values.yaml
- make validate-chart CHART=discount-bandit
  - FULLY VALIDATED, 19 layers
  - k3d cluster: k3d-helmforge-tests-wsl
  - scenarios: default, ci/default-values, ci/dual-stack-values, ci/external-mysql-values, ci/external-secrets-values, ci/gateway-values, ci/ingress-values, ci/network-policy-values, ci/production-values, ci/sqlite-values
- make release-check REPO=charts
- make attribution-check REPO=charts

## Security Evidence
- Kubescape MITRE: 100.00%
- Kubescape NSA: 87.50%
- Kubescape SOC2: 92.00%
- Combined chart score: 91.21%
- Remaining findings are expected for the upstream root runtime, writable application filesystem, and environment-specific NetworkPolicy/firewall controls.