### PR TITLE
chore(medikeep): bump medikeep to 0.68.0

### DIFF
--- a/charts/medikeep/Chart.yaml
+++ b/charts/medikeep/Chart.yaml
@@ -4,7 +4,7 @@ name: medikeep
 description: Self-hosted personal medical records manager with PostgreSQL persistence
 type: application
 version: 1.0.2
-appVersion: "0.67.0"
+appVersion: "0.68.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/medikeep
 sources:
@@ -25,8 +25,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/medikeep.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align chart with helmforge standards (#632)"
+    - kind: changed
+      description: "bump medikeep to 0.68.0 (#697)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/medikeep/DESIGN.md
+++ b/charts/medikeep/DESIGN.md
@@ -14,10 +14,10 @@ Scaling above one pod is blocked because MediKeep writes uploads and generated b
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/afairgiant/medikeep:v0.67.0
+ghcr.io/afairgiant/medikeep:v0.68.0
 ```
 
-The tag maps to the upstream `v0.67.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `v0.68.0` release and publishes Linux `amd64` and `arm64` manifests.
 
 ## Database
 

--- a/charts/medikeep/README.md
+++ b/charts/medikeep/README.md
@@ -2,8 +2,17 @@
 
 Deploy [MediKeep](https://github.com/afairgiant/MediKeep), a self-hosted personal medical records application built with React and FastAPI.
 
-This chart packages the official `ghcr.io/afairgiant/medikeep:v0.67.0` image with PostgreSQL, persistent uploads and backups,
+This chart packages the official `ghcr.io/afairgiant/medikeep:v0.68.0` image with PostgreSQL, persistent uploads and backups,
 Kubernetes Ingress, Gateway API, NetworkPolicy, and External Secrets Operator integration.
+
+## Upgrade Notes
+
+MediKeep `v0.68.0` adds medication reminder configuration and test reminders,
+new clinical data options such as Chikungunya vaccine support, stacked lab
+result views, and practitioner entry improvements. It also includes fixes for
+reference range validation, immunization history linking, condition lab results,
+and a migration file ID overlap. Back up PostgreSQL and uploaded records before
+upgrading.
 
 ## Install
 

--- a/charts/medikeep/tests/templates_test.yaml
+++ b/charts/medikeep/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/afairgiant/medikeep:v0.67.0
+          value: ghcr.io/afairgiant/medikeep:v0.68.0
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/medikeep/values.yaml
+++ b/charts/medikeep/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official MediKeep container image repository.
   repository: ghcr.io/afairgiant/medikeep
   # -- Pinned MediKeep image tag. Floating tags such as latest are not used by default.
-  tag: "v0.67.0"
+  tag: "v0.68.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #697.

## Summary
- Bump MediKeep from 0.67.0 to 0.68.0.
- Update the official GHCR image tag to `v0.68.0`, plus DESIGN, README, and unit test expectations.
- Add upgrade notes for medication reminders, lab result improvements, vaccine data, and migration fixes.

## Upstream Evidence
- GitHub release: https://github.com/afairgiant/MediKeep/releases/tag/v0.68.0
- GHCR image manifest verified: `ghcr.io/afairgiant/medikeep:v0.68.0`
- Manifest platforms: `linux/amd64`, `linux/arm64`.
- The issue listed `0.68.0`, but GHCR does not publish that non-prefixed tag; `v0.68.0` is the stable release image.
- v0.68.0 is a stable, non-prerelease upstream release published on 2026-07-02.
- Release notes include medication reminder configuration and test reminders, Chikungunya vaccine support, stacked lab result views, practitioner entry improvements, reference range validation fixes, immunization history fixes, and migration ID overlap correction.

## Site Sync
- Site PR: helmforgedev/site#378

## Validation
- `make image-verify IMAGE=ghcr.io/afairgiant/medikeep:v0.68.0`
- `make deps-check CHART=medikeep`
- `helm unittest charts/medikeep` passed: 6 suites, 23 tests.
- `make standards-check CHART=medikeep`
- `make validate-chart CHART=medikeep` passed fully: 17 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make site-sync-check CHART=medikeep`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated MediKeep to version `0.68.0`.

* **Documentation**
  * Refreshed chart and upgrade guidance to match the latest release.
  * Added upgrade notes highlighting new reminder, clinical data, lab view, and practitioner workflow improvements.
  * Included a reminder to back up data before upgrading.

* **Chores**
  * Brought chart metadata and release references in line with the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->