### PR TITLE
chore(n8n): bump n8n to 2.28.3

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.5
-appVersion: "2.26.8"
+appVersion: "2.28.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#592)"
+      description: "bump n8n to 2.28.3"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.26.8"
+          value: "docker.io/n8nio/n8n:2.28.3"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.26.8"
+          value: "docker.io/n8nio/runners:2.28.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.26.8"
+          value: "docker.io/n8nio/runners:2.28.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.26.8"
+  tag: "2.28.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #603

| Field | Value |
|---|---|
| **Chart** | n8n |
| **Previous** | 2.26.8 |
| **New** | 2.28.3 |
| **Image** | docker.io/n8nio/n8n:2.28.3 |

### Upstream Evidence
- Image verified: `docker.io/n8nio/n8n:2.28.3` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`n8n: FULLY VALIDATED (20 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 9 CI variants incl. queue mode)