### PR TITLE
fix(metrics-server): complete chart standards

### DIFF
--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -37,6 +37,10 @@ helm install metrics-server oci://ghcr.io/helmforgedev/helm/metrics-server -n ku
 
 Metrics Server `0.8.x` supports Kubernetes `1.31+`. The chart therefore declares `kubeVersion: >=1.31.0-0`.
 
+## Security Scan
+
+Security Scan: Kubescape local scan against `MITRE,NSA,SOC2` reports a 89.90% resource summary score.
+
 ## k3d and Local Clusters
 
 Many local clusters use kubelet serving certificates that do not include the address SANs Metrics Server validates. Use the k3d values file for local validation:
@@ -61,6 +65,12 @@ pdb:
 ```
 
 For best HA behavior, configure the kube-apiserver with aggregator routing enabled so APIService requests are distributed across replicas.
+
+## Existing Metrics API Resources
+
+Some Kubernetes distributions preinstall `v1beta1.metrics.k8s.io` and `system:aggregated-metrics-reader`.
+When those cluster-scoped resources already exist, the chart does not try to adopt them into the Helm release.
+This avoids ownership conflicts while still deploying the Metrics Server workload, Service, RBAC bindings, and optional observability resources.
 
 ## Main Values
 

--- a/charts/metrics-server/ci/dual-stack.yaml
+++ b/charts/metrics-server/ci/dual-stack.yaml
@@ -1,6 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/metrics-server/docs/production.md
+++ b/charts/metrics-server/docs/production.md
@@ -27,6 +27,9 @@ Metrics Server HA works best when kube-apiserver aggregator routing is enabled.
 The default APIService uses `insecureSkipTLSVerify=true` because Metrics Server generates a self-signed serving certificate.
 Set `apiService.caBundle` when your platform injects or manages a trusted serving CA.
 
+If the cluster already provides `v1beta1.metrics.k8s.io` or `system:aggregated-metrics-reader`, the chart skips those
+cluster-scoped resources instead of adopting ownership from the platform-managed object.
+
 ## Host Network
 
 Enable host networking only when the API server cannot reach the Metrics Server pod network:

--- a/charts/metrics-server/templates/NOTES.txt
+++ b/charts/metrics-server/templates/NOTES.txt
@@ -50,4 +50,4 @@ DOCUMENTATION:
    Source: https://github.com/helmforgedev/charts/tree/main/charts/metrics-server
    Metrics Server: https://github.com/kubernetes-sigs/metrics-server
 
-=============================================================================
+Happy Helmforging :)

--- a/charts/metrics-server/templates/apiservice.yaml
+++ b/charts/metrics-server/templates/apiservice.yaml
@@ -1,5 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.apiService.create }}
+{{- $existingAPIService := lookup "apiregistration.k8s.io/v1" "APIService" "" "v1beta1.metrics.k8s.io" }}
+{{- if and .Values.apiService.create (not $existingAPIService) }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:

--- a/charts/metrics-server/templates/rbac.yaml
+++ b/charts/metrics-server/templates/rbac.yaml
@@ -1,6 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.rbac.create }}
-{{- if .Values.rbac.aggregatedMetricsReader.create }}
+{{- $existingAggregatedMetricsReader := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "system:aggregated-metrics-reader" }}
+{{- if and .Values.rbac.aggregatedMetricsReader.create (not $existingAggregatedMetricsReader) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
## Summary
- add the required Metrics Server Security Scan section and standard NOTES footer
- avoid adopting platform-managed Metrics API resources when APIService or aggregate reader ClusterRole already exist
- make the dual-stack CI scenario portable on single-stack k3d clusters

## Validation
- kubescape scan framework "MITRE,NSA,SOC2" charts/metrics-server: 89.90%
- make standards-check CHART=metrics-server JSON=1
- make standards-guard
- make md-lint REPO=charts
- helm unittest charts/metrics-server
- make validate-chart CHART=metrics-server CONTEXT=k3d-helmforge-tests-wsl
- make release-check REPO=charts
- make attribution-check REPO=charts
- make site-sync-check CHART=metrics-server

Site PR: https://github.com/helmforgedev/site/pull/285