### PR TITLE
chore(langflow): bump langflow to 1.10.1

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.0.1
-appVersion: "1.10.0"
+appVersion: "1.10.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add qdrant langflow and mcp charts (#486)"
+    - kind: changed
+      description: "bump langflow to 1.10.1"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.10.0
+          value: docker.io/langflowai/langflow:1.10.1
   - it: renders service
     template: templates/service.yaml
     asserts:

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.10.0"
+  tag: "1.10.1"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #599

| Field | Value |
|---|---|
| **Chart** | langflow |
| **Previous** | 1.10.0 |
| **New** | 1.10.1 |
| **Image** | docker.io/langflowai/langflow:1.10.1 |

### Upstream Evidence
- Image verified: `docker.io/langflowai/langflow:1.10.1` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`langflow: FULLY VALIDATED (17 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 7 CI variants)