### PR TITLE
chore(drupal): bump drupal to 11.3.13

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.5
-appVersion: "11.3.12"
+appVersion: "11.3.13"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump Drupal to 11.3.12 (#560)"
+      description: "bump Drupal to 11.3.13 (#560)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.5
-appVersion: "11.3.11"
+appVersion: "11.3.12"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#558)"
+      description: "bump Drupal to 11.3.12 (#560)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.3.11-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.3.12-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.3.11-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.3.12-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,7 +53,7 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.3.11` is an upstream patch and bugfix release for Drupal 11. The
+Drupal `11.3.12` is an upstream security release for Drupal 11. The
 official release notes state that it is ready for production use and resolves
 Composer security errors from third-party components when installing
 `drupal/core-recommended`.
@@ -144,7 +144,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.3.11-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.3.12-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.3.12-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.3.13-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.3.12-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.3.13-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,9 +53,9 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.3.12` is an upstream security release for Drupal 11. The
-official release notes state that it is ready for production use and resolves
-Composer security errors from third-party components when installing
+Drupal `11.3.13` is an upstream patch release for Drupal 11. The official
+release notes state that it is ready for production use and resolves Composer
+security errors from third-party components when installing
 `drupal/core-recommended`.
 
 ## Production Example
@@ -144,7 +144,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.3.12-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.3.13-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.3.11-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.3.12-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.3.11-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.3.12-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.3.12-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.3.13-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.3.12-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.3.13-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.3.12-php8.5-apache-bookworm"
+  tag: "11.3.13-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.3.11-php8.5-apache-bookworm"
+  tag: "11.3.12-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bump the default Drupal image from `docker.io/library/drupal:11.3.11-php8.5-apache-bookworm` to `docker.io/library/drupal:11.3.13-php8.5-apache-bookworm`
- Update `appVersion`, README references, and deployment unit tests
- Move past 11.3.12 so default installs pick up the current Drupal 11.3 patch image

## Upstream evidence
- Manifest verified: `docker.io/library/drupal:11.3.13-php8.5-apache-bookworm` supports `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/386`, `linux/ppc64le`, and `linux/s390x`
- Release notes: https://www.drupal.org/project/drupal/releases/11.3.13

## Validation
- `make image-verify IMAGE=docker.io/library/drupal:11.3.13-php8.5-apache-bookworm`
- `make deps-check CHART=drupal`
- `make validate-chart CHART=drupal TIMEOUT=180` monitored every 30s; full pass, 17 layers including k3d scenarios
- `make standards-check CHART=drupal`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=drupal JSON=1`

## Site sync
- `site-sync-check` detected default/install-path documentation/playground review is needed; this will be linked from the batch site sync PR for this upstream-update workstream.

Fixes #560