### PR TITLE
chore(clickhouse): bump image to 26.6.1

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -4,7 +4,7 @@ name: clickhouse
 description: Fast column-oriented OLAP database with production-safe standalone defaults
 type: application
 version: 1.0.0
-appVersion: "25.8.28.1"
+appVersion: "26.6.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -15,7 +15,7 @@ helm install clickhouse oci://ghcr.io/helmforgedev/helm/clickhouse
 
 ## Features
 
-- Official ClickHouse image pinned to `25.8.28.1`.
+- Official ClickHouse image pinned to `26.6.1`.
 - StatefulSet with persistent data volume.
 - Client Service exposing HTTP `8123` and native TCP `9000`.
 - Headless Service for stable pod DNS.
@@ -55,7 +55,7 @@ networkPolicy:
 | --- | --- | --- |
 | `replicaCount` | ClickHouse pod count. Must remain `1` | `1` |
 | `image.repository` | Official image repository | `docker.io/clickhouse/clickhouse-server` |
-| `image.tag` | Official full-version tag | `25.8.28.1` |
+| `image.tag` | Official full-version tag | `26.6.1` |
 | `clickhouse.database` | Initial database | `default` |
 | `clickhouse.user` | Initial user | `default` |
 | `clickhouse.password` | Initial password | `""` |
@@ -100,6 +100,13 @@ ClickHouse replication needs Keeper or ZooKeeper, cluster definitions, and
 cluster-aware operations. This chart intentionally blocks `replicaCount > 1`.
 Use the ClickHouse Operator or Altinity operator stack for sharded or replicated
 clusters.
+
+## Upgrade Notes
+
+This release moves ClickHouse from the 25.8 LTS line to 26.6 stable. Review the
+upstream release notes and test application queries, persisted data, and backup
+restore procedures before upgrading production workloads. StatefulSet rolling
+updates reuse the existing data volume; take a verified backup first.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/clickhouse/tests/statefulset_test.yaml
+++ b/charts/clickhouse/tests/statefulset_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/clickhouse/clickhouse-server:25.8.28.1
+          value: docker.io/clickhouse/clickhouse-server:26.6.1
   - it: exposes HTTP and native TCP ports
     template: statefulset.yaml
     asserts:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official ClickHouse image repository
   repository: docker.io/clickhouse/clickhouse-server
   # -- Official full-version tag
-  tag: "25.8.28.1"
+  tag: "26.6.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official ClickHouse server image from 25.8.28.1 to 26.6.1
- update chart metadata, defaults, unit expectations, and upgrade guidance
- document the 25.8 LTS to 26.6 stable compatibility boundary

## Upstream evidence

- official stable release: https://github.com/ClickHouse/ClickHouse/releases/tag/v26.6.1.1193-stable
- official release overview: https://clickhouse.com/blog/clickhouse-release-26-06
- `make image-verify IMAGE=docker.io/clickhouse/clickhouse-server:26.6.1`
- manifest platforms: `linux/amd64`, `linux/arm64`

## Validation

- `make deps-check CHART=clickhouse`
- `make validate-chart CHART=clickhouse` (18 layers, including 9 k3d scenarios)
- `make standards-check CHART=clickhouse`
- `make site-sync-check CHART=clickhouse`
- `make md-lint REPO=charts`
- `make org-check`
- `make preflight`

Site sync: helmforgedev/site#395

Closes #733