### PR TITLE
ci(workflows): fix auto-label permissions for fork prs

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+name: PR Auto Label
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  auto-label:
+    name: Auto Label
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+
+            const labels = new Set();
+            const charts = new Set();
+
+            for (const file of files) {
+              // Detect chart scope
+              const chartMatch = file.filename.match(/^charts\/([^/]+)\//);
+              if (chartMatch) {
+                charts.add(chartMatch[1]);
+                labels.add(`chart:${chartMatch[1]}`);
+              }
+
+              // Detect area
+              if (file.filename.includes('values.yaml')) labels.add('area:values');
+              if (file.filename.includes('values.schema.json')) labels.add('area:schema');
+              if (file.filename.includes('/templates/')) labels.add('area:templates');
+              if (file.filename.includes('/tests/')) labels.add('area:tests');
+              if (file.filename.includes('.github/')) labels.add('area:ci');
+              if (file.filename.endsWith('.md')) labels.add('area:docs');
+            }
+
+            // Size labels based on total lines changed
+            const totalChanges = files.reduce((acc, f) => acc + f.changes, 0);
+            if (totalChanges <= 10) labels.add('size:XS');
+            else if (totalChanges <= 50) labels.add('size:S');
+            else if (totalChanges <= 200) labels.add('size:M');
+            else if (totalChanges <= 500) labels.add('size:L');
+            else labels.add('size:XL');
+
+            // Multi-chart detection
+            if (charts.size > 3) labels.add('multi-chart');
+
+            const labelsArray = [...labels];
+            if (labelsArray.length > 0) {
+              // Create labels that don't exist yet
+              const { data: existingLabels } = await github.rest.issues.listLabelsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              });
+              const existingNames = new Set(existingLabels.map(l => l.name));
+
+              for (const label of labelsArray) {
+                if (!existingNames.has(label)) {
+                  let color = '0e8a16'; // green default
+                  if (label.startsWith('chart:')) color = '1d76db';
+                  else if (label.startsWith('area:')) color = 'e4e669';
+                  else if (label.startsWith('size:')) color = 'c5def5';
+                  else if (label === 'multi-chart') color = 'd93f0b';
+
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: label,
+                      color: color
+                    });
+                  } catch (e) {
+                    // Label may have been created concurrently
+                    if (e.status !== 422) throw e;
+                  }
+                }
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labelsArray
+              });
+
+              core.info(`Applied labels: ${labelsArray.join(', ')}`);
+            }

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -4,16 +4,18 @@ name: PR Governance
 on:
   pull_request:
     types: [opened, edited, synchronize]
-
-permissions:
-  contents: read
-  pull-requests: write
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
   auto-label:
     name: Auto Label
     runs-on: ubuntu-latest
-    if: github.event.action != 'edited'
+    if: github.event_name == 'pull_request_target' && github.event.action != 'edited'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/github-script@v9
         with:
@@ -101,6 +103,10 @@ jobs:
   conventional-commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -4,106 +4,11 @@ name: PR Governance
 on:
   pull_request:
     types: [opened, edited, synchronize]
-  pull_request_target:
-    types: [opened, synchronize]
 
 jobs:
-  auto-label:
-    name: Auto Label
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target' && github.event.action != 'edited'
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: read
-    steps:
-      - uses: actions/github-script@v9
-        with:
-          script: |
-            const { data: files } = await github.rest.pulls.listFiles({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100
-            });
-
-            const labels = new Set();
-            const charts = new Set();
-
-            for (const file of files) {
-              // Detect chart scope
-              const chartMatch = file.filename.match(/^charts\/([^/]+)\//);
-              if (chartMatch) {
-                charts.add(chartMatch[1]);
-                labels.add(`chart:${chartMatch[1]}`);
-              }
-
-              // Detect area
-              if (file.filename.includes('values.yaml')) labels.add('area:values');
-              if (file.filename.includes('values.schema.json')) labels.add('area:schema');
-              if (file.filename.includes('/templates/')) labels.add('area:templates');
-              if (file.filename.includes('/tests/')) labels.add('area:tests');
-              if (file.filename.includes('.github/')) labels.add('area:ci');
-              if (file.filename.endsWith('.md')) labels.add('area:docs');
-            }
-
-            // Size labels based on total lines changed
-            const totalChanges = files.reduce((acc, f) => acc + f.changes, 0);
-            if (totalChanges <= 10) labels.add('size:XS');
-            else if (totalChanges <= 50) labels.add('size:S');
-            else if (totalChanges <= 200) labels.add('size:M');
-            else if (totalChanges <= 500) labels.add('size:L');
-            else labels.add('size:XL');
-
-            // Multi-chart detection
-            if (charts.size > 3) labels.add('multi-chart');
-
-            const labelsArray = [...labels];
-            if (labelsArray.length > 0) {
-              // Create labels that don't exist yet
-              const { data: existingLabels } = await github.rest.issues.listLabelsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                per_page: 100
-              });
-              const existingNames = new Set(existingLabels.map(l => l.name));
-
-              for (const label of labelsArray) {
-                if (!existingNames.has(label)) {
-                  let color = '0e8a16'; // green default
-                  if (label.startsWith('chart:')) color = '1d76db';
-                  else if (label.startsWith('area:')) color = 'e4e669';
-                  else if (label.startsWith('size:')) color = 'c5def5';
-                  else if (label === 'multi-chart') color = 'd93f0b';
-
-                  try {
-                    await github.rest.issues.createLabel({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      name: label,
-                      color: color
-                    });
-                  } catch (e) {
-                    // Label may have been created concurrently
-                    if (e.status !== 422) throw e;
-                  }
-                }
-              }
-
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                labels: labelsArray
-              });
-
-              core.info(`Applied labels: ${labelsArray.join(', ')}`);
-            }
-
   conventional-commits:
     name: Conventional Commits
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary
- Run the auto-label job on `pull_request_target` so fork PRs can receive labels with the base repository token.
- Scope job permissions to the minimum required for each job.
- Keep the conventional commit title check on `pull_request`.

## Root cause
Fork PRs run `pull_request` workflows with a read-only `GITHUB_TOKEN`. The existing auto-label job tried to create labels through the Issues API, which requires `issues: write`, so PRs from forks failed with `403 Resource not accessible by integration`.

## Validation
- `actionlint .github/workflows/pr-governance.yml`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`