### PR TITLE
chore(jenkins): bump image to 2.568.1

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -4,7 +4,7 @@ name: jenkins
 description: Jenkins Helm Chart with secure controller defaults, JCasC, plugin bootstrap, Gateway API, and Kubernetes agent RBAC
 type: application
 version: 1.0.5
-appVersion: "2.555.3"
+appVersion: "2.568.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,8 +27,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/jenkins.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#677)"
+    - kind: changed
+      description: "bump jenkins lts to 2.568.1 (#739)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -3,7 +3,8 @@
 Jenkins is an open source automation server for continuous integration and delivery.
 
 This HelmForge chart deploys the official `jenkins/jenkins` controller image
-with production-oriented Kubernetes defaults. It includes a StatefulSet
+at the pinned `2.568.1-lts-jdk21` release with production-oriented Kubernetes
+defaults. It includes a StatefulSet
 controller, persistent Jenkins home, secure initial admin bootstrap, optional
 Jenkins Configuration as Code, optional plugin installation with
 `jenkins-plugin-cli`, optional RBAC for Kubernetes agents, dual-stack Service

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Jenkins controller image repository.
   repository: docker.io/jenkins/jenkins
   # -- Jenkins controller image tag.
-  tag: "2.555.3-lts-jdk21"
+  tag: "2.568.1-lts-jdk21"
   # -- Jenkins controller image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Jenkins LTS to 2.568.1
- pin the official image to `jenkins/jenkins:2.568.1-lts-jdk21`
- refresh chart documentation and Artifact Hub change metadata

## Upstream evidence

- Jenkins 2.568.1 changelog: https://www.jenkins.io/changelog/2.568.1/
- official image manifest verified for amd64, arm64, s390x, ppc64le, and riscv64

## Validation

- `make image-verify IMAGE=docker.io/jenkins/jenkins:2.568.1-lts-jdk21`
- `make deps-check CHART=jenkins`
- `make validate-chart CHART=jenkins` (20 layers, 11 k3d scenarios)
- `make standards-check CHART=jenkins`
- `make site-sync-check CHART=jenkins`
- `make preflight`

Site sync: https://github.com/helmforgedev/site/pull/401

Closes #739

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded the Jenkins controller to the 2.568.1 LTS release with JDK 21.
  * Updated the Helm chart metadata and documentation to reflect the new Jenkins version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->