### PR TITLE
chore(kubernetes-mcp-server): bump image to 0.0.64

### DIFF
--- a/charts/kubernetes-mcp-server/Chart.yaml
+++ b/charts/kubernetes-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ name: kubernetes-mcp-server
 description: Kubernetes and OpenShift MCP server in HTTP mode
 type: application
 version: 1.0.3
-appVersion: "0.0.63"
+appVersion: "0.0.64"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/kubernetes-mcp-server.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#669)"
+    - kind: changed
+      description: "bump kubernetes-mcp-server to 0.0.64 (#741)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -1,7 +1,7 @@
 # Kubernetes MCP Server Helm Chart
 
 Kubernetes MCP Server exposes Kubernetes cluster inspection and automation through the Model Context Protocol.
-This chart deploys the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.63` image in HTTP mode with in-cluster authentication,
+This chart deploys the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.64` image in HTTP mode with in-cluster authentication,
 read-only safety flags, and least-privilege RBAC by default.
 
 ## Install

--- a/charts/kubernetes-mcp-server/tests/templates_test.yaml
+++ b/charts/kubernetes-mcp-server/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.63
+          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.64
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: kubernetes-mcp-server

--- a/charts/kubernetes-mcp-server/values.schema.json
+++ b/charts/kubernetes-mcp-server/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/containers/kubernetes-mcp-server" },
-        "tag": { "type": "string", "default": "v0.0.63" },
+        "tag": { "type": "string", "default": "v0.0.64" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 commonLabels: {}
 image:
   repository: ghcr.io/containers/kubernetes-mcp-server
-  tag: "v0.0.63"
+  tag: "v0.0.64"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 replicaCount: 1


### PR DESCRIPTION
## Summary

- bump Kubernetes MCP Server to 0.0.64
- pin the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.64` image
- sync schema defaults, tests, docs, and Artifact Hub metadata

## Upstream evidence

- release: https://github.com/containers/kubernetes-mcp-server/releases/tag/v0.0.64
- image manifest verified for amd64, arm64, s390x, and ppc64le

## Validation

- `make image-verify IMAGE=ghcr.io/containers/kubernetes-mcp-server:v0.0.64`
- `make deps-check CHART=kubernetes-mcp-server`
- `make validate-chart CHART=kubernetes-mcp-server` (16 layers)
- `make standards-check CHART=kubernetes-mcp-server`
- `make site-sync-check CHART=kubernetes-mcp-server`
- `make preflight`

Site sync: https://github.com/helmforgedev/site/pull/403

Closes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Kubernetes MCP Server Helm chart to deploy container image version **v0.0.64**.
  * Updated chart metadata, documentation, default configuration, and validation expectations to reflect the new version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->