### PR TITLE
chore(metabase): bump metabase to v0.62.3

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.18
-appVersion: "v0.62.2"
+appVersion: "v0.62.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump metabase to v0.62.2 (#582)"
+      description: "bump metabase to v0.62.3"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.62.2"
+          value: "docker.io/metabase/metabase:v0.62.3"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.62.2"
+  tag: "v0.62.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Upstream Image Update

Closes #601

| Field | Value |
|---|---|
| **Chart** | metabase |
| **Previous** | v0.62.2 |
| **New** | v0.62.3 |
| **Image** | docker.io/metabase/metabase:v0.62.3 |

### Upstream Evidence
- Image verified: `docker.io/metabase/metabase:v0.62.3` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`metabase: FULLY VALIDATED (17 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 7 CI variants)