### PR TITLE
chore(openhab): bump openhab to 5.2.0

### DIFF
--- a/charts/openhab/Chart.yaml
+++ b/charts/openhab/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: openhab
 type: application
 version: 1.1.3
-appVersion: "5.1.4"
+appVersion: "5.2.0"
 kubeVersion: ">=1.26.0-0"
 description: Production-ready openHAB home automation platform for Kubernetes
 icon: https://helmforge.dev/icons/charts/openhab.png
@@ -24,8 +24,8 @@ sources:
   - https://github.com/openhab/openhab-core
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align pod template labels (#674)"
+    - kind: changed
+      description: "bump openhab to 5.2.0 (#702)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/openhab/README.md
+++ b/charts/openhab/README.md
@@ -102,7 +102,7 @@ Use feature flags instead to enable optional components.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.tag` | openHAB image tag | `5.1.4` |
+| `image.tag` | openHAB image tag | `5.2.0` |
 | `image.repository` | Image repository | `docker.io/openhab/openhab` |
 | `replicaCount` | Must be 1 — no clustering support | `1` |
 | `namespaceOverride` | Namespace for chart-managed resources | `""` |
@@ -234,6 +234,16 @@ metrics:
 rule executions, threadpool statistics, JVM metrics (memory, GC, threads).
 
 See [Prometheus Metrics Guide](docs/metrics.md) for full details.
+
+## Upgrade Notes
+
+openHAB `5.2.0` is a stable feature release for the 5.x line. The upstream
+release notes list new add-ons, runtime/UI enhancements, and several breaking
+changes that may require manual action after upgrade. Back up the `userdata`,
+`conf`, and `addons` PVCs before upgrading. Review any affected rules, UI
+layouts, persistence queries, voice IDs, and add-ons before rolling production
+deployments. openHAB 5.x still requires Java 21, which is provided by the
+official container image used by this chart.
 
 ### Security Scan: openhab
 

--- a/charts/openhab/examples/production.yaml
+++ b/charts/openhab/examples/production.yaml
@@ -5,7 +5,7 @@
 #           Karaf console for administration, larger storage.
 
 image:
-  tag: "5.1.4"
+  tag: "5.2.0"
 
 service:
   type: ClusterIP

--- a/charts/openhab/examples/simple.yaml
+++ b/charts/openhab/examples/simple.yaml
@@ -3,7 +3,7 @@
 # Use case: Single-node cluster or home server, basic persistence, port-forward access
 
 image:
-  tag: "5.1.4"
+  tag: "5.2.0"
 
 persistence:
   userdata:

--- a/charts/openhab/examples/with-configmaps.yaml
+++ b/charts/openhab/examples/with-configmaps.yaml
@@ -5,7 +5,7 @@
 #           into the writable conf PVC before openHAB starts.
 
 image:
-  tag: "5.1.4"
+  tag: "5.2.0"
 
 env:
   TZ: "America/Sao_Paulo"

--- a/charts/openhab/examples/with-ingress.yaml
+++ b/charts/openhab/examples/with-ingress.yaml
@@ -4,7 +4,7 @@
 # Requirements: nginx-ingress-controller, cert-manager (for TLS)
 
 image:
-  tag: "5.1.4"
+  tag: "5.2.0"
 
 service:
   type: ClusterIP

--- a/charts/openhab/tests/statefulset_test.yaml
+++ b/charts/openhab/tests/statefulset_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/openhab/openhab:5.1.4
+          value: docker.io/openhab/openhab:5.2.0
 
   # The openHAB entrypoint must start as root to create the openhab user/group
   # (groupadd/useradd/chown) before dropping to UID 9001 via gosu.

--- a/charts/openhab/values.schema.json
+++ b/charts/openhab/values.schema.json
@@ -23,7 +23,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag. Never use 'latest'.",
-          "default": "5.1.4"
+          "default": "5.2.0"
         }
       }
     },

--- a/charts/openhab/values.yaml
+++ b/charts/openhab/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image tag (defaults to chart appVersion). Never use 'latest'.
-  tag: "5.1.4"
+  tag: "5.2.0"
 
 # -- Image pull secrets
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
- Bump openHAB from 5.1.4 to 5.2.0.
- Update chart defaults, schema, tests, examples, and README upgrade notes.
- Sync site documentation and playground defaults.

Closes #702.

## Upstream Evidence
- Release: https://github.com/openhab/openhab-distro/releases/tag/5.2.0
- Release state: stable, not draft, not prerelease; published 2026-07-05.
- Image verified: docker.io/openhab/openhab:5.2.0
- Manifest platforms verified: linux/amd64, linux/arm64.
- Notes: openHAB 5.2.0 is a 5.x feature release with runtime, add-on, and UI improvements. Upstream documents several manual-action breaking changes; the README and site now call out backup and review guidance. Java 21 remains required and is provided by the official image.

## Site Sync
- helmforgedev/site#383

## Validation
- make image-verify IMAGE=docker.io/openhab/openhab:5.2.0
- make deps-check CHART=openhab
- helm unittest charts/openhab: 13 suites, 119 tests
- make standards-check CHART=openhab
- node scripts/charts/template-standards-check.js --chart openhab
- make site-sync-check CHART=openhab
- make validate-chart CHART=openhab: passed 21 layers, including k3d behavioral validation for default and all openHAB CI scenarios
- make release-check REPO=charts
- make attribution-check REPO=charts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the openHAB chart to use version **5.2.0** by default across the main configuration and example setups.

* **Documentation**
  * Added upgrade notes with guidance for moving to openHAB **5.2.0**, including backup recommendations and Java 21 requirements.

* **Chores**
  * Refreshed chart metadata and release notes to reflect the new openHAB version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->