### PR TITLE
chore(homarr): bump homarr to 1.69.2

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.20
-appVersion: "1.68.0"
+appVersion: "1.69.2"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump homarr to 1.68.0 (#612)"
+      description: "bump homarr to 1.69.2 (#694)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.67.0`.
+Current application version: `v1.69.2`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.67.0"` | Homarr image tag |
+| `image.tag` | `"v1.69.2"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,10 +265,9 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.64.0` to `v1.67.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.66.1` fixes the MySQL migration regression introduced in `v1.65.0`, and `v1.67.0` adds
-server-side PostHog analytics, total CPU and memory usage display, session cookie isolation, and downloads sorting fixes.
-No breaking changes were identified in the upstream release metadata.
+This update moves the default image from `v1.68.0` to `v1.69.2`. Review upstream release notes before upgrading production
+environments. Homarr `v1.69.2` is a patch release that fixes layout stacking so the AppShell header renders above indicator
+dots. No breaking changes were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/templates/_helpers.tpl
+++ b/charts/homarr/templates/_helpers.tpl
@@ -46,6 +46,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end }}
 
+{{- define "homarr.validate" -}}
+{{/* Triggers database selection validation through homarr.databaseMode; the return value is unused. */}}
+{{- $databaseMode := include "homarr.databaseMode" . -}}
+{{- end }}
+
 {{/* ======================================================================== */}}
 {{/* Encryption helpers                                                        */}}
 {{/* ======================================================================== */}}

--- a/charts/homarr/templates/validate.yaml
+++ b/charts/homarr/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "homarr.validate" . -}}

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.68.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.69.2"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.68.0"
+  tag: "v1.69.2"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
Closes #694.

## Summary
- Bump Homarr from v1.68.0 to v1.69.2.
- Update the GHCR Homarr image tag, README upgrade notes, and image assertion tests.
- Add the standard chart validate helper/template so template standards are clean.

## Upstream Evidence
- GitHub release: https://github.com/homarr-labs/homarr/releases/tag/v1.69.2
- GHCR image manifest verified: `ghcr.io/homarr-labs/homarr:v1.69.2`
- Manifest platforms: `linux/amd64`, `linux/arm64`.
- The issue listed `1.69.2`, but `ghcr.io/homarr-labs/homarr:1.69.2` is missing; the chart uses the upstream release/image tag format with the `v` prefix.
- Homarr v1.69.2 is a patch release fixing layout stacking for the AppShell header above indicator dots. No breaking changes were identified in the upstream release metadata.

## Site Sync
- Site PR: helmforgedev/site#375

## Validation
- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.69.2`
- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:1.69.2` confirmed the non-prefixed tag is missing.
- `make deps-check CHART=homarr`
- `helm unittest charts/homarr` passed: 9 suites, 55 tests.
- `make validate-chart CHART=homarr` passed fully: 19 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make standards-check CHART=homarr`
- `node scripts/charts/template-standards-check.js --chart homarr`
- `make site-sync-check CHART=homarr`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chart validation during installation and upgrades to catch invalid configuration earlier.
* **Bug Fixes**
  * Updated Homarr to version **1.69.2**.
  * Improved upgrade notes to reflect the latest release.
* **Documentation**
  * Refreshed the chart documentation and default image version to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->