### PR TITLE
fix(docmost): allow s3-backed replicas

### DIFF
--- a/charts/docmost/DESIGN.md
+++ b/charts/docmost/DESIGN.md
@@ -1,6 +1,6 @@
 # Docmost Chart Design
 
-This chart packages Docmost as a single application Deployment backed by
+This chart packages Docmost as an application Deployment backed by
 PostgreSQL, Redis, and either local persistent storage or S3-compatible object
 storage.
 
@@ -25,8 +25,8 @@ User
 - Default installs use HelmForge PostgreSQL `2.0.2` and Redis `1.6.16`
   subcharts so database/cache lifecycle stays inside the HelmForge ecosystem.
 - `replicaCount` defaults to one because local uploaded-file storage is
-  single-writer. Operators that need horizontal scaling should first move
-  uploads to shared object storage and validate upstream runtime behavior.
+  single-writer. Values greater than one are allowed only with S3-compatible
+  object storage.
 - The chart uses only the standard `gateway` block for Gateway API routing.
 - External services are first-class for managed PostgreSQL and Redis setups.
 - External Secrets Operator support is limited to credential materialization and
@@ -39,7 +39,7 @@ User
 The chart exposes pod/container security contexts, scheduling controls,
 resource configuration, Secret indirection, Gateway API, Ingress, dual-stack
 Service options, and backup settings. Defaults are intentionally conservative
-for a practical single-instance install.
+for a practical local-storage install.
 
 ## Non-Goals
 
@@ -56,6 +56,7 @@ for a practical single-instance install.
 - External Secrets rendering
 - Backup CronJob rendering
 - Dual-stack Service rendering
+- S3-backed multi-replica rendering
 
 ## Related Files
 

--- a/charts/docmost/README.md
+++ b/charts/docmost/README.md
@@ -34,7 +34,7 @@ helm install docmost oci://ghcr.io/helmforgedev/helm/docmost
 
 ## Important Notes
 
-- this chart currently supports `replicaCount=1` only
+- `replicaCount` values greater than `1` require `storage.mode=s3`
 - Docmost requires PostgreSQL and Redis
 - local storage uses `/app/data/storage`
 - S3 mode uses the official `AWS_S3_*` environment variables documented by Docmost
@@ -151,7 +151,7 @@ backup:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `replicaCount` | `1` | Number of Docmost application pods |
+| `replicaCount` | `1` | Number of Docmost application pods. Values greater than `1` require `storage.mode=s3` |
 | `image.repository` | `docker.io/docmost/docmost` | Docmost container image repository |
 | `image.tag` | `0.90.1` | Docmost image tag |
 | `docmost.appUrl` | `""` | External Docmost URL |

--- a/charts/docmost/ci/dual-stack.yaml
+++ b/charts/docmost/ci/dual-stack.yaml
@@ -12,6 +12,3 @@ redis:
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/docmost/ci/external-secrets.yaml
+++ b/charts/docmost/ci/external-secrets.yaml
@@ -6,21 +6,95 @@ postgresql:
 database:
   mode: external
   external:
-    host: "postgres-external"
+    host: docmost-external-postgresql
+    username: docmost
+    name: docmost
     existingSecret: docmost-database-credentials
 
 redis:
   enabled: false
   external:
-    host: "redis-external"
+    host: docmost-external-redis
 
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: database-password
       remoteRef:
-        key: docmost/database
-        property: password
+        key: test/password
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: docmost-external-postgresql
+    spec:
+      ports:
+        - name: postgres
+          port: 5432
+          targetPort: postgres
+      selector:
+        app.kubernetes.io/name: docmost-external-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: docmost-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: docmost-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: docmost-external-postgresql
+        spec:
+          containers:
+            - name: postgres
+              image: docker.io/library/postgres:18.4-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgres
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: docmost
+                - name: POSTGRES_USER
+                  value: docmost
+                - name: POSTGRES_PASSWORD
+                  value: helmforge-test-password
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: docmost-external-redis
+    spec:
+      ports:
+        - name: redis
+          port: 6379
+          targetPort: redis
+      selector:
+        app.kubernetes.io/name: docmost-external-redis
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: docmost-external-redis
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: docmost-external-redis
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: docmost-external-redis
+        spec:
+          containers:
+            - name: redis
+              image: docker.io/library/redis:8.8.0
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: redis
+                  containerPort: 6379

--- a/charts/docmost/ci/external-services.yaml
+++ b/charts/docmost/ci/external-services.yaml
@@ -2,7 +2,7 @@
 database:
   mode: external
   external:
-    host: pg.example.internal
+    host: docmost-external-postgresql
     name: docmost
     username: docmost
     password: change-me
@@ -13,7 +13,7 @@ postgresql:
 redis:
   enabled: false
   external:
-    host: redis.example.internal
+    host: docmost-external-redis
     password: change-me
 
 storage:
@@ -23,3 +23,80 @@ storage:
     endpoint: https://minio.example.internal
     accessKey: minio
     secretKey: secret123
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: docmost-external-postgresql
+    spec:
+      ports:
+        - name: postgres
+          port: 5432
+          targetPort: postgres
+      selector:
+        app.kubernetes.io/name: docmost-external-postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: docmost-external-postgresql
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: docmost-external-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: docmost-external-postgresql
+        spec:
+          containers:
+            - name: postgres
+              image: docker.io/library/postgres:18.4-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgres
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: docmost
+                - name: POSTGRES_USER
+                  value: docmost
+                - name: POSTGRES_PASSWORD
+                  value: change-me
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: docmost-external-redis
+    spec:
+      ports:
+        - name: redis
+          port: 6379
+          targetPort: redis
+      selector:
+        app.kubernetes.io/name: docmost-external-redis
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: docmost-external-redis
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: docmost-external-redis
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: docmost-external-redis
+        spec:
+          containers:
+            - name: redis
+              image: docker.io/library/redis:8.8.0
+              imagePullPolicy: IfNotPresent
+              command: ["redis-server"]
+              args:
+                - --requirepass
+                - change-me
+              ports:
+                - name: redis
+                  containerPort: 6379

--- a/charts/docmost/ci/s3-replicas.yaml
+++ b/charts/docmost/ci/s3-replicas.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+replicaCount: 2
+
+storage:
+  mode: s3
+  s3:
+    bucket: docmost
+    accessKey: minio
+    secretKey: secret123

--- a/charts/docmost/docs/architecture.md
+++ b/charts/docmost/docs/architecture.md
@@ -1,11 +1,11 @@
 # Docmost Architecture Notes
 
-This chart packages Docmost as a single application Deployment backed by PostgreSQL and Redis. It is designed
+This chart packages Docmost as an application Deployment backed by PostgreSQL and Redis. It is designed
 with clear defaults, local validation, explicit external-service support, and optional S3-compatible object storage.
 
 ## Supported Model
 
-- one Docmost application pod
+- one Docmost application pod with local storage, or multiple application pods with S3-compatible storage
 - PostgreSQL provided by the bundled subchart or an external PostgreSQL service
 - Redis provided by the bundled subchart or an external Redis service
 - uploaded files stored on a local PVC or an S3-compatible object store
@@ -13,13 +13,13 @@ with clear defaults, local validation, explicit external-service support, and op
 - optional External Secrets Operator integration for credentials managed outside Helm
 - optional PostgreSQL backup CronJob that uploads dumps to S3-compatible storage
 
-## Why Single Replica
+## Replica Model
 
-This first chart release intentionally keeps `replicaCount=1`.
+The chart defaults to `replicaCount=1` and keeps local storage single-replica.
 
 - upstream runtime documentation clearly requires PostgreSQL, Redis, and shared file storage
-- local storage with multiple application replicas can create inconsistent file visibility unless operators provide shared external object storage and validate the runtime behavior carefully
-- the chart therefore favors predictable installs over premature horizontal-scaling claims
+- local storage with multiple application replicas can create inconsistent file visibility
+- values greater than one are accepted only with `storage.mode=s3`, where uploaded files are stored outside the pod filesystem
 
 ## Storage Modes
 
@@ -33,7 +33,7 @@ This first chart release intentionally keeps `replicaCount=1`.
 
 - sets `STORAGE_DRIVER=s3`
 - uses `AWS_S3_*` environment variables documented by Docmost
-- recommended when operators want object storage managed outside the pod filesystem
+- required when operators set `replicaCount` greater than `1`
 
 ## External Services
 

--- a/charts/docmost/templates/deployment.yaml
+++ b/charts/docmost/templates/deployment.yaml
@@ -183,6 +183,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or (eq .Values.storage.mode "local") .Values.extraVolumeMounts }}
           volumeMounts:
             {{- if eq .Values.storage.mode "local" }}
             - name: storage
@@ -191,6 +192,8 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
+      {{- if or (eq .Values.storage.mode "local") .Values.extraVolumes }}
       volumes:
         {{- if eq .Values.storage.mode "local" }}
         - name: storage
@@ -207,6 +210,7 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/docmost/templates/extra-manifests.yaml
+++ b/charts/docmost/templates/extra-manifests.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- with .Values.extraManifests }}
-{{- toYaml . }}
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
 {{- end }}

--- a/charts/docmost/templates/validate.yaml
+++ b/charts/docmost/templates/validate.yaml
@@ -1,6 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if ne (int .Values.replicaCount) 1 -}}
-{{- fail "docmost: replicaCount must be 1 for the current single-instance storage model" -}}
+{{- if and (ne (int .Values.replicaCount) 1) (ne .Values.storage.mode "s3") -}}
+{{- fail "docmost: replicaCount greater than 1 requires storage.mode=s3 because local storage is single-writer" -}}
 {{- end -}}
 {{- if and (eq .Values.storage.mode "local") (not .Values.storage.local.enabled) (not .Values.storage.local.existingClaim) -}}
 {{- fail "docmost: storage.mode=local requires storage.local.enabled=true or storage.local.existingClaim" -}}

--- a/charts/docmost/tests/deployment_test.yaml
+++ b/charts/docmost/tests/deployment_test.yaml
@@ -80,6 +80,23 @@ tests:
             name: AWS_S3_BUCKET
             value: docmost
 
+  - it: should allow multiple replicas with S3 storage
+    template: templates/deployment.yaml
+    set:
+      replicaCount: 2
+      storage.mode: s3
+      storage.s3.bucket: docmost
+      storage.s3.accessKey: minio
+      storage.s3.secretKey: secret123
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[0]
+      - notExists:
+          path: spec.template.spec.volumes[0]
+
   - it: should use external postgresql and redis settings when configured
     template: templates/deployment.yaml
     set:

--- a/charts/docmost/tests/validation_test.yaml
+++ b/charts/docmost/tests/validation_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should reject multiple replicas with local storage
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "docmost: replicaCount greater than 1 requires storage.mode=s3 because local storage is single-writer"
+
+  - it: should allow multiple replicas with S3 storage
+    set:
+      replicaCount: 2
+      storage.mode: s3
+      storage.s3.bucket: docmost
+      storage.s3.accessKey: minio
+      storage.s3.secretKey: secret123
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/docmost/values.schema.json
+++ b/charts/docmost/values.schema.json
@@ -19,7 +19,7 @@
     },
     "replicaCount": {
       "type": "integer",
-      "description": "Number of Docmost application replicas. This chart currently supports only 1."
+      "description": "Number of Docmost application replicas. Values greater than 1 require storage.mode=s3."
     },
     "image": {
       "type": "object",

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -3,8 +3,8 @@
 # Docmost Helm Chart
 # =============================================================================
 # Open-source collaborative wiki and documentation platform.
-# Requires PostgreSQL and Redis. This chart currently targets a single
-# Docmost application replica for predictable shared-storage semantics.
+# Requires PostgreSQL and Redis. Local uploads storage is single-replica;
+# S3-compatible storage can be used for horizontal application replicas.
 # =============================================================================
 
 # -- Override the chart name used in resource names
@@ -16,7 +16,7 @@ fullnameOverride: ""
 # -- Labels added to every resource created by this chart
 commonLabels: {}
 
-# -- Number of Docmost application replicas. This chart currently supports only 1.
+# -- Number of Docmost application replicas. Values greater than 1 require storage.mode=s3.
 replicaCount: 1
 
 image:


### PR DESCRIPTION
## Summary
- Allow Docmost `replicaCount > 1` only when `storage.mode=s3`.
- Keep local uploads storage single-replica with an explicit validation error.
- Add unit coverage and a `ci/s3-replicas.yaml` runtime scenario for S3-backed replicas.
- Make Docmost external-services and External Secrets CI scenarios installable in k3d.
- Fix `extraManifests` rendering so each manifest is emitted as a separate Kubernetes document.

## Root Cause
The chart validation blocked every `replicaCount` value different from `1`, even though the public docs already documented S3 uploads as the scalable storage mode.

## Validation
- `helm unittest charts/docmost`
- `helm lint --strict charts/docmost`
- `make standards-check CHART=docmost`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=docmost`
- `node scripts/charts/validate-chart.js --chart docmost --timeout 60` (18 layers, including all k3d scenarios)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Site Sync
- Site PR: helmforgedev/site#301

Fixes #569
