### PR TITLE
fix(tomcat): align template standards

### DIFF
--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -4,7 +4,7 @@ Apache Tomcat chart for Kubernetes using the official `docker.io/library/tomcat`
 
 ## Highlights
 
-- Official Tomcat image, pinned by default to `11.0.22-jdk17-temurin-noble`.
+- Official Tomcat image, pinned by default to `11.0.23-jdk17-temurin-noble`.
 - Stable default install with an optional ROOT health webapp for deterministic probes and Helm tests.
 - Preserves WARs or exploded applications baked into immutable Tomcat images before mounting the writable webapps volume.
 - Non-root runtime with writable `webapps`, `logs`, `temp`, and `work` volumes.
@@ -79,6 +79,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 
 - Keep `serviceAccount.automountServiceAccountToken=false` unless your app needs Kubernetes API access.
 - Enable `networkPolicy.enabled` and explicitly allow ingress from your gateway or ingress controller namespace.
+- Use `networkPolicy.egress.extraEgress` for complete custom egress rules when applications call platform services.
 - Use persistent `webapps` storage only when applications are installed or mutated at runtime.
 - Prefer immutable app images or init containers that fetch versioned WAR artifacts.
 - Configure `tomcat.serverXml` or `tomcat.existingServerXmlConfigMap` when you need proxy connector attributes such as `proxyName`, `proxyPort`, or `scheme`.
@@ -89,7 +90,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of Tomcat pods when HPA is disabled. |
 | `image.repository` | `docker.io/library/tomcat` | Tomcat image repository. |
-| `image.tag` | `11.0.22-jdk17-temurin-noble` | Tomcat image tag. |
+| `image.tag` | `11.0.23-jdk17-temurin-noble` | Tomcat image tag. |
 | `service.type` | `ClusterIP` | Kubernetes Service type. |
 | `service.ipFamilyPolicy` | `null` | Optional Service dual-stack policy. |
 | `service.ipFamilies` | `[]` | Optional Service IP family ordering. |
@@ -103,6 +104,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 | `ingress.enabled` | `false` | Render Ingress. |
 | `gatewayAPI.enabled` | `false` | Render Gateway API HTTPRoute. |
 | `networkPolicy.enabled` | `false` | Render NetworkPolicy. |
+| `networkPolicy.egress.extraEgress` | `[]` | Additional complete NetworkPolicy egress rules. |
 | `autoscaling.enabled` | `false` | Render HPA. |
 | `pdb.enabled` | `false` | Render PodDisruptionBudget. |
 

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -79,7 +79,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 
 - Keep `serviceAccount.automountServiceAccountToken=false` unless your app needs Kubernetes API access.
 - Enable `networkPolicy.enabled` and explicitly allow ingress from your gateway or ingress controller namespace.
-- Use `networkPolicy.egress.extraEgress` for complete custom egress rules when applications call platform services.
+- Use `networkPolicy.egress.extraTo` to append peers to the built-in egress rules; use `networkPolicy.egress.extraEgress` only for standalone custom egress rules.
 - Use persistent `webapps` storage only when applications are installed or mutated at runtime.
 - Prefer immutable app images or init containers that fetch versioned WAR artifacts.
 - Configure `tomcat.serverXml` or `tomcat.existingServerXmlConfigMap` when you need proxy connector attributes such as `proxyName`, `proxyPort`, or `scheme`.
@@ -104,6 +104,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 | `ingress.enabled` | `false` | Render Ingress. |
 | `gatewayAPI.enabled` | `false` | Render Gateway API HTTPRoute. |
 | `networkPolicy.enabled` | `false` | Render NetworkPolicy. |
+| `networkPolicy.egress.extraTo` | `[]` | Additional peers appended to the built-in egress rules. |
 | `networkPolicy.egress.extraEgress` | `[]` | Additional complete NetworkPolicy egress rules. |
 | `autoscaling.enabled` | `false` | Render HPA. |
 | `pdb.enabled` | `false` | Render PodDisruptionBudget. |

--- a/charts/tomcat/templates/NOTES.txt
+++ b/charts/tomcat/templates/NOTES.txt
@@ -1,35 +1,74 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+1. Release
+
 Apache Tomcat has been deployed.
+Name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart: {{ .Chart.Name }} {{ .Chart.Version }}
+App version: {{ .Chart.AppVersion }}
+Image: {{ include "tomcat.image" . }}
 
-Release:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-  chart: {{ .Chart.Name }} {{ .Chart.Version }}
-  appVersion: {{ .Chart.AppVersion }}
-  image: {{ include "tomcat.image" . }}
+2. Service
 
-Service:
+Internal URL:
   http://{{ include "tomcat.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.ports.http }}
+
+{{- if .Values.ingress.enabled }}
+Ingress hosts:
+{{- range .Values.ingress.hosts }}
+  - {{ .host }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.gatewayAPI.enabled }}
+Gateway API hostnames:
+{{- range .Values.gatewayAPI.hostnames }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+
+3. Workload
 
 Pods:
   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "tomcat.name" . }}
 
-Health:
+4. Health
+
 {{- if and .Values.readinessProbe.enabled (eq .Values.readinessProbe.mode "http") }}
   kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- wget -qO- http://{{ include "tomcat.fullname" . }}:{{ .Values.service.ports.http }}{{ .Values.readinessProbe.path }}
 {{- else }}
   kubectl run {{ include "tomcat.fullname" . }}-check -n {{ .Release.Namespace }} --rm -i --restart=Never --image={{ .Values.tests.image.repository }}:{{ .Values.tests.image.tag }} -- nc -z {{ include "tomcat.fullname" . }} {{ .Values.service.ports.http }}
 {{- end }}
 
+5. Validation
+
+Run Helm tests:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Inspect logs:
+  kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "tomcat.fullname" . }} --since=10m
+
+6. JMX
+
 {{- if .Values.jmx.enabled }}
-JMX:
-  service port: {{ .Values.service.ports.jmx }}
-  registry target port: {{ .Values.jmx.port }}
-  rmi service port: {{ .Values.service.ports.jmxRmi }}
-  rmi target port: {{ .Values.jmx.rmiPort }}
+Enabled: true
+Service port: {{ .Values.service.ports.jmx }}
+Registry target port: {{ .Values.jmx.port }}
+RMI service port: {{ .Values.service.ports.jmxRmi }}
+RMI target port: {{ .Values.jmx.rmiPort }}
+{{- else }}
+Enabled: false
 {{- end }}
 
-Documentation:
+7. Production reminders
+
+Use immutable Tomcat images or versioned init-container artifacts for applications.
+Set probes to application-specific endpoints when disabling the default ROOT webapp.
+Enable NetworkPolicy after confirming ingress, JMX, and application egress paths.
+Keep ServiceAccount token mounting disabled unless the application needs Kubernetes API access.
+
+8. Documentation
+
   https://helmforge.dev/docs/charts/tomcat
 
 Happy Helmforging :)

--- a/charts/tomcat/templates/networkpolicy.yaml
+++ b/charts/tomcat/templates/networkpolicy.yaml
@@ -1,5 +1,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.networkPolicy.enabled }}
+{{- $egress := .Values.networkPolicy.egress }}
+{{- $extraEgress := $egress.extraEgress }}
+{{- $hasBaseEgress := and $egress.enabled (or $egress.allowDNS $egress.allowHTTPS $egress.allowHTTP $egress.extraTo) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -13,7 +16,7 @@ spec:
       app.kubernetes.io/component: tomcat
   policyTypes:
     - Ingress
-    {{- if .Values.networkPolicy.egress.enabled }}
+    {{- if or $egress.enabled $extraEgress }}
     - Egress
     {{- end }}
   ingress:
@@ -39,9 +42,11 @@ spec:
     {{- else }}
     []
     {{- end }}
-  {{- if .Values.networkPolicy.egress.enabled }}
+  {{- if or $egress.enabled $extraEgress }}
   egress:
-    {{- if .Values.networkPolicy.egress.allowDNS }}
+    {{- if or $hasBaseEgress $extraEgress }}
+    {{- if $egress.enabled }}
+    {{- if $egress.allowDNS }}
     - to:
         - namespaceSelector:
             matchLabels:
@@ -52,19 +57,26 @@ spec:
         - protocol: TCP
           port: 53
     {{- end }}
-    {{- if .Values.networkPolicy.egress.allowHTTPS }}
+    {{- if $egress.allowHTTPS }}
     - ports:
         - protocol: TCP
           port: 443
     {{- end }}
-    {{- if .Values.networkPolicy.egress.allowHTTP }}
+    {{- if $egress.allowHTTP }}
     - ports:
         - protocol: TCP
           port: 80
     {{- end }}
-    {{- with .Values.networkPolicy.egress.extraTo }}
+    {{- with $egress.extraTo }}
     - to:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- end }}
+    {{- with $extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- else }}
+    []
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/tomcat/tests/operations_test.yaml
+++ b/charts/tomcat/tests/operations_test.yaml
@@ -87,3 +87,29 @@ tests:
       - equal:
           path: spec.egress[0].to[0].podSelector.matchLabels["app.kubernetes.io/name"]
           value: postgresql
+
+  - it: should render additional egress rules without baseline egress
+    template: networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: false
+      networkPolicy.egress.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.80.0.0/16
+          ports:
+            - protocol: TCP
+              port: 443
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - ipBlock:
+                  cidr: 10.80.0.0/16
+            ports:
+              - protocol: TCP
+                port: 443

--- a/charts/tomcat/values.schema.json
+++ b/charts/tomcat/values.schema.json
@@ -112,7 +112,24 @@
     },
     "ingress": { "type": "object" },
     "gatewayAPI": { "type": "object" },
-    "networkPolicy": { "type": "object" },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingress": { "type": "object" },
+        "egress": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "allowDNS": { "type": "boolean" },
+            "allowHTTP": { "type": "boolean" },
+            "allowHTTPS": { "type": "boolean" },
+            "extraTo": { "type": "array" },
+            "extraEgress": { "type": "array" }
+          }
+        }
+      }
+    },
     "resources": { "type": "object" },
     "podSecurityContext": { "type": "object" },
     "securityContext": { "type": "object" },

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -200,6 +200,8 @@ networkPolicy:
     allowHTTPS: true
     # -- Additional egress peer rules rendered under egress[].to.
     extraTo: []
+    # -- Additional complete NetworkPolicy egress rules.
+    extraEgress: []
 
 # -- Tomcat container resources.
 resources:


### PR DESCRIPTION
## Summary

- keep the Helm test hook under `templates/tests` so `helm test` remains functional
- add `networkPolicy.egress.extraEgress` support with schema and unit coverage
- expand NOTES into numbered operational sections
- update README defaults for the pinned Tomcat image tag and new egress control

## Validation

- `make validate-chart CHART=tomcat TIMEOUT=900`: FULLY VALIDATED (16 layers), including k3d behavioral scenarios for default, gateway-api, hardening, ingress, ip-family-policy, JMX, and standalone.
- `make site-sync-check CHART=tomcat`
- `make release-check REPO=charts` passed with the expected GR-077 post-merge release confirmation warning.
- `make attribution-check REPO=charts`

Site PR: helmforgedev/site#364
Issue: helmforgedev/charts#633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Tomcat chart README to use the newer default “Official Tomcat image” tag.
  * Reformatted and expanded chart NOTES with clearer, numbered sections and more detailed output for JMX and operational steps.
* **New Features**
  * Added `networkPolicy.egress.extraEgress` to support supplying additional complete NetworkPolicy egress rules.
* **Bug Fixes**
  * Improved NetworkPolicy egress rendering to correctly combine built-in settings with `extraEgress`, including when base egress is disabled.
* **Tests**
  * Added an operations test for egress when base egress is disabled and `extraEgress` is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->