### PR TITLE
chore(tomcat): bump tomcat to 11.0.23

### DIFF
--- a/charts/tomcat/Chart.yaml
+++ b/charts/tomcat/Chart.yaml
@@ -4,7 +4,7 @@ name: tomcat
 description: Apache Tomcat Helm chart with official image, Gateway API, JMX, and production controls
 type: application
 version: 1.0.2
-appVersion: "11.0.22"
+appVersion: "11.0.23"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,8 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/tomcat.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#544)"
+    - kind: changed
+      description: "bump tomcat to 11.0.23"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/tomcat:11.0.22-jdk17-temurin-noble
+          value: docker.io/library/tomcat:11.0.23-jdk17-temurin-noble
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Tomcat image repository. Uses the official Docker image.
   repository: docker.io/library/tomcat
   # -- Tomcat image tag.
-  tag: "11.0.22-jdk17-temurin-noble"
+  tag: "11.0.23-jdk17-temurin-noble"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #606

| Field | Value |
|---|---|
| **Chart** | tomcat |
| **Previous** | 11.0.22-jdk17-temurin-noble |
| **New** | 11.0.23-jdk17-temurin-noble |
| **Image** | docker.io/library/tomcat:11.0.23-jdk17-temurin-noble |

### Upstream Evidence
- Image verified: `docker.io/library/tomcat:11.0.23-jdk17-temurin-noble` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`tomcat: FULLY VALIDATED (16 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 6 CI variants)