### PR TITLE
chore(homarr): bump homarr to 1.68.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.19
-appVersion: "1.67.0"
+appVersion: "1.68.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#592)"
+      description: "bump homarr to 1.68.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.67.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.68.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.67.0"
+  tag: "v1.68.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Upstream Image Update

Closes #595

| Field | Value |
|---|---|
| **Chart** | homarr |
| **Previous** | v1.67.0 |
| **New** | v1.68.0 |
| **Image** | ghcr.io/homarr-labs/homarr:v1.68.0 |

### Upstream Evidence
- Image verified: `ghcr.io/homarr-labs/homarr:v1.68.0` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`homarr: FULLY VALIDATED (19 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 8 CI variants)