### PR TITLE
fix(ddns-updater): align template validation standards

### DIFF
--- a/charts/ddns-updater/templates/NOTES.txt
+++ b/charts/ddns-updater/templates/NOTES.txt
@@ -1,58 +1,89 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-DDNS Updater has been deployed.
+ddns-updater has been deployed.
 
-Release:
-  Chart:      {{ .Chart.Name }}
-  Version:    {{ .Chart.Version }}
-  AppVersion: {{ .Chart.AppVersion }}
-  Release:    {{ .Release.Name }}
-  Namespace:  {{ .Release.Namespace }}
+1. Installation summary
+-----------------------
+Chart: {{ .Chart.Name }}
+Version: {{ .Chart.Version }}
+AppVersion: {{ .Chart.AppVersion }}
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Image: {{ include "ddns-updater.image" . }}
 
-Access:
-  DDNS Updater runs as a background service. The web UI is not exposed outside
-  the cluster unless ingress is enabled.
-
+2. Access
+---------
+DDNS Updater runs as a background service. The web UI is exposed outside the
+cluster only when ingress is enabled.
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-  Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- if $host.host }}
+Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+{{- else }}
+Web UI: hostless ingress is enabled. Use the external address assigned by your ingress controller.
+{{- end }}
 {{- end }}
 {{- else }}
-  Port-forward:
-    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ddns-updater.fullname" . }} 8000:{{ .Values.service.port }}
+Port-forward:
 
-  Web UI:
-    http://localhost:8000/
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ddns-updater.fullname" . }} 8000:{{ .Values.service.port }}
+
+Web UI:
+
+  http://localhost:8000/
 {{- end }}
 
-Configuration:
+3. Getting started
+------------------
+Check pod status:
+
+  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Follow logs:
+
+  kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --all-containers --tail=50 -f
+
+4. Credentials
+--------------
 {{- if .Values.config.existingSecret }}
-  Config source: existing Secret {{ .Values.config.existingSecret }}
-  Config key:    {{ .Values.config.existingSecretKey }}
+Config source: existing Secret {{ .Values.config.existingSecret }}
+Config key: {{ .Values.config.existingSecretKey }}
 {{- else }}
-  Config source: chart-managed Secret {{ include "ddns-updater.configSecretName" . }}
-  Records:       {{ len (.Values.config.settings | default list) }}
+Config source: chart-managed Secret {{ include "ddns-updater.configSecretName" . }}
+Configured records: {{ len (.Values.config.settings | default list) }}
 {{- end }}
-  Data path:     /updater/data
-  Persistence:   {{ ternary "enabled" "disabled" .Values.persistence.enabled }}
 
-Security:
-  ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
-  Run as non-root:                {{ .Values.podSecurityContext.runAsNonRoot }}
-  Read-only root filesystem:      {{ .Values.securityContext.readOnlyRootFilesystem }}
+5. Configuration
+----------------
+Data path: /updater/data
+Persistence: {{ ternary "enabled" "disabled" .Values.persistence.enabled }}
+Root URL: {{ .Values.ddns.rootUrl }}
+Update period: {{ .Values.ddns.period }}
+Public IP fetchers: {{ .Values.ddns.publicIpFetchers }}
 
-Next Steps:
-  1. Check pod status:
-       kubectl get pods -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
-  2. Follow logs:
-       kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=50 -f
-  3. Confirm provider credentials and DNS records in the web UI or logs.
+6. Security
+-----------
+ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
+Run as non-root: {{ .Values.podSecurityContext.runAsNonRoot }}
+Read-only root filesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
 
-Troubleshooting:
-  kubectl describe pod -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }}
-  kubectl logs -l app.kubernetes.io/name=ddns-updater -n {{ .Release.Namespace }} --all-containers --tail=100
+7. Troubleshooting
+------------------
+Describe pod:
+
+  kubectl describe pod -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Inspect recent logs:
+
+  kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --all-containers --tail=100
+
+List related resources:
+
   kubectl get all,pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-Documentation:
-  https://helmforge.dev/docs/charts/ddns-updater
+8. Resources
+------------
+Chart docs: https://helmforge.dev/docs/charts/ddns-updater
+Chart source: https://github.com/helmforgedev/charts/tree/main/charts/ddns-updater
+Upstream project: https://github.com/qdm12/ddns-updater
 
 Happy Helmforging :)

--- a/charts/ddns-updater/templates/_helpers.tpl
+++ b/charts/ddns-updater/templates/_helpers.tpl
@@ -47,8 +47,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
 {{- end -}}
-{{- range $key, $_ := .Values.podLabels -}}
-{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- $selectorLabels := include "ddns-updater.selectorLabels" . | fromYaml -}}
+{{- range $key, $_ := $selectorLabels -}}
+{{- if hasKey $podLabels $key -}}
 {{- fail (printf "podLabels must not override selector label %q" $key) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/ddns-updater/templates/_helpers.tpl
+++ b/charts/ddns-updater/templates/_helpers.tpl
@@ -43,6 +43,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "ddns-updater.validate" -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
+{{- end -}}
+{{- range $key, $_ := .Values.podLabels -}}
+{{- if or (eq $key "app.kubernetes.io/name") (eq $key "app.kubernetes.io/instance") -}}
+{{- fail (printf "podLabels must not override selector label %q" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Config secret name */}}
 {{- define "ddns-updater.configSecretName" -}}
 {{- if .Values.config.existingSecret -}}

--- a/charts/ddns-updater/templates/ingress.yaml
+++ b/charts/ddns-updater/templates/ingress.yaml
@@ -26,7 +26,9 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- with .host }}
+      host: {{ . | quote }}
+      {{- end }}
       http:
         paths:
           {{- range (.paths | default (list (dict "path" "/" "pathType" "Prefix"))) }}

--- a/charts/ddns-updater/templates/validate.yaml
+++ b/charts/ddns-updater/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "ddns-updater.validate" . -}}

--- a/charts/ddns-updater/tests/ingress_test.yaml
+++ b/charts/ddns-updater/tests/ingress_test.yaml
@@ -56,3 +56,16 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: nginx
+
+  - it: should support hostless catch-all rules
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - notExists:
+          path: spec.rules[0].host

--- a/charts/ddns-updater/tests/validation_test.yaml
+++ b/charts/ddns-updater/tests/validation_test.yaml
@@ -23,3 +23,11 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'
+
+  - it: should fail when podLabels override release selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/instance"'

--- a/charts/ddns-updater/tests/validation_test.yaml
+++ b/charts/ddns-updater/tests/validation_test.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should render no validation manifest by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should fail when ingress has no rules
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one rule when ingress.enabled=true"
+
+  - it: should fail when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: 'podLabels must not override selector label "app.kubernetes.io/name"'


### PR DESCRIPTION
## Summary
- align ddns-updater NOTES with the numbered HelmForge template standard
- add centralized chart validation for ingress host requirements and reserved selector label overrides
- preserve hostless ingress rendering for catch-all ingress rules and cover it with unittest coverage

## Validation
- make template-standards-check CHART=ddns-updater
- helm unittest charts/ddns-updater
- helm lint --strict charts/ddns-updater
- make standards-check CHART=ddns-updater
- make validate-chart CHART=ddns-updater TIMEOUT=900: FULLY VALIDATED (14 layers)
- make site-sync-check CHART=ddns-updater
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#336
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Helm install notes into a structured, step-by-step guide with access instructions, expanded configuration details, security settings, and grouped resources/troubleshooting.
* **Bug Fixes**
  * Improved ingress rendering to omit the host field when no host is provided, enabling clean hostless/catch-all rules.
* **Bug Fixes / Validation**
  * Added Helm-time validation to fail fast when ingress hosts are missing and to block `podLabels` from overriding chart selector labels.
* **Tests**
  * Added ingress and validation test coverage, including hostless behavior and expected validation failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->