### PR TITLE
chore(kubernetes-mcp-server): bump kubernetes-mcp-server to 0.0.63

### DIFF
--- a/charts/kubernetes-mcp-server/Chart.yaml
+++ b/charts/kubernetes-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ name: kubernetes-mcp-server
 description: Kubernetes and OpenShift MCP server in HTTP mode
 type: application
 version: 1.0.1
-appVersion: "0.0.62"
+appVersion: "0.0.63"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/kubernetes-mcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add qdrant langflow and mcp charts (#486)"
+    - kind: changed
+      description: "bump kubernetes-mcp-server to 0.0.63"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/kubernetes-mcp-server/tests/templates_test.yaml
+++ b/charts/kubernetes-mcp-server/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.62
+          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.63
   - it: renders service
     template: templates/service.yaml
     asserts:

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 commonLabels: {}
 image:
   repository: ghcr.io/containers/kubernetes-mcp-server
-  tag: "v0.0.62"
+  tag: "v0.0.63"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 replicaCount: 1


### PR DESCRIPTION
## Upstream Image Update

Closes #598

| Field | Value |
|---|---|
| **Chart** | kubernetes-mcp-server |
| **Previous** | v0.0.62 |
| **New** | v0.0.63 |
| **Image** | ghcr.io/containers/kubernetes-mcp-server:v0.0.63 |

### Upstream Evidence
- Image verified: `ghcr.io/containers/kubernetes-mcp-server:v0.0.63` (linux/amd64, linux/arm64, linux/s390x, linux/ppc64le)

### Local Validation (GR-027)
`kubernetes-mcp-server: FULLY VALIDATED (16 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 6 CI variants)