### PR TITLE
chore(olivetin): bump image to 3000.17.0

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.14
-appVersion: "3000.16.2"
+appVersion: "3000.17.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump olivetin to 3000.16.2 (#720)"
+      description: "bump olivetin to 3000.17.0 (#748)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -58,7 +58,7 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.resources` | requests/limits set | Resource guardrails for the config bootstrap init container |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.16.2` | OliveTin image tag |
+| `image.tag` | `3000.17.0` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
 | `olivetin.port` | `1337` | Application port |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |
@@ -103,10 +103,11 @@ See the [OliveTin documentation](https://docs.olivetin.app) for all available op
 
 ## Upgrade Notes
 
-OliveTin `3000.16.2` is a bugfix release focused on Windows packaging and
-upstream unit test stability. Upstream reports no upgrade warnings or breaking
-changes between `3000.16.1` and `3000.16.2`; keep the chart-managed config and
-persistent data paths unchanged when rolling production deployments.
+OliveTin `3000.17.0` adds checklist and entity UI support and includes security
+hardening for shell execution, argument types, log access control, and OAuth2
+state growth. Upstream reports no upgrade warnings or breaking changes; keep
+the chart-managed config and persistent data paths unchanged when rolling
+production deployments.
 
 ### Security Scan: olivetin
 

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.16.2"
+          value: "docker.io/jamesread/olivetin:3000.17.0"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.16.2" },
+        "tag": { "type": "string", "default": "3000.17.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.16.2"
+  tag: "3000.17.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the official OliveTin image to 3000.17.0
- synchronize schema, tests, README, appVersion, and Artifact Hub metadata
- document feature and security changes with no upstream breaking changes

Closes #748.

## Upstream evidence

- release: https://github.com/OliveTin/OliveTin/releases/tag/3000.17.0
- docker.io/jamesread/olivetin:3000.17.0: linux/amd64, linux/arm64

## Validation

- make validate-chart CHART=olivetin
- FULLY VALIDATED (15 layers), including all 6 k3d scenarios