### PR TITLE
chore(memcached): bump image to 1.6.45

### DIFF
--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -4,7 +4,7 @@ name: memcached
 description: Memcached Helm Chart for standalone and distributed cache topologies
 type: application
 version: 1.0.7
-appVersion: "1.6.42"
+appVersion: "1.6.45"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,8 +24,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/memcached.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#680)"
+    - kind: changed
+      description: "bump memcached to 1.6.45 (#743)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -316,7 +316,7 @@ networkPolicy:
 | `architecture` | `standalone` | `standalone` or `distributed`. |
 | `replicaCount` | `1` | Number of Memcached pods. Must be `1` for standalone. |
 | `image.repository` | `docker.io/library/memcached` | Official Memcached image. |
-| `image.tag` | `1.6.42` | Pinned image tag. |
+| `image.tag` | `1.6.45` | Pinned image tag. |
 | `memcached.memoryLimitMB` | `64` | Memcached item memory limit passed to `-m`. |
 | `memcached.maxConnections` | `1024` | Maximum simultaneous connections. |
 | `memcached.threads` | `4` | Worker threads. |
@@ -355,7 +355,7 @@ anti-affinity or topology spread constraints.
 
 ## Operations
 
-Memcached `1.6.42` is an upstream security-focused release. Upgrading is
+Memcached `1.6.45` is the pinned upstream release. Upgrading is
 strongly advised when Memcached is reachable by untrusted clients; validate
 connectivity with a `version` or `stats` command after rollout.
 

--- a/charts/memcached/tests/statefulset_test.yaml
+++ b/charts/memcached/tests/statefulset_test.yaml
@@ -20,7 +20,7 @@ tests:
           value: false
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/memcached:1.6.42
+          value: docker.io/library/memcached:1.6.45
       - contains:
           path: spec.template.spec.containers[0].args
           content: -m

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -79,7 +79,7 @@
       "additionalProperties": true,
       "properties": {
         "repository": { "type": "string", "minLength": 1 },
-        "tag": { "type": "string", "minLength": 1, "default": "1.6.42" },
+        "tag": { "type": "string", "minLength": 1, "default": "1.6.45" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
       }
     },

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/library/memcached
-  tag: 1.6.42
+  tag: 1.6.45
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Memcached to 1.6.45
- pin the official `docker.io/library/memcached:1.6.45` image
- sync schema, tests, docs, and Artifact Hub metadata

## Validation

- `make image-verify IMAGE=docker.io/library/memcached:1.6.45`
- `make deps-check CHART=memcached`
- `make validate-chart CHART=memcached`
- `make standards-check CHART=memcached`
- `make site-sync-check CHART=memcached`
- `make preflight`

Site sync: https://github.com/helmforgedev/site/pull/406

Closes #743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Memcached image to version **1.6.45**.
  * Updated chart metadata, documentation, configuration defaults, and validation expectations to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->