### PR TITLE
chore(rabbitmq): bump rabbitmq to 4.3.2

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -4,7 +4,7 @@ name: rabbitmq
 description: RabbitMQ for Kubernetes with explicit single-node and cluster modes
 type: application
 version: 1.6.0
-appVersion: "4.3.1"
+appVersion: "4.3.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,8 +22,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "optimize idle cpu defaults (#476)"
+    - kind: changed
+      description: "bump RabbitMQ to 4.3.2-alpine (#568)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -187,7 +187,7 @@ externalSecrets:
 
 ### Runtime efficiency
 
-- the default image is `docker.io/library/rabbitmq:4.3.1-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
+- the default image is `docker.io/library/rabbitmq:4.3.2-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
 - `runtime.disableSchedulerBusyWait=true` is enabled by default to reduce idle CPU from Erlang scheduler spin-wait in containers
 - default Kubernetes probes use lightweight TCP checks against the active AMQP listener instead of recurring `rabbitmq-diagnostics` commands
 - use `runtime.additionalErlArgs` for extra Erlang VM flags and reserve `extraEnv` for explicit upstream environment variables or full overrides
@@ -198,7 +198,7 @@ externalSecrets:
 |-----------|-------------|---------|
 | `architecture` | `single-node` or `cluster` | `single-node` |
 | `image.repository` | RabbitMQ image repository | `rabbitmq` |
-| `image.tag` | RabbitMQ image tag | `4.3.1-alpine` |
+| `image.tag` | RabbitMQ image tag | `4.3.2-alpine` |
 | `auth.username` | Application username | `user` |
 | `auth.password` | Application password | `""` |
 | `auth.erlangCookie` | Erlang cookie | `""` |

--- a/charts/rabbitmq/ci/dual-stack.yaml
+++ b/charts/rabbitmq/ci/dual-stack.yaml
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario: dual-stack for HTTP service (GR-058)
+# CI scenario: dual-stack networking via service.ipFamilyPolicy.
+#
+# Uses PreferDualStack policy without explicit ipFamilies so this scenario works
+# on both single-stack (IPv4-only) and dual-stack clusters. The Kubernetes API
+# rejects an explicit ipFamilies entry that the cluster does not advertise, so
+# explicit families require a dual-stack cluster for live installation.
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/rabbitmq/ci/existing-secret.yaml
+++ b/charts/rabbitmq/ci/existing-secret.yaml
@@ -1,3 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 auth:
   existingSecret: rabbitmq-auth
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: rabbitmq-auth
+    type: Opaque
+    stringData:
+      rabbitmq-username: user
+      rabbitmq-password: ci-password
+      rabbitmq-erlang-cookie: ci-erlang-cookie

--- a/charts/rabbitmq/ci/external-secrets.yaml
+++ b/charts/rabbitmq/ci/external-secrets.yaml
@@ -7,18 +7,31 @@ auth:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
-    kind: ClusterSecretStore
+    name: rabbitmq-ci-fake-store
+    kind: SecretStore
   data:
     - secretKey: rabbitmq-username
       remoteRef:
-        key: rabbitmq/auth
-        property: username
+        key: rabbitmq/username
     - secretKey: rabbitmq-password
       remoteRef:
-        key: rabbitmq/auth
-        property: password
+        key: rabbitmq/password
     - secretKey: rabbitmq-erlang-cookie
       remoteRef:
-        key: rabbitmq/auth
-        property: erlang-cookie
+        key: rabbitmq/erlang-cookie
+
+extraManifests:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: rabbitmq-ci-fake-store
+    spec:
+      provider:
+        fake:
+          data:
+            - key: rabbitmq/username
+              value: user
+            - key: rabbitmq/password
+              value: ci-password
+            - key: rabbitmq/erlang-cookie
+              value: ci-erlang-cookie

--- a/charts/rabbitmq/ci/secure.yaml
+++ b/charts/rabbitmq/ci/secure.yaml
@@ -14,3 +14,80 @@ management:
         paths:
           - path: /
             pathType: Prefix
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: rabbitmq-tls
+    type: Opaque
+    stringData:
+      ca.crt: |
+        -----BEGIN CERTIFICATE-----
+        MIIDHzCCAgegAwIBAgIUFwuvmwhUUACKaLWuThgz2/zItkswDQYJKoZIhvcNAQEL
+        BQAwHzEdMBsGA1UEAwwUcmFiYml0bXEuZXhhbXBsZS5jb20wHhcNMjYwNjI1MDgz
+        MTI0WhcNMzYwNjIyMDgzMTI0WjAfMR0wGwYDVQQDDBRyYWJiaXRtcS5leGFtcGxl
+        LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJkqujNYER2uZy8T
+        MRdvFD5xAxWGSor4pyq/AV36w69cA188enIKOki+isgpaeSgMqk01sX+SM0B2Uc5
+        MbDNt/KaQ2zNAcyUnEosw10EnHDGQ25wQn2RYor6NzQEuo1KOSLcQCgimvbqpI6+
+        6qXIVcUhZNQqfQrP/0yyeVECmb4sJ1pl6sxOtu+b29UfI9QCbFrUQKd8yFz/ftmi
+        OaCfRTBWwCBXU9aYjG6ZwMRrRgshDJN0wBCVca9rEqxOlBHNOc1J4+m4UQWk1w2u
+        3UE7JZNhW7f+ClWJzcXdLVxVkYTxahMKSFEg4RBfgJgL6xeGtEKWEWMcsUVbId9D
+        zEHTibcCAwEAAaNTMFEwHQYDVR0OBBYEFIoV+GJN9XkzPuDzaf1mH44LgbYEMB8G
+        A1UdIwQYMBaAFIoV+GJN9XkzPuDzaf1mH44LgbYEMA8GA1UdEwEB/wQFMAMBAf8w
+        DQYJKoZIhvcNAQELBQADggEBACRg9aHkgTvLe0tymCtWbQ1qzmLLCSVBHs8SH7WJ
+        kzZ/KsAr1pJinHv0YHFcNHCgGcHEfzp1WaXGrGjXQVMHU3F2JvnH66AKWcjbdhRf
+        TpRzBNSn60LmLlakvvSlPc5iCDGJUyF5zz5waqwrRkdFu+ceMaKbQiNmMfiJZhaQ
+        w3GS2Jff5cq5P6bgyRRaShlO151dnW2nxLlp1jLa7bcQfjyTpGowtGgAXYZnyVRS
+        eRsHJ+NyQIfWrJFA/Avou2GRupzy25GlGBGznNCMtwYgsieCeUP/xIxDEdZDNdpx
+        6MneBJ2GFksvVNq+rqQ5AwbIeezs8TlT2rAzi5PS+yksKrw=
+        -----END CERTIFICATE-----
+      tls.crt: |
+        -----BEGIN CERTIFICATE-----
+        MIIDHzCCAgegAwIBAgIUFwuvmwhUUACKaLWuThgz2/zItkswDQYJKoZIhvcNAQEL
+        BQAwHzEdMBsGA1UEAwwUcmFiYml0bXEuZXhhbXBsZS5jb20wHhcNMjYwNjI1MDgz
+        MTI0WhcNMzYwNjIyMDgzMTI0WjAfMR0wGwYDVQQDDBRyYWJiaXRtcS5leGFtcGxl
+        LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJkqujNYER2uZy8T
+        MRdvFD5xAxWGSor4pyq/AV36w69cA188enIKOki+isgpaeSgMqk01sX+SM0B2Uc5
+        MbDNt/KaQ2zNAcyUnEosw10EnHDGQ25wQn2RYor6NzQEuo1KOSLcQCgimvbqpI6+
+        6qXIVcUhZNQqfQrP/0yyeVECmb4sJ1pl6sxOtu+b29UfI9QCbFrUQKd8yFz/ftmi
+        OaCfRTBWwCBXU9aYjG6ZwMRrRgshDJN0wBCVca9rEqxOlBHNOc1J4+m4UQWk1w2u
+        3UE7JZNhW7f+ClWJzcXdLVxVkYTxahMKSFEg4RBfgJgL6xeGtEKWEWMcsUVbId9D
+        zEHTibcCAwEAAaNTMFEwHQYDVR0OBBYEFIoV+GJN9XkzPuDzaf1mH44LgbYEMB8G
+        A1UdIwQYMBaAFIoV+GJN9XkzPuDzaf1mH44LgbYEMA8GA1UdEwEB/wQFMAMBAf8w
+        DQYJKoZIhvcNAQELBQADggEBACRg9aHkgTvLe0tymCtWbQ1qzmLLCSVBHs8SH7WJ
+        kzZ/KsAr1pJinHv0YHFcNHCgGcHEfzp1WaXGrGjXQVMHU3F2JvnH66AKWcjbdhRf
+        TpRzBNSn60LmLlakvvSlPc5iCDGJUyF5zz5waqwrRkdFu+ceMaKbQiNmMfiJZhaQ
+        w3GS2Jff5cq5P6bgyRRaShlO151dnW2nxLlp1jLa7bcQfjyTpGowtGgAXYZnyVRS
+        eRsHJ+NyQIfWrJFA/Avou2GRupzy25GlGBGznNCMtwYgsieCeUP/xIxDEdZDNdpx
+        6MneBJ2GFksvVNq+rqQ5AwbIeezs8TlT2rAzi5PS+yksKrw=
+        -----END CERTIFICATE-----
+      tls.key: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCZKrozWBEdrmcv
+        EzEXbxQ+cQMVhkqK+KcqvwFd+sOvXANfPHpyCjpIvorIKWnkoDKpNNbF/kjNAdlH
+        OTGwzbfymkNszQHMlJxKLMNdBJxwxkNucEJ9kWKK+jc0BLqNSjki3EAoIpr26qSO
+        vuqlyFXFIWTUKn0Kz/9MsnlRApm+LCdaZerMTrbvm9vVHyPUAmxa1ECnfMhc/37Z
+        ojmgn0UwVsAgV1PWmIxumcDEa0YLIQyTdMAQlXGvaxKsTpQRzTnNSePpuFEFpNcN
+        rt1BOyWTYVu3/gpVic3F3S1cVZGE8WoTCkhRIOEQX4CYC+sXhrRClhFjHLFFWyHf
+        Q8xB04m3AgMBAAECggEACT1gHS/PXISEWf0k5X6AcKHdp0NCJO8KGpSKLxKtEluR
+        IoIh+tYuHOxNr/R7nFyjobx7xlboKmHVqyvCmSFX2u0+awZU+PPwF7Nql6ZrD4yO
+        Tc+82xlVof+lK+CrJlHXb4hs4F7yDTorcicHPbf/oJQ6omfrwia5BnXvxpjLEIM+
+        d1B3LGKXfTeScxh+hyNwNXgvuS7Kalv2iOsrqOoeiSvpLagMwbySHNwU7JG80VvP
+        YcS42a3m8Nwo1ql6oluC0tGBaGth5s7by0bOPu107g6X2qXv99kWaD2t4h5KnFzJ
+        L5FVhGbiHdKljQ0ke6QmmKSiiV45G+nLkVVUvndhFQKBgQDMadIxIReK18aD+q6Q
+        70CNXmjlQZwDqpTYgxokrp/aGlG7ctUXqKJC8G6eZZXNr0AZNAg/JksO29doqvle
+        ewL66L94+8FaFsjbZXFGafIt00opmKOlu7nNo3ET7e1o1aMYTH8NtaegspEKWRSN
+        rS0sR/qBqnvdM/LvJYjKHvzKYwKBgQC/0h2FGWhT5WMTfvKfJ9flmMWLjNNsRHEh
+        w7EAHy1UytAPbCBFEIK+3JkInxcrTAGJwYR8nZMYeSzrxe8bgRakZ1ox0o40yr4o
+        ZIC0OT4pzaeh71HvaYkk/WkUjji2c3Lehm/2aEsES38uKc/dDp5pp9azj8jpbXWS
+        IV+zs4VZnQKBgHkgE28NPtgE+BrohlxXiRa75MhEUmBRyhVpyioGV65zfg7nAqIc
+        SNoFgmbVpyjUOdU1YdWZqUxKtJ/PACkeFyv6ksrr0yzA55Ap0i95RAonc4CmdAIW
+        9QiHWtAGYnGGdjhFy9uh0oyEgzFwi59QCL5+gFApZ3AyAjf3M9Eg/4YlAoGAVeAf
+        TyMczdJ4FJZU0GPqB+PpLJyTWnkZnOAbMc7DYJ6bnwvtNn45ynDAIlf2629PkPiN
+        86wn2mEFd1hZv5p/JIMQohV9jKznjPXRmN23ssdbMOgPant45pJ8pLM3OJde6biO
+        D2aJjxatjWEyqeiNiweU2zaX38kdRZqjWbQZExECgYEAo5F3etsIyASSeVmpjcpl
+        t8HLpAA/O/tZo5vA0ynfmYi7jfNdA27fRyLDZgTrpIXqkkMv0O7dIXLELepTMhLj
+        9Qd+7a6NZodhu5jDR+s+7HasN1vAmfqes4ARc8Dk4/8I8ndrBfhog+7QAs75cvhL
+        djieXkVnw1qsMA55nee2cvs=
+        -----END PRIVATE KEY-----

--- a/charts/rabbitmq/templates/configmap.yaml
+++ b/charts/rabbitmq/templates/configmap.yaml
@@ -12,16 +12,16 @@ data:
     loopback_users.guest = false
     default_vhost = {{ .Values.auth.vhost }}
     default_queue_type = {{ .Values.queueDefaults.type }}
+    {{- if and .Values.tls.enabled .Values.tls.disableNonTLSListeners }}
+    listeners.tcp = none
+    {{- else }}
     listeners.tcp.default = {{ .Values.service.amqpPort }}
     management.tcp.port = {{ .Values.service.managementPort }}
+    {{- end }}
     cluster_partition_handling = {{ .Values.cluster.partitionHandling }}
     {{- if .Values.metrics.enabled }}
     prometheus.return_per_object_metrics = true
     prometheus.tcp.port = {{ .Values.service.metricsPort }}
-    {{- end }}
-    {{- if and .Values.tls.enabled .Values.tls.disableNonTLSListeners }}
-    listeners.tcp = none
-    management.tcp.port = none
     {{- end }}
     {{- if .Values.tls.enabled }}
     listeners.ssl.default = {{ .Values.service.amqpsPort }}

--- a/charts/rabbitmq/templates/service.yaml
+++ b/charts/rabbitmq/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
   selector:
     {{- include "rabbitmq.selectorLabels" . | nindent 4 }}
   ports:
+    {{- if not (and .Values.tls.enabled .Values.tls.disableNonTLSListeners) }}
     - name: amqp
       port: {{ .Values.service.amqpPort }}
       targetPort: amqp
@@ -28,6 +29,7 @@ spec:
     - name: management
       port: {{ .Values.service.managementPort }}
       targetPort: management
+    {{- end }}
     {{- end }}
     {{- if .Values.tls.enabled }}
     - name: amqps

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -104,13 +104,15 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
+            {{- if not (and .Values.tls.enabled .Values.tls.disableNonTLSListeners) }}
             - name: amqp
               containerPort: {{ .Values.service.amqpPort }}
+            {{- end }}
             - name: epmd
               containerPort: {{ .Values.service.epmdPort }}
             - name: dist
               containerPort: {{ .Values.service.distPort }}
-            {{- if .Values.management.enabled }}
+            {{- if and .Values.management.enabled (not (and .Values.tls.enabled .Values.tls.disableNonTLSListeners)) }}
             - name: management
               containerPort: {{ .Values.service.managementPort }}
             {{- end }}

--- a/charts/rabbitmq/tests/service_test.yaml
+++ b/charts/rabbitmq/tests/service_test.yaml
@@ -37,3 +37,34 @@ tests:
             name: management
             port: 15672
             targetPort: management
+
+  - it: should expose only TLS ports when non-TLS listeners are disabled
+    set:
+      tls.enabled: true
+      tls.disableNonTLSListeners: true
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: amqp
+            port: 5672
+            targetPort: amqp
+      - notContains:
+          path: spec.ports
+          content:
+            name: management
+            port: 15672
+            targetPort: management
+      - contains:
+          path: spec.ports
+          content:
+            name: amqps
+            port: 5671
+            targetPort: amqps
+      - contains:
+          path: spec.ports
+          content:
+            name: management-tls
+            port: 15671
+            targetPort: management-tls
+            appProtocol: https

--- a/charts/rabbitmq/tests/statefulset_test.yaml
+++ b/charts/rabbitmq/tests/statefulset_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/rabbitmq:4.3.1-alpine"
+          value: "docker.io/library/rabbitmq:4.3.2-alpine"
 
   - it: should have 1 replica in single-node mode
     template: statefulset.yaml
@@ -81,6 +81,33 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: amqps
+
+  - it: should expose only TLS container ports when non-TLS listeners are disabled
+    template: statefulset.yaml
+    set:
+      tls.enabled: true
+      tls.disableNonTLSListeners: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: amqp
+            containerPort: 5672
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: management
+            containerPort: 15672
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: amqps
+            containerPort: 5671
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: management-tls
+            containerPort: 15671
 
   - it: should disable Erlang scheduler busy-wait by default
     template: statefulset.yaml

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- RabbitMQ image repository
   repository: docker.io/library/rabbitmq
   # -- RabbitMQ image tag
-  tag: "4.3.1-alpine"
+  tag: "4.3.2-alpine"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bumps RabbitMQ from `4.3.1-alpine` to `4.3.2-alpine`.
- Makes RabbitMQ k3d CI scenarios self-contained for dual-stack, existing Secret, External Secrets, and TLS validation.
- Fixes TLS-only rendering so non-TLS AMQP and management listeners/ports are not configured when `tls.disableNonTLSListeners=true`.

## Validation
- `make image-verify IMAGE=docker.io/library/rabbitmq:4.3.2-alpine`
- `make deps-check CHART=rabbitmq`
- `make validate-chart CHART=rabbitmq TIMEOUT=180` (18 layers, monitored every 30s)
- `make standards-check CHART=rabbitmq`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=rabbitmq JSON=1`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Notes
- `site-sync-check` reports a required GR-007 site follow-up for the RabbitMQ chart page/configuration reference.
- RabbitMQ 4.3 rejects `management.tcp.port = none`; the chart now omits the HTTP management listener config when TLS-only management is requested.

Fixes #568