### PR TITLE
chore(n8n): bump image to 2.30.4

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.7
-appVersion: "2.29.7"
+appVersion: "2.30.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.29.7 (#718)"
+      description: "bump n8n to 2.30.4 (#745)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.29.7` | n8n container image tag |
+| `image.tag` | `2.30.4` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,7 +186,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.29.7` is the upstream stable release used by the chart defaults. Review
+n8n `2.30.4` is the upstream stable release used by the chart defaults. Review
 the upstream release notes before upgrading, back up the database, and keep the
 encryption key stable before upgrading live deployments. This chart keeps the
 hardened non-root container defaults with resource requests and limits. Queue
@@ -195,10 +195,8 @@ because workers must share the same PostgreSQL, MySQL, or external database as
 the main pod. Validate database and queue mode in a staging namespace before
 reusing production PVCs.
 
-The issue target `2.29.6` is marked as a pre-release upstream. This chart uses
-`2.29.7`, the next stable release, which includes fixes for Code node workflows
-with AI tools, versioned action generation for nodes with flat Action fields,
-and Salesforce document upload and JWT authentication error reporting.
+This release includes fixes for execution visibility, webhook error handling,
+and compatibility with earlier versions of the Notion node.
 
 The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth
 token, opens the broker port, and runs a `docker.io/n8nio/runners` sidecar next

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.29.7"
+          value: "docker.io/n8nio/n8n:2.30.4"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.29.7"
+          value: "docker.io/n8nio/runners:2.30.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.29.7"
+          value: "docker.io/n8nio/runners:2.30.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.29.7"
+          "default": "2.30.4"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.29.7"
+  tag: "2.30.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official n8n and task runner images to 2.30.4
- synchronize schema, tests, README, appVersion, and Artifact Hub change metadata
- document the upstream bug fixes included in 2.30.4

Closes #745.

## Upstream evidence

- n8n release: https://github.com/n8n-io/n8n/releases/tag/n8n%402.30.4
- docker.io/n8nio/n8n:2.30.4: linux/amd64, linux/arm64
- docker.io/n8nio/runners:2.30.4: linux/amd64, linux/arm64

## Validation

- make validate-chart CHART=n8n
- FULLY VALIDATED (20 layers), including all 11 k3d scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Helm chart to deploy n8n version 2.30.4 by default.
  - Updated the bundled task runner image to version 2.30.4.

- **Documentation**
  - Updated chart documentation and upgrade notes for n8n 2.30.4, including execution visibility, webhook error handling, and Notion compatibility fixes.

- **Tests**
  - Updated deployment checks to validate the new n8n and task runner image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->