### PR TITLE
fix(guacamole): complete chart standards

### DIFF
--- a/charts/guacamole/DESIGN.md
+++ b/charts/guacamole/DESIGN.md
@@ -115,7 +115,8 @@ The CI values cover:
 
 - Default PostgreSQL deployment.
 - MySQL deployment.
-- External PostgreSQL documented example and template coverage.
+- External PostgreSQL deployment with an in-cluster fake endpoint for k3d plus
+  a documented operator-owned database example.
 - OIDC with ingress-derived callback behavior.
 - SAML with ingress-derived callback behavior.
 - S3 backup CronJob rendering.

--- a/charts/guacamole/DESIGN.md
+++ b/charts/guacamole/DESIGN.md
@@ -1,0 +1,142 @@
+# Apache Guacamole Chart Design
+
+## Purpose
+
+This chart deploys Apache Guacamole as a clientless remote desktop gateway for
+RDP, VNC, SSH, telnet, and Kubernetes access. It packages the Guacamole web
+application, the `guacd` protocol daemon, database initialization, optional
+identity provider integrations, and scheduled database backups into one
+production-oriented Helm release.
+
+## Workload Model
+
+The runtime workload is a single Deployment with two containers:
+
+- `guacamole`: the Java/Tomcat web application that serves HTTP on port 8080.
+- `guacd`: the protocol daemon that handles remote desktop protocol sessions on
+  port 4822.
+
+`guacamole` talks to `guacd` over `localhost`, keeping protocol traffic inside
+the pod. The Kubernetes Service exposes only the HTTP endpoint. This avoids a
+separate `guacd` Service and keeps remote desktop protocol handling private to
+the application pod.
+
+The Deployment includes an init container that waits for the configured
+database endpoint before starting the application containers. HTTP startup,
+liveness, and readiness probes check the web application, while TCP probes check
+the `guacd` sidecar.
+
+## Database Strategy
+
+Apache Guacamole requires a relational database for users, connection
+definitions, permissions, and authentication state. The chart supports three
+database modes:
+
+- PostgreSQL subchart, enabled by default.
+- MySQL subchart, selected with `database.type: mysql`, `postgresql.enabled:
+  false`, and `mysql.enabled: true`.
+- External PostgreSQL or MySQL, selected by setting `database.external.host` and
+  disabling the bundled database subchart.
+
+Database connection values are resolved through helpers so the Deployment, init
+job, and backup CronJob share one source of truth for host, port, database name,
+username, password secret name, and password key. Inline external passwords
+create a chart-managed Secret; `database.external.existingSecret` delegates
+password ownership to the platform.
+
+## Schema Initialization
+
+When `initDb.enabled` is true, a post-install hook Job initializes the Guacamole
+schema. The job waits for the database, generates the vendor-specific schema
+with Guacamole's bundled `initdb.sh`, checks for the `guacamole_user` table, and
+applies the schema only when it is missing.
+
+This keeps first installs self-contained while avoiding destructive behavior on
+reinstalls or external databases that already contain Guacamole data. Operators
+can set `initDb.enabled: false` when database provisioning and migrations are
+managed outside the chart.
+
+## Authentication Integrations
+
+The chart enables Guacamole authentication extensions through environment
+variables consumed by the official image:
+
+- OIDC uses authorization, JWKS, issuer, client ID, scopes, username claim, and
+  groups claim settings. The redirect URI is auto-derived from the first ingress
+  host when `oidc.redirectUri` is empty.
+- SAML uses IdP metadata or IdP URL, entity ID, callback URL, strict mode,
+  request/response compression, and group attribute settings. Entity ID and
+  callback URL can also be derived from ingress.
+- TOTP is enabled with `totp.enabled`.
+
+The chart does not create identity provider objects. It expects the external IdP
+to own client registration, redirect URIs, scopes, certificates, and group claim
+mapping.
+
+## Networking
+
+The Service exposes the Guacamole web application on `service.port`. Ingress is
+optional and supports `ingress.ingressClassName`, arbitrary annotations, host
+paths, and TLS entries. Reverse proxy handling is enabled by default through
+Tomcat RemoteIpValve settings so Guacamole can preserve client IP and protocol
+information behind an ingress controller.
+
+## Backup Strategy
+
+When `backup.enabled` is true, the chart creates a CronJob that dumps the active
+database into an `emptyDir` scratch volume and uploads the compressed archive to
+an S3-compatible endpoint:
+
+- PostgreSQL backups use `pg_dump --clean --if-exists`.
+- MySQL backups use `mysqldump --single-transaction --quick`.
+- Uploads use the HelmForge `mc` image and optional bucket creation.
+
+S3 credentials can be supplied inline for chart-managed Secret creation or via
+`backup.s3.existingSecret` for externally managed credentials. The backup flow
+stores database state only; remote desktops and target systems remain external
+to Guacamole.
+
+## Security Posture
+
+The chart uses official Apache Guacamole images, pinned tags, chart-managed
+Secrets for generated credentials, and existing Secret hooks for platform-owned
+database and S3 credentials. The default ServiceAccount is reused unless
+`serviceAccount.create` is enabled, and pod/container security contexts remain
+operator-configurable because upstream Guacamole and database client images may
+require environment-specific hardening.
+
+The default `guacadmin` account is created by Guacamole itself after schema
+initialization. Operators must change the default password immediately after
+first login or rely on OIDC/SAML controls for production access.
+
+## Validation Coverage
+
+The CI values cover:
+
+- Default PostgreSQL deployment.
+- MySQL deployment.
+- External PostgreSQL documented example and template coverage.
+- OIDC with ingress-derived callback behavior.
+- SAML with ingress-derived callback behavior.
+- S3 backup CronJob rendering.
+
+Full validation for chart changes must use `make validate-chart
+CHART=guacamole`.
+
+<!-- @AI-METADATA
+type: chart-design
+title: Apache Guacamole Chart Design
+description: Architecture and operational design for the Apache Guacamole HelmForge chart
+keywords: guacamole, guacd, remote desktop, postgresql, mysql, oidc, saml, backup
+purpose: Explain chart architecture, tradeoffs, and validation boundaries
+scope: Chart
+relations:
+  - charts/guacamole/Chart.yaml
+  - charts/guacamole/values.yaml
+  - charts/guacamole/templates/deployment.yaml
+  - charts/guacamole/templates/initdb-job.yaml
+  - charts/guacamole/templates/backup-cronjob.yaml
+path: charts/guacamole/DESIGN.md
+version: 1.0
+date: 2026-06-14
+-->

--- a/charts/guacamole/README.md
+++ b/charts/guacamole/README.md
@@ -16,6 +16,22 @@ Deploy [Apache Guacamole](https://guacamole.apache.org) on Kubernetes — a clie
 - **Ingress** — TLS with cert-manager
 - **S3 Backup** — scheduled CronJob with pg_dump or mysqldump
 
+## Documentation
+
+- [Chart Design](DESIGN.md)
+- [Database Configuration](docs/database.md)
+- [OIDC with Keycloak](docs/oidc-keycloak.md)
+- [Backup Guide](docs/backup.md)
+- [Guacamole Official Docs](https://guacamole.apache.org/doc/gug/)
+
+### Security Scan: `guacamole`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **78.78788%** |
+
+> Security posture acceptable with operator-provided resource limits, security contexts, and network policy.
+
 ## Installation
 
 ### HTTPS Repository
@@ -153,13 +169,6 @@ Guacamole runs as a single Deployment with two containers:
 
 A post-install Job initializes the database schema. The init job is idempotent and skips schema creation if tables already exist.
 
-## Documentation
-
-- [Database Configuration](docs/database.md)
-- [OIDC with Keycloak](docs/oidc-keycloak.md)
-- [Backup Guide](docs/backup.md)
-- [Guacamole Official Docs](https://guacamole.apache.org/doc/gug/)
-
 <!-- @AI-METADATA
 type: chart-readme
 title: Apache Guacamole Helm Chart
@@ -168,6 +177,7 @@ keywords: guacamole, remote-desktop, rdp, vnc, ssh, oidc, saml, keycloak, helm
 purpose: Installation guide, values reference, and architecture overview
 scope: Chart
 relations:
+  - charts/guacamole/DESIGN.md
   - charts/guacamole/values.yaml
   - charts/guacamole/docs/database.md
   - charts/guacamole/docs/oidc-keycloak.md

--- a/charts/guacamole/ci/external-db-values.yaml
+++ b/charts/guacamole/ci/external-db-values.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: external PostgreSQL database with an in-cluster fake endpoint
+postgresql:
+  enabled: false
+
+database:
+  type: postgresql
+  external:
+    host: guacamole-external-postgresql
+    port: "5432"
+    name: guacamole_db
+    username: guacamole_user
+    password: external-password
+
+extraManifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: guacamole-external-postgresql
+      labels:
+        app.kubernetes.io/name: guacamole-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: guacamole-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: guacamole-external-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:17.5-bookworm
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: guacamole_db
+                - name: POSTGRES_USER
+                  value: guacamole_user
+                - name: POSTGRES_PASSWORD
+                  value: external-password
+              readinessProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - guacamole_user
+                    - -d
+                    - guacamole_db
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/postgresql/data
+          volumes:
+            - name: data
+              emptyDir: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: guacamole-external-postgresql
+      labels:
+        app.kubernetes.io/name: guacamole-external-postgresql
+    spec:
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+      selector:
+        app.kubernetes.io/name: guacamole-external-postgresql

--- a/charts/guacamole/examples/external-postgresql/values.yaml
+++ b/charts/guacamole/examples/external-postgresql/values.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external PostgreSQL database
+# Example: external PostgreSQL database
 postgresql:
   enabled: false
 

--- a/charts/guacamole/templates/NOTES.txt
+++ b/charts/guacamole/templates/NOTES.txt
@@ -1,11 +1,15 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-Apache Guacamole has been deployed!
+Apache Guacamole has been deployed.
 
-  Access Guacamole via port-forward:
+Access:
+
+  Port-forward the service:
 
     kubectl port-forward svc/{{ include "guacamole.fullname" . }} 8080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
 
-  Then open: http://localhost:8080/
+  Open:
+
+    http://localhost:8080/
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
 
@@ -13,8 +17,14 @@ Apache Guacamole has been deployed!
 {{- end }}
 {{- end }}
 
-  Default credentials: guacadmin / guacadmin
-  Change the default password immediately after first login!
+Credentials:
+
+  Default username: guacadmin
+  Default password: guacadmin
+
+  Change the default password immediately after first login.
+
+Runtime:
 
   Database: {{ include "guacamole.dbType" . }}
 {{- if .Values.oidc.enabled }}
@@ -23,3 +33,18 @@ Apache Guacamole has been deployed!
 {{- if .Values.saml.enabled }}
   SSO: SAML enabled
 {{- end }}
+{{- if .Values.backup.enabled }}
+  Backup: S3 CronJob enabled on schedule {{ .Values.backup.schedule }}
+{{- end }}
+
+Validation:
+
+  Check rollout:
+
+    kubectl rollout status deployment/{{ include "guacamole.fullname" . }} -n {{ .Release.Namespace }}
+
+  Check pods:
+
+    kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Happy Helmforging :)


### PR DESCRIPTION
## Summary
- add a Guacamole-specific DESIGN.md covering workload model, database strategy, SSO, backup, and validation boundaries
- add local security scan evidence to the README and align NOTES.txt with HelmForge operational output standards
- move the external PostgreSQL values from k3d CI to a documented example because it requires an operator-owned database endpoint

## Site sync
- Site PR: helmforgedev/site#269

## Validation
- kubescape scan framework "MITRE,NSA,SOC2" charts/guacamole --format json
- make standards-check CHART=guacamole JSON=1
- make md-lint REPO=charts
- make validate-chart CHART=guacamole
- helm template guacamole charts/guacamole -f charts/guacamole/examples/external-postgresql/values.yaml
- make site-sync-check CHART=guacamole