### PR TITLE
fix(valkey): add security contexts for sidecars

### DIFF
--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -188,6 +188,7 @@ Best practices:
 - `existingSecret` avoids chart-owned credential rotation when an external secret manager is authoritative.
 - External Secrets Operator integration lets the chart reference externally managed credentials while still rendering Kubernetes-native Secret consumers.
 - Pods run with restricted security contexts by default where Valkey compatibility allows it.
+- Metrics sidecars and the cluster initialization Job have their own container security context values so all chart-managed pods can satisfy Pod Security Admission `restricted`.
 - The chart avoids privileged containers and host namespace access.
 - Sensitive values should not be embedded in examples, CI values, or NOTES.
 
@@ -218,7 +219,7 @@ Recommended production controls:
 
 Metrics are optional and should be enabled only when the Prometheus Operator or a compatible scraper is present.
 
-When enabled, exporter resources should follow the selected architecture and expose a stable ServiceMonitor target. The chart should not render CRDs owned by observability operators.
+When enabled, exporter resources should follow the selected architecture, use the metrics-specific container security context, and expose a stable ServiceMonitor target. The chart should not render CRDs owned by observability operators.
 
 ## Extension Points
 

--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -219,7 +219,8 @@ Recommended production controls:
 
 Metrics are optional and should be enabled only when the Prometheus Operator or a compatible scraper is present.
 
-When enabled, exporter resources should follow the selected architecture, use the metrics-specific container security context, and expose a stable ServiceMonitor target. The chart should not render CRDs owned by observability operators.
+When enabled, exporter resources should follow the selected architecture, use the metrics-specific container security
+context, and expose a stable ServiceMonitor target. The chart should not render CRDs owned by observability operators.
 
 ## Extension Points
 

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -227,10 +227,13 @@ Use the generic extension values when platform-specific integration is needed:
 | `sentinel.quorum` | Sentinel quorum | `2` |
 | `cluster.nodes` | Number of Valkey Cluster nodes | `6` |
 | `cluster.replicasPerMaster` | Valkey Cluster replicas per master | `1` |
+| `cluster.initJob.securityContext.runAsUser` | Cluster init Job container user ID | `999` |
 | `service.type` | Client Service type where applicable | `ClusterIP` |
 | `service.ipFamilyPolicy` | Service IP family policy for dual-stack clusters | `null` |
 | `service.ipFamilies` | Service IP families for dual-stack clusters | `[]` |
 | `metrics.enabled` | Enable redis_exporter sidecar | `false` |
+| `metrics.securityContext.runAsUser` | Metrics exporter container user ID | `65534` |
+| `metrics.securityContext.capabilities.drop` | Linux capabilities dropped from the metrics exporter | `["ALL"]` |
 | `metrics.serviceMonitor.enabled` | Create ServiceMonitor | `false` |
 | `tests.enabled` | Render Helm test connection pod | `true` |
 | `tests.image.repository` | Helm test image repository | `docker.io/valkey/valkey` |

--- a/charts/valkey/docs/cluster.md
+++ b/charts/valkey/docs/cluster.md
@@ -66,6 +66,7 @@ Common cases:
 | `cluster.replicasPerMaster` | Replicas per master |
 | `cluster.persistence.enabled` | PVC on each node |
 | `cluster.persistence.size` | Volume size per node |
+| `cluster.initJob.securityContext.runAsUser` | Cluster init Job container user ID |
 | `metrics.enabled` | Exporter for monitoring |
 
 ## Example

--- a/charts/valkey/templates/cluster-init-job.yaml
+++ b/charts/valkey/templates/cluster-init-job.yaml
@@ -23,6 +23,8 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "valkey.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: valkey-cli
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -110,6 +112,8 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
             {{- end }}
+          securityContext:
+            {{- toYaml .Values.cluster.initJob.securityContext | nindent 12 }}
           {{- if .Values.tls.enabled }}
           volumeMounts:
             - name: tls

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -121,6 +121,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.metrics.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -149,6 +149,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.metrics.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -182,6 +182,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.metrics.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -106,6 +106,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.metrics.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/tests/security_context_test.yaml
+++ b/charts/valkey/tests/security_context_test.yaml
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Security Contexts
+templates:
+  - standalone-statefulset.yaml
+  - replication-primary-statefulset.yaml
+  - replication-replica-statefulset.yaml
+  - cluster-statefulset.yaml
+  - cluster-init-job.yaml
+  - configmap.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render restricted-compatible metrics sidecar security contexts
+    set:
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 65534
+        template: standalone-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+        template: standalone-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+        template: standalone-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop[0]
+          value: ALL
+        template: standalone-statefulset.yaml
+
+  - it: should render metrics sidecar security contexts in replication pods
+    set:
+      architecture: replication
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 65534
+        template: replication-primary-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 65534
+        template: replication-replica-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+        template: replication-primary-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop[0]
+          value: ALL
+        template: replication-replica-statefulset.yaml
+
+  - it: should render metrics sidecar security contexts in cluster pods
+    set:
+      architecture: cluster
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+          value: 65534
+        template: cluster-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+        template: cluster-statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.capabilities.drop[0]
+          value: ALL
+        template: cluster-statefulset.yaml
+
+  - it: should render pod and container security contexts on cluster init job
+    set:
+      architecture: cluster
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 999
+        template: cluster-init-job.yaml
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+        template: cluster-init-job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 999
+        template: cluster-init-job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+        template: cluster-init-job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+        template: cluster-init-job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+        template: cluster-init-job.yaml

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -257,6 +257,18 @@
             "activeDeadlineSeconds": {
               "type": "integer",
               "description": "Job active deadline in seconds"
+            },
+            "securityContext": {
+              "type": "object",
+              "description": "Container-level security context for the cluster init job",
+              "properties": {
+                "runAsUser": { "type": "integer" },
+                "runAsGroup": { "type": "integer" },
+                "runAsNonRoot": { "type": "boolean" },
+                "allowPrivilegeEscalation": { "type": "boolean" },
+                "readOnlyRootFilesystem": { "type": "boolean" },
+                "capabilities": { "type": "object" }
+              }
             }
           }
         },
@@ -414,6 +426,10 @@
           "type": "boolean",
           "description": "Enable Prometheus metrics exporter"
         },
+        "tlsSkipVerify": {
+          "type": "boolean",
+          "description": "Skip TLS verification for exporter connections to Valkey when TLS is enabled"
+        },
         "image": {
           "type": "object",
           "description": "Metrics exporter image settings",
@@ -426,6 +442,18 @@
         "resources": {
           "type": "object",
           "description": "Resource requests and limits for the metrics exporter"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Container-level security context for the metrics exporter sidecar",
+          "properties": {
+            "runAsUser": { "type": "integer" },
+            "runAsGroup": { "type": "integer" },
+            "runAsNonRoot": { "type": "boolean" },
+            "allowPrivilegeEscalation": { "type": "boolean" },
+            "readOnlyRootFilesystem": { "type": "boolean" },
+            "capabilities": { "type": "object" }
+          }
         },
         "serviceMonitor": {
           "type": "object",

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -165,6 +165,16 @@ cluster:
     backoffLimit: 4
     # -- Active deadline for the cluster initialization Job
     activeDeadlineSeconds: 900
+    # -- Container security context for the cluster initialization Job
+    securityContext:
+      runAsUser: 999
+      runAsGroup: 999
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop:
+          - ALL
   persistence:
     # -- Enable persistent storage for cluster nodes
     enabled: true
@@ -282,6 +292,16 @@ metrics:
     pullPolicy: IfNotPresent
   # -- Resource requests and limits for the metrics exporter
   resources: {}
+  # -- Container security context for the metrics exporter sidecar
+  securityContext:
+    runAsUser: 65534
+    runAsGroup: 65534
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop:
+        - ALL
   serviceMonitor:
     # -- Render a Prometheus Operator ServiceMonitor
     enabled: false


### PR DESCRIPTION
## Summary
- add restricted-compatible security contexts to Valkey metrics sidecars
- add pod and container security contexts to the cluster init Job
- expose the new values in values.yaml, schema, README, and chart docs
- add unit coverage for metrics sidecars and cluster init Job security contexts

## Validation
- `helm unittest charts/valkey`
- `helm lint --strict charts/valkey`
- `make standards-check CHART=valkey`
- `make md-lint REPO=charts`
- `node scripts/charts/validate-chart.js --chart valkey --timeout 60` (20 layers, including all k3d scenarios)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Site PR: helmforgedev/site#302

Fixes #556