### PR TITLE
chore(docmost): bump docmost to 0.95.0

### DIFF
--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -4,7 +4,7 @@ name: docmost
 description: Docmost collaborative wiki and documentation software with PostgreSQL, Redis, local storage, and optional S3
 type: application
 version: 1.2.6
-appVersion: "0.90.1"
+appVersion: "0.95.0"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/docmost.png
 home: https://helmforge.dev

--- a/charts/docmost/README.md
+++ b/charts/docmost/README.md
@@ -38,7 +38,7 @@ helm install docmost oci://ghcr.io/helmforgedev/helm/docmost
 - Docmost requires PostgreSQL and Redis
 - local storage uses `/app/data/storage`
 - S3 mode uses the official `AWS_S3_*` environment variables documented by Docmost
-- the default image tag is `0.90.1`, validated against the published `docmost/docmost:0.90.1` container image
+- the default image tag is `0.95.0`, validated against the published `docmost/docmost:0.95.0` container image
 - upstream telemetry can be disabled with `docmost.disableTelemetry=true`
 - this chart intentionally does not keep `Chart.lock`; dependencies are resolved by the repository release workflow
 
@@ -153,7 +153,7 @@ backup:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Docmost application pods. Values greater than `1` require `storage.mode=s3` |
 | `image.repository` | `docker.io/docmost/docmost` | Docmost container image repository |
-| `image.tag` | `0.90.1` | Docmost image tag |
+| `image.tag` | `0.95.0` | Docmost image tag |
 | `docmost.appUrl` | `""` | External Docmost URL |
 | `docmost.appSecret` | `""` | Application secret, auto-generated when empty |
 | `docmost.jwtTokenExpiresIn` | `30d` | JWT expiration |

--- a/charts/docmost/docs/architecture.md
+++ b/charts/docmost/docs/architecture.md
@@ -60,7 +60,7 @@ and users are supported without editing SQL manually.
 
 ## Version Pinning Note
 
-The chart pins the upstream application image through `image.tag` and `appVersion`. For this release, `docmost/docmost:0.90.1` was verified as available on Docker Hub before updating the chart.
+The chart pins the upstream application image through `image.tag` and `appVersion`. For this release, `docmost/docmost:0.95.0` was verified as available on Docker Hub before updating the chart.
 
 ## Telemetry
 

--- a/charts/docmost/tests/deployment_test.yaml
+++ b/charts/docmost/tests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
           value: 3000
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/docmost/docmost:0.90.1
+          value: docker.io/docmost/docmost:0.95.0
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/docmost/values.yaml
+++ b/charts/docmost/values.yaml
@@ -23,7 +23,7 @@ image:
   # -- Docmost container image repository
   repository: docker.io/docmost/docmost
   # -- Docmost image tag. Defaults to appVersion validated on GitHub Releases and Docker Hub.
-  tag: "0.90.1"
+  tag: "0.95.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #689.

## Summary

- Bump Docmost from 0.90.1 to 0.95.0.
- Update README and architecture notes with the verified image tag.
- Update image assertion tests.

## Upstream Evidence

- Docmost release: https://github.com/docmost/docmost/releases/tag/v0.95.0
- Full changelog: https://github.com/docmost/docmost/compare/v0.90.1...v0.95.0
- Image manifest verified: `docker.io/docmost/docmost:0.95.0` supports `linux/amd64` and `linux/arm64`.
- Release notes state this release contains security fixes and upgrade is recommended.

## Site Sync

- Site PR: helmforgedev/site#370

## Validation

- `make image-verify IMAGE=docker.io/docmost/docmost:0.95.0`
- `make deps-check CHART=docmost`
- `helm unittest charts/docmost`
- `make validate-chart CHART=docmost` passed fully: 18 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=docmost`
- `node scripts/charts/template-standards-check.js --chart docmost`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Docmost version used by the Helm chart to **0.95.0**.
* **Documentation**
  * Refreshed chart documentation to reflect the new default image tag and verified version reference.
* **Tests**
  * Updated deployment test expectations to match the newer default container image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->