### PR TITLE
feat(valkey): Added networkPolicy support

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -27,8 +27,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#530)"
+    - kind: added
+      description: "networkPolicy"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/DESIGN.md
+++ b/charts/valkey/DESIGN.md
@@ -210,6 +210,7 @@ Recommended production controls:
 
 - pod anti-affinity for Valkey replicas and Sentinel pods
 - topology spread constraints across zones or hosts
+- NetworkPolicy for ingress trafic control
 - PodDisruptionBudgets for HA modes
 - explicit resource requests and limits
 - node selectors or tolerations only when they reflect real platform policy

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -28,6 +28,7 @@ helm install valkey oci://ghcr.io/helmforgedev/helm/valkey -f values.yaml
 - dual-stack service fields through `service.ipFamilyPolicy` and `service.ipFamilies`
 - optional TLS file wiring for Valkey server configuration
 - optional Valkey exporter sidecar and `ServiceMonitor`
+- optional `NetworkPolicy` for ingress traffic control
 - optional `PodDisruptionBudget`
 - topology-specific Services, StatefulSets, and Valkey Cluster bootstrap Job
 - `extraEnv`, `extraVolumes`, `extraVolumeMounts`, and `extraManifests` extension points
@@ -230,6 +231,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `service.type` | Client Service type where applicable | `ClusterIP` |
 | `service.ipFamilyPolicy` | Service IP family policy for dual-stack clusters | `null` |
 | `service.ipFamilies` | Service IP families for dual-stack clusters | `[]` |
+| `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 | `metrics.enabled` | Enable redis_exporter sidecar | `false` |
 | `metrics.serviceMonitor.enabled` | Create ServiceMonitor | `false` |
 | `tests.enabled` | Render Helm test connection pod | `true` |
@@ -263,6 +265,7 @@ The `ci/` scenarios validate chart behavior across common configurations:
 - `cluster.yaml`
 - `existing-secret.yaml`
 - `external-secrets.yaml`
+- `networkpolicy.yaml`
 - `metrics.yaml`
 - `dual-stack.yaml`
 - `tls-replication.yaml`

--- a/charts/valkey/ci/networkpolicy.yaml
+++ b/charts/valkey/ci/networkpolicy.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: standalone
+
+auth:
+  enabled: true
+  password: ci-valkey-password
+
+standalone:
+  persistence:
+    enabled: true
+    size: 2Gi
+
+pdb:
+  enabled: false
+
+networkPolicy:
+  enabled: true
+  metrics:
+    enabled: true

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -15,6 +15,7 @@ Valkey has been installed.
 - Authentication enabled: {{ .Values.auth.enabled }}
 - Metrics enabled: {{ .Values.metrics.enabled }}
 - ServiceMonitor enabled: {{ and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+- NetworkPolicy enabled: {{ .Values.networkPolicy.enabled }}
 - PodDisruptionBudget enabled: {{ .Values.pdb.enabled }}
 - External Secrets enabled: {{ .Values.externalSecrets.enabled }}
 

--- a/charts/valkey/templates/networkpolicy.yaml
+++ b/charts/valkey/templates/networkpolicy.yaml
@@ -1,0 +1,42 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingress.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingress.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.ports.valkey }}
+        {{- if eq .Values.architecture "sentinel" }}
+        - protocol: TCP
+          port: {{ .Values.service.ports.sentinel }}
+        {{- end }}
+    {{- if and .Values.metrics.enabled .Values.networkPolicy.metrics.enabled }}
+    - from:
+        {{- if .Values.networkPolicy.metrics.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.metrics.extraFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.ports.metrics }}
+    {{- end }}
+{{- end }}

--- a/charts/valkey/tests/networkpolicy_test.yaml
+++ b/charts/valkey/tests/networkpolicy_test.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: networkpolicy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: should not render NetworkPolicy by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render NetworkPolicy when enabled
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 6379
+      - equal:
+          path: spec.ingress[0].ports[0].protocol
+          value: TCP

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -290,6 +290,10 @@
         }
       }
     },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy configuration"
+    },
     "service": {
       "type": "object",
       "description": "Service configuration",

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -219,16 +219,25 @@ service:
   # -- Service IP families override. Empty uses cluster default.
   ipFamilies: []
 
-serviceAccount:
-  # -- Create a dedicated ServiceAccount
-  create: false
-  # -- Existing ServiceAccount name when serviceAccount.create=false
-  name: ""
-  # -- Annotations added to the ServiceAccount
-  annotations: {}
+# =============================================================================
+# NetworkPolicy
+# =============================================================================
 
-# -- Mount Kubernetes API service account token into pods.
-automountServiceAccountToken: false
+networkPolicy:
+  # -- Create an ingress-only NetworkPolicy for Valkey pods
+  enabled: false
+  ingress:
+    # -- Allow ingress from the same namespace
+    allowSameNamespace: true
+    # -- Additional ingress "from" rules appended to the generated policy
+    extraFrom: []
+  metrics:
+    # -- Allow ingress to the metrics port when metrics.enabled=true
+    enabled: false
+    # -- Allow metrics scraping from the same namespace
+    allowSameNamespace: true
+    # -- Additional ingress "from" rules appended to the generated metrics policy rule
+    extraFrom: []
 
 # =============================================================================
 # Probes
@@ -331,6 +340,17 @@ securityContext:
     # -- Linux capabilities dropped from containers
     drop:
       - ALL
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount
+  create: false
+  # -- Existing ServiceAccount name when serviceAccount.create=false
+  name: ""
+  # -- Annotations added to the ServiceAccount
+  annotations: {}
+
+# -- Mount Kubernetes API service account token into pods.
+automountServiceAccountToken: false
 
 # -- Extra labels added to pods
 podLabels: {}


### PR DESCRIPTION
## Summary

Implemented `networkPolicy` for ingress trafic control

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO