### PR TITLE
fix(valkey): Added missing bus port in NetworkPolicy for Valkey Cluster

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Add labelSelector to topologySpreadConstraints (#631)"
+      description: "Added missing bus port in NetworkPolicy for Valkey Cluster"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/templates/cluster-statefulset.yaml
+++ b/charts/valkey/templates/cluster-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
             - name: valkey
               containerPort: {{ .Values.service.ports.valkey }}
             - name: bus
-              containerPort: 16379
+              containerPort: {{ .Values.service.ports.bus }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/valkey/templates/networkpolicy.yaml
+++ b/charts/valkey/templates/networkpolicy.yaml
@@ -23,6 +23,10 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.service.ports.valkey }}
+        {{- if eq .Values.architecture "cluster" }}
+        - protocol: TCP
+          port: {{ .Values.service.ports.bus }}
+        {{- end }}
         {{- if eq .Values.architecture "sentinel" }}
         - protocol: TCP
           port: {{ .Values.service.ports.sentinel }}

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -378,6 +378,10 @@
               "type": "integer",
               "description": "valkey port"
             },
+            "bus": {
+              "type": "integer",
+              "description": "bus port for cluster architecture"
+            },
             "sentinel": {
               "type": "integer",
               "description": "Sentinel port"

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -242,6 +242,8 @@ service:
   ports:
     # -- Valkey service port
     valkey: 6379
+    # -- Cluster bus service port
+    bus: 16379
     # -- Sentinel service port
     sentinel: 26379
     # -- Metrics service port


### PR DESCRIPTION
## Summary

- Valkey Cluster nodes communicate over the cluster bus port (default 16379) for node-to-node gossip, in addition to the client port. The ingress NetworkPolicy only allowed the client port, so with `networkPolicy.enabled=true` in `architecture: cluster`, bus traffic between nodes was dropped — breaking cluster formation and failover/healing.
- Adds a configurable `service.ports.bus` (default 16379), wires it into the cluster StatefulSet `containerPort` (replacing the hardcoded `16379`), and allows it in the NetworkPolicy ingress rule when `architecture: cluster`.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO