### PR TITLE
docs(keycloak): align 26.7 rollout guidance

### DIFF
--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -155,13 +155,13 @@ externalSecrets:
 
 When an ExternalSecret owns a target Secret, the native generated Secret for that credential is suppressed and Keycloak consumes the materialized Kubernetes Secret.
 
-## Keycloak 26.6.x rollout notes
+## Keycloak 26.7.x rollout notes
 
 The default image is `quay.io/keycloak/keycloak:26.7.0`.
 
 Before rolling this version into production:
 
-- read the official 26.6.x release notes
+- read the official [26.7.0 release notes](https://www.keycloak.org/2026/07/keycloak-2670-released)
 - validate database startup and migration logs
 - validate readiness and liveness on the management service
 - validate login, token refresh, logout, and admin console access through the real reverse proxy path


### PR DESCRIPTION
## Summary

- align the Keycloak production rollout heading and release-notes link with 26.7.0

## Validation

- `make validate-chart CHART=keycloak` (full k3d matrix, exit code 0)
- `make md-lint REPO=charts`

Follow-up to #762 and CodeRabbit discussion r3575401714.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Keycloak production rollout notes to reference version 26.7.x.
  * Added a link to the official Keycloak 26.7.0 release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->