### PR TITLE
chore(n8n): bump n8n to 2.29.7

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.6
-appVersion: "2.28.3"
+appVersion: "2.29.7"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.28.3 (#620)"
+      description: "bump n8n to 2.29.7 (#699)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.26.8` | n8n container image tag |
+| `image.tag` | `2.29.7` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,7 +186,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.26.8` is the upstream stable release used by the chart defaults. Review
+n8n `2.29.7` is the upstream stable release used by the chart defaults. Review
 the upstream release notes before upgrading, back up the database, and keep the
 encryption key stable before upgrading live deployments. This chart keeps the
 hardened non-root container defaults with resource requests and limits. Queue
@@ -194,6 +194,11 @@ mode fails fast when it resolves to SQLite or when Redis is not configured,
 because workers must share the same PostgreSQL, MySQL, or external database as
 the main pod. Validate database and queue mode in a staging namespace before
 reusing production PVCs.
+
+The issue target `2.29.6` is marked as a pre-release upstream. This chart uses
+`2.29.7`, the next stable release, which includes fixes for Code node workflows
+with AI tools, versioned action generation for nodes with flat Action fields,
+and Salesforce document upload and JWT authentication error reporting.
 
 The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth
 token, opens the broker port, and runs a `docker.io/n8nio/runners` sidecar next

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.28.3"
+          value: "docker.io/n8nio/n8n:2.29.7"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.28.3"
+          value: "docker.io/n8nio/runners:2.29.7"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.28.3"
+          value: "docker.io/n8nio/runners:2.29.7"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.26.8"
+          "default": "2.29.7"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.28.3"
+  tag: "2.29.7"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Closes #699.

## Summary
- Bump n8n from `2.28.3` to `2.29.7`.
- Update the main n8n image tag, values schema default, hardcoded unittest expectations, and README upgrade notes.
- Keep the external task runner image repository on `docker.io/n8nio/runners`, with the default runner tag still following `image.tag`.

## Upstream Evidence
- GitHub release: https://github.com/n8n-io/n8n/releases/tag/n8n%402.29.7
- Release status verified with GitHub CLI: not draft, not pre-release, published `2026-07-07T06:29:37Z`.
- The issue target `2.29.6` is marked as pre-release upstream; this PR uses `2.29.7`, the latest stable release that supersedes it.
- `make image-verify IMAGE=docker.io/n8nio/n8n:2.29.7` passed with `linux/amd64` and `linux/arm64` manifests.
- `make image-verify IMAGE=docker.io/n8nio/runners:2.29.7` passed with `linux/amd64` and `linux/arm64` manifests.
- 2.29.7 fixes Code node failures when workflows contain AI tools, versioned action generation for nodes using flat Action fields, and Salesforce document upload/JWT auth error reporting.

## Site Sync
- Site PR: helmforgedev/site#380

## Validation
- `make image-verify IMAGE=docker.io/n8nio/n8n:2.29.7`
- `make image-verify IMAGE=docker.io/n8nio/runners:2.29.7`
- `make deps-check CHART=n8n`
- `helm unittest charts/n8n` passed: 9 suites, 78 tests.
- `make standards-check CHART=n8n`
- `node scripts/charts/template-standards-check.js --chart n8n`
- `make validate-chart CHART=n8n` passed fully: 20 layers, including k3d behavioral validation for default plus all CI values scenarios.
- `make site-sync-check CHART=n8n`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the chart and default image references to version `2.29.7` for the main app and related runner components.

* **Documentation**
  * Refreshed the Helm chart README to reflect the latest release version and upgrade guidance.
  * Added notes highlighting recent fixes included in this release.

* **Tests**
  * Updated deployment test expectations to match the new container image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->