### PR TITLE
fix(castopod): align template standards

### DIFF
--- a/charts/castopod/templates/_helpers.tpl
+++ b/charts/castopod/templates/_helpers.tpl
@@ -46,10 +46,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and (not .Values.mariadb.enabled) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
 {{- fail "database.external.password or database.external.existingSecret is required when mariadb.enabled is false" -}}
 {{- end -}}
-{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- if .Values.ingress.enabled -}}
+{{- if not .Values.ingress.hosts -}}
 {{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
 {{- end -}}
-{{- if .Values.ingress.enabled -}}
 {{- range $index, $host := .Values.ingress.hosts -}}
 {{- if not $host.host -}}
 {{- fail (printf "ingress.hosts[%d].host is required when ingress.enabled is true" $index) -}}

--- a/charts/castopod/templates/_helpers.tpl
+++ b/charts/castopod/templates/_helpers.tpl
@@ -39,6 +39,44 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "castopod.validate" -}}
+{{- if and (not .Values.mariadb.enabled) (not .Values.database.external.host) -}}
+{{- fail "database.external.host is required when mariadb.enabled is false" -}}
+{{- end -}}
+{{- if and (not .Values.mariadb.enabled) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
+{{- fail "database.external.password or database.external.existingSecret is required when mariadb.enabled is false" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
+{{- end -}}
+{{- if .Values.ingress.enabled -}}
+{{- range $index, $host := .Values.ingress.hosts -}}
+{{- if not $host.host -}}
+{{- fail (printf "ingress.hosts[%d].host is required when ingress.enabled is true" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.backup.enabled -}}
+{{- if not .Values.backup.s3.endpoint -}}
+{{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
+{{- end -}}
+{{- if not .Values.backup.s3.bucket -}}
+{{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
+{{- end -}}
+{{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) -}}
+{{- fail "backup.s3.accessKey or backup.s3.existingSecret is required when backup.enabled is true" -}}
+{{- end -}}
+{{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.secretKey) -}}
+{{- fail "backup.s3.secretKey or backup.s3.existingSecret is required when backup.enabled is true" -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "castopod.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
@@ -142,18 +180,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
-{{/* Backup — validate required fields */}}
 {{- define "castopod.backupEnabled" -}}
 {{- if .Values.backup.enabled -}}
-  {{- if not .Values.backup.s3.endpoint -}}
-    {{- fail "backup.s3.endpoint is required when backup.enabled is true" -}}
-  {{- end -}}
-  {{- if not .Values.backup.s3.bucket -}}
-    {{- fail "backup.s3.bucket is required when backup.enabled is true" -}}
-  {{- end -}}
-  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) -}}
-    {{- fail "backup.s3.accessKey or backup.s3.existingSecret is required when backup.enabled is true" -}}
-  {{- end -}}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/castopod/templates/validate.yaml
+++ b/charts/castopod/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "castopod.validate" . -}}

--- a/charts/castopod/tests/validation_test.yaml
+++ b/charts/castopod/tests/validation_test.yaml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when external database host is missing
+    set:
+      mariadb.enabled: false
+      database.external.password: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.host is required when mariadb.enabled is false"
+
+  - it: should fail when external database credentials are missing
+    set:
+      mariadb.enabled: false
+      database.external.host: mariadb.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.password or database.external.existingSecret is required when mariadb.enabled is false"
+
+  - it: should fail when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.enabled requires ingress.hosts to contain at least one host"
+
+  - it: should fail when an ingress host entry has no hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts[0].host is required when ingress.enabled is true"
+
+  - it: should fail when backup endpoint is missing
+    set:
+      backup.enabled: true
+      backup.s3.bucket: castopod
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.endpoint is required when backup.enabled is true"
+
+  - it: should fail when backup bucket is missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.example.com
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.bucket is required when backup.enabled is true"
+
+  - it: should fail when backup access key is missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.example.com
+      backup.s3.bucket: castopod
+      backup.s3.secretKey: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.accessKey or backup.s3.existingSecret is required when backup.enabled is true"
+
+  - it: should fail when backup secret key is missing
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://s3.example.com
+      backup.s3.bucket: castopod
+      backup.s3.accessKey: access
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.s3.secretKey or backup.s3.existingSecret is required when backup.enabled is true"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- add the canonical castopod.validate helper and validate.yaml gate
- centralize fail-fast validation for external MariaDB, ingress hosts, backup S3 settings, and selector label overrides
- add helm-unittest coverage for validation failures

## Validation
- make template-standards-check CHART=castopod
- helm unittest charts/castopod
- helm lint --strict charts/castopod
- make standards-check CHART=castopod
- make validate-chart CHART=castopod TIMEOUT=900: FULLY VALIDATED (13 layers)
- make site-sync-check CHART=castopod
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#329
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter pre-deployment Helm chart validation with fail-fast errors for missing or incomplete database, ingress, and S3 backup settings.
  * Enforces that ingress hosts are provided when ingress is enabled.
  * Validates required S3 backup fields and credentials are set when backups are enabled.
  * Prevents custom `podLabels` from overriding selector label keys.
* **Tests**
  * Added chart validation tests to verify specific failure cases and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->