### PR TITLE
chore(ghost): bump ghost to 6.47.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.16
-appVersion: "6.45.0"
+appVersion: "6.47.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#592)"
+      description: "bump ghost to 6.47.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.45.0"
+          value: "docker.io/library/ghost:6.47.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.45.0"
+  tag: "6.47.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Upstream Image Update

Closes #594

| Field | Value |
|---|---|
| **Chart** | ghost |
| **Previous** | 6.45.0 |
| **New** | 6.47.0 |
| **Image** | docker.io/library/ghost:6.47.0 |

### Upstream Evidence
- Image verified: `docker.io/library/ghost:6.47.0` (linux/amd64, linux/arm, linux/arm64, linux/s390x)

### Local Validation (GR-027)
`ghost: FULLY VALIDATED (16 layers)`
- All static layers PASS (lint, template, unittest, kubeconform, ah lint)
- All k3d behavioral scenarios PASS (default + 6 CI variants)