### PR TITLE
chore(keycloak): bump keycloak to 26.6.4

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 3.0.5
-appVersion: "26.6.3"
+appVersion: "26.6.4"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - keycloak
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#592)"
+      description: "bump keycloak to 26.6.4"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -88,11 +88,11 @@ Recommended reading before installation:
 
 ## Keycloak 26.6.x alignment
 
-This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.6.3`.
+This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.6.4`.
 
 Relevant 26.6.x operational changes to account for during rollout:
 
-- 26.6.3 is a security-focused patch release; prioritize rollout for public or multi-tenant realms and validate custom login/front-channel logout templates
+- 26.6.4 is a security-focused patch release; prioritize rollout for public or multi-tenant realms and validate custom login/front-channel logout templates
 - zero-downtime patch releases are supported within the same minor stream, but still require readiness, proxy, and database validation
 - the HTTP stack supports graceful shutdown, so keep `terminationGracePeriodSeconds` aligned with connection draining at the proxy layer
 - Kubernetes and OpenShift truststore initialization improved upstream; keep custom `truststore` and database CA mounts explicit when the platform uses private CAs
@@ -245,7 +245,7 @@ postgresql:
 |-----------|-------------|---------|
 | `mode` | `dev` or `production` | `dev` |
 | `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `26.6.3` |
+| `image.tag` | Keycloak image tag | `26.6.4` |
 | `admin.existingSecret` | Existing secret for bootstrap admin credentials | `""` |
 | `http.port` | Application HTTP port | `8080` |
 | `http.managementPort` | Management port for health and metrics | `9000` |

--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -157,7 +157,7 @@ When an ExternalSecret owns a target Secret, the native generated Secret for tha
 
 ## Keycloak 26.6.x rollout notes
 
-The default image is `quay.io/keycloak/keycloak:26.6.3`.
+The default image is `quay.io/keycloak/keycloak:26.6.4`.
 
 Before rolling this version into production:
 

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.6.3"
+          value: "quay.io/keycloak/keycloak:26.6.4"
 
   - it: should have 1 replica by default
     template: deployment.yaml

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # -- Keycloak image tag
-  tag: "26.6.3"
+  tag: "26.6.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Upstream Image Update

Closes #597

| Field | Value |
|---|---|
| **Chart** | keycloak |
| **Previous** | 26.6.3 |
| **New** | 26.6.4 |
| **Image** | quay.io/keycloak/keycloak:26.6.4 |

### Upstream Evidence
- Image verified: `quay.io/keycloak/keycloak:26.6.4` (linux/amd64, linux/arm64, linux/ppc64le)

### Local Validation (GR-027)
`keycloak: FULLY VALIDATED (33 layers)`
- All static layers PASS
- All 22 k3d behavioral scenarios PASS (default + 21 CI variants)