### PR TITLE
fix(hoppscotch): align template standards

### DIFF
--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -101,7 +101,7 @@ backend process inside the AIO image.
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
 | `networkPolicy.extraEgress` | Additional egress rules appended after DNS and database baseline rules | `[]` |
 | `podDisruptionBudget.enabled` | Enable PDB | `false` |
-| `extraManifests` | Additional Kubernetes manifests rendered with the release | `[]` |
+| `extraManifests` | Additional Kubernetes manifests rendered with the release; entries are evaluated with Helm `tpl` | `[]` |
 
 ## Upgrade Notes
 

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -99,7 +99,9 @@ backend process inside the AIO image.
 | `externalSecrets.enabled` | Enable ExternalSecret | `false` |
 | `externalSecrets.apiVersion` | ExternalSecret API version | `external-secrets.io/v1` |
 | `networkPolicy.enabled` | Enable NetworkPolicy | `false` |
+| `networkPolicy.extraEgress` | Additional egress rules appended after DNS and database baseline rules | `[]` |
 | `podDisruptionBudget.enabled` | Enable PDB | `false` |
+| `extraManifests` | Additional Kubernetes manifests rendered with the release | `[]` |
 
 ## Upgrade Notes
 

--- a/charts/hoppscotch/ci/dual-stack.yaml
+++ b/charts/hoppscotch/ci/dual-stack.yaml
@@ -1,6 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/hoppscotch/ci/external-db.yaml
+++ b/charts/hoppscotch/ci/external-db.yaml
@@ -4,8 +4,101 @@ postgresql:
 database:
   external:
     enabled: true
-    host: postgres.example.local
+    host: hoppscotch-ci-external-db-postgresql
     port: 5432
     name: hoppscotch
     username: hoppscotch
     password: test-password
+
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: hoppscotch-ci-external-db-init
+      labels:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-db
+        app.kubernetes.io/component: external-database
+    data:
+      01-extensions.sql: |
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: hoppscotch-ci-external-db-postgresql
+      labels:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-db
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: hoppscotch-external-postgresql
+          app.kubernetes.io/instance: hoppscotch-ci-external-db
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: hoppscotch-external-postgresql
+            app.kubernetes.io/instance: hoppscotch-ci-external-db
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.3-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+                  protocol: TCP
+              env:
+                - name: POSTGRES_DB
+                  value: hoppscotch
+                - name: POSTGRES_USER
+                  value: hoppscotch
+                - name: POSTGRES_PASSWORD
+                  value: test-password
+              readinessProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - hoppscotch
+                    - -d
+                    - hoppscotch
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+              volumeMounts:
+                - name: initdb
+                  mountPath: /docker-entrypoint-initdb.d
+          volumes:
+            - name: initdb
+              configMap:
+                name: hoppscotch-ci-external-db-init
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: hoppscotch-ci-external-db-postgresql
+      labels:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-db
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-db
+        app.kubernetes.io/component: external-database

--- a/charts/hoppscotch/ci/external-secrets.yaml
+++ b/charts/hoppscotch/ci/external-secrets.yaml
@@ -1,19 +1,142 @@
 # SPDX-License-Identifier: Apache-2.0
+fullnameOverride: hoppscotch-ci
+postgresql:
+  enabled: false
+database:
+  external:
+    enabled: true
+    host: hoppscotch-ci-external-db-postgresql
+    port: 5432
+    name: hoppscotch
+    username: hoppscotch
+    existingSecret: hoppscotch-ci
+    existingSecretUrlKey: database-url
+encryption:
+  existingSecret: hoppscotch-ci
+signingKey:
+  existingSecret: hoppscotch-ci
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: example-secret-store
-    kind: ClusterSecretStore
+    name: hoppscotch-ci-fake-store
+    kind: SecretStore
   data:
     - secretKey: database-url
       remoteRef:
-        key: prod/hoppscotch
-        property: database-url
+        key: database-url
     - secretKey: data-encryption-key
       remoteRef:
-        key: prod/hoppscotch
-        property: data-encryption-key
+        key: data-encryption-key
     - secretKey: webapp-server-signing-key
       remoteRef:
-        key: prod/hoppscotch
-        property: webapp-server-signing-key
+        key: webapp-server-signing-key
+
+extraManifests:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: hoppscotch-ci-fake-store
+      labels:
+        app.kubernetes.io/name: hoppscotch-ci-fake-store
+        app.kubernetes.io/component: external-secrets
+    spec:
+      provider:
+        fake:
+          data:
+            - key: database-url
+              value: postgresql://hoppscotch:test-password@hoppscotch-ci-external-db-postgresql:5432/hoppscotch
+            - key: data-encryption-key
+              value: "12345678901234567890123456789012"
+            - key: webapp-server-signing-key
+              value: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc4OWFiY2RlZg==
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: hoppscotch-ci-external-db-init
+      labels:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-secrets
+        app.kubernetes.io/component: external-database
+    data:
+      01-extensions.sql: |
+        CREATE EXTENSION IF NOT EXISTS pg_trgm;
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: hoppscotch-ci-external-db-postgresql
+      labels:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-secrets
+        app.kubernetes.io/component: external-database
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: hoppscotch-external-postgresql
+          app.kubernetes.io/instance: hoppscotch-ci-external-secrets
+          app.kubernetes.io/component: external-database
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: hoppscotch-external-postgresql
+            app.kubernetes.io/instance: hoppscotch-ci-external-secrets
+            app.kubernetes.io/component: external-database
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.3-trixie
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+                  protocol: TCP
+              env:
+                - name: POSTGRES_DB
+                  value: hoppscotch
+                - name: POSTGRES_USER
+                  value: hoppscotch
+                - name: POSTGRES_PASSWORD
+                  value: test-password
+              readinessProbe:
+                exec:
+                  command:
+                    - pg_isready
+                    - -U
+                    - hoppscotch
+                    - -d
+                    - hoppscotch
+                initialDelaySeconds: 5
+                periodSeconds: 5
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  cpu: 1000m
+                  memory: 1Gi
+              volumeMounts:
+                - name: initdb
+                  mountPath: /docker-entrypoint-initdb.d
+          volumes:
+            - name: initdb
+              configMap:
+                name: hoppscotch-ci-external-db-init
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: hoppscotch-ci-external-db-postgresql
+      labels:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-secrets
+        app.kubernetes.io/component: external-database
+    spec:
+      type: ClusterIP
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+          protocol: TCP
+      selector:
+        app.kubernetes.io/name: hoppscotch-external-postgresql
+        app.kubernetes.io/instance: hoppscotch-ci-external-secrets
+        app.kubernetes.io/component: external-database

--- a/charts/hoppscotch/templates/extra-manifests.yaml
+++ b/charts/hoppscotch/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/hoppscotch/templates/extra-manifests.yaml
+++ b/charts/hoppscotch/templates/extra-manifests.yaml
@@ -1,5 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- range .Values.extraManifests }}
 ---
-{{ toYaml . }}
+{{ tpl (toYaml .) $ }}
 {{- end }}

--- a/charts/hoppscotch/templates/networkpolicy.yaml
+++ b/charts/hoppscotch/templates/networkpolicy.yaml
@@ -30,7 +30,7 @@ spec:
     - ports:
         - port: {{ include "hoppscotch.databasePort" . | int }}
           protocol: TCP
-    {{- with .Values.networkPolicy.egress }}
+    {{- with concat (.Values.networkPolicy.egress | default list) (.Values.networkPolicy.extraEgress | default list) }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/hoppscotch/tests/connection_test.yaml
+++ b/charts/hoppscotch/tests/connection_test.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Helm Test
+templates:
+  - templates/tests/connection-test.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render the Helm test hook pod
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: test-hoppscotch-test-connection
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test

--- a/charts/hoppscotch/tests/connection_test.yaml
+++ b/charts/hoppscotch/tests/connection_test.yaml
@@ -16,3 +16,12 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: test
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.containers[0].image
+          value: docker.io/library/busybox:1.37
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: /backend/health

--- a/charts/hoppscotch/tests/extra-manifests-values.yaml
+++ b/charts/hoppscotch/tests/extra-manifests-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: hoppscotch-extra
+    data:
+      enabled: "true"

--- a/charts/hoppscotch/tests/extra-manifests-values.yaml
+++ b/charts/hoppscotch/tests/extra-manifests-values.yaml
@@ -6,3 +6,4 @@ extraManifests:
       name: hoppscotch-extra
     data:
       enabled: "true"
+      namespace: "{{ .Release.Namespace }}"

--- a/charts/hoppscotch/tests/extra_manifests_test.yaml
+++ b/charts/hoppscotch/tests/extra_manifests_test.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: extra manifests tests
+templates:
+  - extra-manifests.yaml
+tests:
+  - it: should render additional manifests
+    values:
+      - extra-manifests-values.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: hoppscotch-extra
+      - equal:
+          path: data.enabled
+          value: "true"

--- a/charts/hoppscotch/tests/extra_manifests_test.yaml
+++ b/charts/hoppscotch/tests/extra_manifests_test.yaml
@@ -2,6 +2,8 @@
 suite: extra manifests tests
 templates:
   - extra-manifests.yaml
+release:
+  namespace: default
 tests:
   - it: should render additional manifests
     values:
@@ -15,3 +17,6 @@ tests:
       - equal:
           path: data.enabled
           value: "true"
+      - equal:
+          path: data.namespace
+          value: default

--- a/charts/hoppscotch/tests/networkpolicy-extra-egress-values.yaml
+++ b/charts/hoppscotch/tests/networkpolicy-extra-egress-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 443

--- a/charts/hoppscotch/tests/networkpolicy-legacy-and-extra-egress-values.yaml
+++ b/charts/hoppscotch/tests/networkpolicy-legacy-and-extra-egress-values.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.16.0.0/12
+      ports:
+        - protocol: TCP
+          port: 8443
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 443

--- a/charts/hoppscotch/tests/networkpolicy_test.yaml
+++ b/charts/hoppscotch/tests/networkpolicy_test.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: network policy
+templates:
+  - networkpolicy.yaml
+tests:
+  - it: renders baseline ingress and egress rules
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 53
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 5432
+  - it: appends extra egress rules
+    values:
+      - networkpolicy-extra-egress-values.yaml
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].ipBlock.cidr
+          value: 10.0.0.0/8
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 443
+  - it: preserves legacy egress rules before extraEgress rules
+    values:
+      - networkpolicy-legacy-and-extra-egress-values.yaml
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].ipBlock.cidr
+          value: 172.16.0.0/12
+      - equal:
+          path: spec.egress[3].to[0].ipBlock.cidr
+          value: 10.0.0.0/8

--- a/charts/hoppscotch/values.schema.json
+++ b/charts/hoppscotch/values.schema.json
@@ -468,7 +468,8 @@
       "properties": {
         "enabled": {"type": "boolean"},
         "ingress": {"type": "array"},
-        "egress": {"type": "array"}
+        "egress": {"type": "array"},
+        "extraEgress": {"type": "array"}
       }
     },
     "podDisruptionBudget": {
@@ -487,6 +488,7 @@
     "topologySpreadConstraints": {"type": "array"},
     "initContainers": {"type": "array"},
     "extraEnv": {"type": "array"},
-    "extraEnvFrom": {"type": "array"}
+    "extraEnvFrom": {"type": "array"},
+    "extraManifests": {"type": "array"}
   }
 }

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -431,6 +431,7 @@ networkPolicy:
   enabled: false
   ingress: []
   egress: []
+  extraEgress: []
 
 # =============================================================================
 # Pod Disruption Budget
@@ -459,3 +460,6 @@ extraEnv: []
 
 # -- Extra envFrom entries (ConfigMaps, Secrets)
 extraEnvFrom: []
+
+# -- Additional Kubernetes manifests rendered with the release
+extraManifests: []


### PR DESCRIPTION
## Summary
- Keep the Helm test hook under `templates/tests/connection-test.yaml` so `helm test` renders and executes it, with unittest coverage for the hook pod.
- Add `networkPolicy.extraEgress` while preserving legacy `networkPolicy.egress`.
- Add `extraManifests` and unit coverage for additional rendered manifests.
- Make dual-stack, external-db, and external-secrets CI scenarios self-contained for local k3d.
- Add network policy unit coverage for baseline, extra egress, and legacy egress compatibility.

## Related
- Site sync: helmforgedev/site#353.
- Closes helmforgedev/charts#633.

## Validation
- `helm template test charts/hoppscotch | rg -n "helm.sh/hook|test-connection|connection-test"` (hook rendered from `templates/tests/connection-test.yaml`)
- `helm unittest charts/hoppscotch` (81 tests, 14 suites)
- `make template-standards-check CHART=hoppscotch`
- `node scripts/charts/validate-chart.js --chart hoppscotch --no-k3d`
- `make validate-chart CHART=hoppscotch TIMEOUT=900` (FULLY VALIDATED, 18 layers)
- `make site-sync-check CHART=hoppscotch`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Site Validation
- `npm run lint`
- `npm run format:check`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `extraManifests` to render additional Kubernetes resources during the Helm release (with templating support).
  * Added optional `networkPolicy.extraEgress` to append extra egress rules to generated NetworkPolicies.
* **Bug Fixes**
  * Updated CI chart setup to use an in-cluster PostgreSQL service and updated external-secrets sourcing for CI runs.
  * Adjusted dual-stack service behavior to prefer dual-stack addressing.
* **Tests**
  * Added/updated Helm tests covering extra manifests rendering and NetworkPolicy egress ordering/appending.
* **Documentation**
  * Updated chart docs and `values.schema.json` for `extraManifests` and `extraEgress`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->