### PR TITLE
chore(drupal): bump image to 11.4.1

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.9
-appVersion: "11.4.0"
+appVersion: "11.4.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.4.0-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.4.1-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.4.0-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.4.1-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,15 +53,16 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.4.0` is an upstream feature minor release for Drupal 11 and is
-marked by upstream as ready for production sites. The release changes the
+Drupal `11.4.1` is a production-ready patch release that fixes three regressions
+found in 11.4.0. The 11.4 line changes the
 Composer dependency policy for `drupal/core-recommended`: Guzzle, Twig, and
 Symfony polyfills are no longer pinned there, so security and patch updates can
 be applied without waiting for a new Drupal core release.
 
 Before upgrading production workloads, test the site in staging with the same
 PHP extensions, Composer dependency set, storage class, and database mode used
-in production.
+in production. Review Drupal's 11.4.1 known issues, especially the documented
+search-module update path, before running database updates.
 
 ## Production Example
 
@@ -149,7 +150,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.4.0-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.4.1-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.4.0-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.1-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.4.0-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.1-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.4.0-php8.5-apache-bookworm"
+  tag: "11.4.1-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the Docker Official Drupal image from 11.4.0 to 11.4.1
- update chart metadata, defaults, unit expectations, and documentation
- preserve upstream guidance for the 11.4.1 known upgrade issues

## Upstream evidence

- official release notes: https://www.drupal.org/project/drupal/releases/11.4.1
- `make image-verify IMAGE=docker.io/library/drupal:11.4.1-php8.5-apache-bookworm`
- manifest platforms: `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/386`, `linux/ppc64le`, `linux/s390x`

## Validation

- `make deps-check CHART=drupal`
- `make validate-chart CHART=drupal` (17 layers, including 8 k3d scenarios)
- `make standards-check CHART=drupal`
- `make site-sync-check CHART=drupal`
- `make md-lint REPO=charts`
- `make org-check`
- `make preflight`

Site sync: helmforgedev/site#397

Closes #735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Drupal chart to use Drupal 11.4.1 with PHP 8.5 on Apache Bookworm.
  - Refreshed the default image version and chart metadata.

- **Documentation**
  - Updated version references and upgrade guidance, including recommendations to test upgrades before production deployment.

- **Tests**
  - Updated deployment checks to validate the Drupal 11.4.1 container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->