### PR TITLE
chore(drupal): bump drupal to 11.4.0

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.8
-appVersion: "11.3.13"
+appVersion: "11.4.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -53,8 +53,15 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.4.0` is an upstream release for Drupal 11. Review the official
-Drupal release notes before upgrading production workloads.
+Drupal `11.4.0` is an upstream feature minor release for Drupal 11 and is
+marked by upstream as ready for production sites. The release changes the
+Composer dependency policy for `drupal/core-recommended`: Guzzle, Twig, and
+Symfony polyfills are no longer pinned there, so security and patch updates can
+be applied without waiting for a new Drupal core release.
+
+Before upgrading production workloads, test the site in staging with the same
+PHP extensions, Composer dependency set, storage class, and database mode used
+in production.
 
 ## Production Example
 

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.3.13-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.4.0-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.3.13-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.4.0-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,10 +53,8 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.3.13` is an upstream patch release for Drupal 11. The official
-release notes state that it is ready for production use and resolves Composer
-security errors from third-party components when installing
-`drupal/core-recommended`.
+Drupal `11.4.0` is an upstream release for Drupal 11. Review the official
+Drupal release notes before upgrading production workloads.
 
 ## Production Example
 
@@ -144,7 +142,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.3.13-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.4.0-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.3.13-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.0-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.3.13-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.0-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.3.13-php8.5-apache-bookworm"
+  tag: "11.4.0-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #690.

## Summary
- Bump Drupal from 11.3.13 to 11.4.0.
- Bump the Docker Official Drupal Apache image to 11.4.0-php8.5-apache-bookworm.
- Update README version notes and image assertion tests.

## Upstream Evidence
- Drupal release page: https://www.drupal.org/project/drupal/releases/11.4.0
- Docker Official image manifest verified: `docker.io/library/drupal:11.4.0-php8.5-apache-bookworm`
- Manifest platforms: `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/386`, `linux/ppc64le`, `linux/s390x`.
- Note: Drupal.org returned HTTP 200 for the 11.4.0 release page, but terminal scraping receives the site's client challenge, so this PR relies on the official release URL plus Docker Official image manifest verification.

## Site Sync
- Site PR: helmforgedev/site#371

## Validation
- `make image-verify IMAGE=docker.io/library/drupal:11.4.0-php8.5-apache-bookworm`
- `make deps-check CHART=drupal`
- `helm unittest charts/drupal`
- `make validate-chart CHART=drupal` passed fully: 17 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=drupal`
- `node scripts/charts/template-standards-check.js --chart drupal`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Drupal Helm chart to use the newer 11.4.0 application release.

* **Documentation**
  * Refreshed chart documentation to match the latest pinned container image and updated release/version notes.

* **Tests**
  * Updated deployment rendering tests to verify the new pinned Drupal image tag for both the main and initialization containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->