### PR TITLE
chore(pihole): bump image to 2026.07.2

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: pihole
 type: application
 version: 2.0.11
-appVersion: "2026.06.0"
+appVersion: "2026.07.2"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Pi-hole DNS sinkhole on Kubernetes
 maintainers:
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/pihole.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump pihole to 2026.06.0 (#549)"
+      description: "bump pihole to 2026.07.2 (#749)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -135,7 +135,7 @@ metrics:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/pihole/pihole` | Pi-hole container image repository |
-| `image.tag` | `2026.06.0` | Pi-hole container image tag (official upstream release 2026.06.0) |
+| `image.tag` | `2026.07.2` | Pi-hole container image tag (official upstream release 2026.07.2) |
 | `image.pullPolicy` | `IfNotPresent` | Pi-hole image pull policy |
 | `pihole.timezone` | `UTC` | Timezone for logs and scheduled tasks |
 | `pihole.upstreamDns` | `8.8.8.8;8.8.4.4` | Upstream DNS servers (semicolon-delimited) |
@@ -294,9 +294,10 @@ metrics:
 
 ## Upgrade Notes
 
-Pi-hole `2026.06.0` rolls in the upstream Web `6.5.1` fixes published by the
-Pi-hole project. No chart-specific migration is required for this image bump,
-but production upgrades should still back up `/etc/pihole` and
+Pi-hole `2026.07.2` includes the container-side fix associated with upstream
+security advisory `GHSA-h8w9-qx2v-wrww` and moves the logrotate configuration
+to `/etc/logrotate.d/pihole`. No chart-specific migration is required, but
+production upgrades should still back up `/etc/pihole` and
 `/etc/dnsmasq.d` before rollout.
 
 ## Connection

--- a/charts/pihole/tests/deployment_test.yaml
+++ b/charts/pihole/tests/deployment_test.yaml
@@ -456,7 +456,7 @@ tests:
           value: gravity-update
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: "docker.io/pihole/pihole:2026.06.0"
+          value: "docker.io/pihole/pihole:2026.07.2"
       - matchRegex:
           path: spec.template.spec.initContainers[1].command[2]
           pattern: "pihole -g"

--- a/charts/pihole/values.schema.json
+++ b/charts/pihole/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.06.0"
+          "default": "2026.07.2"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/pihole/pihole
   # -- Container image tag
-  tag: "2026.06.0"
+  tag: "2026.07.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Pi-hole image to 2026.07.2
- synchronize schema, tests, README, appVersion, and Artifact Hub metadata
- document the upstream security-related container fix and logrotate move

Closes #749.

## Upstream evidence

- release: https://github.com/pi-hole/docker-pi-hole/releases/tag/2026.07.2
- docker.io/pihole/pihole:2026.07.2: linux/386, linux/amd64, linux/arm64, linux/riscv64, linux/arm

## Validation

- make validate-chart CHART=pihole
- FULLY VALIDATED (20 layers), including all 11 k3d scenarios