### PR TITLE
chore(minecraft): bump minecraft to 2026.6.1

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.4.13
-appVersion: "2026.6.0"
+appVersion: "2026.6.1"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump minecraft to 2026.6.0 (#553)"
+      description: "bump minecraft to 2026.6.1"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -255,13 +255,10 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.6.0` updates the upstream server image from
-`2026.5.4`. The upstream release adds support for literal newlines in `server.motd`
-when values come from env files, refreshes bundled helper dependencies, and keeps
-the MOTD quoting documentation aligned with the runtime behavior. Review the
-upstream release notes before upgrading production servers, take a world backup,
-and verify plugins, mods, datapacks, proxy settings, and pinned `server.version`
-values in a staging environment before reusing existing PVCs.
+`docker.io/itzg/minecraft-server:2026.6.1` updates the upstream server image from
+`2026.6.0`. Review the upstream release notes before upgrading production servers,
+take a world backup, and verify plugins, mods, datapacks, proxy settings, and
+pinned `server.version` values in a staging environment before reusing existing PVCs.
 
 ## Security Scan
 

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.6.0
+          value: docker.io/itzg/minecraft-server:2026.6.1
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.6.0
+          value: docker.io/itzg/minecraft-server:2026.6.1
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.6.0
+          value: docker.io/itzg/minecraft-server:2026.6.1
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.6.0
+          value: docker.io/itzg/minecraft-server:2026.6.1
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.6.0"
+          "default": "2026.6.1"
         },
         "pullPolicy": {
           "type": "string",
@@ -634,7 +634,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.6.0"
+              "default": "docker.io/itzg/minecraft-server:2026.6.1"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.6.0"
+  tag: "2026.6.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -381,7 +381,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.6.0
+    worker: docker.io/itzg/minecraft-server:2026.6.1
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
## Upstream Image Update

Closes #602

| Field | Value |
|---|---|
| **Chart** | minecraft |
| **Previous** | 2026.6.0 |
| **New** | 2026.6.1 |
| **Image** | docker.io/itzg/minecraft-server:2026.6.1 |

### Upstream Evidence
- Image verified: `docker.io/itzg/minecraft-server:2026.6.1` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`minecraft: FULLY VALIDATED (17 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 7 CI variants)