### PR TITLE
chore(tomcat): bump image to 11.0.24

### DIFF
--- a/charts/tomcat/Chart.yaml
+++ b/charts/tomcat/Chart.yaml
@@ -4,7 +4,7 @@ name: tomcat
 description: Apache Tomcat Helm chart with official image, Gateway API, JMX, and production controls
 type: application
 version: 1.0.4
-appVersion: "11.0.23"
+appVersion: "11.0.24"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,8 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/tomcat.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#686)"
+    - kind: changed
+      description: "bump tomcat to 11.0.24 (#752)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -4,7 +4,7 @@ Apache Tomcat chart for Kubernetes using the official `docker.io/library/tomcat`
 
 ## Highlights
 
-- Official Tomcat image, pinned by default to `11.0.23-jdk17-temurin-noble`.
+- Official Tomcat image, pinned by default to `11.0.24-jdk17-temurin-noble`.
 - Stable default install with an optional ROOT health webapp for deterministic probes and Helm tests.
 - Preserves WARs or exploded applications baked into immutable Tomcat images before mounting the writable webapps volume.
 - Non-root runtime with writable `webapps`, `logs`, `temp`, and `work` volumes.
@@ -90,7 +90,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of Tomcat pods when HPA is disabled. |
 | `image.repository` | `docker.io/library/tomcat` | Tomcat image repository. |
-| `image.tag` | `11.0.23-jdk17-temurin-noble` | Tomcat image tag. |
+| `image.tag` | `11.0.24-jdk17-temurin-noble` | Tomcat image tag. |
 | `service.type` | `ClusterIP` | Kubernetes Service type. |
 | `service.ipFamilyPolicy` | `null` | Optional Service dual-stack policy. |
 | `service.ipFamilies` | `[]` | Optional Service IP family ordering. |

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/tomcat:11.0.23-jdk17-temurin-noble
+          value: docker.io/library/tomcat:11.0.24-jdk17-temurin-noble
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Tomcat image repository. Uses the official Docker image.
   repository: docker.io/library/tomcat
   # -- Tomcat image tag.
-  tag: "11.0.23-jdk17-temurin-noble"
+  tag: "11.0.24-jdk17-temurin-noble"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Tomcat image to 11.0.24-jdk17-temurin-noble
- synchronize tests, README, appVersion, and Artifact Hub metadata

Closes #752.

## Upstream evidence

- upstream tag: https://github.com/apache/tomcat/tree/11.0.24
- docker.io/library/tomcat:11.0.24-jdk17-temurin-noble: linux/amd64, linux/arm, linux/arm64, linux/ppc64le, linux/riscv64, linux/s390x

## Validation

- make validate-chart CHART=tomcat
- FULLY VALIDATED (16 layers), including all 7 k3d scenarios