### PR TITLE
fix(valkey): seed on the current master, not a reachable replica

### DIFF
--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -335,22 +335,25 @@ data:
       # cold-start hint: if a failover already happened and this pod lost its
       # emptyDir, monitoring node-0 again would advertise a stale master until
       # hello-channel gossip converges. Probe the data plane for the real master.
-      master="$SEED_MASTER"
+      # Discover the node currently reporting role:master, not merely a reachable
+      # seed. After a failover the seed (node-0) is a live *replica*, and a
+      # Sentinel seeded on a replica never redirects to the real master — it would
+      # advertise that replica to clients. Fall back to the seed only if no node
+      # answers as master within the bounded budget.
+      master=""
       i=0
-      until vcli -h "$master" -p "$VALKEY_PORT" ping >/dev/null 2>&1; do
-        i=$((i + 1))
+      while :; do
         if m="$(find_current_master)"; then
-          if [ "$m" != "$master" ]; then
-            echo "seed $master unavailable; using discovered master $m"
-            master="$m"
-            continue
-          fi
-        fi
-        if [ "$i" -ge 6 ]; then
-          echo "no reachable master after bounded wait; monitoring seed $master anyway"
+          master="$m"
           break
         fi
-        echo "waiting for master $master:$VALKEY_PORT ($i/6)"
+        i=$((i + 1))
+        if [ "$i" -ge 6 ]; then
+          master="$SEED_MASTER"
+          echo "no master discovered after bounded wait; monitoring seed $master anyway"
+          break
+        fi
+        echo "waiting to discover current master ($i/6)"
         sleep 3
       done
       cp "$BASE" "$CONF"

--- a/charts/valkey/tests/cluster_domain_test.yaml
+++ b/charts/valkey/tests/cluster_domain_test.yaml
@@ -64,6 +64,9 @@ tests:
           pattern: 'SEED_MASTER="test-valkey-node-0\.test-valkey-headless\.valkey-ns\.svc\.corp\.internal"'
       - matchRegex:
           path: data["sentinel-entrypoint.sh"]
+          pattern: 'if m="\$\(find_current_master\)"; then[\s\S]*?master="\$m"'
+      - notMatchRegex:
+          path: data["sentinel-entrypoint.sh"]
           pattern: 'until vcli -h "\$master" -p "\$VALKEY_PORT" ping'
 
   - it: should use custom cluster domain in cluster announce hostname

--- a/charts/valkey/tests/ha_extension_test.yaml
+++ b/charts/valkey/tests/ha_extension_test.yaml
@@ -94,7 +94,7 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["sentinel-entrypoint.sh"]
-          pattern: 'if \[ ! -f "\$CONF" \]; then[\s\S]*?until vcli'
+          pattern: 'if \[ ! -f "\$CONF" \]; then[\s\S]*?find_current_master'
         template: configmap.yaml
       - matchRegex:
           path: data["sentinel-entrypoint.sh"]


### PR DESCRIPTION
## Summary

### Problem

The Sentinel bootstrap seeds on the node currently reporting `role:master`, but the wait loop only ran that discovery when the static seed (`node-0`) was unreachable. After a failover, `node-0` can be a live replica, so a reachability-only check can seed Sentinel from a read-only node and advertise the wrong master.

### Fix

Discover the node reporting `role:master` among the data-node peers first, and fall back to the static seed only if none answers within the bounded budget.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated chart docs for behavior or default changes

## Site Sync (GR-007)

- [x] Site PR: helmforgedev/site#365

## Local Validation

- [x] `make validate-chart CHART=valkey TIMEOUT=1200` passed end-to-end: FULLY VALIDATED (21 layers), including k3d behavioral scenarios for default, cluster, dual-stack, existing-secret, external-secrets, metrics, networkpolicy, replication, sentinel, standalone, tls-cluster, and tls-replication.
- [x] `make site-sync-check CHART=valkey` passed on site#365.
- [x] `make release-check REPO=charts` passed with the expected GR-077 post-merge release confirmation warning.
- [x] `make attribution-check REPO=charts` passed.

## Remote Validation

- [x] GitHub Actions are green; `standards-check` is skipped by fork policy and covered locally.
- [x] CodeRabbit completed with no actionable comments.
- [x] Review threads: 0 unresolved.

Issue: helmforgedev/charts#633