### PR TITLE
chore(elasticsearch): bump elasticsearch to 9.4.3

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.1.3
-appVersion: "9.4.2"
+appVersion: "9.4.3"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -161,7 +161,7 @@ dataTiers:
 | `namespaceOverride` | Namespace for chart-managed namespaced resources | `""` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.4.2` |
+| `image.tag` | Image tag | `9.4.3` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -262,7 +262,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.2` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.3` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -311,11 +311,11 @@ Security posture acceptable.
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.2` is an upstream image update from
-`9.4.1` with upstream security fixes. Review the upstream Elasticsearch release
-notes before upgrading production clusters, take a snapshot backup, and verify
-Kibana compatibility, plugins, ILM policies, and index templates in a staging
-environment before reusing existing PVCs.
+`docker.io/library/elasticsearch:9.4.3` is an upstream image update from
+`9.4.2` with upstream fixes and enhancements. Review the upstream Elasticsearch
+release notes before upgrading production clusters, take a snapshot backup, and
+verify Kibana compatibility, plugins, ILM policies, and index templates in a
+staging environment before reusing existing PVCs.
 
 ## Resources Generated
 

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.4.2
+          value: docker.io/library/kibana:9.4.3
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.4.2
+          value: docker.io/library/elasticsearch:9.4.3
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -37,7 +37,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.4.2"
+          "default": "9.4.3"
         },
         "pullPolicy": {
           "type": "string",
@@ -247,7 +247,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.4.2"
+              "default": "9.4.3"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.4.2"
+  tag: "9.4.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -324,7 +324,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.4.2"
+    tag: "9.4.3"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
Closes #691.

## Summary
- Bump Elasticsearch from 9.4.2 to 9.4.3.
- Bump the optional Kibana default image tag to 9.4.3 to keep the paired Elastic Stack version aligned.
- Update values schema, README defaults, and image assertion tests.

## Upstream Evidence
- Official Elasticsearch release notes: https://www.elastic.co/docs/release-notes/elasticsearch
- Docker Official Elasticsearch manifest verified: `docker.io/library/elasticsearch:9.4.3`
- Docker Official Kibana manifest verified: `docker.io/library/kibana:9.4.3`
- Manifest platforms for both images: `linux/amd64`, `linux/arm64`.
- Elastic 9.4.3 release notes include Elasticsearch fixes and enhancements; no chart-level breaking change was identified for this patch bump.

## Site Sync
- Site PR: helmforgedev/site#372

## Validation
- `make image-verify IMAGE=docker.io/library/elasticsearch:9.4.3`
- `make image-verify IMAGE=docker.io/library/kibana:9.4.3`
- `make deps-check CHART=elasticsearch`
- `helm unittest charts/elasticsearch` passed: 14 suites, 99 tests.
- `make validate-chart CHART=elasticsearch` passed fully: 17 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=elasticsearch`
- `node scripts/charts/template-standards-check.js --chart elasticsearch`
- `make site-sync-check CHART=elasticsearch`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Elasticsearch Helm chart to use version **9.4.3** by default.
  * Aligned the default Kibana image version with the same **9.4.3** release.
* **Documentation**
  * Refreshed chart documentation and upgrade notes to reflect the new default image versions.
* **Tests**
  * Updated chart tests to expect the new Elasticsearch and Kibana image tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->