### PR TITLE
fix(envoy-gateway): align template standards

### DIFF
--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -314,7 +314,7 @@ highAvailability:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `security.networkPolicies` | `false` | Enable NetworkPolicies |
+| `security.networkPolicies` | `false` | Enable rendering of NetworkPolicy resources |
 | `security.podSecurityStandards` | `true` | Enable PodSecurityStandards (restricted mode) |
 
 ### High Availability

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -246,7 +246,7 @@ Central fail-fast validation entrypoint.
 {{- if and .Values.rateLimiting.enabled (not .Values.redis.enabled) (not .Values.rateLimiting.externalRedis.host) -}}
 {{- fail "rateLimiting.enabled requires redis.enabled=true or rateLimiting.externalRedis.host to be set" -}}
 {{- end -}}
-{{- if and .Values.rateLimiting.externalRedis.auth.enabled (not .Values.rateLimiting.externalRedis.auth.secretName) -}}
+{{- if and .Values.rateLimiting.enabled (not .Values.redis.enabled) .Values.rateLimiting.externalRedis.host .Values.rateLimiting.externalRedis.auth.enabled (not .Values.rateLimiting.externalRedis.auth.secretName) -}}
 {{- fail "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName" -}}
 {{- end -}}
 {{- $podLabels := .Values.podLabels | default dict -}}

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -250,13 +250,10 @@ Central fail-fast validation entrypoint.
 {{- fail "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName" -}}
 {{- end -}}
 {{- $podLabels := .Values.podLabels | default dict -}}
-{{- if hasKey $podLabels "app.kubernetes.io/name" -}}
-{{- fail "podLabels must not override selector label app.kubernetes.io/name" -}}
+{{- $selectorLabels := include "envoy-gateway.controller.selectorLabels" . | fromYaml -}}
+{{- range $key, $_ := $selectorLabels -}}
+{{- if hasKey $podLabels $key -}}
+{{- fail (printf "podLabels must not override selector label %s" $key) -}}
 {{- end -}}
-{{- if hasKey $podLabels "app.kubernetes.io/instance" -}}
-{{- fail "podLabels must not override selector label app.kubernetes.io/instance" -}}
-{{- end -}}
-{{- if hasKey $podLabels "app.kubernetes.io/component" -}}
-{{- fail "podLabels must not override selector label app.kubernetes.io/component" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -235,3 +235,28 @@ affinity:
   {{- toYaml $affinity | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Central fail-fast validation entrypoint.
+*/}}
+{{- define "envoy-gateway.validate" -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.rateLimiting.externalRedis.auth.secretName) -}}
+{{- fail "externalSecrets.enabled requires rateLimiting.externalRedis.auth.secretName to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." -}}
+{{- end -}}
+{{- if and .Values.rateLimiting.enabled (not .Values.redis.enabled) (not .Values.rateLimiting.externalRedis.host) -}}
+{{- fail "rateLimiting.enabled requires redis.enabled=true or rateLimiting.externalRedis.host to be set" -}}
+{{- end -}}
+{{- if and .Values.rateLimiting.externalRedis.auth.enabled (not .Values.rateLimiting.externalRedis.auth.secretName) -}}
+{{- fail "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName" -}}
+{{- end -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- if hasKey $podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey $podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- if hasKey $podLabels "app.kubernetes.io/component" -}}
+{{- fail "podLabels must not override selector label app.kubernetes.io/component" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/envoy-gateway/templates/certgen-job.yaml
+++ b/charts/envoy-gateway/templates/certgen-job.yaml
@@ -67,7 +67,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "envoy-gateway.labels" . | nindent 8 }}
+        {{- include "envoy-gateway.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: certgen
     spec:
       serviceAccountName: {{ $fullName }}-certgen

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -49,6 +49,9 @@ spec:
       port: 53
     - protocol: UDP
       port: 53
+  {{- with .Values.security.networkPolicy.extraEgress }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- if and .Values.rateLimiting.enabled .Values.redis.enabled }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/envoy-gateway/templates/validate.yaml
+++ b/charts/envoy-gateway/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "envoy-gateway.validate" . -}}

--- a/charts/envoy-gateway/templates/validate.yaml
+++ b/charts/envoy-gateway/templates/validate.yaml
@@ -1,2 +1,3 @@
+# yamllint disable-file
 # SPDX-License-Identifier: Apache-2.0
 {{- include "envoy-gateway.validate" . -}}

--- a/charts/envoy-gateway/templates/validate.yaml
+++ b/charts/envoy-gateway/templates/validate.yaml
@@ -1,2 +1,2 @@
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-License-Identifier: Apache-2.0
 {{- include "envoy-gateway.validate" . -}}

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -47,6 +47,20 @@ tests:
           content: --disable-topology-injector
         documentIndex: 3
 
+  - it: should keep certgen pod labels limited to selector labels and component
+    asserts:
+      - notExists:
+          path: spec.template.metadata.labels["helm.sh/chart"]
+        documentIndex: 3
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: envoy-gateway
+        documentIndex: 3
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: certgen
+        documentIndex: 3
+
   - it: should have pre-install hook annotation on Job
     asserts:
       - equal:

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -42,6 +42,31 @@ tests:
           count: 0
         template: networkpolicy.yaml
 
+  - it: should append controller extra egress rules
+    set:
+      security:
+        networkPolicies: true
+        networkPolicy:
+          extraEgress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: observability
+              ports:
+                - protocol: TCP
+                  port: 4317
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: observability
+        template: networkpolicy.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 4317
+        template: networkpolicy.yaml
+        documentIndex: 0
+
   - it: should create NetworkPolicies for Redis and ratelimit when rate limiting enabled
     set:
       namespaceOverride: envoy-system

--- a/charts/envoy-gateway/tests/validation_test.yaml
+++ b/charts/envoy-gateway/tests/validation_test.yaml
@@ -16,14 +16,30 @@ tests:
   - it: should reject external redis auth without secret
     set:
       rateLimiting:
+        enabled: true
         externalRedis:
           host: redis.example.com
           auth:
             enabled: true
             secretName: ""
+      redis:
+        enabled: false
     asserts:
       - failedTemplate:
           errorMessage: "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName"
+
+  - it: should allow unused external redis auth settings
+    set:
+      rateLimiting:
+        enabled: false
+        externalRedis:
+          auth:
+            enabled: true
+            secretName: ""
+      redis:
+        enabled: true
+    asserts:
+      - notFailedTemplate: {}
 
   - it: should reject external secrets without external redis auth secret
     set:

--- a/charts/envoy-gateway/tests/validation_test.yaml
+++ b/charts/envoy-gateway/tests/validation_test.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - validate.yaml
+tests:
+  - it: should reject rate limiting without redis backend
+    set:
+      rateLimiting:
+        enabled: true
+      redis:
+        enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "rateLimiting.enabled requires redis.enabled=true or rateLimiting.externalRedis.host to be set"
+
+  - it: should reject external redis auth without secret
+    set:
+      rateLimiting:
+        externalRedis:
+          host: redis.example.com
+          auth:
+            enabled: true
+            secretName: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName"
+
+  - it: should reject external secrets without external redis auth secret
+    set:
+      externalSecrets:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.enabled requires rateLimiting.externalRedis.auth.secretName to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret."
+
+  - it: should reject reserved pod label overrides
+    set:
+      podLabels:
+        app.kubernetes.io/component: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override selector label app.kubernetes.io/component"
+
+  - it: should allow null pod labels
+    set:
+      podLabels: null
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -638,6 +638,18 @@
           "description": "Enable NetworkPolicies for zero-trust networking",
           "default": false
         },
+        "networkPolicy": {
+          "type": "object",
+          "description": "NetworkPolicy rule extensions",
+          "properties": {
+            "extraEgress": {
+              "type": "array",
+              "description": "Additional complete egress rules appended to the controller NetworkPolicy",
+              "items": { "type": "object" },
+              "default": []
+            }
+          }
+        },
         "podSecurityStandards": {
           "type": "boolean",
           "description": "Enable PodSecurityStandard restricted mode",

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -635,12 +635,12 @@
       "properties": {
         "networkPolicies": {
           "type": "boolean",
-          "description": "Enable NetworkPolicies for zero-trust networking",
+          "description": "Enable rendering of NetworkPolicy resources for zero-trust networking",
           "default": false
         },
         "networkPolicy": {
           "type": "object",
-          "description": "NetworkPolicy rule extensions",
+          "description": "NetworkPolicy rule extensions used when security.networkPolicies is enabled",
           "properties": {
             "extraEgress": {
               "type": "array",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -384,10 +384,10 @@ monitoring:
 
 ## Security and Hardening
 security:
-  # -- Enable NetworkPolicies
+  # -- Enable rendering of NetworkPolicy resources
   networkPolicies: false
   networkPolicy:
-    # -- Additional complete egress rules appended to the controller NetworkPolicy
+    # -- Additional complete egress rules appended to the controller NetworkPolicy when security.networkPolicies is enabled
     extraEgress: []
   # -- Enable PodSecurityStandard restricted
   podSecurityStandards: true

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -386,6 +386,9 @@ monitoring:
 security:
   # -- Enable NetworkPolicies
   networkPolicies: false
+  networkPolicy:
+    # -- Additional complete egress rules appended to the controller NetworkPolicy
+    extraEgress: []
   # -- Enable PodSecurityStandard restricted
   podSecurityStandards: true
 


### PR DESCRIPTION
## Summary
- fix certgen Job pod labels to use selector labels plus component only
- add `security.networkPolicy.extraEgress` support with schema and unit coverage
- add centralized `envoy-gateway.validate` entrypoint for rate limiting, external Redis auth, ExternalSecrets, and reserved pod-label validations

## Validation
- helm unittest charts/envoy-gateway
- helm lint --strict charts/envoy-gateway
- make template-standards-check CHART=envoy-gateway
- make standards-check CHART=envoy-gateway
- make validate-chart CHART=envoy-gateway TIMEOUT=900: FULLY VALIDATED (20 layers)
- make site-sync-check CHART=envoy-gateway
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#342
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `security.networkPolicy.extraEgress` to append additional egress rules to the controller NetworkPolicy.
  * Added fail-fast Helm chart validations for incompatible rate-limiting and external Redis/external secrets settings.
* **Bug Fixes**
  * Updated certgen Job pod label behavior to use the chart’s selector labels.
  * Prevented `podLabels` from overriding reserved selector label keys.
* **Tests**
  * Expanded validation, certgen label, and security extra egress test coverage.
* **Documentation**
  * Corrected wording for `security.networkPolicies` in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->