### PR TITLE
chore(poznote): bump poznote to 6.30.2

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.0.1
-appVersion: "6.29.0"
+appVersion: "6.30.2"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -24,8 +24,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add chart (#630)"
+    - kind: changed
+      description: "bump poznote to 6.30.2 (#703)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,10 +14,10 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.29.0
+ghcr.io/timothepoznanski/poznote:6.30.2
 ```
 
-The tag maps to the upstream `6.29.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.30.2` release and publishes Linux `amd64` and `arm64` manifests.
 
 ## Database
 

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.29.0` |
+| `image.tag` | Image tag | `6.30.2` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -137,6 +137,16 @@ This chart intentionally does NOT:
 - Support multi-replica scaling (SQLite limitation)
 - Provide a database subchart (SQLite is embedded)
 - Bundle the MCP server container (separate deployment concern)
+
+## Upgrade Notes
+
+Poznote `6.30.2` is a stable UI, backup, API, and security hardening release.
+Upstream highlights include brute-force login throttling, improved backup import
+validation, trashed notes included in exports, new REST API endpoints, MCP server
+fixes, dark mode fixes, and mobile/task editing fixes. No Kubernetes-facing
+configuration changes are required by this chart, but back up the `data` PVC
+before upgrading because it stores the SQLite database, notes, attachments, and
+application configuration.
 
 ## Security Scan
 

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.29.0"
+          value: "ghcr.io/timothepoznanski/poznote:6.30.2"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.29.0"
+  tag: "6.30.2"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Bump Poznote from 6.29.0 to 6.30.2.
- Update chart defaults, tests, README, and DESIGN notes.
- Add upgrade notes for the UI, backup, API, security hardening, MCP, dark mode, and mobile task fixes.

Closes #703.

## Upstream Evidence
- Issue target was 6.29.2, but upstream already published 6.30.2 as the latest stable release on 2026-07-07, so this PR updates to the current stable tag instead of opening a stale bump.
- Release: https://github.com/timothepoznanski/poznote/releases/tag/6.30.2
- Release state: stable, not draft, not prerelease; published 2026-07-07.
- Image verified: ghcr.io/timothepoznanski/poznote:6.30.2
- Manifest platforms verified: linux/amd64, linux/arm64.
- Relevant upstream notes across 6.29.2 through 6.30.2: UI improvements, MCP server fix, mobile task edit fixes, brute-force login throttling, backup import validation, trashed notes included in exports, new REST API endpoints, and dark mode styling fixes. No Kubernetes-facing configuration change was identified.

## Site Sync
- helmforgedev/site#384

## Validation
- make image-verify IMAGE=ghcr.io/timothepoznanski/poznote:6.30.2
- make deps-check CHART=poznote
- helm unittest charts/poznote: 10 suites, 63 tests
- make standards-check CHART=poznote
- node scripts/charts/template-standards-check.js --chart poznote
- make site-sync-check CHART=poznote
- make validate-chart CHART=poznote: passed 16 layers, including k3d behavioral validation for default and all Poznote CI scenarios
- make release-check REPO=charts
- make attribution-check REPO=charts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default Poznote version to **6.30.2** across the chart.
  * Added upgrade guidance, including a reminder to back up the `data` volume before upgrading.

* **Documentation**
  * Refreshed chart docs and design notes to match the new release version and image tag.

* **Tests**
  * Updated chart rendering checks to validate the new default container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->