### PR TITLE
chore(notediscovery): bump image to 0.28.2

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.0.3
-appVersion: "0.28.1"
+appVersion: "0.28.2"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump notediscovery to 0.28.1 (#719)"
+      description: "bump notediscovery to 0.28.2 (#746)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.28.1` image.
+official `ghcr.io/gamosoft/notediscovery:0.28.2` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.1` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.2` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -149,11 +149,8 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.28.1` includes the large-vault performance work from `0.28.0`
-and the upstream task rendering fix from `0.28.1`. The upstream release adds an
-in-memory note index, background index warmup, faster search and graph
-endpoints, and support for overriding storage paths with `NOTES_DIR` and
-`PLUGINS_DIR`. The chart continues to render `storage.notes_dir` from
+NoteDiscovery `0.28.2` fixes rendering of nested code blocks inside GFM and
+GLFM alerts. The chart continues to render `storage.notes_dir` from
 `persistence.mountPath`; keep that path stable across upgrades and back up the
 PVC before upgrading production vaults.
 

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.28.1
+          value: ghcr.io/gamosoft/notediscovery:0.28.2
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.28.1", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.28.2", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.28.1"
+  tag: "0.28.2"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official NoteDiscovery image to 0.28.2
- synchronize schema, tests, design, README, appVersion, and Artifact Hub metadata
- document the nested code-block rendering fix

Closes #746.

## Upstream evidence

- release: https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.28.2
- ghcr.io/gamosoft/notediscovery:0.28.2: linux/amd64, linux/arm64

## Validation

- make validate-chart CHART=notediscovery
- FULLY VALIDATED (19 layers), including all 10 k3d scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the NoteDiscovery Helm chart and default container image to version 0.28.2.
  * Improved rendering of nested code blocks inside GFM and GLFM alerts.

* **Documentation**
  * Updated deployment documentation and upgrade notes for version 0.28.2.

* **Tests**
  * Updated chart validation to verify the new container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->