### PR TITLE
fix(appwrite): align template standards

### DIFF
--- a/charts/appwrite/templates/_helpers.tpl
+++ b/charts/appwrite/templates/_helpers.tpl
@@ -60,6 +60,13 @@ app.kubernetes.io/component: {{ .component }}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
 {{- end -}}
+{{- if .Values.ingress.enabled -}}
+{{- range $index, $host := .Values.ingress.hosts -}}
+{{- if not $host.host -}}
+{{- fail (printf "ingress.hosts[%d].host is required when ingress.enabled is true" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
 {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." -}}
 {{- end -}}

--- a/charts/appwrite/templates/_helpers.tpl
+++ b/charts/appwrite/templates/_helpers.tpl
@@ -53,6 +53,18 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 {{- end -}}
 
+{{- define "appwrite.validate" -}}
+{{- $databaseMode := include "appwrite.databaseMode" . -}}
+{{- $cacheMode := include "appwrite.cacheMode" . -}}
+{{- $backupEnabled := include "appwrite.backupEnabled" . -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
+{{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "appwrite.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}

--- a/charts/appwrite/templates/validate.yaml
+++ b/charts/appwrite/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "appwrite.validate" . -}}

--- a/charts/appwrite/tests/validation_test.yaml
+++ b/charts/appwrite/tests/validation_test.yaml
@@ -44,6 +44,17 @@ tests:
       - failedTemplate:
           errorMessage: "ingress.enabled requires ingress.hosts to contain at least one host"
 
+  - it: should fail when an ingress host entry has no hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts[0].host is required when ingress.enabled is true"
+
   - it: should fail when gateway is enabled without parentRefs
     set:
       gateway.enabled: true

--- a/charts/appwrite/tests/validation_test.yaml
+++ b/charts/appwrite/tests/validation_test.yaml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when database selection is ambiguous
+    set:
+      database.external.host: mariadb.example.com
+      database.external.rootPassword: secret
+      mariadb.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "appwrite database selection is ambiguous: configure only one of database.external.* or mariadb.enabled"
+
+  - it: should fail when cache selection is ambiguous
+    set:
+      cache.external.host: redis.example.com
+      cache.external.password: secret
+      redis.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "appwrite cache selection is ambiguous: configure only one of cache.external.* or redis.enabled"
+
+  - it: should fail when backup endpoint is missing
+    set:
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.enabled requires ingress.hosts to contain at least one host"
+
+  - it: should fail when gateway is enabled without parentRefs
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."


### PR DESCRIPTION
## Summary
- add the canonical appwrite.validate helper and validate.yaml gate
- centralize fail-fast validation for database, cache, backup, ingress, and Gateway API settings
- add helm-unittest coverage for validation failures

## Validation
- make template-standards-check CHART=appwrite
- helm unittest charts/appwrite
- helm lint --strict charts/appwrite
- make standards-check CHART=appwrite
- make validate-chart CHART=appwrite TIMEOUT=1200: FULLY VALIDATED (19 layers)
- make site-sync-check CHART=appwrite
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#325
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chart rendering-time configuration validation to catch invalid setups early.
  * Improves failure messages for common issues such as missing ingress hosts, incomplete ingress host entries, missing gateway parent references, conflicting database/cache configuration, and missing backup endpoint details when backups are enabled.
* **Bug Fixes**
  * Prevents deployments from proceeding when required settings are missing or mutually exclusive.
* **Tests**
  * Added Helm validation test coverage for valid configurations and targeted failure cases with expected error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->