### PR TITLE
chore(wordpress): bump image to 7.0.1

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: wordpress
 type: application
 version: 3.0.0
-appVersion: "7.0.0"
+appVersion: "7.0.1"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying WordPress on Kubernetes with MySQL support and S3 backup
 maintainers:
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: add bootstrap and cache provider options (#728)"
+      description: "bump wordpress to 7.0.1 (#753)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -7,7 +7,7 @@ release:
   name: test
   namespace: default
 chart:
-  appVersion: "7.0.0"
+  appVersion: "7.0.1"
 tests:
   - it: should not render backup by default
     template: templates/backup-cronjob.yaml

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Container image repository
   repository: docker.io/library/wordpress
   # -- Container image tag
-  tag: "7.0.0-apache"
+  tag: "7.0.1-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official WordPress Apache image to 7.0.1
- update appVersion, CI expectations, and Artifact Hub image metadata
- retain the existing custom memcached example tags

## Validation

- official image manifest verified for amd64, arm, arm64, 386, ppc64le, riscv64, and s390x
- upstream tag: https://github.com/WordPress/wordpress-develop/tree/7.0.1
- make validate-chart CHART=wordpress (24 layers, including 15 k3d scenarios)

## Site sync

- helmforgedev/site#416

Closes #753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default WordPress application version to 7.0.1.
  * Updated the bundled Apache-based WordPress image to version 7.0.1.
  * Refreshed chart metadata and release information to reflect the upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->