### PR TITLE
chore(umami): bump umami to 3.2.0

### DIFF
--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -4,7 +4,7 @@ name: umami
 description: Umami privacy-first web analytics with PostgreSQL, Gateway API, External Secrets, backups, and production controls
 type: application
 version: 2.2.1
-appVersion: "3.1.0"
+appVersion: "3.2.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,7 +27,7 @@ icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#558)"
+      description: "bump umami to 3.2.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/umami-software/umami:3.1.0"
+          value: "ghcr.io/umami-software/umami:3.2.0"
 
   - it: should set custom image tag
     set:

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Umami container image
   repository: ghcr.io/umami-software/umami
   # -- Image tag
-  tag: "3.1.0"
+  tag: "3.2.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Upstream Image Update

Closes #607

| Field | Value |
|---|---|
| **Chart** | umami |
| **Previous** | 3.1.0 |
| **New** | 3.2.0 |
| **Image** | ghcr.io/umami-software/umami:3.2.0 |

### Upstream Evidence
- Image verified: `ghcr.io/umami-software/umami:3.2.0` (linux/amd64, linux/arm64)

### Local Validation (GR-027)
`umami: FULLY VALIDATED (19 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 8 CI variants)