### PR TITLE
chore(olivetin): bump olivetin to 3000.16.1

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.12
-appVersion: "3000.15.0"
+appVersion: "3000.16.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump olivetin to 3000.15.0 (#585)"
+      description: "bump olivetin to 3000.16.1"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.15.0"
+          value: "docker.io/jamesread/olivetin:3000.16.1"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.15.0"
+  tag: "3000.16.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Upstream Image Update

Closes #605

| Field | Value |
|---|---|
| **Chart** | olivetin |
| **Previous** | 3000.15.0 |
| **New** | 3000.16.1 |
| **Image** | docker.io/jamesread/olivetin:3000.16.1 |

### Upstream Evidence
- Image verified: `docker.io/jamesread/olivetin:3000.16.1` (linux/amd64, linux/arm64, linux/arm)

### Local Validation (GR-027)
`olivetin: FULLY VALIDATED (15 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 5 CI variants)