### PR TITLE
fix(automatisch): align template standards

### DIFF
--- a/charts/automatisch/templates/_helpers.tpl
+++ b/charts/automatisch/templates/_helpers.tpl
@@ -59,8 +59,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- $selectorLabels := include "automatisch.selectorLabels" . | fromYaml -}}
 {{- range $key, $_ := .Values.podLabels -}}
-{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- if hasKey $selectorLabels $key -}}
 {{- fail (printf "podLabels must not override selector label %q" $key) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/automatisch/templates/_helpers.tpl
+++ b/charts/automatisch/templates/_helpers.tpl
@@ -39,6 +39,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "automatisch.validate" -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.host) -}}
+{{- fail "database.external.host is required when postgresql.enabled is false" -}}
+{{- end -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
+{{- fail "database.external.password or database.external.existingSecret is required when postgresql.enabled is false" -}}
+{{- end -}}
+{{- if and (not .Values.redis.enabled) (not .Values.redis_config.external.host) -}}
+{{- fail "redis_config.external.host is required when redis.enabled is false" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
+{{- end -}}
+{{- if .Values.ingress.enabled -}}
+{{- range $index, $host := .Values.ingress.hosts -}}
+{{- if not $host.host -}}
+{{- fail (printf "ingress.hosts[%d].host is required when ingress.enabled is true" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "automatisch.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}

--- a/charts/automatisch/templates/validate.yaml
+++ b/charts/automatisch/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "automatisch.validate" . -}}

--- a/charts/automatisch/tests/validation_test.yaml
+++ b/charts/automatisch/tests/validation_test.yaml
@@ -57,3 +57,11 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'
+
+  - it: should fail when podLabels override release selector label
+    set:
+      podLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/instance"'

--- a/charts/automatisch/tests/validation_test.yaml
+++ b/charts/automatisch/tests/validation_test.yaml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when external database host is missing
+    set:
+      postgresql.enabled: false
+      database.external.password: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.host is required when postgresql.enabled is false"
+
+  - it: should fail when external database credentials are missing
+    set:
+      postgresql.enabled: false
+      database.external.host: postgres.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.password or database.external.existingSecret is required when postgresql.enabled is false"
+
+  - it: should fail when external redis host is missing
+    set:
+      redis.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis_config.external.host is required when redis.enabled is false"
+
+  - it: should fail when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.enabled requires ingress.hosts to contain at least one host"
+
+  - it: should fail when an ingress host entry has no hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts[0].host is required when ingress.enabled is true"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- add the canonical automatisch.validate helper and validate.yaml gate
- fail fast for incomplete external PostgreSQL and Redis configuration, invalid ingress hosts, and selector label overrides
- add helm-unittest coverage for the new validation paths

## Validation
- make template-standards-check CHART=automatisch
- helm unittest charts/automatisch
- helm lint --strict charts/automatisch
- make standards-check CHART=automatisch
- make validate-chart CHART=automatisch TIMEOUT=900: FULLY VALIDATED (13 layers)
- make site-sync-check CHART=automatisch
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#328
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm chart validations to fail fast on misconfiguration.
  * Requires external database host and credentials when PostgreSQL is disabled.
  * Requires external Redis host when Redis is disabled.
  * Validates ingress hosts are present and each host entry has a non-empty host.
  * Prevents custom pod labels from overriding key selector labels.
* **Tests**
  * Added validation coverage for the above failure scenarios and exact error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->