### PR TITLE
chore(olivetin): bump olivetin to 3000.15.0

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.11
-appVersion: "3000.14.0"
+appVersion: "3000.15.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
   - https://github.com/OliveTin/OliveTin
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#538)"
+    - kind: changed
+      description: "bump OliveTin to 3000.15.0 (#567)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -58,7 +58,7 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.resources` | requests/limits set | Resource guardrails for the config bootstrap init container |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.14.0` | OliveTin image tag |
+| `image.tag` | `3000.15.0` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
 | `olivetin.port` | `1337` | Application port |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.14.0"
+          value: "docker.io/jamesread/olivetin:3000.15.0"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.14.0" },
+        "tag": { "type": "string", "default": "3000.15.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.14.0"
+  tag: "3000.15.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump OliveTin from `3000.14.0` to `3000.15.0`.
- Update default values, schema, chart appVersion, docs, and deployment unit test image expectation.

## Validation
- `make image-verify IMAGE=docker.io/jamesread/olivetin:3000.15.0`
- `make deps-check CHART=olivetin`
- `make validate-chart CHART=olivetin TIMEOUT=60` (15 layers, k3d scenarios included)
- `make standards-check CHART=olivetin`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=olivetin JSON=1` (site updates required by GR-007; follow-up site PR needed)
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Upstream
- https://github.com/OliveTin/OliveTin/releases/tag/3000.15.0

Fixes #567