### PR TITLE
fix(adguard-home): support service externalTrafficPolicy setting 

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: adguard-home
 description: AdGuard Home network-wide ad and tracker blocking DNS server with sync and S3 backup
 type: application
-version: 1.4.13
+version: 1.4.12
 appVersion: "0.107.77"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: adguard-home
 description: AdGuard Home network-wide ad and tracker blocking DNS server with sync and S3 backup
 type: application
-version: 1.4.12
+version: 1.4.13
 appVersion: "0.107.77"
 kubeVersion: ">=1.26.0-0"
 maintainers:

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -222,6 +222,7 @@ backup:
 | `service.dns.type` | `LoadBalancer` | DNS service type |
 | `service.dns.port` | `53` | DNS port |
 | `service.dns.loadBalancerIP` | `""` | Fixed IP for DNS stability |
+| `service.dns.externalTrafficPolicy` | `Cluster` | Traffic policy for external traffic (`Cluster`, `Local`). Set to `Local` to preserve client source IP |
 | `service.dns.ipFamilyPolicy` | `~` | Dual-stack policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |
 | `service.dns.ipFamilies` | `[]` | IP families (`IPv4`, `IPv6`) |
 

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -44,8 +44,10 @@ spec:
   loadBalancerIP: {{ . }}
   {{- end }}
   {{- if ne .Values.service.dns.type "ClusterIP" }}
-  externalTrafficPolicy: {{ .Values.service.dns.externalTrafficPolicy }}
-  {{- end }}  
+  {{- with .Values.service.dns.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  {{- end }}
   {{- with .Values.service.dns.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -43,6 +43,9 @@ spec:
   {{- with .Values.service.dns.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- if ne .Values.service.dns.type "ClusterIP" }}
+  externalTrafficPolicy: {{ .Values.service.dns.externalTrafficPolicy }}
+  {{- end }}  
   {{- with .Values.service.dns.ipFamilyPolicy }}
   ipFamilyPolicy: {{ . }}
   {{- end }}

--- a/charts/adguard-home/tests/service_test.yaml
+++ b/charts/adguard-home/tests/service_test.yaml
@@ -35,6 +35,23 @@ tests:
           path: spec.type
           value: LoadBalancer
 
+  - it: should set externalTrafficPolicy when specified
+    documentIndex: 1
+    set:
+      service.dns.externalTrafficPolicy: Local
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+
+  - it: should omit externalTrafficPolicy when null
+    documentIndex: 1
+    set:
+      service.dns.externalTrafficPolicy: null
+    asserts:
+      - isNull:
+          path: spec.externalTrafficPolicy
+
   - it: should have DNS TCP and UDP ports
     documentIndex: 1
     asserts:

--- a/charts/adguard-home/values.schema.json
+++ b/charts/adguard-home/values.schema.json
@@ -226,6 +226,11 @@
               "description": "Load balancer IP (optional, for static IP assignment)",
               "default": ""
             },
+            "externalTrafficPolicy": {
+              "type": ["string", "null"],
+              "description": "Set traffic policy for external traffic. 'Local' preserves client source IP for LoadBalancer/NodePort services. 'Cluster' (default) routes to any node but may masquerade source IP.",
+              "enum": [null, "Cluster", "Local"]
+            },
             "ipFamilyPolicy": {
               "type": ["string", "null"],
               "description": "Dual-stack ipFamilyPolicy (GR-058)",

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -137,6 +137,9 @@ service:
     annotations: {}
     # -- Load balancer IP (optional, for static IP assignment)
     loadBalancerIP: ""
+    # -- Set traffic policy for external traffic.
+    # -- "Cluster" (default) routes traffic to any node, may masquerade source IP.
+    externalTrafficPolicy: Cluster
     # -- Service IP family policy: SingleStack | PreferDualStack | RequireDualStack. Empty uses cluster default.
     ipFamilyPolicy: ~
     # -- Service IP families override. Empty uses cluster default.


### PR DESCRIPTION
## Summary

Adds `service.dns.externalTrafficPolicy` value to the AdGuard Home chart, allowing users to set the DNS service's traffic policy.

When deployed on K3s (with Klipper svclb) or other bare-metal Kubernetes distributions using default `Cluster` policy, client source IPs are masqueraded to node/pod network IPs (e.g. `10.42.x.x`). This breaks per-client query logging, filtering and statistics, ll clients appear as internal cluster IPs in the AdGuard Home UI.

Setting `externalTrafficPolicy: Local` preserves real client IPs, restoring correct per-client visibility and enabling meaningful filtering rules.

Related to https://github.com/helmforgedev/charts/issues/99 (same architectural problem raised for Pi-hole chart, this PR addresses the Klipper/MetalLB case for AdGuard Home).

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Site Sync (GR-007)

- [ ] I updated the corresponding page in `site/` repository
- [x] N/A - this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/adguard-home --strict` passed
- [x] `helm unittest charts/adguard-home` passed
- [ ] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

**Default behaviour unchanged.** New value defaults to `Cluster` — matching current deployment and Kubernetes' own default. Existing deployments upgrade with no behavioural change.

**Scope note.** This PR addresses the Klipper/MetalLB case. Users of PureLB in local mode (see issue [#99](https://github.com/helmforgedev/charts/issues/99) for context) may still require `hostNetwork` support, which would be a separate follow-up.

**Template guard.** The `externalTrafficPolicy` field is only valid on `LoadBalancer` and `NodePort` services. The template conditionally omits the field when `service.dns.type: ClusterIP` to avoid validation errors:

```yaml
{{- if ne .Values.service.dns.type "ClusterIP" }}
externalTrafficPolicy: {{ .Values.service.dns.externalTrafficPolicy | default "Cluster" }}
{{- end }}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring DNS traffic handling with a new `service.dns.externalTrafficPolicy` option.
  * Default behavior remains `Cluster`; `Local` can be used to preserve client source IPs.
* **Documentation**
  * Updated the chart README to document `service.dns.externalTrafficPolicy` and its impact.
* **Bug Fixes**
  * Ensured the DNS service’s `externalTrafficPolicy` is rendered correctly for non-`ClusterIP` service types.
* **Tests**
  * Added coverage for `Local` and explicit `null` values for `externalTrafficPolicy`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->