### PR TITLE
fix(discount-bandit): align template standards

### DIFF
--- a/charts/discount-bandit/templates/NOTES.txt
+++ b/charts/discount-bandit/templates/NOTES.txt
@@ -1,81 +1,95 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 Discount Bandit has been deployed.
 
-Chart:      {{ .Chart.Name }}
-Version:    {{ .Chart.Version }}
+1. Installation summary
+-----------------------
+Chart: {{ .Chart.Name }}
+Version: {{ .Chart.Version }}
 AppVersion: {{ .Chart.AppVersion }}
-Release:    {{ .Release.Name }}
-Namespace:  {{ .Release.Namespace }}
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
 
-Runtime
-  Database mode: {{ include "discount-bandit.databaseMode" . }}
-  ServiceAccount: {{ include "discount-bandit.serviceAccountName" . }}
-  ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
-  NetworkPolicy enabled: {{ .Values.networkPolicy.enabled }}
-  Gateway API enabled: {{ .Values.gatewayAPI.enabled }}
-  External Secrets enabled: {{ .Values.externalSecrets.enabled }}
-  Logs persistence enabled: {{ .Values.persistence.logs.enabled }}
-  Supervisor ConfigMap enabled: {{ .Values.supervisor.configMap.enabled }}
+2. Runtime
+----------
+Database mode: {{ include "discount-bandit.databaseMode" . }}
+ServiceAccount: {{ include "discount-bandit.serviceAccountName" . }}
+ServiceAccount token automount: {{ .Values.serviceAccount.automountServiceAccountToken }}
+NetworkPolicy enabled: {{ .Values.networkPolicy.enabled }}
+Gateway API enabled: {{ .Values.gatewayAPI.enabled }}
+External Secrets enabled: {{ .Values.externalSecrets.enabled }}
+Logs persistence enabled: {{ .Values.persistence.logs.enabled }}
+Supervisor ConfigMap enabled: {{ .Values.supervisor.configMap.enabled }}
 
-Getting started
-  Check workload readiness:
-    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=300s
+3. Getting started
+------------------
+Check workload readiness:
 
-Access
+  kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=300s
+
+4. Access
+---------
 {{- if .Values.gatewayAPI.enabled }}
 {{- range .Values.gatewayAPI.hostnames }}
-  WEB UI: https://{{ . }}/
+Web UI: https://{{ . }}/
 {{- end }}
 {{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-  WEB UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
+Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
 {{- end }}
 {{- else }}
-  Port-forward:
-    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "discount-bandit.fullname" . }} 8080:{{ .Values.service.port }}
+Port-forward:
 
-  WEB UI:
-    http://localhost:8080/
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "discount-bandit.fullname" . }} 8080:{{ .Values.service.port }}
+
+Web UI:
+
+  http://localhost:8080/
 {{- end }}
 
-Configuration
-  - Set discountBandit.appUrl and discountBandit.assetUrl to the public URL before exposing the instance.
-  - Store APP_KEY, database passwords, and exchange-rate keys in Kubernetes Secrets or External Secrets.
-  - Use mysql.enabled=true or database.mode=external for production.
+5. Configuration
+----------------
+- Set discountBandit.appUrl and discountBandit.assetUrl to the public URL before exposing the instance.
+- Store APP_KEY, database passwords, and exchange-rate keys in Kubernetes Secrets or External Secrets.
+- Use mysql.enabled=true or database.mode=external for production.
 
-Health checks
+6. Health checks
+----------------
   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --timeout=300s
   kubectl get pods -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} --all-containers --tail=100
 
-Database
+7. Database
+-----------
 {{- if eq (include "discount-bandit.databaseMode" .) "mysql" }}
-  The HelmForge MySQL subchart is enabled.
-  MySQL Service: {{ include "discount-bandit.mysqlFullname" . }}
-  Secret: {{ include "discount-bandit.databaseSecretName" . }}
+The HelmForge MySQL subchart is enabled.
+MySQL Service: {{ include "discount-bandit.mysqlFullname" . }}
+Secret: {{ include "discount-bandit.databaseSecretName" . }}
 {{- else if eq (include "discount-bandit.databaseMode" .) "external" }}
-  External database host: {{ include "discount-bandit.databaseHost" . }}:{{ include "discount-bandit.databasePort" . }}
-  Secret: {{ include "discount-bandit.databaseSecretName" . }}
+External database host: {{ include "discount-bandit.databaseHost" . }}:{{ include "discount-bandit.databasePort" . }}
+Secret: {{ include "discount-bandit.databaseSecretName" . }}
 {{- else }}
-  SQLite is enabled for development/small installs.
-  PVC: {{ include "discount-bandit.dataClaimName" . }}
-  Keep replicaCount=1 with SQLite.
+SQLite is enabled for development/small installs.
+PVC: {{ include "discount-bandit.dataClaimName" . }}
+Keep replicaCount=1 with SQLite.
 {{- end }}
 
-Troubleshooting
+8. Troubleshooting
+------------------
   kubectl describe pod -l app.kubernetes.io/name=discount-bandit,app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
   kubectl get deploy,svc,secret,pvc,networkpolicy,pdb -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
-Production reminders
-  - Use mysql.enabled=true or database.mode=external for production.
-  - Set discountBandit.appUrl and discountBandit.assetUrl to the public URL.
-  - Store APP_KEY, database passwords, and exchange-rate keys in Kubernetes Secrets or External Secrets.
-  - Enable NetworkPolicy only after confirming crawler and notification egress destinations.
-  - Review crawler logs because some stores rely on Chromium headless.
+9. Production reminders
+-----------------------
+- Use mysql.enabled=true or database.mode=external for production.
+- Set discountBandit.appUrl and discountBandit.assetUrl to the public URL.
+- Store APP_KEY, database passwords, and exchange-rate keys in Kubernetes Secrets or External Secrets.
+- Enable NetworkPolicy only after confirming crawler and notification egress destinations.
+- Review crawler logs because some stores rely on Chromium headless.
 
-Resources
-  Documentation: https://helmforge.dev/docs/charts/discount-bandit
-  Upstream: https://github.com/Cybrarist/Discount-Bandit
+10. Resources
+-------------
+Documentation: https://helmforge.dev/docs/charts/discount-bandit
+Upstream: https://github.com/Cybrarist/Discount-Bandit
 
 Happy Helmforging :)

--- a/charts/discount-bandit/templates/networkpolicy.yaml
+++ b/charts/discount-bandit/templates/networkpolicy.yaml
@@ -32,7 +32,7 @@ spec:
     []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
-  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowHTTP .Values.networkPolicy.egress.allowSameNamespaceDatabase .Values.networkPolicy.egress.extraTo }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowHTTP .Values.networkPolicy.egress.allowSameNamespaceDatabase .Values.networkPolicy.egress.extraTo .Values.networkPolicy.egress.extraEgress }}
   egress:
     {{- if $allowEgress }}
     {{- if .Values.networkPolicy.egress.allowDNS }}
@@ -72,6 +72,9 @@ spec:
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- else }}
     []

--- a/charts/discount-bandit/tests/networkpolicy_test.yaml
+++ b/charts/discount-bandit/tests/networkpolicy_test.yaml
@@ -24,3 +24,29 @@ tests:
       - contains:
           path: spec.policyTypes
           content: Egress
+
+  - it: should render canonical extra egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowDNS: false
+      networkPolicy.egress.allowHTTPS: false
+      networkPolicy.egress.allowHTTP: false
+      networkPolicy.egress.allowSameNamespaceDatabase: false
+      networkPolicy.egress.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.0.0.0/8
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.0.0.0/8
+            ports:
+              - protocol: TCP
+                port: 443

--- a/charts/discount-bandit/values.schema.json
+++ b/charts/discount-bandit/values.schema.json
@@ -134,7 +134,35 @@
     "resources": { "type": "object", "additionalProperties": true },
     "podSecurityContext": { "type": "object", "additionalProperties": true },
     "securityContext": { "type": "object", "additionalProperties": true },
-    "networkPolicy": { "type": "object", "additionalProperties": true },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "allowSameNamespace": { "type": "boolean" },
+            "extraFrom": { "type": "array", "items": { "type": "object" } }
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowDNS": { "type": "boolean" },
+            "allowHTTPS": { "type": "boolean" },
+            "allowHTTP": { "type": "boolean" },
+            "allowSameNamespaceDatabase": { "type": "boolean" },
+            "databasePort": { "type": "integer" },
+            "extraTo": { "type": "array", "items": { "type": "object" } },
+            "extraEgress": { "type": "array", "items": { "type": "object" } }
+          }
+        }
+      }
+    },
     "pdb": { "type": "object", "additionalProperties": true },
     "nodeSelector": { "type": "object", "additionalProperties": true },
     "tolerations": { "type": "array", "items": { "type": "object" } },

--- a/charts/discount-bandit/values.yaml
+++ b/charts/discount-bandit/values.yaml
@@ -335,6 +335,8 @@ networkPolicy:
     databasePort: 3306
     # -- Additional NetworkPolicy egress peers
     extraTo: []
+    # -- Additional complete NetworkPolicy egress rules
+    extraEgress: []
 
 # =============================================================================
 # Disruption Budget

--- a/charts/discount-bandit/values.yaml
+++ b/charts/discount-bandit/values.yaml
@@ -335,7 +335,7 @@ networkPolicy:
     databasePort: 3306
     # -- Additional NetworkPolicy egress peers
     extraTo: []
-    # -- Additional complete NetworkPolicy egress rules
+    # -- Additional complete NetworkPolicy egress rules with their own to/ports blocks (unlike extraTo, which only adds peers under one shared to block)
     extraEgress: []
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- align Discount Bandit NOTES with the numbered HelmForge operational sections
- add canonical `networkPolicy.egress.extraEgress` support while preserving existing `extraTo` peers
- document the new NetworkPolicy egress surface in values schema and helm-unittest coverage

## Validation
- make template-standards-check CHART=discount-bandit
- helm unittest charts/discount-bandit
- helm lint --strict charts/discount-bandit
- make standards-check CHART=discount-bandit
- make validate-chart CHART=discount-bandit TIMEOUT=900: FULLY VALIDATED (19 layers)
- make site-sync-check CHART=discount-bandit
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#337
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `networkPolicy.egress.extraEgress`, allowing custom full egress rules (including `to`/ports) to be appended to the rendered NetworkPolicy.

* **Documentation**
  * Reformatted and reorganized the chart notes into a clearer, markdown-style layout.

* **Tests**
  * Added a test to confirm `extraEgress` is correctly rendered in the NetworkPolicy output.

* **Chores**
  * Expanded `values.schema.json` and updated `values.yaml` to document the new `networkPolicy` egress options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->