### PR TITLE
feat(valkey): Added masterSet setting for Sentinel

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Added networkPolicy support (#590)"
+      description: "make Valkey Sentinel master set name configurable"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -230,6 +230,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `node.replicaCount` | Number of Valkey data nodes in sentinel mode | `3` |
 | `node.persistence.enabled` | Enable PVCs for sentinel data nodes | `false` |
 | `sentinel.replicaCount` | Number of Sentinel pods | `3` |
+| `sentinel.masterSet` | Sentinel master set name used by Sentinel clients | `mymaster` |
 | `sentinel.quorum` | Sentinel quorum | `2` |
 | `cluster.nodes` | Number of Valkey Cluster nodes | `6` |
 | `cluster.replicasPerMaster` | Valkey Cluster replicas per master | `1` |

--- a/charts/valkey/ci/sentinel.yaml
+++ b/charts/valkey/ci/sentinel.yaml
@@ -10,6 +10,7 @@ node:
 
 sentinel:
   replicaCount: 3
+  masterSet: ci-master
   quorum: 2
 
 pdb:

--- a/charts/valkey/docs/sentinel.md
+++ b/charts/valkey/docs/sentinel.md
@@ -69,6 +69,7 @@ Data node pod names are role-neutral: `-node-0` is only the seed master at cold 
 | `node.replicaCount` | Number of Valkey data nodes (use >= 2 for data HA) |
 | `node.persistence.enabled` | Data node PVCs (default `false`; peer discovery keeps topology safe without PVCs) |
 | `sentinel.replicaCount` | Number of Sentinel pods (independent of data nodes) |
+| `sentinel.masterSet` | Master set name that Sentinel clients use for primary discovery |
 | `sentinel.quorum` | Quorum for failover decisions |
 | `pdb.enabled` | Protection against planned disruption |
 | `metrics.enabled` | Exporter for monitoring |
@@ -88,6 +89,7 @@ node:
 
 sentinel:
   replicaCount: 3
+  masterSet: mymaster
   quorum: 2
 ```
 

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -52,6 +52,7 @@ Sentinel service:
 - Name: {{ include "valkey.sentinelServiceName" . }}
 - DNS: {{ include "valkey.sentinelServiceFqdn" . }}
 - Port: {{ .Values.service.ports.sentinel }}
+- Master set: {{ .Values.sentinel.masterSet }}
 - Data nodes: {{ include "valkey.nodeStatefulSetName" . }} ({{ .Values.node.replicaCount }} pods)
 - Seed master: {{ include "valkey.nodePodFqdn" . }}:{{ .Values.service.ports.valkey }}
 {{- if lt (int .Values.node.replicaCount) 2 }}
@@ -125,6 +126,10 @@ Use the primary service for writes and the replica service for read-only workloa
 Use the Sentinel service for Sentinel-aware clients:
 
   {{ include "valkey.sentinelServiceFqdn" . }}:{{ .Values.service.ports.sentinel }}
+
+Sentinel master set name:
+
+  {{ .Values.sentinel.masterSet }}
 
 Verify Sentinel can see the primary:
 

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -64,10 +64,10 @@ data:
     dir /tmp
     sentinel resolve-hostnames yes
     sentinel announce-hostnames yes
-    sentinel monitor mymaster {{ include "valkey.nodePodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}
-    sentinel down-after-milliseconds mymaster {{ .Values.sentinel.downAfterMilliseconds }}
-    sentinel failover-timeout mymaster {{ .Values.sentinel.failoverTimeout }}
-    sentinel parallel-syncs mymaster {{ .Values.sentinel.parallelSyncs }}
+    sentinel monitor {{ .Values.sentinel.masterSet }} {{ include "valkey.nodePodFqdn" . }} {{ .Values.service.ports.valkey }} {{ .Values.sentinel.quorum }}
+    sentinel down-after-milliseconds {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.downAfterMilliseconds }}
+    sentinel failover-timeout {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.failoverTimeout }}
+    sentinel parallel-syncs {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.parallelSyncs }}
     {{- with .Values.config.sentinel }}
     {{ . | nindent 4 }}
     {{- end }}

--- a/charts/valkey/templates/sentinel-node-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-node-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
               }
               sentinel_master=""
               for attempt in $(seq 1 30); do
-                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null | awk 'NR == 1 { print $1 }')"
                 [ -n "$sentinel_master" ] && break
                 echo "waiting for Sentinel master discovery ($attempt/30)"
                 sleep 2
@@ -148,7 +148,7 @@ spec:
               bootstrap_marker="/data/.helmforge-sentinel-node-bootstrapped"
               sentinel_master=""
               for attempt in $(seq 1 30); do
-                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null | awk 'NR == 1 { print $1 }')"
                 [ -n "$sentinel_master" ] && break
                 echo "waiting for Sentinel master discovery ($attempt/30)"
                 sleep 2

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -46,11 +46,11 @@ spec:
                 done
                 cp /etc/valkey-base/sentinel.conf /data/sentinel.conf
               else
-                persisted_monitor="$(grep '^sentinel monitor mymaster ' /data/sentinel.conf | tail -n 1 || true)"
+                persisted_monitor="$(grep '^sentinel monitor {{ .Values.sentinel.masterSet }} ' /data/sentinel.conf | tail -n 1 || true)"
                 append_sentinel_base() {
                   if [ -n "$persisted_monitor" ]; then
                     awk -v monitor="$persisted_monitor" '
-                      /^sentinel monitor mymaster / { print monitor; next }
+                      /^sentinel monitor {{ .Values.sentinel.masterSet }} / { print monitor; next }
                       { print }
                     ' /etc/valkey-base/sentinel.conf >> /data/sentinel.conf
                   else
@@ -71,17 +71,17 @@ spec:
                     -e '/^dir /d' \
                     -e '/^sentinel resolve-hostnames /d' \
                     -e '/^sentinel announce-hostnames /d' \
-                    -e '/^sentinel monitor mymaster /d' \
-                    -e '/^sentinel down-after-milliseconds mymaster /d' \
-                    -e '/^sentinel failover-timeout mymaster /d' \
-                    -e '/^sentinel parallel-syncs mymaster /d' \
+                    -e '/^sentinel monitor {{ .Values.sentinel.masterSet }} /d' \
+                    -e '/^sentinel down-after-milliseconds {{ .Values.sentinel.masterSet }} /d' \
+                    -e '/^sentinel failover-timeout {{ .Values.sentinel.masterSet }} /d' \
+                    -e '/^sentinel parallel-syncs {{ .Values.sentinel.masterSet }} /d' \
                     /data/sentinel.conf
                 fi
                 append_sentinel_base
               fi
               {{- if .Values.auth.enabled }}
-              sed -i '/^sentinel auth-pass mymaster /d' /data/sentinel.conf
-              echo "sentinel auth-pass mymaster ${VALKEY_PASSWORD}" >> /data/sentinel.conf
+              sed -i '/^sentinel auth-pass {{ .Values.sentinel.masterSet }} /d' /data/sentinel.conf
+              echo "sentinel auth-pass {{ .Values.sentinel.masterSet }} ${VALKEY_PASSWORD}" >> /data/sentinel.conf
               {{- end }}
               exec valkey-sentinel /data/sentinel.conf
           ports:

--- a/charts/valkey/tests/cluster_domain_test.yaml
+++ b/charts/valkey/tests/cluster_domain_test.yaml
@@ -9,7 +9,7 @@ templates:
   - cluster-init-job.yaml
 release:
   name: test
-  namespace: custom-ns
+  namespace: valkey-ns
 tests:
   - it: should use custom cluster domain in sentinel configuration
     template: configmap.yaml
@@ -19,7 +19,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor mymaster test-valkey-node-0\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
+          pattern: "sentinel monitor mymaster test-valkey-node-0\\.test-valkey-headless\\.valkey-ns\\.svc\\.corp\\.internal 6379 2"
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "sentinel resolve-hostnames yes"
@@ -35,7 +35,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: '--replicaof "test-valkey-primary-0\.test-valkey-headless\.custom-ns\.svc\.corp\.internal" 6379'
+          pattern: '--replicaof "test-valkey-primary-0\.test-valkey-headless\.valkey-ns\.svc\.corp\.internal" 6379'
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "svc\\.cluster\\.local"
@@ -48,7 +48,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'seeding from test-valkey-node-0\.test-valkey-headless\.custom-ns\.svc\.corp\.internal'
+          pattern: 'seeding from test-valkey-node-0\.test-valkey-headless\.valkey-ns\.svc\.corp\.internal'
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "svc\\.cluster\\.local"
@@ -63,7 +63,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: VALKEY_PRIMARY_HOST
-            value: test-valkey-node-0.test-valkey-headless.custom-ns.svc.corp.internal
+            value: test-valkey-node-0.test-valkey-headless.valkey-ns.svc.corp.internal
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "until valkey-cli \\$VALKEY_TLS_ARGS -h \"\\$VALKEY_PRIMARY_HOST\""
@@ -76,7 +76,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "$(POD_NAME).test-valkey-headless.custom-ns.svc.corp.internal"
+          content: "$(POD_NAME).test-valkey-headless.valkey-ns.svc.corp.internal"
 
   - it: should use custom cluster domain in cluster init job
     template: cluster-init-job.yaml
@@ -86,7 +86,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "test-valkey-cluster-\\$\\{i\\}\\.test-valkey-headless\\.custom-ns\\.svc\\.corp\\.internal"
+          pattern: "test-valkey-cluster-\\$\\{i\\}\\.test-valkey-headless\\.valkey-ns\\.svc\\.corp\\.internal"
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "svc\\.cluster\\.local"

--- a/charts/valkey/tests/cluster_init_test.yaml
+++ b/charts/valkey/tests/cluster_init_test.yaml
@@ -4,7 +4,7 @@ templates:
   - cluster-init-job.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should add missing nodes during cluster scale-up
     set:

--- a/charts/valkey/tests/config_rollout_test.yaml
+++ b/charts/valkey/tests/config_rollout_test.yaml
@@ -10,7 +10,7 @@ templates:
   - configmap.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should checksum config in standalone pod template
     template: standalone-statefulset.yaml

--- a/charts/valkey/tests/extra_manifests_test.yaml
+++ b/charts/valkey/tests/extra_manifests_test.yaml
@@ -4,7 +4,7 @@ templates:
   - extra-manifests.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should render extra manifests through tpl
     set:
@@ -24,7 +24,7 @@ tests:
           value: test-extra
       - equal:
           path: metadata.namespace
-          value: default
+          value: valkey-ns
       - equal:
           path: data.release
           value: test

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -9,7 +9,7 @@ templates:
   - configmap.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should render extra env and volumes in replication pods
     set:
@@ -157,7 +157,7 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor mymaster test-valkey-node-0\\.test-valkey-headless\\.default\\.svc\\.cluster\\.local 6379 3"
+          pattern: "sentinel monitor mymaster test-valkey-node-0\\.test-valkey-headless\\.valkey-ns\\.svc\\.cluster\\.local 6379 3"
         template: configmap.yaml
       - matchRegex:
           path: data["sentinel.conf"]
@@ -245,7 +245,7 @@ tests:
         template: sentinel-node-statefulset.yaml
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: "seeding from test-valkey-node-0\\.test-valkey-headless\\.default\\.svc\\.cluster\\.local"
+          pattern: "seeding from test-valkey-node-0\\.test-valkey-headless\\.valkey-ns\\.svc\\.cluster\\.local"
         template: sentinel-node-statefulset.yaml
 
   - it: should monitor the seed master node in sentinel pods
@@ -254,7 +254,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
-          value: test-valkey-node-0.test-valkey-headless.default.svc.cluster.local
+          value: test-valkey-node-0.test-valkey-headless.valkey-ns.svc.cluster.local
         template: sentinel-statefulset.yaml
 
   - it: should keep fixed replicaof in replication mode

--- a/charts/valkey/tests/pdb_test.yaml
+++ b/charts/valkey/tests/pdb_test.yaml
@@ -4,7 +4,7 @@ templates:
   - pdb.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should not create PDB by default
     asserts:

--- a/charts/valkey/tests/secret_test.yaml
+++ b/charts/valkey/tests/secret_test.yaml
@@ -4,7 +4,7 @@ templates:
   - secret.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should be a Secret
     asserts:

--- a/charts/valkey/tests/security_context_test.yaml
+++ b/charts/valkey/tests/security_context_test.yaml
@@ -9,7 +9,7 @@ templates:
   - configmap.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should render restricted-compatible metrics sidecar security contexts
     set:

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -5,7 +5,7 @@ templates:
   - sentinel-node-statefulset.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should render a role-neutral node StatefulSet in sentinel mode
     template: sentinel-node-statefulset.yaml
@@ -150,3 +150,32 @@ tests:
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "sentinel announce-hostnames yes"
+
+  - it: should render a custom Sentinel master set in sentinel.conf
+    template: configmap.yaml
+    set:
+      architecture: sentinel
+      sentinel.masterSet: legacy-master
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel monitor legacy-master test-valkey-node-0\\.test-valkey-headless\\.valkey-ns\\.svc\\.cluster\\.local 6379 2"
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel down-after-milliseconds legacy-master 60000"
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel failover-timeout legacy-master 180000"
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel parallel-syncs legacy-master 1"
+
+  - it: should use the custom Sentinel master set for auth-pass
+    template: sentinel-statefulset.yaml
+    set:
+      architecture: sentinel
+      sentinel.masterSet: legacy-master
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "sentinel auth-pass legacy-master \\$\\{VALKEY_PASSWORD\\}"

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -2,6 +2,7 @@
 suite: Sentinel Node StatefulSet
 templates:
   - configmap.yaml
+  - sentinel-statefulset.yaml
   - sentinel-node-statefulset.yaml
 release:
   name: test

--- a/charts/valkey/tests/service_test.yaml
+++ b/charts/valkey/tests/service_test.yaml
@@ -4,7 +4,7 @@ templates:
   - service.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should render headless and sentinel services only in sentinel mode
     set:

--- a/charts/valkey/tests/servicemonitor_test.yaml
+++ b/charts/valkey/tests/servicemonitor_test.yaml
@@ -4,7 +4,7 @@ templates:
   - servicemonitor.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should select only the dedicated metrics service
     set:

--- a/charts/valkey/tests/standalone_statefulset_test.yaml
+++ b/charts/valkey/tests/standalone_statefulset_test.yaml
@@ -5,7 +5,7 @@ templates:
   - configmap.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should be a StatefulSet in standalone mode
     template: standalone-statefulset.yaml

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -4,7 +4,7 @@ templates:
   - templates/tests/test-connection.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should render a helm test pod by default
     asserts:

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -10,7 +10,7 @@ templates:
   - templates/tests/test-connection.yaml
 release:
   name: test
-  namespace: default
+  namespace: valkey-ns
 tests:
   - it: should make standalone probes use valkey-cli TLS flags
     template: standalone-statefulset.yaml

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -223,6 +223,12 @@
           "type": "integer",
           "description": "Number of sentinel replicas"
         },
+        "masterSet": {
+          "type": "string",
+          "description": "Sentinel master set name used by Sentinel clients",
+          "minLength": 1,
+          "pattern": "^[A-Za-z0-9._-]+$"
+        },
         "quorum": {
           "type": "integer",
           "description": "Quorum for sentinel failover"

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -148,6 +148,8 @@ node:
 sentinel:
   # -- Number of Sentinel pods
   replicaCount: 3
+  # -- Sentinel master set name used by Sentinel clients
+  masterSet: mymaster
   # -- Sentinel quorum required for failover decisions
   quorum: 2
   # -- Milliseconds before Sentinel marks the primary as subjectively down


### PR DESCRIPTION
## Summary

Added `masterSet` setting for Valkey Sentinel, implemented just as in Redis chart.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO