### PR TITLE
fix(drupal): centralize template validation

### DIFF
--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -371,3 +371,26 @@ Backup database username.
 {{- include "drupal.databaseUsername" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Central fail-fast validation entrypoint.
+*/}}
+{{- define "drupal.validate" -}}
+{{- $_ := include "drupal.databaseMode" . -}}
+{{- $_ := include "drupal.replicaCount" . -}}
+{{- $_ := include "drupal.backupEnabled" . -}}
+{{- $_ := include "drupal.autoscalingEnabled" . -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
+{{- end -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- if hasKey $podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey $podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- if hasKey $podLabels "app.kubernetes.io/component" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/component" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/drupal/templates/_helpers.tpl
+++ b/charts/drupal/templates/_helpers.tpl
@@ -384,13 +384,9 @@ Central fail-fast validation entrypoint.
 {{- fail "ingress.hosts must contain at least one rule when ingress.enabled=true" -}}
 {{- end -}}
 {{- $podLabels := .Values.podLabels | default dict -}}
-{{- if hasKey $podLabels "app.kubernetes.io/name" -}}
-{{- fail "podLabels must not override selector label app.kubernetes.io/name" -}}
+{{- range list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/component" -}}
+{{- if hasKey $podLabels . -}}
+{{- fail (printf "podLabels must not override selector label %s" .) -}}
 {{- end -}}
-{{- if hasKey $podLabels "app.kubernetes.io/instance" -}}
-{{- fail "podLabels must not override selector label app.kubernetes.io/instance" -}}
-{{- end -}}
-{{- if hasKey $podLabels "app.kubernetes.io/component" -}}
-{{- fail "podLabels must not override selector label app.kubernetes.io/component" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/drupal/templates/validate.yaml
+++ b/charts/drupal/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "drupal.validate" . -}}

--- a/charts/drupal/tests/validation_test.yaml
+++ b/charts/drupal/tests/validation_test.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 suite: Validations
 templates:
-  - templates/deployment.yaml
+  - templates/validate.yaml
 release:
   name: test
   namespace: default
@@ -35,3 +35,25 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "database.mode=sqlite requires drupal.sqlitePath to stay under sites/ so persistence and backup cover the database file"
+
+  - it: should fail ingress without rules
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one rule when ingress.enabled=true"
+
+  - it: should fail reserved pod label overrides
+    set:
+      podLabels:
+        app.kubernetes.io/component: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override selector label app.kubernetes.io/component"
+
+  - it: should allow null pod labels
+    set:
+      podLabels: null
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/drupal/tests/validation_test.yaml
+++ b/charts/drupal/tests/validation_test.yaml
@@ -52,6 +52,22 @@ tests:
       - failedTemplate:
           errorMessage: "podLabels must not override selector label app.kubernetes.io/component"
 
+  - it: should fail reserved app name label overrides
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override selector label app.kubernetes.io/name"
+
+  - it: should fail reserved app instance label overrides
+    set:
+      podLabels:
+        app.kubernetes.io/instance: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override selector label app.kubernetes.io/instance"
+
   - it: should allow null pod labels
     set:
       podLabels: null


### PR DESCRIPTION
## Summary
- add a centralized `drupal.validate` helper and `templates/validate.yaml` entrypoint
- run existing database, replica, backup, and autoscaling validations through the central entrypoint
- add fail-fast validation for ingress without hosts and reserved selector-label overrides

## Validation
- helm unittest charts/drupal
- helm lint --strict charts/drupal
- make template-standards-check CHART=drupal
- make standards-check CHART=drupal
- make validate-chart CHART=drupal TIMEOUT=900: FULLY VALIDATED (17 layers)
- make site-sync-check CHART=drupal
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#341
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chart validation checks that run during deployment rendering.
  * Enforced required ingress hosts when ingress is enabled.
  * Prevented custom pod labels from overriding reserved selector labels.

* **Tests**
  * Expanded validation coverage with cases for missing ingress hosts, label conflicts, and nullable pod labels.
  * Updated validation checks to run against the dedicated validation template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->