### PR TITLE
fix(valkey): sentinel role neutral nodes

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: valkey
 description: Valkey Helm chart for standalone, replication, sentinel, and cluster topologies
 type: application
-version: 2.0.0
+version: 1.0.2
 appVersion: "9.1.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: valkey
 description: Valkey Helm chart for standalone, replication, sentinel, and cluster topologies
 type: application
-version: 1.0.1
+version: 2.0.0
 appVersion: "9.1.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
@@ -27,8 +27,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#530)"
+    - kind: changed
+      description: "BREAKING: sentinel mode uses role-neutral -node StatefulSet instead of -primary/-replica (#542)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -94,9 +94,12 @@ flowchart LR
   Node2 --> PVC2[(PVC)]
 ```
 
-Sentinel is a distinct architecture because it changes the client contract. Data nodes are role-neutral peers; Sentinel pods monitor the elected master and can promote any data node after failover. Sentinel pods wait for the seed master before startup and use hostname resolution (`resolve-hostnames` and `announce-hostnames`) so custom cluster domains work consistently.
+Sentinel is a distinct architecture because it changes the client contract. Data nodes are role-neutral peers; Sentinel pods monitor the elected master and can promote any data node after failover.
+Sentinel pods wait for the seed master before startup and use hostname resolution (`resolve-hostnames` and `announce-hostnames`) so custom cluster domains work consistently.
 
-Data node bootstrap queries Sentinel first, then probes peer `INFO replication` when Sentinel is unreachable. This prevents split-brain on pod reschedule without PVCs. `node.persistence.enabled` defaults to `false`; enable persistence when RDB/AOF must survive reschedules. Persisted nodes fail closed when neither Sentinel nor peers can confirm the role.
+Data node bootstrap queries Sentinel first, then probes peer `INFO replication` when Sentinel is unreachable.
+This prevents split-brain on pod reschedule without PVCs. `node.persistence.enabled` defaults to `false`; enable persistence when RDB/AOF must survive reschedules.
+Persisted nodes fail closed when neither Sentinel nor peers can confirm the role.
 
 ### Valkey Cluster
 

--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -94,7 +94,9 @@ flowchart LR
   Node2 --> PVC2[(PVC)]
 ```
 
-Sentinel is a distinct architecture because it changes the client contract. Data nodes are role-neutral peers; Sentinel pods monitor the elected master and can promote any data node after failover. Sentinel pods wait for the seed master before startup and use hostname resolution so custom cluster domains work consistently.
+Sentinel is a distinct architecture because it changes the client contract. Data nodes are role-neutral peers; Sentinel pods monitor the elected master and can promote any data node after failover. Sentinel pods wait for the seed master before startup and use hostname resolution (`resolve-hostnames` and `announce-hostnames`) so custom cluster domains work consistently.
+
+Data node bootstrap queries Sentinel first, then probes peer `INFO replication` when Sentinel is unreachable. This prevents split-brain on pod reschedule without PVCs. `node.persistence.enabled` defaults to `false`; enable persistence when RDB/AOF must survive reschedules. Persisted nodes fail closed when neither Sentinel nor peers can confirm the role.
 
 ### Valkey Cluster
 

--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -84,15 +84,17 @@ flowchart LR
   SentinelSvc --> Sentinel0[sentinel-0]
   SentinelSvc --> Sentinel1[sentinel-1]
   SentinelSvc --> Sentinel2[sentinel-2]
-  Sentinel0 --> Primary[Valkey-primary-0]
-  Sentinel1 --> Primary
-  Sentinel2 --> Primary
-  Replica[Valkey-replica-0] --> Primary
-  Primary --> PrimaryPVC[(Primary PVC)]
-  Replica --> ReplicaPVC[(Replica PVC)]
+  Sentinel0 --> Node0[Valkey-node-0 seed master]
+  Sentinel1 --> Node0
+  Sentinel2 --> Node0
+  Node1[Valkey-node-1] --> Node0
+  Node2[Valkey-node-2] --> Node0
+  Node0 --> PVC0[(PVC)]
+  Node1 --> PVC1[(PVC)]
+  Node2 --> PVC2[(PVC)]
 ```
 
-Sentinel is a distinct architecture because it changes the client contract. Sentinel pods wait for the primary before startup and use hostname resolution so custom cluster domains work consistently.
+Sentinel is a distinct architecture because it changes the client contract. Data nodes are role-neutral peers; Sentinel pods monitor the elected master and can promote any data node after failover. Sentinel pods wait for the seed master before startup and use hostname resolution so custom cluster domains work consistently.
 
 ### Valkey Cluster
 
@@ -141,11 +143,12 @@ It does not try to replace dedicated Valkey Cluster operational tooling for resh
 
 ### Sentinel Resources
 
-- primary and replica Valkey resources
-- Sentinel StatefulSet
+- role-neutral Valkey node StatefulSet (`node.replicaCount`)
+- Sentinel StatefulSet (`sentinel.replicaCount`, independently scaled)
 - Sentinel service
 - Sentinel configuration with hostname resolution
-- startup wait loop for primary reachability
+- startup wait loop for seed master reachability
+- client discovery exclusively through Sentinel (no `-primary` Service)
 
 ### Cluster Resources
 

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -38,7 +38,7 @@ helm install valkey oci://ghcr.io/helmforgedev/helm/valkey -f values.yaml
 |-------------|----------|-------------------|----------|
 | `standalone` | One Valkey pod, lowest operational complexity, no HA contract | headless Service, client Service, StatefulSet | [docs/standalone.md](docs/standalone.md) |
 | `replication` | One fixed primary with read replicas, no automatic promotion | headless Service, primary Service, replica Service, primary and replica StatefulSets | [docs/replication.md](docs/replication.md) |
-| `sentinel` | Valkey replication plus Sentinel primary discovery and failover for compatible clients | replication resources, Sentinel Service, Sentinel StatefulSet | [docs/sentinel.md](docs/sentinel.md) |
+| `sentinel` | Valkey data nodes plus Sentinel primary discovery and failover for compatible clients | node StatefulSet, Sentinel Service, Sentinel StatefulSet | [docs/sentinel.md](docs/sentinel.md) |
 | `cluster` | Valkey Cluster sharding and HA for Valkey Cluster-compatible clients | headless Service, client Service, cluster StatefulSet, cluster init Job | [docs/cluster.md](docs/cluster.md) |
 
 ## How to choose the architecture
@@ -120,7 +120,7 @@ The chart creates a headless Service for stable StatefulSet pod DNS and topology
 |------|-----------------------|
 | `standalone` | `<release>-valkey-client` |
 | `replication` | `<release>-valkey-primary` for writes, `<release>-valkey-replicas` for reads |
-| `sentinel` | `<release>-valkey-sentinel` for Sentinel, plus replication services |
+| `sentinel` | `<release>-valkey-sentinel` for Sentinel-aware clients |
 | `cluster` | `<release>-valkey-client` |
 
 ### Cluster domain
@@ -153,6 +153,7 @@ Persistence is configured under each topology:
 - `standalone.persistence`
 - `replication.primary.persistence`
 - `replication.replica.persistence`
+- `node.persistence` (sentinel mode)
 - `sentinel.persistence`
 - `cluster.persistence`
 
@@ -222,7 +223,8 @@ Use the generic extension values when platform-specific integration is needed:
 | `tls.enabled` | Enable Valkey TLS settings. Requires `tls.existingSecret`. | `false` |
 | `tls.insecureSkipVerify` | Append `--insecure` to chart-rendered `valkey-cli` TLS clients for CI or self-signed test certificates | `false` |
 | `standalone.persistence.enabled` | Enable persistence for standalone mode | `true` |
-| `replication.replicaCount` | Number of replica pods in replication and sentinel modes | `2` |
+| `replication.replicaCount` | Number of replica pods in replication mode | `2` |
+| `node.replicaCount` | Number of Valkey data nodes in sentinel mode | `3` |
 | `sentinel.replicaCount` | Number of Sentinel pods | `3` |
 | `sentinel.quorum` | Sentinel quorum | `2` |
 | `cluster.nodes` | Number of Valkey Cluster nodes | `6` |

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -157,7 +157,9 @@ Persistence is configured under each topology:
 - `sentinel.persistence`
 - `cluster.persistence`
 
-Use persistent volumes for production stateful modes. Disable persistence only for ephemeral tests and short-lived environments.
+Use persistent volumes for production stateful modes when RDB/AOF must survive pod reschedules.
+In sentinel mode, `node.persistence.enabled` defaults to `false`; peer discovery keeps topology safe without PVCs.
+Disable persistence only for ephemeral tests and short-lived environments in other modes.
 
 ## Observability
 
@@ -225,6 +227,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `standalone.persistence.enabled` | Enable persistence for standalone mode | `true` |
 | `replication.replicaCount` | Number of replica pods in replication mode | `2` |
 | `node.replicaCount` | Number of Valkey data nodes in sentinel mode | `3` |
+| `node.persistence.enabled` | Enable PVCs for sentinel data nodes | `false` |
 | `sentinel.replicaCount` | Number of Sentinel pods | `3` |
 | `sentinel.quorum` | Sentinel quorum | `2` |
 | `cluster.nodes` | Number of Valkey Cluster nodes | `6` |

--- a/charts/valkey/UPGRADING.md
+++ b/charts/valkey/UPGRADING.md
@@ -11,6 +11,18 @@ In `architecture: sentinel`, the chart no longer renders separate `-primary` and
 
 The `-primary` and `-replicas` Services are no longer created in sentinel mode. Clients must discover the current master through the `-sentinel` Service.
 
+Additionally:
+
+- `node.persistence.enabled` now defaults to `false` for sentinel data nodes.
+- Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain
+  on pod reschedule without PVCs.
+- Sentinel config includes `announce-hostnames yes` for stable hostname-based master discovery.
+
+### Operational impact
+
+- Fresh installs no longer create node PVCs unless you set `node.persistence.enabled=true`.
+- With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers
+
 ### Why this is a breaking change
 
 Kubernetes StatefulSet names and PVC claim names are immutable. An in-place `helm upgrade` from 1.x cannot rename `-primary`/`-replica` workloads to `-node`.
@@ -52,20 +64,6 @@ kubectl exec sts/<release>-valkey-sentinel-0 -- \
 ```
 
 After a forced failover, confirm the elected master pod name is `-node-N`, not `-primary-0`.
-
-## 2.0.x — Sentinel hardening (peer discovery, persistence default)
-
-### What changed
-
-- `node.persistence.enabled` now defaults to `false` for sentinel data nodes.
-- Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain
-  on pod reschedule without PVCs.
-- Sentinel config includes `announce-hostnames yes` for stable hostname-based master discovery.
-
-### Operational impact
-
-- Fresh installs no longer create node PVCs unless you set `node.persistence.enabled=true`.
-- With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers
   can confirm the role until quorum or peer discovery recovers.
 - Enable persistence when RDB/AOF must survive pod reschedules; peer discovery covers topology safety.
 

--- a/charts/valkey/UPGRADING.md
+++ b/charts/valkey/UPGRADING.md
@@ -52,3 +52,21 @@ kubectl exec sts/<release>-valkey-sentinel-0 -- \
 ```
 
 After a forced failover, confirm the elected master pod name is `-node-N`, not `-primary-0`.
+
+## 2.0.x — Sentinel hardening (peer discovery, persistence default)
+
+### What changed
+
+- `node.persistence.enabled` now defaults to `false` for sentinel data nodes.
+- Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain
+  on pod reschedule without PVCs.
+- Sentinel config includes `announce-hostnames yes` for stable hostname-based master discovery.
+
+### Operational impact
+
+- Fresh installs no longer create node PVCs unless you set `node.persistence.enabled=true`.
+- With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers
+  can confirm the role until quorum or peer discovery recovers.
+- Enable persistence when RDB/AOF must survive pod reschedules; peer discovery covers topology safety.
+
+See [docs/sentinel.md](docs/sentinel.md) for resilience trade-offs and k3d validation steps.

--- a/charts/valkey/UPGRADING.md
+++ b/charts/valkey/UPGRADING.md
@@ -14,14 +14,14 @@ The `-primary` and `-replicas` Services are no longer created in sentinel mode. 
 Additionally:
 
 - `node.persistence.enabled` now defaults to `false` for sentinel data nodes.
-- Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain
-  on pod reschedule without PVCs.
+- Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain on pod reschedule without PVCs.
 - Sentinel config includes `announce-hostnames yes` for stable hostname-based master discovery.
 
 ### Operational impact
 
 - Fresh installs no longer create node PVCs unless you set `node.persistence.enabled=true`.
-- With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers
+- With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers can confirm the role until quorum or peer discovery recovers.
+- Enable persistence when RDB/AOF must survive pod reschedules; peer discovery covers topology safety.
 
 ### Why this is a breaking change
 
@@ -64,7 +64,5 @@ kubectl exec sts/<release>-valkey-sentinel-0 -- \
 ```
 
 After a forced failover, confirm the elected master pod name is `-node-N`, not `-primary-0`.
-  can confirm the role until quorum or peer discovery recovers.
-- Enable persistence when RDB/AOF must survive pod reschedules; peer discovery covers topology safety.
 
 See [docs/sentinel.md](docs/sentinel.md) for resilience trade-offs and k3d validation steps.

--- a/charts/valkey/UPGRADING.md
+++ b/charts/valkey/UPGRADING.md
@@ -1,0 +1,54 @@
+# Upgrading Valkey Chart
+
+## 2.0.0 — Sentinel role-neutral data nodes (#542)
+
+### What changed
+
+In `architecture: sentinel`, the chart no longer renders separate `-primary` and `-replica` StatefulSets. It now renders:
+
+- `<release>-valkey-node` — role-neutral Valkey data nodes (`node.replicaCount`)
+- `<release>-valkey-sentinel` — independently scaled Sentinel pods (`sentinel.replicaCount`)
+
+The `-primary` and `-replicas` Services are no longer created in sentinel mode. Clients must discover the current master through the `-sentinel` Service.
+
+### Why this is a breaking change
+
+Kubernetes StatefulSet names and PVC claim names are immutable. An in-place `helm upgrade` from 1.x cannot rename `-primary`/`-replica` workloads to `-node`.
+
+### Migration procedure
+
+1. **Backup data** from all Valkey pods (RDB/AOF snapshot or application-level export).
+2. **Scale down** the release or accept a maintenance window.
+3. **Uninstall** the 1.x release. PVCs remain unless you delete them manually.
+4. **Delete** old PVCs if you want a clean topology (`*-primary-*`, `*-replica-*`).
+5. **Install** chart 2.0.0 with equivalent sizing:
+
+   ```yaml
+   architecture: sentinel
+   node:
+     replicaCount: 3  # was 1 primary + 2 replicas
+   sentinel:
+     replicaCount: 3
+     quorum: 2
+   ```
+
+6. **Restore data** into the new cluster if required, or let replicas resync from the seed master on a fresh install.
+
+### Client changes
+
+- Remove dependencies on the `-primary` Service in sentinel mode.
+- Use Sentinel-aware clients pointing at `<release>-valkey-sentinel:26379`.
+- Update monitoring and runbooks that referenced `-primary-0` as the stable master hostname.
+
+### Validation after upgrade
+
+```bash
+kubectl get sts
+# <release>-valkey-node
+# <release>-valkey-sentinel
+
+kubectl exec sts/<release>-valkey-sentinel-0 -- \
+  valkey-cli -p 26379 sentinel get-master-addr-by-name mymaster
+```
+
+After a forced failover, confirm the elected master pod name is `-node-N`, not `-primary-0`.

--- a/charts/valkey/ci/sentinel.yaml
+++ b/charts/valkey/ci/sentinel.yaml
@@ -5,7 +5,7 @@ auth:
   enabled: true
   password: ci-valkey-password
 
-replication:
+node:
   replicaCount: 2
 
 sentinel:

--- a/charts/valkey/docs/sentinel.md
+++ b/charts/valkey/docs/sentinel.md
@@ -66,7 +66,8 @@ Data node pod names are role-neutral: `-node-0` is only the seed master at cold 
 | Parameter | Description |
 |-----------|-------------|
 | `architecture` | Must be `sentinel` |
-| `node.replicaCount` | Number of Valkey data nodes |
+| `node.replicaCount` | Number of Valkey data nodes (use >= 2 for data HA) |
+| `node.persistence.enabled` | Data node PVCs (default `false`; peer discovery keeps topology safe without PVCs) |
 | `sentinel.replicaCount` | Number of Sentinel pods (independent of data nodes) |
 | `sentinel.quorum` | Quorum for failover decisions |
 | `pdb.enabled` | Protection against planned disruption |
@@ -102,6 +103,49 @@ sentinel:
   replicaCount: 3
   quorum: 2
 ```
+
+## Resilience and trade-offs
+
+### Default: persistence disabled
+
+`node.persistence.enabled` defaults to `false`. Data nodes use `emptyDir` for `/data`.
+Anti-split-brain safety does not depend on the bootstrap marker surviving reschedules.
+When Sentinel is unreachable, each node probes peer `INFO replication` before choosing a role.
+
+Data loss is possible only if every data node restarts at the same time with no peers online.
+Enable `node.persistence.enabled=true` when you need RDB/AOF to survive pod reschedules.
+
+### Fail-closed with persistence enabled
+
+When persistence is enabled and a node was already bootstrapped, it refuses to start as an
+unconfirmed master if neither Sentinel nor any peer can confirm the current topology.
+The pod exits with code 1 (CrashLoopBackOff) until Sentinel quorum or peer discovery succeeds.
+This is a safety-over-availability trade-off.
+
+A prolonged Sentinel quorum outage can block restarts of persisted nodes until Sentinels recover.
+
+### Hostname discovery
+
+Sentinel is configured with `resolve-hostnames yes` and `announce-hostnames yes`.
+`sentinel get-master-addr-by-name mymaster` returns stable pod hostnames instead of ephemeral IPs.
+
+### HA prerequisites
+
+- `node.replicaCount >= 2` for data-plane HA (at least one replica to promote)
+- `sentinel.replicaCount >= 3` with `sentinel.quorum` aligned to the Sentinel count
+- `pdb.enabled=true` for planned disruption protection
+- spread Sentinels and data nodes across failure domains
+
+## End-to-end validation (k3d)
+
+Run on a lab cluster before production rollout. Shell bootstrap logic is not covered by helm unittest.
+
+1. Install with default values (`node.persistence.enabled=false`) and wait for Ready pods.
+2. Resolve the master via Sentinel and write a test key.
+3. Delete the current master pod; confirm another `-node-N` is promoted and the key survives.
+4. Scale Sentinel to 0 or block Sentinel traffic; delete and recreate `-node-0`.
+   Confirm it joins as replica (no double master) via peer discovery.
+5. After Sentinels recover, confirm `get-master-addr-by-name` returns a hostname, not a pod IP.
 
 ## When to move to another mode
 

--- a/charts/valkey/docs/sentinel.md
+++ b/charts/valkey/docs/sentinel.md
@@ -12,20 +12,21 @@ Common cases:
 
 ## What this architecture delivers
 
-- primary and replica data topology
-- dedicated Sentinel pods
+- role-neutral Valkey data nodes (`<release>-valkey-node`)
+- dedicated Sentinel pods scaled independently (`<release>-valkey-sentinel`)
 - configurable quorum
-- primary discovery through the Sentinel service
+- primary discovery exclusively through the Sentinel service
 
 ## What it requires from the client
 
 - the client must support Valkey Sentinel
 - the application must tolerate primary changes discovered through Sentinel
+- do not rely on a fixed `-primary` Service; the elected master can run on any `-node-N` pod after failover
 
 ## Environment requirements
 
 - at least 3 Sentinel instances for consistent quorum
-- enough replicas to fail over without losing service
+- enough data nodes to fail over without losing service
 - distribution across nodes or zones to reduce correlated failure
 - validated client and library behavior before production rollout
 
@@ -33,19 +34,21 @@ Common cases:
 
 `sentinel` is the right option when you want automatic failover without moving to the Valkey Cluster contract.
 It keeps one active primary at a time and uses Sentinels for election, health observation, and replica promotion.
+Data node pod names are role-neutral: `-node-0` is only the seed master at cold start, not a permanent primary identity.
 
 ## Common risks
 
 - choosing a quorum incompatible with the number of Sentinels
-- concentrating Sentinels and replicas on the same node
+- concentrating Sentinels and data nodes on the same node
 - using clients that do not discover the primary correctly
 - treating Sentinel as a substitute for sharding
+- coupling Sentinel count to data node count (not required in this chart)
 
 ## Production best practices
 
 - keep 3 Sentinels as the minimum baseline
 - use majority quorum
-- distribute Sentinels, primary, and replicas across failure domains
+- distribute Sentinels and data nodes across failure domains
 - enable `pdb.enabled=true`
 - validate real failover and application reconnect timing
 - monitor primary changes, replication lag, and Sentinel health
@@ -54,7 +57,7 @@ It keeps one active primary at a time and uses Sentinels for election, health ob
 
 - use at least 3 Sentinels
 - keep `quorum` aligned with the number of Sentinels
-- distribute Sentinels and replicas across distinct nodes
+- distribute Sentinels and data nodes across distinct nodes
 - enable `pdb.enabled=true`
 - validate failover behavior in the real environment
 
@@ -63,8 +66,8 @@ It keeps one active primary at a time and uses Sentinels for election, health ob
 | Parameter | Description |
 |-----------|-------------|
 | `architecture` | Must be `sentinel` |
-| `replication.replicaCount` | Number of Valkey replicas |
-| `sentinel.replicaCount` | Number of Sentinel pods |
+| `node.replicaCount` | Number of Valkey data nodes |
+| `sentinel.replicaCount` | Number of Sentinel pods (independent of data nodes) |
 | `sentinel.quorum` | Quorum for failover decisions |
 | `pdb.enabled` | Protection against planned disruption |
 | `metrics.enabled` | Exporter for monitoring |
@@ -79,7 +82,20 @@ auth:
   existingSecret: valkey-auth
   existingSecretPasswordKey: valkey-password
 
-replication:
+node:
+  replicaCount: 3
+
+sentinel:
+  replicaCount: 3
+  quorum: 2
+```
+
+Decoupled sizing (2 data nodes + 3 Sentinels):
+
+```yaml
+architecture: sentinel
+
+node:
   replicaCount: 2
 
 sentinel:
@@ -91,3 +107,7 @@ sentinel:
 
 - move back to `replication` if the application cannot operate with Sentinel
 - move to `cluster` when the primary need becomes shard-based scale rather than failover
+
+## Upgrading from 1.x
+
+See [UPGRADING.md](../UPGRADING.md) for the 2.0.0 breaking change and migration path.

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -34,7 +34,7 @@ Standalone client service:
 - Port: {{ .Values.service.ports.valkey }}
 {{- end }}
 
-{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+{{- if include "valkey.isReplication" . }}
 Primary service:
 - Name: {{ include "valkey.primaryServiceName" . }}
 - DNS: {{ include "valkey.primaryServiceFqdn" . }}
@@ -51,7 +51,8 @@ Sentinel service:
 - Name: {{ include "valkey.sentinelServiceName" . }}
 - DNS: {{ include "valkey.sentinelServiceFqdn" . }}
 - Port: {{ .Values.service.ports.sentinel }}
-- Monitored primary: {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}
+- Data nodes: {{ include "valkey.nodeStatefulSetName" . }} ({{ .Values.node.replicaCount }} pods)
+- Seed master: {{ include "valkey.nodePodFqdn" . }}:{{ .Values.service.ports.valkey }}
 {{- end }}
 
 {{- if include "valkey.isCluster" . }}
@@ -143,6 +144,9 @@ Persistence:
 - Standalone persistence: {{ .Values.standalone.persistence.enabled }}
 - Primary persistence: {{ .Values.replication.primary.persistence.enabled }}
 - Replica persistence: {{ .Values.replication.replica.persistence.enabled }}
+{{- if include "valkey.isSentinel" . }}
+- Node persistence: {{ .Values.node.persistence.enabled }}
+{{- end }}
 - Sentinel persistence: {{ .Values.sentinel.persistence.enabled }}
 - Cluster persistence: {{ .Values.cluster.persistence.enabled }}
 
@@ -172,7 +176,7 @@ Inspect logs:
 Common checks:
 
 - If replicas cannot connect, verify headless Service DNS and `clusterDomain`.
-- If Sentinel does not start, verify the primary pod FQDN and auth Secret.
+- If Sentinel does not start, verify the seed master pod FQDN and auth Secret.
 - If Valkey Cluster bootstrap is stuck, inspect the cluster init Job logs.
 - If clients cannot authenticate, verify Secret name, key, and password content.
 - If dual-stack fields are rejected, verify the Kubernetes version and cluster network configuration.

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -53,6 +53,9 @@ Sentinel service:
 - Port: {{ .Values.service.ports.sentinel }}
 - Data nodes: {{ include "valkey.nodeStatefulSetName" . }} ({{ .Values.node.replicaCount }} pods)
 - Seed master: {{ include "valkey.nodePodFqdn" . }}:{{ .Values.service.ports.valkey }}
+{{- if lt (int .Values.node.replicaCount) 2 }}
+- WARNING: node.replicaCount is below 2; there is no data-plane HA and no replica to promote on failover
+{{- end }}
 {{- end }}
 
 {{- if include "valkey.isCluster" . }}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -171,6 +171,10 @@ Common names.
 {{- printf "%s-cluster" (include "valkey.fullname" .) -}}
 {{- end -}}
 
+{{- define "valkey.nodeStatefulSetName" -}}
+{{- printf "%s-node" (include "valkey.fullname" .) -}}
+{{- end -}}
+
 {{- define "valkey.configMapName" -}}
 {{- printf "%s-config" (include "valkey.fullname" .) -}}
 {{- end -}}
@@ -209,6 +213,10 @@ Common names.
 
 {{- define "valkey.primaryPodFqdn" -}}
 {{- printf "%s-0.%s" (include "valkey.primaryStatefulSetName" .) (include "valkey.headlessServiceFqdn" .) -}}
+{{- end -}}
+
+{{- define "valkey.nodePodFqdn" -}}
+{{- printf "%s-0.%s" (include "valkey.nodeStatefulSetName" .) (include "valkey.headlessServiceFqdn" .) -}}
 {{- end -}}
 
 {{- define "valkey.clusterPodFqdn" -}}

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -219,6 +219,17 @@ Common names.
 {{- printf "%s-0.%s" (include "valkey.nodeStatefulSetName" .) (include "valkey.headlessServiceFqdn" .) -}}
 {{- end -}}
 
+{{- define "valkey.nodePeerFqdns" -}}
+{{- $root := . -}}
+{{- $count := int .Values.node.replicaCount -}}
+{{- $fqdns := list -}}
+{{- range $i := until $count -}}
+{{- $fqdn := printf "%s-%d.%s" (include "valkey.nodeStatefulSetName" $root) $i (include "valkey.headlessServiceFqdn" $root) -}}
+{{- $fqdns = append $fqdns $fqdn -}}
+{{- end -}}
+{{- join " " $fqdns -}}
+{{- end -}}
+
 {{- define "valkey.clusterPodFqdn" -}}
 {{- printf "%s.%s" .podName (include "valkey.headlessServiceFqdn" .root) -}}
 {{- end -}}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -32,6 +32,15 @@ data:
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
     {{- end }}
+  valkey-node.conf: |
+    {{- include "valkey.commonConfig" . | nindent 4 }}
+    {{- if .Values.tls.enabled }}
+    tls-replication yes
+    {{- end }}
+    replica-read-only yes
+    {{- with .Values.config.valkey }}
+    {{ . | nindent 4 }}
+    {{- end }}
   valkey-cluster.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}
     cluster-enabled yes
@@ -54,7 +63,7 @@ data:
     {{- end }}
     dir /tmp
     sentinel resolve-hostnames yes
-    sentinel monitor mymaster {{ include "valkey.primaryPodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}
+    sentinel monitor mymaster {{ include "valkey.nodePodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}
     sentinel down-after-milliseconds mymaster {{ .Values.sentinel.downAfterMilliseconds }}
     sentinel failover-timeout mymaster {{ .Values.sentinel.failoverTimeout }}
     sentinel parallel-syncs mymaster {{ .Values.sentinel.parallelSyncs }}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -63,6 +63,7 @@ data:
     {{- end }}
     dir /tmp
     sentinel resolve-hostnames yes
+    sentinel announce-hostnames yes
     sentinel monitor mymaster {{ include "valkey.nodePodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}
     sentinel down-after-milliseconds mymaster {{ .Values.sentinel.downAfterMilliseconds }}
     sentinel failover-timeout mymaster {{ .Values.sentinel.failoverTimeout }}

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -1,5 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+{{- if include "valkey.isReplication" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -34,51 +34,14 @@ spec:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if include "valkey.isSentinel" . }}
-          command: ["sh", "-ec"]
-          {{- else }}
           command: ["valkey-server"]
-          {{- end }}
           args:
-            {{- if include "valkey.isSentinel" . }}
-            - |
-              set -- /etc/valkey/valkey.conf
-              {{- if .Values.auth.enabled }}
-              set -- "$@" --requirepass "$VALKEY_PASSWORD" --masterauth "$VALKEY_PASSWORD"
-              {{- end }}
-              bootstrap_marker="/data/.helmforge-sentinel-primary-bootstrapped"
-              sentinel_master=""
-              if [ -f "$bootstrap_marker" ]; then
-                for attempt in $(seq 1 30); do
-                  sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
-                  [ -n "$sentinel_master" ] && break
-                  echo "waiting for Sentinel master discovery ($attempt/30)"
-                  sleep 2
-                done
-                if [ -z "$sentinel_master" ]; then
-                  echo "Sentinel master discovery failed for an already bootstrapped primary; refusing to start without role confirmation"
-                  exit 1
-                fi
-              fi
-              self_fqdn="$(hostname -f)"
-              self_ip="$(hostname -i | awk '{ print $1 }')"
-              if [ -n "$sentinel_master" ] \
-                && [ "$sentinel_master" != "$self_fqdn" ] \
-                && [ "$sentinel_master" != "$self_ip" ] \
-                && [ "$sentinel_master" != {{ include "valkey.primaryPodFqdn" . | quote }} ]; then
-                echo "starting as replica of Sentinel master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
-                set -- "$@" --replicaof "$sentinel_master" {{ .Values.service.ports.valkey }}
-              fi
-              touch "$bootstrap_marker"
-              exec valkey-server "$@"
-            {{- else }}
             - /etc/valkey/valkey.conf
             {{- if .Values.auth.enabled }}
             - --requirepass
             - $(VALKEY_PASSWORD)
             - --masterauth
             - $(VALKEY_PASSWORD)
-            {{- end }}
             {{- end }}
           ports:
             - name: valkey

--- a/charts/valkey/templates/sentinel-node-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-node-statefulset.yaml
@@ -1,22 +1,28 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if include "valkey.isReplication" . }}
+{{- if include "valkey.isSentinel" . }}
+{{- if lt (int .Values.sentinel.replicaCount) 3 }}
+{{- fail "sentinel.replicaCount must be at least 3 for a reliable Sentinel quorum in HA configurations" }}
+{{- end }}
+{{- if gt (int .Values.sentinel.quorum) (int .Values.sentinel.replicaCount) }}
+{{- fail (printf "sentinel.quorum (%v) cannot exceed sentinel.replicaCount (%v)" .Values.sentinel.quorum .Values.sentinel.replicaCount) }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "valkey.replicaStatefulSetName" . }}
+  name: {{ include "valkey.nodeStatefulSetName" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   serviceName: {{ include "valkey.headlessServiceName" . }}
-  replicas: {{ .Values.replication.replicaCount }}
+  replicas: {{ .Values.node.replicaCount }}
   selector:
     matchLabels:
-      {{- include "valkey.componentLabels" (dict "root" . "role" "replica") | nindent 6 }}
+      {{- include "valkey.componentLabels" (dict "root" .) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.componentLabels" (dict "root" . "role" "replica") | nindent 8 }}
+        {{- include "valkey.componentLabels" (dict "root" .) | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -31,14 +37,34 @@ spec:
     spec:
       {{- include "valkey.podSpecCommon" . | nindent 6 }}
       initContainers:
-        - name: wait-for-primary
+        - name: wait-for-master
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-ec"]
           args:
             - |
-              until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.primaryPodFqdn" . | quote }} -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
-                echo "waiting for primary {{ include "valkey.primaryPodFqdn" . }}:{{ .Values.service.ports.valkey }}"
+              sentinel_master=""
+              for attempt in $(seq 1 30); do
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                [ -n "$sentinel_master" ] && break
+                echo "waiting for Sentinel master discovery ($attempt/30)"
+                sleep 2
+              done
+              if [ -z "$sentinel_master" ]; then
+                if [ -f /data/.helmforge-sentinel-node-bootstrapped ]; then
+                  echo "Sentinel unavailable for already bootstrapped node; main container will fail closed if the role cannot be confirmed"
+                  exit 0
+                fi
+                sentinel_master={{ include "valkey.nodePodFqdn" . | quote }}
+              fi
+              self_fqdn="$(hostname -f)"
+              self_ip="$(hostname -i | awk '{ print $1 }')"
+              if [ "$sentinel_master" = "$self_fqdn" ] || [ "$sentinel_master" = "$self_ip" ]; then
+                echo "this pod is the master target; skipping init wait"
+                exit 0
+              fi
+              until valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "$sentinel_master" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
+                echo "waiting for master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
                 sleep 5
               done
           {{- if .Values.auth.enabled }}
@@ -67,7 +93,38 @@ spec:
           args:
             - |
               set -- /etc/valkey/valkey.conf
-              set -- "$@" --replicaof {{ include "valkey.primaryPodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
+              bootstrap_marker="/data/.helmforge-sentinel-node-bootstrapped"
+              sentinel_master=""
+              for attempt in $(seq 1 30); do
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                [ -n "$sentinel_master" ] && break
+                echo "waiting for Sentinel master discovery ($attempt/30)"
+                sleep 2
+              done
+              self_fqdn="$(hostname -f)"
+              self_ip="$(hostname -i | awk '{ print $1 }')"
+              if [ -n "$sentinel_master" ]; then
+                if [ "$sentinel_master" != "$self_fqdn" ] && [ "$sentinel_master" != "$self_ip" ]; then
+                  echo "starting as replica of Sentinel master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
+                  set -- "$@" --replicaof "$sentinel_master" {{ .Values.service.ports.valkey }}
+                else
+                  echo "Sentinel reports this pod as the current master; starting without replicaof"
+                fi
+              elif [ -f "$bootstrap_marker" ]; then
+                echo "Sentinel master discovery failed for an already bootstrapped node; refusing to start as an unconfirmed master"
+                exit 1
+              else
+                case "$(hostname)" in
+                  *-0)
+                    echo "Sentinel unavailable during first bootstrap; starting as seed master"
+                    ;;
+                  *)
+                    echo "Sentinel unavailable during first bootstrap; seeding from {{ include "valkey.nodePodFqdn" . }}:{{ .Values.service.ports.valkey }}"
+                    set -- "$@" --replicaof {{ include "valkey.nodePodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
+                    ;;
+                esac
+              fi
+              touch "$bootstrap_marker"
               {{- if .Values.auth.enabled }}
               set -- "$@" --masterauth "$VALKEY_PASSWORD" --requirepass "$VALKEY_PASSWORD"
               {{- end }}
@@ -107,7 +164,7 @@ spec:
                 - -ec
                 - {{ include "valkey.probeCommand" . | quote }}
             {{- toYaml .Values.startupProbe | nindent 12 }}
-          {{- with .Values.replication.replica.resources }}
+          {{- with .Values.node.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -116,7 +173,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/valkey/valkey.conf
-              subPath: valkey-replica.conf
+              subPath: valkey-node.conf
             - name: data
               mountPath: /data
             {{- if .Values.tls.enabled }}
@@ -146,7 +203,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "valkey.configMapName" . }}
-        {{- if not .Values.replication.replica.persistence.enabled }}
+        {{- if not .Values.node.persistence.enabled }}
         - name: data
           emptyDir: {}
         {{- end }}
@@ -158,8 +215,8 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-  {{- if .Values.replication.replica.persistence.enabled }}
+  {{- if .Values.node.persistence.enabled }}
   volumeClaimTemplates:
-    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.replication.replica.persistence) | nindent 4 }}
+    {{- include "valkey.volumeClaimTemplate" (dict "root" . "persistence" .Values.node.persistence) | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/valkey/templates/sentinel-node-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-node-statefulset.yaml
@@ -43,6 +43,30 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
+              discover_master_from_peers() {
+                discovered=""
+                self_fqdn="$(hostname -f)"
+                for peer in {{ include "valkey.nodePeerFqdns" . }}; do
+                  [ "$peer" = "$self_fqdn" ] && continue
+                  info="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "$peer" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} info replication 2>/dev/null || true)"
+                  [ -z "$info" ] && continue
+                  role="$(echo "$info" | sed -n 's/^role://p' | tr -d '\r' | awk '{ print $1 }')"
+                  case "$role" in
+                    master)
+                      discovered="$peer"
+                      break
+                      ;;
+                    slave|replica)
+                      mh="$(echo "$info" | sed -n 's/^master_host://p' | tr -d '\r' | awk '{ print $1 }')"
+                      if [ -n "$mh" ]; then
+                        discovered="$mh"
+                        break
+                      fi
+                      ;;
+                  esac
+                done
+                echo "$discovered"
+              }
               sentinel_master=""
               for attempt in $(seq 1 30); do
                 sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
@@ -51,11 +75,15 @@ spec:
                 sleep 2
               done
               if [ -z "$sentinel_master" ]; then
-                if [ -f /data/.helmforge-sentinel-node-bootstrapped ]; then
-                  echo "Sentinel unavailable for already bootstrapped node; main container will fail closed if the role cannot be confirmed"
+                sentinel_master="$(discover_master_from_peers)"
+                if [ -n "$sentinel_master" ]; then
+                  echo "discovered master ${sentinel_master} from peer nodes"
+                elif [ -f /data/.helmforge-sentinel-node-bootstrapped ]; then
+                  echo "Sentinel and peers unavailable for already bootstrapped node; main container will fail closed if the role cannot be confirmed"
                   exit 0
+                else
+                  sentinel_master={{ include "valkey.nodePodFqdn" . | quote }}
                 fi
-                sentinel_master={{ include "valkey.nodePodFqdn" . | quote }}
               fi
               self_fqdn="$(hostname -f)"
               self_ip="$(hostname -i | awk '{ print $1 }')"
@@ -92,6 +120,30 @@ spec:
           command: ["sh", "-ec"]
           args:
             - |
+              discover_master_from_peers() {
+                discovered=""
+                self_fqdn="$(hostname -f)"
+                for peer in {{ include "valkey.nodePeerFqdns" . }}; do
+                  [ "$peer" = "$self_fqdn" ] && continue
+                  info="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h "$peer" -p {{ .Values.service.ports.valkey }} {{- if .Values.auth.enabled }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} info replication 2>/dev/null || true)"
+                  [ -z "$info" ] && continue
+                  role="$(echo "$info" | sed -n 's/^role://p' | tr -d '\r' | awk '{ print $1 }')"
+                  case "$role" in
+                    master)
+                      discovered="$peer"
+                      break
+                      ;;
+                    slave|replica)
+                      mh="$(echo "$info" | sed -n 's/^master_host://p' | tr -d '\r' | awk '{ print $1 }')"
+                      if [ -n "$mh" ]; then
+                        discovered="$mh"
+                        break
+                      fi
+                      ;;
+                  esac
+                done
+                echo "$discovered"
+              }
               set -- /etc/valkey/valkey.conf
               bootstrap_marker="/data/.helmforge-sentinel-node-bootstrapped"
               sentinel_master=""
@@ -103,23 +155,29 @@ spec:
               done
               self_fqdn="$(hostname -f)"
               self_ip="$(hostname -i | awk '{ print $1 }')"
+              if [ -z "$sentinel_master" ]; then
+                sentinel_master="$(discover_master_from_peers)"
+                if [ -n "$sentinel_master" ]; then
+                  echo "discovered master ${sentinel_master} from peer nodes"
+                fi
+              fi
               if [ -n "$sentinel_master" ]; then
                 if [ "$sentinel_master" != "$self_fqdn" ] && [ "$sentinel_master" != "$self_ip" ]; then
-                  echo "starting as replica of Sentinel master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
+                  echo "starting as replica of master ${sentinel_master}:{{ .Values.service.ports.valkey }}"
                   set -- "$@" --replicaof "$sentinel_master" {{ .Values.service.ports.valkey }}
                 else
-                  echo "Sentinel reports this pod as the current master; starting without replicaof"
+                  echo "this pod is the current master target; starting without replicaof"
                 fi
               elif [ -f "$bootstrap_marker" ]; then
-                echo "Sentinel master discovery failed for an already bootstrapped node; refusing to start as an unconfirmed master"
+                echo "master discovery failed for an already bootstrapped node; refusing to start as an unconfirmed master"
                 exit 1
               else
                 case "$(hostname)" in
                   *-0)
-                    echo "Sentinel unavailable during first bootstrap; starting as seed master"
+                    echo "Sentinel and peers unavailable during first bootstrap; starting as seed master"
                     ;;
                   *)
-                    echo "Sentinel unavailable during first bootstrap; seeding from {{ include "valkey.nodePodFqdn" . }}:{{ .Values.service.ports.valkey }}"
+                    echo "Sentinel and peers unavailable during first bootstrap; seeding from {{ include "valkey.nodePodFqdn" . }}:{{ .Values.service.ports.valkey }}"
                     set -- "$@" --replicaof {{ include "valkey.nodePodFqdn" . | quote }} {{ .Values.service.ports.valkey }}
                     ;;
                 esac
@@ -198,6 +256,8 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
         {{- end }}
       volumes:
         - name: config

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -70,6 +70,7 @@ spec:
                     -e '/^tls-replication /d' \
                     -e '/^dir /d' \
                     -e '/^sentinel resolve-hostnames /d' \
+                    -e '/^sentinel announce-hostnames /d' \
                     -e '/^sentinel monitor mymaster /d' \
                     -e '/^sentinel down-after-milliseconds mymaster /d' \
                     -e '/^sentinel failover-timeout mymaster /d' \

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
           {{- if .Values.auth.enabled }}
           env:
             - name: VALKEY_PRIMARY_HOST
-              value: {{ include "valkey.primaryPodFqdn" . | quote }}
+              value: {{ include "valkey.nodePodFqdn" . | quote }}
             - name: VALKEY_PRIMARY_PORT
               value: {{ .Values.service.ports.valkey | quote }}
             - name: VALKEY_TLS_ARGS
@@ -105,7 +105,7 @@ spec:
           {{- else }}
           env:
             - name: VALKEY_PRIMARY_HOST
-              value: {{ include "valkey.primaryPodFqdn" . | quote }}
+              value: {{ include "valkey.nodePodFqdn" . | quote }}
             - name: VALKEY_PRIMARY_PORT
               value: {{ .Values.service.ports.valkey | quote }}
             - name: VALKEY_TLS_ARGS

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -93,7 +93,7 @@ spec:
     app.kubernetes.io/role: standalone
 {{- end }}
 
-{{- if or (include "valkey.isReplication" .) (include "valkey.isSentinel" .) }}
+{{- if include "valkey.isReplication" . }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -23,7 +23,23 @@ spec:
       command: ["sh", "-ec"]
       args:
         - |
-          {{- if include "valkey.isCluster" . }}
+          {{- if include "valkey.isSentinel" . }}
+          for i in $(seq 1 30); do
+            addr="$(valkey-cli $VALKEY_TLS_ARGS -h {{ include "valkey.sentinelServiceName" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null)"
+            host="$(echo "$addr" | sed -n '1p')"
+            port="$(echo "$addr" | sed -n '2p')"
+            [ -z "$port" ] && port={{ .Values.service.ports.valkey }}
+            if [ -n "$host" ] && valkey-cli $VALKEY_TLS_ARGS -h "$host" -p "$port" $VALKEY_AUTH_ARGS ping | grep -q PONG; then
+              valkey-cli $VALKEY_TLS_ARGS -h "$host" -p "$port" $VALKEY_AUTH_ARGS set helmforge:health ok | grep -q OK
+              test "$(valkey-cli $VALKEY_TLS_ARGS -h "$host" -p "$port" $VALKEY_AUTH_ARGS get helmforge:health)" = "ok"
+              exit 0
+            fi
+            echo "waiting for Sentinel master discovery ($i/30)"
+            sleep 2
+          done
+          echo "failed to discover Sentinel master"
+          exit 1
+          {{- else if include "valkey.isCluster" . }}
           for i in $(seq 1 30); do
             if valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'; then
               exit 0
@@ -39,6 +55,7 @@ spec:
           test "$(valkey-cli $VALKEY_TLS_ARGS -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS get helmforge:health)" = "ok"
           {{- end }}
       env:
+        {{- if not (include "valkey.isSentinel" .) }}
         - name: VALKEY_HOST
           {{- if or (include "valkey.isStandalone" .) (include "valkey.isCluster" .) }}
           value: {{ include "valkey.clientServiceName" . | quote }}
@@ -47,6 +64,7 @@ spec:
           {{- end }}
         - name: VALKEY_PORT
           value: {{ .Values.service.ports.valkey | quote }}
+        {{- end }}
         - name: VALKEY_TLS_ARGS
           value: {{ include "valkey.cliTlsArgs" . | quote }}
         {{- if .Values.auth.enabled }}

--- a/charts/valkey/tests/cluster_domain_test.yaml
+++ b/charts/valkey/tests/cluster_domain_test.yaml
@@ -3,6 +3,7 @@ suite: Cluster Domain
 templates:
   - configmap.yaml
   - replication-replica-statefulset.yaml
+  - sentinel-node-statefulset.yaml
   - sentinel-statefulset.yaml
   - cluster-statefulset.yaml
   - cluster-init-job.yaml
@@ -18,7 +19,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor mymaster test-valkey-primary-0\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
+          pattern: "sentinel monitor mymaster test-valkey-node-0\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "sentinel resolve-hostnames yes"
@@ -39,7 +40,20 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "svc\\.cluster\\.local"
 
-  - it: should wait for custom primary FQDN before starting sentinel
+  - it: should use custom cluster domain in sentinel node bootstrap args
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      clusterDomain: corp.internal
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'seeding from test-valkey-node-0\.test-valkey-headless\.custom-ns\.svc\.corp\.internal'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "svc\\.cluster\\.local"
+
+  - it: should wait for custom seed master FQDN before starting sentinel
     template: sentinel-statefulset.yaml
     set:
       architecture: sentinel
@@ -49,7 +63,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: VALKEY_PRIMARY_HOST
-            value: test-valkey-primary-0.test-valkey-headless.custom-ns.svc.corp.internal
+            value: test-valkey-node-0.test-valkey-headless.custom-ns.svc.corp.internal
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "until valkey-cli \\$VALKEY_TLS_ARGS -h \"\\$VALKEY_PRIMARY_HOST\""

--- a/charts/valkey/tests/config_rollout_test.yaml
+++ b/charts/valkey/tests/config_rollout_test.yaml
@@ -4,6 +4,7 @@ templates:
   - standalone-statefulset.yaml
   - replication-primary-statefulset.yaml
   - replication-replica-statefulset.yaml
+  - sentinel-node-statefulset.yaml
   - sentinel-statefulset.yaml
   - cluster-statefulset.yaml
   - configmap.yaml
@@ -49,15 +50,15 @@ tests:
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: "^[a-f0-9]{64}$"
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.metadata.annotations["checksum/config"]
-          pattern: "^[a-f0-9]{64}$"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: "^[a-f0-9]{64}$"
         template: sentinel-statefulset.yaml
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/auth-secret"]
+          pattern: "^[a-f0-9]{64}$"
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/auth-secret"]
           pattern: "^[a-f0-9]{64}$"
@@ -110,11 +111,7 @@ tests:
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/auth-secret"]
           pattern: "^[a-f0-9]{64}$"
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.metadata.annotations["checksum/auth-secret"]
-          pattern: "^[a-f0-9]{64}$"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/auth-secret"]
           pattern: "^[a-f0-9]{64}$"

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -3,6 +3,7 @@ suite: HA Extension Points
 templates:
   - replication-primary-statefulset.yaml
   - replication-replica-statefulset.yaml
+  - sentinel-node-statefulset.yaml
   - sentinel-statefulset.yaml
   - cluster-statefulset.yaml
   - configmap.yaml
@@ -156,7 +157,7 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor mymaster test-valkey-primary-0\\.test-valkey-headless\\.default\\.svc\\.cluster\\.local 6379 3"
+          pattern: "sentinel monitor mymaster test-valkey-node-0\\.test-valkey-headless\\.default\\.svc\\.cluster\\.local 6379 3"
         template: configmap.yaml
       - matchRegex:
           path: data["sentinel.conf"]
@@ -179,71 +180,74 @@ tests:
           pattern: "# HelmForge managed sentinel config end"
         template: configmap.yaml
 
-  - it: should reseed sentinel replicas from the current sentinel master on restarts
+  - it: should reseed sentinel data nodes from the current sentinel master on restarts
     set:
       architecture: sentinel
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: "sentinel get-master-addr-by-name mymaster"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
           pattern: "main container will fail closed if the role cannot be confirmed"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "sentinel get-master-addr-by-name mymaster"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "set -- \"\\$@\" --replicaof \"\\$sentinel_master\""
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "refusing to start as an unconfirmed master"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "Sentinel reports this pod as the current master; starting without replicaof"
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "helmforge-sentinel-node-bootstrapped"
+        template: sentinel-node-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "this pod is the master target; skipping init wait"
+        template: sentinel-node-statefulset.yaml
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: data
             mountPath: /data
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
 
-  - it: should start old sentinel primary as a replica of the current sentinel master
+  - it: should seed master only from ordinal zero when Sentinel is unavailable
+    set:
+      architecture: sentinel
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "case \"\\$\\(hostname\\)\" in"
+        template: sentinel-node-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "starting as seed master"
+        template: sentinel-node-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "seeding from test-valkey-node-0\\.test-valkey-headless\\.default\\.svc\\.cluster\\.local"
+        template: sentinel-node-statefulset.yaml
+
+  - it: should monitor the seed master node in sentinel pods
     set:
       architecture: sentinel
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].command
-          value:
-            - sh
-            - -ec
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "sentinel get-master-addr-by-name mymaster"
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "self_ip=\"\\$\\(hostname -i"
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "set -- \"\\$@\" --replicaof \"\\$sentinel_master\""
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "helmforge-sentinel-primary-bootstrapped"
-        template: replication-primary-statefulset.yaml
-      - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "refusing to start without role confirmation"
-        template: replication-primary-statefulset.yaml
+          path: spec.template.spec.containers[0].env[0].value
+          value: test-valkey-node-0.test-valkey-headless.default.svc.cluster.local
+        template: sentinel-statefulset.yaml
 
   - it: should keep fixed replicaof in replication mode
     set:
@@ -331,11 +335,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.memory
           value: 64Mi
-        template: replication-primary-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
       - equal:
           path: spec.template.spec.containers[1].resources.limits.memory
           value: 128Mi
-        template: replication-replica-statefulset.yaml
+        template: sentinel-node-statefulset.yaml
 
   - it: should render metrics resources in cluster pods
     set:

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -190,11 +190,19 @@ tests:
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[0].args[0]
-          pattern: "main container will fail closed if the role cannot be confirmed"
+          pattern: "Sentinel and peers unavailable for already bootstrapped node; main container will fail closed"
+        template: sentinel-node-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: "info replication"
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "sentinel get-master-addr-by-name mymaster"
+        template: sentinel-node-statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "info replication"
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
@@ -206,7 +214,7 @@ tests:
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "Sentinel reports this pod as the current master; starting without replicaof"
+          pattern: "this pod is the current master target; starting without replicaof"
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
@@ -233,7 +241,7 @@ tests:
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "starting as seed master"
+          pattern: "Sentinel and peers unavailable during first bootstrap; starting as seed master"
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -89,3 +89,64 @@ tests:
             name: extra-config
             configMap:
               name: extra-config
+
+  - it: should use emptyDir for data when node persistence is disabled by default
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+      - notExists:
+          path: spec.volumeClaimTemplates
+
+  - it: should render volume claim templates when node persistence is enabled
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      node.persistence.enabled: true
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: should probe peer nodes for master discovery
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: discover_master_from_peers
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: discover_master_from_peers
+
+  - it: should set securityContext on the metrics sidecar
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: metrics
+      - isNotNull:
+          path: spec.template.spec.containers[1].securityContext
+
+  - it: should enable announce-hostnames in managed sentinel config
+    template: configmap.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel announce-hostnames yes"

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Sentinel Node StatefulSet
+templates:
+  - configmap.yaml
+  - sentinel-node-statefulset.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render a role-neutral node StatefulSet in sentinel mode
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: test-valkey-node
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.serviceName
+          value: test-valkey-headless
+      - notExists:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].subPath
+          value: valkey-node.conf
+
+  - it: should honor node replica count
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      node.replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: should fail when sentinel replica count is below three
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      sentinel.replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "sentinel.replicaCount must be at least 3 for a reliable Sentinel quorum in HA configurations"
+
+  - it: should fail when quorum exceeds sentinel replica count
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      sentinel.replicaCount: 3
+      sentinel.quorum: 4
+    asserts:
+      - failedTemplate:
+          errorMessage: "sentinel.quorum (4) cannot exceed sentinel.replicaCount (3)"
+
+  - it: should render extra env and volumes in sentinel node pods
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+      extraEnv:
+        - name: EXTRA_SETTING
+          value: enabled
+      extraVolumes:
+        - name: extra-config
+          configMap:
+            name: extra-config
+      extraVolumeMounts:
+        - name: extra-config
+          mountPath: /extra
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_SETTING
+            value: enabled
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-config
+            mountPath: /extra
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-config
+            configMap:
+              name: extra-config

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -6,6 +6,21 @@ release:
   name: test
   namespace: default
 tests:
+  - it: should render headless and sentinel services only in sentinel mode
+    set:
+      architecture: sentinel
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-valkey-headless
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-valkey-sentinel
+        documentIndex: 1
+
   - it: should render headless and client services
     asserts:
       - hasDocuments:

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -40,13 +40,20 @@ tests:
           path: spec.containers[0].env[0].value
           value: test-valkey-primary
 
-  - it: should target the primary service for sentinel
+  - it: should discover the master through Sentinel in sentinel mode
     set:
       architecture: sentinel
     asserts:
-      - equal:
-          path: spec.containers[0].env[0].value
-          value: test-valkey-primary
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "sentinel get-master-addr-by-name mymaster"
+      - matchRegex:
+          path: spec.containers[0].args[0]
+          pattern: "test-valkey-sentinel"
+      - notContains:
+          path: spec.containers[0].env
+          content:
+            name: VALKEY_HOST
 
   - it: should target the client service for cluster
     set:

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -190,6 +190,31 @@
         }
       }
     },
+    "node": {
+      "type": "object",
+      "description": "Sentinel data node settings",
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of Valkey data nodes in sentinel mode"
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Persistence settings for sentinel data nodes",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for sentinel data nodes"
+        }
+      }
+    },
     "sentinel": {
       "type": "object",
       "description": "Sentinel architecture settings",

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -203,7 +203,7 @@
           "type": "object",
           "description": "Persistence settings for sentinel data nodes",
           "properties": {
-            "enabled": { "type": "boolean" },
+            "enabled": { "type": "boolean", "description": "Enable persistence for sentinel data nodes (default false; peer discovery keeps topology safe without PVCs)" },
             "storageClass": { "type": "string" },
             "accessModes": { "type": "array", "items": { "type": "string" } },
             "size": { "type": "string" }

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -122,6 +122,26 @@ replication:
     resources: {}
 
 # =============================================================================
+# Sentinel data nodes
+# =============================================================================
+
+node:
+  # -- Number of Valkey data nodes in sentinel mode
+  replicaCount: 3
+  persistence:
+    # -- Enable persistent storage for sentinel data nodes
+    enabled: true
+    # -- StorageClass for node PVCs. Empty uses the cluster default.
+    storageClass: ""
+    # -- Access modes for node PVCs
+    accessModes:
+      - ReadWriteOnce
+    # -- Size of each node PVC
+    size: 8Gi
+  # -- Resource requests and limits for sentinel data node containers
+  resources: {}
+
+# =============================================================================
 # Sentinel
 # =============================================================================
 

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -130,7 +130,7 @@ node:
   replicaCount: 3
   persistence:
     # -- Enable persistent storage for sentinel data nodes
-    enabled: true
+    enabled: false
     # -- StorageClass for node PVCs. Empty uses the cluster default.
     storageClass: ""
     # -- Access modes for node PVCs


### PR DESCRIPTION
## Summary

Resolves #542 

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO

## Notes

`node.persistence.enabled` is set to `false` by default for Valkey Sentinel as in 95% of cases it is used as a cache-first server, and with the high-avaiability Sentinel provides it becomes non-mandatory. This architectural choice can be discussed @mberlofa if you want