### PR TITLE
fix(adguard-home): align template standards

### DIFF
--- a/charts/adguard-home/ci/external-secrets.yaml
+++ b/charts/adguard-home/ci/external-secrets.yaml
@@ -18,4 +18,4 @@ externalSecrets:
   data:
     - secretKey: AdGuardHome.yaml
       remoteRef:
-        key: adguard-home/config
+        key: test/adguard-home-config

--- a/charts/adguard-home/templates/_helpers.tpl
+++ b/charts/adguard-home/templates/_helpers.tpl
@@ -85,3 +85,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- printf "%s-sync" (include "adguard-home.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "adguard-home.validate" -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if not .Values.config.existingSecret -}}
+    {{- fail "externalSecrets.enabled requires config.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." -}}
+  {{- end -}}
+  {{- $hasConfigKey := false -}}
+  {{- range .Values.externalSecrets.data -}}
+    {{- if eq .secretKey "AdGuardHome.yaml" -}}
+      {{- $hasConfigKey = true -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not $hasConfigKey -}}
+    {{- fail "externalSecrets.data must contain an entry with secretKey 'AdGuardHome.yaml' when externalSecrets.enabled=true to populate the initial configuration." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/adguard-home/templates/externalsecret.yaml
+++ b/charts/adguard-home/templates/externalsecret.yaml
@@ -1,23 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "adguard-home.validate" . }}
 {{- if .Values.externalSecrets.enabled }}
-{{- /*
-  Guard: when externalSecrets.enabled=true the chart-managed AdGuardHome.yaml Secret
-  is still rendered unless config.existingSecret is set. Without this guard both
-  resources target the same name, creating credential drift between the config
-  Secret and the ExternalSecret. Require config.existingSecret explicitly.
-*/}}
-{{- if not .Values.config.existingSecret }}
-  {{- fail "externalSecrets.enabled requires config.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
-{{- end }}
-{{- $hasConfigKey := false }}
-{{- range .Values.externalSecrets.data }}
-  {{- if eq .secretKey "AdGuardHome.yaml" }}
-    {{- $hasConfigKey = true }}
-  {{- end }}
-{{- end }}
-{{- if not $hasConfigKey }}
-  {{- fail "externalSecrets.data must contain an entry with secretKey 'AdGuardHome.yaml' when externalSecrets.enabled=true to populate the initial configuration." }}
-{{- end }}
 apiVersion: {{ .Values.externalSecrets.apiVersion }}
 kind: ExternalSecret
 metadata:

--- a/charts/adguard-home/templates/validate.yaml
+++ b/charts/adguard-home/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "adguard-home.validate" . -}}

--- a/charts/adguard-home/tests/validation_test.yaml
+++ b/charts/adguard-home/tests/validation_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should require an existing config secret when external secrets are enabled
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+      externalSecrets.data:
+        - secretKey: AdGuardHome.yaml
+          remoteRef:
+            key: adguard-home/config
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.enabled requires config.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret.
+
+  - it: should require the AdGuardHome config key when external secrets are enabled
+    set:
+      config.existingSecret: adguard-config
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: cluster-secrets
+      externalSecrets.data:
+        - secretKey: other-key
+          remoteRef:
+            key: adguard-home/config
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.data must contain an entry with secretKey 'AdGuardHome.yaml' when externalSecrets.enabled=true to populate the initial configuration.


### PR DESCRIPTION
## Summary

Align the AdGuard Home chart with the template standards checker.

Changes:
- add a canonical `adguard-home.validate` helper and `templates/validate.yaml`
- move existing ExternalSecret guard logic into the validation helper
- add helm-unittest coverage for the validation failures
- point the ESO CI scenario at the deterministic `test/adguard-home-config` fake store fixture

Site PR: helmforgedev/site#322

## Validation

- `node scripts/charts/template-standards-check.js --chart adguard-home --json`
- `helm unittest charts/adguard-home`
- `helm lint --strict charts/adguard-home`
- `make validate-chart CHART=adguard-home`
- `make site-sync-check CHART=adguard-home`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AdGuard Home external secret reference to use the new configuration path.
  * Added validation to catch misconfigured external-secrets setups earlier, helping prevent missing configuration or secret drift.
* **Tests**
  * Added validation checks to cover the new external-secrets requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->