### PR TITLE
chore(ntfy): bump ntfy to v2.25.0

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -4,7 +4,7 @@ name: ntfy
 description: ntfy self-hosted push notification service with HTTP-based pub-sub
 type: application
 version: 1.1.10
-appVersion: "v2.24.0"
+appVersion: "v2.25.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ntfy to v2.24.0 (#482)"
+      description: "bump ntfy to v2.25.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/binwiederhier/ntfy:v2.24.0"
+          value: "docker.io/binwiederhier/ntfy:v2.25.0"
 
   - it: should pass serve argument
     template: templates/deployment.yaml

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
   # -- Image tag
-  tag: "v2.24.0"
+  tag: "v2.25.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Upstream Image Update

Closes #604

| Field | Value |
|---|---|
| **Chart** | ntfy |
| **Previous** | v2.24.0 |
| **New** | v2.25.0 |
| **Image** | docker.io/binwiederhier/ntfy:v2.25.0 |

### Upstream Evidence
- Image verified: `docker.io/binwiederhier/ntfy:v2.25.0` (linux/amd64, linux/arm64, linux/arm)

### Local Validation (GR-027)
`ntfy: FULLY VALIDATED (14 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 4 CI variants)