### PR TITLE
fix(alfio): align template standards

### DIFF
--- a/charts/alfio/templates/_helpers.tpl
+++ b/charts/alfio/templates/_helpers.tpl
@@ -105,3 +105,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "alfio.jdbcUrl" -}}
 {{- printf "jdbc:postgresql://%s:%s/%s" (include "alfio.dbHost" .) (include "alfio.dbPort" .) (include "alfio.dbName" .) -}}
 {{- end -}}
+
+{{- define "alfio.validate" -}}
+{{- if and (not .Values.postgresql.enabled) (empty .Values.database.external.host) -}}
+{{- fail "database.external.host is required when postgresql.enabled=false" -}}
+{{- end -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) (empty .Values.database.external.password) -}}
+{{- fail "database.external.password or database.external.existingSecret is required when postgresql.enabled=false" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if .Values.podLabels -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/alfio/templates/validate.yaml
+++ b/charts/alfio/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "alfio.validate" . -}}

--- a/charts/alfio/tests/deployment_test.yaml
+++ b/charts/alfio/tests/deployment_test.yaml
@@ -122,6 +122,7 @@ tests:
       database.external.port: "5433"
       database.external.name: my_alfio
       database.external.username: alfio_user
+      database.external.password: my-password
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/alfio/tests/deployment_test.yaml
+++ b/charts/alfio/tests/deployment_test.yaml
@@ -134,6 +134,14 @@ tests:
           content:
             name: DATASOURCE_USERNAME
             value: "alfio_user"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATASOURCE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-alfio-db
+                key: password
 
   - it: should use existing secret for external db password
     set:

--- a/charts/alfio/tests/validation_test.yaml
+++ b/charts/alfio/tests/validation_test.yaml
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should require an external database host when the subchart is disabled
+    set:
+      postgresql.enabled: false
+      database.external.password: my-password
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.host is required when postgresql.enabled=false
+
+  - it: should require an external database password source when the subchart is disabled
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.password or database.external.existingSecret is required when postgresql.enabled=false
+
+  - it: should require at least one ingress host when ingress is enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress.hosts must contain at least one host when ingress.enabled=true
+
+  - it: should reject podLabels that override the name selector
+    set:
+      podLabels:
+        app.kubernetes.io/name: other
+    asserts:
+      - failedTemplate:
+          errorMessage: podLabels must not override the selector label app.kubernetes.io/name
+
+  - it: should reject podLabels that override the instance selector
+    set:
+      podLabels:
+        app.kubernetes.io/instance: other
+    asserts:
+      - failedTemplate:
+          errorMessage: podLabels must not override the selector label app.kubernetes.io/instance

--- a/charts/alfio/tests/validation_test.yaml
+++ b/charts/alfio/tests/validation_test.yaml
@@ -6,6 +6,20 @@ release:
   name: test
   namespace: default
 tests:
+  - it: should render no validation manifest with valid external database and ingress values
+    set:
+      postgresql.enabled: false
+      database.external.host: db.example.com
+      database.external.password: my-password
+      ingress.enabled: true
+      ingress.hosts:
+        - host: alfio.example.com
+      podLabels:
+        app.kubernetes.io/component: web
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should require an external database host when the subchart is disabled
     set:
       postgresql.enabled: false


### PR DESCRIPTION
## Summary
- add the canonical alfio.validate helper and validate.yaml gate
- fail fast for invalid external database settings when PostgreSQL subchart is disabled
- fail fast for enabled ingress without hosts
- reject podLabels that override immutable selector labels
- add helm-unittest coverage for validation failures

## Validation
- node scripts/charts/template-standards-check.js --chart alfio --json
- helm unittest charts/alfio
- helm lint --strict charts/alfio
- make standards-check CHART=alfio
- make validate-chart CHART=alfio TIMEOUT=1200: FULLY VALIDATED (13 layers)
- make site-sync-check CHART=alfio
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#323
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm chart render-time validation that stops rendering when required external database and ingress settings are missing, and prevents conflicting `podLabels` overrides.

* **Tests**
  * Added a chart validation test suite with positive and negative assertions for external DB requirements, ingress host requirements, and disallowed label overrides.
  * Updated deployment tests to ensure the external database password is provided via a referenced secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->