### PR TITLE
chore(ghost): bump ghost to 6.50.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.17
-appVersion: "6.47.0"
+appVersion: "6.50.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ghost to 6.47.0 (#611)"
+      description: "bump ghost to 6.50.0 (#693)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -65,7 +65,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.45.0` | Ghost image tag |
+| `image.tag` | `6.50.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -77,10 +77,13 @@ database:
 
 ## Upgrade Notes
 
-Ghost `6.45.0` is the current upstream patch release. Review the upstream
-Ghost release notes before upgrading production sites, take a content and
-database backup, and verify themes, custom integrations, newsletter flows,
-comments, and member signup paths in staging before reusing existing PVCs.
+Ghost `6.50.0` is the current upstream patch release. It includes publisher
+gift links, configurable admin session max age, Ghost Admin appearance updates,
+analytics/admin improvements, and fixes including stored XSS hardening in JSON-LD
+output. Review the upstream Ghost release notes before upgrading production
+sites, take a content and database backup, and verify themes, custom
+integrations, newsletter flows, comments, and member signup paths in staging
+before reusing existing PVCs.
 
 ## S3 Backup
 

--- a/charts/ghost/templates/_helpers.tpl
+++ b/charts/ghost/templates/_helpers.tpl
@@ -43,6 +43,39 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "ghost.validate" -}}
+{{/* Triggers backup validation failures through ghost.backupEnabled; the return value is unused. */}}
+{{- $backupEnabled := include "ghost.backupEnabled" . -}}
+{{- if and (not .Values.mysql.enabled) (not .Values.database.external.host) -}}
+{{- fail "database.external.host is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- if and (not .Values.mysql.enabled) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
+{{- fail "database.external.password or database.external.existingSecret is required when mysql.enabled is false" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires ingress.hosts to contain at least one host" -}}
+{{- end -}}
+{{- if .Values.ingress.enabled -}}
+{{- range $index, $host := .Values.ingress.hosts -}}
+{{- if not $host.host -}}
+{{- fail (printf "ingress.hosts[%d].host is required when ingress.enabled is true" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
+{{- fail "gateway.parentRefs must contain at least one parentRef when gateway.enabled is true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.database.external.existingSecret) -}}
+{{- fail "database.external.existingSecret is required when externalSecrets.enabled is true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
+{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled is true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.data) -}}
+{{- fail "externalSecrets.data must contain at least one entry when externalSecrets.enabled is true" -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Content PVC claim name */}}
 {{- define "ghost.contentClaimName" -}}
 {{- if .Values.persistence.existingClaim -}}

--- a/charts/ghost/templates/validate.yaml
+++ b/charts/ghost/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "ghost.validate" . -}}

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.47.0"
+          value: "docker.io/library/ghost:6.50.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/tests/validation_test.yaml
+++ b/charts/ghost/tests/validation_test.yaml
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: passes with default bundled MySQL settings
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when MySQL is disabled without an external database host
+    set:
+      mysql.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.host is required when mysql.enabled is false
+
+  - it: fails when external database has no password source
+    set:
+      mysql.enabled: false
+      database.external.host: mysql.example.com
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.password or database.external.existingSecret is required when mysql.enabled is false
+
+  - it: passes with external database password
+    set:
+      mysql.enabled: false
+      database.external.host: mysql.example.com
+      database.external.password: test-password
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: passes with external database existing secret
+    set:
+      mysql.enabled: false
+      database.external.host: mysql.example.com
+      database.external.existingSecret: ghost-db
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts: []
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress.enabled requires ingress.hosts to contain at least one host
+
+  - it: fails when ingress host entry has no host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress.hosts[0].host is required when ingress.enabled is true
+
+  - it: passes with valid ingress hosts
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: blog.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when gateway is enabled without parentRefs
+    set:
+      gateway.enabled: true
+      gateway.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: gateway.parentRefs must contain at least one parentRef when gateway.enabled is true
+
+  - it: passes with valid gateway parentRefs
+    set:
+      gateway.enabled: true
+      gateway.parentRefs:
+        - name: platform-gateway
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when external secrets has no target database secret
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: database.external.existingSecret is required when externalSecrets.enabled is true
+
+  - it: fails when external secrets has no secret store name
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.secretStoreRef.name is required when externalSecrets.enabled is true
+
+  - it: fails when external secrets has no data entries
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: fake-store
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.data must contain at least one entry when externalSecrets.enabled is true
+
+  - it: passes with complete external secrets settings
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: fake-store
+        data:
+          - secretKey: password
+            remoteRef:
+              key: ghost/db
+              property: password
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.45.0"
+                                                                    "default":  "6.50.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.47.0"
+  tag: "6.50.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Closes #693.

## Summary
- Bump Ghost from 6.47.0 to 6.50.0.
- Update the Docker Official Ghost image tag, values schema default, README upgrade notes, and image assertion tests.
- Add the standard chart validate helper/template so template standards are clean.

## Upstream Evidence
- GitHub release: https://github.com/TryGhost/Ghost/releases/tag/v6.50.0
- Docker Official image manifest verified: `docker.io/library/ghost:6.50.0`
- Manifest platforms: `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/s390x`.
- Ghost 6.50.0 includes publisher/admin improvements and fixes including stored XSS hardening in JSON-LD output.

## Site Sync
- Site PR: helmforgedev/site#374

## Validation
- `make image-verify IMAGE=docker.io/library/ghost:6.50.0`
- `make deps-check CHART=ghost`
- `helm unittest charts/ghost` passed: 6 suites, 23 tests.
- `make validate-chart CHART=ghost` passed fully: 16 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=ghost`
- `node scripts/charts/template-standards-check.js --chart ghost`
- `make site-sync-check CHART=ghost`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Ghost application to **6.50.0** across the chart, default image tags, documentation, and automated tests.

* **Bug Fixes**
  * Added stricter install/upgrade-time configuration validation for external database connectivity, ingress host requirements, gateway parent references, and external secrets setup to fail fast when required values are missing.

* **Documentation**
  * Refreshed upgrade notes with additional **6.50.0** patch highlights, including admin/session updates and security improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->