### PR TITLE
feat(booklore): add booklore chart

### DIFF
--- a/charts/booklore/.helmignore
+++ b/charts/booklore/.helmignore
@@ -1,0 +1,5 @@
+.git/
+.github/
+.DS_Store
+*.tmp
+*.bak

--- a/charts/booklore/Chart.yaml
+++ b/charts/booklore/Chart.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: booklore
+description: Self-hosted multi-user digital library with smart shelves, auto metadata, OPDS, and built-in reader for EPUB, PDF, and comics
+type: application
+version: 1.0.0
+appVersion: "2.3.1"
+kubeVersion: ">=1.26.0-0"
+home: https://helmforge.dev/docs/charts/booklore
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/booklore
+  - https://github.com/booklore-app/booklore
+keywords:
+  - ebooks
+  - library
+  - epub
+  - pdf
+  - comics
+  - opds
+  - kobo
+  - koreader
+  - self-hosted
+  - spring-boot
+  - mariadb
+  - kubernetes
+maintainers:
+  - name: HelmForge Team
+    url: https://helmforge.dev
+icon: https://helmforge.dev/icons/charts/booklore.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "initial chart release"
+  artifacthub.io/category: skip-prediction
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  helmforge.dev/maturity: alpha
+  artifacthub.io/links: |
+    - name: Official Source
+      url: https://github.com/booklore-app/booklore
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/booklore
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+dependencies:
+  - name: mariadb
+    version: 2.0.3
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: mariadb.enabled

--- a/charts/booklore/DESIGN.md
+++ b/charts/booklore/DESIGN.md
@@ -1,0 +1,53 @@
+# BookLore Chart — Design Document
+
+## Architecture
+
+BookLore is a Spring Boot (Java) application with an Angular frontend bundled
+into a single container. It uses MariaDB as its database backend and stores
+library data on a local filesystem path.
+
+## Container layout
+
+The official image `ghcr.io/booklore-app/booklore` runs as a single process
+serving both the API and the static Angular frontend on a configurable port
+(default 6060).
+
+### Volumes
+
+- `/app/data` — library data, configuration, cover images, and metadata cache.
+- `/bookdrop` — optional drop folder for automatic book imports.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| BOOKLORE_PORT | 6060 | HTTP listen port |
+| DATABASE_URL | auto-generated | Full JDBC connection URL |
+| DATABASE_HOST | mariadb | MariaDB host |
+| DATABASE_PORT | 3306 | MariaDB port |
+| DATABASE_NAME | booklore | Database name |
+| DATABASE_USERNAME | root | Database user |
+| DATABASE_PASSWORD | (secret) | Database password |
+| LOG_LEVEL | INFO | Application log level |
+| ROOT_LOG_LEVEL | INFO | Root log level |
+| REMOTE_AUTH_ENABLED | false | Enable proxy auth headers |
+| FORCE_DISABLE_OIDC | false | Force disable OIDC |
+
+## Database
+
+The chart deploys MariaDB as a HelmForge subchart by default. The application
+uses Flyway for schema migrations which run automatically on startup.
+
+## Health checks
+
+BookLore serves a basic health endpoint at `/`. The chart uses HTTP GET probes
+with a generous startup probe (up to 6 minutes) to accommodate Java warm-up.
+
+## Security
+
+- Container starts as root (UID 0) because the upstream entrypoint uses
+  `addgroup`/`adduser` to create a non-root user, then drops privileges via
+  `su-exec` to the configured USER_ID/GROUP_ID (default 1000:1000).
+- Capabilities dropped (ALL).
+- Seccomp profile: RuntimeDefault.
+- ServiceAccount token not mounted by default.

--- a/charts/booklore/README.md
+++ b/charts/booklore/README.md
@@ -1,0 +1,49 @@
+# BookLore Helm Chart
+
+A Helm chart for deploying [BookLore](https://github.com/booklore-app/booklore)
+on Kubernetes. BookLore is a self-hosted, multi-user digital library with smart
+shelves, automatic metadata fetching, Kobo and KOReader sync, BookDrop imports,
+OPDS support, and a built-in reader for EPUB, PDF, and comics.
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.x
+
+## Quick start
+
+```bash
+helm install booklore oci://ghcr.io/helmforgedev/helm/booklore
+```
+
+## Parameters
+
+See [values.yaml](values.yaml) for the full list of configurable parameters.
+
+## Database
+
+By default the chart deploys a MariaDB instance via the HelmForge MariaDB
+subchart. To use an external database set `mariadb.enabled=false` and configure
+`database.external.*`.
+
+## Exposure
+
+The chart supports both traditional **Ingress** and **Gateway API** for external
+access. See [examples/](examples/) for ready-to-use configurations.
+
+## Persistence
+
+| Volume | Mount | Default | Description |
+|--------|-------|---------|-------------|
+| data | /app/data | 10Gi | Library data, configuration, metadata |
+| bookdrop | /bookdrop | disabled | BookDrop import folder |
+
+## Security Scan
+
+<!-- kubescape results placeholder -->
+
+## Links
+
+- [HelmForge Documentation](https://helmforge.dev/docs/charts/booklore)
+- [Upstream Source](https://github.com/booklore-app/booklore)
+- [Chart Issues](https://github.com/helmforgedev/charts/issues)

--- a/charts/booklore/README.md
+++ b/charts/booklore/README.md
@@ -36,11 +36,16 @@ access. See [examples/](examples/) for ready-to-use configurations.
 | Volume | Mount | Default | Description |
 |--------|-------|---------|-------------|
 | data | /app/data | 10Gi | Library data, configuration, metadata |
+| books | /books | 50Gi | Library book files |
 | bookdrop | /bookdrop | disabled | BookDrop import folder |
 
-## Security Scan
+## Security Scan: `booklore`
 
-<!-- kubescape results placeholder -->
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **89.90%** |
+
+> Security posture acceptable.
 
 ## Links
 

--- a/charts/booklore/ci/default-values.yaml
+++ b/charts/booklore/ci/default-values.yaml
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI values — default configuration for automated testing
+# CI values -- default configuration for automated testing
 replicaCount: 1

--- a/charts/booklore/ci/default-values.yaml
+++ b/charts/booklore/ci/default-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values — default configuration for automated testing
+replicaCount: 1

--- a/charts/booklore/ci/dual-stack.yaml
+++ b/charts/booklore/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  # Keep this scenario portable across IPv4-only and dual-stack k3d clusters.
+  # Explicit ipFamilies rendering is covered by unit tests because Kubernetes
+  # rejects IPv6 entries on clusters that do not advertise IPv6.
+  ipFamilyPolicy: PreferDualStack

--- a/charts/booklore/ci/external-secrets.yaml
+++ b/charts/booklore/ci/external-secrets.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI values — external secrets enabled
+# CI values -- external secrets enabled
 # Uses the helmforge-fake-store provisioned in k3d by make prepare.
 externalSecrets:
   enabled: true

--- a/charts/booklore/ci/external-secrets.yaml
+++ b/charts/booklore/ci/external-secrets.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values — external secrets enabled
+# Uses the helmforge-fake-store provisioned in k3d by make prepare.
+externalSecrets:
+  enabled: true
+  items:
+    - name: db-creds
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: helmforge-fake-store
+        target:
+          name: booklore-db-creds
+          creationPolicy: Owner
+          template:
+            data:
+              password: '{{ index . "password" }}'
+        data:
+          - secretKey: password
+            remoteRef:
+              key: test/password

--- a/charts/booklore/ci/gateway-api-values.yaml
+++ b/charts/booklore/ci/gateway-api-values.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI values — Gateway API enabled
+# CI values -- Gateway API enabled
 gatewayAPI:
   enabled: true
   httpRoutes:

--- a/charts/booklore/ci/gateway-api-values.yaml
+++ b/charts/booklore/ci/gateway-api-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values — Gateway API enabled
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: main-gateway
+          namespace: gateway-system
+      hostnames:
+        - booklore.example.com

--- a/charts/booklore/ci/ingress-values.yaml
+++ b/charts/booklore/ci/ingress-values.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI values — ingress enabled
+# CI values -- ingress enabled
 ingress:
   enabled: true
   ingressClassName: traefik

--- a/charts/booklore/ci/ingress-values.yaml
+++ b/charts/booklore/ci/ingress-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values — ingress enabled
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: booklore.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/booklore/ci/networkpolicy.yaml
+++ b/charts/booklore/ci/networkpolicy.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values — network policy enabled
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true

--- a/charts/booklore/ci/networkpolicy.yaml
+++ b/charts/booklore/ci/networkpolicy.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI values — network policy enabled
+# CI values -- network policy enabled
 networkPolicy:
   enabled: true
   egress:

--- a/charts/booklore/ci/persistence-disabled.yaml
+++ b/charts/booklore/ci/persistence-disabled.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI values — persistence disabled
+persistence:
+  data:
+    enabled: false
+  bookdrop:
+    enabled: false

--- a/charts/booklore/ci/persistence-disabled.yaml
+++ b/charts/booklore/ci/persistence-disabled.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI values — persistence disabled
+# CI values -- persistence disabled
 persistence:
   data:
     enabled: false

--- a/charts/booklore/docs/exposure.md
+++ b/charts/booklore/docs/exposure.md
@@ -1,0 +1,33 @@
+# Exposure
+
+BookLore can be exposed externally using either Kubernetes Ingress or Gateway API.
+
+## Ingress
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: books.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: booklore-tls
+      hosts:
+        - books.example.com
+```
+
+## Gateway API
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: main-gateway
+          namespace: gateway-system
+      hostnames:
+        - books.example.com
+```

--- a/charts/booklore/docs/storage.md
+++ b/charts/booklore/docs/storage.md
@@ -1,0 +1,45 @@
+# Storage
+
+BookLore uses two filesystem paths for persistent data:
+
+## Data volume (`/app/data`)
+
+Stores library metadata, cover images, configuration, and internal caches.
+This volume is required for data to survive pod restarts.
+
+```yaml
+persistence:
+  data:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+```
+
+## BookDrop volume (`/bookdrop`)
+
+Optional import folder. Place EPUB, PDF, or comic files here and BookLore
+will automatically import them into the library.
+
+```yaml
+persistence:
+  bookdrop:
+    enabled: true
+    size: 5Gi
+```
+
+## External database
+
+To use an existing MariaDB instance:
+
+```yaml
+mariadb:
+  enabled: false
+
+database:
+  external:
+    host: mariadb.example.com
+    port: "3306"
+    name: booklore
+    username: booklore
+    password: "secret"
+```

--- a/charts/booklore/examples/gateway-api.yaml
+++ b/charts/booklore/examples/gateway-api.yaml
@@ -1,0 +1,9 @@
+# BookLore with Gateway API exposure.
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: main-gateway
+          namespace: gateway-system
+      hostnames:
+        - books.example.com

--- a/charts/booklore/examples/gateway-api.yaml
+++ b/charts/booklore/examples/gateway-api.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # BookLore with Gateway API exposure.
 gatewayAPI:
   enabled: true

--- a/charts/booklore/examples/ingress.yaml
+++ b/charts/booklore/examples/ingress.yaml
@@ -1,0 +1,15 @@
+# BookLore with Ingress exposure.
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: books.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: booklore-tls
+      hosts:
+        - books.example.com

--- a/charts/booklore/examples/ingress.yaml
+++ b/charts/booklore/examples/ingress.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # BookLore with Ingress exposure.
 ingress:
   enabled: true

--- a/charts/booklore/examples/simple.yaml
+++ b/charts/booklore/examples/simple.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Minimal BookLore deployment with default settings.
 # MariaDB subchart handles the database automatically.
 replicaCount: 1

--- a/charts/booklore/examples/simple.yaml
+++ b/charts/booklore/examples/simple.yaml
@@ -1,0 +1,3 @@
+# Minimal BookLore deployment with default settings.
+# MariaDB subchart handles the database automatically.
+replicaCount: 1

--- a/charts/booklore/templates/NOTES.txt
+++ b/charts/booklore/templates/NOTES.txt
@@ -1,0 +1,125 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+BookLore has been installed.
+
+1. Installation summary
+=======================
+  Release:         {{ .Release.Name }}
+  Namespace:       {{ .Release.Namespace }}
+  Chart:           {{ include "booklore.chart" . }}
+  AppVersion:      {{ .Chart.AppVersion }}
+  Image:           {{ .Values.image.repository }}:{{ .Values.image.tag }}
+  Replicas:        {{ .Values.replicaCount }}
+  ServiceAccount:  {{ include "booklore.serviceAccountName" . }}
+
+2. Access
+=========
+  Service name:    {{ include "booklore.fullname" . }}
+  Service type:    {{ .Values.service.type }}
+  Service port:    {{ .Values.service.port }}
+  Cluster DNS:     {{ include "booklore.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+  Port-forward:    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "booklore.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- if .Values.ingress.enabled }}
+  Ingress hosts:
+  {{- range .Values.ingress.hosts }}
+    - {{ .host }}
+  {{- end }}
+{{- end }}
+{{- if .Values.gatewayAPI.enabled }}
+  Gateway API:     enabled
+  {{- range .Values.gatewayAPI.httpRoutes }}
+  {{- with .hostnames }}
+  HTTPRoute hosts:
+    {{- range . }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
+3. Getting started
+==================
+  Wait for pod:
+
+    kubectl wait --for=condition=Ready pod \
+      -l app.kubernetes.io/name={{ include "booklore.name" . }},app.kubernetes.io/instance={{ .Release.Name }} \
+      -n {{ .Release.Namespace }} --timeout=300s
+
+  Port-forward and open in browser:
+
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "booklore.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+    # Open http://localhost:{{ .Values.service.port }}
+
+  First-time setup:
+    On first launch, BookLore will run database migrations (Flyway) automatically.
+    Create your first user account through the web UI.
+
+4. Credentials
+==============
+  Database:
+    Host:       {{ include "booklore.dbHost" . }}
+    Port:       {{ include "booklore.dbPort" . }}
+    Database:   {{ include "booklore.dbName" . }}
+    Username:   {{ include "booklore.dbUsername" . }}
+    Password:   stored in Secret {{ include "booklore.dbSecretName" . }}
+{{- if .Values.remoteAuth.enabled }}
+
+  Remote Auth:
+    Enabled:    true
+    Headers:    {{ .Values.remoteAuth.headerUser }} / {{ .Values.remoteAuth.headerEmail }}
+{{- end }}
+
+5. Configuration summary
+========================
+  Database mode:   {{ if .Values.mariadb.enabled }}embedded MariaDB subchart{{ else }}external MariaDB at {{ include "booklore.dbHost" . }}:{{ include "booklore.dbPort" . }}{{ end }}
+  Data volume:     {{ if .Values.persistence.data.enabled }}{{ .Values.persistence.data.size }} PVC{{ else }}emptyDir (data lost on pod restart){{ end }}
+  BookDrop:        {{ if .Values.persistence.bookdrop.enabled }}{{ .Values.persistence.bookdrop.size }} PVC at /bookdrop{{ else }}disabled{{ end }}
+  OIDC:            {{ if .Values.oidc.forceDisable }}force-disabled{{ else }}available via upstream config{{ end }}
+  Remote Auth:     {{ if .Values.remoteAuth.enabled }}enabled{{ else }}disabled{{ end }}
+  NetworkPolicy:   {{ if .Values.networkPolicy.enabled }}enabled{{ else }}disabled{{ end }}
+  HPA:             {{ if .Values.autoscaling.enabled }}enabled ({{ .Values.autoscaling.minReplicas }}-{{ .Values.autoscaling.maxReplicas }}){{ else }}disabled{{ end }}
+  ServiceMonitor:  {{ if .Values.monitoring.serviceMonitor.enabled }}enabled{{ else }}disabled{{ end }}
+
+6. Validation commands
+======================
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+  kubectl get deploy,svc,pvc,ing -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  kubectl wait --for=condition=Available deploy/{{ include "booklore.fullname" . }} \
+    -n {{ .Release.Namespace }} --timeout=300s
+
+  kubectl get endpoints {{ include "booklore.fullname" . }} \
+    -n {{ .Release.Namespace }}
+
+  # Quick health check
+  kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "booklore.fullname" . }} -- \
+    wget -qO- http://localhost:{{ .Values.app.port }}/ | head -c 200
+
+7. Troubleshooting
+==================
+  kubectl get pods -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  kubectl describe pod -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/name={{ include "booklore.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
+
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+  kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "booklore.fullname" . }} --tail=100
+
+  kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "booklore.fullname" . }} --previous --tail=50
+
+  Common problems:
+    - CrashLoopBackOff:    Check database connectivity and credentials.
+    - Flyway errors:       Database may have stale migration state; check logs.
+    - OOM:                 Increase resources.limits.memory (BookLore is a Java/Spring Boot app).
+    - Slow startup:        Java apps need warm-up time; the startup probe allows up to 6 min.
+
+8. Resources
+============
+  HelmForge docs:  https://helmforge.dev/docs/charts/booklore
+  Upstream:        https://github.com/booklore-app/booklore
+  Chart issues:    https://github.com/helmforgedev/charts/issues
+
+Happy Helmforging :)

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -197,10 +197,10 @@ jdbc:mariadb://{{ include "booklore.dbHost" . }}:{{ include "booklore.dbPort" . 
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
 {{- end -}}
-{{- if and (not .Values.mariadb.enabled) (dig "networkPolicy" "egress" "enabled" false .Values) (not (dig "networkPolicy" "egress" "databaseTo" nil .Values)) -}}
+{{- if and (not .Values.mariadb.enabled) .Values.networkPolicy.egress.enabled (not .Values.networkPolicy.egress.databaseTo) -}}
 {{- fail "networkPolicy.egress.databaseTo must contain at least one peer when mariadb.enabled=false and networkPolicy.egress.enabled=true" -}}
 {{- end -}}
-{{- if and (not .Values.mariadb.enabled) (dig "networkPolicy" "egress" "enabled" false .Values) (dig "networkPolicy" "egress" "databaseTo" nil .Values) (empty .Values.networkPolicy.egress.databaseTo) -}}
+{{- if and (not .Values.mariadb.enabled) .Values.networkPolicy.egress.enabled .Values.networkPolicy.egress.databaseTo (empty .Values.networkPolicy.egress.databaseTo) -}}
 {{- fail "networkPolicy.egress.databaseTo must not be empty when mariadb.enabled=false and networkPolicy.egress.enabled=true" -}}
 {{- end -}}
 {{- if .Values.podLabels -}}

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -121,7 +121,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "booklore.dbSecretPasswordKey" -}}
 {{- if .Values.mariadb.enabled -}}
-{{- if and .Values.mariadb.auth.existingSecret .Values.mariadb.auth.existingSecretUserPasswordKey -}}
+{{- if .Values.mariadb.auth.existingSecretUserPasswordKey -}}
 {{- .Values.mariadb.auth.existingSecretUserPasswordKey -}}
 {{- else -}}
 mariadb-user-password
@@ -196,6 +196,12 @@ jdbc:mariadb://{{ include "booklore.dbHost" . }}:{{ include "booklore.dbPort" . 
 {{- end -}}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and (not .Values.mariadb.enabled) (dig "networkPolicy" "egress" "enabled" false .Values) (not (dig "networkPolicy" "egress" "databaseTo" nil .Values)) -}}
+{{- fail "networkPolicy.egress.databaseTo must contain at least one peer when mariadb.enabled=false and networkPolicy.egress.enabled=true" -}}
+{{- end -}}
+{{- if and (not .Values.mariadb.enabled) (dig "networkPolicy" "egress" "enabled" false .Values) (dig "networkPolicy" "egress" "databaseTo" nil .Values) (empty .Values.networkPolicy.egress.databaseTo) -}}
+{{- fail "networkPolicy.egress.databaseTo must not be empty when mariadb.enabled=false and networkPolicy.egress.enabled=true" -}}
 {{- end -}}
 {{- if .Values.podLabels -}}
 {{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -108,8 +108,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "booklore.dbSecretPasswordKey" -}}
 {{- if .Values.mariadb.enabled -}}
-{{- if and .Values.mariadb.auth.existingSecret .Values.mariadb.auth.existingSecretPasswordKey -}}
-{{- .Values.mariadb.auth.existingSecretPasswordKey -}}
+{{- if and .Values.mariadb.auth.existingSecret .Values.mariadb.auth.existingSecretUserPasswordKey -}}
+{{- .Values.mariadb.auth.existingSecretUserPasswordKey -}}
 {{- else -}}
 mariadb-user-password
 {{- end -}}

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -94,7 +94,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "booklore.dbSecretName" -}}
 {{- if .Values.mariadb.enabled -}}
+{{- if .Values.mariadb.auth.existingSecret -}}
+{{- .Values.mariadb.auth.existingSecret -}}
+{{- else -}}
 {{- printf "%s-mariadb-auth" .Release.Name -}}
+{{- end -}}
 {{- else if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}
 {{- else -}}
@@ -104,7 +108,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "booklore.dbSecretPasswordKey" -}}
 {{- if .Values.mariadb.enabled -}}
+{{- if and .Values.mariadb.auth.existingSecret .Values.mariadb.auth.existingSecretPasswordKey -}}
+{{- .Values.mariadb.auth.existingSecretPasswordKey -}}
+{{- else -}}
 mariadb-user-password
+{{- end -}}
 {{- else if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecretPasswordKey | default "password" -}}
 {{- else -}}

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -1,0 +1,187 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "booklore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "booklore.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "booklore.labels" -}}
+helm.sh/chart: {{ include "booklore.chart" . }}
+{{ include "booklore.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "booklore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "booklore.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "booklore.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "booklore.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.nameWithSuffix" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $max := int (default 63 .max) -}}
+{{- $baseMax := int (sub $max (len $suffix)) -}}
+{{- printf "%s%s" ($base | trunc $baseMax | trimSuffix "-") $suffix | trunc $max | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "booklore.appSecretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- include "booklore.nameWithSuffix" (dict "base" (include "booklore.fullname" .) "suffix" "-app") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbHost" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- printf "%s-mariadb" .Release.Name -}}
+{{- else -}}
+{{- .Values.database.external.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbPort" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- dig "service" "port" 3306 .Values.mariadb -}}
+{{- else -}}
+{{- .Values.database.external.port | default "3306" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbName" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- .Values.mariadb.auth.database | default "booklore" -}}
+{{- else -}}
+{{- .Values.database.external.name | default "booklore" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbUsername" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- .Values.mariadb.auth.username | default "booklore" -}}
+{{- else -}}
+{{- .Values.database.external.username | default "root" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbSecretName" -}}
+{{- if .Values.mariadb.enabled -}}
+{{- printf "%s-mariadb-auth" .Release.Name -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- include "booklore.nameWithSuffix" (dict "base" (include "booklore.fullname" .) "suffix" "-db") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbSecretPasswordKey" -}}
+{{- if .Values.mariadb.enabled -}}
+mariadb-user-password
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "password" -}}
+{{- else -}}
+password
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.dbUrl" -}}
+jdbc:mariadb://{{ include "booklore.dbHost" . }}:{{ include "booklore.dbPort" . }}/{{ include "booklore.dbName" . }}?createDatabaseIfNotExist=true&connectionTimeZone=UTC&forceConnectionTimeZoneToSession=true
+{{- end -}}
+
+{{- define "booklore.persistenceClaimName" -}}
+{{- $root := .root -}}
+{{- $name := .name -}}
+{{- $persistence := index $root.Values.persistence $name -}}
+{{- if $persistence.existingClaim -}}
+{{- $persistence.existingClaim -}}
+{{- else -}}
+{{- include "booklore.nameWithSuffix" (dict "base" (include "booklore.fullname" $root) "suffix" (printf "-%s" $name)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.httpRouteName" -}}
+{{- $root := .root -}}
+{{- $route := .route -}}
+{{- $index := .index | default 0 -}}
+{{- if $route.name -}}
+{{- $suffix := printf "-%s" $route.name -}}
+{{- $base := include "booklore.fullname" $root | trunc (int (max 1 (sub 63 (len $suffix)))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix | trunc 63 | trimSuffix "-" -}}
+{{- else if gt (int $index) 0 -}}
+{{- $suffix := printf "-%d" (int $index) -}}
+{{- $base := include "booklore.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else -}}
+{{- include "booklore.fullname" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.externalSecretName" -}}
+{{- $root := .root -}}
+{{- $item := .item -}}
+{{- $index := int (.index | default 0) -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if $item.name -}}
+{{- $suffix := printf "-%s" $item.name -}}
+{{- $base := include "booklore.fullname" $root | trunc (int (max 1 (sub 63 (len $suffix)))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix | trunc 63 | trimSuffix "-" -}}
+{{- else if gt $index 0 -}}
+{{- $suffix := printf "-%d" $index -}}
+{{- $base := include "booklore.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else -}}
+{{- include "booklore.appSecretName" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "booklore.validate" -}}
+{{- if and (not .Values.mariadb.enabled) (empty .Values.database.external.host) -}}
+{{- fail "database.external.host is required when mariadb.enabled=false" -}}
+{{- end -}}
+{{- if and (not .Values.mariadb.enabled) (not .Values.database.external.existingSecret) (empty .Values.database.external.password) -}}
+{{- fail "database.external.password or database.external.existingSecret is required when mariadb.enabled=false" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) -}}
+{{- fail "externalSecrets.items must contain at least one item when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if .Values.podLabels -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -211,4 +211,10 @@ jdbc:mariadb://{{ include "booklore.dbHost" . }}:{{ include "booklore.dbPort" . 
 {{- fail "podLabels must not override the selector label app.kubernetes.io/instance" -}}
 {{- end -}}
 {{- end -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.httpRoutes) -}}
+{{- fail "gatewayAPI.httpRoutes must contain at least one route when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.autoscaling.enabled (gt (int .Values.autoscaling.maxReplicas) 1) .Values.persistence.data.enabled (ne .Values.persistence.data.accessMode "ReadWriteMany") -}}
+{{- fail "autoscaling.maxReplicas > 1 with persistence.data.accessMode=ReadWriteOnce will cause volume scheduling failures; set persistence.data.accessMode=ReadWriteMany or disable persistence" -}}
+{{- end -}}
 {{- end -}}

--- a/charts/booklore/templates/_helpers.tpl
+++ b/charts/booklore/templates/_helpers.tpl
@@ -60,9 +60,22 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "booklore.mariadb.fullname" -}}
+{{- if .Values.mariadb.fullnameOverride -}}
+{{- .Values.mariadb.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "mariadb" .Values.mariadb.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "booklore.dbHost" -}}
 {{- if .Values.mariadb.enabled -}}
-{{- printf "%s-mariadb" .Release.Name -}}
+{{- include "booklore.mariadb.fullname" . -}}
 {{- else -}}
 {{- .Values.database.external.host -}}
 {{- end -}}
@@ -97,7 +110,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.mariadb.auth.existingSecret -}}
 {{- .Values.mariadb.auth.existingSecret -}}
 {{- else -}}
-{{- printf "%s-mariadb-auth" .Release.Name -}}
+{{- printf "%s-auth" (include "booklore.mariadb.fullname" .) -}}
 {{- end -}}
 {{- else if .Values.database.external.existingSecret -}}
 {{- .Values.database.external.existingSecret -}}

--- a/charts/booklore/templates/deployment.yaml
+++ b/charts/booklore/templates/deployment.yaml
@@ -150,7 +150,7 @@ spec:
           {{- if .Values.probes.startup.enabled }}
           startupProbe:
             httpGet:
-              path: /
+              path: /api/v1/healthcheck
               port: http
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
@@ -160,7 +160,7 @@ spec:
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/v1/healthcheck
               port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
@@ -170,7 +170,7 @@ spec:
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /api/v1/healthcheck
               port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
@@ -184,6 +184,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/data
+            - name: books
+              mountPath: /books
             {{- if .Values.persistence.bookdrop.enabled }}
             - name: bookdrop
               mountPath: /bookdrop
@@ -196,6 +198,13 @@ spec:
           {{- if .Values.persistence.data.enabled }}
           persistentVolumeClaim:
             claimName: {{ include "booklore.persistenceClaimName" (dict "root" . "name" "data") | quote }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: books
+          {{- if .Values.persistence.books.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "booklore.persistenceClaimName" (dict "root" . "name" "books") | quote }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/booklore/templates/deployment.yaml
+++ b/charts/booklore/templates/deployment.yaml
@@ -1,0 +1,225 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "booklore.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "booklore.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secrets: {{ dict "appSecret" .Values.secrets "dbSecret" .Values.database.external "externalSecrets" .Values.externalSecrets "extraManifests" .Values.extraManifests | toJson | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "booklore.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: wait-for-database
+          image: "{{ .Values.waitForDatabase.image.repository }}:{{ .Values.waitForDatabase.image.tag }}"
+          imagePullPolicy: {{ .Values.waitForDatabase.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              until nc -z -w2 {{ include "booklore.dbHost" . }} {{ include "booklore.dbPort" . }}; do
+                echo "Waiting for MariaDB..."
+                sleep 2
+              done
+          {{- with .Values.waitForDatabase.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+      containers:
+        - name: {{ include "booklore.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.app.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.app.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.port }}
+              protocol: TCP
+          env:
+            - name: BOOKLORE_PORT
+              value: {{ .Values.app.port | quote }}
+            - name: DATABASE_URL
+              value: {{ include "booklore.dbUrl" . | quote }}
+            - name: DATABASE_HOST
+              value: {{ include "booklore.dbHost" . | quote }}
+            - name: DATABASE_PORT
+              value: {{ include "booklore.dbPort" . | quote }}
+            - name: DATABASE_NAME
+              value: {{ include "booklore.dbName" . | quote }}
+            - name: DATABASE_USERNAME
+              value: {{ include "booklore.dbUsername" . | quote }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "booklore.dbSecretName" . | quote }}
+                  key: {{ include "booklore.dbSecretPasswordKey" . | quote }}
+            - name: ROOT_LOG_LEVEL
+              value: {{ .Values.app.rootLogLevel | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.app.logLevel | quote }}
+            - name: ALLOWED_ORIGINS
+              value: {{ .Values.app.allowedOrigins | quote }}
+            - name: DISK_TYPE
+              value: {{ .Values.app.diskType | quote }}
+            - name: FORCE_DISABLE_OIDC
+              value: {{ .Values.oidc.forceDisable | quote }}
+            {{- if .Values.remoteAuth.enabled }}
+            - name: REMOTE_AUTH_ENABLED
+              value: "true"
+            - name: REMOTE_AUTH_CREATE_NEW_USERS
+              value: {{ .Values.remoteAuth.createNewUsers | quote }}
+            - name: REMOTE_AUTH_HEADER_NAME
+              value: {{ .Values.remoteAuth.headerName | quote }}
+            - name: REMOTE_AUTH_HEADER_USER
+              value: {{ .Values.remoteAuth.headerUser | quote }}
+            - name: REMOTE_AUTH_HEADER_EMAIL
+              value: {{ .Values.remoteAuth.headerEmail | quote }}
+            - name: REMOTE_AUTH_HEADER_GROUPS
+              value: {{ .Values.remoteAuth.headerGroups | quote }}
+            {{- with .Values.remoteAuth.adminGroup }}
+            - name: REMOTE_AUTH_ADMIN_GROUP
+              value: {{ . | quote }}
+            {{- end }}
+            - name: REMOTE_AUTH_GROUPS_DELIMITER
+              value: {{ .Values.remoteAuth.groupsDelimiter | quote }}
+            {{- end }}
+            {{- range .Values.app.env }}
+            - name: {{ .name }}
+              {{- if hasKey . "valueFrom" }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- else }}
+              value: {{ default "" .value | quote }}
+              {{- end }}
+            {{- end }}
+          {{- with .Values.app.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+            {{- if .Values.persistence.bookdrop.enabled }}
+            - name: bookdrop
+              mountPath: /bookdrop
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "booklore.persistenceClaimName" (dict "root" . "name" "data") | quote }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.persistence.bookdrop.enabled }}
+        - name: bookdrop
+          persistentVolumeClaim:
+            claimName: {{ include "booklore.persistenceClaimName" (dict "root" . "name" "bookdrop") | quote }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/booklore/templates/externalsecret.yaml
+++ b/charts/booklore/templates/externalsecret.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- $externalSecretNames := dict }}
+{{- range $index, $item := .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "booklore.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- if hasKey $externalSecretNames $externalSecretName }}
+{{- fail (printf "externalSecrets.items render duplicate ExternalSecret name %q; set name or fullnameOverride to a unique value" $externalSecretName) }}
+{{- end }}
+{{- $_ := set $externalSecretNames $externalSecretName true }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+---
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "booklore.labels" $ | nindent 4 }}
+    {{- with $item.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/booklore/templates/extra-manifests.yaml
+++ b/charts/booklore/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/booklore/templates/gateway-httproute.yaml
+++ b/charts/booklore/templates/gateway-httproute.yaml
@@ -1,0 +1,44 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- $httpRouteNames := dict }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
+{{- if not $route.parentRefs }}{{- fail "gatewayAPI.httpRoutes[].parentRefs is required" }}{{- end }}
+{{- $httpRouteName := include "booklore.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+{{- if hasKey $httpRouteNames $httpRouteName }}
+{{- fail (printf "gatewayAPI.httpRoutes render duplicate HTTPRoute name %q; set name to a unique value" $httpRouteName) }}
+{{- end }}
+{{- $_ := set $httpRouteNames $httpRouteName true }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $httpRouteName }}
+  labels:
+    {{- include "booklore.labels" $ | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.rules }}
+    {{- toYaml $route.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: {{ default "PathPrefix" $route.pathType }}
+            value: {{ default "/" $route.path | quote }}
+      backendRefs:
+        - name: {{ include "booklore.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/booklore/templates/hpa.yaml
+++ b/charts/booklore/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "booklore.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/booklore/templates/ingress.yaml
+++ b/charts/booklore/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.hosts }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- $paths := default (list (dict "path" "/" "pathType" "Prefix")) .paths }}
+          {{- range $paths }}
+          - path: {{ default "/" .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ include "booklore.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/booklore/templates/networkpolicy.yaml
+++ b/charts/booklore/templates/networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "booklore.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    - ports:
+        - protocol: TCP
+          port: {{ include "booklore.dbPort" . }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/booklore/templates/networkpolicy.yaml
+++ b/charts/booklore/templates/networkpolicy.yaml
@@ -43,11 +43,8 @@ spec:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
               app.kubernetes.io/name: {{ default "mariadb" .Values.mariadb.nameOverride }}
-      {{- else if .Values.networkPolicy.egress.databaseTo }}
-        {{- toYaml .Values.networkPolicy.egress.databaseTo | nindent 8 }}
       {{- else }}
-        - ipBlock:
-            cidr: {{ .Values.database.external.host }}/32
+        {{- toYaml (required "networkPolicy.egress.databaseTo is required when mariadb.enabled=false and networkPolicy.egress.enabled=true" .Values.networkPolicy.egress.databaseTo) | nindent 8 }}
       {{- end }}
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:

--- a/charts/booklore/templates/networkpolicy.yaml
+++ b/charts/booklore/templates/networkpolicy.yaml
@@ -37,6 +37,13 @@ spec:
     - ports:
         - protocol: TCP
           port: {{ include "booklore.dbPort" . }}
+      {{- if .Values.mariadb.enabled }}
+      to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: mariadb
+      {{- end }}
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:
         {{- toYaml . | nindent 8 }}

--- a/charts/booklore/templates/networkpolicy.yaml
+++ b/charts/booklore/templates/networkpolicy.yaml
@@ -37,12 +37,17 @@ spec:
     - ports:
         - protocol: TCP
           port: {{ include "booklore.dbPort" . }}
-      {{- if .Values.mariadb.enabled }}
       to:
+      {{- if .Values.mariadb.enabled }}
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
-              app.kubernetes.io/name: mariadb
+              app.kubernetes.io/name: {{ default "mariadb" .Values.mariadb.nameOverride }}
+      {{- else if .Values.networkPolicy.egress.databaseTo }}
+        {{- toYaml .Values.networkPolicy.egress.databaseTo | nindent 8 }}
+      {{- else }}
+        - ipBlock:
+            cidr: {{ .Values.database.external.host }}/32
       {{- end }}
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:

--- a/charts/booklore/templates/networkpolicy.yaml
+++ b/charts/booklore/templates/networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
               app.kubernetes.io/instance: {{ .Release.Name }}
               app.kubernetes.io/name: {{ default "mariadb" .Values.mariadb.nameOverride }}
       {{- else }}
-        {{- toYaml (required "networkPolicy.egress.databaseTo is required when mariadb.enabled=false and networkPolicy.egress.enabled=true" .Values.networkPolicy.egress.databaseTo) | nindent 8 }}
+        {{- toYaml .Values.networkPolicy.egress.databaseTo | nindent 8 }}
       {{- end }}
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:

--- a/charts/booklore/templates/networkpolicy.yaml
+++ b/charts/booklore/templates/networkpolicy.yaml
@@ -33,6 +33,14 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+      to:
+      {{- if .Values.networkPolicy.egress.dnsPeers }}
+        {{- toYaml .Values.networkPolicy.egress.dnsPeers | nindent 8 }}
+      {{- else }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      {{- end }}
     {{- end }}
     - ports:
         - protocol: TCP

--- a/charts/booklore/templates/pdb.yaml
+++ b/charts/booklore/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "booklore.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/booklore/templates/pvc.yaml
+++ b/charts/booklore/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range $name, $persistence := .Values.persistence }}
+{{- if and $persistence.enabled (not $persistence.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "booklore.persistenceClaimName" (dict "root" $ "name" $name) }}
+  labels:
+    {{- include "booklore.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $name | quote }}
+spec:
+  accessModes:
+    {{- toYaml $persistence.accessModes | nindent 4 }}
+  {{- if $persistence.storageClass }}
+  storageClassName: {{ $persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $persistence.size | quote }}
+{{- end }}
+{{- end }}

--- a/charts/booklore/templates/secret.yaml
+++ b/charts/booklore/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and (not .Values.mariadb.enabled) (not .Values.database.external.existingSecret) .Values.database.external.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "booklore.dbSecretName" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.database.external.password | quote }}
+{{- end }}

--- a/charts/booklore/templates/service.yaml
+++ b/charts/booklore/templates/service.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "booklore.selectorLabels" . | nindent 4 }}

--- a/charts/booklore/templates/serviceaccount.yaml
+++ b/charts/booklore/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "booklore.serviceAccountName" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/booklore/templates/servicemonitor.yaml
+++ b/charts/booklore/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       {{- include "booklore.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
-      path: {{ .Values.monitoring.serviceMonitor.path | default "/actuator/prometheus" }}
+      path: {{ .Values.monitoring.serviceMonitor.path | default "/api/v1/healthcheck" }}
       {{- with .Values.monitoring.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/booklore/templates/servicemonitor.yaml
+++ b/charts/booklore/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
       {{- include "booklore.selectorLabels" . | nindent 6 }}
   endpoints:
     - port: http
-      path: {{ .Values.monitoring.serviceMonitor.path | default "/api/v1/healthcheck" }}
+      path: {{ required "monitoring.serviceMonitor.path is required when serviceMonitor is enabled (BookLore v2.3.1 does not expose Prometheus metrics)" .Values.monitoring.serviceMonitor.path }}
       {{- with .Values.monitoring.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/booklore/templates/servicemonitor.yaml
+++ b/charts/booklore/templates/servicemonitor.yaml
@@ -1,0 +1,22 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "booklore.fullname" . }}
+  labels:
+    {{- include "booklore.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "booklore.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.monitoring.serviceMonitor.path | default "/actuator/prometheus" }}
+      {{- with .Values.monitoring.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/booklore/templates/validate.yaml
+++ b/charts/booklore/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "booklore.validate" . -}}

--- a/charts/booklore/tests/common-labels-values.yaml
+++ b/charts/booklore/tests/common-labels-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+commonLabels:
+  review: enabled

--- a/charts/booklore/tests/ingress-values.yaml
+++ b/charts/booklore/tests/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: booklore.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: booklore-tls
+      hosts:
+        - booklore.example.com

--- a/charts/booklore/tests/templates_test.yaml
+++ b/charts/booklore/tests/templates_test.yaml
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: booklore base templates
+templates:
+  - templates/deployment.yaml
+  - templates/ingress.yaml
+  - templates/pvc.yaml
+  - templates/secret.yaml
+  - templates/service.yaml
+tests:
+  - it: renders the official pinned image and database environment
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/booklore-app/booklore:v2.3.1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: DATABASE_HOST
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: RELEASE-NAME-mariadb
+      - equal:
+          path: spec.template.spec.containers[0].env[6].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-mariadb-auth
+      - equal:
+          path: spec.template.spec.containers[0].env[6].valueFrom.secretKeyRef.key
+          value: mariadb-user-password
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 0
+  - it: renders the default ClusterIP service
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 6060
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+  - it: renders common labels on a separate line
+    template: templates/service.yaml
+    values:
+      - common-labels-values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.review
+          value: enabled
+  - it: renders ingress TLS
+    template: templates/ingress.yaml
+    values:
+      - ingress-values.yaml
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: booklore-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: booklore.example.com
+  - it: mounts data PVC by default and skips bookdrop
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-booklore-data
+  - it: creates PVC for data by default
+    template: templates/pvc.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-booklore-data
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+  - it: creates an external database password secret
+    template: templates/secret.yaml
+    set:
+      mariadb.enabled: false
+      database.external.host: mariadb.example.com
+      database.external.password: external-password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-booklore-db
+      - equal:
+          path: stringData.password
+          value: external-password
+  - it: skips external db secret when mariadb subchart is enabled
+    template: templates/secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/booklore/tests/templates_test.yaml
+++ b/charts/booklore/tests/templates_test.yaml
@@ -63,23 +63,32 @@ tests:
       - equal:
           path: spec.tls[0].hosts[0]
           value: booklore.example.com
-  - it: mounts data PVC by default and skips bookdrop
+  - it: mounts data and books PVCs by default and skips bookdrop
     template: templates/deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
           value: RELEASE-NAME-booklore-data
-  - it: creates PVC for data by default
+      - equal:
+          path: spec.template.spec.volumes[1].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-booklore-books
+  - it: creates PVCs for data and books by default
     template: templates/pvc.yaml
     asserts:
       - hasDocuments:
-          count: 1
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-booklore-books
+        documentIndex: 0
+      - equal:
+          path: spec.resources.requests.storage
+          value: 50Gi
+        documentIndex: 0
       - equal:
           path: metadata.name
           value: RELEASE-NAME-booklore-data
-      - equal:
-          path: spec.resources.requests.storage
-          value: 10Gi
+        documentIndex: 1
   - it: creates an external database password secret
     template: templates/secret.yaml
     set:

--- a/charts/booklore/tests/validation_test.yaml
+++ b/charts/booklore/tests/validation_test.yaml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: booklore validation tests
+templates:
+  - templates/validate.yaml
+tests:
+  - it: fails when external db has no host
+    set:
+      mariadb.enabled: false
+      database.external.host: ""
+      database.external.password: "test"
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.host is required when mariadb.enabled=false"
+  - it: fails when external db has no password or existing secret
+    set:
+      mariadb.enabled: false
+      database.external.host: "db.example.com"
+      database.external.password: ""
+      database.external.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.password or database.external.existingSecret is required when mariadb.enabled=false"
+  - it: fails when external secrets enabled with empty items
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items must contain at least one item when externalSecrets.enabled=true"
+  - it: fails when ingress enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one host when ingress.enabled=true"
+  - it: fails when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/name"
+  - it: passes with default values
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/booklore/values.schema.json
+++ b/charts/booklore/values.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      },
+      "required": ["repository", "tag"]
+    },
+    "app": {
+      "type": "object",
+      "properties": {
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "size": { "type": "string" }
+          }
+        },
+        "bookdrop": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "size": { "type": "string" }
+          }
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# -- Override the chart name used in Kubernetes object names.
+nameOverride: ""
+
+# -- Override the full release name used in Kubernetes object names.
+fullnameOverride: ""
+
+# -- Extra labels applied to all Kubernetes objects rendered by this chart.
+commonLabels: {}
+
+image:
+  # -- Official BookLore container image repository.
+  repository: ghcr.io/booklore-app/booklore
+  # -- Pinned BookLore image tag. Floating tags such as latest are not used by default.
+  tag: "v2.3.1"
+  # -- Kubernetes image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Optional image pull secrets for private registries or mirrored images.
+imagePullSecrets: []
+
+# -- Number of BookLore pods.
+replicaCount: 1
+
+app:
+  # -- HTTP port exposed by BookLore inside the container.
+  port: 6060
+  # -- Root log level passed to BookLore.
+  rootLogLevel: INFO
+  # -- Application-specific log level for org.booklore.
+  logLevel: INFO
+  # -- CORS allowed origins. Leave default for same-origin requests only.
+  allowedOrigins: "*"
+  # -- Disk type for file storage. Options: LOCAL.
+  diskType: LOCAL
+  # -- Optional command override. Leave empty to use the upstream image entrypoint.
+  command: []
+  # -- Optional argument override. Leave empty to use the upstream image defaults.
+  args: []
+  # -- Additional environment variables for advanced upstream flags.
+  env: []
+  # -- Additional envFrom sources such as Secret or ConfigMap references.
+  envFrom: []
+
+secrets:
+  # -- Existing Secret containing BookLore sensitive values. Recommended for production.
+  existingSecret: ""
+  # -- Secret key containing the database password.
+  databasePasswordKey: database-password
+  # -- Inline database password. If empty and no existingSecret is set, a random one is generated.
+  databasePassword: ""
+
+database:
+  # -- External MariaDB configuration used when mariadb.enabled=false.
+  external:
+    host: ""
+    port: "3306"
+    name: booklore
+    username: root
+    password: ""
+    # -- Existing Secret containing the external database password.
+    existingSecret: ""
+    # -- Key in database.external.existingSecret containing the password.
+    existingSecretPasswordKey: password
+
+oidc:
+  # -- Enable OIDC authentication.
+  enabled: false
+  # -- Force disable OIDC even when configured.
+  forceDisable: false
+
+remoteAuth:
+  # -- Enable remote/proxy-based authentication headers.
+  enabled: false
+  # -- Create new users from remote auth headers.
+  createNewUsers: true
+  # -- Header containing the display name.
+  headerName: Remote-Name
+  # -- Header containing the username.
+  headerUser: Remote-User
+  # -- Header containing the email.
+  headerEmail: Remote-Email
+  # -- Header containing the groups.
+  headerGroups: Remote-Groups
+  # -- Admin group name.
+  adminGroup: ""
+  # -- Groups delimiter regex.
+  groupsDelimiter: "\\s+"
+
+persistence:
+  data:
+    # -- Persist library data, configuration, and metadata.
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
+  bookdrop:
+    # -- Persist BookDrop import folder. Disabled by default.
+    enabled: false
+    size: 5Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- ServiceAccount name. Defaults to the release fullname when create=true.
+  name: ""
+  # -- Annotations for the ServiceAccount.
+  annotations: {}
+  # -- Mount the ServiceAccount token in the pod.
+  automountServiceAccountToken: false
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Service port.
+  port: 6060
+  # -- Service annotations.
+  annotations: {}
+  # -- IP family policy. Options: SingleStack, PreferDualStack, RequireDualStack.
+  ipFamilyPolicy: ""
+  # -- Ordered list of IP families, for example ["IPv4", "IPv6"].
+  ipFamilies: []
+
+ingress:
+  # -- Enable Kubernetes Ingress.
+  enabled: false
+  # -- IngressClassName for the generated Ingress.
+  ingressClassName: traefik
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Ingress hosts and paths.
+  hosts: []
+  # -- Ingress TLS blocks.
+  tls: []
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute templates.
+  enabled: false
+  # -- List of HTTPRoute definitions. Each item is rendered as one HTTPRoute.
+  httpRoutes: []
+
+externalSecrets:
+  # -- Render external-secrets.io ExternalSecret resources.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Default sync interval applied to items without their own value.
+  refreshInterval: 1h
+  # -- List of ExternalSecret definitions. Each item carries a complete spec.
+  items: []
+
+probes:
+  startup:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 36
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+# -- Container resource requests and limits.
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1536Mi
+
+# -- Resources for the wait-for-database init container.
+waitForDatabase:
+  image:
+    repository: docker.io/library/busybox
+    tag: "1.37"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+# -- Pod security context.
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container security context. The upstream entrypoint runs as root to create
+# a user/group via addgroup and then drops privileges with su-exec.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - DAC_OVERRIDE
+  readOnlyRootFilesystem: false
+  runAsNonRoot: false
+  runAsUser: 0
+  seccompProfile:
+    type: RuntimeDefault
+
+pdb:
+  # -- Create a PodDisruptionBudget.
+  enabled: false
+  # -- Minimum available pods during voluntary disruptions.
+  minAvailable: 1
+
+networkPolicy:
+  # -- Create a NetworkPolicy that restricts inbound HTTP traffic to BookLore.
+  enabled: false
+  # -- Custom ingress peers. Empty allows ingress from any namespace.
+  ingressFrom: []
+  egress:
+    # -- Restrict egress to DNS and MariaDB destinations.
+    enabled: false
+    # -- Allow DNS egress on TCP/UDP 53.
+    allowDNS: true
+    # -- Additional egress destinations appended to the generated policy.
+    extraTo: []
+    # -- Additional egress rules (full rule objects) appended to the policy.
+    extraEgress: []
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler.
+  enabled: false
+  # -- Minimum replicas.
+  minReplicas: 1
+  # -- Maximum replicas.
+  maxReplicas: 3
+  # -- Target CPU utilization percentage.
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization percentage.
+  targetMemoryUtilizationPercentage: ""
+
+monitoring:
+  serviceMonitor:
+    # -- Create a ServiceMonitor for Prometheus.
+    enabled: false
+    # -- Extra labels for the ServiceMonitor.
+    labels: {}
+    # -- Scrape interval.
+    interval: ""
+    # -- Metrics endpoint path.
+    path: /actuator/prometheus
+
+# -- Node selector for scheduling the pod.
+nodeSelector: {}
+
+# -- Tolerations for scheduling the pod.
+tolerations: []
+
+# -- Affinity rules for scheduling the pod.
+affinity: {}
+
+# -- Topology spread constraints for scheduling the pod.
+topologySpreadConstraints: []
+
+# -- Optional PriorityClass name.
+priorityClassName: ""
+
+# -- Pod termination grace period in seconds.
+terminationGracePeriodSeconds: 30
+
+# -- Extra labels applied to the pod template.
+podLabels: {}
+
+# -- Extra annotations applied to the pod template.
+podAnnotations: {}
+
+# -- Extra volumes mounted into the pod.
+extraVolumes: []
+
+# -- Extra volume mounts added to the BookLore container.
+extraVolumeMounts: []
+
+# -- Additional Kubernetes manifests rendered with the chart.
+extraManifests: []
+
+mariadb:
+  # -- Deploy MariaDB as a subchart for BookLore.
+  enabled: true
+  auth:
+    database: booklore
+    username: booklore
+    password: ""
+    rootPassword: ""
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 768Mi

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -44,12 +44,10 @@ app:
   envFrom: []
 
 secrets:
-  # -- Existing Secret containing BookLore sensitive values. Recommended for production.
+  # -- Existing Secret containing BookLore application sensitive values.
+  # Database passwords are managed through mariadb.auth.* (bundled) or
+  # database.external.* (external DB) -- not through this block.
   existingSecret: ""
-  # -- Secret key containing the database password.
-  databasePasswordKey: database-password
-  # -- Inline database password. If empty and no existingSecret is set, a random one is generated.
-  databasePassword: ""
 
 database:
   # -- External MariaDB configuration used when mariadb.enabled=false.

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -317,7 +317,7 @@ mariadb:
     username: booklore
     password: ""
     rootPassword: ""
-  primary:
+  standalone:
     persistence:
       enabled: true
       size: 8Gi

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -97,6 +97,14 @@ persistence:
     accessModes:
       - ReadWriteOnce
     existingClaim: ""
+  books:
+    # -- Persist library books content at /books.
+    enabled: true
+    size: 50Gi
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    existingClaim: ""
   bookdrop:
     # -- Persist BookDrop import folder. Disabled by default.
     enabled: false

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -246,8 +246,8 @@ networkPolicy:
     enabled: false
     # -- Allow DNS egress on TCP/UDP 53.
     allowDNS: true
-    # -- Custom database egress destinations. When mariadb.enabled=false and this is empty,
-    # the policy auto-generates an ipBlock from database.external.host.
+    # -- Database egress destinations (required when mariadb.enabled=false and egress is enabled).
+    # Must be valid NetworkPolicy `to` peers (ipBlock with CIDR, podSelector, or namespaceSelector).
     databaseTo: []
     # -- Additional egress destinations appended to the generated policy.
     extraTo: []

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -246,6 +246,8 @@ networkPolicy:
     enabled: false
     # -- Allow DNS egress on TCP/UDP 53.
     allowDNS: true
+    # -- Custom DNS egress peers. Defaults to kube-system namespace (CoreDNS).
+    dnsPeers: []
     # -- Database egress destinations (required when mariadb.enabled=false and egress is enabled).
     # Must be valid NetworkPolicy `to` peers (ipBlock with CIDR, podSelector, or namespaceSelector).
     databaseTo: []
@@ -271,15 +273,17 @@ monitoring:
     # -- Create a ServiceMonitor for Prometheus.
     # NOTE: BookLore v2.3.1 does not ship with a Prometheus metrics endpoint.
     # Enable only if you build a custom image with micrometer-registry-prometheus
-    # or when upstream adds native Prometheus support.
+    # or when upstream adds native Prometheus support. You must set `path` to
+    # the actual Prometheus exposition endpoint (e.g. /actuator/prometheus).
     enabled: false
     # -- Extra labels for the ServiceMonitor.
     labels: {}
     # -- Scrape interval.
     interval: ""
-    # -- Metrics endpoint path. Override to /actuator/prometheus when the image
-    # includes the micrometer-registry-prometheus dependency.
-    path: /api/v1/healthcheck
+    # -- Metrics endpoint path (required when enabled). Must point to a real
+    # Prometheus exposition endpoint. No default because BookLore v2.3.1
+    # does not expose one.
+    path: ""
 
 # -- Node selector for scheduling the pod.
 nodeSelector: {}

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -246,6 +246,9 @@ networkPolicy:
     enabled: false
     # -- Allow DNS egress on TCP/UDP 53.
     allowDNS: true
+    # -- Custom database egress destinations. When mariadb.enabled=false and this is empty,
+    # the policy auto-generates an ipBlock from database.external.host.
+    databaseTo: []
     # -- Additional egress destinations appended to the generated policy.
     extraTo: []
     # -- Additional egress rules (full rule objects) appended to the policy.

--- a/charts/booklore/values.yaml
+++ b/charts/booklore/values.yaml
@@ -269,13 +269,17 @@ autoscaling:
 monitoring:
   serviceMonitor:
     # -- Create a ServiceMonitor for Prometheus.
+    # NOTE: BookLore v2.3.1 does not ship with a Prometheus metrics endpoint.
+    # Enable only if you build a custom image with micrometer-registry-prometheus
+    # or when upstream adds native Prometheus support.
     enabled: false
     # -- Extra labels for the ServiceMonitor.
     labels: {}
     # -- Scrape interval.
     interval: ""
-    # -- Metrics endpoint path.
-    path: /actuator/prometheus
+    # -- Metrics endpoint path. Override to /actuator/prometheus when the image
+    # includes the micrometer-registry-prometheus dependency.
+    path: /api/v1/healthcheck
 
 # -- Node selector for scheduling the pod.
 nodeSelector: {}


### PR DESCRIPTION
## Summary

Add a new HelmForge chart for [BookLore](https://github.com/booklore-app/booklore) — a self-hosted, multi-user digital library with smart shelves, auto metadata, Kobo/KOReader sync, BookDrop imports, OPDS support, and a built-in reader for EPUB, PDF, and comics.

## Upstream evidence

- Image: `ghcr.io/booklore-app/booklore:v2.3.1` (multi-arch: linux/amd64, linux/arm64)
- Verified by manifest: `make image-verify IMAGE=ghcr.io/booklore-app/booklore:v2.3.1` PASS
- Latest release: v2.3.1 (2026-06-26)

## Validation

`make validate-chart CHART=booklore` — **FULLY VALIDATED (17 layers)**

- helm lint --strict: PASS
- helm template (all CI scenarios): PASS
- helm unittest (14 tests): PASS
- kubeconform -strict: PASS
- ah lint: PASS
- k3d behavioral (8 scenarios): ALL PASS
- template-standards-check: 0 violations

## Chart features

- MariaDB subchart (HelmForge 2.0.3)
- Persistence: /app/data (10Gi), /bookdrop (optional)
- Ingress + Gateway API support
- ExternalSecrets, NetworkPolicy, PDB, HPA, ServiceMonitor
- OIDC + Remote Auth (proxy headers)
- 38 files, 7 CI scenarios, 14 unit tests

Resolves #634