### PR TITLE
chore(gitea): bump gitea to 1.26.4

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -4,7 +4,7 @@ name: gitea
 description: Gitea self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.12
-appVersion: "1.26.2"
+appVersion: "1.26.4"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
@@ -22,10 +22,8 @@ sources:
   - https://github.com/go-gitea/gitea
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#506)"
     - kind: changed
-      description: "add SPDX-License-Identifier headers across the catalog (#438)"
+      description: "bump Gitea to 1.26.4 (#562)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -52,10 +50,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.8.5
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/gitea/DESIGN.md
+++ b/charts/gitea/DESIGN.md
@@ -9,7 +9,7 @@ ClusterIP HTTP and SSH services, and restricted-compatible pod defaults.
 
 ## Goals
 
-- Run the official `docker.io/gitea/gitea:1.26.2-rootless` image without Bitnami
+- Run the official `docker.io/gitea/gitea:1.26.4-rootless` image without Bitnami
   or third-party runtime substitutions.
 - Keep the default install zero-config through SQLite while making PostgreSQL,
   MySQL, and external database modes explicit.

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -4,8 +4,8 @@
 
 Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
 
-- **Current application version** `1.26.2`
-- **Default image** `docker.io/gitea/gitea:1.26.2-rootless`
+- **Current application version** `1.26.4`
+- **Default image** `docker.io/gitea/gitea:1.26.4-rootless`
 - **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
 - **Rootless storage** PVC paths are prepared for UID/GID 1000 by a small initContainer
 
@@ -137,7 +137,7 @@ gitea:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `gitea/gitea` | Container image repository |
-| `image.tag` | `"1.26.2-rootless"` | Image tag |
+| `image.tag` | `"1.26.4-rootless"` | Image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
 | `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
@@ -191,7 +191,7 @@ Only one database source can be active. The chart fails with a clear error if mu
 
 ## Upgrade Notes
 
-This update moves the default rootless image from `1.26.1-rootless` to `1.26.2-rootless`. Review upstream
+This update moves the default rootless image from `1.26.2-rootless` to `1.26.4-rootless`. Review upstream
 Gitea release notes before upgrading production instances, especially for repository, SSH, and database migration behavior.
 
 ## SSH Access

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -6,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.26.2-rootless"
+  tag: "1.26.4-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary
- Bump the Gitea rootless image from `1.26.2-rootless` to `1.26.4-rootless`.
- Update the chart appVersion and Gitea chart documentation references.
- Refresh the HelmForge PostgreSQL and MySQL subchart dependencies required by GR-074.

## Validation
- `make image-verify IMAGE=docker.io/gitea/gitea:1.26.4-rootless`
- `make deps-check CHART=gitea`
- `make validate-chart CHART=gitea TIMEOUT=60` (17 layers, k3d scenarios included)
- `make standards-check CHART=gitea`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=gitea JSON=1` (site updates required by GR-007; follow-up site PR needed)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Upstream
- https://github.com/go-gitea/gitea/releases/tag/v1.26.4

Fixes #562