### PR TITLE
chore(minecraft): bump minecraft to 2026.7.0

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.4.14
-appVersion: "2026.6.1"
+appVersion: "2026.7.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump minecraft to 2026.6.1 (#619)"
+      description: "bump minecraft to 2026.7.0 (#698)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -255,10 +255,14 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.6.1` updates the upstream server image from
-`2026.6.0`. Review the upstream release notes before upgrading production servers,
-take a world backup, and verify plugins, mods, datapacks, proxy settings, and
-pinned `server.version` values in a staging environment before reusing existing PVCs.
+`docker.io/itzg/minecraft-server:2026.7.0` updates the upstream server image from
+`2026.6.1`. The upstream release adds Purpur support for ServerLibraryCleaner,
+fixes start-utils extraction for non-specific file types, fixes Paper boolean
+flag handling, improves GTNH pack version handling, and reloads
+`LOAD_ENV_FROM_FILE` after the packwiz installer runs.
+Review the upstream release notes before upgrading production servers, take a
+world backup, and verify plugins, mods, datapacks, proxy settings, and pinned
+`server.version` values in a staging environment before reusing existing PVCs.
 
 ## Security Scan
 

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.6.1
+          value: docker.io/itzg/minecraft-server:2026.7.0
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.6.1
+          value: docker.io/itzg/minecraft-server:2026.7.0
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.6.1
+          value: docker.io/itzg/minecraft-server:2026.7.0
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.6.1
+          value: docker.io/itzg/minecraft-server:2026.7.0
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.6.1"
+          "default": "2026.7.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -634,7 +634,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.6.1"
+              "default": "docker.io/itzg/minecraft-server:2026.7.0"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.6.1"
+  tag: "2026.7.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -381,7 +381,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.6.1
+    worker: docker.io/itzg/minecraft-server:2026.7.0
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
Closes #698.

## Summary
- Bump Minecraft server image from 2026.6.1 to 2026.7.0.
- Update the main image tag, backup worker image, values schema defaults, README upgrade notes, and unit test expectations.
- Keep the metrics sidecar image unchanged; this PR only updates the `itzg/minecraft-server` image tracked by the upstream-update issue.

## Upstream Evidence
- GitHub release: https://github.com/itzg/docker-minecraft-server/releases/tag/2026.7.0
- Docker Hub image manifest verified: `docker.io/itzg/minecraft-server:2026.7.0`
- Manifest platforms: `linux/amd64`, `linux/arm64`.
- 2026.7.0 is a stable, non-prerelease upstream release published on 2026-07-04.
- Release notes include Purpur support for ServerLibraryCleaner, start-utils extraction fixes, GTNH pack version handling with spaces, Paper boolean flag handling, and packwiz env-file reload after installer runs.

## Site Sync
- Site PR: helmforgedev/site#379

## Validation
- `make image-verify IMAGE=docker.io/itzg/minecraft-server:2026.7.0`
- `make deps-check CHART=minecraft`
- `helm unittest charts/minecraft` passed: 7 suites, 71 tests.
- `make standards-check CHART=minecraft`
- `make validate-chart CHART=minecraft` passed fully: 17 layers, including k3d behavioral validation for default and all CI values scenarios.
- `make site-sync-check CHART=minecraft`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Minecraft chart to use the latest 2026.7.0 server image by default.
  * Backup-related components now also use the matching newer image version.

* **Documentation**
  * Refreshed upgrade notes with the latest upstream release highlights and a more detailed upgrade checklist.

* **Tests**
  * Adjusted chart tests to match the updated default image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->