### PR TITLE
chore(flowise): bump flowise to 3.1.3

### DIFF
--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -4,7 +4,7 @@ name: flowise
 description: Flowise visual AI orchestration with standalone SQLite mode or scalable queue mode backed by Redis and PostgreSQL
 type: application
 version: 1.3.2
-appVersion: "3.1.2"
+appVersion: "3.1.3"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/flowise.png
@@ -26,7 +26,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh chart subchart dependencies (#587)"
+      description: "bump flowise to 3.1.3"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/flowise/tests/deployment_test.yaml
+++ b/charts/flowise/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
           value: 1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/flowiseai/flowise:3.1.2
+          value: docker.io/flowiseai/flowise:3.1.3
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -39,7 +39,7 @@ flowise:
   # -- Allowed CORS origins
   corsOrigins: "*"
   # -- Allowed iframe origins
-  iframeOrigins: "self"
+  iframeOrigins: "'self'"
   # -- Maximum upload size accepted by Flowise
   fileSizeLimit: 50mb
   # -- Show community nodes in the UI

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -39,7 +39,7 @@ flowise:
   # -- Allowed CORS origins
   corsOrigins: "*"
   # -- Allowed iframe origins
-  iframeOrigins: "*"
+  iframeOrigins: "self"
   # -- Maximum upload size accepted by Flowise
   fileSizeLimit: 50mb
   # -- Show community nodes in the UI

--- a/charts/flowise/values.yaml
+++ b/charts/flowise/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Flowise container image repository
   repository: docker.io/flowiseai/flowise
   # -- Flowise image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
-  tag: "3.1.2"
+  tag: "3.1.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #593

| Field | Value |
|---|---|
| **Chart** | flowise |
| **Previous** | 3.1.2 |
| **New** | 3.1.3 |
| **Image** | docker.io/flowiseai/flowise:3.1.3 |

### Upstream Evidence

- Image verified: `docker.io/flowiseai/flowise:3.1.3` (linux/amd64, linux/arm64)

### Changes

- Updated `appVersion` in Chart.yaml (3.1.2 -> 3.1.3)
- Updated image tag in values.yaml (3.1.2 -> 3.1.3)
- Updated unit test with new image tag

### Local Validation (GR-027)

`make validate-chart CHART=flowise` results:
- PASS: clean Chart.lock, helm dependency build/list, helm lint --strict, helm template, helm unittest, kubeconform, ah lint
- PASS: k3d behavioral [default, ci/backup-values, ci/default, ci/dual-stack, ci/external-postgres, ci/external-secrets, ci/gateway-api]
- KNOWN: ci/queue-s3 (pre-existing: S3 credentials unavailable in k3d, pods restart once)