### PR TITLE
chore(n8n): bump n8n to 2.26.4

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.2
-appVersion: "2.25.6"
+appVersion: "2.26.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.25.6 (#481)"
+      description: "bump n8n to 2.26.4 (#524)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -51,11 +51,11 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.3
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,16 +144,16 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.25.6` | n8n container image tag |
+| `image.tag` | `2.26.4` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
 | `n8n.diagnosticsEnabled` | `false` | Share anonymous diagnostics with n8n |
 | `n8n.gracefulShutdownTimeout` | `60` | Graceful shutdown timeout in seconds for main and workers |
 | `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
-| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) |
+| `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.4`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
-| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.0`) |
+| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.1`) |
 | `queue.enabled` | `false` | Enable queue mode (requires Redis and a non-SQLite database) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
@@ -186,8 +186,10 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.25.6` is an upstream bugfix release. It includes an editor fix for
-copying only the selected markdown editor text. Review the upstream release
+n8n `2.26.4` is an upstream bugfix release. It reduces the delay in AI
+Assistant workflow preview examples and fixes the
+`context.getNodeParameter is not a function` runtime error that could affect npm
+installs. Review the upstream release
 notes before upgrading, back up the database, and keep the encryption key stable
 before upgrading live deployments. This chart keeps the hardened non-root
 container defaults with resource requests and limits. Queue mode fails fast when

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.25.6"
+          value: "docker.io/n8nio/n8n:2.26.4"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.25.6"
+          value: "docker.io/n8nio/runners:2.26.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.25.6"
+          value: "docker.io/n8nio/runners:2.26.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.25.6"
+          "default": "2.26.4"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.25.6"
+  tag: "2.26.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- bump n8n from `2.25.6` to `2.26.4`
- refresh the bundled PostgreSQL and MySQL HelmForge dependencies to the latest required versions
- update the runner image expectations, docs, and validate every CI scenario on k3d

## Upstream evidence
- Image manifest: `docker.io/n8nio/n8n:2.26.4` (`make image-verify IMAGE=docker.io/n8nio/n8n:2.26.4`)
- Release notes: https://github.com/n8n-io/n8n/releases/tag/n8n%402.26.4

## Validation
- `make deps-check CHART=n8n`
- `make validate-chart CHART=n8n`
- `make standards-check CHART=n8n`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=n8n`
- `make org-check`
- `make preflight`

## Notes
- This PR also bumps `helmforge/postgresql` to `2.0.4` and `helmforge/mysql` to `2.0.1`, as required by `make deps-check CHART=n8n`.
- `make site-sync-check CHART=n8n` reports required companion updates in the site docs/playground for GR-007.

Closes #524