### PR TITLE
chore(minecraft): bump minecraft to 2026.6.0

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.4.12
-appVersion: "2026.5.4"
+appVersion: "2026.6.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "complete chart standards (#533)"
+      description: "bump minecraft to 2026.6.0 (#522)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -255,10 +255,10 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.5.4` updates the upstream server image from
-`2026.5.2`. The upstream releases include env-file loading at startup, server
-library cleanup on Paper installs, helper/monitor/RCON dependency updates, and a
-fix for deriving `MC_IMAGE_HELPER_OPTS` from `PROXY_*` variables. Review the
+`docker.io/itzg/minecraft-server:2026.6.0` updates the upstream server image from
+`2026.5.4`. The upstream release adds support for literal newlines in `server.motd`
+when values come from env files, refreshes bundled helper dependencies, and keeps
+the MOTD quoting documentation aligned with the runtime behavior. Review the
 upstream release notes before upgrading production servers, take a world backup,
 and verify plugins, mods, datapacks, proxy settings, and pinned `server.version`
 values in a staging environment before reusing existing PVCs.

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.5.4
+          value: docker.io/itzg/minecraft-server:2026.6.0
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.5.4
+          value: docker.io/itzg/minecraft-server:2026.6.0
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.5.4
+          value: docker.io/itzg/minecraft-server:2026.6.0
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.5.4
+          value: docker.io/itzg/minecraft-server:2026.6.0
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.5.4"
+          "default": "2026.6.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -634,7 +634,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.5.4"
+              "default": "docker.io/itzg/minecraft-server:2026.6.0"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.5.4"
+  tag: "2026.6.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -381,7 +381,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.5.4
+    worker: docker.io/itzg/minecraft-server:2026.6.0
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
## Summary
- bump Minecraft from `2026.5.4` to `2026.6.0`
- keep the backup worker image aligned with the main server image tag
- refresh the README upgrade note for the upstream MOTD and helper changes

## Upstream evidence
- Image manifest: `docker.io/itzg/minecraft-server:2026.6.0` (`make image-verify IMAGE=docker.io/itzg/minecraft-server:2026.6.0`)
- Release notes: https://github.com/itzg/docker-minecraft-server/releases/tag/2026.6.0

## Validation
- `make deps-check CHART=minecraft`
- `make validate-chart CHART=minecraft`
- `make standards-check CHART=minecraft`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=minecraft`
- `make org-check`
- `make preflight`

## Notes
- `make site-sync-check CHART=minecraft` reports required companion updates in the site docs/playground for GR-007.

Closes #522