### PR TITLE
chore(mongodb): bump mongodb to 8.3.4

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -4,7 +4,7 @@ name: mongodb
 description: MongoDB Helm Chart - standalone, replica set, or sharded cluster using the official MongoDB image
 type: application
 version: 1.7.14
-appVersion: "8.3.2"
+appVersion: "8.3.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "complete chart standards (#534)"
+      description: "bump mongodb to 8.3.4 (#523)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -129,7 +129,7 @@ user initialization path.
 |-----------|-------------|---------|
 | `architecture` | `standalone`, `replicaset`, or `sharded` | `standalone` |
 | `image.repository` | MongoDB image | `mongo` |
-| `image.tag` | Image tag | `8.3.2` |
+| `image.tag` | Image tag | `8.3.4` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -260,7 +260,7 @@ See the [`examples/`](examples/) directory:
 
 ## Upgrade Notes
 
-MongoDB `8.3.2` is an upstream minor release update from `8.2.7`.
+MongoDB `8.3.4` is a patch-level update within the MongoDB `8.3` release line.
 Review the MongoDB 8.3 release notes before upgrading production clusters,
 take a backup, and verify the data files are compatible with the target
 `mongod` version before reusing existing PVCs. Keep replica set keyFiles and

--- a/charts/mongodb/examples/replicaset-production.yaml
+++ b/charts/mongodb/examples/replicaset-production.yaml
@@ -5,7 +5,7 @@
 architecture: replicaset
 
 image:
-  tag: "8.3.2"
+  tag: "8.3.4"
 
 auth:
   enabled: true

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mongo:8.3.2"
+          value: "docker.io/library/mongo:8.3.4"
 
   - it: should have 1 replica in standalone mode
     template: statefulset.yaml

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -39,7 +39,7 @@
         "tag": {
           "type": "string",
           "description": "MongoDB image tag",
-          "default": "8.3.2"
+          "default": "8.3.4"
         },
         "pullPolicy": {
           "type": "string",
@@ -662,7 +662,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "8.3.2"
+                  "default": "8.3.4"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/mongo
-  tag: "8.3.2"
+  tag: "8.3.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -315,7 +315,7 @@ backup:
       pullPolicy: IfNotPresent
     mongodb:
       repository: docker.io/library/mongo
-      tag: "8.3.2"
+      tag: "8.3.4"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary
- bump MongoDB from `8.3.2` to `8.3.4`
- keep the backup helper image on the same MongoDB patch level as the main workload
- refresh the example, unittest fixture, and README upgrade notes for the new patch release

## Upstream evidence
- Image manifest: `docker.io/library/mongo:8.3.4` (`make image-verify IMAGE=docker.io/library/mongo:8.3.4`)
- MongoDB Community downloads page: https://www.mongodb.com/try/download/community-edition/releases
- MongoDB 8.3 release notes: https://www.mongodb.com/docs/manual/release-notes/8.3/

## Validation
- `make deps-check CHART=mongodb`
- `make validate-chart CHART=mongodb`
- `make standards-check CHART=mongodb`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=mongodb`
- `make org-check`
- `make preflight`

## Notes
- `make site-sync-check CHART=mongodb` reports required companion updates in the site docs/playground for GR-007.

Closes #523