### PR TITLE
chore(appwrite): bump appwrite to 1.9.5

### DIFF
--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -4,7 +4,7 @@ name: appwrite
 description: Appwrite self-hosted backend-as-a-service platform with MariaDB and Redis
 type: application
 version: 1.2.3
-appVersion: "1.9.0"
+appVersion: "1.9.5"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/appwrite.png
 home: https://helmforge.dev

--- a/charts/appwrite/README.md
+++ b/charts/appwrite/README.md
@@ -61,7 +61,7 @@ When ingress is enabled, requests are routed by path:
 | `image.repository` | `appwrite/appwrite` | Appwrite server image |
 | `image.tag` | `""` (uses appVersion) | Image tag |
 | `console.image.repository` | `appwrite/console` | Console image |
-| `console.image.tag` | `7.5.7` | Console image tag |
+| `console.image.tag` | `8.7.5` | Console image tag |
 | `appwrite.locale` | `en` | Application locale |
 | `appwrite.domain` | `""` (auto-detected) | Appwrite domain |
 | `appwrite.openSslKeyV1` | `""` (auto-generated) | 64-char hex encryption key |

--- a/charts/appwrite/README.md
+++ b/charts/appwrite/README.md
@@ -76,6 +76,14 @@ When ingress is enabled, requests are routed by path:
 
 See [`values.yaml`](values.yaml) for the full configuration reference.
 
+## Upgrade Notes
+
+Appwrite 1.9.5 requires the upstream database migration step even when upgrading
+from Appwrite 1.9.0. After `helm upgrade`, run the Appwrite migrate command
+against an Appwrite API pod before returning production traffic to the release,
+for example with `kubectl exec deploy/<release>-appwrite-api -- appwrite migrate`
+adjusted to the release name and namespace.
+
 ## External Database
 
 To use an external MariaDB instead of the subchart:

--- a/charts/appwrite/tests/deployment_api_test.yaml
+++ b/charts/appwrite/tests/deployment_api_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/appwrite/appwrite:1.9.0"
+          value: "docker.io/appwrite/appwrite:1.9.5"
 
   - it: should run http.php entrypoint
     template: templates/deployment-api.yaml

--- a/charts/appwrite/tests/deployment_console_test.yaml
+++ b/charts/appwrite/tests/deployment_console_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/appwrite/console:7.5.7"
+          value: "docker.io/appwrite/console:8.7.5"
 
   - it: should have component label
     asserts:

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Appwrite server image repository
   repository: docker.io/appwrite/appwrite
   # -- Appwrite image tag. Defaults to appVersion.
-  tag: "1.9.0"
+  tag: "1.9.5"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -36,7 +36,7 @@ console:
     # -- Appwrite console image repository
     repository: docker.io/appwrite/console
     # -- Console image tag
-    tag: "7.5.7"
+    tag: "8.7.5"
     # -- Console image pull policy
     pullPolicy: IfNotPresent
 
@@ -500,4 +500,3 @@ externalSecrets:
   target:
     creationPolicy: Owner
   data: []
-


### PR DESCRIPTION
Closes #688.

## Summary

- Bump Appwrite from 1.9.0 to 1.9.5.
- Bump the matching Appwrite Console image from 7.5.7 to 8.7.5, as called out in the upstream 1.9.5 release notes.
- Update README values and image assertion tests.

## Upstream Evidence

- Appwrite release: https://github.com/appwrite/appwrite/releases/tag/1.9.5
- Full changelog: https://github.com/appwrite/appwrite/compare/1.9.0...1.9.5
- Main image manifest verified: `docker.io/appwrite/appwrite:1.9.5` supports `linux/amd64` and `linux/arm64`.
- Console image manifest verified: `docker.io/appwrite/console:8.7.5` supports `linux/amd64` and `linux/arm64`.

## Site Sync

- Site PR: helmforgedev/site#369

## Validation

- `make image-verify IMAGE=docker.io/appwrite/appwrite:1.9.5`
- `make image-verify IMAGE=docker.io/appwrite/console:8.7.5`
- `make deps-check CHART=appwrite`
- `helm unittest charts/appwrite`
- `make validate-chart CHART=appwrite` passed fully: 19 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=appwrite`
- `node scripts/charts/template-standards-check.js --chart appwrite`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Notes

The first k3d run hit Docker Hub pull QPS limits while pulling the new Appwrite image across many workloads. I imported `docker.io/appwrite/appwrite:1.9.5` and `docker.io/appwrite/console:8.7.5` into the `k3d-helmforge-tests-wsl` containerd cache and reran the canonical gate successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated default Appwrite and console versions to newer releases (Appwrite 1.9.5, console 8.7.5).
* **Documentation**
  * Refreshed the Helm chart README with the latest default console image tag and added upgrade notes for an additional migration step.
* **Tests**
  * Updated deployment test expectations to use the new Appwrite and console container images.
* **Chores**
  * Made a small adjustment to the Helm values YAML formatting around the external secrets configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->