### PR TITLE
fix(druid): complete chart standards

### DIFF
--- a/charts/druid/DESIGN.md
+++ b/charts/druid/DESIGN.md
@@ -1,0 +1,132 @@
+# Apache Druid Chart Design
+
+## Purpose
+
+This chart packages Apache Druid as a production-oriented Kubernetes deployment
+with explicit control over the Druid process topology, metadata storage,
+ZooKeeper coordination, deep storage, router exposure, and security posture.
+
+Druid is not a single-process database. It is a distributed analytics system
+where each component owns a different responsibility:
+
+- Coordinator manages segment availability and retention rules.
+- Overlord manages ingestion task scheduling.
+- Broker receives queries and fans them out to data servers.
+- Router exposes the web console and routes API traffic.
+- Historical serves immutable published segments from cache.
+- MiddleManager runs ingestion tasks and writes task artifacts.
+
+The chart keeps those roles as separate Kubernetes resources so operators can
+scale, tune, and troubleshoot them independently.
+
+## Workload Model
+
+The chart uses StatefulSets for components that benefit from stable network
+identity or local working state:
+
+- `coordinator`
+- `overlord`
+- `historical`
+- `middlemanager`
+- bundled `zookeeper`
+
+The chart uses Deployments for query-facing stateless components:
+
+- `broker`
+- `router`
+
+Historical and MiddleManager receive dedicated PVC templates by default because
+they maintain segment cache and task working data. Coordinator, Overlord,
+Broker, and Router use ephemeral `druid-var` volumes for local runtime state.
+
+## Metadata Storage
+
+Druid metadata is stored in PostgreSQL by default through the HelmForge
+PostgreSQL subchart. This gives a working installation without requiring an
+external database.
+
+For production platforms that already run managed PostgreSQL or MySQL, the
+chart supports `metadata.mode=external`. In that mode the chart can either:
+
+- create a password Secret from `metadata.external.password`, or
+- consume an operator-managed Secret through `metadata.external.existingSecret`.
+
+The existing Secret path is preferred for production because it avoids storing
+credential material in Helm values.
+
+## ZooKeeper Coordination
+
+The chart includes a bundled ZooKeeper StatefulSet for self-contained clusters.
+It can be disabled with `zookeeper.enabled=false` and
+`zookeeperConfig.mode=external` when the platform already provides a ZooKeeper
+ensemble.
+
+Bundled ZooKeeper defaults to one replica. Operators can raise
+`zookeeper.replicaCount` for a real ensemble, but should also size persistent
+storage and scheduling rules accordingly.
+
+## Deep Storage
+
+Druid deep storage is the durable segment authority. The default
+`deepStorage.type=local` is intentionally simple and useful for development,
+CI, and small lab deployments. It is not a production HA design because segment
+publication depends on local filesystem state inside the release.
+
+Production deployments should use `deepStorage.type=s3` with AWS S3 or an
+S3-compatible service such as MinIO. The chart supports direct credentials for
+development and existing Secrets for production. When S3 credentials are
+operator-managed, `externalSecrets.deepStorage.enabled=true` can render the
+ExternalSecret that creates the Secret consumed by Druid.
+
+## Network Exposure
+
+The router is the only public-facing component in the default model. The chart
+exposes it through:
+
+- a ClusterIP Service by default,
+- optional Ingress with `ingress.ingressClassName`, or
+- optional Gateway API HTTPRoute for clusters with shared Gateways.
+
+The Gateway API implementation intentionally references a Gateway created by
+the platform. This keeps TLS termination, listener policy, and cross-namespace
+Gateway ownership outside the application chart.
+
+## Security Model
+
+Druid containers run as UID/GID `1000`, disallow privilege escalation, drop all
+Linux capabilities, and use the runtime default seccomp profile. The
+`prepare-dirs` init container runs as root only long enough to create and chown
+writable Druid directories, using the minimal baseline-compatible capability
+set required for that task.
+
+NetworkPolicy is opt-in. Druid often needs access to PostgreSQL, ZooKeeper, S3,
+extension endpoints, DNS, and cluster-local services. Enabling a restrictive
+egress policy without modeling those dependencies can break ingestion and
+segment serving, so the chart exposes explicit egress switches and `extraTo`
+rules instead of default-denying traffic silently.
+
+## Operational Trade-offs
+
+This chart favors explicit component controls over a compact single
+configuration block. That makes the values surface larger, but gives operators
+the Druid-specific knobs they need for JVM sizing, per-role replica counts,
+component labels, annotations, and runtime properties.
+
+The chart does not create buckets, databases, TLS issuers, Gateways, or external
+SecretStores. Those resources are platform concerns and should be managed by
+the owning infrastructure team.
+
+## Validation Strategy
+
+The chart is validated through HelmForge's standard gate:
+
+- dependency build and dependency list,
+- strict Helm lint,
+- default and CI scenario rendering,
+- helm-unittest coverage for each template family,
+- kubeconform with real CRD schemas,
+- ArtifactHub lint,
+- k3d behavioral installation and cleanup.
+
+The CI values cover default mode, minimal topology, S3 deep storage, external
+metadata, External Secrets, Gateway API, dual-stack Services, and NetworkPolicy.

--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -6,7 +6,7 @@ analytic applications, BI dashboards, and real-time data exploration.
 
 ## Features
 
-- **6-component architecture** - coordinator, overlord, broker, router, historical, and middlemanager
+- **Modular Druid architecture** - coordinator, broker, and router by default, with optional overlord, historical, and middlemanager
 - **Web console** - router component serves the Druid web console
 - **PostgreSQL subchart** - bundled metadata store with option for external database
 - **Bundled ZooKeeper** - native ZooKeeper StatefulSet with option for external cluster
@@ -19,6 +19,21 @@ analytic applications, BI dashboards, and real-time data exploration.
 - **External Secrets Operator** - optional ExternalSecret projection for metadata and S3 credentials
 - **NetworkPolicy** - optional ingress and egress controls for compatible CNIs
 - **Per-component scaling** - independent replica counts and JVM tuning
+
+## Security Scan
+
+🟢 Security Scan: druid
+
+| Framework | Score |
+|-----------|-------|
+| MITRE + NSA + SOC2 | 83.000000% |
+
+✅ Security posture acceptable.
+
+The default scan keeps Druid writable paths and resource limits configurable
+instead of forcing a one-size-fits-all production profile. For hardened
+deployments, enable NetworkPolicy and set explicit CPU and memory requests and
+limits for every Druid component.
 
 ## Install
 
@@ -58,18 +73,18 @@ StatefulSet: middlemanager (port 8091, PVC: task-storage)
 | `coordinator.enabled` | `true` | Enable coordinator |
 | `coordinator.replicaCount` | `1` | Coordinator replicas |
 | `coordinator.port` | `8081` | Coordinator port |
-| `coordinator.javaOpts` | `-Xms256m -Xmx512m` | Coordinator JVM options |
-| `overlord.enabled` | `true` | Enable overlord |
+| `coordinator.javaOpts` | `-Xms128m -Xmx256m` | Coordinator JVM options |
+| `overlord.enabled` | `false` | Enable overlord for ingestion management |
 | `overlord.port` | `8090` | Overlord port |
 | `broker.enabled` | `true` | Enable broker |
 | `broker.port` | `8082` | Broker port |
-| `broker.javaOpts` | `-Xms512m -Xmx1g` | Broker JVM options |
+| `broker.javaOpts` | `-Xms256m -Xmx512m` | Broker JVM options |
 | `router.enabled` | `true` | Enable router (web console) |
 | `router.port` | `8888` | Router port |
-| `historical.enabled` | `true` | Enable historical |
+| `historical.enabled` | `false` | Enable historical segment serving |
 | `historical.port` | `8083` | Historical port |
 | `historical.persistence.size` | `10Gi` | Segment cache volume size |
-| `middleManager.enabled` | `true` | Enable middle manager |
+| `middleManager.enabled` | `false` | Enable middle manager ingestion workers |
 | `middleManager.port` | `8091` | MiddleManager port |
 | `middleManager.workerCapacity` | `2` | Tasks per middle manager |
 | `middleManager.persistence.size` | `10Gi` | Task storage volume size |
@@ -292,6 +307,20 @@ historical:
   extraProperties: |
     druid.segmentCache.locations=[{"path":"/opt/druid/var/druid/segment-cache","maxSize":10737418240}]
 ```
+
+## Examples
+
+- [Simple development deployment](examples/simple.yaml)
+- [S3-backed production deployment](examples/s3-production.yaml)
+- [External metadata and ZooKeeper services](examples/external-services.yaml)
+- [Gateway API with NetworkPolicy](examples/gateway-networkpolicy.yaml)
+- [External Secrets with S3 deep storage](examples/external-secrets-s3.yaml)
+
+## Architecture Guides
+
+- [Architecture](docs/architecture.md)
+- [Storage and secrets](docs/storage-and-secrets.md)
+- [Networking and security](docs/networking-and-security.md)
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/druid/ci/external-metadata-values.yaml
+++ b/charts/druid/ci/external-metadata-values.yaml
@@ -7,7 +7,7 @@ metadata:
   mode: external
   external:
     type: postgresql
-    host: postgres.example.com
+    host: druid-ci-postgresql
     port: 5432
     name: druid
     username: druid
@@ -16,7 +16,114 @@ metadata:
 zookeeperConfig:
   mode: external
   external:
-    hosts: "zk1.example.com:2181,zk2.example.com:2181"
+    hosts: "druid-ci-zookeeper:2181"
 
 zookeeper:
   enabled: false
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: druid-ci-postgresql
+      labels:
+        app.kubernetes.io/name: druid-ci-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: druid-ci-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: druid-ci-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.3-trixie
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: POSTGRES_DB
+                  value: druid
+                - name: POSTGRES_USER
+                  value: druid
+                - name: POSTGRES_PASSWORD
+                  value: my-secret-password
+                - name: PGDATA
+                  value: /var/lib/postgresql/data/pgdata
+              ports:
+                - name: postgres
+                  containerPort: 5432
+              readinessProbe:
+                exec:
+                  command:
+                    - sh
+                    - -ec
+                    - pg_isready -U druid -d druid -h 127.0.0.1
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/postgresql/data
+          volumes:
+            - name: data
+              emptyDir: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: druid-ci-postgresql
+      labels:
+        app.kubernetes.io/name: druid-ci-postgresql
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgres
+          port: 5432
+          targetPort: postgres
+      selector:
+        app.kubernetes.io/name: druid-ci-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: druid-ci-zookeeper
+      labels:
+        app.kubernetes.io/name: druid-ci-zookeeper
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: druid-ci-zookeeper
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: druid-ci-zookeeper
+        spec:
+          containers:
+            - name: zookeeper
+              image: docker.io/library/zookeeper:3.9.4
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: ZOO_4LW_COMMANDS_WHITELIST
+                  value: ruok,mntr,conf
+              ports:
+                - name: client
+                  containerPort: 2181
+              readinessProbe:
+                tcpSocket:
+                  port: client
+                initialDelaySeconds: 10
+                periodSeconds: 5
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: druid-ci-zookeeper
+      labels:
+        app.kubernetes.io/name: druid-ci-zookeeper
+    spec:
+      type: ClusterIP
+      ports:
+        - name: client
+          port: 2181
+          targetPort: client
+      selector:
+        app.kubernetes.io/name: druid-ci-zookeeper

--- a/charts/druid/ci/external-secrets.yaml
+++ b/charts/druid/ci/external-secrets.yaml
@@ -7,7 +7,7 @@ metadata:
   mode: external
   external:
     type: postgresql
-    host: postgres.example.com
+    host: druid-eso-postgresql
     port: 5432
     name: druid
     username: druid
@@ -16,7 +16,7 @@ metadata:
 zookeeperConfig:
   mode: external
   external:
-    hosts: "zk1.example.com:2181,zk2.example.com:2181"
+    hosts: "druid-eso-zookeeper:2181"
 
 zookeeper:
   enabled: false
@@ -30,24 +30,141 @@ deepStorage:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: platform-secrets
-    kind: ClusterSecretStore
+    name: druid-ci-fake-store
+    kind: SecretStore
   metadata:
     enabled: true
     data:
       - secretKey: password
         remoteRef:
-          key: druid/metadata
-          property: password
+          key: druid/metadata-password
   deepStorage:
     enabled: true
     data:
       - secretKey: access-key
         remoteRef:
-          key: druid/s3
-          property: access-key
+          key: druid/s3-access-key
       - secretKey: secret-key
         remoteRef:
-          key: druid/s3
-          property: secret-key
+          key: druid/s3-secret-key
 
+extraManifests:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: druid-ci-fake-store
+    spec:
+      provider:
+        fake:
+          data:
+            - key: druid/metadata-password
+              value: external-password
+            - key: druid/s3-access-key
+              value: test-access-key
+            - key: druid/s3-secret-key
+              value: test-secret-key
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: druid-eso-postgresql
+      labels:
+        app.kubernetes.io/name: druid-eso-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: druid-eso-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: druid-eso-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.3-trixie
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: POSTGRES_DB
+                  value: druid
+                - name: POSTGRES_USER
+                  value: druid
+                - name: POSTGRES_PASSWORD
+                  value: external-password
+                - name: PGDATA
+                  value: /var/lib/postgresql/data/pgdata
+              ports:
+                - name: postgres
+                  containerPort: 5432
+              readinessProbe:
+                exec:
+                  command:
+                    - sh
+                    - -ec
+                    - pg_isready -U druid -d druid -h 127.0.0.1
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/postgresql/data
+          volumes:
+            - name: data
+              emptyDir: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: druid-eso-postgresql
+      labels:
+        app.kubernetes.io/name: druid-eso-postgresql
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgres
+          port: 5432
+          targetPort: postgres
+      selector:
+        app.kubernetes.io/name: druid-eso-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: druid-eso-zookeeper
+      labels:
+        app.kubernetes.io/name: druid-eso-zookeeper
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: druid-eso-zookeeper
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: druid-eso-zookeeper
+        spec:
+          containers:
+            - name: zookeeper
+              image: docker.io/library/zookeeper:3.9.4
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: ZOO_4LW_COMMANDS_WHITELIST
+                  value: ruok,mntr,conf
+              ports:
+                - name: client
+                  containerPort: 2181
+              readinessProbe:
+                tcpSocket:
+                  port: client
+                initialDelaySeconds: 10
+                periodSeconds: 5
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: druid-eso-zookeeper
+      labels:
+        app.kubernetes.io/name: druid-eso-zookeeper
+    spec:
+      type: ClusterIP
+      ports:
+        - name: client
+          port: 2181
+          targetPort: client
+      selector:
+        app.kubernetes.io/name: druid-eso-zookeeper

--- a/charts/druid/docs/architecture.md
+++ b/charts/druid/docs/architecture.md
@@ -1,0 +1,129 @@
+# Apache Druid Architecture Guide
+
+## Overview
+
+Apache Druid splits query serving, ingestion, coordination, and segment storage
+across multiple processes. This chart keeps those processes separate so each
+role can be scaled and tuned independently.
+
+## Component Responsibilities
+
+The Coordinator manages segment assignment, balancing, and retention. It is a
+control-plane process and does not serve user queries directly.
+
+The Overlord manages ingestion supervisors and tasks. MiddleManager workers
+execute those tasks and write task logs or generated segments to the configured
+deep storage backend.
+
+The Broker accepts queries from clients, discovers where segments are served,
+and fans queries out to Historical and real-time ingestion workers.
+
+The Router exposes the web console and can route API calls to Brokers,
+Coordinators, and Overlords. The chart routes Ingress and Gateway API traffic
+to the router Service.
+
+Historical nodes download published segments from deep storage into local
+segment cache and serve those immutable segments to Brokers.
+
+ZooKeeper provides Druid service discovery and coordination. PostgreSQL stores
+Druid metadata such as segment records, datasources, supervisors, and task
+state.
+
+## Kubernetes Mapping
+
+```text
+Client or Gateway
+  -> Service: druid-router
+     -> Deployment: router
+        -> Broker, Coordinator, and Overlord APIs
+
+Broker
+  -> Historical nodes for segment query execution
+  -> ZooKeeper for service discovery
+
+MiddleManager
+  -> Metadata database for task state
+  -> Deep storage for generated segments and task logs
+
+Historical
+  -> Deep storage for segment download
+  -> Local PVC for segment cache
+```
+
+The chart renders StatefulSets for Coordinator, Overlord, Historical, and
+MiddleManager. Historical and MiddleManager use PVC templates by default.
+Broker and Router are Deployments because they are query-facing stateless
+processes.
+
+## Metadata Storage Choices
+
+Use `metadata.mode=subchart` when you want the chart to deploy its own
+PostgreSQL metadata store. This is convenient for development, evaluation, and
+single-release environments.
+
+Use `metadata.mode=external` when metadata is owned by a managed database
+service or a separate database platform team. External metadata mode supports
+PostgreSQL and MySQL.
+
+When using external metadata in production, set
+`metadata.external.existingSecret` instead of `metadata.external.password`.
+That keeps credentials out of Helm values and lets External Secrets Operator or
+another secret workflow own rotation.
+
+## ZooKeeper Choices
+
+Use bundled ZooKeeper for a self-contained install. The default single replica
+is suitable for development and small environments.
+
+Use external ZooKeeper when the platform already has a managed ensemble or when
+Druid availability requirements are tied to a shared coordination layer.
+
+External ZooKeeper is configured with:
+
+```yaml
+zookeeper:
+  enabled: false
+
+zookeeperConfig:
+  mode: external
+  external:
+    hosts: "zookeeper-0.zookeeper:2181,zookeeper-1.zookeeper:2181,zookeeper-2.zookeeper:2181"
+```
+
+## Deep Storage Choices
+
+Local deep storage is the default because it makes the chart easy to install in
+CI and labs. It should be treated as non-HA.
+
+S3 deep storage is the recommended production path:
+
+```yaml
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    baseKey: production/segments
+    region: us-east-1
+    existingSecret: druid-s3
+```
+
+If using MinIO or another S3-compatible service, also set
+`deepStorage.s3.endpointUrl` and keep path-style access enabled through the
+chart-generated runtime properties.
+
+## Scaling Guidance
+
+Scale Broker and Router first for query concurrency. Scale Historical when
+segment serving or cache pressure is the bottleneck. Scale MiddleManager when
+ingestion task concurrency is the bottleneck.
+
+Coordinator and Overlord are control-plane components. Increasing their replica
+counts should be paired with Druid leader-election behavior and operational
+testing for the target version.
+
+## Failure Domains
+
+For production, spread Historical, MiddleManager, Broker, and Router pods with
+affinity rules and topology spread constraints supplied through `affinity` and
+component labels. Keep PostgreSQL, ZooKeeper, and object storage availability
+aligned with the Druid recovery objectives.

--- a/charts/druid/docs/networking-and-security.md
+++ b/charts/druid/docs/networking-and-security.md
@@ -1,0 +1,153 @@
+# Apache Druid Networking and Security Guide
+
+## Router Exposure
+
+The Druid router is the chart's public entry point. It exposes the web console
+and routes API calls to other Druid services.
+
+For local access:
+
+```bash
+kubectl port-forward svc/druid 8080:80
+```
+
+For cluster ingress, enable either Ingress or Gateway API. Do not enable both
+for the same hostname unless your platform intentionally supports parallel
+routes.
+
+## Ingress
+
+Ingress routes traffic to the router Service:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: druid.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: druid-tls
+      hosts:
+        - druid.example.com
+```
+
+The chart uses `ingress.ingressClassName` and does not rely on legacy
+annotation-only class selection.
+
+## Gateway API
+
+Gateway API support renders an HTTPRoute and expects the Gateway to be managed
+outside the chart:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - druid.example.com
+  paths:
+    - type: PathPrefix
+      value: /
+```
+
+This split lets platform teams own listener policy, TLS, and cross-namespace
+route admission while application teams own the backend route.
+
+## Dual-stack Services
+
+Service IP family fields are omitted by default so the cluster default applies.
+For dual-stack clusters:
+
+```yaml
+service:
+  ipFamilyPolicy: PreferDualStack
+```
+
+Set `service.ipFamilies` only when the cluster requires an explicit ordered
+family list.
+
+## NetworkPolicy
+
+NetworkPolicy is disabled by default. Druid requires internal communication
+between all Druid components, metadata storage, ZooKeeper, DNS, and optionally
+S3-compatible storage.
+
+A baseline same-namespace policy:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespace: true
+    allowHTTPS: true
+```
+
+When the router is exposed through a Gateway controller in another namespace,
+add that namespace to `networkPolicy.ingress.extraFrom`.
+
+When using MinIO over plain HTTP, set `networkPolicy.egress.allowHTTP=true` or
+add a more specific `extraTo` rule.
+
+## Pod Security
+
+Druid containers run as non-root by default:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+The init container that prepares writable directories runs as root with a small
+capability set so the main Druid process can run as UID 1000.
+
+## Resource Limits
+
+The chart leaves component `resources` empty by default because Druid sizing is
+workload-specific and tied to JVM heap settings. Production values should set
+requests and limits for every component and keep memory limits above the
+configured heap plus native overhead.
+
+Example Broker sizing:
+
+```yaml
+broker:
+  javaOpts: "-Xms1g -Xmx1g"
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1536Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+```
+
+## Operational Checks
+
+After installation:
+
+```bash
+kubectl get pods -l app.kubernetes.io/instance=druid
+kubectl logs -l app.kubernetes.io/instance=druid --all-containers --tail=200
+kubectl port-forward svc/druid 8080:80
+```
+
+Then open `http://localhost:8080` and verify the Druid console can load
+Services, Datasources, and Tasks.

--- a/charts/druid/docs/storage-and-secrets.md
+++ b/charts/druid/docs/storage-and-secrets.md
@@ -1,0 +1,161 @@
+# Apache Druid Storage and Secrets Guide
+
+## Storage Domains
+
+Druid uses three storage domains:
+
+- metadata storage for cluster state and segment records,
+- deep storage for durable published segments and indexing logs,
+- local working storage for segment cache and ingestion tasks.
+
+The chart exposes each domain separately so operators can choose a simple
+development setup or a production setup with managed backing services.
+
+## Metadata Storage
+
+The default metadata store is the HelmForge PostgreSQL subchart:
+
+```yaml
+postgresql:
+  enabled: true
+
+metadata:
+  mode: subchart
+```
+
+Use external metadata storage for production environments that already provide
+database lifecycle, backups, monitoring, and credential rotation:
+
+```yaml
+postgresql:
+  enabled: false
+
+metadata:
+  mode: external
+  external:
+    type: postgresql
+    host: postgresql.druid-data.svc.cluster.local
+    port: 5432
+    name: druid
+    username: druid
+    existingSecret: druid-metadata
+    existingSecretPasswordKey: password
+```
+
+The same contract can target MySQL by setting `metadata.external.type=mysql`
+and using the MySQL port.
+
+## S3 Deep Storage
+
+S3-compatible deep storage is the recommended production configuration because
+Historical and ingestion processes can recover segment state from a durable
+object store.
+
+```yaml
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    baseKey: production/segments
+    region: us-east-1
+    existingSecret: druid-s3
+```
+
+For MinIO:
+
+```yaml
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    baseKey: minio/segments
+    region: us-east-1
+    endpointUrl: http://minio.minio.svc.cluster.local:9000
+    existingSecret: druid-s3
+```
+
+The Secret referenced by `deepStorage.s3.existingSecret` must contain the keys
+configured by `existingSecretAccessKeyKey` and `existingSecretSecretKeyKey`.
+The defaults are `access-key` and `secret-key`.
+
+## External Secrets Operator
+
+External Secrets Operator integration is opt-in and renders ExternalSecret
+resources for metadata and S3 credential Secrets.
+
+Enable metadata credentials:
+
+```yaml
+metadata:
+  mode: external
+  external:
+    existingSecret: druid-metadata
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  metadata:
+    enabled: true
+    data:
+      - secretKey: password
+        remoteRef:
+          key: druid/metadata
+          property: password
+```
+
+Enable S3 credentials:
+
+```yaml
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    existingSecret: druid-s3
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  deepStorage:
+    enabled: true
+    data:
+      - secretKey: access-key
+        remoteRef:
+          key: druid/s3
+          property: access-key
+      - secretKey: secret-key
+        remoteRef:
+          key: druid/s3
+          property: secret-key
+```
+
+The chart validates that External Secrets paths point at existing Secret names
+from the Druid values contract. This prevents the application from referencing
+one Secret while ESO creates another.
+
+## Local Persistent Volumes
+
+Historical segment cache is controlled by `historical.persistence`.
+MiddleManager task storage is controlled by `middleManager.persistence`.
+Bundled ZooKeeper storage is controlled by `zookeeper.persistence`.
+
+For production, size those PVCs according to segment cache targets, ingestion
+task concurrency, and ZooKeeper retention requirements. Use a storage class
+with predictable latency for ZooKeeper and with enough throughput for segment
+cache warm-up on Historical nodes.
+
+## Backup Stance
+
+This chart does not create database dumps or object storage backup jobs. The
+metadata database and object store are separate durability systems and should
+be backed up by the owning platform service.
+
+For production recovery, verify:
+
+- metadata database backups are restorable,
+- object storage bucket versioning or backup policy protects segments,
+- External Secrets remote keys can be restored,
+- ZooKeeper state can be recreated or restored for the selected topology.

--- a/charts/druid/examples/external-secrets-s3.yaml
+++ b/charts/druid/examples/external-secrets-s3.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Druid with External Secrets Operator managing metadata and S3 credentials.
+# Use case: secret rotation owned by the platform secret store.
+
+postgresql:
+  enabled: false
+
+metadata:
+  mode: external
+  external:
+    type: postgresql
+    host: postgresql.druid-data.svc.cluster.local
+    port: 5432
+    name: druid
+    username: druid
+    existingSecret: druid-metadata
+
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    baseKey: production/segments
+    region: us-east-1
+    existingSecret: druid-s3
+
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: platform-secrets
+    kind: ClusterSecretStore
+  metadata:
+    enabled: true
+    data:
+      - secretKey: password
+        remoteRef:
+          key: druid/metadata
+          property: password
+  deepStorage:
+    enabled: true
+    data:
+      - secretKey: access-key
+        remoteRef:
+          key: druid/s3
+          property: access-key
+      - secretKey: secret-key
+        remoteRef:
+          key: druid/s3
+          property: secret-key
+

--- a/charts/druid/examples/external-services.yaml
+++ b/charts/druid/examples/external-services.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# Druid with platform-owned metadata database and ZooKeeper.
+# Use case: production clusters where shared services own backups and HA.
+
+postgresql:
+  enabled: false
+
+metadata:
+  mode: external
+  external:
+    type: postgresql
+    host: postgresql.druid-data.svc.cluster.local
+    port: 5432
+    name: druid
+    username: druid
+    existingSecret: druid-metadata
+    existingSecretPasswordKey: password
+
+zookeeper:
+  enabled: false
+
+zookeeperConfig:
+  mode: external
+  external:
+    hosts: "zookeeper-0.zookeeper:2181,zookeeper-1.zookeeper:2181,zookeeper-2.zookeeper:2181"
+
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    baseKey: shared-services/segments
+    region: us-east-1
+    existingSecret: druid-s3
+
+overlord:
+  enabled: true
+
+historical:
+  enabled: true
+
+middleManager:
+  enabled: true

--- a/charts/druid/examples/gateway-networkpolicy.yaml
+++ b/charts/druid/examples/gateway-networkpolicy.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Druid router exposed through Gateway API with NetworkPolicy enabled.
+# Use case: platform Gateway owns TLS and listener policy.
+
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: shared-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - druid.example.com
+  paths:
+    - type: PathPrefix
+      value: /
+
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+    extraFrom:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: gateway-system
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespace: true
+    allowHTTPS: true
+

--- a/charts/druid/examples/s3-production.yaml
+++ b/charts/druid/examples/s3-production.yaml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented Druid deployment with S3 deep storage.
+# Use case: durable segment storage and explicit component sizing.
+
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-segments
+    baseKey: production/segments
+    region: us-east-1
+    existingSecret: druid-s3
+
+coordinator:
+  resources:
+    requests:
+      cpu: 250m
+      memory: 768Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+overlord:
+  enabled: true
+  resources:
+    requests:
+      cpu: 250m
+      memory: 768Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+broker:
+  javaOpts: "-Xms1g -Xmx1g"
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1536Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+router:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 750m
+      memory: 768Mi
+
+historical:
+  enabled: true
+  replicaCount: 2
+  persistence:
+    enabled: true
+    size: 100Gi
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 4Gi
+
+middleManager:
+  enabled: true
+  replicaCount: 2
+  workerCapacity: 4
+  persistence:
+    enabled: true
+    size: 50Gi
+  resources:
+    requests:
+      cpu: "1"
+      memory: 1536Mi
+    limits:
+      cpu: "4"
+      memory: 3Gi
+
+networkPolicy:
+  enabled: true
+  ingress:
+    allowSameNamespace: true
+  egress:
+    enabled: true
+    allowDNS: true
+    allowSameNamespace: true
+    allowHTTPS: true

--- a/charts/druid/examples/simple.yaml
+++ b/charts/druid/examples/simple.yaml
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# Simple Druid deployment for development and chart evaluation.
+# Use case: bundled PostgreSQL and ZooKeeper with a dev MinIO backend for shared deep storage.
+
+postgresql:
+  enabled: true
+
+zookeeper:
+  enabled: true
+
+deepStorage:
+  type: s3
+  s3:
+    bucket: druid-dev-segments
+    baseKey: simple/segments
+    region: us-east-1
+    endpointUrl: http://druid-dev-minio:9000
+    accessKey: minioadmin
+    secretKey: minioadmin
+
+service:
+  type: ClusterIP
+  port: 80
+
+overlord:
+  enabled: true
+
+historical:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 10Gi
+
+middleManager:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 10Gi
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: druid-dev-minio
+      labels:
+        app.kubernetes.io/name: druid-dev-minio
+        app.kubernetes.io/component: deep-storage
+    spec:
+      type: ClusterIP
+      ports:
+        - name: api
+          port: 9000
+          targetPort: api
+        - name: console
+          port: 9001
+          targetPort: console
+      selector:
+        app.kubernetes.io/name: druid-dev-minio
+        app.kubernetes.io/component: deep-storage
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: druid-dev-minio
+      labels:
+        app.kubernetes.io/name: druid-dev-minio
+        app.kubernetes.io/component: deep-storage
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: druid-dev-minio
+      labels:
+        app.kubernetes.io/name: druid-dev-minio
+        app.kubernetes.io/component: deep-storage
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: druid-dev-minio
+          app.kubernetes.io/component: deep-storage
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: druid-dev-minio
+            app.kubernetes.io/component: deep-storage
+        spec:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+          containers:
+            - name: minio
+              image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+              imagePullPolicy: IfNotPresent
+              args:
+                - server
+                - /data
+                - --console-address
+                - :9001
+              env:
+                - name: MINIO_ROOT_USER
+                  value: minioadmin
+                - name: MINIO_ROOT_PASSWORD
+                  value: minioadmin
+              ports:
+                - name: api
+                  containerPort: 9000
+                - name: console
+                  containerPort: 9001
+              livenessProbe:
+                httpGet:
+                  path: /minio/health/live
+                  port: api
+              readinessProbe:
+                httpGet:
+                  path: /minio/health/ready
+                  port: api
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: druid-dev-minio
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: druid-dev-minio-bucket
+      labels:
+        app.kubernetes.io/name: druid-dev-minio
+        app.kubernetes.io/component: bucket-bootstrap
+      annotations:
+        helm.sh/hook: post-install,post-upgrade
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    spec:
+      backoffLimit: 6
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: druid-dev-minio
+            app.kubernetes.io/component: bucket-bootstrap
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: create-bucket
+              image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  until mc alias set local http://druid-dev-minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                    sleep 5
+                  done
+                  mc mb --ignore-existing local/druid-dev-segments
+              env:
+                - name: MINIO_ROOT_USER
+                  value: minioadmin
+                - name: MINIO_ROOT_PASSWORD
+                  value: minioadmin
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 64Mi
+                limits:
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsGroup: 1000
+                runAsNonRoot: true
+                runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault

--- a/charts/druid/tests/broker_test.yaml
+++ b/charts/druid/tests/broker_test.yaml
@@ -30,7 +30,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: JAVA_OPTS
-            value: "-Xms512m -Xmx1g"
+            value: "-Xms256m -Xmx512m"
 
   - it: should not render when disabled
     template: templates/broker-deployment.yaml

--- a/charts/druid/tests/coordinator_test.yaml
+++ b/charts/druid/tests/coordinator_test.yaml
@@ -33,7 +33,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: JAVA_OPTS
-            value: "-Xms256m -Xmx512m"
+            value: "-Xms128m -Xmx256m"
 
   - it: should include init containers
     template: templates/coordinator-statefulset.yaml

--- a/charts/druid/tests/historical_test.yaml
+++ b/charts/druid/tests/historical_test.yaml
@@ -4,8 +4,10 @@ templates:
   - templates/historical-statefulset.yaml
   - templates/configmap.yaml
 tests:
-  - it: should render historical statefulset by default
+  - it: should render historical statefulset when enabled
     template: templates/historical-statefulset.yaml
+    set:
+      historical.enabled: true
     asserts:
       - isKind:
           of: StatefulSet
@@ -15,6 +17,8 @@ tests:
 
   - it: should use correct port
     template: templates/historical-statefulset.yaml
+    set:
+      historical.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
@@ -22,6 +26,8 @@ tests:
 
   - it: should have volume claim template with persistence enabled
     template: templates/historical-statefulset.yaml
+    set:
+      historical.enabled: true
     asserts:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.name
@@ -33,6 +39,7 @@ tests:
   - it: should use emptyDir when persistence is disabled
     template: templates/historical-statefulset.yaml
     set:
+      historical.enabled: true
       historical.persistence.enabled: false
     asserts:
       - contains:
@@ -43,10 +50,8 @@ tests:
       - isNull:
           path: spec.volumeClaimTemplates
 
-  - it: should not render when disabled
+  - it: should not render by default
     template: templates/historical-statefulset.yaml
-    set:
-      historical.enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/druid/tests/middlemanager_test.yaml
+++ b/charts/druid/tests/middlemanager_test.yaml
@@ -4,8 +4,10 @@ templates:
   - templates/middlemanager-statefulset.yaml
   - templates/configmap.yaml
 tests:
-  - it: should render middlemanager statefulset by default
+  - it: should render middlemanager statefulset when enabled
     template: templates/middlemanager-statefulset.yaml
+    set:
+      middleManager.enabled: true
     asserts:
       - isKind:
           of: StatefulSet
@@ -15,6 +17,8 @@ tests:
 
   - it: should use correct port
     template: templates/middlemanager-statefulset.yaml
+    set:
+      middleManager.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
@@ -22,6 +26,8 @@ tests:
 
   - it: should have volume claim template with persistence enabled
     template: templates/middlemanager-statefulset.yaml
+    set:
+      middleManager.enabled: true
     asserts:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.name
@@ -30,10 +36,8 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.resources.requests.storage
           value: 10Gi
 
-  - it: should not render when disabled
+  - it: should not render by default
     template: templates/middlemanager-statefulset.yaml
-    set:
-      middleManager.enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/druid/tests/overlord_test.yaml
+++ b/charts/druid/tests/overlord_test.yaml
@@ -4,8 +4,10 @@ templates:
   - templates/overlord-statefulset.yaml
   - templates/configmap.yaml
 tests:
-  - it: should render overlord statefulset by default
+  - it: should render overlord statefulset when enabled
     template: templates/overlord-statefulset.yaml
+    set:
+      overlord.enabled: true
     asserts:
       - isKind:
           of: StatefulSet
@@ -18,15 +20,15 @@ tests:
 
   - it: should use correct port
     template: templates/overlord-statefulset.yaml
+    set:
+      overlord.enabled: true
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8090
 
-  - it: should not render when disabled
+  - it: should not render by default
     template: templates/overlord-statefulset.yaml
-    set:
-      overlord.enabled: false
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/druid/tests/service_test.yaml
+++ b/charts/druid/tests/service_test.yaml
@@ -39,6 +39,10 @@ tests:
 
   - it: should render broker service
     documentIndex: 5
+    set:
+      overlord.enabled: true
+      historical.enabled: true
+      middleManager.enabled: true
     asserts:
       - isKind:
           of: Service

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -108,7 +108,7 @@ coordinator:
   # -- Coordinator port
   port: 8081
   # -- JVM options
-  javaOpts: "-Xms256m -Xmx512m"
+  javaOpts: "-Xms128m -Xmx256m"
   # -- Extra runtime properties
   extraProperties: ""
   # -- Resource requests and limits
@@ -124,13 +124,13 @@ coordinator:
 
 overlord:
   # -- Enable overlord (can be combined with coordinator)
-  enabled: true
+  enabled: false
   # -- Number of overlord replicas
   replicaCount: 1
   # -- Overlord port
   port: 8090
   # -- JVM options
-  javaOpts: "-Xms256m -Xmx512m"
+  javaOpts: "-Xms128m -Xmx256m"
   # -- Extra runtime properties
   extraProperties: ""
   # -- Resource requests and limits
@@ -152,7 +152,7 @@ broker:
   # -- Broker port
   port: 8082
   # -- JVM options
-  javaOpts: "-Xms512m -Xmx1g"
+  javaOpts: "-Xms256m -Xmx512m"
   # -- Extra runtime properties
   extraProperties: ""
   # -- Resource requests and limits
@@ -190,13 +190,13 @@ router:
 
 historical:
   # -- Enable historical
-  enabled: true
+  enabled: false
   # -- Number of historical replicas
   replicaCount: 1
   # -- Historical port
   port: 8083
   # -- JVM options
-  javaOpts: "-Xms512m -Xmx1g"
+  javaOpts: "-Xms256m -Xmx512m"
   # -- Extra runtime properties
   extraProperties: ""
   # -- Segment cache persistence
@@ -219,7 +219,7 @@ historical:
 
 middleManager:
   # -- Enable middle manager
-  enabled: true
+  enabled: false
   # -- Number of middle manager replicas
   replicaCount: 1
   # -- MiddleManager port


### PR DESCRIPTION
## Summary
- Backfill Druid chart standards with DESIGN, chart-specific docs, and runnable examples.
- Make the default topology lighter by keeping coordinator, broker, and router enabled while making ingestion and segment serving opt-in.
- Add k3d-ready external metadata and External Secrets CI fixtures so every scenario validates behaviorally.

## Site sync
- helmforgedev/site#266

## Validation
- make validate-chart CHART=druid
- make standards-check CHART=druid JSON=1
- make md-lint REPO=charts
- make release-check REPO=charts
- make attribution-check REPO=charts