### PR TITLE
fix(changedetection): align template standards

### DIFF
--- a/charts/changedetection/templates/NOTES.txt
+++ b/charts/changedetection/templates/NOTES.txt
@@ -2,8 +2,8 @@
 changedetection.io has been installed
 =====================================
 
-Installation summary
---------------------
+1. Installation summary
+-----------------------
 Release: {{ .Release.Name }}
 Namespace: {{ .Release.Namespace }}
 Chart version: {{ .Chart.Version }}
@@ -14,12 +14,16 @@ Service type: {{ .Values.service.type }}
 Service port: {{ .Values.service.port }}
 Container port: {{ .Values.changedetection.port }}
 
-Access changedetection.io
--------------------------
+2. Access changedetection.io
+----------------------------
 {{- if .Values.ingress.enabled }}
 Ingress routes:
 {{- range .Values.ingress.hosts }}
+{{- if .host }}
   - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}/
+{{- else }}
+  - catch-all host on the configured ingress controller
+{{- end }}
 {{- end }}
 {{- else if .Values.gateway.enabled }}
 Gateway API routes:
@@ -42,8 +46,8 @@ Cluster-local endpoint:
 
   http://{{ include "changedetection.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/
 
-Operational checks
-------------------
+3. Operational checks
+---------------------
 Wait for the workload:
 
   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=changedetection -n {{ .Release.Namespace }} --timeout=300s
@@ -54,8 +58,8 @@ Inspect status:
   kubectl logs -l app.kubernetes.io/name=changedetection -n {{ .Release.Namespace }} --all-containers --tail=50
   kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
 
-Persistence
------------
+4. Persistence
+--------------
 {{- if .Values.persistence.enabled }}
 Datastore persistence is enabled.
 PVC: {{ include "changedetection.dataClaimName" . }}
@@ -68,8 +72,8 @@ Datastore persistence is disabled. /datastore uses emptyDir and all watches,
 history, and snapshots are ephemeral.
 {{- end }}
 
-Browser rendering
------------------
+5. Browser rendering
+--------------------
 {{- if .Values.browser.enabled }}
 Playwright browser rendering is enabled.
 Browser image: {{ .Values.browser.image.repository }}:{{ .Values.browser.image.tag }}
@@ -80,8 +84,8 @@ Enable browser.enabled=true for JavaScript-heavy pages, SPAs, and rendered
 price or inventory checks.
 {{- end }}
 
-Routing summary
----------------
+6. Routing summary
+------------------
 Ingress: {{ ternary "enabled" "disabled" .Values.ingress.enabled }}
 Gateway API HTTPRoute: {{ ternary "enabled" "disabled" .Values.gateway.enabled }}
 Service IP family policy: {{ default "cluster default" .Values.service.ipFamilyPolicy }}
@@ -89,8 +93,8 @@ Service IP family policy: {{ default "cluster default" .Values.service.ipFamilyP
 Service IP families: {{ join ", " . }}
 {{- end }}
 
-External Secrets
-----------------
+7. External Secrets
+-------------------
 {{- if .Values.externalSecrets.enabled }}
 ExternalSecret is enabled.
 Target Secret: {{ include "changedetection.externalSecretName" . }}
@@ -106,8 +110,8 @@ externalSecrets.enabled to materialize environment-backed credentials through
 External Secrets Operator.
 {{- end }}
 
-Common operations
------------------
+8. Common operations
+--------------------
 Open a shell in the main container:
 
   kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "changedetection.fullname" . }} -c changedetection -- sh
@@ -116,8 +120,8 @@ List rendered resources:
 
   kubectl get all,pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
-Documentation
--------------
+9. Documentation
+----------------
 Chart docs: https://helmforge.dev/docs/charts/changedetection
 Chart source: https://github.com/helmforgedev/charts/tree/main/charts/changedetection
 Upstream project: https://changedetection.io

--- a/charts/changedetection/templates/_helpers.tpl
+++ b/charts/changedetection/templates/_helpers.tpl
@@ -59,8 +59,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.data) (not .Values.externalSecrets.dataFrom) -}}
 {{- fail "externalSecrets.data or externalSecrets.dataFrom is required when externalSecrets.enabled=true" -}}
 {{- end -}}
+{{- $selectorLabels := include "changedetection.selectorLabels" . | fromYaml -}}
 {{- range $key, $_ := .Values.podLabels -}}
-{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- if hasKey $selectorLabels $key -}}
 {{- fail (printf "podLabels must not override selector label %q" $key) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/changedetection/templates/_helpers.tpl
+++ b/charts/changedetection/templates/_helpers.tpl
@@ -39,6 +39,33 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "changedetection.validate" -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
+{{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." -}}
+{{- end -}}
+{{- if .Values.gateway.enabled -}}
+{{- range $index, $parentRef := .Values.gateway.parentRefs -}}
+{{- if not $parentRef.name -}}
+{{- fail (printf "gateway.parentRefs[%d].name is required when gateway.enabled is true" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
+{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.data) (not .Values.externalSecrets.dataFrom) -}}
+{{- fail "externalSecrets.data or externalSecrets.dataFrom is required when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "changedetection.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}

--- a/charts/changedetection/templates/ingress.yaml
+++ b/charts/changedetection/templates/ingress.yaml
@@ -26,7 +26,9 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- with .host }}
+      host: {{ . | quote }}
+      {{- end }}
       http:
         paths:
           {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}

--- a/charts/changedetection/templates/validate.yaml
+++ b/charts/changedetection/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "changedetection.validate" . -}}

--- a/charts/changedetection/tests/ingress_test.yaml
+++ b/charts/changedetection/tests/ingress_test.yaml
@@ -22,3 +22,16 @@ tests:
     asserts:
       - isKind:
           of: Ingress
+
+  - it: should allow catch-all ingress rules without host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - notExists:
+          path: spec.rules[0].host

--- a/charts/changedetection/tests/validation_test.yaml
+++ b/charts/changedetection/tests/validation_test.yaml
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.enabled requires ingress.hosts to contain at least one host"
+
+  - it: should fail when gateway is enabled without parentRefs
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."
+
+  - it: should fail when gateway parentRef has no name
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - namespace: ingress
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.parentRefs[0].name is required when gateway.enabled is true"
+
+  - it: should fail when external secret store reference is missing
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.data:
+        - secretKey: LOGGER_LEVEL
+          remoteRef:
+            key: changedetection/app
+            property: loggerLevel
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true"
+
+  - it: should fail when external secret has no data mappings
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: helmforge-fake-store
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data or externalSecrets.dataFrom is required when externalSecrets.enabled=true"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/instance"'

--- a/charts/changedetection/tests/validation_test.yaml
+++ b/charts/changedetection/tests/validation_test.yaml
@@ -59,3 +59,11 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'podLabels must not override selector label "app.kubernetes.io/instance"'
+
+  - it: should fail when podLabels override chart name selector label
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- add the canonical changedetection.validate helper and validate.yaml gate
- validate ingress, Gateway API, External Secrets, and selector label override combinations before rendering broken manifests
- add helm-unittest coverage for validation failures and align NOTES.txt with numbered sections

## Validation
- make template-standards-check CHART=changedetection
- helm unittest charts/changedetection
- helm lint --strict charts/changedetection
- make standards-check CHART=changedetection
- make validate-chart CHART=changedetection TIMEOUT=900: FULLY VALIDATED (15 layers)
- make site-sync-check CHART=changedetection
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#330 (merged)
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm chart validation to fail fast on common misconfigurations (ingress hosts, gateway parent references, external secret store settings, and restricted selector label overrides).
* **Bug Fixes**
  * Improved Ingress rendering so `spec.rules[].host` is omitted when no host is provided, while still producing a valid catch-all rule.
* **Documentation**
  * Refreshed post-install notes with clearer numbered sections and reorganized routing/external secrets guidance.
* **Tests**
  * Added validation and Ingress test coverage for both success cases and specific expected failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->