### PR TITLE
fix(chiefonboarding): align template standards

### DIFF
--- a/charts/chiefonboarding/templates/_helpers.tpl
+++ b/charts/chiefonboarding/templates/_helpers.tpl
@@ -39,6 +39,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "chiefonboarding.validate" -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.host) -}}
+{{- fail "database.external.host is required when postgresql.enabled is false" -}}
+{{- end -}}
+{{- if and (not .Values.postgresql.enabled) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
+{{- fail "database.external.password or database.external.existingSecret is required when postgresql.enabled is false" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one rule" -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "chiefonboarding.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}

--- a/charts/chiefonboarding/templates/ingress.yaml
+++ b/charts/chiefonboarding/templates/ingress.yaml
@@ -26,7 +26,9 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- with .host }}
+      host: {{ . | quote }}
+      {{- end }}
       http:
         paths:
           {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}

--- a/charts/chiefonboarding/templates/validate.yaml
+++ b/charts/chiefonboarding/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "chiefonboarding.validate" . -}}

--- a/charts/chiefonboarding/tests/ingress_test.yaml
+++ b/charts/chiefonboarding/tests/ingress_test.yaml
@@ -26,6 +26,19 @@ tests:
           path: metadata.name
           value: test-chiefonboarding
 
+  - it: should allow catch-all ingress rules without host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - notExists:
+          path: spec.rules[0].host
+
   - it: should set ingressClassName
     set:
       ingress.enabled: true

--- a/charts/chiefonboarding/tests/validation_test.yaml
+++ b/charts/chiefonboarding/tests/validation_test.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when external database host is missing
+    set:
+      postgresql.enabled: false
+      database.external.password: secret
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.host is required when postgresql.enabled is false"
+
+  - it: should fail when external database credentials are missing
+    set:
+      postgresql.enabled: false
+      database.external.host: postgresql.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.external.password or database.external.existingSecret is required when postgresql.enabled is false"
+
+  - it: should fail when ingress is enabled without rules
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.enabled requires ingress.hosts to contain at least one rule"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- add the canonical chiefonboarding.validate helper and validate.yaml gate
- fail fast for incomplete external PostgreSQL, missing ingress rules, and selector label overrides
- preserve hostless catch-all Ingress support by omitting spec.rules[].host when not configured
- add helm-unittest coverage for validation paths and catch-all Ingress rendering

## Validation
- make template-standards-check CHART=chiefonboarding
- helm unittest charts/chiefonboarding
- helm lint --strict charts/chiefonboarding
- make standards-check CHART=chiefonboarding
- make validate-chart CHART=chiefonboarding TIMEOUT=1200: FULLY VALIDATED (13 layers)
- make site-sync-check CHART=chiefonboarding
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#331
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ingress rules now omit the `host` field when no host is provided, enabling catch-all routing.
* **New Features**
  * Added render-time validation for external database settings, ingress host configuration, and `podLabels` to prevent selector label overrides.
* **Tests**
  * Added tests for catch-all ingress rendering and for the expected validation failure messages under misconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->