### PR TITLE
chore(metabase): bump image to 0.62.4

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.19
-appVersion: "v0.62.3"
+appVersion: "v0.62.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump metabase to v0.62.3 (#618)"
+      description: "bump metabase to v0.62.4 (#744)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.62.2
+  tag: v0.62.4
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.62.2` | Metabase container image tag |
+| `image.tag` | `v0.62.4` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,7 +184,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.62.2` updates the application to the latest upstream release and
+Metabase `v0.62.4` updates the application to the latest upstream release and
 repairs the chart's validation scenarios for single-stack clusters, external
 database fixtures, and External Secrets. Back up the Metabase application
 database before upgrading, keep the encryption key stable, and validate the

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.62.3"
+          value: "docker.io/metabase/metabase:v0.62.4"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.62.3"
+  tag: "v0.62.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Metabase to v0.62.4
- pin the official `docker.io/metabase/metabase:v0.62.4` image
- sync tests, examples, and Artifact Hub metadata

## Upstream evidence

- release: https://github.com/metabase/metabase/releases/tag/v0.62.4
- image manifest verified for amd64 and arm64

## Validation

- `make image-verify IMAGE=docker.io/metabase/metabase:v0.62.4`
- `make deps-check CHART=metabase`
- `make validate-chart CHART=metabase` (17 layers)
- `make standards-check CHART=metabase`
- `make site-sync-check CHART=metabase`
- `make preflight`

Site sync: https://github.com/helmforgedev/site/pull/407

Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Helm chart to deploy Metabase version **v0.62.4** by default.
  * Updated the air-gapped or proxied registry documentation example to use the matching **v0.62.4** image tag.
* **Tests**
  * Updated deployment validation to confirm the **v0.62.4** default image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->