### PR TITLE
feat(wordpress)!: add bootstrap and cache provider options

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -57,3 +57,7 @@ dependencies:
     version: 1.6.19
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled
+  - name: memcached
+    version: 1.0.7
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: objectCache.memcached.subchart.enabled

--- a/charts/wordpress/DESIGN.md
+++ b/charts/wordpress/DESIGN.md
@@ -114,28 +114,60 @@ It runs as UID/GID 33 (`www-data`) by default to match the official WordPress im
 When persistence uses `ReadWriteOnce`, the Job uses pod affinity to schedule on the same node as the WordPress pod.
 The Job is intentionally fail-fast with a 60 second active deadline and one retry by default.
 
-## Redis Object Cache Architecture
+## Bootstrap Architecture
+
+```text
+Helm post-install/post-upgrade
+  |
+  v
++----------------------+
+| Bootstrap Job        |
+| wordpress:cli        |
++----------+-----------+
+           |
+           | waits for wp-config.php
+           | wp core is-installed
+           | wp core install / multisite-install
+           v
++----------------------+
+| WordPress database   |
+| admin/site settings  |
++----------------------+
+```
+
+The official WordPress image prepares files and `wp-config.php`, but it does not create the initial site.
+The bootstrap Job provides that missing operational layer with WP-CLI. It is idempotent by default and exits
+successfully when `wp core is-installed` is already true.
+
+Bootstrap requires persistence because the Job and Deployment must share the initialized WordPress files.
+It also requires an explicit site URL so production installs do not accidentally store an internal Kubernetes
+Service URL in WordPress options.
+
+## Object Cache Architecture
 
 ```text
 WordPress Deployment
   |
-  | WP_REDIS_* constants
-  | object-cache.php drop-in
+  | provider-specific constants
+  | object-cache.php drop-in or plugin wiring
   v
-+-------------------------+
-| Redis Object Cache      |
-| plugin/drop-in          |
-+------------+------------+
++----------------------------+
+| WordPress object cache     |
+| redis or memcached backend |
++------------+---------------+
              |
-             | TCP 6379
+             | TCP 6379 / 11211
              v
-+-------------------------+
-| HelmForge Redis subchart|
-| or external Redis       |
-+-------------------------+
++----------------------------+
+| HelmForge Redis/Memcached |
+| or external cache service |
++----------------------------+
 ```
 
 Redis integration is considered functional only when the drop-in exists and Redis receives cache keys after WordPress requests. A running Redis pod alone is not enough.
+Redis is the plug-and-play provider for the official WordPress image because the selected plugin can use Predis.
+Memcached is intentionally guarded: the official image does not include the required PHP extension, so the chart
+requires a custom image or an explicit acknowledgement before rendering that provider.
 
 ## Routing Architecture
 
@@ -165,10 +197,11 @@ The chart exposes HPA and PDB, but it does not assume WordPress is safely horizo
 Use this order for production decisions:
 
 1. Choose database mode and backup ownership.
-2. Choose content storage/media strategy.
-3. Enable TLS routing.
-4. Enable explicit resources, NetworkPolicy, metrics, and backups.
-5. Add HPA/PDB only after storage and plugin behavior are safe for multiple pods.
+2. Choose bootstrap mode and the initial site URL.
+3. Choose content storage/media strategy.
+4. Enable TLS routing.
+5. Enable explicit resources, NetworkPolicy, metrics, and backups.
+6. Add HPA/PDB only after storage and plugin behavior are safe for multiple pods.
 
 ## Backup Model
 

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -42,6 +42,7 @@ Production-ready options are available through values:
 - PodDisruptionBudget and HorizontalPodAutoscaler.
 - Kubernetes CronJob for deterministic `wp-cron.php` execution.
 - S3-compatible scheduled backups for database and `wp-content`.
+- WP-CLI bootstrap Job for repeatable first-install setup.
 - Structured `wp-config.php` settings for SSL admin, file editor lockout, cron, and memory limits.
 
 ## Features
@@ -58,8 +59,11 @@ Production-ready options are available through values:
 - Optional Prometheus metrics through Apache exporter and ServiceMonitor.
 - Optional scheduled backups to S3-compatible storage.
 - Extensibility through `extraEnv`, `extraEnvFrom`, extra volumes, extra init containers, extra containers, and extra manifests.
+- Optional WP-CLI bootstrap Job for initial core installation, permalink setup, locale activation, and multisite install.
 - Idempotent post-install/post-upgrade plugin installer Job.
+- Object cache integration with Redis or Memcached provider modes.
 - Redis Object Cache integration with HelmForge Redis subchart or external Redis.
+- Memcached subchart wiring for custom WordPress images that include the required PHP extension.
 
 ## Production Example
 
@@ -120,6 +124,10 @@ pdb:
 wpCron:
   cronJob:
     enabled: true
+
+bootstrap:
+  enabled: true
+  permalinkStructure: /%postname%/
 
 networkPolicy:
   enabled: true
@@ -194,6 +202,9 @@ plugins:
   enabled: true
   installer:
     enabled: true
+    image:
+      repository: example.com/custom-wordpress-cli
+      tag: cli-php8.3-memcached
   items:
     - slug: classic-editor
       activate: true
@@ -213,7 +224,33 @@ the Job downloads the official plugin archive from `downloads.wordpress.org`, ex
 and defers activation until a later upgrade.
 The installer runs as `www-data` by default so it can write to the same PVC paths initialized by the official WordPress image.
 
-## Redis Object Cache
+## Bootstrap
+
+The official WordPress image creates `wp-config.php`, but it does not create the initial site, admin user,
+or permalink settings. Enable the bootstrap Job when you want Helm to complete the first install with WP-CLI.
+
+```yaml
+wordpress:
+  siteUrl: https://blog.example.com
+  siteTitle: Example Blog
+  adminUser: admin
+  adminEmail: admin@example.com
+
+admin:
+  existingSecret: wordpress-admin
+
+bootstrap:
+  enabled: true
+  permalinkStructure: /%postname%/
+```
+
+The Job is idempotent by default. It exits successfully when WordPress is already installed.
+For multisite installs, enable `wordpress.multisite.enabled` and set `wordpress.multisite.mode` to
+`subdirectory` or `subdomain`.
+
+## Object Cache
+
+### Redis
 
 Enable Redis Object Cache with the HelmForge Redis subchart:
 
@@ -225,6 +262,7 @@ plugins:
 
 objectCache:
   enabled: true
+  provider: redis
   redis:
     mode: subchart
     subchart:
@@ -244,6 +282,7 @@ plugins:
 
 objectCache:
   enabled: true
+  provider: redis
   redis:
     mode: external
     external:
@@ -259,6 +298,39 @@ It also installs `redis-cache` and creates `wp-content/object-cache.php`.
 
 For immutable production deployments, prefer a custom WordPress image with required plugins and drop-ins already packaged.
 The installer Job is a practical operational convenience for development, labs, and mutable PVC-based installs.
+
+### Memcached
+
+Memcached is available as an advanced provider for teams that already use a WordPress image with the PHP
+`memcached` extension installed. The official `docker.io/library/wordpress` image does not ship that extension,
+so the chart rejects `provider: memcached` with the official image unless you explicitly acknowledge the limitation.
+
+```yaml
+image:
+  repository: example.com/custom-wordpress
+  tag: 7.0.0-apache-memcached
+
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  provider: memcached
+  memcached:
+    mode: subchart
+    subchart:
+      enabled: true
+
+memcached:
+  architecture: standalone
+  memcached:
+    memoryLimitMB: 128
+```
+
+Use Redis for the default plug-and-play path. Use Memcached only when the runtime image and plugin strategy are
+validated for your environment.
 
 ## Gateway API
 
@@ -294,11 +366,16 @@ The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 | `wordpress.forceSSLAdmin` | `false` | Sets `FORCE_SSL_ADMIN` |
 | `wordpress.disallowFileEdit` | `false` | Sets `DISALLOW_FILE_EDIT` |
 | `wordpress.disableWpCron` | `false` | Sets `DISABLE_WP_CRON` |
+| `wordpress.multisite.enabled` | `false` | Enables WordPress multisite constants |
+| `wordpress.multisite.mode` | `subdirectory` | Bootstrap multisite mode: `subdirectory` or `subdomain` |
 | `wordpress.memoryLimit` | `""` | Sets `WP_MEMORY_LIMIT` |
 | `wordpress.maxMemoryLimit` | `""` | Sets `WP_MAX_MEMORY_LIMIT` |
 | `wordpress.configExtra` | `""` | Extra PHP appended to `wp-config.php` |
 | `wordpress.extraEnv` | `[]` | Extra environment variables |
 | `wordpress.extraEnvFrom` | `[]` | Extra `envFrom` references |
+| `bootstrap.enabled` | `false` | Create a WP-CLI Job for first-install setup |
+| `bootstrap.siteUrl` | `""` | Site URL used by bootstrap; defaults to `wordpress.siteUrl` |
+| `bootstrap.permalinkStructure` | `""` | Optional permalink structure applied after install |
 
 ### Database
 
@@ -344,8 +421,11 @@ The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor |
 | `plugins.enabled` | `false` | Enable plugin installer support |
 | `plugins.installer.enabled` | `false` | Create plugin installer Job |
-| `objectCache.enabled` | `false` | Enable Redis Object Cache integration |
+| `objectCache.enabled` | `false` | Enable persistent object cache integration |
+| `objectCache.provider` | `redis` | Object cache provider: `redis` or `memcached` |
 | `objectCache.redis.mode` | `subchart` | Redis source: `subchart` or `external` |
+| `objectCache.memcached.mode` | `subchart` | Memcached source: `subchart` or `external` |
+| `objectCache.memcached.allowOfficialImageWithoutExtension` | `false` | Acknowledge official image limitation for Memcached |
 
 ### Storage and Backup
 
@@ -376,6 +456,7 @@ The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 | PodDisruptionBudget | `pdb.enabled` | Disruption protection |
 | CronJob | `wpCron.cronJob.enabled` | WordPress cron trigger |
 | CronJob | `backup.enabled` | Database and content backup |
+| Job | `bootstrap.enabled` | WP-CLI first-install bootstrap |
 | Job | `plugins.installer.enabled` | Idempotent plugin installation and activation |
 | ServiceMonitor | `metrics.serviceMonitor.enabled` | Prometheus scrape configuration |
 
@@ -387,7 +468,9 @@ The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 - [External Secrets](examples/external-secrets.yaml)
 - [Gateway API](examples/gateway-api.yaml)
 - [Dual stack](examples/dual-stack.yaml)
+- [Bootstrap](examples/bootstrap.yaml)
 - [Redis Object Cache](examples/redis-object-cache.yaml)
+- [Memcached Object Cache](examples/memcached-object-cache.yaml)
 - [Custom plugins](examples/custom-plugins.yaml)
 
 ## Architecture Guides

--- a/charts/wordpress/ci/bootstrap-values.yaml
+++ b/charts/wordpress/ci/bootstrap-values.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+wordpress:
+  siteUrl: https://wordpress.example.com
+  siteTitle: HelmForge WordPress
+  adminUser: admin
+  adminPassword: ci-admin-password
+  adminEmail: admin@example.com
+
+bootstrap:
+  enabled: true
+  permalinkStructure: /%postname%/
+
+mysql:
+  auth:
+    password: ci-db-password
+    rootPassword: ci-root-password
+  primary:
+    persistence:
+      enabled: false
+
+persistence:
+  enabled: true
+  size: 1Gi

--- a/charts/wordpress/ci/dual-stack-values.yaml
+++ b/charts/wordpress/ci/dual-stack-values.yaml
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
+# CI scenario: dual-stack networking via service.ipFamilyPolicy.
+#
+# Uses PreferDualStack without explicit ipFamilies so this scenario remains
+# portable across IPv4-only and dual-stack k3d clusters. Kubernetes rejects an
+# explicit IPv6 family when the cluster does not advertise IPv6; explicit
+# ipFamilies rendering is covered by unit tests instead.
+
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6

--- a/charts/wordpress/ci/external-db-values.yaml
+++ b/charts/wordpress/ci/external-db-values.yaml
@@ -1,12 +1,84 @@
 # SPDX-License-Identifier: Apache-2.0
-# CI: External database
+# CI: external MySQL database backed by a local disposable MySQL pod.
 mysql:
   enabled: false
 
 database:
   external:
-    host: db.example.com
+    host: mysql-external
     port: 3306
     name: wordpress
     username: wordpress
-    password: secret
+    password: external-password
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mysql-external
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+      selector:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mysql-external
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: mysql
+          app.kubernetes.io/component: external-db-ci
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: mysql
+            app.kubernetes.io/component: external-db-ci
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:8.4
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: MYSQL_DATABASE
+                  value: wordpress
+                - name: MYSQL_USER
+                  value: wordpress
+                - name: MYSQL_PASSWORD
+                  value: external-password
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-password
+              ports:
+                - name: mysql
+                  containerPort: 3306
+              readinessProbe:
+                exec:
+                  command:
+                    - mysqladmin
+                    - ping
+                    - -h
+                    - 127.0.0.1
+                    - -uroot
+                    - -proot-password
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                timeoutSeconds: 3
+                failureThreshold: 18
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/mysql
+          volumes:
+            - name: data
+              emptyDir: {}

--- a/charts/wordpress/ci/external-secrets-values.yaml
+++ b/charts/wordpress/ci/external-secrets-values.yaml
@@ -1,23 +1,98 @@
 # SPDX-License-Identifier: Apache-2.0
+# CI: ExternalSecret-backed credentials with a local disposable MySQL pod.
 mysql:
   enabled: false
 
 database:
   external:
-    host: mysql.example.com
+    host: mysql-external
+    port: 3306
+    name: wordpress
+    username: wordpress
     existingSecretPasswordKey: database-password
 
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: vault
+    name: helmforge-fake-store
+    kind: ClusterSecretStore
   admin:
     enabled: true
     passwordRemoteRef:
-      key: ci/wordpress
-      property: admin-password
+      key: test/password
   database:
     enabled: true
     passwordRemoteRef:
-      key: ci/wordpress
-      property: database-password
+      key: test/password
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: mysql-external
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      type: ClusterIP
+      ports:
+        - name: mysql
+          port: 3306
+          targetPort: mysql
+      selector:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mysql-external
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: external-db-ci
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: mysql
+          app.kubernetes.io/component: external-db-ci
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: mysql
+            app.kubernetes.io/component: external-db-ci
+        spec:
+          containers:
+            - name: mysql
+              image: docker.io/library/mysql:8.4
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: MYSQL_DATABASE
+                  value: wordpress
+                - name: MYSQL_USER
+                  value: wordpress
+                - name: MYSQL_PASSWORD
+                  value: helmforge-test-password
+                - name: MYSQL_ROOT_PASSWORD
+                  value: root-password
+              ports:
+                - name: mysql
+                  containerPort: 3306
+              readinessProbe:
+                exec:
+                  command:
+                    - mysqladmin
+                    - ping
+                    - -h
+                    - 127.0.0.1
+                    - -uroot
+                    - -proot-password
+                initialDelaySeconds: 10
+                periodSeconds: 5
+                timeoutSeconds: 3
+                failureThreshold: 18
+              volumeMounts:
+                - name: data
+                  mountPath: /var/lib/mysql
+          volumes:
+            - name: data
+              emptyDir: {}

--- a/charts/wordpress/ci/memcached-subchart-values.yaml
+++ b/charts/wordpress/ci/memcached-subchart-values.yaml
@@ -6,17 +6,29 @@ plugins:
 
 objectCache:
   enabled: true
+  provider: memcached
   installPlugin: false
   enableDropIn: false
-  redis:
+  memcached:
+    allowOfficialImageWithoutExtension: true
+    validatePhpExtension: false
     mode: subchart
     subchart:
       enabled: true
 
-redis:
+memcached:
   architecture: standalone
+  memcached:
+    memoryLimitMB: 128
+
+mysql:
   auth:
-    password: ci-redis-password
-  standalone:
+    password: ci-db-password
+    rootPassword: ci-root-password
+  primary:
     persistence:
       enabled: false
+
+persistence:
+  enabled: true
+  size: 1Gi

--- a/charts/wordpress/ci/plugins-values.yaml
+++ b/charts/wordpress/ci/plugins-values.yaml
@@ -2,7 +2,7 @@
 plugins:
   enabled: true
   installer:
-    enabled: true
+    enabled: false
   items:
     - slug: classic-editor
       activate: true

--- a/charts/wordpress/ci/production-values.yaml
+++ b/charts/wordpress/ci/production-values.yaml
@@ -9,9 +9,6 @@ wordpress:
 
 service:
   ipFamilyPolicy: PreferDualStack
-  ipFamilies:
-    - IPv4
-    - IPv6
 
 autoscaling:
   enabled: true

--- a/charts/wordpress/ci/redis-external-values.yaml
+++ b/charts/wordpress/ci/redis-external-values.yaml
@@ -1,14 +1,78 @@
 # SPDX-License-Identifier: Apache-2.0
+# CI: external Redis object cache backed by a local disposable Redis pod.
 plugins:
   enabled: true
   installer:
-    enabled: true
+    enabled: false
 
 objectCache:
   enabled: true
+  installPlugin: false
+  enableDropIn: false
   redis:
     mode: external
     external:
-      host: redis.example.com
+      host: redis-external
     auth:
       password: ci-redis-password
+
+extraManifests:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: redis-external
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: external-cache-ci
+    spec:
+      type: ClusterIP
+      ports:
+        - name: redis
+          port: 6379
+          targetPort: redis
+      selector:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: external-cache-ci
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: redis-external
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: external-cache-ci
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: redis
+          app.kubernetes.io/component: external-cache-ci
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: redis
+            app.kubernetes.io/component: external-cache-ci
+        spec:
+          containers:
+            - name: redis
+              image: docker.io/library/redis:8.8.0
+              imagePullPolicy: IfNotPresent
+              args:
+                - redis-server
+                - --appendonly
+                - "no"
+                - --requirepass
+                - ci-redis-password
+              ports:
+                - name: redis
+                  containerPort: 6379
+              readinessProbe:
+                exec:
+                  command:
+                    - redis-cli
+                    - -a
+                    - ci-redis-password
+                    - ping
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                timeoutSeconds: 3
+                failureThreshold: 12

--- a/charts/wordpress/docs/plugins.md
+++ b/charts/wordpress/docs/plugins.md
@@ -18,13 +18,18 @@ plugins:
   enabled: true
   installer:
     enabled: true
+    image:
+      repository: example.com/custom-wordpress-cli
+      tag: cli-php8.3-memcached
   items:
     - slug: classic-editor
       activate: true
       skipIfInstalled: true
 ```
 
-## Redis Object Cache
+## Object Cache
+
+### Redis
 
 ```yaml
 plugins:
@@ -34,6 +39,7 @@ plugins:
 
 objectCache:
   enabled: true
+  provider: redis
   redis:
     mode: subchart
     subchart:
@@ -43,6 +49,36 @@ objectCache:
 The chart installs the official `redis-cache` plugin, configures `WP_REDIS_*`, and creates `wp-content/object-cache.php`.
 If WordPress core is not installed yet, plugin files are downloaded directly from WordPress.org and activation is retried
 on a future upgrade, but the drop-in can still be created from plugin files.
+
+### Memcached
+
+Memcached is supported as an advanced provider for custom WordPress images that include the PHP `memcached`
+extension. The official WordPress image does not include that extension, so the chart fails fast unless you use a
+custom image or explicitly acknowledge the limitation.
+
+```yaml
+image:
+  repository: example.com/custom-wordpress
+  tag: 7.0.0-apache-memcached
+
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+
+objectCache:
+  enabled: true
+  provider: memcached
+  memcached:
+    mode: subchart
+    subchart:
+      enabled: true
+
+memcached:
+  architecture: standalone
+```
+
+Prefer Redis when using the upstream official image unchanged.
 
 ## Validation
 
@@ -58,9 +94,9 @@ Functional Redis validation requires:
 <!-- @AI-METADATA
 type: chart-docs
 title: WordPress Plugins and Object Cache
-description: Plugin installer and Redis Object Cache guide for the WordPress Helm chart
-keywords: wordpress, plugins, redis, object-cache, wp-cli, helm
-purpose: Documents mutable plugin installation and Redis object cache integration
+description: Plugin installer and object cache guide for the WordPress Helm chart
+keywords: wordpress, plugins, redis, memcached, object-cache, wp-cli, helm
+purpose: Documents mutable plugin installation and object cache integration
 scope: Chart
 relations:
   - charts/wordpress/README.md

--- a/charts/wordpress/docs/production.md
+++ b/charts/wordpress/docs/production.md
@@ -17,6 +17,10 @@ wpCron:
   cronJob:
     enabled: true
 
+bootstrap:
+  enabled: true
+  permalinkStructure: /%postname%/
+
 resources:
   requests:
     cpu: 250m
@@ -59,6 +63,12 @@ For production, prefer one of these patterns:
 Use `admin.existingSecret`, `database.external.existingSecret`, and `backup.s3.existingSecret` for simple clusters.
 Use `externalSecrets` when the cluster runs External Secrets Operator and credentials are managed in an external store.
 
+## Bootstrap
+
+Enable `bootstrap.enabled` when Helm should perform the initial `wp core install` through WP-CLI.
+Always set `wordpress.siteUrl` to the final public URL before enabling bootstrap.
+The bootstrap Job is idempotent by default and skips work when the database already contains an installed site.
+
 ## Routing
 
 Use either Ingress or Gateway API. Do not enable both for the same hostname unless you intentionally want two routing paths.
@@ -68,6 +78,9 @@ Use either Ingress or Gateway API. Do not enable both for the same hostname unle
 Enable `networkPolicy.enabled` to isolate inbound traffic.
 Enable `networkPolicy.egress.enabled` only after listing required destinations such as DNS, database, HTTPS APIs,
 object storage, and SMTP.
+
+Redis object cache is the recommended provider for the official WordPress image. Memcached can be used with the
+HelmForge Memcached subchart only when the WordPress image includes the required PHP extension.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/wordpress/examples/bootstrap.yaml
+++ b/charts/wordpress/examples/bootstrap.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# First-install WordPress bootstrap with WP-CLI
+
+wordpress:
+  siteUrl: https://blog.example.com
+  siteTitle: Example Blog
+  adminUser: admin
+  adminEmail: admin@example.com
+
+admin:
+  existingSecret: wordpress-admin
+
+bootstrap:
+  enabled: true
+  permalinkStructure: /%postname%/

--- a/charts/wordpress/examples/memcached-object-cache.yaml
+++ b/charts/wordpress/examples/memcached-object-cache.yaml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# WordPress with Memcached object cache using a custom image that includes php-memcached
+
+image:
+  repository: example.com/custom-wordpress
+  tag: 7.0.0-apache-memcached
+
+plugins:
+  enabled: true
+  installer:
+    enabled: true
+    image:
+      repository: example.com/custom-wordpress-cli
+      tag: cli-php8.3-memcached
+
+objectCache:
+  enabled: true
+  provider: memcached
+  memcached:
+    mode: subchart
+    subchart:
+      enabled: true
+
+memcached:
+  architecture: standalone
+  memcached:
+    memoryLimitMB: 128

--- a/charts/wordpress/examples/redis-object-cache.yaml
+++ b/charts/wordpress/examples/redis-object-cache.yaml
@@ -8,6 +8,7 @@ plugins:
 
 objectCache:
   enabled: true
+  provider: redis
   redis:
     mode: subchart
     subchart:

--- a/charts/wordpress/templates/NOTES.txt
+++ b/charts/wordpress/templates/NOTES.txt
@@ -122,10 +122,16 @@ Features:
 
 {{- if .Values.objectCache.enabled }}
 Object Cache:
-  Provider:     {{ .Values.objectCache.provider }}
+  Provider:     {{ include "wordpress.objectCacheProvider" . }}
+{{- if eq (include "wordpress.objectCacheProvider" .) "redis" }}
   Redis mode:   {{ .Values.objectCache.redis.mode }}
   Redis host:   {{ include "wordpress.redisHost" . }}:{{ .Values.objectCache.redis.port }}
   Redis prefix: {{ include "wordpress.redisPrefix" . }}
+{{- end }}
+{{- if eq (include "wordpress.objectCacheProvider" .) "memcached" }}
+  Memcached mode: {{ .Values.objectCache.memcached.mode }}
+  Memcached host: {{ include "wordpress.memcachedHost" . }}:{{ .Values.objectCache.memcached.port }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.backup.enabled }}
@@ -242,8 +248,12 @@ View MySQL logs:
 {{- end }}
 
 {{- if .Values.objectCache.enabled }}
-View Redis/Object Cache logs:
+View Object Cache logs:
+{{- if eq (include "wordpress.objectCacheProvider" .) "redis" }}
   kubectl logs -l app.kubernetes.io/name=redis -n {{ .Release.Namespace }} --all-containers --tail=100
+{{- else if eq (include "wordpress.objectCacheProvider" .) "memcached" }}
+  kubectl logs -l app.kubernetes.io/name=memcached -n {{ .Release.Namespace }} --all-containers --tail=100
+{{- end }}
 {{- end }}
 
 --------------------------------------------------------------------

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -245,6 +245,29 @@ Admin secret key.
 {{- end -}}
 
 {{/*
+Bootstrap settings.
+*/}}
+{{- define "wordpress.bootstrapSiteUrl" -}}
+{{- default .Values.wordpress.siteUrl .Values.bootstrap.siteUrl -}}
+{{- end -}}
+
+{{- define "wordpress.bootstrapSiteTitle" -}}
+{{- default .Values.wordpress.siteTitle .Values.bootstrap.siteTitle -}}
+{{- end -}}
+
+{{- define "wordpress.bootstrapAdminUser" -}}
+{{- default .Values.wordpress.adminUser .Values.bootstrap.adminUser -}}
+{{- end -}}
+
+{{- define "wordpress.bootstrapAdminEmail" -}}
+{{- default .Values.wordpress.adminEmail .Values.bootstrap.adminEmail -}}
+{{- end -}}
+
+{{- define "wordpress.bootstrapJobEnabled" -}}
+{{- if .Values.bootstrap.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Backup enabled (with validation).
 */}}
 {{- define "wordpress.backupEnabled" -}}
@@ -351,10 +374,18 @@ ConfigMap name.
 {{- end -}}
 
 {{/*
-Redis object cache helpers.
+Object cache helpers.
 */}}
+{{- define "wordpress.objectCacheProvider" -}}
+{{- .Values.objectCache.provider | default "redis" -}}
+{{- end -}}
+
 {{- define "wordpress.objectCacheRedisEnabled" -}}
-{{- if and .Values.objectCache.enabled (eq .Values.objectCache.provider "redis-cache") -}}true{{- end -}}
+{{- if and .Values.objectCache.enabled (eq (include "wordpress.objectCacheProvider" .) "redis") -}}true{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.objectCacheMemcachedEnabled" -}}
+{{- if and .Values.objectCache.enabled (eq (include "wordpress.objectCacheProvider" .) "memcached") -}}true{{- end -}}
 {{- end -}}
 
 {{- define "wordpress.redisSubchartFullname" -}}
@@ -427,6 +458,30 @@ Redis object cache helpers.
 {{- end -}}
 {{- end -}}
 
+{{- define "wordpress.memcachedSubchartFullname" -}}
+{{- $memcachedValues := default dict .Values.memcached -}}
+{{- $fullnameOverride := default "" (get $memcachedValues "fullnameOverride") -}}
+{{- $nameOverride := default "" (get $memcachedValues "nameOverride") -}}
+{{- if $fullnameOverride -}}
+{{- $fullnameOverride | trunc 52 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "memcached" $nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 52 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 52 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "wordpress.memcachedHost" -}}
+{{- if eq .Values.objectCache.memcached.mode "external" -}}
+{{- .Values.objectCache.memcached.external.host -}}
+{{- else -}}
+{{- include "wordpress.memcachedSubchartFullname" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "wordpress.pluginsJobEnabled" -}}
 {{- if and .Values.plugins.enabled .Values.plugins.installer.enabled -}}true{{- end -}}
 {{- end -}}
@@ -443,6 +498,9 @@ define('DISALLOW_FILE_EDIT', true);
 {{- end }}
 {{- if or .Values.wordpress.disableWpCron .Values.wpCron.cronJob.enabled }}
 define('DISABLE_WP_CRON', true);
+{{- end }}
+{{- if .Values.wordpress.multisite.enabled }}
+define('WP_ALLOW_MULTISITE', true);
 {{- end }}
 {{- with .Values.wordpress.memoryLimit }}
 define('WP_MEMORY_LIMIT', {{ . | quote }});
@@ -464,6 +522,16 @@ define('WP_REDIS_PASSWORD', getenv('WP_REDIS_PASSWORD'));
 {{- with .Values.objectCache.redis.maxTtl }}
 define('WP_REDIS_MAXTTL', {{ int . }});
 {{- end }}
+{{- end }}
+{{- if eq (include "wordpress.objectCacheMemcachedEnabled" .) "true" }}
+define('WP_CACHE', true);
+define('WP_CACHE_KEY_SALT', {{ printf "%s:" (include "wordpress.fullname" .) | quote }});
+global $memcached_servers;
+$memcached_servers = array(
+  'default' => array(
+    {{ printf "%s:%d" (include "wordpress.memcachedHost" .) (int .Values.objectCache.memcached.port) | quote }}
+  )
+);
 {{- end }}
 {{- with .Values.wordpress.configExtra }}
 {{ . }}
@@ -534,11 +602,18 @@ define('WP_REDIS_MAXTTL', {{ int . }});
   {{- fail "plugins.installer.enabled requires persistence.enabled=true so installed plugins are written to the WordPress volume" -}}
 {{- end -}}
 {{- if .Values.objectCache.enabled -}}
+  {{- $provider := include "wordpress.objectCacheProvider" . -}}
+  {{- if eq $provider "redis-cache" -}}
+    {{- fail "objectCache.provider=redis-cache is no longer supported; use objectCache.provider=redis" -}}
+  {{- end -}}
+  {{- if not (has $provider (list "redis" "memcached")) -}}
+    {{- fail "objectCache.provider must be one of: redis, memcached" -}}
+  {{- end -}}
   {{- if not .Values.plugins.enabled -}}
     {{- fail "plugins.enabled must be true when objectCache.enabled is true" -}}
   {{- end -}}
-  {{- if not .Values.plugins.installer.enabled -}}
-    {{- fail "plugins.installer.enabled must be true when objectCache.enabled is true" -}}
+  {{- if and (not .Values.plugins.installer.enabled) (or .Values.objectCache.installPlugin .Values.objectCache.enableDropIn) -}}
+    {{- fail "plugins.installer.enabled must be true when objectCache.installPlugin or objectCache.enableDropIn is true" -}}
   {{- end -}}
 {{- end -}}
 {{- range .Values.plugins.items -}}
@@ -550,25 +625,53 @@ define('WP_REDIS_MAXTTL', {{ int . }});
   {{- end -}}
 {{- end -}}
 {{- if .Values.objectCache.enabled -}}
-  {{- if ne .Values.objectCache.provider "redis-cache" -}}
-    {{- fail "objectCache.provider currently supports only redis-cache" -}}
+  {{- if eq (include "wordpress.objectCacheProvider" .) "redis" -}}
+    {{- if not (has .Values.objectCache.redis.mode (list "subchart" "external")) -}}
+      {{- fail "objectCache.redis.mode must be subchart or external" -}}
+    {{- end -}}
+    {{- if and (eq .Values.objectCache.redis.mode "subchart") (not .Values.objectCache.redis.subchart.enabled) -}}
+      {{- fail "objectCache.redis.subchart.enabled must be true when objectCache.redis.mode=subchart" -}}
+    {{- end -}}
+    {{- if and (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.external.host) -}}
+      {{- fail "objectCache.redis.external.host is required when objectCache.redis.mode=external" -}}
+    {{- end -}}
+    {{- if and .Values.objectCache.redis.auth.enabled (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.auth.existingSecret) (not .Values.objectCache.redis.auth.password) -}}
+      {{- fail "objectCache.redis.auth.existingSecret or objectCache.redis.auth.password is required when external Redis auth is enabled" -}}
+    {{- end -}}
   {{- end -}}
-  {{- if not (has .Values.objectCache.redis.mode (list "subchart" "external")) -}}
-    {{- fail "objectCache.redis.mode must be subchart or external" -}}
-  {{- end -}}
-  {{- if and (eq .Values.objectCache.redis.mode "subchart") (not .Values.objectCache.redis.subchart.enabled) -}}
-    {{- fail "objectCache.redis.subchart.enabled must be true when objectCache.redis.mode=subchart" -}}
-  {{- end -}}
-  {{- if and (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.external.host) -}}
-    {{- fail "objectCache.redis.external.host is required when objectCache.redis.mode=external" -}}
-  {{- end -}}
-  {{- if and .Values.objectCache.redis.auth.enabled (eq .Values.objectCache.redis.mode "external") (not .Values.objectCache.redis.auth.existingSecret) (not .Values.objectCache.redis.auth.password) -}}
-    {{- fail "objectCache.redis.auth.existingSecret or objectCache.redis.auth.password is required when external Redis auth is enabled" -}}
+  {{- if eq (include "wordpress.objectCacheProvider" .) "memcached" -}}
+    {{- if not (has .Values.objectCache.memcached.mode (list "subchart" "external")) -}}
+      {{- fail "objectCache.memcached.mode must be subchart or external" -}}
+    {{- end -}}
+    {{- if and (eq .Values.objectCache.memcached.mode "subchart") (not .Values.objectCache.memcached.subchart.enabled) -}}
+      {{- fail "objectCache.memcached.subchart.enabled must be true when objectCache.memcached.mode=subchart" -}}
+    {{- end -}}
+    {{- if and (eq .Values.objectCache.memcached.mode "external") (not .Values.objectCache.memcached.external.host) -}}
+      {{- fail "objectCache.memcached.external.host is required when objectCache.memcached.mode=external" -}}
+    {{- end -}}
+    {{- if and (or (eq .Values.image.repository "docker.io/library/wordpress") (eq .Values.plugins.installer.image.repository "docker.io/library/wordpress")) (not .Values.objectCache.memcached.allowOfficialImageWithoutExtension) -}}
+      {{- fail "objectCache.provider=memcached requires custom WordPress and installer images with the php-memcached extension, or set objectCache.memcached.allowOfficialImageWithoutExtension=true to acknowledge the official image limitation" -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- range $i, $plugin := .Values.plugins.items }}
   {{- if not $plugin.slug -}}
     {{- fail (printf "plugins.items[%d].slug is required" $i) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate bootstrap settings */}}
+{{- define "wordpress.validateBootstrap" -}}
+{{- if .Values.bootstrap.enabled -}}
+  {{- if not .Values.persistence.enabled -}}
+    {{- fail "bootstrap.enabled requires persistence.enabled=true so WordPress files and wp-config.php are shared with the bootstrap Job" -}}
+  {{- end -}}
+  {{- if not (include "wordpress.bootstrapSiteUrl" .) -}}
+    {{- fail "bootstrap.enabled requires bootstrap.siteUrl or wordpress.siteUrl" -}}
+  {{- end -}}
+  {{- if not (has .Values.wordpress.multisite.mode (list "subdirectory" "subdomain")) -}}
+    {{- fail "wordpress.multisite.mode must be subdirectory or subdomain" -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/wordpress/templates/bootstrap-job.yaml
+++ b/charts/wordpress/templates/bootstrap-job.yaml
@@ -27,7 +27,14 @@ spec:
         app.kubernetes.io/component: bootstrap
     spec:
       restartPolicy: Never
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.bootstrap.preferWordPressPodNode .Values.persistence.enabled }}
       affinity:
         podAffinity:

--- a/charts/wordpress/templates/bootstrap-job.yaml
+++ b/charts/wordpress/templates/bootstrap-job.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/component: bootstrap
     spec:
       restartPolicy: Never
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/wordpress/templates/bootstrap-job.yaml
+++ b/charts/wordpress/templates/bootstrap-job.yaml
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+{{- include "wordpress.validateBootstrap" . }}
+{{- if eq (include "wordpress.bootstrapJobEnabled" .) "true" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "wordpress.fullname" . }}-bootstrap
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: bootstrap
+  {{- if .Values.bootstrap.useHelmHooks }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": {{ .Values.bootstrap.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.bootstrap.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.bootstrap.activeDeadlineSeconds }}
+  {{- with .Values.bootstrap.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "wordpress.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: bootstrap
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- if and .Values.bootstrap.preferWordPressPodNode .Values.persistence.enabled }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "wordpress.selectorLabels" . | nindent 18 }}
+                  app.kubernetes.io/component: wordpress
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
+      containers:
+        - name: bootstrap
+          image: "{{ .Values.bootstrap.image.repository }}:{{ .Values.bootstrap.image.tag }}"
+          imagePullPolicy: {{ .Values.bootstrap.image.pullPolicy }}
+          workingDir: /var/www/html
+          {{- with .Values.bootstrap.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -ec
+            - |
+              wait_for_wordpress_files() {
+                for i in $(seq 1 60); do
+                  if [ -f /var/www/html/wp-config.php ] && [ -d /var/www/html/wp-content ]; then
+                    return 0
+                  fi
+                  echo "Waiting for WordPress files on the shared volume..."
+                  sleep 2
+                done
+                echo "WordPress files were not initialized in time." >&2
+                return 1
+              }
+
+              wait_for_wordpress_files
+
+              if wp core is-installed --path=/var/www/html >/dev/null 2>&1; then
+                if [ "$BOOTSTRAP_SKIP_IF_INSTALLED" = "true" ]; then
+                  echo "WordPress is already installed; bootstrap skipped."
+                  exit 0
+                fi
+                echo "WordPress is already installed and bootstrap.skipIfInstalled=false." >&2
+                exit 1
+              fi
+
+              if [ "$WORDPRESS_MULTISITE_ENABLED" = "true" ]; then
+                args=""
+                if [ "$WORDPRESS_MULTISITE_MODE" = "subdomain" ]; then
+                  args="--subdomains"
+                fi
+                wp core multisite-install \
+                  --path=/var/www/html \
+                  --url="$BOOTSTRAP_SITE_URL" \
+                  --title="$BOOTSTRAP_SITE_TITLE" \
+                  --admin_user="$BOOTSTRAP_ADMIN_USER" \
+                  --admin_password="$BOOTSTRAP_ADMIN_PASSWORD" \
+                  --admin_email="$BOOTSTRAP_ADMIN_EMAIL" \
+                  --skip-email \
+                  $args
+              else
+                wp core install \
+                  --path=/var/www/html \
+                  --url="$BOOTSTRAP_SITE_URL" \
+                  --title="$BOOTSTRAP_SITE_TITLE" \
+                  --admin_user="$BOOTSTRAP_ADMIN_USER" \
+                  --admin_password="$BOOTSTRAP_ADMIN_PASSWORD" \
+                  --admin_email="$BOOTSTRAP_ADMIN_EMAIL" \
+                  --skip-email
+              fi
+
+              if [ -n "$BOOTSTRAP_LANGUAGE" ]; then
+                wp language core install "$BOOTSTRAP_LANGUAGE" --activate --path=/var/www/html
+              fi
+
+              if [ -n "$BOOTSTRAP_PERMALINK_STRUCTURE" ]; then
+                wp rewrite structure "$BOOTSTRAP_PERMALINK_STRUCTURE" --hard --path=/var/www/html
+              fi
+          env:
+            - name: BOOTSTRAP_SITE_URL
+              value: {{ include "wordpress.bootstrapSiteUrl" . | quote }}
+            - name: BOOTSTRAP_SITE_TITLE
+              value: {{ include "wordpress.bootstrapSiteTitle" . | quote }}
+            - name: BOOTSTRAP_ADMIN_USER
+              value: {{ include "wordpress.bootstrapAdminUser" . | quote }}
+            - name: BOOTSTRAP_ADMIN_EMAIL
+              value: {{ include "wordpress.bootstrapAdminEmail" . | quote }}
+            - name: BOOTSTRAP_SKIP_IF_INSTALLED
+              value: {{ .Values.bootstrap.skipIfInstalled | quote }}
+            - name: BOOTSTRAP_LANGUAGE
+              value: {{ .Values.bootstrap.language | quote }}
+            - name: BOOTSTRAP_PERMALINK_STRUCTURE
+              value: {{ .Values.bootstrap.permalinkStructure | quote }}
+            - name: WORDPRESS_MULTISITE_ENABLED
+              value: {{ .Values.wordpress.multisite.enabled | quote }}
+            - name: WORDPRESS_MULTISITE_MODE
+              value: {{ .Values.wordpress.multisite.mode | quote }}
+            - name: BOOTSTRAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.adminSecretName" . }}
+                  key: {{ include "wordpress.adminSecretKey" . }}
+            - name: WORDPRESS_DB_HOST
+              value: {{ printf "%s:%s" (include "wordpress.databaseHost" .) (include "wordpress.databasePort" .) | quote }}
+            - name: WORDPRESS_DB_NAME
+              value: {{ include "wordpress.databaseName" . | quote }}
+            - name: WORDPRESS_DB_USER
+              value: {{ include "wordpress.databaseUsername" . | quote }}
+            - name: WORDPRESS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.databaseSecretName" . }}
+                  key: {{ include "wordpress.databaseSecretKey" . }}
+          {{- with .Values.bootstrap.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: wordpress-data
+              mountPath: /var/www/html
+      volumes:
+        - name: wordpress-data
+          persistentVolumeClaim:
+            claimName: {{ default (include "wordpress.fullname" .) .Values.persistence.existingClaim }}
+{{- end }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+{{- include "wordpress.validateBootstrap" . }}
+{{- include "wordpress.validatePlugins" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/wordpress/templates/networkpolicy.yaml
+++ b/charts/wordpress/templates/networkpolicy.yaml
@@ -54,7 +54,7 @@ spec:
     []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
-  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespaceDatabase .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowSMTP .Values.networkPolicy.egress.extraTo }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespaceDatabase (and .Values.networkPolicy.egress.allowSameNamespaceCache .Values.objectCache.enabled) .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowSMTP .Values.networkPolicy.egress.extraTo }}
   egress:
     {{- if $allowEgress }}
     {{- if .Values.networkPolicy.egress.allowDNS }}
@@ -77,6 +77,16 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.egress.databasePort }}
+    {{- end }}
+    {{- if and .Values.networkPolicy.egress.allowSameNamespaceCache .Values.objectCache.enabled }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ ternary .Values.objectCache.memcached.port .Values.objectCache.redis.port (eq (include "wordpress.objectCacheProvider" .) "memcached") }}
     {{- end }}
     {{- if .Values.networkPolicy.egress.allowHTTPS }}
     - to:

--- a/charts/wordpress/templates/plugin-installer-job.yaml
+++ b/charts/wordpress/templates/plugin-installer-job.yaml
@@ -128,10 +128,21 @@ spec:
               install_plugin {{ default "" .slug | quote }} {{ $activate | quote }} {{ $skipIfInstalled | quote }}
               {{- end }}
               {{- if and .Values.objectCache.enabled .Values.objectCache.installPlugin }}
+              {{- if eq (include "wordpress.objectCacheRedisEnabled" .) "true" }}
               install_plugin "redis-cache" "true" "true"
               {{- end }}
+              {{- if eq (include "wordpress.objectCacheMemcachedEnabled" .) "true" }}
+              if [ {{ .Values.objectCache.memcached.validatePhpExtension | quote }} = "true" ]; then
+                if ! php -m | grep -Eiq '^{{ .Values.objectCache.memcached.requiredPhpExtension }}$'; then
+                  echo "PHP extension {{ .Values.objectCache.memcached.requiredPhpExtension }} is required for Memcached object cache." >&2
+                  exit 1
+                fi
+              fi
+              install_plugin {{ .Values.objectCache.memcached.pluginSlug | quote }} "true" "true"
+              {{- end }}
+              {{- end }}
 
-              {{- if and .Values.objectCache.enabled .Values.objectCache.enableDropIn }}
+              {{- if and (eq (include "wordpress.objectCacheRedisEnabled" .) "true") .Values.objectCache.enableDropIn }}
               if [ -f /var/www/html/wp-content/object-cache.php ]; then
                 echo "Redis object-cache.php drop-in already exists."
               elif [ -f /var/www/html/wp-content/plugins/redis-cache/includes/object-cache.php ]; then

--- a/charts/wordpress/templates/plugin-installer-job.yaml
+++ b/charts/wordpress/templates/plugin-installer-job.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/component: plugin-installer
     spec:
       restartPolicy: Never
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
       {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/wordpress/templates/plugin-installer-job.yaml
+++ b/charts/wordpress/templates/plugin-installer-job.yaml
@@ -27,7 +27,14 @@ spec:
         app.kubernetes.io/component: plugin-installer
     spec:
       restartPolicy: Never
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
+      {{- end }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.plugins.installer.preferWordPressPodNode .Values.persistence.enabled }}
       affinity:
         podAffinity:
@@ -154,6 +161,25 @@ spec:
               else
                 echo "Redis plugin files are missing; cannot create object-cache.php." >&2
                 exit 1
+              fi
+              {{- end }}
+
+              {{- if and (eq (include "wordpress.objectCacheMemcachedEnabled" .) "true") .Values.objectCache.enableDropIn }}
+              if [ -f /var/www/html/wp-content/object-cache.php ]; then
+                echo "Memcached object-cache.php drop-in already exists."
+              else
+                memcached_plugin={{ .Values.objectCache.memcached.pluginSlug | quote }}
+                memcached_dropin="$(find "/var/www/html/wp-content/plugins/${memcached_plugin}" -path "*/object-cache.php" -type f | head -n 1 || true)"
+                if [ -n "$memcached_dropin" ]; then
+                  echo "Creating Memcached object-cache.php drop-in."
+                  cp "$memcached_dropin" /var/www/html/wp-content/object-cache.php
+                elif is_installed; then
+                  echo "Enabling Memcached object-cache.php drop-in through WP-CLI."
+                  wp total-cache fix_environment --path=/var/www/html --allow-root
+                else
+                  echo "Memcached plugin files are missing; cannot create object-cache.php." >&2
+                  exit 1
+                fi
               fi
               {{- end }}
           env:

--- a/charts/wordpress/tests/bootstrap_test.yaml
+++ b/charts/wordpress/tests/bootstrap_test.yaml
@@ -18,6 +18,9 @@ tests:
       wordpress.siteTitle: Example Blog
       wordpress.adminUser: editor
       wordpress.adminEmail: editor@example.com
+      serviceAccount.create: true
+      imagePullSecrets:
+        - name: registry-auth
     asserts:
       - isKind:
           of: Job
@@ -30,6 +33,12 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
           value: "0"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-wordpress
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: registry-auth
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -73,6 +82,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "bootstrap.enabled requires bootstrap.siteUrl or wordpress.siteUrl"
+
+  - it: should reject an invalid multisite mode
+    set:
+      bootstrap.enabled: true
+      wordpress.siteUrl: https://blog.example.com
+      wordpress.multisite.mode: invalid
+    asserts:
+      - failedTemplate:
+          errorPattern: "value must be one of 'subdirectory', 'subdomain'"
 
   - it: should require persistence when enabled
     set:

--- a/charts/wordpress/tests/bootstrap_test.yaml
+++ b/charts/wordpress/tests/bootstrap_test.yaml
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Bootstrap
+templates:
+  - templates/bootstrap-job.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a WP-CLI bootstrap hook job
+    set:
+      bootstrap.enabled: true
+      wordpress.siteUrl: https://blog.example.com
+      wordpress.siteTitle: Example Blog
+      wordpress.adminUser: editor
+      wordpress.adminEmail: editor@example.com
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: test-wordpress-bootstrap
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-install,post-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BOOTSTRAP_SITE_URL
+            value: https://blog.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BOOTSTRAP_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-wordpress-admin
+                key: admin-password
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "wp core install"
+
+  - it: should use multisite bootstrap when multisite is enabled
+    set:
+      bootstrap.enabled: true
+      wordpress.siteUrl: https://network.example.com
+      wordpress.multisite.enabled: true
+      wordpress.multisite.mode: subdomain
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "wp core multisite-install"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "--subdomains"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WORDPRESS_MULTISITE_ENABLED
+            value: "true"
+
+  - it: should require a site URL when enabled
+    set:
+      bootstrap.enabled: true
+      wordpress.siteUrl: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "bootstrap.enabled requires bootstrap.siteUrl or wordpress.siteUrl"
+
+  - it: should require persistence when enabled
+    set:
+      bootstrap.enabled: true
+      wordpress.siteUrl: https://blog.example.com
+      persistence.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "bootstrap.enabled requires persistence.enabled=true so WordPress files and wp-config.php are shared with the bootstrap Job"

--- a/charts/wordpress/tests/bootstrap_test.yaml
+++ b/charts/wordpress/tests/bootstrap_test.yaml
@@ -18,7 +18,7 @@ tests:
       wordpress.siteTitle: Example Blog
       wordpress.adminUser: editor
       wordpress.adminEmail: editor@example.com
-      serviceAccount.create: true
+      serviceAccount.name: existing-wordpress
       imagePullSecrets:
         - name: registry-auth
     asserts:
@@ -35,7 +35,7 @@ tests:
           value: "0"
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: test-wordpress
+          value: existing-wordpress
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: registry-auth

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -45,6 +45,15 @@ tests:
           path: spec.template.spec.automountServiceAccountToken
           value: false
 
+  - it: should use a configured existing service account
+    template: templates/deployment.yaml
+    set:
+      serviceAccount.name: existing-wordpress
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-wordpress
+
   - it: should use default image tag with appVersion
     template: templates/deployment.yaml
     asserts:

--- a/charts/wordpress/tests/deployment_test.yaml
+++ b/charts/wordpress/tests/deployment_test.yaml
@@ -138,6 +138,7 @@ tests:
       wordpress.forceSSLAdmin: true
       wordpress.disallowFileEdit: true
       wordpress.disableWpCron: true
+      wordpress.multisite.enabled: true
       wordpress.memoryLimit: 256M
       wordpress.maxMemoryLimit: 512M
     asserts:
@@ -150,6 +151,9 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].env[5].value
           pattern: "DISABLE_WP_CRON"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "WP_ALLOW_MULTISITE"
 
   - it: should configure Redis object cache env and wp-config constants
     template: templates/deployment.yaml
@@ -212,6 +216,36 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].env[5].value
           pattern: "WP_REDIS_PASSWORD"
+
+  - it: should configure Memcached object cache constants with a custom image
+    template: templates/deployment.yaml
+    set:
+      image.repository: example.com/custom-wordpress
+      plugins.installer.image.repository: example.com/custom-wordpress-cli
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.provider: memcached
+      objectCache.memcached.subchart.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "memcached_servers"
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[5].value
+          pattern: "test-memcached:11211"
+
+  - it: should reject Memcached with the official image unless explicitly acknowledged
+    template: templates/deployment.yaml
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.provider: memcached
+      objectCache.memcached.subchart.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "objectCache.provider=memcached requires custom WordPress and installer images with the php-memcached extension, or set objectCache.memcached.allowOfficialImageWithoutExtension=true to acknowledge the official image limitation"
 
   - it: should include extra env vars
     template: templates/deployment.yaml

--- a/charts/wordpress/tests/networkpolicy_test.yaml
+++ b/charts/wordpress/tests/networkpolicy_test.yaml
@@ -46,6 +46,38 @@ tests:
             protocol: TCP
             port: 443
 
+  - it: should allow Redis cache egress when object cache is enabled
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+    asserts:
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            protocol: TCP
+            port: 6379
+
+  - it: should allow Memcached cache egress when object cache is enabled
+    set:
+      image.repository: example.com/custom-wordpress
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.provider: memcached
+      objectCache.memcached.subchart.enabled: true
+    asserts:
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            protocol: TCP
+            port: 11211
+
   - it: should render empty ingress list for default deny ingress
     set:
       networkPolicy.enabled: true

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -53,6 +53,36 @@ tests:
                 name: test-redis-auth
                 key: redis-password
 
+  - it: should install Memcached cache plugin with a custom image
+    set:
+      image.repository: example.com/custom-wordpress
+      plugins.installer.image.repository: example.com/custom-wordpress-cli
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.provider: memcached
+      objectCache.memcached.subchart.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "PHP extension memcached is required"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "install_plugin \"w3-total-cache\""
+
+  - it: should allow explicitly acknowledged Memcached with the official image
+    set:
+      plugins.enabled: true
+      plugins.installer.enabled: true
+      objectCache.enabled: true
+      objectCache.provider: memcached
+      objectCache.memcached.subchart.enabled: true
+      objectCache.memcached.allowOfficialImageWithoutExtension: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "install_plugin \"w3-total-cache\""
+
   - it: should use Redis subchart existingSecret in installer job
     set:
       plugins.enabled: true
@@ -102,6 +132,15 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "plugins.enabled must be true when objectCache.enabled is true"
+
+  - it: should require installer when object cache manages plugins or drop-ins
+    set:
+      plugins.enabled: true
+      objectCache.enabled: true
+      objectCache.redis.subchart.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "plugins.installer.enabled must be true when objectCache.installPlugin or objectCache.enableDropIn is true"
 
   - it: should require persistence for installer job writes
     set:

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -15,7 +15,7 @@ tests:
     set:
       plugins.enabled: true
       plugins.installer.enabled: true
-      serviceAccount.create: true
+      serviceAccount.name: existing-wordpress
       imagePullSecrets:
         - name: registry-auth
       plugins.items:
@@ -32,7 +32,7 @@ tests:
           value: post-install,post-upgrade
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: test-wordpress
+          value: existing-wordpress
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: registry-auth

--- a/charts/wordpress/tests/plugin_installer_test.yaml
+++ b/charts/wordpress/tests/plugin_installer_test.yaml
@@ -15,6 +15,9 @@ tests:
     set:
       plugins.enabled: true
       plugins.installer.enabled: true
+      serviceAccount.create: true
+      imagePullSecrets:
+        - name: registry-auth
       plugins.items:
         - slug: classic-editor
           activate: true
@@ -27,6 +30,12 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: post-install,post-upgrade
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-wordpress
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: registry-auth
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "install_plugin \"classic-editor\""
@@ -69,6 +78,12 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "install_plugin \"w3-total-cache\""
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "Creating Memcached object-cache.php drop-in"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "wp total-cache fix_environment"
 
   - it: should allow explicitly acknowledged Memcached with the official image
     set:

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -90,6 +90,21 @@
           "type": "boolean",
           "description": "Disable WordPress pseudo-cron (DISABLE_WP_CRON)"
         },
+        "multisite": {
+          "type": "object",
+          "description": "WordPress multisite configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable WordPress multisite constants in wp-config.php"
+            },
+            "mode": {
+              "type": "string",
+              "description": "Multisite mode used by bootstrap",
+              "enum": ["subdirectory", "subdomain"]
+            }
+          }
+        },
         "memoryLimit": {
           "type": "string",
           "description": "WordPress frontend memory limit (WP_MEMORY_LIMIT)"
@@ -126,6 +141,37 @@
           "type": "string",
           "description": "Key in the existing secret for the admin password"
         }
+      }
+    },
+    "bootstrap": {
+      "type": "object",
+      "description": "WP-CLI bootstrap Job for initial WordPress installation",
+      "properties": {
+        "enabled": { "type": "boolean", "description": "Install WordPress core with WP-CLI when not initialized" },
+        "skipIfInstalled": { "type": "boolean", "description": "Skip bootstrap when WordPress is already installed" },
+        "siteUrl": { "type": "string", "description": "Full site URL used by wp core install" },
+        "siteTitle": { "type": "string", "description": "Site title used by wp core install" },
+        "adminUser": { "type": "string", "description": "Admin username used by wp core install" },
+        "adminEmail": { "type": "string", "description": "Admin email used by wp core install" },
+        "permalinkStructure": { "type": "string", "description": "Permalink structure applied after install" },
+        "language": { "type": "string", "description": "Optional WordPress locale installed after bootstrap" },
+        "useHelmHooks": { "type": "boolean", "description": "Run bootstrap as a Helm hook" },
+        "hookWeight": { "type": "string", "description": "Helm hook weight" },
+        "image": {
+          "type": "object",
+          "description": "WordPress CLI image used by bootstrap",
+          "properties": {
+            "repository": { "type": "string", "description": "Image repository" },
+            "tag": { "type": "string", "description": "Image tag" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Image pull policy" }
+          }
+        },
+        "backoffLimit": { "type": "integer", "description": "Job backoff limit" },
+        "activeDeadlineSeconds": { "type": "integer", "description": "Job active deadline" },
+        "ttlSecondsAfterFinished": { "type": ["integer", "null"], "description": "Job TTL after finish" },
+        "resources": { "type": "object", "description": "Bootstrap resources" },
+        "securityContext": { "type": "object", "description": "Bootstrap container security context" },
+        "preferWordPressPodNode": { "type": "boolean", "description": "Schedule near WordPress pods for ReadWriteOnce PVCs" }
       }
     },
     "database": {
@@ -520,7 +566,7 @@
       "description": "WordPress persistent object cache integration",
       "properties": {
         "enabled": { "type": "boolean", "description": "Enable object cache integration" },
-        "provider": { "type": "string", "enum": ["redis-cache"], "description": "Object cache provider" },
+        "provider": { "type": "string", "enum": ["redis", "memcached"], "description": "Object cache provider" },
         "installPlugin": { "type": "boolean", "description": "Install the object cache plugin" },
         "enableDropIn": { "type": "boolean", "description": "Create the object-cache.php drop-in" },
         "redis": {
@@ -538,6 +584,20 @@
             "maxTtl": { "type": ["integer", "string"], "description": "Maximum TTL for Redis cache keys" },
             "auth": { "type": "object", "description": "Redis authentication settings" }
           }
+        },
+        "memcached": {
+          "type": "object",
+          "description": "Memcached object cache settings",
+          "properties": {
+            "mode": { "type": "string", "enum": ["subchart", "external"], "description": "Memcached deployment mode" },
+            "subchart": { "type": "object", "description": "HelmForge Memcached subchart settings" },
+            "external": { "type": "object", "description": "External Memcached settings" },
+            "port": { "type": "integer", "description": "Memcached port" },
+            "pluginSlug": { "type": "string", "description": "Plugin installed for Memcached cache wiring" },
+            "requiredPhpExtension": { "type": "string", "description": "PHP extension required by the Memcached object cache plugin" },
+            "allowOfficialImageWithoutExtension": { "type": "boolean", "description": "Allow official WordPress image despite missing php-memcached" },
+            "validatePhpExtension": { "type": "boolean", "description": "Validate PHP extension availability in the installer job" }
+          }
         }
       }
     },
@@ -548,7 +608,21 @@
         "enabled": { "type": "boolean", "description": "Create a NetworkPolicy for WordPress pods" },
         "ingress": { "type": "object", "description": "Ingress policy rules" },
         "metrics": { "type": "object", "description": "Metrics ingress policy rules" },
-        "egress": { "type": "object", "description": "Egress policy rules" }
+        "egress": {
+          "type": "object",
+          "description": "Egress policy rules",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Manage egress allow list" },
+            "allowDNS": { "type": "boolean", "description": "Allow DNS egress" },
+            "allowSameNamespaceDatabase": { "type": "boolean", "description": "Allow database egress in the same namespace" },
+            "databasePort": { "type": "integer", "description": "Database egress port" },
+            "allowSameNamespaceCache": { "type": "boolean", "description": "Allow object cache egress in the same namespace" },
+            "allowHTTPS": { "type": "boolean", "description": "Allow HTTPS egress" },
+            "allowSMTP": { "type": "boolean", "description": "Allow SMTP egress" },
+            "smtpPort": { "type": "integer", "description": "SMTP egress port" },
+            "extraTo": { "type": "array", "description": "Additional egress destinations", "items": { "type": "object" } }
+          }
+        }
       }
     },
     "externalSecrets": {

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -70,6 +70,12 @@ wordpress:
   # -- Disable WordPress pseudo-cron. Pair with wpCron.cronJob.enabled for scheduled execution.
   disableWpCron: false
 
+  multisite:
+    # -- Enable WordPress multisite constants in wp-config.php.
+    enabled: false
+    # -- Multisite mode used by bootstrap when creating a new network: subdirectory or subdomain.
+    mode: subdirectory
+
   # -- WordPress frontend memory limit (WP_MEMORY_LIMIT)
   memoryLimit: ""
 
@@ -104,6 +110,47 @@ admin:
 
   # -- Key in the existing secret for the admin password
   existingSecretPasswordKey: admin-password
+
+# =============================================================================
+# WordPress Bootstrap
+# =============================================================================
+
+bootstrap:
+  # -- Install WordPress core with WP-CLI when the database is not initialized yet.
+  enabled: false
+  # -- Skip bootstrap when wp core is already installed.
+  skipIfInstalled: true
+  # -- Full site URL used by wp core install. Defaults to wordpress.siteUrl.
+  siteUrl: ""
+  # -- Site title used by wp core install. Defaults to wordpress.siteTitle.
+  siteTitle: ""
+  # -- Admin username used by wp core install. Defaults to wordpress.adminUser.
+  adminUser: ""
+  # -- Admin email used by wp core install. Defaults to wordpress.adminEmail.
+  adminEmail: ""
+  # -- Permalink structure applied after installation. Empty leaves WordPress default.
+  permalinkStructure: ""
+  # -- Optional locale installed and activated after core installation, for example pt_BR.
+  language: ""
+  # -- Hook annotations make the Job run after install/upgrade and before plugin installation.
+  useHelmHooks: true
+  hookWeight: "0"
+  image:
+    # -- WordPress CLI image used by the bootstrap Job.
+    repository: docker.io/library/wordpress
+    tag: cli-php8.3
+    pullPolicy: IfNotPresent
+  backoffLimit: 1
+  activeDeadlineSeconds: 180
+  ttlSecondsAfterFinished: 300
+  resources: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 33
+    runAsGroup: 33
+  # -- Prefer scheduling the Job on nodes already running WordPress pods. Useful with ReadWriteOnce PVCs.
+  preferWordPressPodNode: true
 
 # =============================================================================
 # Database
@@ -421,7 +468,8 @@ plugins:
 objectCache:
   # -- Enable WordPress persistent object cache integration.
   enabled: false
-  provider: redis-cache
+  # -- Object cache provider: redis or memcached.
+  provider: redis
   # -- Install/activate the Redis Object Cache plugin and enable the object-cache.php drop-in.
   installPlugin: true
   enableDropIn: true
@@ -444,6 +492,35 @@ objectCache:
       password: ""
       existingSecret: ""
       existingSecretPasswordKey: redis-password
+  memcached:
+    # -- Memcached mode: subchart or external.
+    mode: subchart
+    subchart:
+      # -- Deploy HelmForge Memcached as a subchart when objectCache.provider=memcached.
+      enabled: false
+    external:
+      host: ""
+    port: 11211
+    # -- Plugin used for Memcached cache wiring.
+    pluginSlug: w3-total-cache
+    # -- PHP extension expected in the WordPress image. Official wordpress images do not ship this extension.
+    requiredPhpExtension: memcached
+    # -- Allow the official WordPress image even though it does not ship the required Memcached PHP extension.
+    allowOfficialImageWithoutExtension: false
+    # -- Validate that the required PHP extension is loaded before installing/configuring Memcached cache.
+    validatePhpExtension: true
+
+# =============================================================================
+# Memcached Subchart
+# =============================================================================
+# When objectCache.provider is memcached and objectCache.memcached.mode is
+# subchart, the chart deploys HelmForge Memcached as a subchart dependency.
+# The default official WordPress image does not include php-memcached, so use a
+# custom WordPress image or explicitly acknowledge that limitation.
+# =============================================================================
+
+memcached:
+  enabled: false
 
 # =============================================================================
 # NetworkPolicy
@@ -471,6 +548,8 @@ networkPolicy:
     allowSameNamespaceDatabase: true
     # -- Database port allowed when allowSameNamespaceDatabase=true
     databasePort: 3306
+    # -- Allow TCP egress to object cache pods in the same namespace when objectCache.enabled=true
+    allowSameNamespaceCache: true
     # -- Allow HTTPS egress for updates, plugin/theme downloads, APIs, and object storage endpoints
     allowHTTPS: false
     # -- Allow SMTP egress when a mail plugin or SMTP configuration needs it


### PR DESCRIPTION
## Summary

Adds WordPress chart support for WP-CLI bootstrap and selectable object cache providers.

Related to #323

## Changes

- Adds an optional bootstrap Job that can run initial `wp core install`, permalink setup, locale activation, and multisite install.
- Adds `objectCache.provider` with `redis` and `memcached` modes.
- Adds HelmForge Memcached as an optional subchart dependency.
- Keeps Redis as the plug-and-play provider for the official WordPress image.
- Guards Memcached usage because the official WordPress image does not ship the `php-memcached` extension.
- Makes WordPress CI profiles deterministic for k3d by replacing external fixture hosts and fake images with local disposable fixtures.
- Addresses review feedback for Job service accounts, private image pulls, and Memcached drop-in creation.

## Breaking change

`objectCache.provider=redis-cache` is no longer accepted. Use `objectCache.provider=redis`.

## Site sync

Related to helmforgedev/site#388
Site PR: helmforgedev/site#388

## Validation

- `helm lint charts/wordpress --strict`
- `helm unittest charts/wordpress` - 125 tests passed
- `make standards-check CHART=wordpress`
- `make site-sync-check CHART=wordpress`
- `make validate-chart CHART=wordpress` - fully validated, 24 layers including all k3d scenarios
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Notes: `make release-check REPO=charts` reports expected warnings for touching `Chart.yaml` dependency metadata and for confirming the chart release after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm-managed WordPress bootstrap Job for idempotent initial setup (including multisite, admin credentials, language, and permalink structure).
  * Expanded object cache configuration to support both Redis and Memcached, including provider-specific plugin installation and Memcached drop-in wiring.
  * Updated NetworkPolicy egress rules to allow traffic to the configured cache backend.
* **Documentation**
  * Updated README/design/production docs and examples for bootstrap and Memcached object-cache requirements.
* **Tests**
  * Added/expanded Helm template coverage for bootstrap, NetworkPolicy cache egress, and Memcached installer flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->