### PR TITLE
chore(listmonk): bump listmonk to 6.2.0

### DIFF
--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -4,7 +4,7 @@ name: listmonk
 description: Listmonk self-hosted newsletter and mailing list manager with PostgreSQL
 type: application
 version: 1.1.12
-appVersion: "6.1.0"
+appVersion: "6.2.0"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/listmonk.png
 home: https://helmforge.dev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#558)"
+      description: "bump listmonk to 6.2.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/listmonk/tests/deployment_test.yaml
+++ b/charts/listmonk/tests/deployment_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/listmonk/listmonk:v6.1.0"
+          value: "docker.io/listmonk/listmonk:v6.2.0"
 
   - it: exposes port 9000
     template: templates/deployment.yaml

--- a/charts/listmonk/values.yaml
+++ b/charts/listmonk/values.yaml
@@ -22,7 +22,7 @@ image:
   # -- Listmonk container image repository
   repository: docker.io/listmonk/listmonk
   # -- Listmonk image tag. Defaults to appVersion when empty.
-  tag: "v6.1.0"
+  tag: "v6.2.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #600

| Field | Value |
|---|---|
| **Chart** | listmonk |
| **Previous** | v6.1.0 |
| **New** | v6.2.0 |
| **Image** | docker.io/listmonk/listmonk:v6.2.0 |

### Upstream Evidence
- Image verified: `docker.io/listmonk/listmonk:v6.2.0` (linux/amd64, linux/arm64, linux/arm)

### Local Validation (GR-027)
`listmonk: FULLY VALIDATED (13 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 3 CI variants)