### PR TITLE
chore(poznote): bump image to 6.33.0

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.0.2
-appVersion: "6.30.2"
+appVersion: "6.33.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump poznote to 6.30.2 (#722)"
+      description: "bump poznote to 6.33.0 (#750)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,10 +14,10 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.30.2
+ghcr.io/timothepoznanski/poznote:6.33.0
 ```
 
-The tag maps to the upstream `6.30.2` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.33.0` release and publishes Linux `amd64` and `arm64` manifests.
 
 ## Database
 

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.30.2` |
+| `image.tag` | Image tag | `6.33.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -140,11 +140,9 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.30.2` is a stable UI, backup, API, and security hardening release.
-Upstream highlights include brute-force login throttling, improved backup import
-validation, trashed notes included in exports, new REST API endpoints, MCP server
-fixes, dark mode fixes, and mobile/task editing fixes. No Kubernetes-facing
-configuration changes are required by this chart, but back up the `data` PVC
+Poznote `6.33.0` adds the graph view and improves dashboard and mobile
+navigation. No Kubernetes-facing configuration changes are required by this
+chart, but back up the `data` PVC
 before upgrading because it stores the SQLite database, notes, attachments, and
 application configuration.
 

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.30.2"
+          value: "ghcr.io/timothepoznanski/poznote:6.33.0"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.30.2"
+  tag: "6.33.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Poznote image to 6.33.0
- synchronize tests, design, README, appVersion, and Artifact Hub metadata
- document the graph view and dashboard/mobile navigation changes

Closes #750.

## Upstream evidence

- release: https://github.com/timothepoznanski/poznote/releases/tag/6.33.0
- ghcr.io/timothepoznanski/poznote:6.33.0: linux/amd64, linux/arm64

## Validation

- make validate-chart CHART=poznote
- FULLY VALIDATED (16 layers), including all 7 k3d scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Poznote deployment to version 6.33.0.
  * Added documentation for the new graph view and dashboard/mobile navigation improvements.

* **Documentation**
  * Updated image version references and upgrade notes for Poznote 6.33.0.

* **Tests**
  * Updated deployment validation to confirm the 6.33.0 container image is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->