### PR TITLE
chore(envoy-gateway): bump envoy gateway to 1.8.2

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 1.7.3
-appVersion: "v1.8.1"
+appVersion: "v1.8.2"
 kubeVersion: ">=1.24.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,7 +1,7 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.8.1 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
+v1.8.2 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
 Envoy proxy pods automatically in response to Gateway API resources.
 
 ## Installation
@@ -27,7 +27,7 @@ The Envoy Gateway operator CRDs (`gateway.envoyproxy.io/*`: `EnvoyProxy`,
 chart's `crds/` directory, so Helm installs them automatically on first install
 when they are absent (and skips them if already present). Only the upstream
 **Gateway API** CRDs (`gateway.networking.k8s.io/*`) are a separate cluster
-prerequisite, installed once below. Envoy Gateway v1.8.1 requires the Gateway API
+prerequisite, installed once below. Envoy Gateway v1.8.2 requires the Gateway API
 **experimental** channel (v1.5.1) — it watches `ListenerSet`, which only ships in
 the experimental channel; the standard channel is not sufficient. These CRDs are
 cluster-scoped and shared, so they are NOT bundled in the chart (Helm's release
@@ -173,7 +173,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.8.1` | Controller image tag |
+| `controller.image.tag` | `v1.8.2` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -191,7 +191,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.8.1` | Certgen image tag |
+| `certgen.image.tag` | `v1.8.2` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -210,7 +210,7 @@ highAvailability:
 | `proxy.image.tag` | `distroless-v1.38.0` | Proxy image tag |
 | `proxy.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `proxy.shutdownManager.image.repository` | `docker.io/envoyproxy/gateway` | Shutdown manager sidecar image repository |
-| `proxy.shutdownManager.image.tag` | `v1.8.1` | Shutdown manager sidecar image tag |
+| `proxy.shutdownManager.image.tag` | `v1.8.2` | Shutdown manager sidecar image tag |
 | `proxy.shutdownManager.image.pullPolicy` | `IfNotPresent` | Shutdown manager image pull policy |
 | `proxy.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `proxy.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -445,25 +445,21 @@ Major architectural redesign to align with the EG operator model.
 
 ## Upgrade Notes
 
-`docker.io/envoyproxy/gateway:v1.8.1` is the upstream patch update from
-`v1.8.0`. The automatically generated issue referenced `1.8.1`, but Docker Hub
+`docker.io/envoyproxy/gateway:v1.8.2` is the upstream patch update from
+`v1.8.1`. The automatically generated issue referenced `1.8.2`, but Docker Hub
 publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
 also updates the managed Envoy proxy image to
 `docker.io/envoyproxy/envoy:distroless-v1.38.0`, matching the upstream v1.8
 compatibility matrix.
 
-Envoy Gateway v1.8.1 includes security fixes for GatewayNamespaceMode xDS
-authentication, Lua validator sandbox path normalization, Wasm HTTP fetch gzip
-decompression limits, ReferenceGrant bypass handling, and related controller
-runtime issues. The chart now also pins the EG-managed `shutdown-manager`
-sidecar to `docker.io/envoyproxy/gateway:v1.8.1` through the EnvoyProxy strategic
-merge patch, avoiding the upstream-generated `gateway-dev:latest` runtime image.
-It also moves Gateway API safe-upgrades ValidatingAdmissionPolicy resources from
-the CRD bundle into the gateway Helm templates upstream. Before upgrading
-production controllers, review ownership of existing
-`safe-upgrades.gateway.networking.k8s.io` ValidatingAdmissionPolicy resources,
-verify Gateway API and Envoy Gateway CRDs in staging, and test existing Gateway,
-HTTPRoute, EnvoyProxy, and policy resources.
+Envoy Gateway v1.8.2 includes upstream bug fixes for Gateway API conditions,
+Backend TLS ALPN handling, ExternalName backends, Kubernetes 1.36 rate limit
+validation, EnvoyGateway config hot reload, and route timeout handling. It also
+tightens admission validation for `SecurityPolicy.spec.apiKeyAuth.extractFrom`:
+each entry must specify exactly one of `headers`, `params`, or `cookies`, and
+source names must be non-empty. Before upgrading production controllers, verify
+Gateway API and Envoy Gateway CRDs in staging, and test existing Gateway,
+HTTPRoute, EnvoyProxy, `BackendTrafficPolicy`, and `SecurityPolicy` resources.
 
 ### Version 1.0.0
 

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -448,9 +448,9 @@ Major architectural redesign to align with the EG operator model.
 `docker.io/envoyproxy/gateway:v1.8.2` is the upstream patch update from
 `v1.8.1`. The automatically generated issue referenced `1.8.2`, but Docker Hub
 publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
-also updates the managed Envoy proxy image to
-`docker.io/envoyproxy/envoy:distroless-v1.38.0`, matching the upstream v1.8
-compatibility matrix.
+keeps the managed Envoy proxy image pinned to
+`docker.io/envoyproxy/envoy:distroless-v1.38.0`, which remains aligned with the
+upstream v1.8 compatibility matrix.
 
 Envoy Gateway v1.8.2 includes upstream bug fixes for Gateway API conditions,
 Backend TLS ALPN handling, ExternalName backends, Kubernetes 1.36 rate limit

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -34,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.8.1
+    tag: v1.8.2
   resources:
     requests:
       cpu: 10m

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -79,7 +79,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "envoyproxy/gateway:v1.8.1"
+          pattern: "envoyproxy/gateway:v1.8.2"
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
+++ b/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
@@ -40,7 +40,7 @@ tests:
           value: shutdown-manager
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.1
+          value: docker.io/envoyproxy/gateway:v1.8.2
 
   - it: should configure DaemonSet mode when kind is DaemonSet
     set:
@@ -53,7 +53,7 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment
       - equal:
           path: spec.provider.kubernetes.envoyDaemonSet.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.1
+          value: docker.io/envoyproxy/gateway:v1.8.2
 
   - it: should set proxy service type
     set:

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -88,7 +88,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.8.1"
+              "default": "v1.8.2"
             },
             "pullPolicy": {
               "type": "string",
@@ -239,7 +239,7 @@
                 "tag": {
                   "type": "string",
                   "description": "Shutdown manager sidecar image tag",
-                  "default": "v1.8.1"
+                  "default": "v1.8.2"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -28,7 +28,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.8.1"
+    tag: "v1.8.2"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -70,7 +70,7 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.8.1"
+    tag: "v1.8.2"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:
@@ -94,7 +94,7 @@ proxy:
       # -- Shutdown manager sidecar image repository
       repository: docker.io/envoyproxy/gateway
       # -- Shutdown manager sidecar image tag
-      tag: "v1.8.1"
+      tag: "v1.8.2"
       # -- Shutdown manager image pull policy
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #692.

## Summary
- Bump Envoy Gateway from v1.8.1 to v1.8.2.
- Update controller, certgen, and shutdown-manager gateway image defaults to `docker.io/envoyproxy/gateway:v1.8.2`.
- Update values schema, README upgrade notes, certificates docs, and image assertion tests.

## Upstream Evidence
- Official release announcement: https://gateway.envoyproxy.io/news/releases/notes/v1.8.2
- GitHub release: https://github.com/envoyproxy/gateway/releases/tag/v1.8.2
- Docker manifest verified: `docker.io/envoyproxy/gateway:v1.8.2`
- Manifest platforms: `linux/amd64`, `linux/arm64`.
- `docker.io/envoyproxy/gateway:1.8.2` was checked and does not exist; the canonical upstream image tag keeps the `v` prefix.
- Upstream v1.8.2 tightens `SecurityPolicy.spec.apiKeyAuth.extractFrom` admission validation. The chart does not render SecurityPolicy resources by default, and the upgrade note documents the validation change for users with existing custom policies.

## Site Sync
- Site PR: helmforgedev/site#373

## Validation
- `make image-verify IMAGE=docker.io/envoyproxy/gateway:v1.8.2`
- `make image-verify IMAGE=docker.io/envoyproxy/gateway:1.8.2` failed as expected because the non-prefixed tag is not published.
- `make deps-check CHART=envoy-gateway`
- `helm unittest charts/envoy-gateway` passed: 16 suites, 120 tests.
- `make validate-chart CHART=envoy-gateway` passed fully: 20 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=envoy-gateway`
- `node scripts/charts/template-standards-check.js --chart envoy-gateway`
- `make site-sync-check CHART=envoy-gateway`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Bumped the Helm chart appVersion and default component image tags to **v1.8.2** (controller, certgen, shutdown-manager).
* **Documentation**
  * Updated quick-start prerequisites, image tag references, parameters tables, and upgrade notes to **v1.8.2**.
* **Tests**
  * Updated certgen and envoyproxy configuration tests to expect **v1.8.2** image tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->