### PR TITLE
ci(workflows): fix pr auto-label permissions

### DIFF
--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/github-script@v9
         with:


### PR DESCRIPTION
## Summary
- Allow the `PR Auto Label` workflow to update pull request labels by granting `pull-requests: write`.
- Keep the workflow scoped to the existing `pull_request_target` labeler with `contents: read` and `issues: write`.

## Root cause
`github.rest.issues.addLabels()` failed on PR #592 with `403 Resource not accessible by integration`. The response header reported the accepted permissions as `issues=write; pull_requests=write`, while the workflow only granted `pull-requests: read`.

## Current PR behavior
The `Auto Label` check on this PR is expected to fail until this fix is merged, because `pull_request_target` runs the workflow file from the base branch (`main`), not from this PR branch. The corrected permission will apply to subsequent PR runs after merge.

## Pages deploy warning
The `pages-build-deployment` warning is emitted by GitHub's dynamic Pages workflow (`dynamic/pages/pages-build-deployment`) for this repository's legacy Pages source (`gh-pages`). The repo does not contain an editable workflow file for that job.

Verified against upstream sources:
- `actions/deploy-pages` latest release is `v5.0.0`.
- `actions/deploy-pages@v5.0.0` runs on Node 24.
- Upstream issue `actions/deploy-pages#413` tracks the remaining bundled `punycode` `DEP0040` warning.

Because this warning comes from the GitHub-managed Pages deployment action and the deployment succeeds, there is no repository-side YAML fix in this PR beyond documenting the limitation here.

## Validation
- `actionlint .github/workflows/pr-auto-label.yml .github/workflows/pr-governance.yml .github/workflows/publish.yml`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`