### PR TITLE
fix(redis): honor service type in cluster mode

### DIFF
--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -205,7 +205,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   {{- with .Values.service.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}

--- a/charts/redis/tests/service_test.yaml
+++ b/charts/redis/tests/service_test.yaml
@@ -76,3 +76,28 @@ tests:
             port: 9121
             targetPort: metrics
         documentIndex: 1
+
+  - it: should honor service type for cluster client service
+    set:
+      architecture: cluster
+      service.type: LoadBalancer
+    asserts:
+      - isKind:
+          of: Service
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: test-redis-client
+        documentIndex: 1
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: redis-client
+        documentIndex: 1
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+        documentIndex: 1
+      - equal:
+          path: spec.selector["app.kubernetes.io/role"]
+          value: cluster
+        documentIndex: 1


### PR DESCRIPTION
## Summary

- Fix the Redis cluster-mode client Service to honor `.Values.service.type`.
- Add helm-unittest coverage for `architecture: cluster` with `service.type: LoadBalancer`.

## Root Cause

The standalone client Service already used `.Values.service.type`, but the cluster-mode client Service was hardcoded to `ClusterIP`. As a result, `service.type=LoadBalancer` or `service.type=NodePort` did not affect the cluster client endpoint.

Closes #571.

## Validation

- `helm unittest charts/redis`
- `helm lint --strict charts/redis`
- `make standards-check CHART=redis`
- `node scripts/charts/validate-chart.js --chart redis --timeout 60`
- `make site-sync-check CHART=redis`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`