### PR TITLE
chore(langflow): bump image to 1.10.2

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.0.3
-appVersion: "1.10.1"
+appVersion: "1.10.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#670)"
+    - kind: changed
+      description: "bump langflow to 1.10.2 (#742)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,7 +1,7 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.10.1` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.10.2` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
 
 ## Install

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.10.1
+          value: docker.io/langflowai/langflow:1.10.2
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.10.1" },
+        "tag": { "type": "string", "default": "1.10.2" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.10.1"
+  tag: "1.10.2"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Langflow to 1.10.2
- pin the official `docker.io/langflowai/langflow:1.10.2` image
- sync schema defaults, tests, docs, and Artifact Hub metadata

## Upstream evidence

- release: https://github.com/langflow-ai/langflow/releases/tag/v1.10.2
- image manifest verified for amd64 and arm64

## Validation

- `make image-verify IMAGE=docker.io/langflowai/langflow:1.10.2`
- `make deps-check CHART=langflow`
- `make validate-chart CHART=langflow` (17 layers)
- `make standards-check CHART=langflow`
- `make site-sync-check CHART=langflow`
- `make preflight`

Site sync: https://github.com/helmforgedev/site/pull/404

Closes #742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Helm chart to deploy Langflow version 1.10.2 by default.
* **Documentation**
  * Updated chart documentation to reference the Langflow 1.10.2 container image.
* **Tests**
  * Updated deployment validation to expect the Langflow 1.10.2 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->