### PR TITLE
chore(cloudflared): bump image to 2026.7.1

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.10
-appVersion: "2026.6.1"
+appVersion: "2026.7.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.6.1"
+  tag: "2026.7.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the official cloudflared image from 2026.6.1 to 2026.7.1
- synchronize the chart application version and image default
- correct pre-existing version drift in the companion site documentation

## Upstream evidence

- official release: https://github.com/cloudflare/cloudflared/releases/tag/2026.7.1
- `make image-verify IMAGE=docker.io/cloudflare/cloudflared:2026.7.1`
- manifest platforms: `linux/amd64`, `linux/arm64`

## Validation

- `make deps-check CHART=cloudflared`
- `make validate-chart CHART=cloudflared` (16 layers, including 7 k3d scenarios)
- isolated Quick Tunnel reproduction after one transient external connection restart
- clean full rerun with zero restarts or crash terminations
- `make standards-check CHART=cloudflared`
- `make site-sync-check CHART=cloudflared`
- `make org-check`
- `make preflight`

Site sync: helmforgedev/site#396

Closes #734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cloudflared Helm chart to release version 2026.7.1.
  * Updated the default container image to use Cloudflared 2026.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->