### PR TITLE
chore(ghost): bump image to 6.52.1

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.18
-appVersion: "6.50.0"
+appVersion: "6.52.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -77,13 +77,11 @@ database:
 
 ## Upgrade Notes
 
-Ghost `6.52.1` is the current upstream patch release. It includes publisher
-gift links, configurable admin session max age, Ghost Admin appearance updates,
-analytics/admin improvements, and fixes including stored XSS hardening in JSON-LD
-output. Review the upstream Ghost release notes before upgrading production
-sites, take a content and database backup, and verify themes, custom
-integrations, newsletter flows, comments, and member signup paths in staging
-before reusing existing PVCs.
+Ghost `6.52.1` is the current upstream patch release and fixes link selection
+in the automations email editor. Review the upstream Ghost release notes before
+upgrading production sites, take a content and database backup, and verify
+themes, custom integrations, newsletter flows, comments, and member signup
+paths in staging before reusing existing PVCs.
 
 ## S3 Backup
 

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -65,7 +65,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.50.0` | Ghost image tag |
+| `image.tag` | `6.52.1` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -77,7 +77,7 @@ database:
 
 ## Upgrade Notes
 
-Ghost `6.50.0` is the current upstream patch release. It includes publisher
+Ghost `6.52.1` is the current upstream patch release. It includes publisher
 gift links, configurable admin session max age, Ghost Admin appearance updates,
 analytics/admin improvements, and fixes including stored XSS hardening in JSON-LD
 output. Review the upstream Ghost release notes before upgrading production

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.50.0"
+          value: "docker.io/library/ghost:6.52.1"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.50.0"
+                                                                    "default":  "6.52.1"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.50.0"
+  tag: "6.52.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the Docker Official Ghost image from 6.50.0 to 6.52.1
- synchronize chart metadata, defaults, schema, unit expectations, and docs

## Upstream evidence

- official release: https://github.com/TryGhost/Ghost/releases/tag/v6.52.1
- `make image-verify IMAGE=docker.io/library/ghost:6.52.1`
- manifest platforms: `linux/amd64`, `linux/arm`, `linux/arm64`

## Validation

- `make deps-check CHART=ghost`
- `make validate-chart CHART=ghost` (16 layers, including 7 k3d scenarios)
- `make standards-check CHART=ghost`
- `make site-sync-check CHART=ghost`
- `make md-lint REPO=charts`
- `make org-check`
- `make preflight`

Site sync: helmforgedev/site#398

Closes #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default Ghost application image to version 6.52.1.

* **Documentation**
  * Updated chart metadata, default-value references, and upgrade notes to reflect Ghost 6.52.1.

* **Tests**
  * Updated deployment validation to expect the Ghost 6.52.1 container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->