### PR TITLE
chore(kafka): bump kafka to 4.3.1

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -4,7 +4,7 @@ name: kafka
 description: Apache Kafka Helm chart for KRaft single-broker and production-oriented cluster topologies
 type: application
 version: 1.3.13
-appVersion: "4.3.0"
+appVersion: "4.3.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,8 +22,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/kafka.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#511)"
+    - kind: changed
+      description: "bump kafka to 4.3.1"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -32,7 +32,7 @@ helm install kafka oci://ghcr.io/helmforgedev/helm/kafka -f values.yaml
 ## What this chart covers
 
 - KRaft only
-- official Kafka `4.3.0` runtime image
+- official Kafka `4.3.1` runtime image
 - persistent storage for single-broker, controllers, and brokers
 - automatic cleanup of `lost+found` directories in PVCs (ext4/xfs compatibility)
 - stable in-cluster advertised listeners for brokers
@@ -128,7 +128,7 @@ metrics:
 |-----------|-------------|---------|
 | `architecture` | `single-broker` or `cluster` | `single-broker` |
 | `image.repository` | Kafka image repository | `apache/kafka` |
-| `image.tag` | Kafka image tag | `4.3.0` |
+| `image.tag` | Kafka image tag | `4.3.1` |
 | `service.type` | Client bootstrap service type | `ClusterIP` |
 | `service.ipFamilyPolicy` | Service IP family policy for client, headless, and metrics Services | `""` |
 | `service.ipFamilies` | Service IP families for client, headless, and metrics Services | `[]` |

--- a/charts/kafka/tests/single_broker_test.yaml
+++ b/charts/kafka/tests/single_broker_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: 1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/apache/kafka:4.3.0
+          value: docker.io/apache/kafka:4.3.1
       - contains:
           path: spec.template.spec.containers[0].ports
           content:

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -187,7 +187,7 @@ metrics:
     # -- Init image used to download the JMX exporter javaagent. Defaults to the official Kafka image.
     repository: docker.io/apache/kafka
     # -- Init image tag
-    tag: "4.3.0"
+    tag: "4.3.1"
     # -- Init image pull policy
     pullPolicy: IfNotPresent
   agent:

--- a/charts/kafka/values.yaml
+++ b/charts/kafka/values.yaml
@@ -26,7 +26,7 @@ image:
   # -- Kafka image repository
   repository: docker.io/apache/kafka
   # -- Kafka image tag
-  tag: "4.3.0"
+  tag: "4.3.1"
   # -- Kafka image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #596

| Field | Value |
|---|---|
| **Chart** | kafka |
| **Previous** | 4.3.0 |
| **New** | 4.3.1 |
| **Image** | docker.io/apache/kafka:4.3.1 |

### Upstream Evidence
- Image verified: `docker.io/apache/kafka:4.3.1` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
- All static layers PASS (lint, template, unittest, kubeconform, ah lint)
- k3d default: PASS
- k3d ci/cluster-tuned: workloads healthy (6 pods stable, no restarts), but namespace cleanup timed out (k3d infra)