### PR TITLE
fix(komga): complete chart standards

### DIFF
--- a/charts/komga/DESIGN.md
+++ b/charts/komga/DESIGN.md
@@ -1,0 +1,94 @@
+# Komga Chart Design
+
+## Scope
+
+This chart deploys Komga as a single-instance media server for comics, manga,
+magazines, and ebooks. It uses the official `gotson/komga` image, SQLite-backed
+application state on `/config`, a separate library volume on `/data`, and
+optional HTTP exposure through Ingress or Gateway API.
+
+The chart is intentionally focused on the Komga application and the Kubernetes
+resources needed to run it predictably. It does not install external databases,
+object storage, authentication proxies, media indexers, or backup storage
+services.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  users[Readers and admins] --> service[Komga Service]
+  ingress[Ingress optional] --> service
+  route[HTTPRoute optional] --> service
+  service --> deploy[Komga Deployment]
+  deploy --> config[(Config PVC /config)]
+  deploy --> data[(Library PVC /data)]
+  cron[Backup CronJob optional] --> config
+  cron --> s3[S3-compatible bucket]
+  eso[ExternalSecret optional] --> secret[S3 credentials Secret]
+  secret --> cron
+```
+
+The workload is a single Deployment with one replica because Komga stores its
+application database in SQLite. The chart separates `/config` and `/data` so the
+database/config volume can be backed up independently from large media files.
+
+## Main Design Choices
+
+- Use the official upstream `gotson/komga` image pinned to the chart appVersion.
+- Keep SQLite as the default and only database mode.
+- Persist both `/config` and `/data` by default.
+- Keep the service internal by default, with explicit opt-in for Ingress or
+  Gateway API.
+- Expose JVM tuning through `komga.javaToolOptions` without forcing a memory
+  profile on small installs.
+- Provide an optional S3 backup CronJob for consistent SQLite exports and config
+  archives.
+- Support External Secrets Operator for S3 backup credentials without making ESO
+  a chart dependency.
+
+## Production Boundary
+
+Production deployments should keep persistence enabled, size the `/data` PVC for
+the media library, configure `komga.javaToolOptions` for the available memory,
+set explicit resource requests and limits, and use Ingress or Gateway API only
+with TLS termination handled by the cluster ingress layer.
+
+Backups cover SQLite database files and top-level application configuration from
+`/config`. They intentionally exclude library media under `/data`; media backup
+or replication belongs to the storage platform or a separate backup workflow.
+
+## Current Gaps and Improvement Candidates
+
+- Add first-class NetworkPolicy support for web traffic and backup egress.
+- Add an optional PodDisruptionBudget if the chart grows beyond a single
+  replica model.
+- Add hardened default security contexts after validating the upstream image
+  user, writable paths, and backup containers across amd64 and arm64.
+- Add documented restore smoke tests for the backup workflow.
+- Add optional ServiceMonitor support if Komga exposes stable application
+  metrics in a future release.
+
+## Explicit Non-Goals
+
+- running multiple Komga replicas against the same SQLite database
+- external database automation
+- bundled object storage
+- bundled authentication proxy or SSO gateway
+- media file backup for `/data`
+- installing External Secrets Operator, Gateway API CRDs, or cert-manager
+
+<!-- @AI-METADATA
+type: design
+title: Komga Chart Design
+description: Design document for the Komga Helm chart
+keywords: komga, comics, manga, sqlite, media-server, backup
+purpose: Document chart architecture, decisions, production boundaries, and non-goals
+scope: Chart Design
+relations:
+  - charts/komga/README.md
+  - charts/komga/docs/backup.md
+  - charts/komga/examples/production/values.yaml
+path: charts/komga/DESIGN.md
+version: 1.0
+date: 2026-06-14
+-->

--- a/charts/komga/README.md
+++ b/charts/komga/README.md
@@ -9,7 +9,14 @@ Deploy [Komga](https://komga.org) on Kubernetes — a media server for comics, m
 - **Java Tool Options** — configurable JVM tuning via `JAVA_TOOL_OPTIONS`
 - **Timezone Support** — configurable via `TZ` environment variable
 - **Ingress** — optional with TLS and cert-manager support
+- **Gateway API** — optional HTTPRoute for clusters using Gateway API
+- **External Secrets** — optional ExternalSecret for S3 backup credentials
 - **S3 Backup** — scheduled CronJob with consistent SQLite exports and config archive upload
+
+## Design
+
+See [DESIGN.md](DESIGN.md) for the chart architecture, production boundary, and
+explicit non-goals.
 
 ## Installation
 
@@ -90,8 +97,8 @@ backup:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.repository` | `gotson/komga` | Image repository |
-| `image.tag` | `""` (appVersion) | Image tag |
+| `image.repository` | `docker.io/gotson/komga` | Image repository |
+| `image.tag` | `"1.24.4"` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### Komga Configuration
@@ -123,6 +130,8 @@ backup:
 |-----|---------|-------------|
 | `service.type` | `ClusterIP` | Service type |
 | `service.port` | `80` | Service port |
+| `service.ipFamilyPolicy` | `""` | Optional Service IP family policy |
+| `service.ipFamilies` | `[]` | Optional Service IP families |
 
 ### Ingress
 
@@ -132,6 +141,56 @@ backup:
 | `ingress.ingressClassName` | `traefik` | Ingress class (`traefik`, `nginx`, etc.) |
 | `ingress.hosts` | `[]` | Ingress host rules |
 | `ingress.tls` | `[]` | TLS configuration |
+
+### Gateway API
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `gateway.enabled` | `false` | Create an HTTPRoute |
+| `gateway.parentRefs` | `[]` | Gateway parent references |
+| `gateway.hostnames` | `[]` | HTTPRoute hostnames |
+| `gateway.path` | `/` | HTTPRoute path match |
+| `gateway.pathType` | `PathPrefix` | HTTPRoute path match type |
+
+### External Secrets
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `externalSecrets.enabled` | `false` | Render an ExternalSecret for backup credentials |
+| `externalSecrets.refreshInterval` | `1h` | Default sync interval for items without `spec.refreshInterval` |
+| `externalSecrets.items` | `[]` | ExternalSecret definitions with complete `spec` blocks |
+
+Example projecting S3 backup credentials:
+
+```yaml
+backup:
+  enabled: true
+  s3:
+    endpoint: https://s3.amazonaws.com
+    bucket: my-backups
+    existingSecret: komga-backup-s3
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: backup-s3
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          name: komga-backup-s3
+          creationPolicy: Owner
+        data:
+          - secretKey: access-key
+            remoteRef:
+              key: komga/backup
+              property: access-key
+          - secretKey: secret-key
+            remoteRef:
+              key: komga/backup
+              property: secret-key
+```
 
 ### Backup
 
@@ -150,6 +209,17 @@ backup:
 
 The backup CronJob exports each SQLite database found in `/config` using `sqlite3 VACUUM INTO`, then packages those exported databases together with top-level application config files and optional logs before uploading the archive to S3. Search indexes are intentionally excluded because Komga can rebuild them.
 
+## Security Scan
+
+### Security Scan: `komga`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **73%** |
+
+Security posture: acceptable with follow-up hardening candidates documented in
+[DESIGN.md](DESIGN.md).
+
 ## Architecture
 
 Komga runs as a single Deployment with a Java-based server on port 25600. It uses SQLite for its database (stored in `/config`) and serves comic/manga libraries from `/data`.
@@ -161,6 +231,7 @@ The chart creates two separate PVCs:
 
 ## Documentation
 
+- [Design](DESIGN.md)
 - [Backup Guide](docs/backup.md)
 - [Komga Official Docs](https://komga.org/docs/introduction)
 

--- a/charts/komga/README.md
+++ b/charts/komga/README.md
@@ -207,7 +207,11 @@ externalSecrets:
 
 ## Backup Behavior
 
-The backup CronJob exports each SQLite database found in `/config` using `sqlite3 VACUUM INTO`, then packages those exported databases together with top-level application config files and optional logs before uploading the archive to S3. Search indexes are intentionally excluded because Komga can rebuild them.
+The backup CronJob exports each SQLite database found in `/config` using
+`sqlite3 VACUUM INTO`, then packages those exported databases together with
+top-level application config files and optional logs before uploading the
+archive to S3. Search indexes are intentionally excluded because Komga can
+rebuild them.
 
 ## Security Scan
 

--- a/charts/komga/ci/external-secrets.yaml
+++ b/charts/komga/ci/external-secrets.yaml
@@ -1,17 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: External Secrets Operator integration (GR-061)
 # Renders the ExternalSecret manifest for backup S3 credentials
+backup:
+  enabled: true
+  suspend: true
+  s3:
+    endpoint: https://s3.example.com
+    bucket: komga-backup
+    existingSecret: komga-ci-external-secrets-komga-backup-s3
+
 externalSecrets:
   enabled: true
-  secretStoreRef:
-    name: my-store
-    kind: ClusterSecretStore
-  data:
-    - secretKey: access-key
-      remoteRef:
-        key: komga/backup
-        property: access-key
-    - secretKey: secret-key
-      remoteRef:
-        key: komga/backup
-        property: secret-key
+  items:
+    - name: backup-s3
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        data:
+          - secretKey: access-key
+            remoteRef:
+              key: test/username
+          - secretKey: secret-key
+            remoteRef:
+              key: test/password

--- a/charts/komga/ci/external-secrets.yaml
+++ b/charts/komga/ci/external-secrets.yaml
@@ -17,6 +17,9 @@ externalSecrets:
         secretStoreRef:
           name: helmforge-fake-store
           kind: ClusterSecretStore
+        target:
+          name: komga-ci-external-secrets-komga-backup-s3
+          creationPolicy: Owner
         data:
           - secretKey: access-key
             remoteRef:

--- a/charts/komga/templates/NOTES.txt
+++ b/charts/komga/templates/NOTES.txt
@@ -1,18 +1,54 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-Komga has been deployed!
+Komga has been deployed.
 
-  Access Komga via port-forward:
+Access:
 
+  Internal service:
+    http://{{ include "komga.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+
+  Port-forward:
     kubectl port-forward svc/{{ include "komga.fullname" . }} {{ .Values.komga.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
-
-  Then open: http://localhost:{{ .Values.komga.port }}
+    http://localhost:{{ .Values.komga.port }}
 
 {{- if .Values.ingress.enabled }}
+  Ingress:
 {{- range .Values.ingress.hosts }}
-
-  Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
 {{- end }}
 {{- end }}
 
-  On first access, create your admin account.
-  Add libraries pointing to subdirectories under /data.
+{{- if .Values.gateway.enabled }}
+  Gateway API:
+{{- range .Values.gateway.hostnames }}
+    http://{{ . }}{{ $.Values.gateway.path }}
+{{- end }}
+{{- end }}
+
+Storage:
+  Config/database volume: {{ if .Values.persistence.config.enabled }}persistent{{ else }}ephemeral{{ end }}
+  Library volume: {{ if .Values.persistence.data.enabled }}persistent{{ else }}ephemeral{{ end }}
+
+Runtime:
+  Timezone: {{ .Values.komga.timezone }}
+  Context path: {{ .Values.komga.contextPath }}
+  Session timeout: {{ .Values.komga.sessionTimeout }}
+{{- $javaToolOptions := .Values.komga.javaToolOptions | default .Values.komga.javaMemory }}
+{{- if $javaToolOptions }}
+  Java options: {{ $javaToolOptions }}
+{{- end }}
+
+Backup:
+{{- if .Values.backup.enabled }}
+  CronJob enabled on schedule {{ .Values.backup.schedule }}.
+  Target bucket: {{ .Values.backup.s3.bucket }}
+  Credential secret: {{ include "komga.backupSecretName" . }}
+{{- else }}
+  Disabled. Enable backup.enabled and configure backup.s3 for S3-compatible backups.
+{{- end }}
+
+Next steps:
+  1. Open Komga and create the first admin account.
+  2. Add libraries that point to subdirectories under /data.
+  3. For production, set resource requests and limits and verify backups.
+
+Happy Helmforging :)

--- a/charts/komga/templates/_helpers.tpl
+++ b/charts/komga/templates/_helpers.tpl
@@ -77,3 +77,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "komga.backupSecretSecretKeyKey" -}}
 {{- .Values.backup.s3.existingSecretSecretKeyKey | default "secret-key" -}}
 {{- end -}}
+
+{{/* ExternalSecret resource name */}}
+{{- define "komga.externalSecretName" -}}
+{{- $root := index . "root" -}}
+{{- $item := index . "item" -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $fullname := include "komga.fullname" $root -}}
+{{- $itemName := $item.name | default "external" | trunc 32 | trimSuffix "-" -}}
+{{- printf "%s-%s" ($fullname | trunc (int (sub 62 (len $itemName))) | trimSuffix "-") $itemName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/komga/templates/externalsecret.yaml
+++ b/charts/komga/templates/externalsecret.yaml
@@ -1,8 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
 {{- $items := .Values.externalSecrets.items | default list }}
+{{- $legacyCreationPolicy := "Owner" }}
+{{- with .Values.externalSecrets.target }}
+{{- $legacyCreationPolicy = .creationPolicy | default "Owner" }}
+{{- end }}
 {{- if and (not $items) .Values.externalSecrets.data }}
-{{- $items = list (dict "name" "backup-s3" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" (include "komga.backupSecretName" .) "creationPolicy" .Values.externalSecrets.target.creationPolicy) "data" .Values.externalSecrets.data)) }}
+{{- $items = list (dict "name" "backup-s3" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" (include "komga.backupSecretName" .) "creationPolicy" $legacyCreationPolicy) "data" .Values.externalSecrets.data)) }}
 {{- end }}
 {{- range $items }}
 {{- $externalSecretName := include "komga.externalSecretName" (dict "root" $ "item" .) }}

--- a/charts/komga/templates/externalsecret.yaml
+++ b/charts/komga/templates/externalsecret.yaml
@@ -6,7 +6,7 @@
 {{- $legacyCreationPolicy = .creationPolicy | default "Owner" }}
 {{- end }}
 {{- if and (not $items) .Values.externalSecrets.data }}
-{{- $items = list (dict "name" "backup-s3" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" (include "komga.backupSecretName" .) "creationPolicy" $legacyCreationPolicy) "data" .Values.externalSecrets.data)) }}
+{{- $items = list (dict "name" "backup" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" (include "komga.backupSecretName" .) "creationPolicy" $legacyCreationPolicy) "data" .Values.externalSecrets.data)) }}
 {{- end }}
 {{- range $items }}
 {{- $externalSecretName := include "komga.externalSecretName" (dict "root" $ "item" .) }}

--- a/charts/komga/templates/externalsecret.yaml
+++ b/charts/komga/templates/externalsecret.yaml
@@ -1,19 +1,52 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
-apiVersion: {{ .Values.externalSecrets.apiVersion }}
+{{- $items := .Values.externalSecrets.items | default list }}
+{{- if and (not $items) .Values.externalSecrets.data }}
+{{- $items = list (dict "name" "backup-s3" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" (include "komga.backupSecretName" .) "creationPolicy" .Values.externalSecrets.target.creationPolicy) "data" .Values.externalSecrets.data)) }}
+{{- end }}
+{{- range $items }}
+{{- $externalSecretName := include "komga.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{ include "komga.fullname" . }}-backup
+  name: {{ $externalSecretName }}
   labels:
-    {{- include "komga.labels" . | nindent 4 }}
+    {{- include "komga.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
-  secretStoreRef:
-    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
-    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
-  target:
-    name: {{ include "komga.fullname" . }}-backup-s3
-    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
-  data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/komga/templates/externalsecret.yaml
+++ b/charts/komga/templates/externalsecret.yaml
@@ -1,5 +1,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
+{{- if and .Values.externalSecrets.apiVersion (ne .Values.externalSecrets.apiVersion "external-secrets.io/v1") }}
+{{- fail "externalSecrets.apiVersion is deprecated; Komga renders external-secrets.io/v1 only. Upgrade External Secrets Operator CRDs or remove this value." }}
+{{- end }}
 {{- $items := .Values.externalSecrets.items | default list }}
 {{- $legacyCreationPolicy := "Owner" }}
 {{- with .Values.externalSecrets.target }}
@@ -7,6 +10,9 @@
 {{- end }}
 {{- if and (not $items) .Values.externalSecrets.data }}
 {{- $items = list (dict "name" "backup" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" (include "komga.backupSecretName" .) "creationPolicy" $legacyCreationPolicy) "data" .Values.externalSecrets.data)) }}
+{{- end }}
+{{- if not $items }}
+{{- fail "externalSecrets.items or externalSecrets.data is required when externalSecrets.enabled=true" }}
 {{- end }}
 {{- range $items }}
 {{- $externalSecretName := include "komga.externalSecretName" (dict "root" $ "item" .) }}

--- a/charts/komga/tests/externalsecret_test.yaml
+++ b/charts/komga/tests/externalsecret_test.yaml
@@ -129,3 +129,29 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"
+
+  - it: requires at least one ExternalSecret item
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items or externalSecrets.data is required when externalSecrets.enabled=true"
+
+  - it: rejects deprecated non-v1 apiVersion values
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.apiVersion: external-secrets.io/v1beta1
+      externalSecrets.items:
+        - name: backup-s3
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            data:
+              - secretKey: access-key
+                remoteRef:
+                  key: komga/backup
+                  property: access-key
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.apiVersion is deprecated; Komga renders external-secrets.io/v1 only. Upgrade External Secrets Operator CRDs or remove this value."

--- a/charts/komga/tests/externalsecret_test.yaml
+++ b/charts/komga/tests/externalsecret_test.yaml
@@ -94,6 +94,30 @@ tests:
           path: spec.target.name
           value: komga-s3-credentials
 
+  - it: preserves the legacy single ExternalSecret surface without target
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef:
+        name: platform-secrets
+        kind: ClusterSecretStore
+      externalSecrets.data:
+        - secretKey: access-key
+          remoteRef:
+            key: komga/backup
+            property: access-key
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: metadata.name
+          value: test-komga-backup-s3
+      - equal:
+          path: spec.target.name
+          value: test-komga-backup-s3
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+
   - it: requires a SecretStore reference
     set:
       externalSecrets.enabled: true

--- a/charts/komga/tests/externalsecret_test.yaml
+++ b/charts/komga/tests/externalsecret_test.yaml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a backup credentials ExternalSecret item
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: backup-s3
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            target:
+              name: komga-backup-s3
+              creationPolicy: Owner
+            data:
+              - secretKey: access-key
+                remoteRef:
+                  key: komga/backup
+                  property: access-key
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: test-komga-backup-s3
+      - equal:
+          path: spec.secretStoreRef.name
+          value: platform-secrets
+      - equal:
+          path: spec.target.name
+          value: komga-backup-s3
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: defaults the target name to the ExternalSecret name
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: backup-s3
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            data:
+              - secretKey: access-key
+                remoteRef:
+                  key: komga/backup
+                  property: access-key
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-komga-backup-s3
+      - equal:
+          path: spec.target.name
+          value: test-komga-backup-s3
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: supports a literal fullnameOverride
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: komga-s3-credentials
+          spec:
+            secretStoreRef:
+              name: platform-secrets
+              kind: ClusterSecretStore
+            data:
+              - secretKey: secret-key
+                remoteRef:
+                  key: komga/backup
+                  property: secret-key
+    asserts:
+      - equal:
+          path: metadata.name
+          value: komga-s3-credentials
+      - equal:
+          path: spec.target.name
+          value: komga-s3-credentials
+
+  - it: requires a SecretStore reference
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: broken
+          spec:
+            target:
+              name: broken
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"

--- a/charts/komga/tests/externalsecret_test.yaml
+++ b/charts/komga/tests/externalsecret_test.yaml
@@ -110,7 +110,7 @@ tests:
           of: ExternalSecret
       - equal:
           path: metadata.name
-          value: test-komga-backup-s3
+          value: test-komga-backup
       - equal:
           path: spec.target.name
           value: test-komga-backup-s3

--- a/charts/komga/values.schema.json
+++ b/charts/komga/values.schema.json
@@ -623,23 +623,41 @@
     },
     "externalSecrets": {
       "type": "object",
-      "description": "External Secrets Operator integration",
+      "description": "External Secrets Operator resources for S3 backup credentials or related integrations",
+      "additionalProperties": false,
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Render ExternalSecret resources for clusters running External Secrets Operator",
+          "description": "Render ExternalSecret resources",
           "default": false
         },
         "apiVersion": {
           "type": "string",
+          "description": "Deprecated compatibility field. ExternalSecret resources render as external-secrets.io/v1.",
           "default": "external-secrets.io/v1"
         },
         "refreshInterval": {
           "type": "string",
+          "description": "Default provider sync interval for ExternalSecret items that do not set spec.refreshInterval",
           "default": "1h"
+        },
+        "items": {
+          "type": "array",
+          "description": "ExternalSecret definitions with full spec blocks",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "fullnameOverride": { "type": "string" },
+              "labels": { "type": "object" },
+              "annotations": { "type": "object" },
+              "spec": { "type": "object" }
+            }
+          }
         },
         "secretStoreRef": {
           "type": "object",
+          "description": "Deprecated compatibility field for the legacy single ExternalSecret surface",
           "properties": {
             "name": { "type": "string", "default": "" },
             "kind": {
@@ -651,6 +669,7 @@
         },
         "target": {
           "type": "object",
+          "description": "Deprecated compatibility field for the legacy single ExternalSecret surface",
           "properties": {
             "creationPolicy": {
               "type": "string",
@@ -661,6 +680,7 @@
         },
         "data": {
           "type": "array",
+          "description": "Deprecated compatibility field for the legacy single ExternalSecret surface",
           "items": { "type": "object" }
         }
       }

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -149,28 +149,30 @@ gateway:
 # =============================================================================
 
 externalSecrets:
-  # -- Render ExternalSecret for clusters running External Secrets Operator.
+  # -- Render ExternalSecret resources for S3 backup credentials or related integrations.
   enabled: false
-  # -- ExternalSecret apiVersion.
-  apiVersion: external-secrets.io/v1
-  # -- Refresh interval.
+  # -- Default provider sync interval for ExternalSecret items that do not set spec.refreshInterval.
   refreshInterval: 1h
-  secretStoreRef:
-    # -- Existing SecretStore or ClusterSecretStore name.
-    name: ""
-    kind: SecretStore
-  target:
-    creationPolicy: Owner
-  # -- ExternalSecret data entries for S3 backup credentials.
-  data: []
-  #   - secretKey: access-key
-  #     remoteRef:
-  #       key: komga/backup
-  #       property: access-key
-  #   - secretKey: secret-key
-  #     remoteRef:
-  #       key: komga/backup
-  #       property: secret-key
+  # -- ExternalSecret definitions. Each item requires a full `spec`.
+  # @default -- `[]`
+  items: []
+    # - name: backup-s3
+    #   spec:
+    #     secretStoreRef:
+    #       name: platform-secrets
+    #       kind: ClusterSecretStore
+    #     target:
+    #       name: komga-backup-s3
+    #       creationPolicy: Owner
+    #     data:
+    #       - secretKey: access-key
+    #         remoteRef:
+    #           key: komga/backup
+    #           property: access-key
+    #       - secretKey: secret-key
+    #         remoteRef:
+    #           key: komga/backup
+    #           property: secret-key
 
 # =============================================================================
 # Probes


### PR DESCRIPTION
## Summary
- add a Komga-specific DESIGN.md with production boundaries and improvement candidates
- align ExternalSecrets with the HelmForge items[] pattern while preserving legacy compatibility
- update NOTES output and README security/defaults documentation
- add ExternalSecret unit coverage and a k3d-valid fake-store CI profile

## Validation
- make standards-check CHART=komga JSON=1
- make standards-guard
- make md-lint REPO=charts
- make deps-check CHART=komga JSON=1
- make image-verify IMAGE=docker.io/gotson/komga:1.24.4
- make image-verify IMAGE=docker.io/helmforge/mc:1.0.0
- make image-verify IMAGE=docker.io/library/alpine:3.22
- helm unittest charts/komga
- helm template komga-ci-external-secrets charts/komga -f charts/komga/ci/external-secrets.yaml | kubeconform -strict -summary -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
- node scripts/charts/k3d-validate.js --chart komga --release komga-ci-external-secrets --values ci/external-secrets.yaml
- make validate-chart CHART=komga
- make release-check REPO=charts
- make attribution-check REPO=charts

## Site Sync
- helmforgedev/site#274