### PR TITLE
chore(keycloak): bump image to 26.7.0

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 3.0.6
-appVersion: "26.6.4"
+appVersion: "26.7.0"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - keycloak
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump keycloak to 26.6.4 (#614)"
+      description: "bump keycloak to 26.7.0 (#740)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -86,13 +86,13 @@ Recommended reading before installation:
 - [Kubernetes Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/)
 - [External Secrets Operator](https://external-secrets.io/latest/)
 
-## Keycloak 26.6.x alignment
+## Keycloak 26.7.x alignment
 
-This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.6.4`.
+This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.0`.
 
-Relevant 26.6.x operational changes to account for during rollout:
+Relevant 26.7.x operational changes to account for during rollout:
 
-- 26.6.4 is a security-focused patch release; prioritize rollout for public or multi-tenant realms and validate custom login/front-channel logout templates
+- 26.7.0 includes security fixes and new administration capabilities; review the upstream migration guide before production rollout
 - zero-downtime patch releases are supported within the same minor stream, but still require readiness, proxy, and database validation
 - the HTTP stack supports graceful shutdown, so keep `terminationGracePeriodSeconds` aligned with connection draining at the proxy layer
 - Kubernetes and OpenShift truststore initialization improved upstream; keep custom `truststore` and database CA mounts explicit when the platform uses private CAs
@@ -245,7 +245,7 @@ postgresql:
 |-----------|-------------|---------|
 | `mode` | `dev` or `production` | `dev` |
 | `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `26.6.4` |
+| `image.tag` | Keycloak image tag | `26.7.0` |
 | `admin.existingSecret` | Existing secret for bootstrap admin credentials | `""` |
 | `http.port` | Application HTTP port | `8080` |
 | `http.managementPort` | Management port for health and metrics | `9000` |

--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -157,7 +157,7 @@ When an ExternalSecret owns a target Secret, the native generated Secret for tha
 
 ## Keycloak 26.6.x rollout notes
 
-The default image is `quay.io/keycloak/keycloak:26.6.4`.
+The default image is `quay.io/keycloak/keycloak:26.7.0`.
 
 Before rolling this version into production:
 

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.6.4"
+          value: "quay.io/keycloak/keycloak:26.7.0"
 
   - it: should have 1 replica by default
     template: deployment.yaml

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # -- Keycloak image tag
-  tag: "26.6.4"
+  tag: "26.7.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Keycloak to 26.7.0
- pin the official `quay.io/keycloak/keycloak:26.7.0` image
- refresh tests, production documentation, and Artifact Hub metadata

## Upstream evidence

- release notes: https://www.keycloak.org/2026/07/keycloak-2670-released
- official downloads list 26.7.0: https://www.keycloak.org/downloads

## Validation

- `make image-verify IMAGE=quay.io/keycloak/keycloak:26.7.0`
- `make deps-check CHART=keycloak`
- `make validate-chart CHART=keycloak` (full k3d matrix, exit code 0)
- `make standards-check CHART=keycloak`
- `make site-sync-check CHART=keycloak`
- `make preflight`

Site sync: https://github.com/helmforgedev/site/pull/402

Closes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Keycloak deployment to version 26.7.0, including the default container image.
  * Includes the upstream release’s security fixes and new administration capabilities.

* **Documentation**
  * Updated version references, rollout guidance, and configuration examples for Keycloak 26.7.0.

* **Tests**
  * Updated deployment validation to confirm the Keycloak 26.7.0 image is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->