### PR TITLE
chore(hoppscotch): bump hoppscotch to 2026.6.0

### DIFF
--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
 version: 1.1.6
-appVersion: "2026.5.0"
+appVersion: "2026.6.0"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -29,8 +29,8 @@ dependencies:
 
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#675)"
+    - kind: changed
+      description: "bump hoppscotch to 2026.6.0 (#695)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -77,7 +77,7 @@ backend process inside the AIO image.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.5.0` |
+| `image.tag` | Hoppscotch image tag | `2026.6.0` |
 | `namespaceOverride` | Namespace for chart-managed resources. Use with an external database; bundled PostgreSQL remains in the Helm release namespace. | `""` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
@@ -105,9 +105,10 @@ backend process inside the AIO image.
 
 ## Upgrade Notes
 
-Hoppscotch `2026.5.0` adds OpenAPI 3.1 collection export, configurable proxy URLs through environment/admin settings,
-Mongolian language support, security patches, and fixes that prevent secret variable values from leaking to the backend.
-Back up the PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
+Hoppscotch `2026.6.0` adds OAuth2 `id_token` support, fixes mock server URL handling for subpath deployments, adds Thai
+language support, improves self-hosted admin validation messages, and includes backend ownership, SMTP URL validation, and
+dependency security hardening. The upstream release notes mention a rollback for Hoppscotch Cloud only; self-hosted
+deployments are not affected. Back up the PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
 The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
 user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs
 a pre-upgrade hook to apply `pg_trgm` to existing bundled PostgreSQL PVCs before
@@ -152,7 +153,7 @@ This chart does not:
 - Manage OAuth provider registration (do this in the provider's developer console)
 - Provide built-in backup for PostgreSQL (use the HelmForge PostgreSQL chart with backup enabled)
 
-### 🟢 Security Scan: `hoppscotch`
+### Security Scan: `hoppscotch`
 
 | Framework | Score |
 |---|---|

--- a/charts/hoppscotch/docs/production.md
+++ b/charts/hoppscotch/docs/production.md
@@ -92,7 +92,7 @@ For Traefik, use middleware with websocket passthrough configured.
 
 ## Default Proxy URL
 
-Hoppscotch `2026.5.0` can read a default proxy URL from `PROXY_APP_URL`. Set it when you run a self-hosted proxy and want
+Hoppscotch `2026.6.0` can read a default proxy URL from `PROXY_APP_URL`. Set it when you run a self-hosted proxy and want
 new users to inherit a default without configuring it individually:
 
 ```yaml

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.5.0"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.6.0"
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -53,7 +53,7 @@ tests:
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[1].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.5.0"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.6.0"
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
@@ -87,7 +87,7 @@ tests:
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[2].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.5.0"
+          pattern: "docker.io/hoppscotch/hoppscotch:2026.6.0"
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].command[0]

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -25,9 +25,9 @@ tests:
 
   - it: should use pinned image tag
     asserts:
-      - matchRegex:
+      - equal:
           path: spec.template.spec.containers[0].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.6.0"
+          value: docker.io/hoppscotch/hoppscotch:2026.6.0
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -51,9 +51,9 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: migrate
         template: deployment.yaml
-      - matchRegex:
+      - equal:
           path: spec.template.spec.initContainers[1].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.6.0"
+          value: docker.io/hoppscotch/hoppscotch:2026.6.0
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
@@ -85,9 +85,9 @@ tests:
           path: spec.template.spec.initContainers[2].name
           value: bootstrap-infra-config
         template: deployment.yaml
-      - matchRegex:
+      - equal:
           path: spec.template.spec.initContainers[2].image
-          pattern: "docker.io/hoppscotch/hoppscotch:2026.6.0"
+          value: docker.io/hoppscotch/hoppscotch:2026.6.0
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].command[0]

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.5.0"
+  tag: "2026.6.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #695.

## Summary
- Bump Hoppscotch from 2026.5.0 to 2026.6.0.
- Update the Docker Hub Hoppscotch AIO image tag, README upgrade notes, production docs, and image assertion tests.
- Remove the decorative marker from the README security scan heading while touching the file.

## Upstream Evidence
- GitHub release: https://github.com/hoppscotch/hoppscotch/releases/tag/2026.6.0
- Official release blog: https://hoppscotch.com/blog/hoppscotch-v2026-6-0
- Docker Hub image manifest verified: `docker.io/hoppscotch/hoppscotch:2026.6.0`
- Manifest platforms: `linux/amd64`, `linux/arm64`.
- The upstream cloud rollback note applies to Hoppscotch Cloud only; release notes state self-hosted deployments are not affected.
- 2026.6.0 adds OAuth2 `id_token` support, mock server URL handling for subpath deployments, Thai language support, self-hosted admin validation improvements, and security hardening.

## Site Sync
- Site PR: helmforgedev/site#376

## Validation
- `make image-verify IMAGE=docker.io/hoppscotch/hoppscotch:2026.6.0`
- `make deps-check CHART=hoppscotch`
- `helm unittest charts/hoppscotch` passed: 14 suites, 81 tests.
- `node scripts/charts/template-standards-check.js --chart hoppscotch`
- `make standards-check CHART=hoppscotch`
- `make validate-chart CHART=hoppscotch` passed fully: 18 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make site-sync-check CHART=hoppscotch`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Lab Note
- An earlier k3d run failed because the Docker Desktop VM/host disk was out of space and the API server timed out. After clearing generated/temp files and restarting Docker Desktop, `make validate-chart CHART=hoppscotch` passed end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the deployed Hoppscotch version to `2026.6.0`.
* **Documentation**
  * Refreshed Helm chart notes, including default image tag details and upgrade notes for the latest release.
  * Updated production guidance for the default proxy URL hardening to reference `PROXY_APP_URL`.
* **Tests**
  * Updated deployment assertions to verify the `2026.6.0` Hoppscotch image tags across the main container and init containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->