### PR TITLE
fix(archivebox): align template standards

### DIFF
--- a/charts/archivebox/templates/_helpers.tpl
+++ b/charts/archivebox/templates/_helpers.tpl
@@ -40,6 +40,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "archivebox.validate" -}}
+{{/* Triggers backup validation failures through archivebox.backupEnabled; the return value is unused. */}}
 {{- $backupEnabled := include "archivebox.backupEnabled" . -}}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}

--- a/charts/archivebox/templates/_helpers.tpl
+++ b/charts/archivebox/templates/_helpers.tpl
@@ -39,6 +39,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "archivebox.validate" -}}
+{{- $backupEnabled := include "archivebox.backupEnabled" . -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
+{{- end -}}
+{{- if .Values.ingress.enabled -}}
+{{- range $index, $host := .Values.ingress.hosts -}}
+{{- if not $host.host -}}
+{{- fail (printf "ingress.hosts[%d].host is required when ingress.enabled is true" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "archivebox.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
@@ -96,8 +115,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if not .Values.backup.s3.bucket -}}
     {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
   {{- end -}}
-  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) -}}
-    {{- fail "backup.s3.accessKey or backup.s3.existingSecret is required when backup.enabled is true" -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (or (not .Values.backup.s3.accessKey) (not .Values.backup.s3.secretKey)) -}}
+    {{- fail "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey" -}}
   {{- end -}}
 true
 {{- end -}}

--- a/charts/archivebox/templates/validate.yaml
+++ b/charts/archivebox/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "archivebox.validate" . -}}

--- a/charts/archivebox/tests/backup_test.yaml
+++ b/charts/archivebox/tests/backup_test.yaml
@@ -89,3 +89,14 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "backup.s3.bucket is required when backup.enabled is true"
+
+  - it: should fail without s3 secret key
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: http://minio:9000
+      backup.s3.bucket: backups
+      backup.s3.accessKey: admin
+    template: backup-cronjob.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey"

--- a/charts/archivebox/tests/validation_test.yaml
+++ b/charts/archivebox/tests/validation_test.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when backup endpoint is missing
+    set:
+      backup.enabled: true
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail when backup credentials are missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: http://minio:9000
+      backup.s3.bucket: backups
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup requires either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey"
+
+  - it: should fail when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.enabled requires ingress.hosts to contain at least one host"
+
+  - it: should fail when an ingress host entry has no hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts[0].host is required when ingress.enabled is true"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: archivebox-custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- add the canonical archivebox.validate helper and validate.yaml gate
- centralize fail-fast validation for backup, ingress hosts, and selector label overrides
- require both S3 access key and secret key when backup uses inline credentials
- add helm-unittest coverage for validation failures

## Validation
- make template-standards-check CHART=archivebox
- helm unittest charts/archivebox
- helm lint --strict charts/archivebox
- make standards-check CHART=archivebox
- make validate-chart CHART=archivebox TIMEOUT=1200: FULLY VALIDATED (13 layers)
- make site-sync-check CHART=archivebox
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#326
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added fail-fast chart validation for common misconfigurations, including enabling ingress without hosts, ingress hosts missing required host values, conflicting pod label overrides, and incomplete/absent backup settings.
  * Strengthened S3 backup credential checks: when not using an existing S3 secret, both S3 access key and secret key must be provided together (with a consolidated error message).
* **Tests**
  * Expanded chart validation test coverage for the above failure scenarios, including incomplete S3 backup credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->