### PR TITLE
chore(komga): bump komga to 1.25.0

### DIFF
--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -4,7 +4,7 @@ name: komga
 description: Komga media server for comics and manga with persistent SQLite storage, library management, and S3 backup
 type: application
 version: 1.4.12
-appVersion: "1.24.4"
+appVersion: "1.25.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#512)"
+    - kind: changed
+      description: "bump komga to 1.25.0 (#696)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/komga/README.md
+++ b/charts/komga/README.md
@@ -52,6 +52,13 @@ After deploying, port-forward to access the web interface and create your admin 
 kubectl port-forward svc/<release>-komga 25600:80
 ```
 
+## Upgrade Notes
+
+Komga `1.25.0` adds support for solid RAR4 archives, enforces Kobo content
+restrictions more consistently, flattens hierarchical OpenAPI schemas, and
+updates application dependencies including Spring Boot. Back up the `/config`
+PVC before upgrading because Komga stores its SQLite databases there.
+
 ## Production Example
 
 ```yaml
@@ -98,7 +105,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/gotson/komga` | Image repository |
-| `image.tag` | `"1.24.4"` | Image tag |
+| `image.tag` | `"1.25.0"` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### Komga Configuration

--- a/charts/komga/tests/deployment_test.yaml
+++ b/charts/komga/tests/deployment_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/gotson/komga:1.24.4"
+          value: "docker.io/gotson/komga:1.25.0"
 
   - it: should set container port to 25600
     asserts:

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Komga image repository
   repository: docker.io/gotson/komga
   # -- Komga image tag
-  tag: "1.24.4"
+  tag: "1.25.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Closes #696.

## Summary
- Bump Komga from 1.24.4 to 1.25.0.
- Update the official Docker Hub image tag, deployment image assertion, README defaults, and Artifact Hub change note.
- Add upgrade notes for the upstream 1.25.0 changes and the `/config` backup requirement.

## Upstream Evidence
- GitHub release: https://github.com/gotson/komga/releases/tag/1.25.0
- Docker Hub image manifest verified: `docker.io/gotson/komga:1.25.0`
- Manifest platforms: `linux/amd64`, `linux/arm`, `linux/arm64`.
- 1.25.0 is a stable, non-prerelease upstream release published on 2026-06-30.
- Release notes include solid RAR4 archive support, Kobo content restriction enforcement, OpenAPI schema flattening, Spring Boot 3.5.14, and dependency updates.

## Site Sync
- Site PR: helmforgedev/site#377

## Validation
- `make image-verify IMAGE=docker.io/gotson/komga:1.25.0`
- `make deps-check CHART=komga`
- `helm unittest charts/komga` passed: 8 suites, 50 tests.
- `make standards-check CHART=komga`
- `make validate-chart CHART=komga` passed fully: 17 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make site-sync-check CHART=komga`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default Komga version to **1.25.0**.

* **Documentation**
  * Added upgrade notes highlighting key changes in this release.
  * Updated the documented default image tag to match the new version.

* **Tests**
  * Adjusted chart rendering checks to expect the new default image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->