### PR TITLE
fix(cronicle): align template validation standards

### DIFF
--- a/charts/cronicle/templates/_helpers.tpl
+++ b/charts/cronicle/templates/_helpers.tpl
@@ -43,6 +43,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "cronicle.validate" -}}
+{{- if and (not .Values.secret.create) (not .Values.secret.existingSecret) -}}
+{{- fail "secret.existingSecret is required when secret.create=false" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Data PVC claim name */}}
 {{- define "cronicle.dataClaimName" -}}
 {{- if .Values.persistence.existingClaim -}}

--- a/charts/cronicle/templates/_helpers.tpl
+++ b/charts/cronicle/templates/_helpers.tpl
@@ -50,8 +50,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
 {{- end -}}
-{{- range $key, $_ := .Values.podLabels -}}
-{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- $selectorLabels := include "cronicle.selectorLabels" . | fromYaml -}}
+{{- range $key, $_ := $selectorLabels -}}
+{{- if hasKey $podLabels $key -}}
 {{- fail (printf "podLabels must not override selector label %q" $key) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/cronicle/templates/ingress.yaml
+++ b/charts/cronicle/templates/ingress.yaml
@@ -26,7 +26,9 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- with .host }}
+      host: {{ . | quote }}
+      {{- end }}
       http:
         paths:
           {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}

--- a/charts/cronicle/templates/validate.yaml
+++ b/charts/cronicle/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "cronicle.validate" . -}}

--- a/charts/cronicle/tests/ingress_test.yaml
+++ b/charts/cronicle/tests/ingress_test.yaml
@@ -22,3 +22,16 @@ tests:
     asserts:
       - isKind:
           of: Ingress
+
+  - it: should support hostless catch-all rules
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - notExists:
+          path: spec.rules[0].host

--- a/charts/cronicle/tests/validation_test.yaml
+++ b/charts/cronicle/tests/validation_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when secret creation is disabled without existing secret
+    set:
+      secret.create: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "secret.existingSecret is required when secret.create=false"
+
+  - it: should fail when ingress has no rules
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one rule when ingress.enabled=true"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- add centralized cronicle values validation through templates/validate.yaml
- add helm-unittest coverage for secret, ingress, and selector-label guardrails
- preserve hostless catch-all Ingress rendering by omitting spec.rules[].host when unset

## Validation
- make template-standards-check CHART=cronicle
- helm unittest charts/cronicle
- helm lint --strict charts/cronicle
- make standards-check CHART=cronicle
- make validate-chart CHART=cronicle TIMEOUT=900: FULLY VALIDATED (12 layers)
- make site-sync-check CHART=cronicle
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#335
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added render-time chart validation to fail fast on invalid configuration (e.g., missing required secret settings, missing Ingress hosts, and conflicting pod label configuration).
  * Added support for “hostless” Ingress rules by omitting the `host` field when no host is provided.
* **Bug Fixes**
  * Prevented `podLabels` from overriding the chart’s selector label keys.
* **Tests**
  * Added Ingress coverage for hostless catch-all behavior.
  * Added a validation test suite for both passing and failing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->