### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -58,10 +58,10 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -53,6 +53,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -50,6 +50,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -12,7 +12,7 @@ sources:
   - https://github.com/envoyproxy/gateway
 dependencies:
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -54,6 +54,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     condition: postgresql.enabled
   - name: redis
     alias: valkey
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: valkey.internal.enabled

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -55,7 +55,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -48,6 +48,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -50,10 +50,10 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.1
+    version: 2.0.2
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.18
+    version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- answer: mysql 2.0.1 -> 2.0.2
- authelia: mysql 2.0.1 -> 2.0.2
- authelia: redis 1.6.18 -> 1.6.19
- discount-bandit: mysql 2.0.1 -> 2.0.2
- docmost: redis 1.6.18 -> 1.6.19
- dolibarr: mysql 2.0.1 -> 2.0.2
- drupal: mysql 2.0.1 -> 2.0.2
- envoy-gateway: redis 1.6.18 -> 1.6.19
- ghost: mysql 2.0.1 -> 2.0.2
- homarr: mysql 2.0.1 -> 2.0.2
- immich: redis 1.6.18 -> 1.6.19
- keycloak: mysql 2.0.1 -> 2.0.2
- n8n: mysql 2.0.1 -> 2.0.2
- opencut: redis 1.6.18 -> 1.6.19
- uptime-kuma: mysql 2.0.1 -> 2.0.2
- vaultwarden: mysql 2.0.1 -> 2.0.2
- wordpress: mysql 2.0.1 -> 2.0.2
- wordpress: redis 1.6.18 -> 1.6.19

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._