### PR TITLE
feat(certimate)!: add chart

### DIFF
--- a/charts/certimate/.helmignore
+++ b/charts/certimate/.helmignore
@@ -1,0 +1,6 @@
+.git/
+.github/
+.DS_Store
+*.tmp
+*.bak
+charts/

--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: certimate
+description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
+type: application
+version: 0.0.0
+appVersion: "0.4.26"
+home: https://helmforge.dev/docs/charts/certimate
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/certimate
+  - https://github.com/certimate-go/certimate
+  - https://docs.certimate.me
+keywords:
+  - certificates
+  - acme
+  - tls
+  - ssl
+  - automation
+  - self-hosted
+  - kubernetes
+maintainers:
+  - name: HelmForge Team
+    url: https://helmforge.dev
+icon: https://helmforge.dev/icons/charts/certimate.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "add Certimate chart (#779)"
+  artifacthub.io/category: security
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  helmforge.dev/maturity: alpha

--- a/charts/certimate/DESIGN.md
+++ b/charts/certimate/DESIGN.md
@@ -1,0 +1,42 @@
+# certimate Chart Design
+
+Certimate is packaged as a single web application container. The upstream Docker deployment exposes HTTP on port `8090` and persists all runtime state in `/app/pb_data`.
+
+## Workload Model
+
+The chart uses a Deployment with `Recreate` strategy and defaults to
+`replicaCount: 1`. This avoids concurrent writers against the same PocketBase
+data directory. Operators that need more than one replica must provide storage
+semantics that are safe for their environment and set
+`persistence.existingClaim`.
+
+## Storage
+
+The generated PVC is mounted at `/app/pb_data`. This directory contains
+application data, user accounts, provider credentials, ACME state, workflows,
+and issued certificate material. Backup and restore procedures should treat the
+whole directory as sensitive.
+
+## Exposure
+
+The chart supports Kubernetes Ingress and Gateway API HTTPRoute. TLS termination is expected at the ingress controller or gateway. Certimate itself remains an internal HTTP service.
+
+## Secrets
+
+Certimate manages most user and provider secrets inside PocketBase. The chart
+does not invent a separate configuration file. `app.env`, `app.envFrom`, and
+`externalSecrets.items` are available for deployment-specific environment
+variables.
+
+## Network Policy
+
+NetworkPolicy is optional because certificate workflows vary widely. Production
+installs should enable it and model required egress explicitly: DNS provider
+APIs, ACME endpoints, SMTP, webhook receivers, SSH/API targets, and Kubernetes
+services used by deployment tasks.
+
+## Validation
+
+The chart includes unit tests for rendering, storage, exposure, Gateway API,
+NetworkPolicy, ExternalSecret, and validation failures. Runtime readiness is
+verified through the HelmForge `make validate-chart CHART=certimate` gate.

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -1,0 +1,93 @@
+# certimate
+
+Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
+
+This chart packages the official `certimate/certimate:v0.4.26` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+
+## Production Defaults
+
+- one Deployment using `Recreate` strategy for single-writer PocketBase storage
+- one PersistentVolumeClaim mounted at `/app/pb_data`
+- restricted ServiceAccount token mounting by default
+- Kubernetes Ingress and Gateway API HTTPRoute support
+- optional NetworkPolicy with explicit additional egress for ACME DNS APIs, DNS, SMTP, webhooks, and target deployment systems
+- ExternalSecret support for environment variables or other integration secrets
+- test hook for in-cluster HTTP reachability
+
+## Install
+
+```bash
+helm repo add helmforge https://helmforge.dev/charts
+helm install certimate helmforge/certimate
+```
+
+Forward the service for the first login:
+
+```bash
+kubectl port-forward svc/certimate 8090:8090
+```
+
+Then open `http://127.0.0.1:8090`.
+
+The upstream image documents a default administrator account. Change it
+immediately after first login, then store production users, provider
+credentials, workflows, and certificate material on persistent storage.
+
+## Exposure
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: certs.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: certimate-tls
+      hosts:
+        - certs.example.com
+```
+
+Gateway API is also supported:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - certs.example.com
+```
+
+## Operations
+
+Back up the PersistentVolumeClaim before upgrades. Certimate stores its
+PocketBase database, uploaded certificate material, ACME account state, workflow
+definitions, and provider credentials under `/app/pb_data`.
+
+For production, enable `networkPolicy.enabled` and add egress rules for the DNS
+providers, certificate deployment targets, SMTP relays, webhook endpoints, and
+ACME endpoints required by your workflows.
+
+## Security Scan
+
+Local security scan:
+
+```text
+Image: certimate/certimate:v0.4.26
+Scanner: pending local repository security scan
+Result: pending
+```
+
+The chart is designed for the HelmForge security scan workflow. Local scan
+evidence must be refreshed before merge with the repository security tooling and
+then pasted into this section if required by the release checklist.
+
+## Documentation
+
+- [Storage](docs/storage.md)
+- [Exposure](docs/exposure.md)

--- a/charts/certimate/ci/default-values.yaml
+++ b/charts/certimate/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/charts/certimate/ci/dual-stack.yaml
+++ b/charts/certimate/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  # Keep this scenario portable across IPv4-only and dual-stack k3d clusters.
+  # Explicit ipFamilies rendering is covered by unit tests because Kubernetes
+  # rejects IPv6 entries on clusters that do not advertise IPv6.
+  ipFamilyPolicy: PreferDualStack

--- a/charts/certimate/ci/external-secrets.yaml
+++ b/charts/certimate/ci/external-secrets.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: env
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: helmforge-fake-store
+        target:
+          name: certimate-env
+          creationPolicy: Owner
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: test/password

--- a/charts/certimate/ci/gateway-api-values.yaml
+++ b/charts/certimate/ci/gateway-api-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - certimate.example.test
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/certimate/ci/ingress-values.yaml
+++ b/charts/certimate/ci/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: certimate.example.test
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: certimate-tls
+      hosts:
+        - certimate.example.test

--- a/charts/certimate/ci/networkpolicy.yaml
+++ b/charts/certimate/ci/networkpolicy.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system

--- a/charts/certimate/ci/persistence-disabled.yaml
+++ b/charts/certimate/ci/persistence-disabled.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false

--- a/charts/certimate/docs/exposure.md
+++ b/charts/certimate/docs/exposure.md
@@ -1,0 +1,35 @@
+# Certimate Exposure
+
+Certimate serves HTTP on port `8090`. Terminate TLS at your Ingress controller or Gateway.
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: certs.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: certimate-tls
+      hosts:
+        - certs.example.com
+```
+
+Gateway API example:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: public
+          namespace: gateway-system
+      hostnames:
+        - certs.example.com
+```
+
+After exposing the service, rotate the upstream default administrator credentials and restrict access to trusted operators.

--- a/charts/certimate/docs/storage.md
+++ b/charts/certimate/docs/storage.md
@@ -1,0 +1,22 @@
+# Certimate Storage
+
+Certimate stores durable PocketBase data under `/app/pb_data`.
+
+This directory should be backed up as a single unit because it contains application users, provider credentials, ACME account state, workflow definitions, issued certificates, and audit-relevant history.
+
+Use a chart-managed PVC for simple installs:
+
+```yaml
+persistence:
+  enabled: true
+  size: 10Gi
+```
+
+Use an existing claim when your platform owns backup, restore, encryption, or snapshot policy:
+
+```yaml
+persistence:
+  existingClaim: certimate-data
+```
+
+Do not disable persistence outside ephemeral validation environments.

--- a/charts/certimate/examples/gateway-api.yaml
+++ b/charts/certimate/examples/gateway-api.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - certs.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/certimate/examples/ingress.yaml
+++ b/charts/certimate/examples/ingress.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: certs.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: certimate-tls
+      hosts:
+        - certs.example.com

--- a/charts/certimate/examples/secured.yaml
+++ b/charts/certimate/examples/secured.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: true
+  size: 20Gi
+
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 443
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1
+    memory: 1Gi

--- a/charts/certimate/examples/simple.yaml
+++ b/charts/certimate/examples/simple.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: true
+  size: 5Gi

--- a/charts/certimate/templates/NOTES.txt
+++ b/charts/certimate/templates/NOTES.txt
@@ -1,0 +1,78 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+1. Summary
+
+certimate release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Application port: {{ .Values.service.port }}
+Data directory: {{ .Values.persistence.mountPath }}
+
+2. Workload
+
+Check the Deployment and rollout status:
+
+  kubectl get deploy {{ include "certimate.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl rollout status deploy/{{ include "certimate.fullname" . }} -n {{ .Release.Namespace }}
+
+3. Access
+
+Check the Service:
+
+  kubectl get svc {{ include "certimate.fullname" . }} -n {{ .Release.Namespace }}
+
+Use a local port-forward when Ingress or Gateway API is not enabled:
+
+  kubectl port-forward svc/{{ include "certimate.fullname" . }} 8090:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+Then open:
+
+  http://127.0.0.1:8090
+
+4. Credentials
+
+Certimate stores application users, provider credentials, ACME accounts, workflows, and issued certificate material in PocketBase under {{ .Values.persistence.mountPath }}. Change the upstream default administrator immediately after first login and back up the PVC before upgrades.
+
+5. Configuration
+
+{{- if .Values.persistence.existingClaim }}
+Storage: existing PVC {{ .Values.persistence.existingClaim }} is mounted.
+{{- else if .Values.persistence.enabled }}
+Storage: chart-managed PVC is enabled. Back up the data volume before upgrades.
+{{- else }}
+Storage: persistence is disabled and certimate data is stored in an emptyDir.
+{{- end }}
+{{- if .Values.networkPolicy.enabled }}
+NetworkPolicy: enabled.
+{{- else }}
+NetworkPolicy: disabled.
+{{- end }}
+
+6. Validation
+
+Run Helm tests:
+
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Run the HelmForge chart gate from the ops repo:
+
+  make validate-chart CHART=certimate
+
+7. Troubleshooting
+
+Inspect logs and pod events:
+
+  kubectl logs deploy/{{ include "certimate.fullname" . }} -n {{ .Release.Namespace }}
+  kubectl describe pod -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+If the UI does not load, check the container logs and verify that the PVC is writable by the configured pod security context.
+
+8. Resources
+
+Chart documentation:
+
+  https://github.com/helmforgedev/charts/tree/main/charts/certimate
+
+Upstream project:
+
+  https://github.com/certimate-go/certimate
+
+Happy Helmforging :)

--- a/charts/certimate/templates/_helpers.tpl
+++ b/charts/certimate/templates/_helpers.tpl
@@ -1,0 +1,125 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "certimate.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "certimate.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "certimate.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "certimate.labels" -}}
+helm.sh/chart: {{ include "certimate.chart" . }}
+{{ include "certimate.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "certimate.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "certimate.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "certimate.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "certimate.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+HTTPRoute name helper.
+*/}}
+{{- define "certimate.httpRouteName" -}}
+{{- $root := .root -}}
+{{- $route := .route -}}
+{{- $index := .index | default 0 -}}
+{{- if $route.name -}}
+{{- $suffix := printf "-%s" $route.name -}}
+{{- $base := include "certimate.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else if gt (int $index) 0 -}}
+{{- $suffix := printf "-%d" (int $index) -}}
+{{- $base := include "certimate.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else -}}
+{{- include "certimate.fullname" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ExternalSecret name helper.
+*/}}
+{{- define "certimate.externalSecretName" -}}
+{{- $root := .root -}}
+{{- $item := .item -}}
+{{- $index := int (.index | default 0) -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if $item.name -}}
+{{- $suffix := printf "-%s" $item.name -}}
+{{- $base := include "certimate.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else if gt $index 0 -}}
+{{- $suffix := printf "-%d" $index -}}
+{{- $base := printf "%s-secret" (include "certimate.fullname" $root) | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else -}}
+{{- printf "%s-secret" (include "certimate.fullname" $root) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate chart values.
+*/}}
+{{- define "certimate.validate" -}}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.persistence.existingClaim) -}}
+{{- fail "replicaCount > 1 requires persistence.existingClaim because Certimate stores PocketBase state on a single writable volume" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) -}}
+{{- fail "externalSecrets.items must contain at least one item when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- range $key := (list "app.kubernetes.io/name" "app.kubernetes.io/instance") -}}
+{{- if hasKey $podLabels $key -}}
+{{- fail (printf "podLabels must not override the selector label %s" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/certimate/templates/deployment.yaml
+++ b/charts/certimate/templates/deployment.yaml
@@ -1,0 +1,147 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "certimate.fullname" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "certimate.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "certimate.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/pod-settings: {{ dict "env" .Values.app.env "envFrom" .Values.app.envFrom "extraManifests" .Values.extraManifests | toJson | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "certimate.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: {{ include "certimate.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.app.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.app.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.port }}
+              protocol: TCP
+          env:
+            - name: TZ
+              value: {{ .Values.app.timezone | quote }}
+            {{- range .Values.app.env }}
+            - name: {{ .name }}
+              {{- if hasKey . "valueFrom" }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- else }}
+              value: {{ default "" .value | quote }}
+              {{- end }}
+            {{- end }}
+          {{- with .Values.app.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath | quote }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | quote }}
+          {{- else if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "certimate.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/certimate/templates/externalsecret.yaml
+++ b/charts/certimate/templates/externalsecret.yaml
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- $externalSecretNames := dict }}
+{{- range $index, $item := .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "certimate.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- if hasKey $externalSecretNames $externalSecretName }}
+{{- fail (printf "externalSecrets.items render duplicate ExternalSecret name %q; set name or fullnameOverride to a unique value" $externalSecretName) }}
+{{- end }}
+{{- $_ := set $externalSecretNames $externalSecretName true }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasTopLevelStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasTopLevelStoreRef = true }}
+{{- end }}
+{{- if not $hasTopLevelStoreRef }}
+{{- range $dataIndex, $dataItem := ($spec.data | default list) }}
+{{- $sourceRef := get $dataItem "sourceRef" | default dict }}
+{{- $storeRef := get $sourceRef "storeRef" | default dict }}
+{{- $generatorRef := get $sourceRef "generatorRef" | default dict }}
+{{- if not (or (get $storeRef "name") (get $generatorRef "name")) }}
+{{- fail (printf "externalSecrets.items[%d].spec.data[%d] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set" $index $dataIndex) }}
+{{- end }}
+{{- end }}
+{{- range $dataFromIndex, $dataFromItem := ($spec.dataFrom | default list) }}
+{{- $sourceRef := get $dataFromItem "sourceRef" | default dict }}
+{{- $storeRef := get $sourceRef "storeRef" | default dict }}
+{{- $generatorRef := get $sourceRef "generatorRef" | default dict }}
+{{- if not (or (get $storeRef "name") (get $generatorRef "name")) }}
+{{- fail (printf "externalSecrets.items[%d].spec.dataFrom[%d] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set" $index $dataFromIndex) }}
+{{- end }}
+{{- end }}
+{{- if and (empty ($spec.data | default list)) (empty ($spec.dataFrom | default list)) }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- end }}
+---
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "certimate.labels" $ | nindent 4 }}
+    {{- with $item.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/certimate/templates/extra-manifests.yaml
+++ b/charts/certimate/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/certimate/templates/gateway-httproute.yaml
+++ b/charts/certimate/templates/gateway-httproute.yaml
@@ -1,0 +1,44 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- $httpRouteNames := dict }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
+{{- if not $route.parentRefs }}{{- fail "gatewayAPI.httpRoutes[].parentRefs is required" }}{{- end }}
+{{- $httpRouteName := include "certimate.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+{{- if hasKey $httpRouteNames $httpRouteName }}
+{{- fail (printf "gatewayAPI.httpRoutes render duplicate HTTPRoute name %q; set name to a unique value" $httpRouteName) }}
+{{- end }}
+{{- $_ := set $httpRouteNames $httpRouteName true }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $httpRouteName }}
+  labels:
+    {{- include "certimate.labels" $ | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.rules }}
+    {{- toYaml $route.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: {{ default "PathPrefix" $route.pathType }}
+            value: {{ default "/" $route.path | quote }}
+      backendRefs:
+        - name: {{ include "certimate.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/certimate/templates/ingress.yaml
+++ b/charts/certimate/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "certimate.fullname" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- $paths := default (list (dict "path" "/" "pathType" "Prefix")) .paths }}
+          {{- range $paths }}
+          - path: {{ default "/" .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ include "certimate.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/certimate/templates/networkpolicy.yaml
+++ b/charts/certimate/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "certimate.fullname" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "certimate.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.extraEgress }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+  {{- with .Values.networkPolicy.extraEgress }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 443
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/certimate/templates/pdb.yaml
+++ b/charts/certimate/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "certimate.fullname" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "certimate.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/certimate/templates/pvc.yaml
+++ b/charts/certimate/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "certimate.fullname" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/certimate/templates/service.yaml
+++ b/charts/certimate/templates/service.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "certimate.fullname" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "certimate.selectorLabels" . | nindent 4 }}

--- a/charts/certimate/templates/serviceaccount.yaml
+++ b/charts/certimate/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "certimate.serviceAccountName" . }}
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/certimate/templates/tests/test-connection.yaml
+++ b/charts/certimate/templates/tests/test-connection.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "certimate.fullname" . }}-test-connection
+  labels:
+    {{- include "certimate.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  containers:
+    - name: wget
+      image: busybox:1.37.0
+      command:
+        - wget
+      args:
+        - -qO-
+        - http://{{ include "certimate.fullname" . }}:{{ .Values.service.port }}/api/health
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/certimate/templates/validate.yaml
+++ b/charts/certimate/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "certimate.validate" . -}}

--- a/charts/certimate/tests/common-labels-values.yaml
+++ b/charts/certimate/tests/common-labels-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+commonLabels:
+  review: enabled

--- a/charts/certimate/tests/dual-stack-values.yaml
+++ b/charts/certimate/tests/dual-stack-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6

--- a/charts/certimate/tests/external-secrets-colliding-config-index-values.yaml
+++ b/charts/certimate/tests/external-secrets-colliding-config-index-values.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate/smtp
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: CERTIMATE_TOKEN
+            remoteRef:
+              key: certimate/token
+    - name: secret-1
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: CERTIMATE_TOKEN
+            remoteRef:
+              key: certimate/named-secret-1

--- a/charts/certimate/tests/external-secrets-colliding-config-name-values.yaml
+++ b/charts/certimate/tests/external-secrets-colliding-config-name-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate/smtp
+    - name: secret
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate/named-secret

--- a/charts/certimate/tests/external-secrets-default-target-values.yaml
+++ b/charts/certimate/tests/external-secrets-default-target-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate
+              property: CERTIMATE_SMTP_PASSWORD

--- a/charts/certimate/tests/external-secrets-fullname-values.yaml
+++ b/charts/certimate/tests/external-secrets-fullname-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: literal-certimate-config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate
+              property: smtpPassword

--- a/charts/certimate/tests/external-secrets-long-name-named-values.yaml
+++ b/charts/certimate/tests/external-secrets-long-name-named-values.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: certimate/config
+    - name: token
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: certimate/token

--- a/charts/certimate/tests/external-secrets-long-name-values.yaml
+++ b/charts/certimate/tests/external-secrets-long-name-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: certimate/config
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: certimate/token

--- a/charts/certimate/tests/external-secrets-mixed-data-missing-sourceref-values.yaml
+++ b/charts/certimate/tests/external-secrets-mixed-data-missing-sourceref-values.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate-password
+            sourceRef:
+              storeRef:
+                name: fake
+          - secretKey: CERTIMATE_TOKEN
+            remoteRef:
+              key: certimate-token

--- a/charts/certimate/tests/external-secrets-mixed-datafrom-missing-sourceref-values.yaml
+++ b/charts/certimate/tests/external-secrets-mixed-datafrom-missing-sourceref-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        dataFrom:
+          - extract:
+              key: certimate
+            sourceRef:
+              storeRef:
+                name: fake
+          - extract:
+              key: certimate-extra

--- a/charts/certimate/tests/external-secrets-multiple-unnamed-values.yaml
+++ b/charts/certimate/tests/external-secrets-multiple-unnamed-values.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate/smtp
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: certimate/token

--- a/charts/certimate/tests/external-secrets-values.yaml
+++ b/charts/certimate/tests/external-secrets-values.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: env
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        target:
+          name: RELEASE-NAME-certimate-env
+          creationPolicy: Owner
+        data:
+          - secretKey: CERTIMATE_SMTP_PASSWORD
+            remoteRef:
+              key: certimate
+              property: smtpPassword

--- a/charts/certimate/tests/external_secrets_test.yaml
+++ b/charts/certimate/tests/external_secrets_test.yaml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: certimate external secrets
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: renders an ExternalSecret for a environment secret
+    values:
+      - external-secrets-values.yaml
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.secretStoreRef.name
+          value: fake
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-certimate-env
+      - equal:
+          path: spec.data[0].secretKey
+          value: CERTIMATE_SMTP_PASSWORD
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+  - it: defaults target name to the rendered ExternalSecret name
+    values:
+      - external-secrets-default-target-values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-certimate-secret
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-certimate-secret
+  - it: gives multiple unnamed ExternalSecrets unique fallback names
+    values:
+      - external-secrets-multiple-unnamed-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-certimate-secret
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-certimate-secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-certimate-secret-1
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-certimate-secret-1
+        documentIndex: 1
+  - it: reserves suffix room for unnamed ExternalSecrets with a long secret name
+    values:
+      - external-secrets-long-name-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+  - it: reserves suffix room for named ExternalSecrets with a long fullname
+    values:
+      - external-secrets-long-name-named-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-config
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-token
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-token
+        documentIndex: 1
+  - it: uses fullnameOverride literally
+    values:
+      - external-secrets-fullname-values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: literal-certimate-config
+      - equal:
+          path: spec.target.name
+          value: literal-certimate-config
+  - it: fails when a named ExternalSecret collides with the unnamed secret fallback
+    values:
+      - external-secrets-colliding-config-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items render duplicate ExternalSecret name \"RELEASE-NAME-certimate-secret\"; set name or fullnameOverride to a unique value"
+  - it: fails when a named ExternalSecret collides with an indexed unnamed fallback
+    values:
+      - external-secrets-colliding-config-index-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items render duplicate ExternalSecret name \"RELEASE-NAME-certimate-secret-1\"; set name or fullnameOverride to a unique value"
+  - it: fails without a secretStoreRef or sourceRef
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items[0].spec.data[0].secretKey: CERTIMATE_SMTP_PASSWORD
+      externalSecrets.items[0].spec.data[0].remoteRef.key: certimate
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0].spec.data[0] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set"
+  - it: fails when one data item lacks sourceRef without a top-level store
+    values:
+      - external-secrets-mixed-data-missing-sourceref-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0].spec.data[1] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set"
+  - it: fails when one dataFrom item lacks sourceRef without a top-level store
+    values:
+      - external-secrets-mixed-datafrom-missing-sourceref-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0].spec.dataFrom[1] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set"

--- a/charts/certimate/tests/gateway-colliding-index-name-values.yaml
+++ b/charts/certimate/tests/gateway-colliding-index-name-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: "1"
+      parentRefs:
+        - name: public
+      path: /named-index
+    - parentRefs:
+        - name: internal
+      path: /unnamed-index

--- a/charts/certimate/tests/gateway-long-name-named-values.yaml
+++ b/charts/certimate/tests/gateway-long-name-named-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: public
+      parentRefs:
+        - name: public
+      path: /
+    - name: internal
+      parentRefs:
+        - name: internal
+      path: /internal

--- a/charts/certimate/tests/gateway-long-name-values.yaml
+++ b/charts/certimate/tests/gateway-long-name-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: public
+      path: /
+    - parentRefs:
+        - name: internal
+      path: /internal

--- a/charts/certimate/tests/gateway-values.yaml
+++ b/charts/certimate/tests/gateway-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - certimate.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/certimate/tests/gateway_test.yaml
+++ b/charts/certimate/tests/gateway_test.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: certimate gateway api
+templates:
+  - templates/gateway-httproute.yaml
+tests:
+  - it: renders an HTTPRoute to the chart service
+    values:
+      - gateway-values.yaml
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-certimate
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8090
+  - it: reserves suffix room for multiple unnamed routes with a long fullname
+    values:
+      - gateway-long-name-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+  - it: reserves suffix room for named routes with a long fullname
+    values:
+      - gateway-long-name-named-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-public
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-internal
+        documentIndex: 1
+  - it: fails when a named route collides with an indexed unnamed fallback
+    values:
+      - gateway-colliding-index-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.httpRoutes render duplicate HTTPRoute name \"RELEASE-NAME-certimate-1\"; set name to a unique value"

--- a/charts/certimate/tests/ingress-host-only-values.yaml
+++ b/charts/certimate/tests/ingress-host-only-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: certimate.example.com

--- a/charts/certimate/tests/ingress-values.yaml
+++ b/charts/certimate/tests/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: certimate.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: certimate-tls
+      hosts:
+        - certimate.example.com

--- a/charts/certimate/tests/networkpolicy-extra-egress-values.yaml
+++ b/charts/certimate/tests/networkpolicy-extra-egress-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 8443

--- a/charts/certimate/tests/networkpolicy-values.yaml
+++ b/charts/certimate/tests/networkpolicy-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system

--- a/charts/certimate/tests/networkpolicy_test.yaml
+++ b/charts/certimate/tests/networkpolicy_test.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: certimate network policy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: limits inbound certimate HTTP traffic
+    values:
+      - networkpolicy-values.yaml
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: http
+      - notContains:
+          path: spec.policyTypes
+          content: Egress
+  - it: enables egress isolation when extraEgress is configured
+    values:
+      - networkpolicy-extra-egress-values.yaml
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 53
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 443
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 8443

--- a/charts/certimate/tests/podlabels-selector-instance-values.yaml
+++ b/charts/certimate/tests/podlabels-selector-instance-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/instance: custom

--- a/charts/certimate/tests/podlabels-selector-name-values.yaml
+++ b/charts/certimate/tests/podlabels-selector-name-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/name: custom

--- a/charts/certimate/tests/service_test.yaml
+++ b/charts/certimate/tests/service_test.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: certimate service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders dual-stack service settings
+    values:
+      - dual-stack-values.yaml
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: certimate base templates
+templates:
+  - templates/deployment.yaml
+  - templates/ingress.yaml
+  - templates/pvc.yaml
+  - templates/service.yaml
+tests:
+  - it: renders the official pinned image
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: certimate/certimate:v0.4.26
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/pod-settings"]
+          pattern: "^[a-f0-9]{64}$"
+  - it: renders the default ClusterIP service
+    template: templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+  - it: renders common labels on a separate line
+    template: templates/service.yaml
+    values:
+      - common-labels-values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels.review
+          value: enabled
+  - it: renders ingress TLS
+    template: templates/ingress.yaml
+    values:
+      - ingress-values.yaml
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: certimate-tls
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: certimate.example.com
+  - it: defaults ingress host paths when omitted
+    template: templates/ingress.yaml
+    values:
+      - ingress-host-only-values.yaml
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Prefix
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-certimate
+  - it: uses emptyDir when persistence is disabled
+    template: templates/deployment.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: data
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}
+  - it: creates a PVC when persistence is chart-managed
+    template: templates/pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi

--- a/charts/certimate/tests/test_connection_test.yaml
+++ b/charts/certimate/tests/test_connection_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Helm Test
+templates:
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render the Helm test hook pod
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: test-certimate-test-connection
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded

--- a/charts/certimate/tests/validation_test.yaml
+++ b/charts/certimate/tests/validation_test.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: certimate validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: fails when scaling without shared storage
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "replicaCount > 1 requires persistence.existingClaim because Certimate stores PocketBase state on a single writable volume"
+  - it: fails when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one host when ingress.enabled=true"
+  - it: fails when ExternalSecrets is enabled without items
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items must contain at least one item when externalSecrets.enabled=true"
+  - it: fails when podLabels override selector name
+    values:
+      - podlabels-selector-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/name"
+  - it: fails when podLabels override selector instance
+    values:
+      - podlabels-selector-instance-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/instance"

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Certimate Helm Chart Values",
+  "description": "Values for the Certimate self-hosted certificate automation chart",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string", "default": "" },
+    "fullnameOverride": { "type": "string", "default": "" },
+    "commonLabels": { "type": "object" },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "default": "certimate/certimate" },
+        "tag": { "type": "string", "default": "v0.4.26", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
+      }
+    },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "replicaCount": { "type": "integer", "minimum": 1, "default": 1 },
+    "app": {
+      "type": "object",
+      "properties": {
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 8090 },
+        "timezone": { "type": "string", "default": "UTC" },
+        "command": { "type": "array", "items": { "type": "string" } },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": { "type": "string" },
+              "value": { "type": "string" },
+              "valueFrom": { "type": "object" }
+            }
+          }
+        },
+        "envFrom": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "size": { "type": "string", "default": "5Gi" },
+        "storageClass": { "type": "string", "default": "" },
+        "accessModes": { "type": "array", "items": { "type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"] } },
+        "existingClaim": { "type": "string", "default": "" },
+        "mountPath": { "type": "string", "default": "/app/pb_data" }
+      }
+    },
+    "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+    "service": { "$ref": "#/definitions/service" },
+    "ingress": { "$ref": "#/definitions/ingress" },
+    "gatewayAPI": { "$ref": "#/definitions/gatewayAPI" },
+    "externalSecrets": { "$ref": "#/definitions/externalSecrets" },
+    "probes": { "$ref": "#/definitions/probes" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "pdb": { "$ref": "#/definitions/pdb" },
+    "networkPolicy": { "$ref": "#/definitions/networkPolicy" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string", "default": "" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0, "default": 30 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
+  },
+  "definitions": {
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean", "default": true },
+        "name": { "type": "string", "default": "" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean", "default": false }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"], "default": "ClusterIP" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 8090 },
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressClassName": { "type": "string", "default": "traefik" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "httpRoutes": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "apiVersion": { "type": "string", "default": "external-secrets.io/v1" },
+        "refreshInterval": { "type": "string", "default": "1h" },
+        "items": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "startup": { "$ref": "#/definitions/probe" },
+        "liveness": { "$ref": "#/definitions/probe" },
+        "readiness": { "$ref": "#/definitions/probe" }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "minAvailable": { "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }] }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "ingressFrom": { "type": "array", "items": { "type": "object" } },
+        "extraEgress": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  }
+}

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# -- Override the chart name used in Kubernetes object names.
+nameOverride: ""
+
+# -- Override the full release name used in Kubernetes object names.
+fullnameOverride: ""
+
+# -- Extra labels applied to all Kubernetes objects rendered by this chart.
+commonLabels: {}
+
+image:
+  # -- Official Certimate container image repository.
+  repository: certimate/certimate
+  # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
+  tag: "v0.4.26"
+  # -- Kubernetes image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Optional image pull secrets for private registries or mirrored images.
+imagePullSecrets: []
+
+# -- Number of Certimate pods. Keep 1 because Certimate stores PocketBase state on one writable volume.
+replicaCount: 1
+
+app:
+  # -- HTTP port exposed by Certimate inside the container.
+  port: 8090
+  # -- Timezone passed to the container.
+  timezone: UTC
+  # -- Optional command override. Leave empty to use the upstream image entrypoint.
+  command: []
+  # -- Optional argument override. Leave empty to use the upstream image defaults.
+  args: []
+  # -- Additional environment variables for upstream options or integrations.
+  env: []
+  # -- Additional envFrom sources such as Secret or ConfigMap references.
+  envFrom: []
+
+persistence:
+  # -- Persist Certimate PocketBase data, certificates, account data, workflows, and provider credentials.
+  enabled: true
+  # -- PersistentVolumeClaim size for /app/pb_data.
+  size: 5Gi
+  # -- StorageClass for the generated PersistentVolumeClaim. Empty uses the cluster default.
+  storageClass: ""
+  # -- Access modes for the generated PersistentVolumeClaim.
+  accessModes:
+    - ReadWriteOnce
+  # -- Existing PersistentVolumeClaim to mount instead of creating a new claim.
+  existingClaim: ""
+  # -- Container data directory used by upstream Certimate.
+  mountPath: /app/pb_data
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- ServiceAccount name. Defaults to the release fullname when create=true.
+  name: ""
+  # -- Annotations for the ServiceAccount.
+  annotations: {}
+  # -- Mount the ServiceAccount token in the pod.
+  automountServiceAccountToken: false
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Service port.
+  port: 8090
+  # -- Service annotations.
+  annotations: {}
+  # -- IP family policy. Options: SingleStack, PreferDualStack, RequireDualStack.
+  ipFamilyPolicy: ""
+  # -- Ordered list of IP families, for example ["IPv4", "IPv6"].
+  ipFamilies: []
+
+ingress:
+  # -- Enable Kubernetes Ingress.
+  enabled: false
+  # -- IngressClassName for the generated Ingress.
+  ingressClassName: traefik
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Ingress hosts and paths.
+  hosts: []
+  # -- Ingress TLS blocks.
+  tls: []
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute templates.
+  enabled: false
+  # -- List of HTTPRoute definitions. Each item is rendered as one HTTPRoute.
+  httpRoutes: []
+
+externalSecrets:
+  # -- Render external-secrets.io ExternalSecret resources.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Default sync interval applied to items without their own value.
+  refreshInterval: 1h
+  # -- List of ExternalSecret definitions. Each item carries a complete spec.
+  items: []
+
+probes:
+  # -- Startup probe settings.
+  startup:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 30
+  # -- Liveness probe settings.
+  liveness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  # -- Readiness probe settings.
+  readiness:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+# -- Container resource requests and limits.
+resources: {}
+
+# -- Pod security context.
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+
+# -- Container security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+pdb:
+  # -- Create a PodDisruptionBudget.
+  enabled: false
+  # -- Minimum available pods during voluntary disruptions.
+  minAvailable: 1
+
+networkPolicy:
+  # -- Create a NetworkPolicy that restricts inbound HTTP traffic to certimate.
+  enabled: false
+  # -- Custom ingress peers. Empty allows ingress from any namespace.
+  ingressFrom: []
+  # -- Additional egress rules. When set, the policy also isolates egress while preserving DNS and HTTPS access.
+  extraEgress: []
+
+# -- Node selector for scheduling the pod.
+nodeSelector: {}
+
+# -- Tolerations for scheduling the pod.
+tolerations: []
+
+# -- Affinity rules for scheduling the pod.
+affinity: {}
+
+# -- Topology spread constraints for scheduling the pod.
+topologySpreadConstraints: []
+
+# -- Optional PriorityClass name.
+priorityClassName: ""
+
+# -- Pod termination grace period in seconds.
+terminationGracePeriodSeconds: 30
+
+# -- Extra labels applied to the pod template.
+podLabels: {}
+
+# -- Extra annotations applied to the pod template.
+podAnnotations: {}
+
+# -- Extra volumes mounted into the pod.
+extraVolumes: []
+
+# -- Extra volume mounts added to the certimate container.
+extraVolumeMounts: []
+
+# -- Additional Kubernetes manifests rendered with the chart.
+extraManifests: []


### PR DESCRIPTION
Resolves #779
Parent request: #777
Site PR: helmforgedev/site#417

## Summary

- Add a production-ready Certimate chart using the official `certimate/certimate:v0.4.26` image.
- Persist PocketBase state under `/app/pb_data` with single-writer defaults and Recreate rollout strategy.
- Add Ingress, Gateway API, ExternalSecret, NetworkPolicy, dual-stack Service, PDB, test hook, docs, examples, schema, and unit tests.

## Validation

- `make image-verify IMAGE=certimate/certimate:v0.4.26`
- `helm lint charts/certimate --strict`
- `helm template certimate charts/certimate --debug`
- `helm unittest charts/certimate`
- `make validate-chart CHART=certimate` (17 layers, including k3d behavioral scenarios)
- `make standards-check CHART=certimate`
- `node scripts/charts/template-standards-check.js --chart certimate`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=certimate JSON=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Certimate Helm chart for Kubernetes, including Service, persistence options, health probes, PodDisruptionBudget, Ingress and Gateway API HTTPRoute support, TLS examples, NetworkPolicy controls, External Secrets integration, and extra-manifest rendering.
  * Added end-user documentation, install notes, CI values scenarios, and a values schema to guide configuration.
* **Bug Fixes**
  * Added render-time safety checks to catch common misconfigurations (unsafe label/selector overrides, missing required route/secret inputs, and naming collisions).
* **Tests**
  * Added comprehensive Helm tests covering rendering, connectivity to the health endpoint, and negative validation cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->