### PR TITLE
fix(valkey): Add labelSelector to topologySpreadConstraints

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -27,8 +27,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added masterSet setting for Sentinel (#626)"
+    - kind: fixed
+      description: "Fixed topologySpreadConstraints behaviour"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -385,15 +385,31 @@ volumeMounts:
 {{- end -}}
 
 {{/*
-Pod labels with component and role.
+Valkey pod labels with component and role.
 */}}
-{{- define "valkey.componentLabels" -}}
+{{- define "valkey.valkeyLabels" -}}
 {{ include "valkey.selectorLabels" .root }}
 app.kubernetes.io/component: valkey
 app.kubernetes.io/part-of: valkey
 {{- if .role }}
 app.kubernetes.io/role: {{ .role }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Sentinel pod labels with component.
+*/}}
+{{- define "valkey.sentinelLabels" -}}
+{{ include "valkey.selectorLabels" . }}
+app.kubernetes.io/component: sentinel
+{{- end -}}
+
+{{/*
+Metrics pod labels with component.
+*/}}
+{{- define "valkey.metricsLabels" -}}
+{{ include "valkey.selectorLabels" . }}
+app.kubernetes.io/component: metrics
 {{- end -}}
 
 {{/*
@@ -419,12 +435,12 @@ Volume claim template.
 Common pod spec fragments.
 */}}
 {{- define "valkey.podSpecCommon" -}}
+serviceAccountName: {{ include "valkey.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-serviceAccountName: {{ include "valkey.serviceAccountName" . }}
-automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
 {{- with .Values.priorityClassName }}
 priorityClassName: {{ . }}
 {{- end }}
@@ -445,8 +461,26 @@ affinity:
 tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .Values.topologySpreadConstraints }}
+{{- end -}}
+
+{{/*
+Generic pod spec fragment with topology spread constraints.
+*/}}
+{{- define "valkey.podSpec" -}}
+{{- $root := .root }}
+{{- $role := .role }}
+{{- include "valkey.podSpecCommon" $root }}
+{{- with $root.Values.topologySpreadConstraints }}
 topologySpreadConstraints:
-  {{- toYaml . | nindent 2 }}
+  {{- range . }}
+  - {{ toYaml . | nindent 4 | trim }}
+    labelSelector:
+      matchLabels:
+        {{- if eq $role "sentinel" }}
+        {{- include "valkey.sentinelLabels" $root | nindent 8 }}
+        {{- else }}
+        {{- include "valkey.valkeyLabels" (dict "root" $root "role" $role) | nindent 8 }}
+        {{- end }}
+  {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -13,11 +13,11 @@ spec:
   podManagementPolicy: Parallel
   selector:
     matchLabels:
-      {{- include "valkey.componentLabels" (dict "root" . "role" "cluster") | nindent 6 }}
+      {{- include "valkey.valkeyLabels" (dict "root" . "role" "cluster") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.componentLabels" (dict "root" . "role" "cluster") | nindent 8 }}
+        {{- include "valkey.valkeyLabels" (dict "root" . "role" "cluster") | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -30,7 +30,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      {{- include "valkey.podSpec" (dict "root" . "role" "cluster") | nindent 6 }}
       containers:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -11,8 +11,7 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "valkey.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: valkey
+      {{- include "valkey.valkeyLabels" (dict "root" .) | nindent 6 }}
 {{- end }}
 {{- if and .Values.pdb.enabled (include "valkey.isSentinel" .) }}
 ---
@@ -21,13 +20,11 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "valkey.sentinelStatefulSetName" . }}
   labels:
-    {{- include "valkey.labels" . | nindent 4 }}
-    app.kubernetes.io/component: sentinel
+    {{- include "valkey.sentinelLabels" . | nindent 4 }}
   {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   minAvailable: {{ .Values.sentinel.quorum }}
   selector:
     matchLabels:
-      {{- include "valkey.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: sentinel
+      {{- include "valkey.sentinelLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      {{- include "valkey.podSpec" (dict "root" . "role" "primary") | nindent 6 }}
       containers:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/templates/replication-primary-statefulset.yaml
+++ b/charts/valkey/templates/replication-primary-statefulset.yaml
@@ -12,11 +12,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "valkey.componentLabels" (dict "root" . "role" "primary") | nindent 6 }}
+      {{- include "valkey.valkeyLabels" (dict "root" . "role" "primary") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.componentLabels" (dict "root" . "role" "primary") | nindent 8 }}
+        {{- include "valkey.valkeyLabels" (dict "root" . "role" "primary") | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/valkey/templates/replication-replica-statefulset.yaml
+++ b/charts/valkey/templates/replication-replica-statefulset.yaml
@@ -12,11 +12,11 @@ spec:
   replicas: {{ .Values.replication.replicaCount }}
   selector:
     matchLabels:
-      {{- include "valkey.componentLabels" (dict "root" . "role" "replica") | nindent 6 }}
+      {{- include "valkey.valkeyLabels" (dict "root" . "role" "replica") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.componentLabels" (dict "root" . "role" "replica") | nindent 8 }}
+        {{- include "valkey.valkeyLabels" (dict "root" . "role" "replica") | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -29,7 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      {{- include "valkey.podSpec" (dict "root" . "role" "replica") | nindent 6 }}
       initContainers:
         - name: wait-for-primary
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/templates/sentinel-node-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-node-statefulset.yaml
@@ -18,11 +18,11 @@ spec:
   replicas: {{ .Values.node.replicaCount }}
   selector:
     matchLabels:
-      {{- include "valkey.componentLabels" (dict "root" .) | nindent 6 }}
+      {{- include "valkey.valkeyLabels" (dict "root" . "role" "node") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.componentLabels" (dict "root" .) | nindent 8 }}
+        {{- include "valkey.valkeyLabels" (dict "root" . "role" "node") | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      {{- include "valkey.podSpec" (dict "root" . "role" "node") | nindent 6 }}
       initContainers:
         - name: wait-for-master
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -12,13 +12,11 @@ spec:
   replicas: {{ .Values.sentinel.replicaCount }}
   selector:
     matchLabels:
-      {{- include "valkey.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: sentinel
+      {{- include "valkey.sentinelLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: sentinel
+        {{- include "valkey.sentinelLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -31,7 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      {{- include "valkey.podSpec" (dict "root" . "role" "sentinel") | nindent 6 }}
       containers:
         - name: sentinel
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -28,8 +28,7 @@ spec:
       targetPort: metrics
     {{- end }}
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
+    {{- include "valkey.valkeyLabels" (dict "root" .) | nindent 4 }}
 {{- end }}
 
 {{- if and .Values.metrics.enabled (or (include "valkey.isStandalone" .) (include "valkey.isReplication" .) (include "valkey.isSentinel" .) (include "valkey.isCluster" .)) }}
@@ -56,8 +55,7 @@ spec:
       port: {{ .Values.service.ports.metrics }}
       targetPort: metrics
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
+    {{- include "valkey.valkeyLabels" (dict "root" .) | nindent 4 }}
 {{- end }}
 
 {{- if include "valkey.isStandalone" . }}
@@ -88,9 +86,7 @@ spec:
       targetPort: metrics
     {{- end }}
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
-    app.kubernetes.io/role: standalone
+    {{- include "valkey.valkeyLabels" (dict "root" . "role" "standalone") | nindent 4 }}
 {{- end }}
 
 {{- if include "valkey.isReplication" . }}
@@ -121,9 +117,7 @@ spec:
       targetPort: metrics
     {{- end }}
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
-    app.kubernetes.io/role: primary
+    {{- include "valkey.valkeyLabels" (dict "root" . "role" "primary") | nindent 4 }}
 ---
 apiVersion: v1
 kind: Service
@@ -151,9 +145,7 @@ spec:
       targetPort: metrics
     {{- end }}
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
-    app.kubernetes.io/role: replica
+    {{- include "valkey.valkeyLabels" (dict "root" . "role" "replica") | nindent 4 }}
 {{- end }}
 
 {{- if include "valkey.isSentinel" . }}
@@ -179,8 +171,7 @@ spec:
       port: {{ .Values.service.ports.sentinel }}
       targetPort: sentinel
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: sentinel
+    {{- include "valkey.sentinelLabels" . | nindent 4 }}
 {{- end }}
 
 {{- if include "valkey.isCluster" . }}
@@ -211,7 +202,5 @@ spec:
       targetPort: metrics
     {{- end }}
   selector:
-    {{- include "valkey.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
-    app.kubernetes.io/role: cluster
+    {{- include "valkey.valkeyLabels" (dict "root" . "role" "cluster") | nindent 4 }}
 {{- end }}

--- a/charts/valkey/templates/servicemonitor.yaml
+++ b/charts/valkey/templates/servicemonitor.yaml
@@ -16,8 +16,7 @@ spec:
       interval: {{ .Values.metrics.serviceMonitor.interval }}
   selector:
     matchLabels:
-      {{- include "valkey.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: metrics
+      {{- include "valkey.metricsLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -12,11 +12,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "valkey.componentLabels" (dict "root" . "role" "standalone") | nindent 6 }}
+      {{- include "valkey.valkeyLabels" (dict "root" . "role" "standalone") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "valkey.componentLabels" (dict "root" . "role" "standalone") | nindent 8 }}
+        {{- include "valkey.valkeyLabels" (dict "root" . "role" "standalone") | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/valkey/templates/standalone-statefulset.yaml
+++ b/charts/valkey/templates/standalone-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "valkey.podSpecCommon" . | nindent 6 }}
+      {{- include "valkey.podSpec" (dict "root" . "role" "standalone") | nindent 6 }}
       containers:
         - name: valkey
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/valkey/tests/pod_role_test.yaml
+++ b/charts/valkey/tests/pod_role_test.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Pod Roles
+templates:
+  - configmap.yaml
+  - standalone-statefulset.yaml
+  - cluster-statefulset.yaml
+  - sentinel-node-statefulset.yaml
+  - replication-primary-statefulset.yaml
+  - replication-replica-statefulset.yaml
+release:
+  name: test
+  namespace: valkey-ns
+tests:
+  - it: should render a standalone role in StatefulSet standalone mode
+    template: standalone-statefulset.yaml
+    set:
+      architecture: standalone
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: standalone
+
+  - it: should render a cluster role in StatefulSet cluster mode
+    template: cluster-statefulset.yaml
+    set:
+      architecture: cluster
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: cluster
+
+  - it: should render a node role in StatefulSet sentinel mode
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: node
+
+  - it: should render a primary role in StatefulSet replication mode
+    template: replication-primary-statefulset.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: primary
+
+  - it: should render a replica role in StatefulSet replication mode
+    template: replication-replica-statefulset.yaml
+    set:
+      architecture: replication
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: replica

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -172,6 +172,15 @@ tests:
           path: data["sentinel.conf"]
           pattern: "sentinel parallel-syncs legacy-master 1"
 
+  - it: should render a sentinel component in StatefulSet sentinel mode
+    template: sentinel-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: sentinel
+
   - it: should use the custom Sentinel master set for auth-pass
     template: sentinel-statefulset.yaml
     set:

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -24,8 +24,9 @@ tests:
       - equal:
           path: spec.serviceName
           value: test-valkey-headless
-      - notExists:
+      - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: node
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].subPath
           value: valkey-node.conf


### PR DESCRIPTION
## Summary

`topologySpreadConstraints` values previously had no `labelSelector`, so the constraint wasn't scoped to the right pods — Kubernetes would spread based on an empty/default selector rather than matching this component's own labels.

Each entry now gets a `labelSelector.matchLabels` block generated per-role (replica, cluster, node, sentinel), built from the chart's existing label helpers so it stays consistent with the labels already applied to the pods themselves.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO