### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -54,6 +54,6 @@ annotations:
 dependencies:
   - name: elasticsearch
     alias: bundled-elasticsearch
-    version: 1.1.3
+    version: 1.1.4
     repository: oci://ghcr.io/helmforgedev/helm
     condition: bundledElasticsearch.enabled


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- kibana: elasticsearch 1.1.3 -> 1.1.4

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Elasticsearch chart to version 1.1.4 for improved deployment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->