### PR TITLE
fix(heimdall): complete chart standards

### DIFF
--- a/charts/heimdall/DESIGN.md
+++ b/charts/heimdall/DESIGN.md
@@ -1,0 +1,92 @@
+# Heimdall Chart Design
+
+## Purpose
+
+This chart deploys Heimdall as a lightweight application dashboard for
+self-hosted services. Heimdall stores its application links, settings, and
+SQLite data under `/config`, so the chart is intentionally modeled as a
+single-replica workload with persistent storage and optional S3 backup.
+
+## Workload Model
+
+The runtime workload is one Deployment running the official
+`docker.io/linuxserver/heimdall` image. The container exposes HTTP on port 80
+and receives LinuxServer-style environment variables:
+
+- `PUID` controls the numeric user ID used for file ownership.
+- `PGID` controls the numeric group ID used for file ownership.
+- `TZ` controls the application timezone.
+
+When persistence is enabled, the Deployment uses `strategy.type: Recreate`.
+This avoids running two pods against the same SQLite-backed `/config` data
+during rolling updates.
+
+## Storage Strategy
+
+Heimdall stores mutable state in `/config`. The chart creates a PVC by default
+and mounts it at `/config`. Operators can disable persistence for disposable
+tests or provide `persistence.existingClaim` when storage is managed outside the
+release.
+
+Because the application is SQLite-backed, the chart does not expose replica
+configuration. Running multiple replicas against the same PVC is not supported.
+
+## Networking
+
+The Service exposes the application HTTP port through `service.port`.
+Ingress is optional and supports Kubernetes networking.k8s.io/v1 hosts, paths,
+class name, annotations, and TLS entries. TLS is modeled as an explicit list so
+operators can use cert-manager, pre-created Secrets, or HTTP-only ingress.
+
+## Backup Strategy
+
+When `backup.enabled` is true, the chart creates a CronJob that mounts the same
+configuration PVC read-only, creates a compressed tar archive of `/config`, and
+uploads the archive to an S3-compatible endpoint with the HelmForge `mc` image.
+
+The backup job supports:
+
+- Inline credentials for test environments.
+- `backup.s3.existingSecret` for production-managed credentials.
+- Optional bucket creation.
+- A configurable archive prefix and S3 object prefix.
+
+Backups capture Heimdall configuration and SQLite state only. They do not back
+up target applications linked from the dashboard.
+
+## Security Posture
+
+The chart uses a pinned LinuxServer Heimdall image and keeps pod and container
+security contexts operator-configurable. This is important because LinuxServer
+images use PUID/PGID-based file ownership and storage backends vary across
+clusters. Production installs should set resource requests and limits, provide
+an explicit security context compatible with the storage driver, and apply
+NetworkPolicy outside this chart when the cluster supports it.
+
+## Validation Coverage
+
+The CI values cover:
+
+- Default persistent deployment.
+- Persistence disabled.
+- Ingress with TLS.
+- S3 backup rendering with an existing credentials Secret.
+
+Full validation for chart changes must use `make validate-chart CHART=heimdall`.
+
+<!-- @AI-METADATA
+type: chart-design
+title: Heimdall Chart Design
+description: Architecture and operational design for the Heimdall HelmForge chart
+keywords: heimdall, dashboard, sqlite, persistence, backup, ingress
+purpose: Explain workload, storage, networking, backup, and validation design
+scope: Chart
+relations:
+  - charts/heimdall/Chart.yaml
+  - charts/heimdall/values.yaml
+  - charts/heimdall/templates/deployment.yaml
+  - charts/heimdall/templates/backup-cronjob.yaml
+path: charts/heimdall/DESIGN.md
+version: 1.0
+date: 2026-06-14
+-->

--- a/charts/heimdall/README.md
+++ b/charts/heimdall/README.md
@@ -82,7 +82,7 @@ backup:
 
 ## Parameters
 
-### Heimdall
+### Heimdall Settings
 
 | Key | Default | Description |
 |-----|---------|-------------|

--- a/charts/heimdall/README.md
+++ b/charts/heimdall/README.md
@@ -26,6 +26,21 @@ helm install heimdall oci://ghcr.io/helmforgedev/helm/heimdall
 - **Ingress Support** — configurable ingress with TLS for HTTPS access
 - **PUID/PGID** — file ownership control for the container
 
+## Documentation
+
+- [Chart Design](DESIGN.md)
+- [Operations Guide](docs/operations.md)
+- [Backup Guide](docs/backup.md)
+- [Heimdall Source](https://github.com/linuxserver/Heimdall)
+
+### Security Scan: `heimdall`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **72.72727%** |
+
+> Security posture acceptable with operator-provided resource limits, security contexts, and network policy.
+
 ## Configuration
 
 ### Minimal
@@ -131,7 +146,11 @@ keywords: heimdall, dashboard, homepage, launcher, self-hosted, helm, kubernetes
 purpose: User-facing chart documentation with install, examples, and values reference
 scope: Chart
 
-relations: []
+relations:
+  - charts/heimdall/DESIGN.md
+  - charts/heimdall/docs/operations.md
+  - charts/heimdall/docs/backup.md
+  - charts/heimdall/values.yaml
 path: charts/heimdall/README.md
 version: 1.0
 date: 2026-03-31

--- a/charts/heimdall/docs/backup.md
+++ b/charts/heimdall/docs/backup.md
@@ -1,0 +1,71 @@
+# Heimdall Backup
+
+The backup CronJob archives the Heimdall `/config` directory and uploads it to
+an S3-compatible bucket. This captures dashboard links, settings, and SQLite
+state.
+
+## Enable Backup
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: heimdall-backups
+    prefix: heimdall
+    existingSecret: heimdall-s3-credentials
+```
+
+The existing Secret must contain:
+
+- `access-key`
+- `secret-key`
+
+Use custom key names when the platform Secret uses different fields:
+
+```yaml
+backup:
+  s3:
+    existingSecret: platform-s3
+    existingSecretAccessKeyKey: AWS_ACCESS_KEY_ID
+    existingSecretSecretKeyKey: AWS_SECRET_ACCESS_KEY
+```
+
+## Inline Test Credentials
+
+Inline credentials create a chart-managed Secret and are intended for local
+testing only:
+
+```yaml
+backup:
+  enabled: true
+  s3:
+    endpoint: http://minio.minio.svc:9000
+    bucket: heimdall
+    accessKey: minio
+    secretKey: minio123
+```
+
+## Restore Outline
+
+1. Scale the Deployment to zero.
+2. Download the desired archive from S3.
+3. Extract it into the PVC mounted at `/config`.
+4. Scale the Deployment back to one replica.
+5. Confirm the dashboard loads and application links are present.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Heimdall Backup
+description: Backup and restore guidance for the Heimdall chart
+keywords: heimdall, backup, s3, cronjob, restore
+purpose: Document S3 backup and restore workflow for Heimdall
+scope: Chart
+relations:
+  - charts/heimdall/README.md
+  - charts/heimdall/templates/backup-cronjob.yaml
+path: charts/heimdall/docs/backup.md
+version: 1.0
+date: 2026-06-14
+-->

--- a/charts/heimdall/docs/operations.md
+++ b/charts/heimdall/docs/operations.md
@@ -1,0 +1,108 @@
+# Heimdall Operations
+
+## Access
+
+For local access without ingress, forward the Service:
+
+```bash
+kubectl port-forward svc/<release>-heimdall 8080:80
+```
+
+Then open `http://localhost:8080/`.
+
+For production access, enable ingress and set at least one host:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: dashboard.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+TLS is optional. Add `ingress.tls` only when the certificate Secret is available
+or cert-manager annotations will create it.
+
+## Persistence
+
+Heimdall writes its SQLite database and configuration files to `/config`.
+Persistence is enabled by default:
+
+```yaml
+persistence:
+  enabled: true
+  size: 1Gi
+```
+
+Use `persistence.existingClaim` when a platform-owned PVC should be reused:
+
+```yaml
+persistence:
+  enabled: true
+  existingClaim: heimdall-config
+```
+
+Disabling persistence is appropriate only for disposable environments:
+
+```yaml
+persistence:
+  enabled: false
+```
+
+## File Ownership
+
+The LinuxServer image uses `PUID` and `PGID` to align application file
+ownership with the mounted volume:
+
+```yaml
+heimdall:
+  puid: 1000
+  pgid: 1000
+  timezone: America/New_York
+```
+
+If the pod starts but cannot write configuration, confirm the PVC supports the
+configured IDs or set a compatible pod/container security context.
+
+## Upgrade Behavior
+
+When persistence is enabled, the Deployment uses `Recreate` strategy to avoid
+two pods writing to the same SQLite-backed `/config` directory during upgrades.
+
+## Troubleshooting
+
+Check rollout:
+
+```bash
+kubectl rollout status deployment/<release>-heimdall
+```
+
+Check pod logs:
+
+```bash
+kubectl logs -l app.kubernetes.io/instance=<release> --all-containers --tail=100
+```
+
+Check PVC binding:
+
+```bash
+kubectl get pvc -l app.kubernetes.io/instance=<release>
+```
+
+<!-- @AI-METADATA
+type: chart-docs
+title: Heimdall Operations
+description: Operational guidance for Heimdall access, persistence, ownership, upgrades, and troubleshooting
+keywords: heimdall, operations, persistence, pvc, ingress, linuxserver
+purpose: Document production operations for the Heimdall chart
+scope: Chart
+relations:
+  - charts/heimdall/README.md
+  - charts/heimdall/values.yaml
+path: charts/heimdall/docs/operations.md
+version: 1.0
+date: 2026-06-14
+-->

--- a/charts/heimdall/templates/NOTES.txt
+++ b/charts/heimdall/templates/NOTES.txt
@@ -1,7 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Heimdall has been successfully deployed!
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Heimdall has been successfully deployed.
 
 Chart:      {{ .Chart.Name }}
 Version:    {{ .Chart.Version }}
@@ -9,56 +7,46 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ACCESS INFORMATION
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Access:
 
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-DASHBOARD:  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+  Dashboard: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else }}
-Port-forward to access Heimdall locally:
+  Port-forward to access Heimdall locally:
 
-  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "heimdall.fullname" . }} 8080:{{ .Values.service.port | default 80 }}
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "heimdall.fullname" . }} 8080:{{ .Values.service.port | default 80 }}
 
-  DASHBOARD:  http://localhost:8080/
+  Dashboard: http://localhost:8080/
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  GETTING STARTED
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Getting Started:
 
 1. kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }} --timeout=300s
 2. kubectl get pods -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }}
 3. kubectl logs -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }} --all-containers --tail=50 -f
 4. Open the dashboard and add your application links
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  TROUBLESHOOTING
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Troubleshooting:
 
   kubectl describe pod -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=heimdall -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  WARNINGS
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Warnings:
 
 {{- if not .Values.persistence.enabled }}
 
-WARNING: Persistence is disabled! Your Heimdall configuration will be lost on pod restart.
+  Persistence is disabled. Heimdall configuration will be lost on pod restart.
 {{- end }}
 {{- if not .Values.ingress.enabled }}
 
-NOTE: Ingress is not enabled. Access via port-forward (see above).
+  Ingress is not enabled. Access via port-forward.
 {{- end }}
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ADDITIONAL RESOURCES
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Additional Resources:
 
 Documentation:  https://helmforge.dev/docs/charts/heimdall
 Heimdall:       https://heimdall.site | https://github.com/linuxserver/Heimdall


### PR DESCRIPTION
## Summary
- add Heimdall-specific DESIGN.md plus operations and backup docs
- add local security scan evidence to README
- replace decorative NOTES output with plain operational text aligned to chart standards

## Site sync
- Site PR: helmforgedev/site#270

## Validation
- kubescape scan framework "MITRE,NSA,SOC2" charts/heimdall --format json
- make standards-check CHART=heimdall JSON=1
- make md-lint REPO=charts
- make validate-chart CHART=heimdall
- make site-sync-check CHART=heimdall