### PR TITLE
chore(cloudflared): bump cloudflared to 2026.6.0

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.7
-appVersion: "2026.5.2"
+appVersion: "2026.6.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.5.2"
+  tag: "2026.6.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- bump the default cloudflared image to `2026.6.0`
- align `appVersion` with the verified upstream tag

## Upstream evidence
- image manifest: `docker.io/cloudflare/cloudflared:2026.6.0` verified with `make image-verify`
- release notes: https://github.com/cloudflare/cloudflared/releases/tag/2026.6.0

## Validation
- `make deps-check CHART=cloudflared`
- `make validate-chart CHART=cloudflared`
- `make standards-check CHART=cloudflared`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=cloudflared`

Closes #517
