### PR TITLE
chore(changedetection): bump image to 0.55.8

### DIFF
--- a/charts/changedetection/Chart.yaml
+++ b/charts/changedetection/Chart.yaml
@@ -4,7 +4,7 @@ name: changedetection
 description: changedetection.io website change detection and monitoring with optional Playwright browser
 type: application
 version: 1.1.13
-appVersion: "0.55.7"
+appVersion: "0.55.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/changedetection/README.md
+++ b/charts/changedetection/README.md
@@ -243,7 +243,7 @@ probes:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/dgtlmoon/changedetection.io` | changedetection.io image repository |
-| `image.tag` | `0.55.7` | changedetection.io image tag |
+| `image.tag` | `0.55.8` | changedetection.io image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `changedetection.port` | `5000` | Application port |
 | `changedetection.baseUrl` | `""` | Public base URL |
@@ -283,10 +283,11 @@ probes:
 
 ## Upgrade Notes
 
-For this release the application image is updated to `0.55.7`. The upstream
+For this release the application image is updated to `0.55.8`. The upstream
 `0.55.6` release includes a security fix for an SSRF parser differential,
 notification and preview fixes, plus an `LLM_FEATURES_DISABLED` flag. The
-`0.55.7` release fixes the LLM settings UI path. Review the upstream changelog
+`0.55.8` release adds translation updates and fixes page title extraction,
+password-protected RSS feeds, URL fragments, restock tokens, and LLM handling. Review the upstream changelog
 before production rollout and test restores from the `/datastore` backup when
 upgrading long-lived instances.
 

--- a/charts/changedetection/tests/deployment_test.yaml
+++ b/charts/changedetection/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.7"
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.8"
 
   - it: should expose port 5000
     asserts:
@@ -140,7 +140,7 @@ tests:
           value: initialize-datastore
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.7"
+          value: "ghcr.io/dgtlmoon/changedetection.io:0.55.8"
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "include_default_watches=False"

--- a/charts/changedetection/values.schema.json
+++ b/charts/changedetection/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/dgtlmoon/changedetection.io" },
-        "tag": { "type": "string", "default": "0.55.7" },
+        "tag": { "type": "string", "default": "0.55.8" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/changedetection/values.yaml
+++ b/charts/changedetection/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- changedetection.io container image
   repository: ghcr.io/dgtlmoon/changedetection.io
   # -- Image tag
-  tag: "0.55.7"
+  tag: "0.55.8"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- Bump the official changedetection.io image and appVersion from 0.55.7 to 0.55.8.
- Keep values, schema, unit tests, and README defaults aligned.
- Document upstream fixes for title extraction, protected RSS feeds, URL fragments, restock tokens, and LLM handling.

## Upstream Evidence

- Manifest verified for linux/amd64, linux/arm64, and linux/arm.
- Stable release: https://github.com/dgtlmoon/changedetection.io/releases/tag/0.55.8
- Full changelog: https://github.com/dgtlmoon/changedetection.io/compare/0.55.7...0.55.8
- No breaking changes or new runtime requirements identified.

## Quality Gates

- [x] make validate-chart CHART=changedetection (15 layers, all k3d scenarios)
- [x] make standards-check CHART=changedetection
- [x] template standards check with zero warnings for changedetection
- [x] make deps-check CHART=changedetection
- [x] make md-lint REPO=charts
- [x] make preflight
- [x] Kubescape MITRE + NSA + SOC2: 87.88%

## Site Sync

- Site PR: helmforgedev/site#394

Closes #732
