### PR TITLE
chore(pihole): bump pihole to 2026.06.0

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: pihole
 type: application
 version: 2.0.10
-appVersion: "2026.05.0"
+appVersion: "2026.06.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Pi-hole DNS sinkhole on Kubernetes
 maintainers:
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/pihole.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "complete chart standards (#540)"
+      description: "bump pihole to 2026.06.0 (#526)"
     - kind: changed
       description: "add SPDX-License-Identifier headers across the catalog (#438)"
   artifacthub.io/maintainers: |

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -135,7 +135,7 @@ metrics:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/pihole/pihole` | Pi-hole container image repository |
-| `image.tag` | `2026.05.0` | Pi-hole container image tag (Core v6.4.2, Web v6.5, FTL v6.6.2) |
+| `image.tag` | `2026.06.0` | Pi-hole container image tag (official upstream release 2026.06.0) |
 | `image.pullPolicy` | `IfNotPresent` | Pi-hole image pull policy |
 | `pihole.timezone` | `UTC` | Timezone for logs and scheduled tasks |
 | `pihole.upstreamDns` | `8.8.8.8;8.8.4.4` | Upstream DNS servers (semicolon-delimited) |
@@ -294,10 +294,10 @@ metrics:
 
 ## Upgrade Notes
 
-Pi-hole `2026.05.0` ships FTL `v6.6.2`, which imports six upstream `dnsmasq`
-security fixes covering the publicly disclosed CVEs against the dnsmasq
-2.92/2.93 line. Back up `/etc/pihole` and `/etc/dnsmasq.d` before upgrading
-live deployments.
+Pi-hole `2026.06.0` rolls in the upstream Web `6.5.1` fixes published by the
+Pi-hole project. No chart-specific migration is required for this image bump,
+but production upgrades should still back up `/etc/pihole` and
+`/etc/dnsmasq.d` before rollout.
 
 ## Connection
 

--- a/charts/pihole/tests/deployment_test.yaml
+++ b/charts/pihole/tests/deployment_test.yaml
@@ -456,7 +456,7 @@ tests:
           value: gravity-update
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "docker.io/pihole/pihole:2026.05.0"
+          value: "docker.io/pihole/pihole:2026.06.0"
       - matchRegex:
           path: spec.template.spec.initContainers[1].command[2]
           pattern: "pihole -g"

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.05.0"
+          "default": "2026.06.0"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/pihole/pihole
   # -- Container image tag
-  tag: "2026.05.0"
+  tag: "2026.06.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump Pi-hole from `2026.05.0` to `2026.06.0`
- refresh the values schema, unittest fixture, and README upgrade notes for the new upstream image
- validate the chart end to end, including all k3d CI scenarios

## Upstream evidence
- Image manifest: `docker.io/pihole/pihole:2026.06.0` (`make image-verify IMAGE=docker.io/pihole/pihole:2026.06.0`)
- Release notes: https://github.com/pi-hole/docker-pi-hole/releases/tag/2026.06.0

## Validation
- `make deps-check CHART=pihole`
- `make validate-chart CHART=pihole`
- `make standards-check CHART=pihole`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=pihole`
- `make org-check`
- `make preflight`

## Notes
- `make site-sync-check CHART=pihole` reports required companion updates in the site docs/playground for GR-007.

Closes #526