### PR TITLE
docs(memcached): clarify standard pool deployment

### DIFF
--- a/charts/memcached/DESIGN.md
+++ b/charts/memcached/DESIGN.md
@@ -5,7 +5,8 @@
 This chart deploys Memcached on Kubernetes using the official image. It focuses on predictable cache infrastructure, secure-by-option production settings,
 and integration points commonly required by platform teams.
 
-It does not turn Memcached into a replicated database. Cache distribution remains a client responsibility.
+It does not turn Memcached into a replicated database or perform server-side
+sharding. Cache distribution remains a client responsibility.
 
 ## Architecture
 
@@ -57,7 +58,10 @@ Applications -------------------------------------+
 +-------------+   +-------------+   +-------------+
 ```
 
-Memcached does not replicate entries. A production client should use consistent hashing or another distribution strategy and tolerate cache misses during node replacement.
+Memcached does not replicate entries. This is the standard Memcached pool model:
+run several independent servers and configure the application client to spread
+keys across them. A production client should use consistent hashing or another
+distribution strategy and tolerate cache misses during node replacement.
 
 ### Secure Integration Flow
 

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -6,6 +6,27 @@ The chart supports a simple standalone cache for development and a distributed s
 
 ## Install
 
+### Standard Memcached pool
+
+For a typical production-style Memcached pool, run independent cache nodes and
+let the application client distribute keys across them:
+
+```yaml
+architecture: distributed
+replicaCount: 3
+```
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install memcached helmforge/memcached -f values.yaml
+```
+
+This creates three Memcached pods. The chart does not replicate cache entries
+or shard keys inside Kubernetes. Use a Memcached client library that supports
+multiple servers, preferably with consistent hashing. The headless Service gives
+pod-aware clients stable DNS names for explicit pool membership.
+
 ### HTTPS repository
 
 ```bash
@@ -42,9 +63,11 @@ helm install memcached oci://ghcr.io/helmforgedev/helm/memcached -f values.yaml
 | Architecture | Contract | Typical use |
 |--------------|----------|-------------|
 | `standalone` | One Memcached pod behind one Service. | Development, tests, small non-critical caches. |
-| `distributed` | Multiple independent Memcached pods behind one Service and stable pod DNS. | Production caches where the client library handles node distribution. |
+| `distributed` | Multiple independent Memcached pods with a client Service and stable pod DNS. | Standard Memcached pools where the client library distributes keys. |
 
-Memcached does not replicate cache entries between nodes. In distributed mode, use client-side consistent hashing when cache hit ratio matters during scale events.
+Memcached does not replicate cache entries between nodes. In distributed mode,
+the client is responsible for choosing a node for each key. Use client-side
+consistent hashing when cache hit ratio matters during scale events.
 
 ## Development quick start
 
@@ -71,7 +94,7 @@ Production-ready deployments are possible through values. The defaults stay deve
 
 Start from [examples/production.yaml](examples/production.yaml) and adapt:
 
-- use `architecture: distributed` with at least three replicas
+- use `architecture: distributed` with at least three nodes (`replicaCount: 3`)
 - size `memcached.memoryLimitMB` and Kubernetes memory limits together
 - set explicit CPU and memory requests
 - disable `flush_all` with `memcached.disableFlushAll=true`

--- a/charts/memcached/docs/production.md
+++ b/charts/memcached/docs/production.md
@@ -2,11 +2,23 @@
 
 ## Deployment Model
 
-Memcached stores cache entries in memory and does not replicate data between
-pods. In production, prefer `architecture: distributed` with at least three
-replicas and a client library that supports consistent hashing. The chart keeps
-stable StatefulSet pod identities and a headless Service so clients can address
-individual cache nodes when they need deterministic distribution.
+The standard Memcached production pattern is a pool of independent cache nodes.
+For example:
+
+```yaml
+architecture: distributed
+replicaCount: 3
+```
+
+This starts three Memcached pods. Memcached stores cache entries in memory and
+does not replicate data between pods. The application client must distribute
+keys across the pool, ideally with consistent hashing. The chart keeps stable
+StatefulSet pod identities and a headless Service so clients can address
+individual cache nodes when they need deterministic pool membership.
+
+The regular client Service is useful for simple connectivity and smoke tests.
+It does not replace client-side key distribution for workloads that expect a
+multi-node Memcached pool.
 
 Use `standalone` only when losing a single cache node is acceptable. It is a
 good fit for development, CI, preview environments, or small workloads where a
@@ -150,8 +162,8 @@ kubectl run memcached-client --rm -it --restart=Never \
   sh -ec "printf 'version\r\nquit\r\n' | nc memcached 11211"
 ```
 
-For distributed deployments, validate that all expected pods are addressable
-through the headless Service:
+For distributed deployments, validate that all expected pool members are
+addressable through the headless Service:
 
 ```bash
 kubectl get endpoints memcached-headless


### PR DESCRIPTION
## Summary
- Clarifies the Memcached chart docs around the standard Memcached pool model.
- Shows the production-style `architecture: distributed` plus `replicaCount: 3` values before the install path.
- Explains that the chart does not add replication or server-side sharding; clients must distribute keys across independent servers.

## Validation
- `make standards-check CHART=memcached`
- `make validate-chart CHART=memcached`
- `make site-sync-check CHART=memcached`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Related
- Site sync: https://github.com/helmforgedev/site/pull/320
- Upstream discussion: https://github.com/memcached/memcached/issues/1299#issuecomment-4869207786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Memcached chart behavior for distributed setups, including that entries are not replicated between nodes and client-side key distribution is required.
  * Added clearer guidance for the standard pool configuration, with example settings and installation notes.
  * Improved production documentation to explain stable pool membership, headless service usage, and rollout checks for expected members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->