### PR TITLE
fix(memcached): align template standards

### DIFF
--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -306,6 +306,7 @@ networkPolicy:
     enabled: true
     allowSameNamespace: true
     allowDNS: true
+  extraEgress: []
 ```
 
 ## Important values
@@ -331,6 +332,7 @@ networkPolicy:
 | `metrics.memcachedTLS.serverName` | computed Service DNS | TLS verification name used by the metrics exporter. |
 | `networkPolicy.enabled` | `false` | Enables NetworkPolicy resources. |
 | `networkPolicy.egress.allowSameNamespace` | `true` | Allows cache and metrics responses to same-namespace clients. |
+| `networkPolicy.extraEgress` | `[]` | Additional full NetworkPolicy egress rules appended to generated egress. |
 | `pdb.maxUnavailable` | `""` | Optional PDB disruption limit. Explicit `0` is honored. |
 | `service.ipFamilyPolicy` | `""` | Optional Kubernetes Service dual-stack policy. |
 | `service.ipFamilies` | `[]` | Optional ordered Service IP families. |

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -306,7 +306,7 @@ networkPolicy:
     enabled: true
     allowSameNamespace: true
     allowDNS: true
-  extraEgress: []
+    extraEgress: []
 ```
 
 ## Important values
@@ -332,7 +332,7 @@ networkPolicy:
 | `metrics.memcachedTLS.serverName` | computed Service DNS | TLS verification name used by the metrics exporter. |
 | `networkPolicy.enabled` | `false` | Enables NetworkPolicy resources. |
 | `networkPolicy.egress.allowSameNamespace` | `true` | Allows cache and metrics responses to same-namespace clients. |
-| `networkPolicy.extraEgress` | `[]` | Additional full NetworkPolicy egress rules appended to generated egress. |
+| `networkPolicy.egress.extraEgress` | `[]` | Additional full NetworkPolicy egress rules appended to generated egress. |
 | `pdb.maxUnavailable` | `""` | Optional PDB disruption limit. Explicit `0` is honored. |
 | `service.ipFamilyPolicy` | `""` | Optional Kubernetes Service dual-stack policy. |
 | `service.ipFamilies` | `[]` | Optional ordered Service IP families. |

--- a/charts/memcached/templates/NOTES.txt
+++ b/charts/memcached/templates/NOTES.txt
@@ -1,9 +1,9 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-# Getting started
+1. Getting Started
 
 Memcached has been deployed as {{ .Values.architecture }}.
 
-## Access
+2. Access
 
 Client service:
   {{ include "memcached.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.port }}
@@ -11,7 +11,7 @@ Client service:
 Headless service for pod-aware client hashing:
   {{ include "memcached.headlessServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
 
-## Configuration
+3. Configuration
 
 Architecture: {{ .Values.architecture }}
 Replicas: {{ .Values.replicaCount }}
@@ -37,7 +37,7 @@ Metrics: disabled
 Service IP family policy: {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
 {{- end }}
 
-## Validation
+4. Validation
 
 Validate connectivity:
   kubectl run memcached-client --rm -it --restart=Never \
@@ -45,8 +45,9 @@ Validate connectivity:
     --image=docker.io/library/busybox:1.37.0 -- \
     sh -ec "printf 'version\r\n' | nc {{ include "memcached.fullname" . }} {{ .Values.service.port }}"
 
-{{- if .Values.auth.enabled }}
+5. Authentication
 
+{{- if .Values.auth.enabled }}
 Authentication is enabled with mode {{ .Values.auth.mode }}.
 {{- if eq .Values.auth.mode "ascii" }}
 ASCII auth uses a fake set command before regular commands:
@@ -55,20 +56,28 @@ ASCII auth uses a fake set command before regular commands:
 SASL mode requires binary protocol clients and the mounted SASL database from Secret {{ include "memcached.authSecretName" . }}.
 The chart sets SASL_CONF_PATH={{ .Values.auth.sasl.mountPath }}.
 {{- end }}
+{{- else }}
+Authentication is disabled.
 {{- end }}
+
+6. TLS
 
 {{- if .Values.tls.enabled }}
-
 TLS is enabled. Use a Memcached client that supports TLS and trusts the mounted certificate chain.
+{{- else }}
+TLS is disabled.
 {{- end }}
+
+7. Observability
 
 {{- if .Values.metrics.enabled }}
-
 Metrics endpoint:
   {{ include "memcached.metricsServiceName" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.metrics.port }}/metrics
+{{- else }}
+Metrics are disabled.
 {{- end }}
 
-## Troubleshooting
+8. Troubleshooting
 
 Inspect pods:
   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
@@ -79,7 +88,7 @@ Inspect logs:
 Inspect events:
   kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
 
-## Resources
+9. Resources
 
 Chart documentation:
   https://helmforge.dev/docs/charts/memcached
@@ -87,7 +96,8 @@ Chart documentation:
 Upstream Memcached:
   https://memcached.org
 
-Production reminders:
+10. Production Reminders
+
   - Memcached is a volatile cache, not a database.
   - Use distributed mode only with client-side hashing or application-aware node lists.
   - Enable NetworkPolicy with explicit client namespaces before exposing shared cache services.

--- a/charts/memcached/templates/networkpolicy.yaml
+++ b/charts/memcached/templates/networkpolicy.yaml
@@ -55,7 +55,7 @@ spec:
     []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
-  {{- $allowEgress := or .Values.networkPolicy.egress.allowSameNamespace .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.extraTo }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowSameNamespace .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.extraTo .Values.networkPolicy.extraEgress }}
   egress:
     {{- if $allowEgress }}
     {{- if .Values.networkPolicy.egress.allowSameNamespace }}
@@ -87,6 +87,9 @@ spec:
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- else }}
     []

--- a/charts/memcached/templates/networkpolicy.yaml
+++ b/charts/memcached/templates/networkpolicy.yaml
@@ -55,7 +55,7 @@ spec:
     []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
-  {{- $allowEgress := or .Values.networkPolicy.egress.allowSameNamespace .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.extraTo .Values.networkPolicy.extraEgress }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowSameNamespace .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.extraTo .Values.networkPolicy.egress.extraEgress }}
   egress:
     {{- if $allowEgress }}
     {{- if .Values.networkPolicy.egress.allowSameNamespace }}
@@ -88,7 +88,7 @@ spec:
     - to:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.networkPolicy.extraEgress }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- else }}

--- a/charts/memcached/tests/networkpolicy_test.yaml
+++ b/charts/memcached/tests/networkpolicy_test.yaml
@@ -63,3 +63,27 @@ tests:
       - equal:
           path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: "false"
+
+  - it: appends extra NetworkPolicy egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      networkPolicy.egress.allowSameNamespace: false
+      networkPolicy.egress.allowDNS: false
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.80.0.0/16
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.80.0.0/16
+            ports:
+              - protocol: TCP
+                port: 443

--- a/charts/memcached/tests/networkpolicy_test.yaml
+++ b/charts/memcached/tests/networkpolicy_test.yaml
@@ -70,7 +70,7 @@ tests:
       networkPolicy.egress.enabled: true
       networkPolicy.egress.allowSameNamespace: false
       networkPolicy.egress.allowDNS: false
-      networkPolicy.extraEgress:
+      networkPolicy.egress.extraEgress:
         - to:
             - ipBlock:
                 cidr: 10.80.0.0/16

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -264,10 +264,6 @@
       "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean" },
-        "extraEgress": {
-          "type": "array",
-          "items": { "type": "object" }
-        },
         "egress": {
           "type": "object",
           "additionalProperties": true,
@@ -275,7 +271,11 @@
             "enabled": { "type": "boolean" },
             "allowSameNamespace": { "type": "boolean" },
             "allowDNS": { "type": "boolean" },
-            "allowHTTPS": { "type": "boolean" }
+            "allowHTTPS": { "type": "boolean" },
+            "extraEgress": {
+              "type": "array",
+              "items": { "type": "object" }
+            }
           }
         }
       }

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -264,6 +264,10 @@
       "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean" },
+        "extraEgress": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
         "egress": {
           "type": "object",
           "additionalProperties": true,

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -144,8 +144,8 @@ networkPolicy:
     allowSameNamespace: true
     allowDNS: true
     allowHTTPS: false
+    extraEgress: []
     extraTo: []
-  extraEgress: []
 
 autoscaling:
   enabled: false

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -145,6 +145,7 @@ networkPolicy:
     allowDNS: true
     allowHTTPS: false
     extraTo: []
+  extraEgress: []
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Summary
- Keep the Helm test hook under `templates/tests/` so `helm test` renders and executes it, with unittest coverage preserved.
- Add `networkPolicy.extraEgress` so callers can append full custom egress rules.
- Number `NOTES.txt` sections and sync README values documentation.

## Related
- Site sync: helmforgedev/site#358.

## Validation
- `helm template test charts/memcached | rg -n "helm.sh/hook|test-connection"` (hook rendered from `templates/tests/test-connection.yaml`)
- `helm unittest charts/memcached` (41 tests, 9 suites)
- `make template-standards-check CHART=memcached`
- `node scripts/charts/validate-chart.js --chart memcached --no-k3d`
- `make validate-chart CHART=memcached TIMEOUT=900` (FULLY VALIDATED, 19 layers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `networkPolicy.egress.extraEgress` to append additional egress rules to Memcached NetworkPolicy.
* **Bug Fixes**
  * NetworkPolicy rendering now includes the extra egress rules when configured (covered by rendering tests).
* **Documentation**
  * Updated Memcached chart docs and NetworkPolicy examples to describe `networkPolicy.extraEgress`.
  * Improved startup notes formatting and validation instructions with clearer numbered sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->