### PR TITLE
fix(dolibarr): centralize template validation

### DIFF
--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -297,10 +297,11 @@ true
     {{- fail (printf "externalSecrets.data must include a mapping for key '%s' (admin password)" $passKey) -}}
   {{- end -}}
 {{- end -}}
-{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- if hasKey $podLabels "app.kubernetes.io/name" -}}
 {{- fail "podLabels must not override selector label app.kubernetes.io/name" -}}
 {{- end -}}
-{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+{{- if hasKey $podLabels "app.kubernetes.io/instance" -}}
 {{- fail "podLabels must not override selector label app.kubernetes.io/instance" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/dolibarr/templates/_helpers.tpl
+++ b/charts/dolibarr/templates/_helpers.tpl
@@ -262,3 +262,45 @@ true
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "dolibarr.validate" -}}
+{{- $_ := include "dolibarr.databaseMode" . -}}
+{{- if .Values.backup.enabled -}}
+{{- $_ := include "dolibarr.backupEnabled" . -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
+{{- end -}}
+{{- if .Values.gateway.enabled -}}
+  {{- if not .Values.gateway.parentRefs -}}
+    {{- fail "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute." -}}
+  {{- end -}}
+  {{- range .Values.gateway.parentRefs -}}
+    {{- if not .name -}}
+      {{- fail "Each gateway.parentRefs entry must define a 'name' field" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if .Values.externalSecrets.enabled -}}
+  {{- if not .Values.admin.existingSecret -}}
+    {{- fail "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." -}}
+  {{- end -}}
+  {{- if not .Values.externalSecrets.data -}}
+    {{- fail "externalSecrets.data must not be empty when externalSecrets.enabled=true" -}}
+  {{- end -}}
+  {{- $passKey := .Values.admin.existingSecretPasswordKey | default "admin-password" -}}
+  {{- $hasPass := false -}}
+  {{- range .Values.externalSecrets.data -}}
+    {{- if eq .secretKey $passKey }}{{ $hasPass = true }}{{ end -}}
+  {{- end -}}
+  {{- if not $hasPass -}}
+    {{- fail (printf "externalSecrets.data must include a mapping for key '%s' (admin password)" $passKey) -}}
+  {{- end -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dolibarr/templates/validate.yaml
+++ b/charts/dolibarr/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "dolibarr.validate" . -}}

--- a/charts/dolibarr/tests/validation_test.yaml
+++ b/charts/dolibarr/tests/validation_test.yaml
@@ -11,6 +11,23 @@ tests:
       - failedTemplate:
           errorMessage: "ingress.hosts must contain at least one rule when ingress.enabled=true"
 
+  - it: should reject gateway without parentRefs
+    set:
+      gateway.enabled: true
+      gateway.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "gateway.enabled requires gateway.parentRefs to be populated to create a valid HTTPRoute."
+
+  - it: should reject gateway parentRefs entry missing name
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - namespace: default
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each gateway.parentRefs entry must define a 'name' field"
+
   - it: should reject reserved selector label overrides
     set:
       podLabels:
@@ -43,3 +60,24 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."
+
+  - it: should reject external secrets without data
+    set:
+      admin.existingSecret: dolibarr-admin
+      externalSecrets.enabled: true
+      externalSecrets.data: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data must not be empty when externalSecrets.enabled=true"
+
+  - it: should reject external secrets missing admin password mapping
+    set:
+      admin.existingSecret: dolibarr-admin
+      externalSecrets.enabled: true
+      externalSecrets.data:
+        - secretKey: some-other-key
+          remoteRef:
+            key: dolibarr/other
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.data must include a mapping for key 'admin-password' (admin password)"

--- a/charts/dolibarr/tests/validation_test.yaml
+++ b/charts/dolibarr/tests/validation_test.yaml
@@ -19,6 +19,12 @@ tests:
       - failedTemplate:
           errorMessage: "podLabels must not override selector label app.kubernetes.io/name"
 
+  - it: should allow null pod labels
+    set:
+      podLabels: null
+    asserts:
+      - notFailedTemplate: {}
+
   - it: should reject missing backup settings
     set:
       backup.enabled: true

--- a/charts/dolibarr/tests/validation_test.yaml
+++ b/charts/dolibarr/tests/validation_test.yaml
@@ -36,6 +36,14 @@ tests:
       - failedTemplate:
           errorMessage: "podLabels must not override selector label app.kubernetes.io/name"
 
+  - it: should reject reserved instance selector label overrides
+    set:
+      podLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override selector label app.kubernetes.io/instance"
+
   - it: should allow null pod labels
     set:
       podLabels: null
@@ -81,3 +89,25 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "externalSecrets.data must include a mapping for key 'admin-password' (admin password)"
+
+  - it: should allow ingress gateway and external secrets together
+    set:
+      admin.existingSecret: dolibarr-admin
+      ingress.enabled: true
+      ingress.hosts:
+        - host: dolibarr.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: shared-gateway
+          namespace: default
+      externalSecrets.enabled: true
+      externalSecrets.secretStoreRef.name: fake-store
+      externalSecrets.data:
+        - secretKey: admin-password
+          remoteRef:
+            key: dolibarr/admin-password
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/dolibarr/tests/validation_test.yaml
+++ b/charts/dolibarr/tests/validation_test.yaml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: should reject ingress without rules
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one rule when ingress.enabled=true"
+
+  - it: should reject reserved selector label overrides
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override selector label app.kubernetes.io/name"
+
+  - it: should reject missing backup settings
+    set:
+      backup.enabled: true
+      backup.s3.bucket: dolibarr-backups
+    asserts:
+      - failedTemplate:
+          errorMessage: "backup.enabled requires backup.s3.endpoint, backup.s3.bucket, and either backup.s3.existingSecret or both backup.s3.accessKey and backup.s3.secretKey"
+
+  - it: should reject external secrets without an existing admin secret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.data:
+        - secretKey: admin-password
+          remoteRef:
+            key: dolibarr/admin
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled requires admin.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."


### PR DESCRIPTION
## Summary
- add a `dolibarr.validate` helper and `validate.yaml` entrypoint for fail-fast chart validation
- cover ingress, Gateway API, External Secrets, backup, and reserved selector-label validation with unit tests
- guard reserved selector-label validation when `podLabels` is unset

## Validation
- make template-standards-check CHART=dolibarr
- helm unittest charts/dolibarr
- helm lint --strict charts/dolibarr
- make standards-check CHART=dolibarr
- make validate-chart CHART=dolibarr TIMEOUT=1200: FULLY VALIDATED (17 layers)
- make site-sync-check CHART=dolibarr
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#339
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added chart-time validation to fail fast on misconfigurations for ingress, gateway, S3 backups, and external secrets.
  * Prevents overriding reserved selector labels that could break label matching.

* **Tests**
  * Expanded Helm validation coverage for gateway and external-secrets failure scenarios, including required admin-password mapping behavior.
  * Added assertions ensuring reserved pod label restrictions are enforced and `podLabels: null` is accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->