### PR TITLE
chore(ghost): bump ghost to 6.45.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.14
-appVersion: "6.44.1"
+appVersion: "6.45.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ghost to 6.44.1 (#475)"
+      description: "bump ghost to 6.45.0 (#518)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -65,7 +65,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.44.1` | Ghost image tag |
+| `image.tag` | `6.45.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -77,11 +77,10 @@ database:
 
 ## Upgrade Notes
 
-`docker.io/library/ghost:6.44.1` is an upstream image update from `6.42.0`.
-Review the upstream Ghost release notes before upgrading production sites, take
-a content and database backup, and verify themes, custom integrations,
-newsletter flows, comments, and member signup paths in staging before reusing
-existing PVCs.
+Ghost `6.45.0` is the current upstream patch release. Review the upstream
+Ghost release notes before upgrading production sites, take a content and
+database backup, and verify themes, custom integrations, newsletter flows,
+comments, and member signup paths in staging before reusing existing PVCs.
 
 ## S3 Backup
 

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.44.1"
+          value: "docker.io/library/ghost:6.45.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.44.1"
+                                                                    "default":  "6.45.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.44.1"
+  tag: "6.45.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- bump the default Ghost image to `6.45.0`
- align `appVersion`, schema defaults, tests, and README references
- update the bundled HelmForge `mysql` dependency to `2.0.1`

## Upstream evidence
- image manifest: `docker.io/library/ghost:6.45.0` verified with `make image-verify`
- release notes: https://github.com/TryGhost/Ghost/releases/tag/v6.45.0
- dependency check: `make deps-check CHART=ghost` required `mysql` `2.0.0 -> 2.0.1`

## Validation
- `make deps-check CHART=ghost`
- `make validate-chart CHART=ghost`
- `make standards-check CHART=ghost`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=ghost`

Closes #518
