### PR TITLE
chore(olivetin): bump olivetin to 3000.16.2

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.13
-appVersion: "3000.16.1"
+appVersion: "3000.16.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump olivetin to 3000.16.1 (#622)"
+      description: "bump olivetin to 3000.16.2 (#701)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -58,7 +58,7 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.resources` | requests/limits set | Resource guardrails for the config bootstrap init container |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.15.0` | OliveTin image tag |
+| `image.tag` | `3000.16.2` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
 | `olivetin.port` | `1337` | Application port |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |
@@ -100,6 +100,13 @@ so OliveTin runtime expressions such as `{{ message }}` remain literal for Olive
 only when you intentionally want Helm to render templates inside `config`.
 
 See the [OliveTin documentation](https://docs.olivetin.app) for all available options.
+
+## Upgrade Notes
+
+OliveTin `3000.16.2` is a bugfix release focused on Windows packaging and
+upstream unit test stability. Upstream reports no upgrade warnings or breaking
+changes between `3000.16.1` and `3000.16.2`; keep the chart-managed config and
+persistent data paths unchanged when rolling production deployments.
 
 ### Security Scan: olivetin
 

--- a/charts/olivetin/examples/gateway-api.yaml
+++ b/charts/olivetin/examples/gateway-api.yaml
@@ -8,9 +8,3 @@ gatewayAPI:
           namespace: gateway-system
       hostnames:
         - olivetin.example.com
-      rules:
-        - matches:
-            - path:
-                type: PathPrefix
-                value: /
-

--- a/charts/olivetin/templates/_helpers.tpl
+++ b/charts/olivetin/templates/_helpers.tpl
@@ -65,6 +65,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "olivetin.validate" -}}
+{{- end -}}
+
 {{/* Data PVC claim name */}}
 {{- define "olivetin.dataClaimName" -}}
 {{- if .Values.persistence.existingClaim -}}

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.16.1"
+          value: "docker.io/jamesread/olivetin:3000.16.2"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.15.0" },
+        "tag": { "type": "string", "default": "3000.16.2" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.16.1"
+  tag: "3000.16.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
Closes #701.

## Summary
- Bump OliveTin from `3000.16.1` to `3000.16.2`.
- Update chart defaults, values schema, unittest expectations, README, and site docs.
- Fix existing template standards warnings by adding the chart validate helper and simplifying the Gateway API example so the template generates the default backendRef.

## Upstream Evidence
- GitHub release: https://github.com/OliveTin/OliveTin/releases/tag/3000.16.2
- Release status verified with GitHub CLI: not draft, not pre-release, published `2026-06-29T20:12:19Z`.
- Docker Hub image manifest verified: `docker.io/jamesread/olivetin:3000.16.2`.
- Manifest platforms: `linux/amd64`, `linux/arm64`.
- Upstream notes: bugfix release for Windows packaging/installer bits and flaky unit tests; upstream reports no upgrade warnings or breaking changes.

## Site Sync
- Site PR: helmforgedev/site#382

## Validation
- `make image-verify IMAGE=docker.io/jamesread/olivetin:3000.16.2`
- `make deps-check CHART=olivetin`
- `helm unittest charts/olivetin` passed: 6 suites, 38 tests.
- `make standards-check CHART=olivetin`
- `node scripts/charts/template-standards-check.js --chart olivetin`
- `make validate-chart CHART=olivetin` passed fully: 15 layers, including k3d behavioral validation for default plus all CI values scenarios.
- `make site-sync-check CHART=olivetin`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the chart and default container image to version `3000.16.2`.
  * Added release notes covering the latest version and upgrade guidance.

* **Documentation**
  * Refreshed the chart README to match the new default image tag.
  * Clarified that this update has no breaking changes or upgrade warnings.

* **Tests**
  * Updated chart rendering expectations to use the new image version.

* **Refactor**
  * Minor chart template and example cleanup to align with the updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->