### PR TITLE
chore(cloudflared): bump cloudflared to 2026.6.1

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.8
-appVersion: "2026.6.0"
+appVersion: "2026.6.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump cloudflared to 2026.6.0 (#546)"
+      description: "bump cloudflared to 2026.6.1 (#559)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.6.0"
+  tag: "2026.6.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump the default Cloudflared image from `docker.io/cloudflare/cloudflared:2026.6.0` to `docker.io/cloudflare/cloudflared:2026.6.1`
- Update `appVersion` and Artifact Hub change metadata for the new upstream version

## Upstream evidence
- Manifest verified: `docker.io/cloudflare/cloudflared:2026.6.1` supports `linux/amd64` and `linux/arm64`
- Release notes: https://github.com/cloudflare/cloudflared/releases/tag/2026.6.1

## Validation
- `make image-verify IMAGE=docker.io/cloudflare/cloudflared:2026.6.1`
- `make deps-check CHART=cloudflared`
- `make validate-chart CHART=cloudflared TIMEOUT=60` monitored every 30s; full pass, 16 layers including k3d scenarios
- `make standards-check CHART=cloudflared`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=cloudflared JSON=1`

## Site sync
- `site-sync-check` detected default-value documentation/playground review is needed; this will be linked from the batch site sync PR for this upstream-update workstream.

Fixes #559