### PR TITLE
chore(apache): bump apache to 2.4.68

### DIFF
--- a/charts/apache/Chart.yaml
+++ b/charts/apache/Chart.yaml
@@ -4,7 +4,7 @@ name: apache
 description: Apache HTTP Server Helm Chart with secure non-root defaults, custom content, Gateway API, and optional metrics
 type: application
 version: 1.0.3
-appVersion: "2.4.67"
+appVersion: "2.4.68"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/apache.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "complete chart standards (#498)"
+      description: "bump apache to 2.4.68 (#516)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/apache/README.md
+++ b/charts/apache/README.md
@@ -29,7 +29,7 @@ helm install apache oci://ghcr.io/helmforgedev/helm/apache \
 
 ## Differentiators
 
-- Official Apache HTTP Server image only, pinned to `2.4.67`.
+- Official Apache HTTP Server image only, pinned to `2.4.68`.
 - Non-root runtime on port `8080` with `RuntimeDefault` seccomp and dropped
   Linux capabilities.
 - Read-only root filesystem with explicit writable `emptyDir` volumes for logs

--- a/charts/apache/values.yaml
+++ b/charts/apache/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Apache HTTP Server image repository.
   repository: docker.io/library/httpd
   # -- Apache HTTP Server image tag.
-  tag: "2.4.67"
+  tag: "2.4.68"
   # -- Apache HTTP Server image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump the default Apache HTTP Server image to `2.4.68`
- align `appVersion` and Artifact Hub change metadata
- refresh README version references

## Upstream evidence
- image manifest: `docker.io/library/httpd:2.4.68` verified with `make image-verify`
- release notes: https://httpd.apache.org/download.cgi
- changes: https://downloads.apache.org/httpd/CHANGES_2.4.68

## Validation
- `make deps-check CHART=apache`
- `make validate-chart CHART=apache`
- `make standards-check CHART=apache`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=apache`
- `make org-check`

Closes #516
