### PR TITLE
feat(notediscovery): add chart

### DIFF
--- a/charts/notediscovery/.helmignore
+++ b/charts/notediscovery/.helmignore
@@ -1,0 +1,6 @@
+.git/
+.github/
+.DS_Store
+*.tmp
+*.bak
+charts/

--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
@@ -22,7 +23,7 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/category: skip-prediction
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"
   artifacthub.io/changes: |
     - kind: added

--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: notediscovery
+description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
+type: application
+version: 1.0.0
+appVersion: "0.27.3"
+home: https://helmforge.dev/docs/charts/notediscovery
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
+  - https://github.com/gamosoft/NoteDiscovery
+  - https://www.notediscovery.com
+keywords:
+  - notes
+  - knowledge-base
+  - markdown
+  - mcp
+  - self-hosted
+  - kubernetes
+maintainers:
+  - name: HelmForge Team
+    url: https://helmforge.dev
+icon: https://helmforge.dev/icons/charts/notediscovery.png
+annotations:
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/license: MIT
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/changes: |
+    - kind: added
+      description: Initial NoteDiscovery chart
+  helmforge.dev/maturity: beta

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,0 +1,78 @@
+# NoteDiscovery Chart Design
+
+This chart deploys NoteDiscovery as a self-hosted knowledge base using the official `ghcr.io/gamosoft/notediscovery:0.27.3` image.
+
+## Product Model
+
+NoteDiscovery serves the UI and API from one Python process and stores durable Markdown notes and related data in a local data directory. The upstream Docker workflow mounts `/app/data` and exposes HTTP on port `8000`.
+
+The chart therefore treats the application as a single-writer workload by default. It uses a Deployment with `Recreate` strategy and a chart-managed PersistentVolumeClaim. `Recreate` avoids overlapping writes during rollouts for the default single-replica topology.
+
+## Runtime Configuration
+
+Upstream NoteDiscovery reads `config.yaml`. The chart renders that file in two modes:
+
+- unauthenticated installs use a ConfigMap
+- authenticated installs use a Secret
+
+`auth.existingSecret` points at a Secret containing a complete `config.yaml`. The chart does not split individual auth keys into separate environment variables because the upstream contract is file-based and keeping the full file together avoids partially duplicated configuration paths.
+
+## Default Topology
+
+Defaults target a production-style single instance:
+
+- `replicaCount: 1`
+- `persistence.enabled: true`
+- data mounted at `/app/data`
+- generated unauthenticated config for local bootstrap
+- non-root UID/GID `1000`
+- ServiceAccount token automount disabled
+
+Authentication remains opt-in because the upstream app is often first configured locally. Documentation and examples show Secret-backed auth for shared deployments.
+
+## Scaling
+
+The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set. Generated PVCs are single workload claims and do not prove that a storage backend is safe for multiple writers.
+
+Operators that scale NoteDiscovery must provide their own claim and choose storage semantics appropriate for the workload, typically ReadWriteMany storage. The chart keeps the default topology single-replica because note files are durable local state.
+
+## Exposure
+
+The chart supports:
+
+- ClusterIP, NodePort, or LoadBalancer Service
+- Kubernetes Ingress with `ingressClassName`
+- Gateway API HTTPRoute
+- dual-stack Service fields
+
+`notediscovery.allowedOrigins` should be restricted to the public HTTPS origin when exposing the app through a reverse proxy.
+
+## External Secrets
+
+External Secrets support renders `ExternalSecret` resources that can materialize the complete `config.yaml` Secret. The expected production pattern is:
+
+- `auth.existingSecret` names the target Secret
+- `externalSecrets.items[].spec.target.name` materializes the same Secret
+- `externalSecrets.items[].spec.data[].secretKey` is `config.yaml`
+
+This keeps sensitive configuration outside the chart values while preserving the upstream config-file contract.
+
+## Security Choices
+
+The chart uses a non-root security context, drops Linux capabilities, disables ServiceAccount token automount, and supports NetworkPolicy. `readOnlyRootFilesystem` remains false because the upstream Python application and image may need write access outside the mounted note directory during startup.
+
+## Validation Scope
+
+The chart has template tests for:
+
+- official pinned image
+- generated ConfigMap and Secret config
+- existing config Secret references
+- invalid scaling and auth combinations
+- ExternalSecret rendering
+- Gateway API HTTPRoute
+- NetworkPolicy
+- dual-stack Service fields
+- Ingress TLS rendering
+
+Behavioral validation uses the default single-replica topology because it can run in an isolated k3d cluster without external secret manager dependencies.

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,12 +1,18 @@
 # NoteDiscovery Chart Design
 
-This chart deploys NoteDiscovery as a self-hosted knowledge base using the official `ghcr.io/gamosoft/notediscovery:0.27.3` image.
+This chart deploys NoteDiscovery as a self-hosted knowledge base using the
+official `ghcr.io/gamosoft/notediscovery:0.27.3` image.
 
 ## Product Model
 
-NoteDiscovery serves the UI and API from one Python process and stores durable Markdown notes and related data in a local data directory. The upstream Docker workflow mounts `/app/data` and exposes HTTP on port `8000`.
+NoteDiscovery serves the UI and API from one Python process and stores durable
+Markdown notes and related data in a local data directory. The upstream Docker
+workflow mounts `/app/data` and exposes HTTP on port `8000`.
 
-The chart therefore treats the application as a single-writer workload by default. It uses a Deployment with `Recreate` strategy and a chart-managed PersistentVolumeClaim. `Recreate` avoids overlapping writes during rollouts for the default single-replica topology.
+The chart therefore treats the application as a single-writer workload by
+default. It uses a Deployment with `Recreate` strategy and a chart-managed
+PersistentVolumeClaim. `Recreate` avoids overlapping writes during rollouts for
+the default single-replica topology.
 
 ## Runtime Configuration
 
@@ -15,7 +21,10 @@ Upstream NoteDiscovery reads `config.yaml`. The chart renders that file in two m
 - unauthenticated installs use a ConfigMap
 - authenticated installs use a Secret
 
-`auth.existingSecret` points at a Secret containing a complete `config.yaml`. The chart does not split individual auth keys into separate environment variables because the upstream contract is file-based and keeping the full file together avoids partially duplicated configuration paths.
+`auth.existingSecret` points at a Secret containing a complete `config.yaml`.
+The chart does not split individual auth keys into separate environment
+variables because the upstream contract is file-based. Keeping the full file
+together avoids partially duplicated configuration paths.
 
 ## Default Topology
 
@@ -28,13 +37,20 @@ Defaults target a production-style single instance:
 - non-root UID/GID `1000`
 - ServiceAccount token automount disabled
 
-Authentication remains opt-in because the upstream app is often first configured locally. Documentation and examples show Secret-backed auth for shared deployments.
+Authentication remains opt-in because the upstream app is often first configured
+locally. Documentation and examples show Secret-backed auth for shared
+deployments.
 
 ## Scaling
 
-The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set. Generated PVCs are single workload claims and do not prove that a storage backend is safe for multiple writers.
+The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set.
+Generated PVCs are single workload claims and do not prove that a storage
+backend is safe for multiple writers.
 
-Operators that scale NoteDiscovery must provide their own claim and choose storage semantics appropriate for the workload, typically ReadWriteMany storage. The chart keeps the default topology single-replica because note files are durable local state.
+Operators that scale NoteDiscovery must provide their own claim and choose
+storage semantics appropriate for the workload, typically ReadWriteMany storage.
+The chart keeps the default topology single-replica because note files are
+durable local state.
 
 ## Exposure
 
@@ -45,11 +61,13 @@ The chart supports:
 - Gateway API HTTPRoute
 - dual-stack Service fields
 
-`notediscovery.allowedOrigins` should be restricted to the public HTTPS origin when exposing the app through a reverse proxy.
+`notediscovery.allowedOrigins` should be restricted to the public HTTPS origin
+when exposing the app through a reverse proxy.
 
 ## External Secrets
 
-External Secrets support renders `ExternalSecret` resources that can materialize the complete `config.yaml` Secret. The expected production pattern is:
+External Secrets support renders `ExternalSecret` resources that can materialize
+the complete `config.yaml` Secret. The expected production pattern is:
 
 - `auth.existingSecret` names the target Secret
 - `externalSecrets.items[].spec.target.name` materializes the same Secret
@@ -59,7 +77,11 @@ This keeps sensitive configuration outside the chart values while preserving the
 
 ## Security Choices
 
-The chart uses a non-root security context, drops Linux capabilities, disables ServiceAccount token automount, and supports NetworkPolicy. `readOnlyRootFilesystem` remains false because the upstream Python application and image may need write access outside the mounted note directory during startup.
+The chart uses a non-root security context, drops Linux capabilities, disables
+ServiceAccount token automount, and supports NetworkPolicy.
+`readOnlyRootFilesystem` remains false because the upstream Python application
+and image may need write access outside the mounted note directory during
+startup.
 
 ## Validation Scope
 
@@ -75,4 +97,5 @@ The chart has template tests for:
 - dual-stack Service fields
 - Ingress TLS rendering
 
-Behavioral validation uses the default single-replica topology because it can run in an isolated k3d cluster without external secret manager dependencies.
+Behavioral validation uses the default single-replica topology because it can
+run in an isolated k3d cluster without external secret manager dependencies.

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -1,12 +1,20 @@
 # NoteDiscovery Helm Chart
 
-Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration.
+Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
+self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
+integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.27.3` image and exposes the runtime settings that matter for Kubernetes: persistent note storage, generated or externally managed `config.yaml`, optional authentication, ingress/Gateway API exposure, network policy, pod disruption budget, and non-root security context.
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.27.3` image
+and exposes the runtime settings that matter for Kubernetes: persistent note
+storage, generated or externally managed `config.yaml`, optional authentication,
+ingress/Gateway API exposure, network policy, pod disruption budget, and
+non-root security context.
 
 ## Architecture
 
-NoteDiscovery runs as one Python web service listening on port `8000`. The upstream container stores durable notes and related files under `/app/data` and reads application settings from `/app/config.yaml`.
+NoteDiscovery runs as one Python web service listening on port `8000`. The
+upstream container stores durable notes and related files under `/app/data` and
+reads application settings from `/app/config.yaml`.
 
 The default chart topology is intentionally conservative:
 
@@ -16,7 +24,10 @@ The default chart topology is intentionally conservative:
 - ServiceAccount token automount disabled
 - non-root container security context
 
-When authentication is enabled, the generated `config.yaml` is stored in a Kubernetes Secret so `secret_key`, `password`, and `api_key` are not rendered into a ConfigMap. For GitOps and production, prefer `auth.existingSecret` with a complete `config.yaml` key.
+When authentication is enabled, the generated `config.yaml` is stored in a
+Kubernetes Secret so `secret_key`, `password`, and `api_key` are not rendered
+into a ConfigMap. For GitOps and production, prefer `auth.existingSecret` with a
+complete `config.yaml` key.
 
 ## Install
 
@@ -110,7 +121,9 @@ stringData:
 
 ## Authentication
 
-`auth.enabled=false` is the default so first-time local installs start without credentials. For any shared or internet-facing deployment, enable authentication and provide either:
+`auth.enabled=false` is the default so first-time local installs start without
+credentials. For any shared or internet-facing deployment, enable authentication
+and provide either:
 
 - `auth.secretKey` and `auth.password`, which render into a chart-managed Secret
 - `auth.existingSecret`, which must contain a complete `config.yaml`
@@ -119,9 +132,13 @@ stringData:
 
 ## Storage
 
-Back up the PersistentVolumeClaim before upgrades. NoteDiscovery stores notes and local application data under `/app/data` by default.
+Back up the PersistentVolumeClaim before upgrades. NoteDiscovery stores notes
+and local application data under `/app/data` by default.
 
-The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set. Multiple pods require storage semantics chosen by the operator, typically a shared ReadWriteMany claim; the default generated claim is a single-writer volume.
+The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set.
+Multiple pods require storage semantics chosen by the operator, typically a
+shared ReadWriteMany claim; the default generated claim is a single-writer
+volume.
 
 ## Documentation
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -1,0 +1,142 @@
+# NoteDiscovery Helm Chart
+
+Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration.
+
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.27.3` image and exposes the runtime settings that matter for Kubernetes: persistent note storage, generated or externally managed `config.yaml`, optional authentication, ingress/Gateway API exposure, network policy, pod disruption budget, and non-root security context.
+
+## Architecture
+
+NoteDiscovery runs as one Python web service listening on port `8000`. The upstream container stores durable notes and related files under `/app/data` and reads application settings from `/app/config.yaml`.
+
+The default chart topology is intentionally conservative:
+
+- one Deployment replica with `Recreate` rollout strategy
+- one PersistentVolumeClaim mounted at `/app/data`
+- generated ConfigMap for unauthenticated `config.yaml`
+- ServiceAccount token automount disabled
+- non-root container security context
+
+When authentication is enabled, the generated `config.yaml` is stored in a Kubernetes Secret so `secret_key`, `password`, and `api_key` are not rendered into a ConfigMap. For GitOps and production, prefer `auth.existingSecret` with a complete `config.yaml` key.
+
+## Install
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm install notediscovery helmforge/notediscovery
+```
+
+Forward the service for local validation:
+
+```bash
+kubectl port-forward svc/notediscovery 8000:8000
+```
+
+Then open `http://127.0.0.1:8000`.
+
+## Production Values
+
+```yaml
+notediscovery:
+  allowedOrigins:
+    - https://notes.example.com
+
+auth:
+  enabled: true
+  existingSecret: notediscovery-config
+  existingSecretKey: config.yaml
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: notes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: notediscovery-tls
+      hosts:
+        - notes.example.com
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1
+    memory: 1Gi
+
+networkPolicy:
+  enabled: true
+```
+
+Create the existing Secret with a complete NoteDiscovery config file:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: notediscovery-config
+type: Opaque
+stringData:
+  config.yaml: |
+    app:
+      name: "NoteDiscovery"
+    server:
+      host: "0.0.0.0"
+      port: 8000
+      reload: false
+      allowed_origins:
+        - https://notes.example.com
+      debug: false
+    storage:
+      notes_dir: "/app/data"
+      plugins_dir: "./plugins"
+    search:
+      enabled: true
+    ui:
+      autosave_delay_ms: 1000
+    authentication:
+      enabled: true
+      secret_key: "replace-with-a-long-random-secret"
+      password: "replace-with-a-strong-password"
+      session_max_age: 604800
+      api_key: ""
+```
+
+## Authentication
+
+`auth.enabled=false` is the default so first-time local installs start without credentials. For any shared or internet-facing deployment, enable authentication and provide either:
+
+- `auth.secretKey` and `auth.password`, which render into a chart-managed Secret
+- `auth.existingSecret`, which must contain a complete `config.yaml`
+
+`auth.existingSecret` is preferred for production because it avoids putting secret values in Helm values files.
+
+## Storage
+
+Back up the PersistentVolumeClaim before upgrades. NoteDiscovery stores notes and local application data under `/app/data` by default.
+
+The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set. Multiple pods require storage semantics chosen by the operator, typically a shared ReadWriteMany claim; the default generated claim is a single-writer volume.
+
+## Documentation
+
+- [Storage](docs/storage.md)
+- [Authentication](docs/authentication.md)
+- [Exposure](docs/exposure.md)
+- [MCP integration](docs/mcp.md)
+
+## Security Scan: `notediscovery`
+
+| Framework | Score |
+|---|---|
+| Overall | **87.37%** |
+| MITRE | **100.00%** |
+| NSA | **82.50%** |
+| SOC2 | **86.67%** |
+
+> Security posture acceptable.

--- a/charts/notediscovery/ci/auth-values.yaml
+++ b/charts/notediscovery/ci/auth-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  enabled: true
+  secretKey: test-session-secret-change-me
+  password: test-password-change-me
+  apiKey: test-api-key

--- a/charts/notediscovery/ci/default-values.yaml
+++ b/charts/notediscovery/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/charts/notediscovery/ci/dual-stack.yaml
+++ b/charts/notediscovery/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  # Keep this scenario portable across IPv4-only and dual-stack k3d clusters.
+  # Explicit ipFamilies rendering is covered by unit tests because Kubernetes
+  # rejects IPv6 entries on clusters that do not advertise IPv6.
+  ipFamilyPolicy: PreferDualStack

--- a/charts/notediscovery/ci/existing-config-secret.yaml
+++ b/charts/notediscovery/ci/existing-config-secret.yaml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  existingSecret: notediscovery-existing-config
+  existingSecretKey: config.yaml
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: notediscovery-existing-config
+    type: Opaque
+    stringData:
+      config.yaml: |
+        app:
+          name: "NoteDiscovery"
+        server:
+          host: "0.0.0.0"
+          port: 8000
+          reload: false
+          allowed_origins:
+            - "*"
+          debug: false
+        storage:
+          notes_dir: "/app/data"
+          plugins_dir: "./plugins"
+        search:
+          enabled: true
+        ui:
+          autosave_delay_ms: 1000
+        authentication:
+          enabled: false
+          secret_key: ""
+          password: ""
+          session_max_age: 604800
+          api_key: ""

--- a/charts/notediscovery/ci/external-secrets.yaml
+++ b/charts/notediscovery/ci/external-secrets.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  existingSecret: notediscovery-config
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: helmforge-fake-store
+        target:
+          name: notediscovery-config
+          creationPolicy: Owner
+          template:
+            data:
+              config.yaml: |
+                app:
+                  name: "NoteDiscovery"
+                server:
+                  host: "0.0.0.0"
+                  port: 8000
+                  reload: false
+                  allowed_origins:
+                    - "*"
+                  debug: false
+                storage:
+                  notes_dir: "/app/data"
+                  plugins_dir: "./plugins"
+                search:
+                  enabled: true
+                ui:
+                  autosave_delay_ms: 1000
+                authentication:
+                  enabled: true
+                  secret_key: "{{ .token }}"
+                  password: "{{ .password }}"
+                  session_max_age: 604800
+                  api_key: "{{ .token }}"
+        data:
+          - secretKey: password
+            remoteRef:
+              key: test/password
+          - secretKey: token
+            remoteRef:
+              key: test/token

--- a/charts/notediscovery/ci/gateway-api-values.yaml
+++ b/charts/notediscovery/ci/gateway-api-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - notediscovery.example.test
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/notediscovery/ci/ingress-values.yaml
+++ b/charts/notediscovery/ci/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: notediscovery.example.test
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: notediscovery-tls
+      hosts:
+        - notediscovery.example.test

--- a/charts/notediscovery/ci/networkpolicy.yaml
+++ b/charts/notediscovery/ci/networkpolicy.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system

--- a/charts/notediscovery/ci/persistence-disabled.yaml
+++ b/charts/notediscovery/ci/persistence-disabled.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false

--- a/charts/notediscovery/docs/authentication.md
+++ b/charts/notediscovery/docs/authentication.md
@@ -1,0 +1,53 @@
+# NoteDiscovery Authentication
+
+Authentication is disabled by default for local bootstrap. Enable it for shared, team, or internet-facing deployments.
+
+## Chart-Managed Secret
+
+```yaml
+auth:
+  enabled: true
+  secretKey: replace-with-a-long-random-secret
+  password: replace-with-a-strong-password
+  apiKey: ""
+```
+
+When `auth.enabled=true`, the chart stores the generated `config.yaml` in a Kubernetes Secret.
+
+## Existing Secret
+
+For production and GitOps, prefer an existing Secret containing a complete `config.yaml`:
+
+```yaml
+auth:
+  existingSecret: notediscovery-config
+  existingSecretKey: config.yaml
+```
+
+The Secret must contain every runtime setting that NoteDiscovery expects, not just authentication fields.
+
+## External Secrets
+
+When using External Secrets Operator, materialize the same complete config file into the Secret referenced by `auth.existingSecret`:
+
+```yaml
+auth:
+  existingSecret: notediscovery-config
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: production
+        target:
+          name: notediscovery-config
+          creationPolicy: Owner
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: apps/notediscovery
+              property: config.yaml
+```

--- a/charts/notediscovery/docs/exposure.md
+++ b/charts/notediscovery/docs/exposure.md
@@ -1,0 +1,55 @@
+# NoteDiscovery Exposure
+
+The chart exposes NoteDiscovery through a Kubernetes Service and optionally through Ingress or Gateway API.
+
+## Service
+
+```yaml
+service:
+  type: ClusterIP
+  port: 8000
+```
+
+Dual-stack settings are available through `service.ipFamilyPolicy` and `service.ipFamilies`.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: notes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: notediscovery-tls
+      hosts:
+        - notes.example.com
+```
+
+Set `notediscovery.allowedOrigins` to the public HTTPS origin:
+
+```yaml
+notediscovery:
+  allowedOrigins:
+    - https://notes.example.com
+```
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - notes.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix
+```
+
+Each `httpRoutes` item renders one HTTPRoute. Set `rules` for advanced Gateway API routing when the default path-to-service route is not enough.

--- a/charts/notediscovery/docs/mcp.md
+++ b/charts/notediscovery/docs/mcp.md
@@ -1,0 +1,17 @@
+# NoteDiscovery MCP Integration
+
+NoteDiscovery includes MCP integration in the upstream application. The Helm chart does not create separate MCP resources; it deploys the upstream web application and its persistent data volume.
+
+Use `auth.apiKey` or an existing `config.yaml` Secret when MCP clients or automation need API-key access:
+
+```yaml
+auth:
+  enabled: true
+  secretKey: replace-with-a-long-random-secret
+  password: replace-with-a-strong-password
+  apiKey: replace-with-a-long-random-api-key
+```
+
+For production, prefer `auth.existingSecret` so the API key is not stored in Helm values.
+
+Restrict network access with Ingress authentication, Gateway policy, or `networkPolicy.enabled=true` when exposing MCP-capable endpoints outside a trusted network.

--- a/charts/notediscovery/docs/storage.md
+++ b/charts/notediscovery/docs/storage.md
@@ -1,6 +1,8 @@
 # NoteDiscovery Storage
 
-NoteDiscovery stores durable notes and local application data under `/app/data` by default. The chart mounts that path from a PersistentVolumeClaim when `persistence.enabled=true`.
+NoteDiscovery stores durable notes and local application data under `/app/data`
+by default. The chart mounts that path from a PersistentVolumeClaim when
+`persistence.enabled=true`.
 
 ## Default PVC
 
@@ -16,7 +18,8 @@ The generated claim uses the cluster default StorageClass unless `persistence.st
 
 ## Existing Claim
 
-Use an existing claim when storage must be pre-provisioned, shared, snapshotted by a storage controller, or retained independently of Helm release lifecycle:
+Use an existing claim when storage must be pre-provisioned, shared, snapshotted
+by a storage controller, or retained independently of Helm release lifecycle:
 
 ```yaml
 persistence:
@@ -25,8 +28,12 @@ persistence:
 
 ## Scaling
 
-The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set. Scaling requires an operator-managed storage backend with semantics appropriate for multiple writers.
+The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set.
+Scaling requires an operator-managed storage backend with semantics appropriate
+for multiple writers.
 
 ## Backups
 
-Back up the PersistentVolumeClaim before upgrades and before changing storage settings. For production, prefer volume snapshots from the storage backend or a backup controller that can capture the `/app/data` contents consistently.
+Back up the PersistentVolumeClaim before upgrades and before changing storage
+settings. For production, prefer volume snapshots from the storage backend or a
+backup controller that can capture the `/app/data` contents consistently.

--- a/charts/notediscovery/docs/storage.md
+++ b/charts/notediscovery/docs/storage.md
@@ -1,0 +1,32 @@
+# NoteDiscovery Storage
+
+NoteDiscovery stores durable notes and local application data under `/app/data` by default. The chart mounts that path from a PersistentVolumeClaim when `persistence.enabled=true`.
+
+## Default PVC
+
+```yaml
+persistence:
+  enabled: true
+  size: 5Gi
+  accessModes:
+    - ReadWriteOnce
+```
+
+The generated claim uses the cluster default StorageClass unless `persistence.storageClass` is set.
+
+## Existing Claim
+
+Use an existing claim when storage must be pre-provisioned, shared, snapshotted by a storage controller, or retained independently of Helm release lifecycle:
+
+```yaml
+persistence:
+  existingClaim: notediscovery-data
+```
+
+## Scaling
+
+The chart blocks `replicaCount > 1` unless `persistence.existingClaim` is set. Scaling requires an operator-managed storage backend with semantics appropriate for multiple writers.
+
+## Backups
+
+Back up the PersistentVolumeClaim before upgrades and before changing storage settings. For production, prefer volume snapshots from the storage backend or a backup controller that can capture the `/app/data` contents consistently.

--- a/charts/notediscovery/examples/existing-secret.yaml
+++ b/charts/notediscovery/examples/existing-secret.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  existingSecret: notediscovery-config
+  existingSecretKey: config.yaml

--- a/charts/notediscovery/examples/gateway-api.yaml
+++ b/charts/notediscovery/examples/gateway-api.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+notediscovery:
+  allowedOrigins:
+    - https://notes.example.com
+
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - notes.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/notediscovery/examples/ingress.yaml
+++ b/charts/notediscovery/examples/ingress.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+notediscovery:
+  allowedOrigins:
+    - https://notes.example.com
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: notes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: notediscovery-tls
+      hosts:
+        - notes.example.com

--- a/charts/notediscovery/examples/secured.yaml
+++ b/charts/notediscovery/examples/secured.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  enabled: true
+  secretKey: replace-with-a-long-random-secret
+  password: replace-with-a-strong-password
+
+persistence:
+  enabled: true
+  size: 20Gi
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1
+    memory: 1Gi

--- a/charts/notediscovery/examples/simple.yaml
+++ b/charts/notediscovery/examples/simple.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: true
+  size: 5Gi

--- a/charts/notediscovery/templates/NOTES.txt
+++ b/charts/notediscovery/templates/NOTES.txt
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+NoteDiscovery release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Workload:
+  kubectl get deploy {{ include "notediscovery.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl rollout status deploy/{{ include "notediscovery.fullname" . }} -n {{ .Release.Namespace }}
+
+Service:
+  kubectl get svc {{ include "notediscovery.fullname" . }} -n {{ .Release.Namespace }}
+
+Local access:
+  kubectl port-forward svc/{{ include "notediscovery.fullname" . }} 8000:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+  Open http://127.0.0.1:8000
+
+Runtime configuration:
+  Data directory: {{ .Values.persistence.mountPath }}
+  Search enabled: {{ .Values.notediscovery.searchEnabled }}
+  Authentication enabled: {{ .Values.auth.enabled }}
+
+Persistence:
+{{- if .Values.persistence.existingClaim }}
+  Existing PVC {{ .Values.persistence.existingClaim }} is mounted.
+{{- else if .Values.persistence.enabled }}
+  PVC is enabled. Back up the data volume before upgrades.
+{{- else }}
+  Persistence is disabled and NoteDiscovery data is stored in an emptyDir.
+{{- end }}
+
+Troubleshooting:
+  kubectl logs deploy/{{ include "notediscovery.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl describe pod -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Validation:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+  make validate-chart CHART=notediscovery
+
+Happy Helmforging :)

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -111,7 +111,9 @@ HTTPRoute name helper.
 {{- $route := .route -}}
 {{- $index := .index | default 0 -}}
 {{- if $route.name -}}
-{{- printf "%s-%s" (include "notediscovery.fullname" $root) $route.name | trunc 63 | trimSuffix "-" -}}
+{{- $suffix := printf "-%s" $route.name -}}
+{{- $base := include "notediscovery.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
 {{- else if gt (int $index) 0 -}}
 {{- $suffix := printf "-%d" (int $index) -}}
 {{- $base := include "notediscovery.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
@@ -131,7 +133,9 @@ ExternalSecret name helper.
 {{- if $item.fullnameOverride -}}
 {{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else if $item.name -}}
-{{- printf "%s-%s" (include "notediscovery.fullname" $root) $item.name | trunc 63 | trimSuffix "-" -}}
+{{- $suffix := printf "-%s" $item.name -}}
+{{- $base := include "notediscovery.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
 {{- else if gt $index 0 -}}
 {{- $suffix := printf "-%d" $index -}}
 {{- $base := include "notediscovery.configName" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -1,0 +1,137 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "notediscovery.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "notediscovery.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "notediscovery.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "notediscovery.labels" -}}
+helm.sh/chart: {{ include "notediscovery.chart" . }}
+{{ include "notediscovery.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "notediscovery.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "notediscovery.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "notediscovery.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "notediscovery.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Configuration resource name.
+*/}}
+{{- define "notediscovery.configName" -}}
+{{- printf "%s-config" (include "notediscovery.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Rendered config source name. Auth uses Secret; non-auth uses ConfigMap.
+*/}}
+{{- define "notediscovery.configSourceName" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecret -}}
+{{- else -}}
+{{- include "notediscovery.configName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Rendered config source key.
+*/}}
+{{- define "notediscovery.configSourceKey" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- .Values.auth.existingSecretKey -}}
+{{- else -}}
+config.yaml
+{{- end -}}
+{{- end -}}
+
+{{/*
+HTTPRoute name helper.
+*/}}
+{{- define "notediscovery.httpRouteName" -}}
+{{- $root := .root -}}
+{{- $route := .route -}}
+{{- $index := .index | default 0 -}}
+{{- if $route.name -}}
+{{- printf "%s-%s" (include "notediscovery.fullname" $root) $route.name | trunc 63 | trimSuffix "-" -}}
+{{- else if gt (int $index) 0 -}}
+{{- printf "%s-%d" (include "notediscovery.fullname" $root) $index | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "notediscovery.fullname" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ExternalSecret name helper.
+*/}}
+{{- define "notediscovery.externalSecretName" -}}
+{{- $root := .root -}}
+{{- $item := .item -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if $item.name -}}
+{{- printf "%s-%s" (include "notediscovery.fullname" $root) $item.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- include "notediscovery.configName" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate chart values.
+*/}}
+{{- define "notediscovery.validate" -}}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.persistence.existingClaim) -}}
+{{- fail "replicaCount > 1 requires persistence.existingClaim because NoteDiscovery stores notes as local files on a single writable volume" -}}
+{{- end -}}
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) (or (empty .Values.auth.secretKey) (empty .Values.auth.password)) -}}
+{{- fail "auth.secretKey and auth.password are required when auth.enabled=true unless auth.existingSecret is set" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) -}}
+{{- fail "externalSecrets.items must contain at least one item when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -113,7 +113,9 @@ HTTPRoute name helper.
 {{- if $route.name -}}
 {{- printf "%s-%s" (include "notediscovery.fullname" $root) $route.name | trunc 63 | trimSuffix "-" -}}
 {{- else if gt (int $index) 0 -}}
-{{- printf "%s-%d" (include "notediscovery.fullname" $root) $index | trunc 63 | trimSuffix "-" -}}
+{{- $suffix := printf "-%d" (int $index) -}}
+{{- $base := include "notediscovery.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
 {{- else -}}
 {{- include "notediscovery.fullname" $root -}}
 {{- end -}}
@@ -131,7 +133,9 @@ ExternalSecret name helper.
 {{- else if $item.name -}}
 {{- printf "%s-%s" (include "notediscovery.fullname" $root) $item.name | trunc 63 | trimSuffix "-" -}}
 {{- else if gt $index 0 -}}
-{{- printf "%s-%d" (include "notediscovery.configName" $root) $index | trunc 63 | trimSuffix "-" -}}
+{{- $suffix := printf "-%d" $index -}}
+{{- $base := include "notediscovery.configName" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
 {{- else -}}
 {{- include "notediscovery.configName" $root -}}
 {{- end -}}

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -125,10 +125,13 @@ ExternalSecret name helper.
 {{- define "notediscovery.externalSecretName" -}}
 {{- $root := .root -}}
 {{- $item := .item -}}
+{{- $index := int (.index | default 0) -}}
 {{- if $item.fullnameOverride -}}
 {{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else if $item.name -}}
 {{- printf "%s-%s" (include "notediscovery.fullname" $root) $item.name | trunc 63 | trimSuffix "-" -}}
+{{- else if gt $index 0 -}}
+{{- printf "%s-%d" (include "notediscovery.configName" $root) $index | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- include "notediscovery.configName" $root -}}
 {{- end -}}

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -95,7 +95,7 @@ Configuration checksum for pod rollouts.
 */}}
 {{- define "notediscovery.configChecksum" -}}
 {{- if .Values.auth.existingSecret -}}
-{{- dict "existingSecret" .Values.auth.existingSecret "existingSecretKey" .Values.auth.existingSecretKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum -}}
+{{- dict "existingSecret" .Values.auth.existingSecret "existingSecretKey" .Values.auth.existingSecretKey "externalSecrets" .Values.externalSecrets "extraManifests" .Values.extraManifests | toJson | sha256sum -}}
 {{- else if .Values.auth.enabled -}}
 {{- include (print .Template.BasePath "/secret.yaml") . | sha256sum -}}
 {{- else -}}

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -91,6 +91,19 @@ config.yaml
 {{- end -}}
 
 {{/*
+Configuration checksum for pod rollouts.
+*/}}
+{{- define "notediscovery.configChecksum" -}}
+{{- if .Values.auth.existingSecret -}}
+{{- dict "existingSecret" .Values.auth.existingSecret "existingSecretKey" .Values.auth.existingSecretKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum -}}
+{{- else if .Values.auth.enabled -}}
+{{- include (print .Template.BasePath "/secret.yaml") . | sha256sum -}}
+{{- else -}}
+{{- include (print .Template.BasePath "/configmap.yaml") . | sha256sum -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 HTTPRoute name helper.
 */}}
 {{- define "notediscovery.httpRouteName" -}}

--- a/charts/notediscovery/templates/configmap.yaml
+++ b/charts/notediscovery/templates/configmap.yaml
@@ -1,0 +1,34 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "notediscovery.validate" . }}
+{{- if and (not .Values.auth.enabled) (not .Values.auth.existingSecret) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "notediscovery.configName" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    app:
+      name: {{ .Values.notediscovery.appName | quote }}
+    server:
+      host: "0.0.0.0"
+      port: {{ .Values.app.port }}
+      reload: false
+      allowed_origins:
+        {{- toYaml .Values.notediscovery.allowedOrigins | nindent 8 }}
+      debug: {{ .Values.notediscovery.debug }}
+    storage:
+      notes_dir: {{ .Values.persistence.mountPath | quote }}
+      plugins_dir: "./plugins"
+    search:
+      enabled: {{ .Values.notediscovery.searchEnabled }}
+    ui:
+      autosave_delay_ms: {{ .Values.notediscovery.autosaveDelayMs }}
+    authentication:
+      enabled: false
+      secret_key: ""
+      password: ""
+      session_max_age: {{ .Values.auth.sessionMaxAge }}
+      api_key: ""
+{{- end }}

--- a/charts/notediscovery/templates/deployment.yaml
+++ b/charts/notediscovery/templates/deployment.yaml
@@ -19,10 +19,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include "notediscovery.configChecksum" . }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "notediscovery.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/notediscovery/templates/deployment.yaml
+++ b/charts/notediscovery/templates/deployment.yaml
@@ -1,0 +1,160 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "notediscovery.fullname" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "notediscovery.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "notediscovery.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "notediscovery.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: {{ include "notediscovery.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.app.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.app.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.port }}
+              protocol: TCP
+          env:
+            - name: TZ
+              value: {{ .Values.app.timezone | quote }}
+            - name: PORT
+              value: {{ .Values.app.port | quote }}
+            {{- range .Values.app.env }}
+            - name: {{ .name }}
+              {{- if hasKey . "valueFrom" }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- else }}
+              value: {{ default "" .value | quote }}
+              {{- end }}
+            {{- end }}
+          {{- with .Values.app.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath | quote }}
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: {{ include "notediscovery.configSourceKey" . | quote }}
+              readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | quote }}
+          {{- else if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "notediscovery.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: config
+          {{- if or .Values.auth.enabled .Values.auth.existingSecret }}
+          secret:
+            secretName: {{ include "notediscovery.configSourceName" . | quote }}
+          {{- else }}
+          configMap:
+            name: {{ include "notediscovery.configSourceName" . | quote }}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/notediscovery/templates/externalsecret.yaml
+++ b/charts/notediscovery/templates/externalsecret.yaml
@@ -1,7 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
+{{- $externalSecretNames := dict }}
 {{- range $index, $item := .Values.externalSecrets.items | default list }}
 {{- $externalSecretName := include "notediscovery.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- if hasKey $externalSecretNames $externalSecretName }}
+{{- fail (printf "externalSecrets.items render duplicate ExternalSecret name %q; set name or fullnameOverride to a unique value" $externalSecretName) }}
+{{- end }}
+{{- $_ := set $externalSecretNames $externalSecretName true }}
 {{- $spec := deepCopy ($item.spec | default dict) }}
 {{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
 {{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}

--- a/charts/notediscovery/templates/externalsecret.yaml
+++ b/charts/notediscovery/templates/externalsecret.yaml
@@ -1,8 +1,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
-{{- range .Values.externalSecrets.items | default list }}
-{{- $externalSecretName := include "notediscovery.externalSecretName" (dict "root" $ "item" .) }}
-{{- $spec := deepCopy (.spec | default dict) }}
+{{- range $index, $item := .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "notediscovery.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
 {{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
 {{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
 {{- end }}
@@ -35,10 +35,10 @@ metadata:
   name: {{ $externalSecretName }}
   labels:
     {{- include "notediscovery.labels" $ | nindent 4 }}
-    {{- with .labels }}
+    {{- with $item.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .annotations }}
+  {{- with $item.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/notediscovery/templates/externalsecret.yaml
+++ b/charts/notediscovery/templates/externalsecret.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "notediscovery.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "notediscovery.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/notediscovery/templates/extra-manifests.yaml
+++ b/charts/notediscovery/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/notediscovery/templates/gateway-httproute.yaml
+++ b/charts/notediscovery/templates/gateway-httproute.yaml
@@ -1,14 +1,20 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gatewayAPI.enabled }}
+{{- $httpRouteNames := dict }}
 {{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
 {{- if not $route.parentRefs }}{{- fail "gatewayAPI.httpRoutes[].parentRefs is required" }}{{- end }}
+{{- $httpRouteName := include "notediscovery.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+{{- if hasKey $httpRouteNames $httpRouteName }}
+{{- fail (printf "gatewayAPI.httpRoutes render duplicate HTTPRoute name %q; set name to a unique value" $httpRouteName) }}
+{{- end }}
+{{- $_ := set $httpRouteNames $httpRouteName true }}
 {{- if gt $index 0 }}
 ---
 {{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ include "notediscovery.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+  name: {{ $httpRouteName }}
   labels:
     {{- include "notediscovery.labels" $ | nindent 4 }}
   {{- with $route.annotations }}

--- a/charts/notediscovery/templates/gateway-httproute.yaml
+++ b/charts/notediscovery/templates/gateway-httproute.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
+{{- if not $route.parentRefs }}{{- fail "gatewayAPI.httpRoutes[].parentRefs is required" }}{{- end }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "notediscovery.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+  labels:
+    {{- include "notediscovery.labels" $ | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.rules }}
+    {{- toYaml $route.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: {{ default "PathPrefix" $route.pathType }}
+            value: {{ default "/" $route.path | quote }}
+      backendRefs:
+        - name: {{ include "notediscovery.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/notediscovery/templates/ingress.yaml
+++ b/charts/notediscovery/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "notediscovery.fullname" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "notediscovery.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/notediscovery/templates/ingress.yaml
+++ b/charts/notediscovery/templates/ingress.yaml
@@ -21,9 +21,10 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          {{- $paths := default (list (dict "path" "/" "pathType" "Prefix")) .paths }}
+          {{- range $paths }}
+          - path: {{ default "/" .path }}
+            pathType: {{ default "Prefix" .pathType }}
             backend:
               service:
                 name: {{ include "notediscovery.fullname" $ }}

--- a/charts/notediscovery/templates/networkpolicy.yaml
+++ b/charts/notediscovery/templates/networkpolicy.yaml
@@ -1,0 +1,25 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "notediscovery.fullname" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "notediscovery.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+{{- end }}

--- a/charts/notediscovery/templates/pdb.yaml
+++ b/charts/notediscovery/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "notediscovery.fullname" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "notediscovery.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/notediscovery/templates/pvc.yaml
+++ b/charts/notediscovery/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "notediscovery.fullname" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/notediscovery/templates/secret.yaml
+++ b/charts/notediscovery/templates/secret.yaml
@@ -1,0 +1,35 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "notediscovery.validate" . }}
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "notediscovery.configName" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  config.yaml: |
+    app:
+      name: {{ .Values.notediscovery.appName | quote }}
+    server:
+      host: "0.0.0.0"
+      port: {{ .Values.app.port }}
+      reload: false
+      allowed_origins:
+        {{- toYaml .Values.notediscovery.allowedOrigins | nindent 8 }}
+      debug: {{ .Values.notediscovery.debug }}
+    storage:
+      notes_dir: {{ .Values.persistence.mountPath | quote }}
+      plugins_dir: "./plugins"
+    search:
+      enabled: {{ .Values.notediscovery.searchEnabled }}
+    ui:
+      autosave_delay_ms: {{ .Values.notediscovery.autosaveDelayMs }}
+    authentication:
+      enabled: true
+      secret_key: {{ .Values.auth.secretKey | quote }}
+      password: {{ .Values.auth.password | quote }}
+      session_max_age: {{ .Values.auth.sessionMaxAge }}
+      api_key: {{ .Values.auth.apiKey | quote }}
+{{- end }}

--- a/charts/notediscovery/templates/service.yaml
+++ b/charts/notediscovery/templates/service.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "notediscovery.fullname" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "notediscovery.selectorLabels" . | nindent 4 }}

--- a/charts/notediscovery/templates/serviceaccount.yaml
+++ b/charts/notediscovery/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "notediscovery.serviceAccountName" . }}
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/notediscovery/templates/tests/test-connection.yaml
+++ b/charts/notediscovery/templates/tests/test-connection.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "notediscovery.fullname" . }}-test-connection
+  labels:
+    {{- include "notediscovery.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  containers:
+    - name: wget
+      image: busybox:1.37.0
+      command:
+        - wget
+      args:
+        - -qO-
+        - http://{{ include "notediscovery.fullname" . }}:{{ .Values.service.port }}/health
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/notediscovery/templates/validate.yaml
+++ b/charts/notediscovery/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "notediscovery.validate" . -}}

--- a/charts/notediscovery/tests/auth-values.yaml
+++ b/charts/notediscovery/tests/auth-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  enabled: true
+  secretKey: test-session-secret-change-me
+  password: test-password-change-me
+  apiKey: test-api-key

--- a/charts/notediscovery/tests/auth_test.yaml
+++ b/charts/notediscovery/tests/auth_test.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery auth configuration
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+  - templates/secret.yaml
+tests:
+  - it: stores generated authenticated config in a Secret
+    values:
+      - auth-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/configmap.yaml
+      - isKind:
+          of: Secret
+        template: templates/secret.yaml
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: "enabled: true"
+        template: templates/secret.yaml
+      - equal:
+          path: spec.template.spec.volumes[1].secret.secretName
+          value: RELEASE-NAME-notediscovery-config
+        template: templates/deployment.yaml
+  - it: mounts an existing complete config Secret
+    values:
+      - existing-config-secret-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/configmap.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/secret.yaml
+      - equal:
+          path: spec.template.spec.volumes[1].secret.secretName
+          value: notediscovery-config
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].subPath
+          value: config.yaml
+        template: templates/deployment.yaml

--- a/charts/notediscovery/tests/common-labels-values.yaml
+++ b/charts/notediscovery/tests/common-labels-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+commonLabels:
+  review: enabled

--- a/charts/notediscovery/tests/dual-stack-values.yaml
+++ b/charts/notediscovery/tests/dual-stack-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/notediscovery/tests/existing-config-secret-values.yaml
+++ b/charts/notediscovery/tests/existing-config-secret-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  existingSecret: notediscovery-config
+  existingSecretKey: config.yaml

--- a/charts/notediscovery/tests/external-secrets-colliding-config-index-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-colliding-config-index-values.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery/config
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: notediscovery/token
+    - name: config-1
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config-1.yaml
+            remoteRef:
+              key: notediscovery/named-config-1

--- a/charts/notediscovery/tests/external-secrets-colliding-config-name-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-colliding-config-name-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery/config
+    - name: config
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery/named-config

--- a/charts/notediscovery/tests/external-secrets-default-target-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-default-target-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery
+              property: config.yaml

--- a/charts/notediscovery/tests/external-secrets-fullname-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-fullname-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: literal-notediscovery-config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery
+              property: config.yaml

--- a/charts/notediscovery/tests/external-secrets-long-name-named-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-long-name-named-values.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery/config
+    - name: token
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: notediscovery/token

--- a/charts/notediscovery/tests/external-secrets-long-name-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-long-name-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery/config
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: notediscovery/token

--- a/charts/notediscovery/tests/external-secrets-multiple-unnamed-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-multiple-unnamed-values.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery/config
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: notediscovery/token

--- a/charts/notediscovery/tests/external-secrets-values.yaml
+++ b/charts/notediscovery/tests/external-secrets-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+auth:
+  existingSecret: RELEASE-NAME-notediscovery-config
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        target:
+          name: RELEASE-NAME-notediscovery-config
+          creationPolicy: Owner
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: notediscovery
+              property: config.yaml

--- a/charts/notediscovery/tests/external_secrets_test.yaml
+++ b/charts/notediscovery/tests/external_secrets_test.yaml
@@ -71,6 +71,28 @@ tests:
           path: spec.target.name
           value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
         documentIndex: 1
+  - it: reserves suffix room for named ExternalSecrets with a long fullname
+    values:
+      - external-secrets-long-name-named-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-config
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-token
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-token
+        documentIndex: 1
   - it: uses fullnameOverride literally
     values:
       - external-secrets-fullname-values.yaml

--- a/charts/notediscovery/tests/external_secrets_test.yaml
+++ b/charts/notediscovery/tests/external_secrets_test.yaml
@@ -31,6 +31,28 @@ tests:
       - equal:
           path: spec.target.name
           value: RELEASE-NAME-notediscovery-config
+  - it: gives multiple unnamed ExternalSecrets unique fallback names
+    values:
+      - external-secrets-multiple-unnamed-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-notediscovery-config
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-notediscovery-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-notediscovery-config-1
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-notediscovery-config-1
+        documentIndex: 1
   - it: uses fullnameOverride literally
     values:
       - external-secrets-fullname-values.yaml

--- a/charts/notediscovery/tests/external_secrets_test.yaml
+++ b/charts/notediscovery/tests/external_secrets_test.yaml
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery external secrets
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: renders an ExternalSecret for a complete config file
+    values:
+      - external-secrets-values.yaml
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.secretStoreRef.name
+          value: fake
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-notediscovery-config
+      - equal:
+          path: spec.data[0].secretKey
+          value: config.yaml
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+  - it: defaults target name to the rendered ExternalSecret name
+    values:
+      - external-secrets-default-target-values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-notediscovery-config
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-notediscovery-config
+  - it: uses fullnameOverride literally
+    values:
+      - external-secrets-fullname-values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: literal-notediscovery-config
+      - equal:
+          path: spec.target.name
+          value: literal-notediscovery-config
+  - it: fails without a secretStoreRef or sourceRef
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items[0].spec.data[0].secretKey: config.yaml
+      externalSecrets.items[0].spec.data[0].remoteRef.key: notediscovery
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"

--- a/charts/notediscovery/tests/external_secrets_test.yaml
+++ b/charts/notediscovery/tests/external_secrets_test.yaml
@@ -103,6 +103,18 @@ tests:
       - equal:
           path: spec.target.name
           value: literal-notediscovery-config
+  - it: fails when a named ExternalSecret collides with the unnamed config fallback
+    values:
+      - external-secrets-colliding-config-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items render duplicate ExternalSecret name \"RELEASE-NAME-notediscovery-config\"; set name or fullnameOverride to a unique value"
+  - it: fails when a named ExternalSecret collides with an indexed unnamed fallback
+    values:
+      - external-secrets-colliding-config-index-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items render duplicate ExternalSecret name \"RELEASE-NAME-notediscovery-config-1\"; set name or fullnameOverride to a unique value"
   - it: fails without a secretStoreRef or sourceRef
     set:
       externalSecrets.enabled: true

--- a/charts/notediscovery/tests/external_secrets_test.yaml
+++ b/charts/notediscovery/tests/external_secrets_test.yaml
@@ -53,6 +53,24 @@ tests:
           path: spec.target.name
           value: RELEASE-NAME-notediscovery-config-1
         documentIndex: 1
+  - it: reserves suffix room for unnamed ExternalSecrets with a long config name
+    values:
+      - external-secrets-long-name-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
   - it: uses fullnameOverride literally
     values:
       - external-secrets-fullname-values.yaml

--- a/charts/notediscovery/tests/gateway-colliding-index-name-values.yaml
+++ b/charts/notediscovery/tests/gateway-colliding-index-name-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: "1"
+      parentRefs:
+        - name: public
+      path: /named-index
+    - parentRefs:
+        - name: internal
+      path: /unnamed-index

--- a/charts/notediscovery/tests/gateway-long-name-named-values.yaml
+++ b/charts/notediscovery/tests/gateway-long-name-named-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: public
+      parentRefs:
+        - name: public
+      path: /
+    - name: internal
+      parentRefs:
+        - name: internal
+      path: /internal

--- a/charts/notediscovery/tests/gateway-long-name-values.yaml
+++ b/charts/notediscovery/tests/gateway-long-name-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: public
+      path: /
+    - parentRefs:
+        - name: internal
+      path: /internal

--- a/charts/notediscovery/tests/gateway-values.yaml
+++ b/charts/notediscovery/tests/gateway-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - notediscovery.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/notediscovery/tests/gateway_test.yaml
+++ b/charts/notediscovery/tests/gateway_test.yaml
@@ -32,3 +32,17 @@ tests:
           path: metadata.name
           value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
         documentIndex: 1
+  - it: reserves suffix room for named routes with a long fullname
+    values:
+      - gateway-long-name-named-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-public
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-internal
+        documentIndex: 1

--- a/charts/notediscovery/tests/gateway_test.yaml
+++ b/charts/notediscovery/tests/gateway_test.yaml
@@ -46,3 +46,9 @@ tests:
           path: metadata.name
           value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-internal
         documentIndex: 1
+  - it: fails when a named route collides with an indexed unnamed fallback
+    values:
+      - gateway-colliding-index-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.httpRoutes render duplicate HTTPRoute name \"RELEASE-NAME-notediscovery-1\"; set name to a unique value"

--- a/charts/notediscovery/tests/gateway_test.yaml
+++ b/charts/notediscovery/tests/gateway_test.yaml
@@ -18,3 +18,17 @@ tests:
       - equal:
           path: spec.rules[0].backendRefs[0].port
           value: 8000
+  - it: reserves suffix room for multiple unnamed routes with a long fullname
+    values:
+      - gateway-long-name-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1

--- a/charts/notediscovery/tests/gateway_test.yaml
+++ b/charts/notediscovery/tests/gateway_test.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery gateway api
+templates:
+  - templates/gateway-httproute.yaml
+tests:
+  - it: renders an HTTPRoute to the chart service
+    values:
+      - gateway-values.yaml
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-notediscovery
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8000

--- a/charts/notediscovery/tests/ingress-host-only-values.yaml
+++ b/charts/notediscovery/tests/ingress-host-only-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: notediscovery.example.com

--- a/charts/notediscovery/tests/ingress-values.yaml
+++ b/charts/notediscovery/tests/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: notediscovery.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: notediscovery-tls
+      hosts:
+        - notediscovery.example.com

--- a/charts/notediscovery/tests/networkpolicy-values.yaml
+++ b/charts/notediscovery/tests/networkpolicy-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system

--- a/charts/notediscovery/tests/networkpolicy_test.yaml
+++ b/charts/notediscovery/tests/networkpolicy_test.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery network policy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: limits inbound NoteDiscovery HTTP traffic
+    values:
+      - networkpolicy-values.yaml
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: http

--- a/charts/notediscovery/tests/service_test.yaml
+++ b/charts/notediscovery/tests/service_test.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders dual-stack service settings
+    values:
+      - dual-stack-values.yaml
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery base templates
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+  - templates/ingress.yaml
+  - templates/pvc.yaml
+  - templates/service.yaml
+tests:
+  - it: renders the official pinned image
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/gamosoft/notediscovery:0.27.3
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+  - it: renders the default ClusterIP service
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+  - it: renders common labels on a separate line
+    template: templates/service.yaml
+    values:
+      - common-labels-values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.review
+          value: enabled
+  - it: renders the default config as a ConfigMap
+    template: templates/configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "enabled: false"
+  - it: renders ingress TLS
+    template: templates/ingress.yaml
+    values:
+      - ingress-values.yaml
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: notediscovery-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: notediscovery.example.com
+  - it: uses emptyDir when persistence is disabled
+    template: templates/deployment.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: data
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+  - it: creates a PVC when persistence is chart-managed
+    template: templates/pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -56,6 +56,20 @@ tests:
       - equal:
           path: spec.tls[0].hosts[0]
           value: notediscovery.example.com
+  - it: defaults ingress host paths when omitted
+    template: templates/ingress.yaml
+    values:
+      - ingress-host-only-values.yaml
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-notediscovery
   - it: uses emptyDir when persistence is disabled
     template: templates/deployment.yaml
     set:

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -18,6 +18,9 @@ tests:
       - equal:
           path: spec.strategy.type
           value: Recreate
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: "^[a-f0-9]{64}$"
   - it: renders the default ClusterIP service
     template: templates/service.yaml
     asserts:

--- a/charts/notediscovery/tests/validation_test.yaml
+++ b/charts/notediscovery/tests/validation_test.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: fails when scaling without shared storage
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "replicaCount > 1 requires persistence.existingClaim because NoteDiscovery stores notes as local files on a single writable volume"
+  - it: fails when auth is missing generated credentials
+    set:
+      auth.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "auth.secretKey and auth.password are required when auth.enabled=true unless auth.existingSecret is set"
+  - it: fails when ExternalSecrets is enabled without items
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items must contain at least one item when externalSecrets.enabled=true"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "NoteDiscovery Helm Chart Values",
+  "description": "Values for the NoteDiscovery self-hosted knowledge base chart",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
+        "tag": { "type": "string", "default": "0.27.3", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "replicaCount": { "type": "integer", "minimum": 1, "default": 1 },
+    "app": {
+      "type": "object",
+      "properties": {
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 8000 },
+        "timezone": { "type": "string", "default": "UTC" },
+        "command": { "type": "array", "items": { "type": "string" } },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string" },
+              "value": { "type": "string" },
+              "valueFrom": { "type": "object" }
+            }
+          }
+        },
+        "envFrom": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "notediscovery": {
+      "type": "object",
+      "properties": {
+        "appName": { "type": "string", "default": "NoteDiscovery" },
+        "allowedOrigins": { "type": "array", "items": { "type": "string" } },
+        "debug": { "type": "boolean", "default": false },
+        "searchEnabled": { "type": "boolean", "default": true },
+        "autosaveDelayMs": { "type": "integer", "minimum": 0, "default": 1000 }
+      }
+    },
+    "auth": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "secretKey": { "type": "string", "default": "" },
+        "password": { "type": "string", "default": "" },
+        "apiKey": { "type": "string", "default": "" },
+        "sessionMaxAge": { "type": "integer", "minimum": 1, "default": 604800 },
+        "existingSecret": { "type": "string", "default": "" },
+        "existingSecretKey": { "type": "string", "default": "config.yaml" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "5Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"] } },
+        "existingClaim": { "type": "string", "default": "" },
+        "mountPath": { "type": "string", "default": "/app/data" }
+      }
+    },
+    "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+    "service": { "$ref": "#/definitions/service" },
+    "ingress": { "$ref": "#/definitions/ingress" },
+    "gatewayAPI": { "$ref": "#/definitions/gatewayAPI" },
+    "externalSecrets": { "$ref": "#/definitions/externalSecrets" },
+    "probes": { "$ref": "#/definitions/probes" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "pdb": { "$ref": "#/definitions/pdb" },
+    "networkPolicy": { "$ref": "#/definitions/networkPolicy" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0, "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
+  },
+  "definitions": {
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": true },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean", "default": false }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 8000 },
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "httpRoutes": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "items": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "startup": { "$ref": "#/definitions/probe" },
+        "liveness": { "$ref": "#/definitions/probe" },
+        "readiness": { "$ref": "#/definitions/probe" }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "minAvailable": { "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }] }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressFrom": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  }
+}

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# -- Override the chart name used in Kubernetes object names.
+nameOverride: ""
+
+# -- Override the full release name used in Kubernetes object names.
+fullnameOverride: ""
+
+# -- Extra labels applied to all Kubernetes objects rendered by this chart.
+commonLabels: {}
+
+image:
+  # -- Official NoteDiscovery container image repository.
+  repository: ghcr.io/gamosoft/notediscovery
+  # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
+  tag: "0.27.3"
+  # -- Kubernetes image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Optional image pull secrets for private registries or mirrored images.
+imagePullSecrets: []
+
+# -- Number of NoteDiscovery pods. Keep 1 because notes are local markdown files on a single writable volume.
+replicaCount: 1
+
+app:
+  # -- HTTP port exposed by NoteDiscovery inside the container.
+  port: 8000
+  # -- Timezone passed to the container.
+  timezone: UTC
+  # -- Optional command override. Leave empty to use the upstream image entrypoint.
+  command: []
+  # -- Optional argument override. Leave empty to use the upstream image defaults.
+  args: []
+  # -- Additional environment variables for advanced upstream flags.
+  env: []
+  # -- Additional envFrom sources such as Secret or ConfigMap references.
+  envFrom: []
+
+notediscovery:
+  # -- Display name shown by the application.
+  appName: NoteDiscovery
+  # -- Allowed CORS origins. Use specific HTTPS origins for production.
+  allowedOrigins:
+    - "*"
+  # -- Enable debug responses. Keep disabled in production.
+  debug: false
+  # -- Enable the built-in search index.
+  searchEnabled: true
+  # -- Autosave debounce in milliseconds.
+  autosaveDelayMs: 1000
+
+auth:
+  # -- Require login before users can access notes.
+  enabled: false
+  # -- Session secret key. Required when auth.enabled=true unless auth.existingSecret is set.
+  secretKey: ""
+  # -- Login password. Required when auth.enabled=true unless auth.existingSecret is set.
+  password: ""
+  # -- Optional API key for integrations. Empty disables API key authentication.
+  apiKey: ""
+  # -- Session max age in seconds.
+  sessionMaxAge: 604800
+  # -- Existing Secret containing a complete config.yaml key.
+  existingSecret: ""
+  # -- Key in auth.existingSecret containing the complete NoteDiscovery config file.
+  existingSecretKey: config.yaml
+
+persistence:
+  # -- Persist markdown notes, images, drawings, and application data.
+  enabled: true
+  # -- PersistentVolumeClaim size for /app/data.
+  size: 5Gi
+  # -- StorageClass for the generated PersistentVolumeClaim. Empty uses the cluster default.
+  storageClass: ""
+  # -- Access modes for the generated PersistentVolumeClaim.
+  accessModes:
+    - ReadWriteOnce
+  # -- Existing PersistentVolumeClaim to mount instead of creating a new claim.
+  existingClaim: ""
+  # -- Container data directory used by upstream NoteDiscovery.
+  mountPath: /app/data
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- ServiceAccount name. Defaults to the release fullname when create=true.
+  name: ""
+  # -- Annotations for the ServiceAccount.
+  annotations: {}
+  # -- Mount the ServiceAccount token in the pod.
+  automountServiceAccountToken: false
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Service port.
+  port: 8000
+  # -- Service annotations.
+  annotations: {}
+  # -- IP family policy. Options: SingleStack, PreferDualStack, RequireDualStack.
+  ipFamilyPolicy: ""
+  # -- Ordered list of IP families, for example ["IPv4", "IPv6"].
+  ipFamilies: []
+
+ingress:
+  # -- Enable Kubernetes Ingress.
+  enabled: false
+  # -- IngressClassName for the generated Ingress.
+  ingressClassName: traefik
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Ingress hosts and paths.
+  hosts: []
+  # -- Ingress TLS blocks.
+  tls: []
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute templates.
+  enabled: false
+  # -- List of HTTPRoute definitions. Each item is rendered as one HTTPRoute.
+  httpRoutes: []
+
+externalSecrets:
+  # -- Render external-secrets.io ExternalSecret resources.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Default sync interval applied to items without their own value.
+  refreshInterval: 1h
+  # -- List of ExternalSecret definitions. Each item carries a complete spec.
+  items: []
+
+probes:
+  # -- Startup probe settings.
+  startup:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 30
+  # -- Liveness probe settings.
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # -- Readiness probe settings.
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+# -- Container resource requests and limits.
+resources: {}
+
+# -- Pod security context.
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+
+# -- Container security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+pdb:
+  # -- Create a PodDisruptionBudget.
+  enabled: false
+  # -- Minimum available pods during voluntary disruptions.
+  minAvailable: 1
+
+networkPolicy:
+  # -- Create a NetworkPolicy that restricts inbound HTTP traffic to NoteDiscovery.
+  enabled: false
+  # -- Custom ingress peers. Empty allows ingress from any namespace.
+  ingressFrom: []
+
+# -- Node selector for scheduling the pod.
+nodeSelector: {}
+
+# -- Tolerations for scheduling the pod.
+tolerations: []
+
+# -- Affinity rules for scheduling the pod.
+affinity: {}
+
+# -- Topology spread constraints for scheduling the pod.
+topologySpreadConstraints: []
+
+# -- Optional PriorityClass name.
+priorityClassName: ""
+
+# -- Pod termination grace period in seconds.
+terminationGracePeriodSeconds: 30
+
+# -- Extra labels applied to the pod template.
+podLabels: {}
+
+# -- Extra annotations applied to the pod template.
+podAnnotations: {}
+
+# -- Extra volumes mounted into the pod.
+extraVolumes: []
+
+# -- Extra volume mounts added to the NoteDiscovery container.
+extraVolumeMounts: []
+
+# -- Additional Kubernetes manifests rendered with the chart.
+extraManifests: []


### PR DESCRIPTION
## Summary
- Add a production-oriented NoteDiscovery Helm chart using the official `ghcr.io/gamosoft/notediscovery:0.27.3` image.
- Include config-file based runtime support, optional Secret-backed auth, PVC storage, Ingress, Gateway API, External Secrets, NetworkPolicy, PDB, docs, examples, CI scenarios, schema, and unit tests.
- Add local security scan evidence to the chart README.

## Related
- Closes helmforgedev/charts#627
- Site sync: helmforgedev/site#314
- Org profile sync: helmforgedev/.github#9

## Validation
- make image-verify IMAGE=ghcr.io/gamosoft/notediscovery:0.27.3
- helm unittest charts/notediscovery
- make validate-chart CHART=notediscovery
- make standards-check CHART=notediscovery
- make deps-check CHART=notediscovery
- make site-sync-check CHART=notediscovery
- make org-check
- make attribution-check REPO=charts
- make release-check REPO=charts
- Kubescape MITRE,NSA,SOC2 on rendered default manifests: Overall 87.37%, MITRE 100.00%, NSA 82.50%, SOC2 86.67%