### PR TITLE
chore(mysql): bump mysql to 9.7.1

### DIFF
--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -4,7 +4,7 @@ name: mysql
 description: MySQL for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.0.1
-appVersion: "9.7.0"
+appVersion: "9.7.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#536)"
+    - kind: changed
+      description: "bump MySQL to 9.7.1 (#565)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -209,7 +209,7 @@ Operational documents:
 |-----------|-------------|---------|
 | `architecture` | `standalone` or `replication` | `standalone` |
 | `image.repository` | MySQL image repository | `docker.io/library/mysql` |
-| `image.tag` | MySQL image tag | `9.7.0` |
+| `image.tag` | MySQL image tag | `9.7.1` |
 | `auth.database` | App database created at bootstrap | `app` |
 | `auth.username` | App user created at bootstrap | `app` |
 | `auth.existingSecret` | Existing secret for passwords | `""` |

--- a/charts/mysql/tests/statefulset_source_test.yaml
+++ b/charts/mysql/tests/statefulset_source_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mysql:9.7.0"
+          value: "docker.io/library/mysql:9.7.1"
 
   - it: should always have 1 replica
     template: statefulset-source.yaml

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -44,7 +44,7 @@
         "tag": {
           "type": "string",
           "description": "MySQL image tag",
-          "default": "9.7.0"
+          "default": "9.7.1"
         },
         "pullPolicy": {
           "type": "string",
@@ -719,7 +719,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "9.7.0"
+                  "default": "9.7.1"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- MySQL image repository
   repository: docker.io/library/mysql
   # -- MySQL image tag
-  tag: "9.7.0"
+  tag: "9.7.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -277,7 +277,7 @@ backup:
       pullPolicy: IfNotPresent
     mysql:
       repository: docker.io/library/mysql
-      tag: "9.7.0"
+      tag: "9.7.1"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary
- Bump MySQL from `9.7.0` to `9.7.1`.
- Update the primary image, backup MySQL image, schema defaults, chart appVersion, docs, and unit test image expectation.

## Validation
- `make image-verify IMAGE=docker.io/library/mysql:9.7.1`
- `make deps-check CHART=mysql`
- `make validate-chart CHART=mysql TIMEOUT=180` (27 layers, k3d scenarios included; monitored every 30s because replication/TLS scenarios exceed 60s)
- `make standards-check CHART=mysql`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=mysql JSON=1` (site updates required by GR-007; follow-up site PR needed)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Upstream
- https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-7-1.html

Fixes #565