### PR TITLE
fix(valkey): restored missing labels in PDB

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Add labelSelector to topologySpreadConstraints (#631)"
+      description: "Added missing labels to PDB"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "valkey.fullname" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
   {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   maxUnavailable: 1
@@ -20,7 +21,8 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ include "valkey.sentinelStatefulSetName" . }}
   labels:
-    {{- include "valkey.sentinelLabels" . | nindent 4 }}
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
   {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
   minAvailable: {{ .Values.sentinel.quorum }}


### PR DESCRIPTION
## Summary

Restored missing labels from the `PodDisruptionBudget` in Valkey chart due to changes in v1.2.1.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO