### PR TITLE
chore(oauth2-proxy): bump oauth2-proxy to v7.15.3

### DIFF
--- a/charts/oauth2-proxy/Chart.yaml
+++ b/charts/oauth2-proxy/Chart.yaml
@@ -4,7 +4,7 @@ name: oauth2-proxy
 description: OAuth2 Proxy reverse proxy for OAuth2 and OIDC authentication in Kubernetes
 type: application
 version: 1.0.3
-appVersion: "7.15.2"
+appVersion: "7.15.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/oauth2-proxy.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "complete chart standards (#537)"
+      description: "bump oauth2-proxy to v7.15.3 (#525)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -8,8 +8,8 @@ and runtime validation.
 ## Highlights
 
 - Official `quay.io/oauth2-proxy/oauth2-proxy` image.
-- `v7.15.2` default, including the upstream security fixes for critical
-  authentication bypass advisories.
+- `v7.15.3` default, including the upstream Go `1.26.4` rebuild and the latest
+  dependency vulnerability fixes published by the oauth2-proxy project.
 - Reverse proxy header trust disabled by default, with required explicit
   `trusted_proxy_ips` CIDRs when enabled behind ingress controllers, gateways,
   or service mesh edge proxies.
@@ -57,6 +57,13 @@ OAuth2 Proxy `v7.15.2` introduced `trusted_proxy_ips` to prevent trusting
 client-supplied `X-Forwarded-*` headers from untrusted sources. Keep this list
 narrow and aligned with the IP ranges used by your ingress controller, Gateway
 implementation, or edge proxy.
+
+## Upgrade Notes
+
+OAuth2 Proxy `v7.15.3` keeps the same chart-facing configuration surface as
+`v7.15.2`, but refreshes the runtime to Go `1.26.4` and rolls in the upstream
+dependency CVE fixes called out in the official release notes. No values change
+is required for this chart bump.
 
 The chart keeps `config.reverseProxy.enabled=false` by default. If you enable
 reverse proxy header handling, the chart requires at least one

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/oauth2-proxy/oauth2-proxy:v7.15.2
+          value: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -13,7 +13,7 @@
       "additionalProperties": false,
       "properties": {
         "repository": { "type": "string", "default": "quay.io/oauth2-proxy/oauth2-proxy" },
-        "tag": { "type": "string", "default": "v7.15.2" },
+        "tag": { "type": "string", "default": "v7.15.3" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -20,7 +20,7 @@ image:
   # -- Official upstream OAuth2 Proxy image
   repository: quay.io/oauth2-proxy/oauth2-proxy
   # -- Image tag
-  tag: "v7.15.2"
+  tag: "v7.15.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- bump oauth2-proxy from `v7.15.2` to `v7.15.3`
- refresh the README upgrade notes for the Go `1.26.4` rebuild and upstream CVE fixes
- validate the chart end to end, including all k3d CI scenarios

## Upstream evidence
- Image manifest: `quay.io/oauth2-proxy/oauth2-proxy:v7.15.3` (`make image-verify IMAGE=quay.io/oauth2-proxy/oauth2-proxy:v7.15.3`)
- Release notes: https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.3

## Validation
- `make deps-check CHART=oauth2-proxy`
- `make validate-chart CHART=oauth2-proxy`
- `make standards-check CHART=oauth2-proxy`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=oauth2-proxy`
- `make org-check`
- `make preflight`

## Notes
- `make site-sync-check CHART=oauth2-proxy` reports required companion updates in the site docs/playground for GR-007.

Closes #525