### PR TITLE
fix(openhab): align pod template labels

### DIFF
--- a/charts/openhab/templates/_helpers.tpl
+++ b/charts/openhab/templates/_helpers.tpl
@@ -100,6 +100,19 @@ Validate ConfigMap sync configuration.
 {{- end }}
 
 {{/*
+Validate pod labels do not override immutable selector labels.
+*/}}
+{{- define "openhab.validatePodLabels" -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- if hasKey $podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey $podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve the admin secret name.
 */}}
 {{- define "openhab.adminSecretName" -}}

--- a/charts/openhab/templates/statefulset.yaml
+++ b/charts/openhab/templates/statefulset.yaml
@@ -2,6 +2,7 @@
 {{- include "openhab.validateReplicaCount" . }}
 {{- include "openhab.validateAdmin" . }}
 {{- include "openhab.validateConfigMaps" . }}
+{{- include "openhab.validatePodLabels" . }}
 {{- $hasSitemaps := and .Values.configMaps.sitemaps.enabled (gt (len (.Values.configMaps.sitemaps.files | default dict)) 0) }}
 {{- $hasThings := and .Values.configMaps.things.enabled (gt (len (.Values.configMaps.things.files | default dict)) 0) }}
 {{- $hasItems := and .Values.configMaps.items.enabled (gt (len (.Values.configMaps.items.files | default dict)) 0) }}
@@ -35,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "openhab.labels" . | nindent 8 }}
+        {{- include "openhab.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/openhab/tests/podlabels-selector-combined-values.yaml
+++ b/charts/openhab/tests/podlabels-selector-combined-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/name: custom
+  app.kubernetes.io/instance: custom

--- a/charts/openhab/tests/podlabels-selector-instance-values.yaml
+++ b/charts/openhab/tests/podlabels-selector-instance-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/instance: custom

--- a/charts/openhab/tests/podlabels-selector-name-values.yaml
+++ b/charts/openhab/tests/podlabels-selector-name-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/name: custom

--- a/charts/openhab/tests/validation_test.yaml
+++ b/charts/openhab/tests/validation_test.yaml
@@ -49,6 +49,13 @@ tests:
       - failedTemplate:
           errorMessage: "podLabels must not override the selector label app.kubernetes.io/name"
 
+  - it: should fail when podLabels override selector name and instance
+    values:
+      - podlabels-selector-combined-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/name"
+
   - it: should fail when podLabels override selector instance
     values:
       - podlabels-selector-instance-values.yaml

--- a/charts/openhab/tests/validation_test.yaml
+++ b/charts/openhab/tests/validation_test.yaml
@@ -41,3 +41,17 @@ tests:
     asserts:
       - isKind:
           of: StatefulSet
+
+  - it: should fail when podLabels override selector name
+    values:
+      - podlabels-selector-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/name"
+
+  - it: should fail when podLabels override selector instance
+    values:
+      - podlabels-selector-instance-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/instance"


### PR DESCRIPTION
## Summary

- Align openHAB StatefulSet pod template labels with immutable selector labels plus user `podLabels`.
- Add fail-fast validation to prevent `podLabels` from overriding selector labels.
- Add unit coverage for selector-label override validation.

## Validation

- `helm unittest charts/openhab`: 118 tests passed
- `helm lint --strict charts/openhab`: passed
- `make template-standards-check CHART=openhab`: passed
- `make standards-check CHART=openhab`: passed
- `make standards-guard CHART=openhab`: passed
- `node scripts/charts/validate-chart.js --chart openhab --no-k3d`: static layers passed, including kubeconform and ah lint
- k3d behavioral validation on `k3d-helmforge-tests-wsl`: default plus every `ci/*.yaml` passed sequentially
- `make site-sync-check CHART=openhab`: passed
- site `npm run lint`, `npm run format:check`, `npm run build`: passed
- `make release-check REPO=charts`: passed with expected post-merge release warning
- `make attribution-check REPO=charts`: passed

## Site Sync

Site PR: helmforgedev/site#352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent custom pod labels from overriding required selector labels, avoiding invalid StatefulSet output.
  * Updated pod label rendering to consistently use the selector labels set for pods.
* **Tests**
  * Expanded validation tests to cover conflicts for both selector label keys (name and instance).
  * Added dedicated test values to confirm rendering fails with the expected error message when conflicts occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->