### PR TITLE
chore(velero): bump velero to v1.18.2

### DIFF
--- a/charts/velero/Chart.yaml
+++ b/charts/velero/Chart.yaml
@@ -5,7 +5,7 @@ name: velero
 description: Velero Helm Chart for Kubernetes backup, restore, and migration with S3-compatible object storage
 type: application
 version: 1.4.9
-appVersion: "v1.18.1"
+appVersion: "v1.18.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/velero.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#529)"
+    - kind: changed
+      description: "bump velero to v1.18.2"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/velero/tests/deployment_test.yaml
+++ b/charts/velero/tests/deployment_test.yaml
@@ -10,7 +10,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/velero/velero:v1.18.1
+          value: docker.io/velero/velero:v1.18.2
       - contains:
           path: spec.template.spec.containers[0].args
           content: --uploader-type=kopia

--- a/charts/velero/values.yaml
+++ b/charts/velero/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- Velero server image repository
   repository: docker.io/velero/velero
   # -- Velero server image tag
-  tag: "v1.18.1"
+  tag: "v1.18.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Upstream Image Update

Closes #608

| Field | Value |
|---|---|
| **Chart** | velero |
| **Previous** | v1.18.1 |
| **New** | v1.18.2 |
| **Image** | docker.io/velero/velero:v1.18.2 |

### Upstream Evidence
- Image verified: `docker.io/velero/velero:v1.18.2` (linux/amd64, linux/arm64, linux/ppc64le)

### Local Validation (GR-027)
`velero: FULLY VALIDATED (14 layers)`
- All static layers PASS
- All k3d behavioral scenarios PASS (default + 4 CI variants)