### PR TITLE
chore(jenkins): bump jenkins to 2.555.3

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -4,7 +4,7 @@ name: jenkins
 description: Jenkins Helm Chart with secure controller defaults, JCasC, plugin bootstrap, Gateway API, and Kubernetes agent RBAC
 type: application
 version: 1.0.3
-appVersion: "2.555.2"
+appVersion: "2.555.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Jenkins controller image repository.
   repository: docker.io/jenkins/jenkins
   # -- Jenkins controller image tag.
-  tag: "2.555.2-lts-jdk21"
+  tag: "2.555.3-lts-jdk21"
   # -- Jenkins controller image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump the default Jenkins controller image to `2.555.3-lts-jdk21`
- align `appVersion` to Jenkins `2.555.3`

## Upstream evidence
- image manifest: `docker.io/jenkins/jenkins:2.555.3-lts-jdk21` verified with `make image-verify`
- release notes: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.555.3

## Validation
- `make deps-check CHART=jenkins`
- `make validate-chart CHART=jenkins`
- `make standards-check CHART=jenkins`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=jenkins`

Closes #520
