### PR TITLE
fix(fastmcp-server): align template standards

### DIFF
--- a/charts/fastmcp-server/templates/NOTES.txt
+++ b/charts/fastmcp-server/templates/NOTES.txt
@@ -1,5 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-FastMCP Server deployed!
+1. Installation summary
+
+FastMCP Server deployed.
 
   Server:   {{ .Values.server.name }}
   Namespace: {{ include "fastmcp-server.namespace" . }}
@@ -14,12 +16,16 @@ FastMCP Server deployed!
   Metrics:  http://{{ include "fastmcp-server.fullname" . }}.{{ include "fastmcp-server.namespace" . }}.svc:{{ .Values.service.port }}/metrics
 {{- end }}
 
+2. Access
+
 To access the MCP endpoint:
 
   kubectl port-forward svc/{{ include "fastmcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ include "fastmcp-server.namespace" . }}
   curl http://localhost:{{ .Values.service.port }}{{ .Values.server.path }}
 
 {{- if .Values.ingress.enabled }}
+
+3. Ingress routes
 {{- range .Values.ingress.hosts }}
 
   Ingress: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (first .paths).path }}
@@ -28,7 +34,7 @@ To access the MCP endpoint:
 
 {{- if .Values.gatewayAPI.enabled }}
 
-  HTTPRoute:
+4. Gateway API routes
 {{- range .Values.gatewayAPI.hostnames }}
     http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.server.path }}
 {{- end }}
@@ -36,13 +42,15 @@ To access the MCP endpoint:
 
 {{- if ne .Values.auth.type "none" }}
 
-Authentication: {{ .Values.auth.type }}
+5. Authentication
+
+  Type: {{ .Values.auth.type }}
 {{- if eq .Values.auth.type "bearer" }}
   Requests must include: Authorization: Bearer <token>
 {{- end }}
 {{- end }}
 
-Sources:
+6. Sources
 {{- if (include "fastmcp-server.hasAnyInline" .) }}
   - Inline (ConfigMap): enabled
 {{- end }}
@@ -53,6 +61,8 @@ Sources:
   - Git: {{ .Values.sources.git.repository }} ({{ .Values.sources.git.branch }})
 {{- end }}
 
-Documentation: https://helmforge.dev/docs/charts/fastmcp-server
+7. Documentation
+
+  https://helmforge.dev/docs/charts/fastmcp-server
 
 Happy Helmforging :)

--- a/charts/fastmcp-server/templates/NOTES.txt
+++ b/charts/fastmcp-server/templates/NOTES.txt
@@ -36,7 +36,7 @@ To access the MCP endpoint:
 
 4. Gateway API routes
 {{- range .Values.gatewayAPI.hostnames }}
-    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.server.path }}
+    http://{{ . }}{{ $.Values.server.path }}
 {{- end }}
 {{- end }}
 

--- a/charts/fastmcp-server/templates/_helpers.tpl
+++ b/charts/fastmcp-server/templates/_helpers.tpl
@@ -105,9 +105,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
 {{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
 {{- end -}}
+{{- if .Values.gatewayAPI.enabled -}}
 {{- range .Values.gatewayAPI.parentRefs }}
 {{- if empty .name -}}
 {{- fail "Each gatewayAPI.parentRefs entry must define a name" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- if and (eq .Values.auth.type "bearer") (not .Values.auth.bearer.token) (not .Values.auth.bearer.existingSecret) -}}

--- a/charts/fastmcp-server/templates/_helpers.tpl
+++ b/charts/fastmcp-server/templates/_helpers.tpl
@@ -97,3 +97,52 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "fastmcp-server.hasAnyInline" -}}
 {{- if or (include "fastmcp-server.hasInlineTools" .) (include "fastmcp-server.hasInlineResources" .) (include "fastmcp-server.hasInlinePrompts" .) (include "fastmcp-server.hasInlineKnowledge" .) -}}true{{- end -}}
 {{- end -}}
+
+{{- define "fastmcp-server.validate" -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.parentRefs) -}}
+{{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- range .Values.gatewayAPI.parentRefs }}
+{{- if empty .name -}}
+{{- fail "Each gatewayAPI.parentRefs entry must define a name" -}}
+{{- end -}}
+{{- end -}}
+{{- if and (eq .Values.auth.type "bearer") (not .Values.auth.bearer.token) (not .Values.auth.bearer.existingSecret) -}}
+{{- fail "auth.type=bearer requires auth.bearer.token or auth.bearer.existingSecret" -}}
+{{- end -}}
+{{- if eq .Values.auth.type "jwt" -}}
+{{- if or (empty .Values.auth.jwt.issuer) (empty .Values.auth.jwt.audience) (empty .Values.auth.jwt.jwksUri) -}}
+{{- fail "auth.type=jwt requires auth.jwt.issuer, auth.jwt.audience, and auth.jwt.jwksUri" -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.sources.s3.enabled -}}
+{{- if empty .Values.sources.s3.bucket -}}
+{{- fail "sources.s3.enabled requires sources.s3.bucket" -}}
+{{- end -}}
+{{- if and (empty .Values.sources.s3.existingSecret) (or (empty .Values.sources.s3.accessKey) (empty .Values.sources.s3.secretKey)) -}}
+{{- fail "sources.s3.enabled requires sources.s3.existingSecret or both sources.s3.accessKey and sources.s3.secretKey" -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.sources.git.enabled (empty .Values.sources.git.repository) -}}
+{{- fail "sources.git.enabled requires sources.git.repository" -}}
+{{- end -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- if lt (int .Values.autoscaling.maxReplicas) (int .Values.autoscaling.minReplicas) -}}
+{{- fail "autoscaling.maxReplicas must be greater than or equal to autoscaling.minReplicas" -}}
+{{- end -}}
+{{- if and (empty .Values.autoscaling.targetCPUUtilizationPercentage) (empty .Values.autoscaling.targetMemoryUtilizationPercentage) -}}
+{{- fail "autoscaling.enabled requires at least one target metric" -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.podLabels -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/fastmcp-server/templates/httproute.yaml
+++ b/charts/fastmcp-server/templates/httproute.yaml
@@ -1,9 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.gatewayAPI.enabled }}
-{{- if not .Values.gatewayAPI.parentRefs }}
-{{- fail "gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled is true" }}
-{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/fastmcp-server/templates/networkpolicy.yaml
+++ b/charts/fastmcp-server/templates/networkpolicy.yaml
@@ -14,8 +14,15 @@ spec:
       {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
+    {{- if .Values.networkPolicy.extraEgress }}
+    - Egress
+    {{- end }}
   ingress:
     - ports:
         - port: {{ .Values.server.port }}
           protocol: TCP
+  {{- with .Values.networkPolicy.extraEgress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/fastmcp-server/templates/networkpolicy.yaml
+++ b/charts/fastmcp-server/templates/networkpolicy.yaml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.networkPolicy.enabled }}
+{{- $extraEgress := .Values.networkPolicy.extraEgress }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -14,14 +15,14 @@ spec:
       {{- include "fastmcp-server.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
-    {{- if .Values.networkPolicy.extraEgress }}
+    {{- if $extraEgress }}
     - Egress
     {{- end }}
   ingress:
     - ports:
         - port: {{ .Values.server.port }}
           protocol: TCP
-  {{- with .Values.networkPolicy.extraEgress }}
+  {{- with $extraEgress }}
   egress:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/fastmcp-server/templates/validate.yaml
+++ b/charts/fastmcp-server/templates/validate.yaml
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- include "fastmcp-server.validate" . -}}

--- a/charts/fastmcp-server/tests/httproute_test.yaml
+++ b/charts/fastmcp-server/tests/httproute_test.yaml
@@ -64,12 +64,3 @@ tests:
       - equal:
           path: spec.rules[0].backendRefs[0].name
           value: RELEASE-NAME-fastmcp-server
-
-  - it: should fail when enabled without parentRefs
-    set:
-      gatewayAPI:
-        enabled: true
-        parentRefs: []
-    asserts:
-      - failedTemplate:
-          errorMessage: gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled is true

--- a/charts/fastmcp-server/tests/networkpolicy_test.yaml
+++ b/charts/fastmcp-server/tests/networkpolicy_test.yaml
@@ -30,6 +30,31 @@ tests:
           path: spec.ingress[0].ports[0].port
           value: 8000
 
+  - it: should render extra egress rules
+    set:
+      networkPolicy:
+        enabled: true
+        extraEgress:
+          - to:
+              - ipBlock:
+                  cidr: 10.0.0.0/8
+            ports:
+              - protocol: TCP
+                port: 443
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.0.0.0/8
+            ports:
+              - protocol: TCP
+                port: 443
+
   - it: should have correct pod selector
     set:
       networkPolicy:

--- a/charts/fastmcp-server/tests/notes_test.yaml
+++ b/charts/fastmcp-server/tests/notes_test.yaml
@@ -10,3 +10,21 @@ tests:
     asserts:
       - matchRegexRaw:
           pattern: "kubectl port-forward svc/RELEASE-NAME-fastmcp-server 8000:8000 -n fastmcp-runtime"
+
+  - it: should not derive Gateway API route scheme from ingress TLS
+    set:
+      ingress.tls:
+        - hosts:
+            - mcp.example.com
+          secretName: mcp-tls
+      gatewayAPI:
+        enabled: true
+        parentRefs:
+          - name: public-gateway
+        hostnames:
+          - mcp.example.com
+    asserts:
+      - matchRegexRaw:
+          pattern: "http://mcp.example.com/mcp"
+      - notMatchRegexRaw:
+          pattern: "https://mcp.example.com/mcp"

--- a/charts/fastmcp-server/tests/validation_test.yaml
+++ b/charts/fastmcp-server/tests/validation_test.yaml
@@ -33,6 +33,15 @@ tests:
       - failedTemplate:
           errorMessage: Each gatewayAPI.parentRefs entry must define a name
 
+  - it: ignores gateway API parentRefs when gateway API is disabled
+    set:
+      gatewayAPI.enabled: false
+      gatewayAPI.parentRefs:
+        - namespace: gateway-system
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: fails when bearer auth has no token or existing secret
     set:
       auth.type: bearer

--- a/charts/fastmcp-server/tests/validation_test.yaml
+++ b/charts/fastmcp-server/tests/validation_test.yaml
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: passes with default values
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress.hosts must contain at least one host when ingress.enabled=true
+
+  - it: fails when gateway API is enabled without parentRefs
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: gatewayAPI.parentRefs must contain at least one parentRef when gatewayAPI.enabled=true
+
+  - it: fails when a gateway API parentRef has no name
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.parentRefs:
+        - namespace: gateway-system
+    asserts:
+      - failedTemplate:
+          errorMessage: Each gatewayAPI.parentRefs entry must define a name
+
+  - it: fails when bearer auth has no token or existing secret
+    set:
+      auth.type: bearer
+      auth.bearer.token: ""
+      auth.bearer.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: auth.type=bearer requires auth.bearer.token or auth.bearer.existingSecret
+
+  - it: fails when JWT auth is incomplete
+    set:
+      auth.type: jwt
+      auth.jwt.issuer: https://issuer.example.com
+      auth.jwt.audience: ""
+      auth.jwt.jwksUri: https://issuer.example.com/.well-known/jwks.json
+    asserts:
+      - failedTemplate:
+          errorMessage: auth.type=jwt requires auth.jwt.issuer, auth.jwt.audience, and auth.jwt.jwksUri
+
+  - it: fails when S3 source has no bucket
+    set:
+      sources.s3.enabled: true
+      sources.s3.bucket: ""
+      sources.s3.existingSecret: fastmcp-s3
+    asserts:
+      - failedTemplate:
+          errorMessage: sources.s3.enabled requires sources.s3.bucket
+
+  - it: fails when S3 source has no credentials
+    set:
+      sources.s3.enabled: true
+      sources.s3.bucket: fastmcp
+      sources.s3.accessKey: ""
+      sources.s3.secretKey: ""
+      sources.s3.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: sources.s3.enabled requires sources.s3.existingSecret or both sources.s3.accessKey and sources.s3.secretKey
+
+  - it: fails when Git source has no repository
+    set:
+      sources.git.enabled: true
+      sources.git.repository: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: sources.git.enabled requires sources.git.repository
+
+  - it: fails when autoscaling max is lower than min
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 3
+      autoscaling.maxReplicas: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: autoscaling.maxReplicas must be greater than or equal to autoscaling.minReplicas
+
+  - it: fails when autoscaling has no metrics
+    set:
+      autoscaling.enabled: true
+      autoscaling.targetCPUUtilizationPercentage: null
+      autoscaling.targetMemoryUtilizationPercentage: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: autoscaling.enabled requires at least one target metric
+
+  - it: fails when podLabels override selector labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: custom
+    asserts:
+      - failedTemplate:
+          errorMessage: podLabels must not override the selector label app.kubernetes.io/name

--- a/charts/fastmcp-server/values.schema.json
+++ b/charts/fastmcp-server/values.schema.json
@@ -256,7 +256,14 @@
     "networkPolicy": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "extraEgress": {
+          "type": "array",
+          "description": "Additional NetworkPolicy egress rules",
+          "items": {
+            "type": "object"
+          }
+        }
       }
     },
     "pdb": {

--- a/charts/fastmcp-server/values.yaml
+++ b/charts/fastmcp-server/values.yaml
@@ -345,6 +345,8 @@ serviceAccount:
 networkPolicy:
   # -- Enable NetworkPolicy
   enabled: false
+  # -- Additional egress rules for external services required by tools or sources
+  extraEgress: []
 
 # =============================================================================
 # Resources and Security


### PR DESCRIPTION
## Summary
- add centralized `fastmcp-server.validate` checks for invalid ingress, Gateway API, auth, source, autoscaling, and selector-label configurations
- add `networkPolicy.extraEgress` support and schema coverage
- number NOTES sections and move HTTPRoute validation into the shared validation template

## Validation
- helm unittest charts/fastmcp-server
- helm lint --strict charts/fastmcp-server
- make template-standards-check CHART=fastmcp-server
- make standards-check CHART=fastmcp-server
- make standards-guard CHART=fastmcp-server
- make validate-chart CHART=fastmcp-server TIMEOUT=900: FULLY VALIDATED (16 layers)
- make site-sync-check CHART=fastmcp-server
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#343
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm-time validation for required configuration combinations, with clearer failure messages.
  * Added support for optional extra egress rules in network policy configuration.
* **Bug Fixes**
  * Updated HTTPRoute rendering so it no longer hard-fails when Gateway API parent references are missing; validation messaging is handled via chart validation.
* **Documentation**
  * Reformatted deployment NOTES to improve readability and section structure.
* **Tests**
  * Expanded chart test coverage for validation behavior, extra egress rendering, Gateway API route URL scheme, and HTTPRoute scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->