### PR TITLE
feat(valkey)!: Added Sentinel control-plane authentication + tests

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -27,8 +27,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Add labelSelector to topologySpreadConstraints (#631)"
+    - kind: added
+      description: "Add Sentinel control-plane authentication"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/templates/NOTES.txt
+++ b/charts/valkey/templates/NOTES.txt
@@ -133,7 +133,7 @@ Sentinel master set name:
 
 Verify Sentinel can see the primary:
 
-  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "valkey.sentinelStatefulSetName" . }} -- valkey-cli -p {{ .Values.service.ports.sentinel }} SENTINEL masters
+  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "valkey.sentinelStatefulSetName" . }} -- valkey-cli -p {{ .Values.service.ports.sentinel }}{{ if and .Values.auth.enabled .Values.auth.sentinel }} -a "$(kubectl get secret {{ include "valkey.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath='{.data.{{ .Values.auth.existingSecretPasswordKey }}}' | base64 -d)"{{ end }} SENTINEL masters
 {{- end }}
 
 {{- if include "valkey.isCluster" . }}

--- a/charts/valkey/templates/sentinel-node-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-node-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
               }
               sentinel_master=""
               for attempt in $(seq 1 30); do
-                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }}{{- if and .Values.auth.enabled .Values.auth.sentinel }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null | awk 'NR == 1 { print $1 }')"
                 [ -n "$sentinel_master" ] && break
                 echo "waiting for Sentinel master discovery ($attempt/30)"
                 sleep 2
@@ -148,7 +148,7 @@ spec:
               bootstrap_marker="/data/.helmforge-sentinel-node-bootstrapped"
               sentinel_master=""
               for attempt in $(seq 1 30); do
-                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null | awk 'NR == 1 { print $1 }')"
+                sentinel_master="$(valkey-cli {{ include "valkey.cliTlsArgs" . }}{{- if and .Values.auth.enabled .Values.auth.sentinel }} -a "$VALKEY_PASSWORD" --no-auth-warning {{- end }} -h {{ include "valkey.sentinelServiceFqdn" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null | awk 'NR == 1 { print $1 }')"
                 [ -n "$sentinel_master" ] && break
                 echo "waiting for Sentinel master discovery ($attempt/30)"
                 sleep 2

--- a/charts/valkey/templates/sentinel-statefulset.yaml
+++ b/charts/valkey/templates/sentinel-statefulset.yaml
@@ -81,6 +81,11 @@ spec:
               sed -i '/^sentinel auth-pass {{ .Values.sentinel.masterSet }} /d' /data/sentinel.conf
               echo "sentinel auth-pass {{ .Values.sentinel.masterSet }} ${VALKEY_PASSWORD}" >> /data/sentinel.conf
               {{- end }}
+              sed -i -e '/^requirepass /d' -e '/^sentinel sentinel-pass /d' /data/sentinel.conf
+              {{- if and .Values.auth.enabled .Values.auth.sentinel }}
+              echo "requirepass ${VALKEY_PASSWORD}" >> /data/sentinel.conf
+              echo "sentinel sentinel-pass ${VALKEY_PASSWORD}" >> /data/sentinel.conf
+              {{- end }}
               exec valkey-sentinel /data/sentinel.conf
           ports:
             - name: sentinel

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -25,7 +25,7 @@ spec:
         - |
           {{- if include "valkey.isSentinel" . }}
           for i in $(seq 1 30); do
-            addr="$(valkey-cli $VALKEY_TLS_ARGS -h {{ include "valkey.sentinelServiceName" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name mymaster 2>/dev/null)"
+            addr="$(valkey-cli $VALKEY_TLS_ARGS{{- if and .Values.auth.enabled .Values.auth.sentinel }} -a "$VALKEY_PASSWORD" --no-auth-warning{{- end }} -h {{ include "valkey.sentinelServiceName" . | quote }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} 2>/dev/null)"
             host="$(echo "$addr" | sed -n '1p')"
             port="$(echo "$addr" | sed -n '2p')"
             [ -z "$port" ] && port={{ .Values.service.ports.valkey }}

--- a/charts/valkey/tests/sentinel_node_test.yaml
+++ b/charts/valkey/tests/sentinel_node_test.yaml
@@ -190,3 +190,48 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: "sentinel auth-pass legacy-master \\$\\{VALKEY_PASSWORD\\}"
+
+  - it: injects sentinel requirepass and sentinel-pass when auth.sentinel=true
+    set:
+      architecture: sentinel
+      auth:
+        enabled: true
+        sentinel: true
+    template: sentinel-statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'echo "requirepass \$\{VALKEY_PASSWORD\}"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'echo "sentinel sentinel-pass \$\{VALKEY_PASSWORD\}"'
+
+  - it: omits sentinel auth when auth.sentinel=false but keeps the strip
+    set:
+      architecture: sentinel
+      auth:
+        enabled: true
+        sentinel: false
+    template: sentinel-statefulset.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: 'echo "requirepass'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "sed -i -e '/\\^requirepass /d'"
+
+  - it: both node containers authenticate to Sentinel when auth.sentinel=true
+    set:
+      architecture: sentinel
+      auth:
+        enabled: true
+        sentinel: true
+    template: sentinel-node-statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].args[0]
+          pattern: '-a "\$VALKEY_PASSWORD"[^\n]*sentinel get-master-addr-by-name'
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '-a "\$VALKEY_PASSWORD"[^\n]*sentinel get-master-addr-by-name'

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -72,6 +72,10 @@
         "existingSecretPasswordKey": {
           "type": "string",
           "description": "Secret key name for the password in auth.existingSecret"
+        },
+        "sentinel": {
+          "type": "boolean",
+          "description": "Secure the Sentinel control plane (requirepass + inter-sentinel auth). No effect if auth.enabled=false"
         }
       }
     },

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -42,7 +42,7 @@ imagePullSecrets: []
 # =============================================================================
 
 auth:
-  # -- Enable password authentication
+  # -- Enable password authentication on Valkey
   enabled: true
   # -- Valkey password. Auto-generated if empty and auth.enabled=true
   password: ""
@@ -50,6 +50,8 @@ auth:
   existingSecret: ""
   # -- Secret key name for the password in auth.existingSecret
   existingSecretPasswordKey: valkey-password
+  # -- Enable password authentication on the Sentinel control plane
+  sentinel: true
 
 # =============================================================================
 # TLS


### PR DESCRIPTION
## Summary

- Adds optional authentication on the Sentinel control plane via `auth.sentinel` (default `true`). Previously the Sentinel port had no `requirepass`, leaving `SENTINEL FAILOVER`/`SET`/`REMOVE`/`RESET` reachable by anyone with network access — the data plane was password-protected but the control plane was open.
- When `auth.enabled && auth.sentinel`, injects `requirepass` and `sentinel sentinel-pass` at runtime (never in the ConfigMap), reusing the Valkey password. Both node-container Sentinel queries (init + main) and the test hook authenticate accordingly. The strip step is unconditional so toggling `auth.sentinel` off is reversible on restart.
> **BREAKING:** external Sentinel-aware clients must now authenticate; set 'auth.sentinel: false' to preserve prior behavior.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance
- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist
- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification
- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced upstream GitHub Releases and Docker Hub tags

## Site Sync (GR-007)
- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation
- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/valkey --strict` passed
- [x] `helm unittest charts/valkey` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO