### PR TITLE
chore(homarr): bump image to 1.70.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump homarr to 1.69.2 (#713)"
+      description: "bump homarr to 1.70.0 (#738)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.21
-appVersion: "1.69.2"
+appVersion: "1.70.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.69.2`.
+Current application version: `v1.70.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.69.2"` | Homarr image tag |
+| `image.tag` | `"v1.70.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,8 +265,8 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.68.0` to `v1.69.2`. Review upstream release notes before upgrading production
-environments. Homarr `v1.69.2` is a patch release that fixes layout stacking so the AppShell header renders above indicator
+This update moves the default image from `v1.69.2` to `v1.70.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.70.0` adds integrations and fixes widget secrets, forms, query caching, and layout stacking so the AppShell header renders above indicator
 dots. No breaking changes were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.69.2"
+          value: "ghcr.io/homarr-labs/homarr:v1.70.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.69.2"
+  tag: "v1.70.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- bump the official Homarr image from v1.69.2 to v1.70.0
- synchronize chart metadata, defaults, unit expectations, and release guidance
- retain the required `v` prefix because the issue-suggested `1.70.0` GHCR tag does not exist

## Upstream evidence

- official release: https://github.com/homarr-labs/homarr/releases/tag/v1.70.0
- `ghcr.io/homarr-labs/homarr:1.70.0`: manifest missing
- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.70.0`: pass
- manifest platforms: `linux/amd64`, `linux/arm64`

## Validation

- `make deps-check CHART=homarr`
- `make validate-chart CHART=homarr` (19 layers, including 10 k3d scenarios)
- `make standards-check CHART=homarr`
- `make site-sync-check CHART=homarr`
- `make md-lint REPO=charts`
- `make org-check`
- `make preflight`

Site sync: helmforgedev/site#400

Closes #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documented Homarr application version and default image tag to 1.70.0, including revised upgrade notes.
* **Tests**
  * Updated deployment rendering validation to expect the Homarr 1.70.0 image tag.
* **Chores**
  * Updated Helm chart metadata and default versioning to 1.70.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->