### PR TITLE
chore(strava-statistics): bump image to v4.8.8

### DIFF
--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -4,7 +4,7 @@ name: strava-statistics
 description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
 type: application
 version: 1.1.14
-appVersion: "4.8.7"
+appVersion: "4.8.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to v4.8.7 (#484)"
+      description: "bump image to v4.8.8 (#527)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strava-statistics/DESIGN.md
+++ b/charts/strava-statistics/DESIGN.md
@@ -20,7 +20,7 @@ flowchart LR
   svc --> pod[Statistics for Strava pod]
   pod --> cfg[ConfigMap app config]
   pod --> secret[Strava credential Secret]
-  pod --> pvc[(PVC /data SQLite and assets)]
+  pod --> pvc[(PVC mounted for /var/www/storage and legacy /data access)]
   eso[External Secrets Operator] -. optional .-> secret
   pod --> strava[Strava API]
 ```
@@ -30,6 +30,7 @@ flowchart LR
 - Use the upstream `robiningelbrecht/strava-statistics` image.
 - Keep the deployment single-replica because SQLite is single-writer and the upstream app is not designed for horizontal scaling with shared writes.
 - Keep persistence enabled by default because imports, generated assets, and SQLite data are stateful.
+- Bootstrap the upstream v4.8.8+ storage layout on the PVC so upgrades from older `/data`-only releases keep reading legacy SQLite files.
 - Render Gateway API HTTPRoutes as an opt-in HTTP exposure path alongside Ingress.
 - Keep the deprecated `gatewayApi` alias only for compatibility; new values should use `gatewayAPI`.
 - Render ExternalSecret resources only when requested. The chart does not install External Secrets Operator or provider-side SecretStores.

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -115,7 +115,7 @@ gatewayAPI:
 | `strava.config` | See `values.yaml` | Application `config.yaml` content mounted at `/var/www/config/app/config.yaml` |
 | `persistence.enabled` | `true` | Enable persistence for Statistics for Strava storage data |
 | `persistence.size` | `2Gi` | PVC size |
-| `persistence.bootstrap.enabled` | `true` | Prepare `/var/www/storage` for v4.8.8+ and keep legacy root-level SQLite files readable after upgrades |
+| `persistence.bootstrap.enabled` | `true` | Prepare `/var/www/storage` for v4.8.8+ on both PVC and emptyDir installs, and keep legacy root-level SQLite files readable after upgrades |
 | `ingress.enabled` | `false` | Enable ingress |
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | omitted | Optional Service IP family policy for dual-stack clusters |
@@ -130,7 +130,9 @@ Statistics for Strava `v4.8.8` moves database migrations into the container
 entrypoint and refreshes the onboarding flow. Upstream now reads SQLite data
 from `/var/www/storage/database`, so this chart mounts the PVC on the upstream
 path and bootstraps compatibility symlinks for legacy root-level `strava.db`
-or `dreeve.db` files. No values change is required, but production upgrades
+or `dreeve.db` files. The bootstrap also runs for `persistence.enabled=false`
+so ephemeral installs still get the upstream storage directories. No values
+change is required, but production upgrades
 should still keep a current PVC backup before rollout.
 
 ## Limitations

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -105,7 +105,7 @@ gatewayAPI:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.tag` | `v4.8.7` | Statistics for Strava image tag |
+| `image.tag` | `v4.8.8` | Statistics for Strava image tag |
 | `strava.port` | `8080` | Application port |
 | `strava.clientId` | `""` | Strava OAuth Client ID |
 | `strava.clientSecret` | `""` | Strava OAuth Client Secret |
@@ -113,8 +113,9 @@ gatewayAPI:
 | `strava.existingSecret` | `""` | Use existing secret for credentials |
 | `strava.timezone` | `UTC` | Timezone |
 | `strava.config` | See `values.yaml` | Application `config.yaml` content mounted at `/var/www/config/app/config.yaml` |
-| `persistence.enabled` | `true` | Enable persistence for /data |
+| `persistence.enabled` | `true` | Enable persistence for Statistics for Strava storage data |
 | `persistence.size` | `2Gi` | PVC size |
+| `persistence.bootstrap.enabled` | `true` | Prepare `/var/www/storage` for v4.8.8+ and keep legacy root-level SQLite files readable after upgrades |
 | `ingress.enabled` | `false` | Enable ingress |
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | omitted | Optional Service IP family policy for dual-stack clusters |
@@ -122,6 +123,15 @@ gatewayAPI:
 | `gatewayApi.enabled` | `false` | Deprecated compatibility alias for `gatewayAPI.enabled` |
 | `externalSecrets.enabled` | `false` | Enable ExternalSecret rendering for credential integrations |
 | `externalSecrets.apiVersion` | `external-secrets.io/v1` | ExternalSecret API version |
+
+## Upgrade Notes
+
+Statistics for Strava `v4.8.8` moves database migrations into the container
+entrypoint and refreshes the onboarding flow. Upstream now reads SQLite data
+from `/var/www/storage/database`, so this chart mounts the PVC on the upstream
+path and bootstraps compatibility symlinks for legacy root-level `strava.db`
+or `dreeve.db` files. No values change is required, but production upgrades
+should still keep a current PVC backup before rollout.
 
 ## Limitations
 

--- a/charts/strava-statistics/templates/NOTES.txt
+++ b/charts/strava-statistics/templates/NOTES.txt
@@ -53,8 +53,10 @@
   Step 3: Open the UI and authorize the application with your Strava account.
 
 Upgrade reminder:
-  The chart stores SQLite data and generated files under /data. Back up the PVC
-  before production upgrades and keep Strava credentials stable across releases.
+  The chart stores SQLite data and generated files on the PVC and mounts it on
+  both the upstream /var/www/storage path and the legacy /data path for upgrade
+  compatibility. Back up the PVC before production upgrades and keep Strava
+  credentials stable across releases.
 
 5. Validation Commands
 ======================

--- a/charts/strava-statistics/templates/deployment.yaml
+++ b/charts/strava-statistics/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- if and .Values.persistence.enabled .Values.persistence.bootstrap.enabled }}
+      {{- if .Values.persistence.bootstrap.enabled }}
       initContainers:
         - name: storage-bootstrap
           image: "{{ .Values.persistence.bootstrap.image.repository }}:{{ .Values.persistence.bootstrap.image.tag }}"

--- a/charts/strava-statistics/templates/deployment.yaml
+++ b/charts/strava-statistics/templates/deployment.yaml
@@ -40,6 +40,26 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if and .Values.persistence.enabled .Values.persistence.bootstrap.enabled }}
+      initContainers:
+        - name: storage-bootstrap
+          image: "{{ .Values.persistence.bootstrap.image.repository }}:{{ .Values.persistence.bootstrap.image.tag }}"
+          imagePullPolicy: {{ .Values.persistence.bootstrap.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              mkdir -p /work/database /work/files /work/gear-maintenance /work/watch
+              if [ -f /work/dreeve.db ] && [ ! -e /work/database/dreeve.db ]; then
+                ln -sf ../dreeve.db /work/database/dreeve.db
+              fi
+              if [ -f /work/strava.db ] && [ ! -e /work/database/strava.db ] && [ ! -e /work/database/dreeve.db ]; then
+                ln -sf ../strava.db /work/database/strava.db
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /work
+      {{- end }}
       containers:
         - name: strava-statistics
           image: {{ include "strava-statistics.image" . | quote }}
@@ -111,6 +131,8 @@ spec:
               readOnly: true
             - name: data
               mountPath: /data
+            - name: data
+              mountPath: /var/www/storage
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/robiningelbrecht/strava-statistics:v4.8.7"
+          value: "docker.io/robiningelbrecht/strava-statistics:v4.8.8"
 
   - it: should allow custom image tag
     set:
@@ -107,6 +107,11 @@ tests:
           content:
             name: data
             mountPath: /data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /var/www/storage
 
   - it: should roll pods when config changes
     asserts:
@@ -159,7 +164,23 @@ tests:
             containerPort: 8080
             protocol: TCP
 
-  - it: should not have init containers
+  - it: should bootstrap the upstream storage layout when persistence is enabled
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: storage-bootstrap
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "docker.io/library/busybox:1.37"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /work
+
+  - it: should not bootstrap storage when persistence is disabled
+    set:
+      persistence.enabled: false
     asserts:
       - notExists:
           path: spec.template.spec.initContainers

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -164,7 +164,7 @@ tests:
             containerPort: 8080
             protocol: TCP
 
-  - it: should bootstrap the upstream storage layout when persistence is enabled
+  - it: should bootstrap the upstream storage layout by default
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].name
@@ -178,9 +178,17 @@ tests:
             name: data
             mountPath: /work
 
-  - it: should not bootstrap storage when persistence is disabled
+  - it: should bootstrap storage when persistence is disabled
     set:
       persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: storage-bootstrap
+
+  - it: should not bootstrap storage when bootstrap is disabled
+    set:
+      persistence.bootstrap.enabled: false
     asserts:
       - notExists:
           path: spec.template.spec.initContainers

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "v4.8.7"
+                                                                    "default":  "v4.8.8"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",
@@ -104,7 +104,7 @@
                                   },
                        "persistence":  {
                                            "type":  "object",
-                                           "description":  "Persistence for /data (SQLite database + files)",
+                                           "description":  "Persistence for Statistics for Strava storage data",
                                            "properties":  {
                                                               "enabled":  {
                                                                               "type":  "boolean",
@@ -127,6 +127,38 @@
                                                               "existingClaim":  {
                                                                                     "type":  "string",
                                                                                     "default":  ""
+                                                                                },
+                                                              "bootstrap":  {
+                                                                                "type":  "object",
+                                                                                "description":  "Bootstrap the upstream v4.8.8+ storage layout and preserve access to legacy SQLite files stored at the root of the PVC",
+                                                                                "properties":  {
+                                                                                                   "enabled":  {
+                                                                                                                   "type":  "boolean",
+                                                                                                                   "default":  true
+                                                                                                               },
+                                                                                                   "image":  {
+                                                                                                                 "type":  "object",
+                                                                                                                 "properties":  {
+                                                                                                                                    "repository":  {
+                                                                                                                                                       "type":  "string",
+                                                                                                                                                       "default":  "docker.io/library/busybox"
+                                                                                                                                                   },
+                                                                                                                                    "tag":  {
+                                                                                                                                                "type":  "string",
+                                                                                                                                                "default":  "1.37"
+                                                                                                                                            },
+                                                                                                                                    "pullPolicy":  {
+                                                                                                                                                       "type":  "string",
+                                                                                                                                                       "enum":  [
+                                                                                                                                                                    "Always",
+                                                                                                                                                                    "IfNotPresent",
+                                                                                                                                                                    "Never"
+                                                                                                                                                                ],
+                                                                                                                                                       "default":  "IfNotPresent"
+                                                                                                                                                   }
+                                                                                                                                }
+                                                                                                             }
+                                                                                               }
                                                                                 }
                                                           }
                                        },

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Statistics for Strava container image
   repository: docker.io/robiningelbrecht/strava-statistics
   # -- Image tag
-  tag: "v4.8.7"
+  tag: "v4.8.8"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -167,7 +167,7 @@ strava:
 # =============================================================================
 
 persistence:
-  # -- Enable persistence for /data (SQLite DB + files)
+  # -- Enable persistence for Statistics for Strava storage data
   enabled: true
   # -- Storage size
   size: 2Gi
@@ -178,6 +178,13 @@ persistence:
     - ReadWriteOnce
   # -- Use an existing PVC
   existingClaim: ""
+  bootstrap:
+    # -- Prepare the upstream v4.8.8+ storage layout and keep legacy root-level SQLite files readable after upgrades
+    enabled: true
+    image:
+      repository: docker.io/library/busybox
+      tag: "1.37"
+      pullPolicy: IfNotPresent
 
 # =============================================================================
 # Service Account


### PR DESCRIPTION
## Summary
- bump Statistics for Strava from `v4.8.7` to `v4.8.8`
- update the chart for the new upstream storage layout used by the container entrypoint
- document the upgrade behavior and validate every CI scenario on k3d

## Upstream evidence
- Image manifest: `docker.io/robiningelbrecht/strava-statistics:v4.8.8` (`make image-verify IMAGE=docker.io/robiningelbrecht/strava-statistics:v4.8.8`)
- Release notes: https://github.com/robiningelbrecht/statistics-for-strava/releases/tag/v4.8.8

## Validation
- `make deps-check CHART=strava-statistics`
- `make validate-chart CHART=strava-statistics`
- `make standards-check CHART=strava-statistics`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=strava-statistics`
- `make org-check`
- `make preflight`

## Notes
- Upstream `v4.8.8` now runs migrations against `/var/www/storage/database`, so the chart mounts the PVC on the upstream path and bootstraps compatibility symlinks for legacy root-level `strava.db`/`dreeve.db` files.
- `make site-sync-check CHART=strava-statistics` reports required companion updates in the site docs/playground for GR-007.

Closes #527