### PR TITLE
chore(valkey): Removed non-mounted per-architecture config entries

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -28,7 +28,7 @@ icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Add labelSelector to topologySpreadConstraints (#631)"
+      description: "Removed non-mounted per-architecture config entries"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -10,11 +10,14 @@ metadata:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- include "valkey.renderAnnotations" (dict "root" .) | nindent 2 }}
 data:
+  {{- if eq .Values.architecture "standalone" }}
   valkey-standalone.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
     {{- end }}
+  {{- end }}
+  {{- if eq .Values.architecture "replication" }}
   valkey-primary.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}
     {{- if .Values.tls.enabled }}
@@ -32,25 +35,14 @@ data:
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
     {{- end }}
+  {{- end }}
+  {{- if eq .Values.architecture "sentinel" }}
   valkey-node.conf: |
     {{- include "valkey.commonConfig" . | nindent 4 }}
     {{- if .Values.tls.enabled }}
     tls-replication yes
     {{- end }}
     replica-read-only yes
-    {{- with .Values.config.valkey }}
-    {{ . | nindent 4 }}
-    {{- end }}
-  valkey-cluster.conf: |
-    {{- include "valkey.commonConfig" . | nindent 4 }}
-    cluster-enabled yes
-    cluster-config-file nodes.conf
-    cluster-node-timeout 5000
-    {{- if .Values.tls.enabled }}
-    tls-cluster yes
-    tls-replication yes
-    {{- end }}
-    appendonly yes
     {{- with .Values.config.valkey }}
     {{ . | nindent 4 }}
     {{- end }}
@@ -72,3 +64,19 @@ data:
     {{ . | nindent 4 }}
     {{- end }}
     # HelmForge managed sentinel config end
+  {{- end }}
+  {{- if eq .Values.architecture "cluster" }}
+  valkey-cluster.conf: |
+    {{- include "valkey.commonConfig" . | nindent 4 }}
+    cluster-enabled yes
+    cluster-config-file nodes.conf
+    cluster-node-timeout 5000
+    {{- if .Values.tls.enabled }}
+    tls-cluster yes
+    tls-replication yes
+    {{- end }}
+    appendonly yes
+    {{- with .Values.config.valkey }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  {{- end }}

--- a/charts/valkey/tests/tls_test.yaml
+++ b/charts/valkey/tests/tls_test.yaml
@@ -151,10 +151,10 @@ tests:
             mountPath: /tls
             readOnly: true
 
-  - it: should enable replication and cluster TLS directives
+  - it: should enable replication TLS directives
     template: configmap.yaml
     set:
-      architecture: cluster
+      architecture: replication
       tls.enabled: true
       tls.existingSecret: valkey-tls
     asserts:
@@ -164,12 +164,28 @@ tests:
       - matchRegex:
           path: data["valkey-replica.conf"]
           pattern: "tls-replication yes"
+
+  - it: should enable cluster TLS directives
+    template: configmap.yaml
+    set:
+      architecture: cluster
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
       - matchRegex:
           path: data["valkey-cluster.conf"]
           pattern: "tls-cluster yes"
       - matchRegex:
           path: data["valkey-cluster.conf"]
           pattern: "tls-replication yes"
+
+  - it: should enable sentinel TLS directives
+    template: configmap.yaml
+    set:
+      architecture: sentinel
+      tls.enabled: true
+      tls.existingSecret: valkey-tls
+    asserts:
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "tls-port 26379"


### PR DESCRIPTION
## Summary

- The ConfigMap previously rendered every architecture's config file (`valkey-standalone.conf`, `valkey-primary.conf`, `valkey-replica.conf`, `valkey-node.conf`, `valkey-cluster.conf`, `sentinel.conf`) on every release, regardless of the deployed topology — so a standalone install shipped a sentinel/cluster config it never mounted.
- Gates each config block by `.Values.architecture`, so the ConfigMap now contains only the config file(s) the deployed topology actually mounts. No behavioral change for a correctly-deployed release; smaller, mode-specific ConfigMap.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO