### PR TITLE
chore(strapi): bump image to 5.50.0

### DIFF
--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -4,7 +4,7 @@ name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
 version: 2.3.8
-appVersion: "5.49.0"
+appVersion: "5.50.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump strapi to 5.49.0 (#723)"
+      description: "bump strapi to 5.50.0 (#751)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strapi/README.md
+++ b/charts/strapi/README.md
@@ -18,9 +18,9 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 
 ## HelmForge Base Image
 
-This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.49.0`) which provides:
+This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.50.0`) which provides:
 
-- **Strapi 5.49.0** with all official plugins pre-installed
+- **Strapi 5.50.0** with all official plugins pre-installed
 - **Multi-database support** — SQLite, PostgreSQL, MySQL ready to use
 - **Health check endpoint** — HTTP health checks on `/_health` for proper Kubernetes integration
 - **Security hardened** — Non-root user (UID 1000), minimal attack surface
@@ -107,7 +107,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `helmforge/strapi-base` | Container image for the Strapi project |
-| `image.tag` | `5.49.0` | HelmForge Strapi base image version |
+| `image.tag` | `5.50.0` | HelmForge Strapi base image version |
 | `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
 | `strapi.port` | `1337` | Container port |
 | `strapi.telemetryDisabled` | `true` | Disable telemetry |
@@ -141,18 +141,17 @@ database:
 
 ## Notes
 
-- The default image is `helmforge/strapi-base:5.49.0`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
+- The default image is `helmforge/strapi-base:5.50.0`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
 - SQLite is supported for simple deployments, but server-based databases are recommended for production workloads.
 - Horizontal scaling is intentionally out of scope for this v1 chart because default local uploads persistence is single-writer oriented.
 - For ingress, set `ingress.ingressClassName` to the class used in your cluster, such as `traefik`, `nginx`, or another supported controller.
 
 ## Upgrade Notes
 
-Strapi `5.49.0` is a stable release with MCP builder exports, upload provider
-enhancements, dashboard/admin fixes, safer large upload MIME detection, and
-dependency security updates. Upstream calls out one user-visible behavior change:
-in the Content Manager, `Cmd/Ctrl+Enter` now saves a draft, while
-`Cmd/Ctrl+Shift+Enter` publishes. Back up the database and uploads PVC before
+Strapi `5.50.0` adds active device session management, secure scaffold defaults,
+EU SendGrid region support, and AWS credential provider functions. It also
+defaults legacy JWT verification to HS256 and includes admin, relation, upload,
+and dynamic-zone fixes. Back up the database and uploads PVC before
 upgrading production workloads.
 
 ## More Information

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:5.49.0"
+          value: "docker.io/helmforge/strapi-base:5.50.0"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -26,7 +26,7 @@ replicaCount: 1
 # Image
 # =============================================================================
 # HelmForge provides a production-ready Strapi base image (helmforge/strapi-base)
-# that includes Strapi 5.49.0 with all official plugins, multi-database support,
+# that includes Strapi 5.50.0 with all official plugins, multi-database support,
 # security hardening, and health check endpoints. This image is multi-arch
 # (amd64/arm64), regularly updated, and optimized for Kubernetes deployments.
 #
@@ -38,7 +38,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "5.49.0"
+  tag: "5.50.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the HelmForge Strapi base image to 5.50.0
- synchronize tests, values comments, README, appVersion, and Artifact Hub metadata
- document upstream feature, security, and bug-fix changes

Closes #751.

## Upstream evidence

- release: https://github.com/strapi/strapi/releases/tag/v5.50.0
- docker.io/helmforge/strapi-base:5.50.0: linux/amd64, linux/arm64

## Validation

- make validate-chart CHART=strapi
- FULLY VALIDATED (18 layers), including all 9 k3d scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Strapi Helm chart to version 5.50.0.
  * Updated the default Strapi base image to 5.50.0.

* **Documentation**
  * Refreshed version references and upgrade notes for Strapi 5.50.0.

* **Tests**
  * Updated deployment validation to expect the 5.50.0 default image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->