### PR TITLE
chore(n8n): bump n8n to 2.26.8

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.3
-appVersion: "2.27.3"
+appVersion: "2.26.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.27.3 (#566)"
+      description: "bump n8n to 2.26.8 (#566)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.3
-appVersion: "2.26.4"
+appVersion: "2.27.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.26.4 (#554)"
+      description: "bump n8n to 2.27.3 (#566)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.26.4` | n8n container image tag |
+| `image.tag` | `2.27.3` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -159,7 +159,7 @@ externalSecrets:
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
 | `queue.persistence.shareMainVolume` | `true` | Mount the main n8n data PVC into worker pods |
 | `terminationGracePeriodSeconds` | `75` | Kubernetes pod shutdown grace period |
-| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.18`) |
+| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.19`) |
 | `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
 | `taskRunners.image.repository` | `docker.io/n8nio/runners` | External task runner sidecar image repository |
 | `taskRunners.image.tag` | `""` | External task runner sidecar tag (defaults to `image.tag`) |
@@ -186,7 +186,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.26.4` is an upstream bugfix release. It reduces the delay in AI
+n8n `2.27.3` is an upstream bugfix release. It reduces the delay in AI
 Assistant workflow preview examples and fixes the
 `context.getNodeParameter is not a function` runtime error that could affect npm
 installs. Review the upstream release

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.27.3` | n8n container image tag |
+| `image.tag` | `2.26.8` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,16 +186,14 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.27.3` is an upstream bugfix release. It reduces the delay in AI
-Assistant workflow preview examples and fixes the
-`context.getNodeParameter is not a function` runtime error that could affect npm
-installs. Review the upstream release
-notes before upgrading, back up the database, and keep the encryption key stable
-before upgrading live deployments. This chart keeps the hardened non-root
-container defaults with resource requests and limits. Queue mode fails fast when
-it resolves to SQLite or when Redis is not configured, because workers must share
-the same PostgreSQL, MySQL, or external database as the main pod. Validate
-database and queue mode in a staging namespace before reusing production PVCs.
+n8n `2.26.8` is the upstream stable release used by the chart defaults. Review
+the upstream release notes before upgrading, back up the database, and keep the
+encryption key stable before upgrading live deployments. This chart keeps the
+hardened non-root container defaults with resource requests and limits. Queue
+mode fails fast when it resolves to SQLite or when Redis is not configured,
+because workers must share the same PostgreSQL, MySQL, or external database as
+the main pod. Validate database and queue mode in a staging namespace before
+reusing production PVCs.
 
 The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth
 token, opens the broker port, and runs a `docker.io/n8nio/runners` sidecar next

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.26.4"
+          value: "docker.io/n8nio/n8n:2.27.3"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.26.4"
+          value: "docker.io/n8nio/runners:2.27.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.27.3"
+          value: "docker.io/n8nio/n8n:2.26.8"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.27.3"
+          value: "docker.io/n8nio/runners:2.26.8"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.27.3"
+          value: "docker.io/n8nio/runners:2.26.8"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.26.4"
+          value: "docker.io/n8nio/runners:2.27.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.26.4"
+          "default": "2.27.3"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.27.3"
+          "default": "2.26.8"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.27.3"
+  tag: "2.26.8"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.26.4"
+  tag: "2.27.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bump n8n from `2.26.4` to the upstream stable `2.26.8`.
- Update default values, schema, chart appVersion, docs, main deployment tests, and worker runner image tests.
- Refresh the HelmForge Redis subchart dependency from `1.6.18` to `1.6.19` as required by GR-074.
- Keep chart defaults on the upstream stable channel instead of `2.27.3`, which is currently beta.

## Validation
- `make image-verify IMAGE=docker.io/n8nio/n8n:2.26.8`
- `make image-verify IMAGE=docker.io/n8nio/runners:2.26.8`
- `make deps-check CHART=n8n`
- `make validate-chart CHART=n8n TIMEOUT=180` (20 layers, k3d scenarios included; monitored every 30s because image pull/readiness exceeded 60s)
- `make standards-check CHART=n8n`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=n8n JSON=1` (site updates required by GR-007; follow-up site PR needed)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Upstream
- https://docs.n8n.io/release-notes/

Fixes #566