### PR TITLE
chore(liwan): bump liwan to 1.6.0

### DIFF
--- a/charts/liwan/Chart.yaml
+++ b/charts/liwan/Chart.yaml
@@ -4,7 +4,7 @@ name: liwan
 description: Liwan ultra-lightweight privacy-first web analytics with embedded DuckDB
 type: application
 version: 1.2.2
-appVersion: "1.5.0"
+appVersion: "1.6.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
   - https://github.com/explodingcamera/liwan
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#497)"
+    - kind: changed
+      description: "bump Liwan to 1.6.0 (#563)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/liwan/DESIGN.md
+++ b/charts/liwan/DESIGN.md
@@ -1,6 +1,6 @@
 # Liwan Chart Design
 
-This chart deploys Liwan as a single-instance web analytics service using the official `ghcr.io/explodingcamera/liwan:1.5.0` image.
+This chart deploys Liwan as a single-instance web analytics service using the official `ghcr.io/explodingcamera/liwan:1.6.0` image.
 
 ## Product Model
 

--- a/charts/liwan/README.md
+++ b/charts/liwan/README.md
@@ -3,7 +3,7 @@
 # Liwan Helm Chart
 
 Deploy [Liwan](https://liwan.dev) on Kubernetes with the official
-`ghcr.io/explodingcamera/liwan:1.5.0` image.
+`ghcr.io/explodingcamera/liwan:1.6.0` image.
 
 Liwan is a lightweight, privacy-focused web analytics application. It runs as a single Rust service and stores analytics
 data in embedded DuckDB under `/data`.
@@ -107,7 +107,7 @@ endpoint.
 | Key | Default | Description |
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/explodingcamera/liwan` | Liwan image repository. |
-| `image.tag` | `"1.5.0"` | Liwan image tag. |
+| `image.tag` | `"1.6.0"` | Liwan image tag. |
 | `liwan.port` | `9042` | Application HTTP port. |
 | `liwan.baseUrl` | `""` | Public base URL for UI and tracking scripts. |
 | `liwan.extraEnv` | `[]` | Extra environment variables for advanced upstream settings. |

--- a/charts/liwan/tests/deployment_test.yaml
+++ b/charts/liwan/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/explodingcamera/liwan:1.5.0"
+          value: "ghcr.io/explodingcamera/liwan:1.6.0"
 
   - it: should run as non-root UID 1000
     asserts:

--- a/charts/liwan/values.schema.json
+++ b/charts/liwan/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/explodingcamera/liwan" },
-        "tag": { "type": "string", "default": "1.5.0" },
+        "tag": { "type": "string", "default": "1.6.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/liwan/values.yaml
+++ b/charts/liwan/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Liwan container image
   repository: ghcr.io/explodingcamera/liwan
   # -- Image tag
-  tag: "1.5.0"
+  tag: "1.6.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump Liwan from `1.5.0` to `1.6.0`.
- Update default values, schema, chart appVersion, docs, and unit test image expectation.

## Validation
- `make image-verify IMAGE=ghcr.io/explodingcamera/liwan:1.6.0`
- `make deps-check CHART=liwan`
- `make validate-chart CHART=liwan TIMEOUT=60` (14 layers, k3d scenarios included)
- `make standards-check CHART=liwan`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=liwan JSON=1` (site updates required by GR-007; follow-up site PR needed)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Upstream
- https://github.com/explodingcamera/liwan/releases/tag/liwan-v1.6.0

Fixes #563