### PR TITLE
chore(metabase): bump metabase to v0.62.2

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.17
-appVersion: "v0.62.1"
+appVersion: "v0.62.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "make wait image configurable (#576)"
+    - kind: changed
+      description: "bump Metabase to v0.62.2 (#564)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.62.1
+  tag: v0.62.2
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.62.1` | Metabase container image tag |
+| `image.tag` | `v0.62.2` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,7 +184,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.62.1` updates the application to the latest upstream release and
+Metabase `v0.62.2` updates the application to the latest upstream release and
 repairs the chart's validation scenarios for single-stack clusters, external
 database fixtures, and External Secrets. Back up the Metabase application
 database before upgrading, keep the encryption key stable, and validate the

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.62.1"
+          value: "docker.io/metabase/metabase:v0.62.2"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.schema.json
+++ b/charts/metabase/values.schema.json
@@ -13,7 +13,7 @@
       "description": "Container image configuration",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/metabase/metabase" },
-        "tag": { "type": "string", "description": "Image tag", "default": "v0.62.1" },
+        "tag": { "type": "string", "description": "Image tag", "default": "v0.62.2" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.62.1"
+  tag: "v0.62.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump Metabase from `v0.62.1` to `v0.62.2`.
- Update default values, schema, chart appVersion, docs, and unit test image expectation.
- Use the valid upstream Docker tag `v0.62.2`; the issue text mentioned `0.62.2`, but that tag does not have a Docker manifest.

## Validation
- `make image-verify IMAGE=docker.io/metabase/metabase:v0.62.2`
- `make deps-check CHART=metabase`
- `make validate-chart CHART=metabase TIMEOUT=180` (17 layers, k3d scenarios included; monitored every 30s because initial migrations exceed 60s)
- `make standards-check CHART=metabase`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=metabase JSON=1` (site updates required by GR-007; follow-up site PR needed)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Upstream
- https://github.com/metabase/metabase/releases/tag/v0.62.2

Fixes #564