### PR TITLE
fix(druid): align template standards

### DIFF
--- a/charts/druid/templates/NOTES.txt
+++ b/charts/druid/templates/NOTES.txt
@@ -1,10 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 Apache Druid has been deployed!
 
-Getting started:
+1. Getting started
+==================
   Review the component list below, wait for Pods to become Ready, then access the router/web console.
 
-Components:
+2. Components
+=============
 {{- if .Values.coordinator.enabled }}
   - Coordinator: {{ include "druid.fullname" . }}-coordinator:{{ .Values.coordinator.port }}
 {{- end }}
@@ -26,33 +28,40 @@ Components:
 
 {{- if .Values.router.enabled }}
 
-Access:
+3. Access
+=========
   kubectl port-forward svc/{{ include "druid.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
   Then open http://localhost:{{ .Values.service.port }}
 {{- end }}
 
-Configuration:
+4. Configuration
+================
   Image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
   Metadata mode: {{ .Values.metadata.mode }}
   ZooKeeper mode: {{ .Values.zookeeperConfig.mode }}
   Deep storage: {{ .Values.deepStorage.type }}
 
-Validation:
+5. Validation
+=============
   kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance={{ .Release.Name }} --timeout=900s
   kubectl get pods,svc -l app.kubernetes.io/instance={{ .Release.Name }}
 
-Troubleshooting:
+6. Troubleshooting
+==================
   kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} --all-containers --tail=200
 
 {{- if .Values.ingress.enabled }}
 {{- range .Values.ingress.hosts }}
 
-Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+7. Ingress
+==========
+  URL: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
 {{- end }}
 {{- end }}
 
 {{- if .Values.gatewayAPI.enabled }}
-Gateway API:
+8. Gateway API
+==============
   HTTPRoute: {{ include "druid.fullname" . }}
   Backend:   {{ include "druid.fullname" . }}:{{ .Values.service.port }}
 {{- with .Values.gatewayAPI.hostnames }}
@@ -61,24 +70,29 @@ Gateway API:
 {{- end }}
 
 {{- with .Values.service.ipFamilyPolicy }}
-Networking:
+9. Networking
+=============
   Service IP family policy: {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
 {{- end }}
 
 {{- if .Values.externalSecrets.enabled }}
-External Secrets:
+10. External Secrets
+====================
   ExternalSecret resources are enabled. Ensure External Secrets Operator and the configured {{ .Values.externalSecrets.secretStoreRef.kind }} {{ .Values.externalSecrets.secretStoreRef.name }} exist before install.
 {{- end }}
 
 {{- if .Values.networkPolicy.enabled }}
-NetworkPolicy:
-  NetworkPolicy is enabled. If Druid cannot reach PostgreSQL, ZooKeeper, DNS, or S3 endpoints, review networkPolicy.egress settings and extraTo peers.
+11. NetworkPolicy
+=================
+  NetworkPolicy is enabled. If Druid cannot reach PostgreSQL, ZooKeeper, DNS, or S3 endpoints, review networkPolicy.egress settings, extraTo peers, and extraEgress rules.
 {{- end }}
 
-Upgrade notes:
+12. Upgrade notes
+=================
   This chart deploys Apache Druid {{ .Chart.AppVersion }}. Review upstream release notes and upgrade notes before upgrading persistent clusters, especially Hadoop-based ingestion removal, AWS SDK v2 migration, and Broker segment metadata cache changes.
 
-Resources:
+13. Resources
+=============
   Chart documentation: https://helmforge.dev/docs/charts/druid
   Upstream documentation: https://druid.apache.org/docs/latest/
 

--- a/charts/druid/templates/networkpolicy.yaml
+++ b/charts/druid/templates/networkpolicy.yaml
@@ -37,7 +37,7 @@ spec:
     []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
-  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespace .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowHTTP .Values.networkPolicy.egress.extraTo }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespace .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowHTTP .Values.networkPolicy.egress.extraTo .Values.networkPolicy.egress.extraEgress }}
   egress:
     {{- if $allowEgress }}
     {{- if .Values.networkPolicy.egress.allowDNS }}
@@ -81,6 +81,9 @@ spec:
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- else }}
     []

--- a/charts/druid/tests/networkpolicy_test.yaml
+++ b/charts/druid/tests/networkpolicy_test.yaml
@@ -59,3 +59,26 @@ tests:
       - equal:
           path: spec.ingress[0].from[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: gateway-system
+
+  - it: renders extra egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowDNS: false
+      networkPolicy.egress.allowSameNamespace: false
+      networkPolicy.egress.allowHTTPS: false
+      networkPolicy.egress.extraEgress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: observability
+          ports:
+            - protocol: TCP
+              port: 4317
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: observability
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 4317

--- a/charts/druid/values.schema.json
+++ b/charts/druid/values.schema.json
@@ -420,7 +420,12 @@
             "allowSameNamespace": { "type": "boolean", "description": "Allow same-namespace egress" },
             "allowHTTPS": { "type": "boolean", "description": "Allow HTTPS egress" },
             "allowHTTP": { "type": "boolean", "description": "Allow HTTP egress" },
-            "extraTo": { "type": "array", "description": "Additional egress peers", "items": { "type": "object" } }
+            "extraTo": { "type": "array", "description": "Additional egress peers", "items": { "type": "object" } },
+            "extraEgress": {
+              "type": "array",
+              "description": "Additional complete egress rules appended to the NetworkPolicy",
+              "items": { "type": "object" }
+            }
           }
         }
       }

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -377,6 +377,8 @@ networkPolicy:
     allowHTTP: false
     # -- Additional egress peers
     extraTo: []
+    # -- Additional complete egress rules appended to the NetworkPolicy
+    extraEgress: []
 
 # =============================================================================
 # ServiceAccount


### PR DESCRIPTION
## Summary
- number Druid NOTES sections to match chart template standards
- add canonical `networkPolicy.egress.extraEgress` support with schema and unit coverage
- keep default NetworkPolicy rendering unchanged unless users opt into extra egress rules

## Validation
- make template-standards-check CHART=druid
- helm unittest charts/druid
- helm lint --strict charts/druid
- make standards-check CHART=druid
- make validate-chart CHART=druid TIMEOUT=900: FULLY VALIDATED (18 layers)
- make site-sync-check CHART=druid
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#340
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `networkPolicy.egress.extraEgress` to allow users to append additional complete egress rules.
  * Refreshed the chart documentation notes with clearer, sectioned guidance (including networking, external secrets, and troubleshooting).

* **Bug Fixes**
  * NetworkPolicy egress generation now also activates and renders rules when `networkPolicy.egress.extraEgress` is set.

* **Tests**
  * Added a test to verify the rendered NetworkPolicy includes the configured extra egress peer and TCP port `4317`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->