### PR TITLE
chore(homarr): update image to v1.67.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.17
-appVersion: "1.64.0"
+appVersion: "1.67.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#558)"
+      description: "update Homarr image to v1.67.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,13 +5,13 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.64.0`.
+Current application version: `v1.67.0`.
 
 ## Features
 
 - **Official Homarr image** from `ghcr.io/homarr-labs/homarr`
 - **Database backends** SQLite3 (default), PostgreSQL, or MySQL with auto-detection
-- **PostgreSQL and MySQL subcharts** optional bundled database deployments using HelmForge PostgreSQL `2.0.2` and MySQL `2.0.0`
+- **PostgreSQL and MySQL subcharts** optional bundled database deployments using HelmForge PostgreSQL `2.0.4` and MySQL `2.0.1`
 - **Encryption key management** auto-generated or existing secret for `SECRET_ENCRYPTION_KEY`
 - **Kubernetes integration** optional workload discovery via `ENABLE_KUBERNETES`
 - **External Redis** optional external Redis for multi-instance setups
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.64.0"` | Homarr image tag |
+| `image.tag` | `"v1.67.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,10 +265,10 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.63.0` to `v1.64.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.64.0` includes demo mode, PeaNUT UPS monitoring, Docker UI improvements, onboarding updates,
-media request search, widget editing, authentication fixes, and UI bug fixes; no breaking
-changes were identified in the upstream release metadata.
+This update moves the default image from `v1.64.0` to `v1.67.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.66.1` fixes the MySQL migration regression introduced in `v1.65.0`, and `v1.67.0` adds
+server-side PostHog analytics, total CPU and memory usage display, session cookie isolation, and downloads sorting fixes.
+No breaking changes were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/ci/mysql.yaml
+++ b/charts/homarr/ci/mysql.yaml
@@ -7,3 +7,12 @@ mysql:
     username: homarr
     password: testpassword
     rootPassword: testrootpassword
+
+startupProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 2
+  timeoutSeconds: 5
+
+readinessProbe:
+  periodSeconds: 2
+  timeoutSeconds: 5

--- a/charts/homarr/ci/postgresql.yaml
+++ b/charts/homarr/ci/postgresql.yaml
@@ -6,3 +6,12 @@ postgresql:
     database: homarr
     username: homarr
     password: testpassword
+
+startupProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 2
+  timeoutSeconds: 5
+
+readinessProbe:
+  periodSeconds: 2
+  timeoutSeconds: 5

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.64.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.67.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.64.0"
+  tag: "v1.67.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary
- Update Homarr from `v1.64.0` to `v1.67.0`
- Keep MySQL coverage enabled now that the upstream migration regression from `v1.65.0` is fixed in `v1.66.1`
- Add CI-only faster probes for bundled MySQL/PostgreSQL scenarios so behavioral validation completes within the 60s test timeout
- Refresh Homarr README defaults and upgrade notes

## Upstream evidence
- `homarr-labs/homarr#5967` is closed
- Homarr `v1.66.1` release notes include: `db: crash on MySQL — replace onConflictDoNothing with dialect-neutral pre-filter (#5995)`
- Homarr `v1.67.0` is the latest stable release validated here
- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.67.0` passed for `linux/amd64` and `linux/arm64`

## Validation
- `node scripts/charts/validate-chart.js --chart homarr --timeout 60`
- `make standards-check CHART=homarr`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=homarr JSON=1`

## Site sync
- helmforgedev/site#303

Fixes #519
Related to homarr-labs/homarr#5967