### PR TITLE
chore(heimdall): bump image to 2.8.1

### DIFF
--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: heimdall
 type: application
 version: 1.1.11
-appVersion: "2.7.6"
+appVersion: "2.8.1"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Heimdall application dashboard on Kubernetes
 maintainers:

--- a/charts/heimdall/tests/deployment_test.yaml
+++ b/charts/heimdall/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/linuxserver/heimdall:2.7.6"
+          value: "docker.io/linuxserver/heimdall:2.8.1"
 
   - it: should set PUID, PGID, and TZ env vars
     asserts:

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- Container image repository
   repository: docker.io/linuxserver/heimdall
   # -- Image tag
-  tag: "2.7.6"
+  tag: "2.8.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the LinuxServer Heimdall image from 2.7.6 to 2.8.1
- synchronize chart metadata, defaults, and unit expectations

## Upstream evidence

- official release: https://github.com/linuxserver/Heimdall/releases/tag/v2.8.1
- `make image-verify IMAGE=docker.io/linuxserver/heimdall:2.8.1`
- manifest platforms: `linux/amd64`, `linux/arm64`

## Validation

- `make deps-check CHART=heimdall`
- `make validate-chart CHART=heimdall` (14 layers, including 5 k3d scenarios)
- `make standards-check CHART=heimdall`
- `make site-sync-check CHART=heimdall`
- `make org-check`
- `make preflight`

Site sync: helmforgedev/site#399

Closes #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Heimdall deployment to use version 2.8.1.

* **Tests**
  * Updated deployment validation to confirm the new Heimdall image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->