### PR TITLE
fix(jupyterhub): complete chart standards

### DIFF
--- a/charts/jupyterhub/README.md
+++ b/charts/jupyterhub/README.md
@@ -64,3 +64,21 @@ singleuser:
         cpu_limit: 1
         mem_limit: 2G
 ```
+
+## Security Scan: `jupyterhub`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **81.666664%** |
+
+> Security posture acceptable with non-root Hub and proxy containers, restricted single-user pod defaults, explicit public exposure guardrails, and operator-controlled RBAC for KubeSpawner.
+
+## Documentation
+
+- [Design](./DESIGN.md)
+- [Production guide](./docs/production.md)
+- [Networking](./docs/networking.md)
+- [External Secrets](./docs/external-secrets.md)
+- [Production values example](./examples/production.yaml)
+- [Gateway API example](./examples/gateway.yaml)
+- [External Secrets example](./examples/external-secrets.yaml)

--- a/charts/jupyterhub/ci/dual-stack-values.yaml
+++ b/charts/jupyterhub/ci/dual-stack-values.yaml
@@ -1,6 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack networking via service.ipFamilyPolicy.
+#
+# Uses PreferDualStack policy without explicit ipFamilies so this scenario
+# works on both single-stack (IPv4-only) and dual-stack clusters. The
+# Kubernetes API rejects an explicit ipFamilies entry that the cluster
+# does not advertise, so explicit families remain covered by Helm unittest
+# and require a dual-stack cluster for live installation.
+#
+# To test explicit families on a dual-stack cluster, also set:
+#   service:
+#     ipFamilies:
+#       - IPv4
+#       - IPv6
+#
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/jupyterhub/ci/external-secrets-values.yaml
+++ b/charts/jupyterhub/ci/external-secrets-values.yaml
@@ -4,10 +4,9 @@ proxy:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: cluster-secrets
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: proxy-token
       remoteRef:
-        key: jupyterhub/proxy
-        property: token
+        key: test/token

--- a/charts/jupyterhub/ci/security-values.yaml
+++ b/charts/jupyterhub/ci/security-values.yaml
@@ -9,6 +9,14 @@ networkPolicy:
   enabled: true
 proxy:
   existingSecret: jupyterhub-proxy-token
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: jupyterhub-proxy-token
+    type: Opaque
+    stringData:
+      proxy-token: helmforge-test-token
 auth:
   type: custom
 hub:

--- a/charts/jupyterhub/templates/NOTES.txt
+++ b/charts/jupyterhub/templates/NOTES.txt
@@ -1,7 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-=============================================================================
 JupyterHub deployed successfully!
-=============================================================================
 
 ACCESS:
    kubectl port-forward svc/{{ include "jupyterhub.proxyName" . }} -n {{ .Release.Namespace }} 8080:{{ .Values.service.port }}
@@ -64,4 +62,4 @@ DOCUMENTATION:
    Source: https://github.com/helmforgedev/charts/tree/main/charts/jupyterhub
    JupyterHub: https://jupyter.org/hub
 
-=============================================================================
+Happy Helmforging :)


### PR DESCRIPTION
## Summary
- add JupyterHub Security Scan evidence and chart documentation links to the README
- normalize NOTES.txt to the HelmForge final line convention
- make CI scenarios deterministic for k3d: dual-stack policy without forced IPv6, ESO fake store, and self-contained existing proxy Secret in the security profile

## Validation
- make standards-check CHART=jupyterhub JSON=1
- kubescape scan framework "MITRE,NSA" "charts/jupyterhub" --format json
- node scripts/charts/k3d-validate.js --chart jupyterhub --release jupyterhub-ci-external-secrets-values --values ci/external-secrets-values.yaml
- node scripts/charts/k3d-validate.js --chart jupyterhub --release jupyterhub-ci-security-values --values ci/security-values.yaml
- make validate-chart CHART=jupyterhub
- make release-check REPO=charts
- make attribution-check REPO=charts
- make site-sync-check CHART=jupyterhub

## Site Sync
- helmforgedev/site#272
