### PR TITLE
fix(dolibarr): complete chart standards

### DIFF
--- a/charts/dolibarr/README.md
+++ b/charts/dolibarr/README.md
@@ -184,6 +184,20 @@ HelmForge MySQL 2.x dependency.
 | `ingress.hosts` | `[]` | Ingress hosts and paths |
 | `ingress.tls` | `[]` | TLS configuration |
 
+### Security Scan: `dolibarr`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **87.878784%** |
+| MITRE | **100.00%** |
+| NSA | **82.50%** |
+| SOC2 | **90.00%** |
+
+Security posture is acceptable for the HelmForge gate. Remaining findings are
+medium or low severity and reflect the official Dolibarr container's current
+root-based Apache setup, writable application filesystem, and operator-owned
+network boundary choices.
+
 ## Notes
 
 - this chart intentionally supports **MySQL/MariaDB only** for automated setups

--- a/charts/dolibarr/ci/dual-stack.yaml
+++ b/charts/dolibarr/ci/dual-stack.yaml
@@ -1,14 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: dual-stack for HTTP service (GR-058)
-mysql:
-  enabled: false
-
-database:
-  external:
-    host: mysql.external.svc.cluster.local
+# CI scenario: dual-stack networking via service.ipFamilyPolicy.
+#
+# Uses PreferDualStack without explicit ipFamilies so this scenario remains
+# portable across IPv4-only and dual-stack k3d clusters. Kubernetes rejects an
+# explicit IPv6 family when the cluster does not advertise IPv6; explicit
+# ipFamilies rendering is covered by unit tests instead.
+#
+# Keep the bundled MySQL dependency enabled so the k3d behavioral gate validates
+# a reachable database instead of waiting on a synthetic external hostname.
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/dolibarr/ci/external-db-values.yaml
+++ b/charts/dolibarr/ci/external-db-values.yaml
@@ -1,12 +1,84 @@
 # SPDX-License-Identifier: Apache-2.0
+# CI scenario: external MySQL with a local fixture.
 mysql:
   enabled: false
 
 database:
   mode: external
   external:
-    host: mariadb.example.com
+    host: dolibarr-external-mysql
     port: 3306
     name: dolibarr
     username: dolibarr
     password: external-password
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: dolibarr-external-mysql
+      labels:
+        app.kubernetes.io/name: dolibarr-external-mysql
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: dolibarr-external-mysql
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: dolibarr-external-mysql
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:8.4.7
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: mysql
+                  containerPort: 3306
+                  protocol: TCP
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-password
+                - name: MYSQL_DATABASE
+                  value: dolibarr
+                - name: MYSQL_USER
+                  value: dolibarr
+                - name: MYSQL_PASSWORD
+                  value: external-password
+              readinessProbe:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - mysqladmin ping -h 127.0.0.1 -uroot -p"${MYSQL_ROOT_PASSWORD}"
+                periodSeconds: 5
+                timeoutSeconds: 3
+                failureThreshold: 30
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: dolibarr-external-mysql
+      labels:
+        app.kubernetes.io/name: dolibarr-external-mysql
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: dolibarr-external-mysql
+        app.kubernetes.io/component: external-database

--- a/charts/dolibarr/ci/external-secrets.yaml
+++ b/charts/dolibarr/ci/external-secrets.yaml
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: ExternalSecrets with drift guard (GR-061)
+# CI scenario: External Secrets Operator with drift guard (GR-061).
 mysql:
   enabled: false
 
 database:
+  mode: external
   external:
-    host: mysql.external.svc.cluster.local
+    host: dolibarr-eso-mysql
+    port: 3306
+    name: dolibarr
+    username: dolibarr
+    password: external-password
 
 admin:
   existingSecret: dolibarr-admin-credentials
@@ -13,10 +18,90 @@ admin:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
-    kind: ClusterSecretStore
+    name: dolibarr-ci-fake-store
+    kind: SecretStore
   data:
     - secretKey: admin-password
       remoteRef:
-        key: dolibarr/auth
-        property: password
+        key: dolibarr/admin-password
+
+extraManifests:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: dolibarr-ci-fake-store
+    spec:
+      provider:
+        fake:
+          data:
+            - key: dolibarr/admin-password
+              value: helmforge-admin-password
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: dolibarr-eso-mysql
+      labels:
+        app.kubernetes.io/name: dolibarr-eso-mysql
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: dolibarr-eso-mysql
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: dolibarr-eso-mysql
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:8.4.7
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: mysql
+                  containerPort: 3306
+                  protocol: TCP
+              env:
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-password
+                - name: MYSQL_DATABASE
+                  value: dolibarr
+                - name: MYSQL_USER
+                  value: dolibarr
+                - name: MYSQL_PASSWORD
+                  value: external-password
+              readinessProbe:
+                exec:
+                  command:
+                    - sh
+                    - -c
+                    - mysqladmin ping -h 127.0.0.1 -uroot -p"${MYSQL_ROOT_PASSWORD}"
+                periodSeconds: 5
+                timeoutSeconds: 3
+                failureThreshold: 30
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: dolibarr-eso-mysql
+      labels:
+        app.kubernetes.io/name: dolibarr-eso-mysql
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: dolibarr-eso-mysql
+        app.kubernetes.io/component: external-database

--- a/charts/dolibarr/ci/gateway-api.yaml
+++ b/charts/dolibarr/ci/gateway-api.yaml
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: Gateway API (GR-060)
-mysql:
-  enabled: false
-
-database:
-  external:
-    host: mysql.external.svc.cluster.local
+# Keep the bundled MySQL dependency enabled so this scenario validates the
+# HTTPRoute path against a reachable application/database pair in k3d.
 
 gateway:
   enabled: true

--- a/charts/dolibarr/tests/service_test.yaml
+++ b/charts/dolibarr/tests/service_test.yaml
@@ -23,3 +23,20 @@ tests:
             port: 80
             targetPort: http
             protocol: TCP
+
+  - it: should render explicit service IP families when configured
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv4
+        - IPv6
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6


### PR DESCRIPTION
## Summary
- add the Dolibarr README Security Scan section from the local Kubescape MITRE/NSA/SOC2 run
- make CI scenarios k3d-validatable by replacing synthetic external database hosts with local MySQL fixtures where needed
- keep dual-stack CI portable by validating `PreferDualStack` without forcing IPv6 on IPv4-only k3d clusters
- add unit coverage for explicit Service `ipFamilies` rendering

## Validation
- kubescape scan framework "MITRE,NSA,SOC2" charts/dolibarr --format json
- helm lint charts/dolibarr --strict
- helm unittest charts/dolibarr
- make standards-check CHART=dolibarr JSON=1
- make k3d-validate CHART=dolibarr VALUES=ci/dual-stack.yaml
- make k3d-validate CHART=dolibarr VALUES=ci/external-db-values.yaml
- make k3d-validate CHART=dolibarr VALUES=ci/external-secrets.yaml
- make k3d-validate CHART=dolibarr VALUES=ci/gateway-api.yaml
- make validate-chart CHART=dolibarr
- make release-check REPO=charts
- make attribution-check REPO=charts

## Site Sync
- Site PR: https://github.com/helmforgedev/site/pull/265