### PR TITLE
fix(metabase): make wait image configurable

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump metabase to v0.62.1 (#555)"
+      description: "make the Metabase wait-for-db init image configurable (#541)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -75,6 +75,26 @@ resources:
     memory: 3Gi
 ```
 
+## Air-Gapped or Proxied Registries
+
+The `wait-for-db` init container image is configurable separately from the main
+Metabase image, so proxy-based environments can mirror both images:
+
+```yaml
+image:
+  repository: registry.example.com/proxy/metabase/metabase
+  tag: v0.62.1
+
+waitForDatabase:
+  image:
+    repository: registry.example.com/proxy/library/busybox
+    tag: "1.37"
+```
+
+Use `extraInitContainers` with `extraVolumes` and `extraVolumeMounts` when you
+need to prepare files before Metabase starts, for example JDBC drivers mounted
+into a shared plugin directory.
+
 ## Dual-Stack Service
 
 ```yaml
@@ -131,6 +151,9 @@ externalSecrets:
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
 | `image.tag` | `v0.62.1` | Metabase container image tag |
+| `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
+| `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
+| `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
 | `metabase.port` | `3000` | Application port |
 | `metabase.encryptionSecretKey` | `""` | Encryption key (auto-generated) |
 | `metabase.siteUrl` | `""` | Public site URL |
@@ -146,6 +169,7 @@ externalSecrets:
 | `service.port` | `80` | Service port |
 | `service.ipFamilyPolicy` | `~` | IP family policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
 | `service.ipFamilies` | `[]` | IP families override (`IPv4`, `IPv6`) |
+| `extraInitContainers` | `[]` | Additional init containers rendered after `wait-for-db` |
 | `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
 | `gateway.parentRefs` | `[]` | Gateway parentRefs (required when `gateway.enabled=true`) |
 | `gateway.hostnames` | `[]` | HTTPRoute hostnames |

--- a/charts/metabase/templates/NOTES.txt
+++ b/charts/metabase/templates/NOTES.txt
@@ -76,7 +76,7 @@
     kubectl get pods -l app.kubernetes.io/name=metabase -n {{ $namespace }} -o wide
 
   Check health from inside the cluster:
-    kubectl run metabase-smoke -n {{ $namespace }} --rm -i --restart=Never --image=docker.io/library/busybox:1.37 -- \
+    kubectl run metabase-smoke -n {{ $namespace }} --rm -i --restart=Never --image={{ .Values.waitForDatabase.image.repository }}:{{ .Values.waitForDatabase.image.tag }} -- \
       wget -qO- http://{{ $fullname }}:{{ .Values.service.port }}/api/health
 
   Inspect release events:

--- a/charts/metabase/templates/deployment.yaml
+++ b/charts/metabase/templates/deployment.yaml
@@ -41,7 +41,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       initContainers:
         - name: wait-for-db
-          image: docker.io/library/busybox:1.37
+          image: "{{ .Values.waitForDatabase.image.repository }}:{{ .Values.waitForDatabase.image.tag }}"
+          imagePullPolicy: {{ .Values.waitForDatabase.image.pullPolicy }}
           command:
             - sh
             - -c
@@ -52,6 +53,9 @@ spec:
                 sleep 2
               done
               echo "Database is ready."
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: metabase
           image: {{ include "metabase.image" . | quote }}

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -97,6 +97,40 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: "docker.io/library/busybox:1.37"
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should allow overriding the wait-for-db init container image
+    set:
+      waitForDatabase.image.repository: registry.example.com/mirror/busybox
+      waitForDatabase.image.tag: "1.37"
+      waitForDatabase.image.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "registry.example.com/mirror/busybox:1.37"
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always
+
+  - it: should append extra init containers
+    set:
+      extraInitContainers:
+        - name: install-oracle-driver
+          image: registry.example.com/tools/curl:8
+          command:
+            - sh
+            - -c
+          args:
+            - wget -O /plugins/ojdbc.jar http://repo.local/ojdbc.jar
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: install-oracle-driver
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: registry.example.com/tools/curl:8
 
   - it: should set external database host when subchart is disabled
     set:

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -18,6 +18,21 @@
       }
     },
     "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "waitForDatabase": {
+      "type": "object",
+      "description": "Wait-for-database init container configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "description": "Wait init container image configuration",
+          "properties": {
+            "repository": { "type": "string", "default": "docker.io/library/busybox" },
+            "tag": { "type": "string", "default": "1.37" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+          }
+        }
+      }
+    },
     "metabase": {
       "type": "object",
       "description": "Metabase application configuration",
@@ -117,6 +132,7 @@
     "podAnnotations": { "type": "object" },
     "extraVolumes": { "type": "array", "items": { "type": "object" } },
     "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraInitContainers": { "type": "array", "items": { "type": "object" } },
     "extraManifests": { "type": "array", "items": { "type": "object" } },
     "backup": {
       "type": "object",

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -22,6 +22,19 @@ image:
 imagePullSecrets: []
 
 # =============================================================================
+# Wait for Database Init Container
+# =============================================================================
+
+waitForDatabase:
+  image:
+    # -- Wait init container image repository
+    repository: docker.io/library/busybox
+    # -- Wait init container image tag
+    tag: "1.37"
+    # -- Wait init container image pull policy
+    pullPolicy: IfNotPresent
+
+# =============================================================================
 # Metabase Configuration
 # =============================================================================
 
@@ -258,6 +271,7 @@ podAnnotations: {}
 
 extraVolumes: []
 extraVolumeMounts: []
+extraInitContainers: []
 
 # -- Extra manifests to deploy alongside the chart
 extraManifests: []


### PR DESCRIPTION
## Summary
- Replace the hard-coded `docker.io/library/busybox:1.37` wait-for-db init image with configurable `waitForDatabase.image.*` values
- Keep the existing BusyBox image as the default for backward compatibility
- Add `extraInitContainers` so users can add custom init workflows, such as preparing JDBC driver files before Metabase starts
- Update README, NOTES, schema, and unit tests

## Validation
- `helm unittest charts/metabase`
- `helm lint --strict charts/metabase`
- `helm template metabase charts/metabase -f charts/metabase/ci/default-values.yaml`
- `node scripts/charts/validate-chart.js --chart metabase --timeout 180` with pods/events/logs monitored every 30s because first-run Metabase migrations exceed 60s
- `make standards-check CHART=metabase`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=metabase JSON=1`

## Site sync
- helmforgedev/site#304

Fixes #541