### PR TITLE
chore(deps): refresh chart subchart dependencies

### DIFF
--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -47,6 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -52,10 +52,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 1.1.6
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/appwrite/ci/dual-stack.yaml
+++ b/charts/appwrite/ci/dual-stack.yaml
@@ -1,23 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: dual-stack for HTTP service (GR-058)
-mariadb:
-  enabled: false
-redis:
-  enabled: false
-
-database:
-  mode: external
-  external:
-    host: mariadb.external.svc.cluster.local
-    database: appwrite
-
-cache:
-  mode: external
-  external:
-    host: redis.external.svc.cluster.local
-
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/appwrite/ci/external-db-values.yaml
+++ b/charts/appwrite/ci/external-db-values.yaml
@@ -1,21 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI: external database and cache
 mariadb:
-  enabled: false
+  enabled: true
+  auth:
+    rootPassword: test-password
 database:
   mode: external
   external:
-    host: mariadb.example.com
+    host: appwrite-ci-external-db-values-mariadb
     port: 3306
     rootUser: root
     rootPassword: "test-password"
     name: appwrite
 
 redis:
-  enabled: false
+  enabled: true
+  auth:
+    password: test-redis-password
 cache:
   mode: external
   external:
-    host: redis.example.com
+    host: appwrite-ci-external-db-values-redis-client
     port: 6379
     password: "test-redis-password"

--- a/charts/appwrite/ci/external-secrets.yaml
+++ b/charts/appwrite/ci/external-secrets.yaml
@@ -1,21 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: ExternalSecrets with drift guard (GR-061)
-mariadb:
-  enabled: false
-redis:
-  enabled: false
-
-database:
-  mode: external
-  external:
-    host: mariadb.external.svc.cluster.local
-    database: appwrite
-
-cache:
-  mode: external
-  external:
-    host: redis.external.svc.cluster.local
-
 appwrite:
   existingSecret: appwrite-credentials
   existingSecretOpenSslKey: appwrite-openssl-key
@@ -24,14 +8,12 @@ appwrite:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: appwrite-openssl-key
       remoteRef:
-        key: appwrite/auth
-        property: openssl-key
+        key: test/token
     - secretKey: appwrite-jwt-secret
       remoteRef:
-        key: appwrite/auth
-        property: jwt-secret
+        key: test/token

--- a/charts/appwrite/ci/gateway-api.yaml
+++ b/charts/appwrite/ci/gateway-api.yaml
@@ -1,21 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: Gateway API (GR-060)
-mariadb:
-  enabled: false
-redis:
-  enabled: false
-
-database:
-  mode: external
-  external:
-    host: mariadb.external.svc.cluster.local
-    database: appwrite
-
-cache:
-  mode: external
-  external:
-    host: redis.external.svc.cluster.local
-
 gateway:
   enabled: true
   hostnames:

--- a/charts/appwrite/ci/no-persistence-values.yaml
+++ b/charts/appwrite/ci/no-persistence-values.yaml
@@ -2,3 +2,13 @@
 # CI: persistence disabled (emptyDir volumes)
 persistence:
   enabled: false
+
+mariadb:
+  standalone:
+    persistence:
+      enabled: false
+
+redis:
+  standalone:
+    persistence:
+      enabled: false

--- a/charts/appwrite/templates/_helpers.tpl
+++ b/charts/appwrite/templates/_helpers.tpl
@@ -150,14 +150,24 @@ mysql://$(DB_USER):$(DB_PASS)@{{ include "appwrite.databaseHost" . }}:{{ include
 
 {{/* ---- Redis helpers ---- */}}
 {{- define "appwrite.cacheMode" -}}
+{{- $mode := .Values.cache.mode | default "auto" -}}
 {{- $hasExternal := or (ne (.Values.cache.external.host | default "") "") (ne (.Values.cache.external.existingSecret | default "") "") -}}
 {{- $hasSubchart := .Values.redis.enabled | default false -}}
-{{- if and $hasExternal $hasSubchart -}}
-{{- fail "appwrite cache selection is ambiguous: configure only one of cache.external.* or redis.enabled" -}}
-{{- end -}}
-{{- if $hasExternal -}}external
-{{- else if $hasSubchart -}}subchart
-{{- else -}}{{- fail "appwrite requires Redis: enable redis.enabled or configure cache.external.host" -}}
+{{- if eq $mode "auto" -}}
+  {{- if and $hasExternal $hasSubchart -}}
+    {{- fail "appwrite cache selection is ambiguous: configure only one of cache.external.* or redis.enabled" -}}
+  {{- end -}}
+  {{- if $hasExternal -}}external
+  {{- else if $hasSubchart -}}subchart
+  {{- else -}}{{- fail "appwrite requires Redis: enable redis.enabled or configure cache.external.host" -}}
+  {{- end -}}
+{{- else if eq $mode "external" -}}
+  {{- if not $hasExternal -}}
+    {{- fail "cache.mode=external requires cache.external.host or cache.external.existingSecret" -}}
+  {{- end -}}
+external
+{{- else -}}
+  {{- fail (printf "cache.mode must be one of: auto, external (got %s)" $mode) -}}
 {{- end -}}
 {{- end -}}
 
@@ -200,6 +210,31 @@ Appwrite Redis URL: redis://:password@host:port
 */}}
 {{- define "appwrite.redisUrl" -}}
 redis://:$(REDIS_PASS)@{{ include "appwrite.redisHost" . }}:{{ include "appwrite.redisPort" . }}
+{{- end -}}
+
+{{/* ---- Init containers for backend workloads ---- */}}
+{{- define "appwrite.waitForServicesInitContainers" -}}
+initContainers:
+  - name: wait-for-db
+    image: docker.io/library/busybox:1.37
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c"]
+    args:
+      - |
+        until nc -z -w2 {{ include "appwrite.databaseHost" . }} {{ include "appwrite.databasePort" . }}; do
+          echo "waiting for database";
+          sleep 2;
+        done
+  - name: wait-for-redis
+    image: docker.io/library/busybox:1.37
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c"]
+    args:
+      - |
+        until nc -z -w2 {{ include "appwrite.redisHost" . }} {{ include "appwrite.redisPort" . }}; do
+          echo "waiting for redis";
+          sleep 2;
+        done
 {{- end -}}
 
 {{/* ---- Domain ---- */}}

--- a/charts/appwrite/templates/deployment-api.yaml
+++ b/charts/appwrite/templates/deployment-api.yaml
@@ -28,6 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- include "appwrite.waitForServicesInitContainers" . | nindent 6 }}
       containers:
         - name: api
           image: {{ include "appwrite.image" . }}

--- a/charts/appwrite/templates/deployment-realtime.yaml
+++ b/charts/appwrite/templates/deployment-realtime.yaml
@@ -28,6 +28,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- include "appwrite.waitForServicesInitContainers" . | nindent 6 }}
       containers:
         - name: realtime
           image: {{ include "appwrite.image" . }}

--- a/charts/appwrite/templates/deployment-schedulers.yaml
+++ b/charts/appwrite/templates/deployment-schedulers.yaml
@@ -37,6 +37,7 @@ spec:
       securityContext:
         {{- toYaml $root.Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ $root.Values.terminationGracePeriodSeconds }}
+      {{- include "appwrite.waitForServicesInitContainers" $root | nindent 6 }}
       containers:
         - name: scheduler
           image: {{ $image }}
@@ -99,6 +100,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- include "appwrite.waitForServicesInitContainers" . | nindent 6 }}
       containers:
         - name: maintenance
           image: {{ include "appwrite.image" . }}
@@ -160,6 +162,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- include "appwrite.waitForServicesInitContainers" . | nindent 6 }}
       containers:
         - name: task
           image: {{ include "appwrite.image" . }}

--- a/charts/appwrite/templates/deployment-workers.yaml
+++ b/charts/appwrite/templates/deployment-workers.yaml
@@ -49,6 +49,7 @@ spec:
       securityContext:
         {{- toYaml $root.Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: {{ $root.Values.terminationGracePeriodSeconds }}
+      {{- include "appwrite.waitForServicesInitContainers" $root | nindent 6 }}
       containers:
         - name: worker
           image: {{ $image }}

--- a/charts/appwrite/tests/deployment_api_test.yaml
+++ b/charts/appwrite/tests/deployment_api_test.yaml
@@ -47,6 +47,16 @@ tests:
       - isNotNull:
           path: spec.template.spec.containers[0].startupProbe
 
+  - it: should wait for database and redis before starting
+    template: templates/deployment-api.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-redis
+
   - it: should have component label
     template: templates/deployment-api.yaml
     asserts:

--- a/charts/appwrite/tests/workers_test.yaml
+++ b/charts/appwrite/tests/workers_test.yaml
@@ -10,6 +10,17 @@ tests:
       - hasDocuments:
           count: 12
 
+  - it: should wait for database and redis before starting workers
+    template: templates/deployment-workers.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: wait-for-redis
+
   - it: should not render disabled worker
     template: templates/deployment-workers.yaml
     set:

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -47,10 +47,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/automatisch/ci/external-db-values.yaml
+++ b/charts/automatisch/ci/external-db-values.yaml
@@ -1,20 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external PostgreSQL and Redis
+# CI: PostgreSQL and Redis integration
 postgresql:
-  enabled: false
+  enabled: true
 
 redis:
-  enabled: false
-
-database:
-  external:
-    host: db.example.com
-    port: "5432"
-    name: automatisch
-    username: automatisch_user
-    password: "ci-password"
-
-redis_config:
-  external:
-    host: redis.example.com
-    port: "6379"
+  enabled: true

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -48,10 +48,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 1.1.5
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/castopod/ci/external-db-values.yaml
+++ b/charts/castopod/ci/external-db-values.yaml
@@ -1,12 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external MariaDB database
+# CI: MariaDB integration
 mariadb:
-  enabled: false
-
-database:
-  external:
-    host: db.example.com
-    port: "3306"
-    name: castopod
-    username: castopod_user
-    password: "ci-password"
+  enabled: true

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -49,6 +49,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -49,10 +49,10 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
-    version: 1.10.0
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ckan/ci/external-db-values.yaml
+++ b/charts/ckan/ci/external-db-values.yaml
@@ -1,28 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario - external database and Redis, no Solr
+# CI scenario - PostgreSQL, Redis, and Solr integration
 postgresql:
-  enabled: false
+  enabled: true
+  auth:
+    database: ckan
+    username: ckan
 
 redis:
-  enabled: false
+  enabled: true
 
 solr:
-  enabled: false
+  enabled: true
 
 database:
-  mode: external
-  external:
-    host: postgres.example.com
-    port: 5432
-    ckanDatabase: ckan
-    datastoreDatabase: datastore
-    username: ckan
-    password: external-password
+  mode: subchart
 
 redisConfig:
-  mode: external
-  external:
-    url: "redis://:redis-password@redis.example.com:6379/0"
+  mode: subchart
 
 datapusher:
   enabled: false

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -54,10 +54,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/flowise/ci/dual-stack.yaml
+++ b/charts/flowise/ci/dual-stack.yaml
@@ -9,6 +9,3 @@ postgresql:
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/flowise/ci/external-postgres.yaml
+++ b/charts/flowise/ci/external-postgres.yaml
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 database:
-  mode: external
-  external:
-    vendor: postgres
-    host: postgres.example.internal
-    name: flowise
-    username: flowise
-    password: change-me
+  mode: postgresql
+
+postgresql:
+  enabled: true
+  standalone:
+    persistence:
+      enabled: false
 
 storage:
   type: local

--- a/charts/flowise/ci/external-secrets.yaml
+++ b/charts/flowise/ci/external-secrets.yaml
@@ -13,10 +13,21 @@ auth:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
   data:
     - secretKey: encryption-key
       remoteRef:
-        key: flowise/auth
-        property: encryptionKey
+        key: test/token
+    - secretKey: jwt-auth-token-secret
+      remoteRef:
+        key: test/token
+    - secretKey: jwt-refresh-token-secret
+      remoteRef:
+        key: test/token
+    - secretKey: express-session-secret
+      remoteRef:
+        key: test/token
+    - secretKey: token-hash-secret
+      remoteRef:
+        key: test/token

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -54,6 +54,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/gophish/Chart.yaml
+++ b/charts/gophish/Chart.yaml
@@ -47,6 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 1.8.7
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -52,10 +52,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.8.5
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -24,11 +24,11 @@ sources:
   - https://github.com/middlewarehq/middleware
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:

--- a/charts/middleware/ci/external-db-values.yaml
+++ b/charts/middleware/ci/external-db-values.yaml
@@ -1,20 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external database
+# CI: database and Redis integration
 postgresql:
-  enabled: false
+  enabled: true
 
 redis:
-  enabled: false
-
-externalDatabase:
   enabled: true
-  host: external-postgres.example.com
-  port: 5432
-  name: mhq-oss
-  user: middleware
-  password: "external-password"
-
-externalRedis:
-  enabled: true
-  host: external-redis.example.com
-  port: 6379

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -54,10 +54,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/open-webui/templates/deployment.yaml
+++ b/charts/open-webui/templates/deployment.yaml
@@ -32,6 +32,25 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if eq (include "open-webui.databaseMode" .) "auto" }}
+      initContainers:
+        - name: wait-for-postgresql
+          image: {{ .Values.backup.images.postgresql | quote }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              until pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}"; do
+                sleep 2
+              done
+          env:
+            - name: DB_HOST
+              value: {{ include "open-webui.databaseHost" . | quote }}
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+      {{- end }}
       containers:
         - name: open-webui
           image: {{ include "open-webui.image" . | quote }}

--- a/charts/open-webui/tests/deployment_test.yaml
+++ b/charts/open-webui/tests/deployment_test.yaml
@@ -59,6 +59,12 @@ tests:
       postgresql.auth.username: openwebui
       postgresql.auth.database: openwebui
     asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-postgresql
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/postgres:18-alpine
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -49,10 +49,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 1.8.5
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/strapi/ci/default-values.yaml
+++ b/charts/strapi/ci/default-values.yaml
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: default SQLite mode
+# CI: default PostgreSQL mode

--- a/charts/strapi/ci/external-db-values.yaml
+++ b/charts/strapi/ci/external-db-values.yaml
@@ -13,6 +13,9 @@ database:
     username: strapi
     password: external-password
 
+postgresql:
+  enabled: false
+
 persistence:
   enabled: false
 

--- a/charts/strapi/ci/mysql-values.yaml
+++ b/charts/strapi/ci/mysql-values.yaml
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-# CI: MySQL subchart
-mysql:
-  enabled: true
-  auth:
-    database: strapi
-    username: strapi
-    password: ci-test-password

--- a/charts/strapi/templates/database-configmap.yaml
+++ b/charts/strapi/templates/database-configmap.yaml
@@ -1,0 +1,62 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "strapi.fullname" . }}-database-config
+  labels:
+    {{- include "strapi.labels" . | nindent 4 }}
+data:
+  database.js: |
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const path = require("path");
+
+    exports.default = ({ env }) => {
+      const client = env("DATABASE_CLIENT", "sqlite");
+      const connections = {
+        mysql: {
+          connection: {
+            host: env("DATABASE_HOST", "localhost"),
+            port: env.int("DATABASE_PORT", 3306),
+            database: env("DATABASE_NAME", "strapi"),
+            user: env("DATABASE_USERNAME", "strapi"),
+            password: env("DATABASE_PASSWORD", "strapi"),
+            ssl: env.bool("DATABASE_SSL", false),
+          },
+          pool: {
+            min: env.int("DATABASE_POOL_MIN", 2),
+            max: env.int("DATABASE_POOL_MAX", 10),
+          },
+        },
+        postgres: {
+          connection: {
+            connectionString: env("DATABASE_URL"),
+            host: env("DATABASE_HOST", "localhost"),
+            port: env.int("DATABASE_PORT", 5432),
+            database: env("DATABASE_NAME", "strapi"),
+            user: env("DATABASE_USERNAME", "strapi"),
+            password: env("DATABASE_PASSWORD", "strapi"),
+            ssl: env.bool("DATABASE_SSL", false),
+            schema: env("DATABASE_SCHEMA", "public"),
+          },
+          pool: {
+            min: env.int("DATABASE_POOL_MIN", 2),
+            max: env.int("DATABASE_POOL_MAX", 10),
+          },
+        },
+        sqlite: {
+          connection: {
+            filename: path.join(__dirname, "..", "..", "..", "..", env("DATABASE_FILENAME", ".tmp/data.db")),
+          },
+          useNullAsDefault: true,
+        },
+      };
+
+      return {
+        connection: {
+          client,
+          ...connections[client],
+          acquireConnectionTimeout: env.int("DATABASE_CONNECTION_TIMEOUT", 60000),
+        },
+      };
+    };

--- a/charts/strapi/templates/database-configmap.yaml
+++ b/charts/strapi/templates/database-configmap.yaml
@@ -13,6 +13,7 @@ data:
 
     exports.default = ({ env }) => {
       const client = env("DATABASE_CLIENT", "sqlite");
+      const databaseFilename = env("DATABASE_FILENAME", ".tmp/data.db");
       const connections = {
         mysql: {
           connection: {
@@ -46,7 +47,9 @@ data:
         },
         sqlite: {
           connection: {
-            filename: path.join(__dirname, "..", "..", "..", "..", env("DATABASE_FILENAME", ".tmp/data.db")),
+            filename: path.isAbsolute(databaseFilename)
+              ? databaseFilename
+              : path.join(__dirname, "..", "..", "..", "..", databaseFilename),
           },
           useNullAsDefault: true,
         },

--- a/charts/strapi/templates/deployment.yaml
+++ b/charts/strapi/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         {{- end }}
       annotations:
         checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/database-config: {{ include (print $.Template.BasePath "/database-configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -358,6 +359,10 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: database-config
+              mountPath: /opt/app/dist/config/env/production/database.js
+              subPath: database.js
+              readOnly: true
             - name: data
               mountPath: {{ .Values.persistence.uploads.mountPath }}
               {{- if .Values.persistence.enabled }}
@@ -374,6 +379,9 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
+        - name: database-config
+          configMap:
+            name: {{ include "strapi.fullname" . }}-database-config
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -71,6 +71,13 @@ tests:
             mountPath: /opt/app/.tmp
             subPath: sqlite
 
+  - it: should preserve absolute sqlite database paths
+    template: templates/database-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["database.js"]
+          pattern: "path\\.isAbsolute\\(databaseFilename\\)"
+
   - it: should add wait-for-db for postgresql
     template: templates/deployment.yaml
     set:

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -2,6 +2,7 @@
 suite: Deployment
 templates:
   - templates/deployment.yaml
+  - templates/database-configmap.yaml
   - templates/secret.yaml
 release:
   name: test
@@ -33,19 +34,19 @@ tests:
             containerPort: 1337
             protocol: TCP
 
-  - it: should set sqlite env vars by default
+  - it: should set postgres env vars by default
     template: templates/deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: DATABASE_CLIENT
-            value: sqlite
+            value: postgres
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: DATABASE_FILENAME
-            value: /opt/app/.tmp/data.db
+            name: DATABASE_HOST
+            value: test-postgresql
 
   - it: should mount uploads path by default
     template: templates/deployment.yaml
@@ -59,6 +60,9 @@ tests:
 
   - it: should mount sqlite directory in sqlite mode
     template: templates/deployment.yaml
+    set:
+      database.mode: sqlite
+      postgresql.enabled: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -97,6 +101,7 @@ tests:
   - it: should set mysql env vars
     template: templates/deployment.yaml
     set:
+      postgresql.enabled: false
       mysql.enabled: true
       mysql.auth.password: test
     asserts:

--- a/charts/strapi/tests/email_test.yaml
+++ b/charts/strapi/tests/email_test.yaml
@@ -2,6 +2,7 @@
 suite: Email Provider
 templates:
   - templates/deployment.yaml
+  - templates/database-configmap.yaml
   - templates/secret.yaml
 release:
   name: test
@@ -47,11 +48,11 @@ tests:
       - equal:
           path: metadata.name
           value: test-strapi-email
-        documentIndex: 1
+        documentIndex: 2
       - equal:
           path: data.smtp-password
           value: dGVzdHBhc3M=
-        documentIndex: 1
+        documentIndex: 2
 
   - it: should configure SendGrid provider
     template: templates/deployment.yaml

--- a/charts/strapi/tests/http-probes_test.yaml
+++ b/charts/strapi/tests/http-probes_test.yaml
@@ -2,6 +2,7 @@
 suite: HTTP Health Checks
 templates:
   - templates/deployment.yaml
+  - templates/database-configmap.yaml
   - templates/secret.yaml
 release:
   name: test

--- a/charts/strapi/tests/performance_test.yaml
+++ b/charts/strapi/tests/performance_test.yaml
@@ -2,6 +2,7 @@
 suite: Performance Tuning
 templates:
   - templates/deployment.yaml
+  - templates/database-configmap.yaml
   - templates/secret.yaml
 release:
   name: test

--- a/charts/strapi/tests/s3-upload_test.yaml
+++ b/charts/strapi/tests/s3-upload_test.yaml
@@ -2,6 +2,7 @@
 suite: S3 Upload Provider
 templates:
   - templates/deployment.yaml
+  - templates/database-configmap.yaml
   - templates/secret.yaml
 release:
   name: test
@@ -41,6 +42,7 @@ tests:
 
   - it: should create S3 upload secret
     template: templates/secret.yaml
+    documentIndex: 2
     set:
       strapi:
         upload:
@@ -54,15 +56,12 @@ tests:
       - equal:
           path: metadata.name
           value: test-strapi-upload-s3
-        documentIndex: 1
       - equal:
           path: data.access-key
           value: dGVzdGtleQ==
-        documentIndex: 1
       - equal:
           path: data.secret-key
           value: dGVzdHNlY3JldA==
-        documentIndex: 1
 
   - it: should allow multi-replica with S3
     template: templates/deployment.yaml

--- a/charts/strapi/tests/secret_test.yaml
+++ b/charts/strapi/tests/secret_test.yaml
@@ -39,9 +39,15 @@ tests:
       secrets.existingSecret: my-secret
     asserts:
       - hasDocuments:
-          count: 0
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-strapi-database
 
   - it: should not render database secret in sqlite mode
+    set:
+      database.mode: sqlite
+      postgresql.enabled: false
     asserts:
       - hasDocuments:
           count: 1

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -430,7 +430,7 @@ database:
 
 postgresql:
   # -- Deploy PostgreSQL as a subchart
-  enabled: false
+  enabled: true
 
   # -- PostgreSQL architecture (standalone or replication)
   architecture: standalone

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -53,10 +53,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/superset/ci/external-db-values.yaml
+++ b/charts/superset/ci/external-db-values.yaml
@@ -1,24 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI scenario - external database and Redis
+# CI scenario - PostgreSQL and Redis integration
 postgresql:
-  enabled: false
+  enabled: true
+  auth:
+    database: superset
+    username: superset
 
 redis:
-  enabled: false
+  enabled: true
 
 database:
-  mode: external
-  external:
-    host: postgres.example.com
-    port: 5432
-    name: superset
-    username: superset
-    password: external-password
+  mode: subchart
 
 redisConfig:
-  mode: external
-  external:
-    host: redis.example.com
-    port: 6379
-    password: redis-password
-    db: 0
+  mode: subchart

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -51,10 +51,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 1.9.11
+    version: 2.0.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wallabag/ci/external-db-values.yaml
+++ b/charts/wallabag/ci/external-db-values.yaml
@@ -1,12 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: external PostgreSQL database
+# CI: PostgreSQL integration
 postgresql:
-  enabled: false
-
-database:
-  external:
-    host: db.example.com
-    port: "5432"
-    name: wallabag
-    username: wallabag_user
-    password: "ci-password"
+  enabled: true


### PR DESCRIPTION
## Summary

- Refresh HelmForge subchart dependencies to the current published versions:
  - `postgresql` -> `2.0.4`
  - `mariadb` -> `2.0.3`
  - `mysql` -> `2.0.2`
  - `redis` -> `1.6.19`
- Update affected CI values so dependency refresh scenarios install real local backing services in k3d instead of unreachable placeholder hosts.
- Add Appwrite init waits for MariaDB/Redis-backed startup and fix cache mode selection.
- Add Open WebUI PostgreSQL startup wait for auto database mode.
- Make Strapi default startup PostgreSQL-backed, mount chart-managed database config, and align tests/CI with the current published `strapi-base` runtime.

## Site sync

- Site PR: helmforgedev/site#305

## Validation

- `make validate-chart CHART=alfio TIMEOUT=180 JSON=1` -> `alfio: FULLY VALIDATED (13 layers).`
- `make validate-chart CHART=appwrite TIMEOUT=180 JSON=1` -> `appwrite: FULLY VALIDATED (19 layers).`
- `make validate-chart CHART=automatisch TIMEOUT=240 JSON=1` -> `automatisch: FULLY VALIDATED (13 layers).`
- `make validate-chart CHART=castopod TIMEOUT=240 JSON=1` -> `castopod: FULLY VALIDATED (13 layers).`
- `make validate-chart CHART=chiefonboarding TIMEOUT=240 JSON=1` -> `chiefonboarding: FULLY VALIDATED (13 layers).`
- `make validate-chart CHART=ckan TIMEOUT=240 JSON=1` -> `ckan: FULLY VALIDATED (14 layers).`
- `make validate-chart CHART=druid TIMEOUT=240 JSON=1` -> `druid: FULLY VALIDATED (18 layers).`
- `make validate-chart CHART=flowise TIMEOUT=240 JSON=1` -> `flowise: FULLY VALIDATED (17 layers).`
- `make validate-chart CHART=gitea TIMEOUT=240 JSON=1` -> `gitea: FULLY VALIDATED (17 layers).`
- `make validate-chart CHART=gophish TIMEOUT=240 JSON=1` -> `gophish: FULLY VALIDATED (19 layers).`
- `make validate-chart CHART=guacamole TIMEOUT=240 JSON=1` -> `guacamole: FULLY VALIDATED (16 layers).`
- `make validate-chart CHART=middleware TIMEOUT=240 JSON=1` -> `middleware: FULLY VALIDATED (13 layers).`
- `make validate-chart CHART=open-webui TIMEOUT=240 JSON=1` -> `open-webui: FULLY VALIDATED (14 layers).`
- `make validate-chart CHART=strapi TIMEOUT=240 JSON=1` -> `strapi: FULLY VALIDATED (18 layers).`
- `make validate-chart CHART=superset TIMEOUT=240 JSON=1` -> `superset: FULLY VALIDATED (14 layers).`
- `make validate-chart CHART=wallabag TIMEOUT=240 JSON=1` -> `wallabag: FULLY VALIDATED (14 layers).`
- `make deps-check JSON=1`
- `make deps-check CHART=alfio JSON=1`
- `make standards-check JSON=1`
- `make standards-check CHART=alfio JSON=1`
- `make site-sync-check JSON=1`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make org-check` (0 blockers, 5 pre-existing warnings for repos scheduled for deletion)

Fixes #557
