### PR TITLE
feat(mosquitto): allow custom probe ports

### DIFF
--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -153,6 +153,26 @@ broker:
     messageSizeLimit: 262144
 ```
 
+### Eliminating TLS health check log spam (OpenSSL EOF)
+
+When `broker.tls.enabled` is true and `broker.listeners.websocketEnabled` is false, Kubernetes TCP socket health probes and/or a Cloud Load Balancer health checks (e.g., AWS NLB) will ping the `mqtts` port. Because the probes immediately close the connection without completing a TLS handshake, Mosquitto will constantly log OpenSSL errors (e.g., `error:0A000126:SSL routines::unexpected eof while reading`).
+
+To eliminate this log spam, you can use `broker.extraConfig` to create a dedicated, plaintext health check listener, and use `broker.probePortOverride` to point the Kubernetes probes to it.
+
+```yaml
+broker:
+  # Point health probes/checks to the custom plaintext port
+  probePortOverride: 9000
+
+  extraConfig: |
+    # Create a dedicated plaintext listener for health checks
+    listener 9000 0.0.0.0
+    protocol mqtt
+
+    # Silence the TCP connection logs
+    connection_messages false
+```
+
 ## Key Values
 
 | Key | Default | Description |

--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -155,7 +155,9 @@ broker:
 
 ### Eliminating TLS health check log spam (OpenSSL EOF)
 
-When `broker.tls.enabled` is true and `broker.listeners.websocketEnabled` is false, Kubernetes TCP socket health probes and/or a Cloud Load Balancer health checks (e.g., AWS NLB) will ping the `mqtts` port. Because the probes immediately close the connection without completing a TLS handshake, Mosquitto will constantly log OpenSSL errors (e.g., `error:0A000126:SSL routines::unexpected eof while reading`).
+When `broker.tls.enabled` is true and `broker.listeners.websocketEnabled` is false, Kubernetes TCP socket health probes and/or a Cloud Load Balancer health checks (e.g., AWS NLB) will ping the
+`mqtts` port. Because the probes immediately close the connection without completing a TLS handshake, Mosquitto will constantly log OpenSSL errors
+(e.g., `error:0A000126:SSL routines::unexpected eof while reading`).
 
 To eliminate this log spam, you can use `broker.extraConfig` to create a dedicated, plaintext health check listener, and use `broker.probePortOverride` to point the Kubernetes probes to it.
 

--- a/charts/mosquitto/templates/statefulset.yaml
+++ b/charts/mosquitto/templates/statefulset.yaml
@@ -11,6 +11,9 @@ spec:
   {{- if .Values.broker.tls.enabled }}
     {{- $probePort = ternary "websocket" "mqtts" .Values.broker.listeners.websocketEnabled -}}
   {{- end }}
+  {{- if .Values.broker.probePortOverride }}
+    {{- $probePort = .Values.broker.probePortOverride }}
+  {{- end }}
   serviceName: {{ include "mosquitto.headlessServiceName" . }}
   replicas: {{ .Values.broker.replicaCount }}
   podManagementPolicy: Parallel

--- a/charts/mosquitto/tests/statefulset_test.yaml
+++ b/charts/mosquitto/tests/statefulset_test.yaml
@@ -173,3 +173,18 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
           value: mqtts
+
+  - it: should use probePortOverride for probes when provided
+    template: templates/statefulset.yaml
+    set:
+      broker.probePortOverride: 9000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.tcpSocket.port
+          value: 9000

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -105,7 +105,7 @@
           "description": "Append raw Mosquitto configuration lines to the generated mosquitto.conf"
         },
         "probePortOverride": {
-          "type": "integer",
+          "type": ["integer", "null"],
           "description": "Override the port number used for Kubernetes health probes (e.g., 9000 for a custom plaintext listener)"
         },
         "listeners": {

--- a/charts/mosquitto/values.schema.json
+++ b/charts/mosquitto/values.schema.json
@@ -104,6 +104,10 @@
           "type": "string",
           "description": "Append raw Mosquitto configuration lines to the generated mosquitto.conf"
         },
+        "probePortOverride": {
+          "type": "integer",
+          "description": "Override the port number used for Kubernetes health probes (e.g., 9000 for a custom plaintext listener)"
+        },
         "listeners": {
           "type": "object",
           "description": "Broker listener ports",

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -48,6 +48,9 @@ broker:
   # -- Append raw Mosquitto configuration lines to the generated mosquitto.conf
   extraConfig: ""
 
+  # -- Override the port number used for Kubernetes health probes (e.g., 9000 for a custom plaintext listener)
+  probePortOverride: ""
+
   listeners:
     # -- MQTT TCP listener port (used only when broker.tls.enabled=false)
     mqtt: 1883

--- a/charts/mosquitto/values.yaml
+++ b/charts/mosquitto/values.yaml
@@ -49,7 +49,7 @@ broker:
   extraConfig: ""
 
   # -- Override the port number used for Kubernetes health probes (e.g., 9000 for a custom plaintext listener)
-  probePortOverride: ""
+  probePortOverride: null
 
   listeners:
     # -- MQTT TCP listener port (used only when broker.tls.enabled=false)


### PR DESCRIPTION
## Summary

- When `broker.tls.enabled` is true and `broker.listeners.websocketEnabled` is false, Kubernetes TCP socket health probes and/or a Cloud Load Balancer health checks (e.g., AWS NLB) will ping the `mqtts` port. Because the probes immediately close the connection without completing a TLS handshake, Mosquitto will constantly log OpenSSL errors (e.g., `error:0A000126:SSL routines::unexpected eof while reading`). To eliminate this log spam, you can use `broker.extraConfig` to create a dedicated, plaintext health check listener, and use `broker.probePortOverride` to point the Kubernetes probes to it.
- This is a [known issue when running Mosquitto behind Cloud Load Balancers](https://stackoverflow.com/questions/76779801/how-to-configure-aws-nlb-network-load-balancer-for-mqtt-mosquitto-error0a000).

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [ ] All relevant `ci/*.yaml` scenarios rendered successfully
- [ ] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

- Added a recipe to the `README.md` demonstrating how to use this override alongside `extraConfig` to create a dedicated, silent, plaintext health check listener.

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.
