### PR TITLE
fix(openreel-video): align template standards

### DIFF
--- a/charts/openreel-video/README.md
+++ b/charts/openreel-video/README.md
@@ -46,6 +46,16 @@ ingress:
           pathType: Prefix
 ```
 
+## NetworkPolicy
+
+```yaml
+networkPolicy:
+  enabled: true
+  extraEgress: []
+```
+
+Use `networkPolicy.extraEgress` to append full custom egress rules.
+
 ## Documentation
 
 - [Design](DESIGN.md)
@@ -66,7 +76,7 @@ kubeconform -strict -summary rendered.yaml
 ### Security Scan: `openreel-video`
 
 | Framework | Score |
-|---|---|
+| --- | --- |
 | MITRE + NSA + SOC2 | **86.580086%** |
 
-> Security posture acceptable.
+Security posture: acceptable.

--- a/charts/openreel-video/templates/NOTES.txt
+++ b/charts/openreel-video/templates/NOTES.txt
@@ -1,9 +1,6 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-=============================================================================
-OpenReel Video deployed successfully!
-=============================================================================
+1. Access
 
-ACCESS:
 {{- if .Values.ingress.enabled }}
   {{- range .Values.ingress.hosts }}
    http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
@@ -17,17 +14,20 @@ ACCESS:
    Open: http://localhost:8080
 {{- end }}
 
-SERVICE:
+2. Service
+
    Internal: {{ include "openreel-video.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
    Health:   /healthz
    Image:    {{ include "openreel-video.image" . }}
 
-RUNTIME:
+3. Runtime
+
    Static web editor: enabled
    Container port: {{ .Values.service.targetPort }}
    Temporary volume: {{ ternary "enabled" "disabled" .Values.tmpVolume.enabled }}
 
-OPERATIONS:
+4. Operations
+
    Run Helm tests:
      helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
 
@@ -35,14 +35,25 @@ OPERATIONS:
      kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
      kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "openreel-video.fullname" . }}
 
-PRODUCTION REMINDERS:
+5. Production Reminders
+
    1. Configure Ingress or Gateway API with HTTPS and COOP/COEP-compatible edge behavior.
    2. Keep resource limits explicit for browser-heavy static asset delivery.
    3. Enable NetworkPolicy after confirming ingress-controller namespace selectors.
 
-DOCUMENTATION:
+6. Documentation
+
    Chart: https://helmforge.dev/docs/charts/openreel-video
    Source: https://github.com/helmforgedev/charts/tree/main/charts/openreel-video
    OpenReel Video: https://github.com/Augani/openreel-video
+
+7. Validation
+
+   Verify the editor health endpoint:
+     kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "openreel-video.fullname" . }} -- wget -qO- http://127.0.0.1:{{ .Values.service.targetPort }}/healthz
+
+8. Resources
+
+   Values: https://github.com/helmforgedev/charts/blob/main/charts/openreel-video/values.yaml
 
 Happy Helmforging :)

--- a/charts/openreel-video/templates/_helpers.tpl
+++ b/charts/openreel-video/templates/_helpers.tpl
@@ -47,3 +47,9 @@ app.kubernetes.io/part-of: helmforge
 {{- define "openreel-video.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
+
+{{- define "openreel-video.validate" -}}
+{{- if and (eq .Values.service.type "ExternalName") (not .Values.service.externalName) -}}
+{{- fail "service.externalName is required when service.type=ExternalName" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openreel-video/templates/networkpolicy.yaml
+++ b/charts/openreel-video/templates/networkpolicy.yaml
@@ -25,8 +25,13 @@ spec:
           port: http
     {{- end }}
   egress:
-    {{- if .Values.networkPolicy.egress }}
-    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    {{- if or .Values.networkPolicy.egress .Values.networkPolicy.extraEgress }}
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- else }}
     []
     {{- end }}

--- a/charts/openreel-video/templates/service.yaml
+++ b/charts/openreel-video/templates/service.yaml
@@ -1,7 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if and (eq .Values.service.type "ExternalName") (not .Values.service.externalName) }}
-{{- fail "service.externalName is required when service.type=ExternalName" }}
-{{- end }}
+{{- include "openreel-video.validate" . }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/openreel-video/tests/networkpolicy_test.yaml
+++ b/charts/openreel-video/tests/networkpolicy_test.yaml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: NetworkPolicy
+templates:
+  - templates/networkpolicy.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render default ingress and deny-all egress
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: http
+      - equal:
+          path: spec.egress
+          value: []
+
+  - it: should append extra egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.80.0.0/16
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].ipBlock.cidr
+          value: 10.80.0.0/16
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 443

--- a/charts/openreel-video/tests/networkpolicy_test.yaml
+++ b/charts/openreel-video/tests/networkpolicy_test.yaml
@@ -36,3 +36,30 @@ tests:
       - equal:
           path: spec.egress[0].ports[0].port
           value: 443
+
+  - it: should combine egress and extra egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress:
+        - to:
+            - namespaceSelector: {}
+          ports:
+            - protocol: TCP
+              port: 53
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.80.0.0/16
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 53
+      - equal:
+          path: spec.egress[1].to[0].ipBlock.cidr
+          value: 10.80.0.0/16
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 443

--- a/charts/openreel-video/values.schema.json
+++ b/charts/openreel-video/values.schema.json
@@ -55,7 +55,16 @@
         "pathType": { "type": "string", "enum": ["Exact", "PathPrefix", "RegularExpression"] }
       }
     },
-    "networkPolicy": { "type": "object" },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingress": { "type": "array", "items": { "type": "object" } },
+        "egress": { "type": "array", "items": { "type": "object" } },
+        "extraEgress": { "type": "array", "items": { "type": "object" } }
+      }
+    },
     "autoscaling": { "type": "object" },
     "pdb": { "type": "object" },
     "probes": { "type": "object" },

--- a/charts/openreel-video/values.yaml
+++ b/charts/openreel-video/values.yaml
@@ -113,6 +113,8 @@ networkPolicy:
   ingress: []
   # -- Additional egress rules appended to the default web policy.
   egress: []
+  # -- Additional full egress rules appended to the default web policy.
+  extraEgress: []
 
 # =============================================================================
 # Autoscaling and Availability


### PR DESCRIPTION
## Summary

- keep the Helm test hook under `templates/tests` so `helm test` remains functional
- add central validation helper coverage for `service.externalName`
- add `networkPolicy.extraEgress` support with schema and unit coverage
- fix empty-egress rendering when only `extraEgress` is configured
- expand NOTES and README coverage for the operational controls

## Validation

- `make validate-chart CHART=openreel-video TIMEOUT=900`: FULLY VALIDATED (12 layers), including k3d behavioral scenarios for default, `ci/ci-values.yaml`, and `ci/k3d-values.yaml`.
- `make site-sync-check CHART=openreel-video`
- `make release-check REPO=charts` passed with the expected GR-077 post-merge release confirmation warning.
- `make attribution-check REPO=charts`

Site PR: helmforgedev/site#362
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `networkPolicy.extraEgress` to append additional egress rules to the chart’s NetworkPolicy.
- **Bug Fixes**
  - NetworkPolicy egress now correctly includes both configured `egress` rules and any appended `extraEgress` rules.
- **Documentation**
  - Updated chart README with `networkPolicy.extraEgress` guidance and refreshed security scan formatting.
  - Improved Helm NOTES with a numbered, checklist-style verification guide.
- **Validation & Schema**
  - Strengthened validation for `ExternalName` services.
  - Expanded the NetworkPolicy section in the values schema to document `enabled`, `ingress`, `egress`, and `extraEgress`.
- **Tests**
  - Extended NetworkPolicy Helm tests to cover combined `egress` + `extraEgress` rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->