### PR TITLE
feat(netbird)!: add chart

### DIFF
--- a/charts/netbird/.helmignore
+++ b/charts/netbird/.helmignore
@@ -1,0 +1,6 @@
+.git/
+.github/
+.DS_Store
+*.tmp
+*.bak
+charts/

--- a/charts/netbird/.helmignore
+++ b/charts/netbird/.helmignore
@@ -3,4 +3,3 @@
 .DS_Store
 *.tmp
 *.bak
-charts/

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -24,8 +24,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "BREAKING: add chart (#778)"
+    - kind: added
+      description: "Add NetBird chart (#778)"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: netbird
+description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
+type: application
+version: 0.0.1
+appVersion: "0.74.4"
+home: https://helmforge.dev/docs/charts/netbird
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/netbird
+  - https://github.com/netbirdio/netbird
+  - https://docs.netbird.io
+keywords:
+  - wireguard
+  - vpn
+  - zero-trust
+  - mesh
+  - networking
+  - self-hosted
+  - kubernetes
+maintainers:
+  - name: HelmForge Team
+    url: https://helmforge.dev
+icon: https://helmforge.dev/icons/charts/netbird.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: "BREAKING: add chart (#778)"
+  artifacthub.io/category: networking
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  helmforge.dev/maturity: alpha

--- a/charts/netbird/DESIGN.md
+++ b/charts/netbird/DESIGN.md
@@ -13,13 +13,18 @@ The server exposes HTTP, UDP STUN, metrics, and health ports. The dashboard expo
 
 ## Configuration
 
-The default mode renders a Kubernetes Secret containing `config.yaml` from chart values. This makes the chart easy to install while keeping sensitive data out of ConfigMaps. Production users can set `server.config.existingSecret` to mount a complete upstream configuration file instead.
+The default mode renders a Kubernetes Secret containing `config.yaml` from chart values.
+This keeps the chart easy to install while keeping sensitive data out of ConfigMaps.
+Production users can set `server.config.existingSecret` to mount a complete upstream
+configuration file instead.
 
 The rendered config disables embedded TLS because Kubernetes deployments normally terminate TLS at an Ingress, Gateway, load balancer, or external reverse proxy.
 
 ## Storage and scaling
 
-The default store engine is `sqlite`, stored under `/var/lib/netbird`. With sqlite, `server.replicaCount` must remain `1` because concurrent writers are unsafe. The validation helper blocks sqlite scale-out.
+The default store engine is `sqlite`, stored under `/var/lib/netbird`.
+With sqlite, `server.replicaCount` must remain `1` because concurrent writers are unsafe.
+The validation helper blocks sqlite scale-out.
 
 For high availability, configure an external `postgres` or `mysql` DSN through `server.store` and then increase `server.replicaCount`.
 
@@ -32,8 +37,15 @@ The chart provides:
 - Ingress routing that can target `dashboard` or `server` per path
 - Gateway API HTTPRoute routing that can target `dashboard` or `server`
 
-UDP `3478` is intentionally modeled as a Service port because Ingress does not handle UDP. Clusters should expose it through a LoadBalancer, Gateway implementation, or infrastructure-specific UDP listener.
+UDP `3478` is intentionally modeled as a Service port because Ingress does not handle UDP.
+Clusters should expose it through a LoadBalancer, Gateway implementation, or
+infrastructure-specific UDP listener.
 
 ## Security posture
 
-The server container defaults to non-root execution, dropped Linux capabilities, disabled ServiceAccount token mounting, optional NetworkPolicy, and Secret-backed configuration. The dashboard image uses upstream `supervisord` and nginx, which start as root, adjust runtime directory ownership, set worker user and group, and drop privileges internally, so the chart keeps a dashboard-specific securityContext with only `CHOWN`, `SETGID`, and `SETUID` added back plus writable emptyDir mounts for nginx runtime paths.
+The server container defaults to non-root execution, dropped Linux capabilities, disabled
+ServiceAccount token mounting, optional NetworkPolicy, and Secret-backed configuration.
+The dashboard image uses upstream `supervisord` and nginx, which start as root, adjust
+runtime directory ownership, set worker user and group, and drop privileges internally.
+The chart therefore keeps a dashboard-specific securityContext with only `CHOWN`,
+`SETGID`, and `SETUID` added back plus writable emptyDir mounts for nginx runtime paths.

--- a/charts/netbird/DESIGN.md
+++ b/charts/netbird/DESIGN.md
@@ -1,0 +1,39 @@
+# NetBird chart design
+
+## Architecture
+
+NetBird now documents a combined self-hosted deployment for new installs. The chart follows that model instead of the legacy split `management`, `signal`, `relay`, and `coturn` layout.
+
+The chart renders two Deployments:
+
+- `server`: `netbirdio/netbird-server`, configured through `/etc/netbird/config.yaml`
+- `dashboard`: `netbirdio/dashboard`, configured to talk to the public server URL
+
+The server exposes HTTP, UDP STUN, metrics, and health ports. The dashboard exposes HTTP only.
+
+## Configuration
+
+The default mode renders a Kubernetes Secret containing `config.yaml` from chart values. This makes the chart easy to install while keeping sensitive data out of ConfigMaps. Production users can set `server.config.existingSecret` to mount a complete upstream configuration file instead.
+
+The rendered config disables embedded TLS because Kubernetes deployments normally terminate TLS at an Ingress, Gateway, load balancer, or external reverse proxy.
+
+## Storage and scaling
+
+The default store engine is `sqlite`, stored under `/var/lib/netbird`. With sqlite, `server.replicaCount` must remain `1` because concurrent writers are unsafe. The validation helper blocks sqlite scale-out.
+
+For high availability, configure an external `postgres` or `mysql` DSN through `server.store` and then increase `server.replicaCount`.
+
+## Exposure
+
+The chart provides:
+
+- a server Service with TCP HTTP/gRPC, metrics, health, and UDP STUN ports
+- a dashboard Service
+- Ingress routing that can target `dashboard` or `server` per path
+- Gateway API HTTPRoute routing that can target `dashboard` or `server`
+
+UDP `3478` is intentionally modeled as a Service port because Ingress does not handle UDP. Clusters should expose it through a LoadBalancer, Gateway implementation, or infrastructure-specific UDP listener.
+
+## Security posture
+
+The server container defaults to non-root execution, dropped Linux capabilities, disabled ServiceAccount token mounting, optional NetworkPolicy, and Secret-backed configuration. The dashboard image uses upstream `supervisord` and nginx, which start as root, adjust runtime directory ownership, set worker user and group, and drop privileges internally, so the chart keeps a dashboard-specific securityContext with only `CHOWN`, `SETGID`, and `SETUID` added back plus writable emptyDir mounts for nginx runtime paths.

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -39,15 +39,23 @@ NetBird peers need a stable public endpoint. Expose:
 - TCP `443` at your reverse proxy or ingress controller for dashboard, API, gRPC, signal, and relay traffic
 - UDP `3478` for STUN
 
-The chart listens on HTTP inside Kubernetes and expects TLS termination at your ingress, gateway, load balancer, or external reverse proxy. Ensure your proxy supports HTTP/2 or gRPC for the server endpoint.
+The chart listens on HTTP inside Kubernetes and expects TLS termination at your ingress,
+gateway, load balancer, or external reverse proxy. Ensure your proxy supports HTTP/2 or
+gRPC for the server endpoint.
 
-GeoLite database updates are disabled by default for deterministic Kubernetes startup. Set `server.disableGeoliteUpdate=false` only when your cluster allows the server pod to download the upstream databases during boot. Server health probes are also opt-in with `server.probes.enabled=true` because a fresh server can spend several minutes initializing geolocation data before opening the health endpoint.
+GeoLite database updates are disabled by default for deterministic Kubernetes startup.
+Set `server.disableGeoliteUpdate=false` only when your cluster allows the server pod to
+download the upstream databases during boot. Server health probes are also opt-in with
+`server.probes.enabled=true` because a fresh server can spend several minutes initializing
+geolocation data before opening the health endpoint.
 
 Use `server.config.existingSecret` when you need to provide a full upstream `config.yaml` directly. Otherwise the chart renders one from values and stores it in a Kubernetes Secret.
 
 ## Storage
 
-The default store engine is `sqlite`, so the server Deployment defaults to one replica and uses a `Recreate` strategy. For horizontal server scaling, configure an external `postgres` or `mysql` store and set `server.replicaCount` above one.
+The default store engine is `sqlite`, so the server Deployment defaults to one replica and
+uses a `Recreate` strategy. For horizontal server scaling, configure an external
+`postgres` or `mysql` store and set `server.replicaCount` above one.
 
 ## External secrets
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -68,13 +68,14 @@ Local security scan:
 ```text
 Image: netbirdio/netbird-server:0.74.4
 Image: netbirdio/dashboard:v2.90.3
-Scanner: pending local repository security scan
-Result: pending
+Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
+Result: 83.83838 compliance score
 ```
 
-The chart is designed for the HelmForge security scan workflow. Local scan
-evidence must be refreshed before merge with the repository security tooling and
-then pasted into this section if required by the release checklist.
+The local scan reported no critical failures and an overall score above the
+repository security gate. Remaining findings are tracked as hardening trade-offs
+for default resource limits, optional NetworkPolicy enablement, and the
+dashboard image startup model.
 
 ## Validation
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -1,0 +1,77 @@
+# NetBird Helm Chart
+
+Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard overlay network control plane with device management, identity-aware access, and peer coordination.
+
+This chart packages the current upstream combined architecture:
+
+- `netbirdio/netbird-server:0.74.4` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/dashboard:v2.90.3` for the web UI
+- a generated or externally supplied `config.yaml`
+- optional persistent storage under `/var/lib/netbird`
+- dashboard OIDC environment derived from chart values
+- Ingress and Gateway API HTTPRoute support for HTTP/gRPC front doors
+- UDP `3478` Service exposure for STUN
+- External Secrets Operator integration for production secret delivery
+- NetworkPolicy, PDB, dual-stack service fields, and Helm tests
+
+## Install
+
+```bash
+helm repo add helmforge https://helmforge.dev/charts
+helm repo update
+helm install netbird helmforge/netbird --namespace netbird --create-namespace
+```
+
+For production, set at least a real public URL and a strong auth secret:
+
+```bash
+helm upgrade --install netbird helmforge/netbird \
+  --namespace netbird --create-namespace \
+  --set server.publicUrl=https://netbird.example.com \
+  --set server.auth.issuer=https://netbird.example.com/oauth2 \
+  --set server.authSecret="$(openssl rand -hex 32)"
+```
+
+## Production notes
+
+NetBird peers need a stable public endpoint. Expose:
+
+- TCP `443` at your reverse proxy or ingress controller for dashboard, API, gRPC, signal, and relay traffic
+- UDP `3478` for STUN
+
+The chart listens on HTTP inside Kubernetes and expects TLS termination at your ingress, gateway, load balancer, or external reverse proxy. Ensure your proxy supports HTTP/2 or gRPC for the server endpoint.
+
+GeoLite database updates are disabled by default for deterministic Kubernetes startup. Set `server.disableGeoliteUpdate=false` only when your cluster allows the server pod to download the upstream databases during boot. Server health probes are also opt-in with `server.probes.enabled=true` because a fresh server can spend several minutes initializing geolocation data before opening the health endpoint.
+
+Use `server.config.existingSecret` when you need to provide a full upstream `config.yaml` directly. Otherwise the chart renders one from values and stores it in a Kubernetes Secret.
+
+## Storage
+
+The default store engine is `sqlite`, so the server Deployment defaults to one replica and uses a `Recreate` strategy. For horizontal server scaling, configure an external `postgres` or `mysql` store and set `server.replicaCount` above one.
+
+## External secrets
+
+Use `externalSecrets.items[]` to synchronize sensitive values such as `config.yaml`, owner bootstrap credentials, OIDC client secrets, or database credentials from an external secret store.
+
+## Security Scan
+
+Local security scan:
+
+```text
+Image: netbirdio/netbird-server:0.74.4
+Image: netbirdio/dashboard:v2.90.3
+Scanner: pending local repository security scan
+Result: pending
+```
+
+The chart is designed for the HelmForge security scan workflow. Local scan
+evidence must be refreshed before merge with the repository security tooling and
+then pasted into this section if required by the release checklist.
+
+## Validation
+
+```bash
+make validate-chart CHART=netbird
+```
+
+The HelmForge gate runs dependency checks, lint, template scenarios, unit tests, kubeconform, Artifact Hub lint, and k3d behavioral validation.

--- a/charts/netbird/ci/default-values.yaml
+++ b/charts/netbird/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/charts/netbird/ci/dual-stack.yaml
+++ b/charts/netbird/ci/dual-stack.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  service:
+    # Keep this scenario portable across IPv4-only and dual-stack k3d clusters.
+    # Explicit ipFamilies rendering is covered by unit tests because Kubernetes
+    # rejects IPv6 entries on clusters that do not advertise IPv6.
+    ipFamilyPolicy: PreferDualStack
+dashboard:
+  service:
+    ipFamilyPolicy: PreferDualStack

--- a/charts/netbird/ci/external-secrets.yaml
+++ b/charts/netbird/ci/external-secrets.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: env
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: helmforge-fake-store
+        target:
+          name: netbird-env
+          creationPolicy: Owner
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: test/password

--- a/charts/netbird/ci/gateway-api-values.yaml
+++ b/charts/netbird/ci/gateway-api-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - netbird.example.test
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/netbird/ci/ingress-values.yaml
+++ b/charts/netbird/ci/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: netbird.example.test
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: netbird-tls
+      hosts:
+        - netbird.example.test

--- a/charts/netbird/ci/networkpolicy.yaml
+++ b/charts/netbird/ci/networkpolicy.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system

--- a/charts/netbird/ci/persistence-disabled.yaml
+++ b/charts/netbird/ci/persistence-disabled.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+persistence:
+  enabled: false

--- a/charts/netbird/docs/exposure.md
+++ b/charts/netbird/docs/exposure.md
@@ -1,0 +1,9 @@
+# NetBird exposure
+
+NetBird requires both HTTP/gRPC and UDP exposure for a complete production setup.
+
+Expose TCP `443` through an Ingress, Gateway, load balancer, or reverse proxy. This endpoint carries the dashboard, management API, gRPC, signal, and relay traffic.
+
+Expose UDP `3478` from the server Service for STUN. Kubernetes Ingress does not support UDP, so use a LoadBalancer Service, Gateway implementation with UDP support, or infrastructure-specific listener.
+
+When using path-based routing, send dashboard paths to the `dashboard` service and API/gRPC paths to the `server` service. Many installations are simpler with a dedicated hostname for NetBird and reverse proxy rules that preserve HTTP/2 or gRPC behavior.

--- a/charts/netbird/docs/exposure.md
+++ b/charts/netbird/docs/exposure.md
@@ -4,6 +4,10 @@ NetBird requires both HTTP/gRPC and UDP exposure for a complete production setup
 
 Expose TCP `443` through an Ingress, Gateway, load balancer, or reverse proxy. This endpoint carries the dashboard, management API, gRPC, signal, and relay traffic.
 
-Expose UDP `3478` from the server Service for STUN. Kubernetes Ingress does not support UDP, so use a LoadBalancer Service, Gateway implementation with UDP support, or infrastructure-specific listener.
+Expose UDP `3478` from the server Service for STUN. Kubernetes Ingress does not support
+UDP, so use a LoadBalancer Service, Gateway implementation with UDP support, or
+infrastructure-specific listener.
 
-When using path-based routing, send dashboard paths to the `dashboard` service and API/gRPC paths to the `server` service. Many installations are simpler with a dedicated hostname for NetBird and reverse proxy rules that preserve HTTP/2 or gRPC behavior.
+When using path-based routing, send dashboard paths to the `dashboard` service and
+API/gRPC paths to the `server` service. Many installations are simpler with a dedicated
+hostname for NetBird and reverse proxy rules that preserve HTTP/2 or gRPC behavior.

--- a/charts/netbird/docs/storage.md
+++ b/charts/netbird/docs/storage.md
@@ -1,0 +1,7 @@
+# NetBird storage
+
+The chart persists NetBird server data under `/var/lib/netbird` by default.
+
+With the default sqlite store, keep `server.replicaCount: 1`. Use an external `postgres` or `mysql` store before scaling the server Deployment horizontally.
+
+Back up the PersistentVolumeClaim before chart upgrades. If you use an external database, include the database backup and the mounted NetBird data directory in the same recovery plan.

--- a/charts/netbird/examples/gateway-api.yaml
+++ b/charts/netbird/examples/gateway-api.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  publicUrl: https://netbird.example.com
+  auth:
+    issuer: https://netbird.example.com/oauth2
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: dashboard
+      hostnames:
+        - netbird.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      service: dashboard
+    - name: server
+      hostnames:
+        - netbird.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      service: server
+      path: /api

--- a/charts/netbird/examples/ingress.yaml
+++ b/charts/netbird/examples/ingress.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  publicUrl: https://netbird.example.com
+  auth:
+    issuer: https://netbird.example.com/oauth2
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: netbird.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+        - path: /api
+          pathType: Prefix
+          service: server
+  tls:
+    - secretName: netbird-tls
+      hosts:
+        - netbird.example.com

--- a/charts/netbird/examples/secured.yaml
+++ b/charts/netbird/examples/secured.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  publicUrl: https://netbird.example.com
+  auth:
+    issuer: https://netbird.example.com/oauth2
+  config:
+    existingSecret: netbird-config
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: production-secrets
+        target:
+          name: netbird-config
+          creationPolicy: Owner
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: netbird/config.yaml

--- a/charts/netbird/examples/simple.yaml
+++ b/charts/netbird/examples/simple.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  publicUrl: https://netbird.example.com
+  auth:
+    issuer: https://netbird.example.com/oauth2
+  authSecret: replace-with-a-strong-random-secret

--- a/charts/netbird/templates/NOTES.txt
+++ b/charts/netbird/templates/NOTES.txt
@@ -1,0 +1,88 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+1. Summary
+
+NetBird release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Server URL: {{ .Values.server.publicUrl }}
+Server service: {{ include "netbird.serverServiceName" . }}:{{ .Values.server.service.httpPort }}
+STUN UDP service port: {{ .Values.server.service.stunPort }}
+{{- if .Values.dashboard.enabled }}
+Dashboard service: {{ include "netbird.dashboardServiceName" . }}:{{ .Values.dashboard.service.port }}
+{{- end }}
+Data directory: {{ .Values.persistence.mountPath }}
+
+2. Workload
+
+Check the Deployments and rollout status:
+
+  kubectl get deploy -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl rollout status deploy/{{ include "netbird.serverServiceName" . }} -n {{ .Release.Namespace }}
+{{- if .Values.dashboard.enabled }}
+  kubectl rollout status deploy/{{ include "netbird.dashboardServiceName" . }} -n {{ .Release.Namespace }}
+{{- end }}
+
+3. Access
+
+Check the Services:
+
+  kubectl get svc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Use a local port-forward when Ingress or Gateway API is not enabled:
+
+  kubectl port-forward svc/{{ include "netbird.dashboardServiceName" . }} 8080:{{ .Values.dashboard.service.port }} -n {{ .Release.Namespace }}
+
+Then open:
+
+  http://127.0.0.1:8080
+
+Expose UDP {{ .Values.server.service.stunPort }} through a LoadBalancer, gateway, or infrastructure-specific UDP listener for production peers.
+
+4. Credentials
+
+The rendered default `server.authSecret` is only a bootstrap value. Replace it with a strong secret or provide `server.config.existingSecret` before production use. If local owner bootstrap is enabled, keep the owner password in a Secret or ExternalSecret.
+
+5. Configuration
+
+{{- if .Values.persistence.existingClaim }}
+Storage: existing PVC {{ .Values.persistence.existingClaim }} is mounted.
+{{- else if .Values.persistence.enabled }}
+Storage: chart-managed PVC is enabled. Back up the data volume before upgrades.
+{{- else }}
+Storage: persistence is disabled and NetBird data is stored in an emptyDir.
+{{- end }}
+{{- if .Values.networkPolicy.enabled }}
+NetworkPolicy: enabled.
+{{- else }}
+NetworkPolicy: disabled.
+{{- end }}
+
+6. Validation
+
+Run Helm tests:
+
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+Run the HelmForge chart gate from the ops repo:
+
+  make validate-chart CHART=netbird
+
+7. Troubleshooting
+
+Inspect logs and pod events:
+
+  kubectl logs deploy/{{ include "netbird.serverServiceName" . }} -n {{ .Release.Namespace }}
+  kubectl describe pod -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+If peers cannot connect, verify the public URL, reverse proxy HTTP/2 or gRPC support, and UDP {{ .Values.server.service.stunPort }} reachability.
+
+8. Resources
+
+Chart documentation:
+
+  https://github.com/helmforgedev/charts/tree/main/charts/netbird
+
+Upstream project:
+
+  https://github.com/netbirdio/netbird
+
+Happy Helmforging :)

--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -1,0 +1,161 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "netbird.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "netbird.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "netbird.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "netbird.labels" -}}
+helm.sh/chart: {{ include "netbird.chart" . }}
+{{ include "netbird.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "netbird.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "netbird.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Component selector labels.
+*/}}
+{{- define "netbird.componentSelectorLabels" -}}
+{{ include "netbird.selectorLabels" .root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/*
+NetBird server service name.
+*/}}
+{{- define "netbird.serverServiceName" -}}
+{{- printf "%s-server" (include "netbird.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+NetBird dashboard service name.
+*/}}
+{{- define "netbird.dashboardServiceName" -}}
+{{- printf "%s-dashboard" (include "netbird.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+NetBird config secret name.
+*/}}
+{{- define "netbird.configSecretName" -}}
+{{- if .Values.server.config.existingSecret -}}
+{{- .Values.server.config.existingSecret -}}
+{{- else -}}
+{{- printf "%s-config" (include "netbird.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "netbird.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "netbird.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+HTTPRoute name helper.
+*/}}
+{{- define "netbird.httpRouteName" -}}
+{{- $root := .root -}}
+{{- $route := .route -}}
+{{- $index := .index | default 0 -}}
+{{- if $route.name -}}
+{{- $suffix := printf "-%s" $route.name -}}
+{{- $base := include "netbird.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else if gt (int $index) 0 -}}
+{{- $suffix := printf "-%d" (int $index) -}}
+{{- $base := include "netbird.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else -}}
+{{- include "netbird.fullname" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ExternalSecret name helper.
+*/}}
+{{- define "netbird.externalSecretName" -}}
+{{- $root := .root -}}
+{{- $item := .item -}}
+{{- $index := int (.index | default 0) -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if $item.name -}}
+{{- $suffix := printf "-%s" $item.name -}}
+{{- $base := include "netbird.fullname" $root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else if gt $index 0 -}}
+{{- $suffix := printf "-%d" $index -}}
+{{- $base := printf "%s-secret" (include "netbird.fullname" $root) | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix -}}
+{{- else -}}
+{{- printf "%s-secret" (include "netbird.fullname" $root) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate chart values.
+*/}}
+{{- define "netbird.validate" -}}
+{{- if and (gt (int .Values.server.replicaCount) 1) (eq .Values.server.store.engine "sqlite") -}}
+{{- fail "server.replicaCount > 1 requires server.store.engine other than sqlite" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and (not .Values.server.config.existingSecret) (not .Values.server.authSecret) -}}
+{{- fail "server.authSecret is required when server.config.existingSecret is not set" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) -}}
+{{- fail "externalSecrets.items must contain at least one item when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- $podLabels := .Values.podLabels | default dict -}}
+{{- range $key := (list "app.kubernetes.io/name" "app.kubernetes.io/instance") -}}
+{{- if hasKey $podLabels $key -}}
+{{- fail (printf "podLabels must not override the selector label %s" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -143,6 +143,9 @@ Validate chart values.
 {{- if and (gt (int .Values.server.replicaCount) 1) (eq .Values.server.store.engine "sqlite") -}}
 {{- fail "server.replicaCount > 1 requires server.store.engine other than sqlite" -}}
 {{- end -}}
+{{- if and (ne .Values.server.store.engine "sqlite") (empty .Values.server.store.dsn) -}}
+{{- fail "server.store.dsn is required when server.store.engine is postgres or mysql" -}}
+{{- end -}}
 {{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
 {{- end -}}

--- a/charts/netbird/templates/deployment.yaml
+++ b/charts/netbird/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ dict "publicUrl" .Values.server.publicUrl "authSecret" .Values.server.authSecret "config" .Values.server.config "auth" .Values.server.auth "store" .Values.server.store "persistence" .Values.persistence.mountPath | toJson | sha256sum }}
-        checksum/pod-settings: {{ dict "env" .Values.server.env "envFrom" .Values.server.envFrom "extraManifests" .Values.extraManifests | toJson | sha256sum }}
+        checksum/config: {{ dict "publicUrl" .Values.server.publicUrl "authSecret" .Values.server.authSecret "disableAnonymousMetrics" .Values.server.disableAnonymousMetrics "disableGeoliteUpdate" .Values.server.disableGeoliteUpdate "config" .Values.server.config "auth" .Values.server.auth "store" .Values.server.store "persistence" .Values.persistence.mountPath | toJson | sha256sum }}
+        checksum/pod-settings: {{ dict "env" .Values.server.env "envFrom" .Values.server.envFrom "probes" .Values.server.probes "globalProbes" .Values.probes | toJson | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -88,7 +88,7 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.probes.enabled }}
+          {{- if and .Values.server.probes.enabled .Values.probes.startup.enabled }}
           startupProbe:
             tcpSocket:
               port: health
@@ -96,6 +96,8 @@ spec:
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if and .Values.server.probes.enabled .Values.probes.liveness.enabled }}
           livenessProbe:
             tcpSocket:
               port: health
@@ -103,6 +105,8 @@ spec:
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if and .Values.server.probes.enabled .Values.probes.readiness.enabled }}
           readinessProbe:
             tcpSocket:
               port: health

--- a/charts/netbird/templates/deployment.yaml
+++ b/charts/netbird/templates/deployment.yaml
@@ -1,0 +1,316 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "netbird.serverServiceName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.server.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "server") | nindent 6 }}
+  {{- if eq .Values.server.store.engine "sqlite" }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "server") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ dict "publicUrl" .Values.server.publicUrl "authSecret" .Values.server.authSecret "config" .Values.server.config "auth" .Values.server.auth "store" .Values.server.store "persistence" .Values.persistence.mountPath | toJson | sha256sum }}
+        checksum/pod-settings: {{ dict "env" .Values.server.env "envFrom" .Values.server.envFrom "extraManifests" .Values.extraManifests | toJson | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "netbird.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: server
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          {{- with .Values.server.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: stun-udp
+              containerPort: 3478
+              protocol: UDP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+            - name: health
+              containerPort: 9000
+              protocol: TCP
+          {{- with .Values.server.env }}
+          env:
+            {{- range . }}
+            - name: {{ .name }}
+              {{- if hasKey . "valueFrom" }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- else }}
+              value: {{ default "" .value | quote }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.server.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.server.probes.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: health
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          livenessProbe:
+            tcpSocket:
+              port: health
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            tcpSocket:
+              port: health
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/netbird
+              readOnly: true
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath | quote }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: {{ include "netbird.configSecretName" . }}
+            items:
+              - key: {{ .Values.server.config.existingSecretKey | quote }}
+                path: config.yaml
+        - name: data
+          {{- if .Values.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | quote }}
+          {{- else if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "netbird.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if .Values.dashboard.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "netbird.dashboardServiceName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  replicas: {{ .Values.dashboard.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "dashboard") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "dashboard") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/pod-settings: {{ dict "env" .Values.dashboard.env "envFrom" .Values.dashboard.envFrom | toJson | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "netbird.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: dashboard
+          image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
+          imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
+          {{- with .Values.dashboard.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: NETBIRD_MGMT_API_ENDPOINT
+              value: {{ .Values.server.publicUrl | quote }}
+            - name: NETBIRD_MGMT_GRPC_API_ENDPOINT
+              value: {{ .Values.server.publicUrl | quote }}
+            - name: AUTH_AUTHORITY
+              value: {{ .Values.server.auth.issuer | quote }}
+            - name: AUTH_CLIENT_ID
+              value: {{ .Values.dashboard.auth.clientId | quote }}
+            - name: AUTH_AUDIENCE
+              value: {{ .Values.dashboard.auth.audience | quote }}
+            - name: AUTH_SUPPORTED_SCOPES
+              value: {{ .Values.dashboard.auth.supportedScopes | quote }}
+            - name: NETBIRD_TOKEN_SOURCE
+              value: {{ .Values.dashboard.auth.tokenSource | quote }}
+            - name: USE_AUTH0
+              value: {{ .Values.dashboard.auth.useAuth0 | quote }}
+            {{- range .Values.dashboard.env }}
+            - name: {{ .name }}
+              {{- if hasKey . "valueFrom" }}
+              valueFrom:
+                {{- toYaml .valueFrom | nindent 16 }}
+              {{- else }}
+              value: {{ default "" .value | quote }}
+              {{- end }}
+            {{- end }}
+          {{- with .Values.dashboard.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: nginx-var
+              mountPath: /var/lib/nginx
+            - name: nginx-logs
+              mountPath: /var/lib/nginx/logs
+            - name: nginx-tmp
+              mountPath: /var/lib/nginx/tmp
+            - name: nginx-run
+              mountPath: /run/nginx
+          {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: nginx-var
+          emptyDir: {}
+        - name: nginx-logs
+          emptyDir: {}
+        - name: nginx-tmp
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/netbird/templates/externalsecret.yaml
+++ b/charts/netbird/templates/externalsecret.yaml
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- $externalSecretNames := dict }}
+{{- range $index, $item := .Values.externalSecrets.items | default list }}
+{{- $externalSecretName := include "netbird.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- if hasKey $externalSecretNames $externalSecretName }}
+{{- fail (printf "externalSecrets.items render duplicate ExternalSecret name %q; set name or fullnameOverride to a unique value" $externalSecretName) }}
+{{- end }}
+{{- $_ := set $externalSecretNames $externalSecretName true }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasTopLevelStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasTopLevelStoreRef = true }}
+{{- end }}
+{{- if not $hasTopLevelStoreRef }}
+{{- range $dataIndex, $dataItem := ($spec.data | default list) }}
+{{- $sourceRef := get $dataItem "sourceRef" | default dict }}
+{{- $storeRef := get $sourceRef "storeRef" | default dict }}
+{{- $generatorRef := get $sourceRef "generatorRef" | default dict }}
+{{- if not (or (get $storeRef "name") (get $generatorRef "name")) }}
+{{- fail (printf "externalSecrets.items[%d].spec.data[%d] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set" $index $dataIndex) }}
+{{- end }}
+{{- end }}
+{{- range $dataFromIndex, $dataFromItem := ($spec.dataFrom | default list) }}
+{{- $sourceRef := get $dataFromItem "sourceRef" | default dict }}
+{{- $storeRef := get $sourceRef "storeRef" | default dict }}
+{{- $generatorRef := get $sourceRef "generatorRef" | default dict }}
+{{- if not (or (get $storeRef "name") (get $generatorRef "name")) }}
+{{- fail (printf "externalSecrets.items[%d].spec.dataFrom[%d] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set" $index $dataFromIndex) }}
+{{- end }}
+{{- end }}
+{{- if and (empty ($spec.data | default list)) (empty ($spec.dataFrom | default list)) }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- end }}
+---
+apiVersion: {{ $.Values.externalSecrets.apiVersion | default "external-secrets.io/v1" }}
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "netbird.labels" $ | nindent 4 }}
+    {{- with $item.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/netbird/templates/extra-manifests.yaml
+++ b/charts/netbird/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/netbird/templates/gateway-httproute.yaml
+++ b/charts/netbird/templates/gateway-httproute.yaml
@@ -1,0 +1,45 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- $httpRouteNames := dict }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
+{{- if not $route.parentRefs }}{{- fail "gatewayAPI.httpRoutes[].parentRefs is required" }}{{- end }}
+{{- $httpRouteName := include "netbird.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+{{- if hasKey $httpRouteNames $httpRouteName }}
+{{- fail (printf "gatewayAPI.httpRoutes render duplicate HTTPRoute name %q; set name to a unique value" $httpRouteName) }}
+{{- end }}
+{{- $_ := set $httpRouteNames $httpRouteName true }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $httpRouteName }}
+  labels:
+    {{- include "netbird.labels" $ | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.rules }}
+    {{- toYaml $route.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: {{ default "PathPrefix" $route.pathType }}
+            value: {{ default "/" $route.path | quote }}
+      backendRefs:
+        {{- $service := default "dashboard" $route.service }}
+        - name: {{- if eq $service "server" }} {{ include "netbird.serverServiceName" $ }}{{- else }} {{ include "netbird.dashboardServiceName" $ }}{{- end }}
+          port: {{- if eq $service "server" }} {{ $.Values.server.service.httpPort }}{{- else }} {{ $.Values.dashboard.service.port }}{{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/netbird/templates/ingress.yaml
+++ b/charts/netbird/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "netbird.fullname" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- $paths := default (list (dict "path" "/" "pathType" "Prefix")) .paths }}
+          {{- range $paths }}
+          {{- $service := default "dashboard" .service }}
+          - path: {{ default "/" .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{- if eq $service "server" }} {{ include "netbird.serverServiceName" $ }}{{- else }} {{ include "netbird.dashboardServiceName" $ }}{{- end }}
+                port:
+                  number: {{- if eq $service "server" }} {{ $.Values.server.service.httpPort }}{{- else }} {{ $.Values.dashboard.service.port }}{{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/netbird/templates/networkpolicy.yaml
+++ b/charts/netbird/templates/networkpolicy.yaml
@@ -1,0 +1,57 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "netbird.fullname" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "netbird.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.extraEgress }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+        - protocol: TCP
+          port: metrics
+        - protocol: TCP
+          port: health
+        - protocol: UDP
+          port: stun-udp
+  {{- with .Values.networkPolicy.extraEgress }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        - ipBlock:
+            cidr: ::/0
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+        - protocol: UDP
+          port: 3478
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/netbird/templates/pdb.yaml
+++ b/charts/netbird/templates/pdb.yaml
@@ -1,0 +1,30 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "netbird.serverServiceName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "server") | nindent 6 }}
+{{- if .Values.dashboard.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "netbird.dashboardServiceName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "dashboard") | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/netbird/templates/pvc.yaml
+++ b/charts/netbird/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "netbird.fullname" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/netbird/templates/secret-config.yaml
+++ b/charts/netbird/templates/secret-config.yaml
@@ -1,0 +1,53 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if not .Values.server.config.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netbird.configSecretName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  config.yaml: |
+    server:
+      listenAddress: ":80"
+      exposedAddress: {{ .Values.server.publicUrl | quote }}
+      metricsPort: 9090
+      healthcheckAddress: ":9000"
+      logLevel: "info"
+      logFile: "console"
+      authSecret: {{ .Values.server.authSecret | quote }}
+      dataDir: {{ printf "%s/" (.Values.persistence.mountPath | trimSuffix "/") | quote }}
+      disableAnonymousMetrics: {{ .Values.server.disableAnonymousMetrics }}
+      disableGeoliteUpdate: {{ .Values.server.disableGeoliteUpdate }}
+      tls:
+        certFile: ""
+        keyFile: ""
+        letsencrypt:
+          enabled: false
+          dataDir: ""
+          domains: []
+          email: ""
+          awsRoute53: false
+      auth:
+        issuer: {{ .Values.server.auth.issuer | quote }}
+        localAuthDisabled: {{ .Values.server.auth.localAuthDisabled }}
+        signKeyRefreshEnabled: {{ .Values.server.auth.signKeyRefreshEnabled }}
+        dashboardRedirectURIs:
+          - {{ printf "%s/nb-auth" (.Values.server.publicUrl | trimSuffix "/") | quote }}
+          - {{ printf "%s/nb-silent-auth" (.Values.server.publicUrl | trimSuffix "/") | quote }}
+        cliRedirectURIs:
+          - "http://localhost:53000/"
+        {{- if or .Values.server.auth.owner.email .Values.server.auth.owner.password }}
+        owner:
+          email: {{ .Values.server.auth.owner.email | quote }}
+          password: {{ .Values.server.auth.owner.password | quote }}
+        {{- end }}
+      store:
+        engine: {{ .Values.server.store.engine | quote }}
+        dsn: {{ .Values.server.store.dsn | quote }}
+        encryptionKey: {{ .Values.server.store.encryptionKey | quote }}
+{{- with .Values.server.config.extraYaml }}
+{{ . | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/charts/netbird/templates/service.yaml
+++ b/charts/netbird/templates/service.yaml
@@ -1,0 +1,70 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netbird.serverServiceName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.server.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.server.service.type }}
+  {{- if .Values.server.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.server.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.server.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.server.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+    - name: stun-udp
+      port: {{ .Values.server.service.stunPort }}
+      targetPort: stun-udp
+      protocol: UDP
+    - name: metrics
+      port: {{ .Values.server.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+    - name: health
+      port: {{ .Values.server.service.healthPort }}
+      targetPort: health
+      protocol: TCP
+  selector:
+    {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "server") | nindent 4 }}
+{{- if .Values.dashboard.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "netbird.dashboardServiceName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+    app.kubernetes.io/component: dashboard
+  {{- with .Values.dashboard.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.dashboard.service.type }}
+  {{- if .Values.dashboard.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.dashboard.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- with .Values.dashboard.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.dashboard.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "netbird.componentSelectorLabels" (dict "root" . "component" "dashboard") | nindent 4 }}
+{{- end }}

--- a/charts/netbird/templates/serviceaccount.yaml
+++ b/charts/netbird/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "netbird.serviceAccountName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/netbird/templates/tests/test-connection.yaml
+++ b/charts/netbird/templates/tests/test-connection.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "netbird.fullname" . }}-test-connection
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  containers:
+    - name: wget
+      image: busybox:1.37.0
+      command:
+        - wget
+      args:
+        - -qO-
+        - http://{{ include "netbird.dashboardServiceName" . }}:{{ .Values.dashboard.service.port }}/
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault

--- a/charts/netbird/templates/validate.yaml
+++ b/charts/netbird/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "netbird.validate" . -}}

--- a/charts/netbird/tests/common-labels-values.yaml
+++ b/charts/netbird/tests/common-labels-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+commonLabels:
+  review: enabled

--- a/charts/netbird/tests/dual-stack-values.yaml
+++ b/charts/netbird/tests/dual-stack-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  service:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv4
+      - IPv6
+dashboard:
+  service:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv4
+      - IPv6

--- a/charts/netbird/tests/external-secrets-colliding-config-index-values.yaml
+++ b/charts/netbird/tests/external-secrets-colliding-config-index-values.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird/smtp
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: netbird_TOKEN
+            remoteRef:
+              key: netbird/token
+    - name: secret-1
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: netbird_TOKEN
+            remoteRef:
+              key: netbird/named-secret-1

--- a/charts/netbird/tests/external-secrets-colliding-config-name-values.yaml
+++ b/charts/netbird/tests/external-secrets-colliding-config-name-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird/smtp
+    - name: secret
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird/named-secret

--- a/charts/netbird/tests/external-secrets-default-target-values.yaml
+++ b/charts/netbird/tests/external-secrets-default-target-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird
+              property: netbird_SMTP_PASSWORD

--- a/charts/netbird/tests/external-secrets-fullname-values.yaml
+++ b/charts/netbird/tests/external-secrets-fullname-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: literal-netbird-config
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird
+              property: smtpPassword

--- a/charts/netbird/tests/external-secrets-long-name-named-values.yaml
+++ b/charts/netbird/tests/external-secrets-long-name-named-values.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+externalSecrets:
+  enabled: true
+  items:
+    - name: config
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: netbird/config
+    - name: token
+      spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: netbird/token

--- a/charts/netbird/tests/external-secrets-long-name-values.yaml
+++ b/charts/netbird/tests/external-secrets-long-name-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: config.yaml
+            remoteRef:
+              key: netbird/config
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: netbird/token

--- a/charts/netbird/tests/external-secrets-mixed-data-missing-sourceref-values.yaml
+++ b/charts/netbird/tests/external-secrets-mixed-data-missing-sourceref-values.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird-password
+            sourceRef:
+              storeRef:
+                name: fake
+          - secretKey: netbird_TOKEN
+            remoteRef:
+              key: netbird-token

--- a/charts/netbird/tests/external-secrets-mixed-datafrom-missing-sourceref-values.yaml
+++ b/charts/netbird/tests/external-secrets-mixed-datafrom-missing-sourceref-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        dataFrom:
+          - extract:
+              key: netbird
+            sourceRef:
+              storeRef:
+                name: fake
+          - extract:
+              key: netbird-extra

--- a/charts/netbird/tests/external-secrets-multiple-unnamed-values.yaml
+++ b/charts/netbird/tests/external-secrets-multiple-unnamed-values.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird/smtp
+    - spec:
+        secretStoreRef:
+          name: fake
+        data:
+          - secretKey: token
+            remoteRef:
+              key: netbird/token

--- a/charts/netbird/tests/external-secrets-values.yaml
+++ b/charts/netbird/tests/external-secrets-values.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: env
+      spec:
+        secretStoreRef:
+          kind: ClusterSecretStore
+          name: fake
+        target:
+          name: RELEASE-NAME-netbird-env
+          creationPolicy: Owner
+        data:
+          - secretKey: netbird_SMTP_PASSWORD
+            remoteRef:
+              key: netbird
+              property: smtpPassword

--- a/charts/netbird/tests/external_secrets_test.yaml
+++ b/charts/netbird/tests/external_secrets_test.yaml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbird external secrets
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: renders an ExternalSecret for a environment secret
+    values:
+      - external-secrets-values.yaml
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.secretStoreRef.name
+          value: fake
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-netbird-env
+      - equal:
+          path: spec.data[0].secretKey
+          value: netbird_SMTP_PASSWORD
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+  - it: defaults target name to the rendered ExternalSecret name
+    values:
+      - external-secrets-default-target-values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-netbird-secret
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-netbird-secret
+  - it: gives multiple unnamed ExternalSecrets unique fallback names
+    values:
+      - external-secrets-multiple-unnamed-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-netbird-secret
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-netbird-secret
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-netbird-secret-1
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: RELEASE-NAME-netbird-secret-1
+        documentIndex: 1
+  - it: reserves suffix room for unnamed ExternalSecrets with a long secret name
+    values:
+      - external-secrets-long-name-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+  - it: reserves suffix room for named ExternalSecrets with a long fullname
+    values:
+      - external-secrets-long-name-named-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-config
+        documentIndex: 0
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-config
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-token
+        documentIndex: 1
+      - equal:
+          path: spec.target.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-token
+        documentIndex: 1
+  - it: uses fullnameOverride literally
+    values:
+      - external-secrets-fullname-values.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: literal-netbird-config
+      - equal:
+          path: spec.target.name
+          value: literal-netbird-config
+  - it: fails when a named ExternalSecret collides with the unnamed secret fallback
+    values:
+      - external-secrets-colliding-config-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items render duplicate ExternalSecret name \"RELEASE-NAME-netbird-secret\"; set name or fullnameOverride to a unique value"
+  - it: fails when a named ExternalSecret collides with an indexed unnamed fallback
+    values:
+      - external-secrets-colliding-config-index-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items render duplicate ExternalSecret name \"RELEASE-NAME-netbird-secret-1\"; set name or fullnameOverride to a unique value"
+  - it: fails without a secretStoreRef or sourceRef
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items[0].spec.data[0].secretKey: netbird_SMTP_PASSWORD
+      externalSecrets.items[0].spec.data[0].remoteRef.key: netbird
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0].spec.data[0] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set"
+  - it: fails when one data item lacks sourceRef without a top-level store
+    values:
+      - external-secrets-mixed-data-missing-sourceref-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0].spec.data[1] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set"
+  - it: fails when one dataFrom item lacks sourceRef without a top-level store
+    values:
+      - external-secrets-mixed-datafrom-missing-sourceref-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0].spec.dataFrom[1] requires sourceRef.storeRef.name or sourceRef.generatorRef.name when spec.secretStoreRef.name is not set"

--- a/charts/netbird/tests/gateway-colliding-index-name-values.yaml
+++ b/charts/netbird/tests/gateway-colliding-index-name-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: "1"
+      parentRefs:
+        - name: public
+      path: /named-index
+    - parentRefs:
+        - name: internal
+      path: /unnamed-index

--- a/charts/netbird/tests/gateway-long-name-named-values.yaml
+++ b/charts/netbird/tests/gateway-long-name-named-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: public
+      parentRefs:
+        - name: public
+      path: /
+    - name: internal
+      parentRefs:
+        - name: internal
+      path: /internal

--- a/charts/netbird/tests/gateway-long-name-values.yaml
+++ b/charts/netbird/tests/gateway-long-name-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - parentRefs:
+        - name: public
+      path: /
+    - parentRefs:
+        - name: internal
+      path: /internal

--- a/charts/netbird/tests/gateway-values.yaml
+++ b/charts/netbird/tests/gateway-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - hostnames:
+        - netbird.example.com
+      parentRefs:
+        - name: public
+          namespace: gateway-system
+      path: /
+      pathType: PathPrefix

--- a/charts/netbird/tests/gateway_test.yaml
+++ b/charts/netbird/tests/gateway_test.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbird gateway api
+templates:
+  - templates/gateway-httproute.yaml
+tests:
+  - it: renders an HTTPRoute to the chart service
+    values:
+      - gateway-values.yaml
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-netbird-dashboard
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+  - it: reserves suffix room for multiple unnamed routes with a long fullname
+    values:
+      - gateway-long-name-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1
+        documentIndex: 1
+  - it: reserves suffix room for named routes with a long fullname
+    values:
+      - gateway-long-name-named-values.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-public
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-internal
+        documentIndex: 1
+  - it: fails when a named route collides with an indexed unnamed fallback
+    values:
+      - gateway-colliding-index-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "gatewayAPI.httpRoutes render duplicate HTTPRoute name \"RELEASE-NAME-netbird-1\"; set name to a unique value"

--- a/charts/netbird/tests/ingress-host-only-values.yaml
+++ b/charts/netbird/tests/ingress-host-only-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: netbird.example.com

--- a/charts/netbird/tests/ingress-values.yaml
+++ b/charts/netbird/tests/ingress-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: netbird.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: netbird-tls
+      hosts:
+        - netbird.example.com

--- a/charts/netbird/tests/networkpolicy-extra-egress-values.yaml
+++ b/charts/netbird/tests/networkpolicy-extra-egress-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 8443

--- a/charts/netbird/tests/networkpolicy-values.yaml
+++ b/charts/netbird/tests/networkpolicy-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system

--- a/charts/netbird/tests/networkpolicy_test.yaml
+++ b/charts/netbird/tests/networkpolicy_test.yaml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbird network policy
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: limits inbound netbird HTTP traffic
+    values:
+      - networkpolicy-values.yaml
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            protocol: TCP
+            port: http
+      - notContains:
+          path: spec.policyTypes
+          content: Egress
+  - it: enables egress isolation when extraEgress is configured
+    values:
+      - networkpolicy-extra-egress-values.yaml
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 53
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 80
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 8443

--- a/charts/netbird/tests/podlabels-selector-instance-values.yaml
+++ b/charts/netbird/tests/podlabels-selector-instance-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/instance: custom

--- a/charts/netbird/tests/podlabels-selector-name-values.yaml
+++ b/charts/netbird/tests/podlabels-selector-name-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+podLabels:
+  app.kubernetes.io/name: custom

--- a/charts/netbird/tests/service_test.yaml
+++ b/charts/netbird/tests/service_test.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbird service
+templates:
+  - templates/service.yaml
+tests:
+  - it: renders dual-stack service settings
+    values:
+      - dual-stack-values.yaml
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv4
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilies[1]
+          value: IPv6
+        documentIndex: 0
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+        documentIndex: 1

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 suite: netbird base templates
 templates:
   - templates/deployment.yaml

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -1,0 +1,48 @@
+suite: netbird base templates
+templates:
+  - templates/deployment.yaml
+  - templates/service.yaml
+  - templates/pvc.yaml
+  - templates/secret-config.yaml
+  - templates/ingress.yaml
+tests:
+  - it: renders the official pinned server image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: netbirdio/netbird-server:0.74.4
+        template: templates/deployment.yaml
+        documentIndex: 0
+  - it: renders the official pinned dashboard image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: netbirdio/dashboard:v2.90.3
+        template: templates/deployment.yaml
+        documentIndex: 1
+  - it: renders separate server and dashboard services
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-netbird-server
+        template: templates/service.yaml
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-netbird-dashboard
+        template: templates/service.yaml
+        documentIndex: 1
+  - it: uses emptyDir when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - exists:
+          path: spec.template.spec.volumes[1].emptyDir
+        template: templates/deployment.yaml
+        documentIndex: 0
+  - it: creates a PVC when persistence is chart-managed
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+        template: templates/pvc.yaml

--- a/charts/netbird/tests/test_connection_test.yaml
+++ b/charts/netbird/tests/test_connection_test.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Helm Test
+templates:
+  - templates/tests/test-connection.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should render the Helm test hook pod
+    asserts:
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: test-netbird-test-connection
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded

--- a/charts/netbird/tests/validation_test.yaml
+++ b/charts/netbird/tests/validation_test.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbird validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: fails when scaling sqlite server replicas
+    set:
+      server.replicaCount: 2
+      server.store.engine: sqlite
+    asserts:
+      - failedTemplate:
+          errorMessage: "server.replicaCount > 1 requires server.store.engine other than sqlite"
+  - it: fails when ingress is enabled without hosts
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.hosts must contain at least one host when ingress.enabled=true"
+  - it: fails when ExternalSecrets is enabled without items
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items must contain at least one item when externalSecrets.enabled=true"
+  - it: fails when podLabels override selector name
+    values:
+      - podlabels-selector-name-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/name"
+  - it: fails when podLabels override selector instance
+    values:
+      - podlabels-selector-instance-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the selector label app.kubernetes.io/instance"

--- a/charts/netbird/values.schema.json
+++ b/charts/netbird/values.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "netbird Helm Chart Values",
+  "description": "Values for the NetBird self-hosted control plane chart",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object" },
+    "server": { "$ref": "#/definitions/server" },
+    "dashboard": { "$ref": "#/definitions/dashboard" },
+    "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "persistence": { "$ref": "#/definitions/persistence" },
+    "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+    "ingress": { "$ref": "#/definitions/ingress" },
+    "gatewayAPI": { "$ref": "#/definitions/gatewayAPI" },
+    "externalSecrets": { "$ref": "#/definitions/externalSecrets" },
+    "probes": { "$ref": "#/definitions/probes" },
+    "resources": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "pdb": { "$ref": "#/definitions/pdb" },
+    "networkPolicy": { "$ref": "#/definitions/networkPolicy" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "topologySpreadConstraints": { "type": "array", "items": { "type": "object" } },
+    "priorityClassName": { "type": "string" },
+    "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
+    "podLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraManifests": { "type": "array", "items": { "type": "object" } }
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string", "pattern": "^[0-9v][0-9A-Za-z._-]*$" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" },
+          "valueFrom": { "type": "object" }
+        }
+      }
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "image": { "$ref": "#/definitions/image" },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "publicUrl": { "type": "string" },
+        "authSecret": { "type": "string" },
+        "disableAnonymousMetrics": { "type": "boolean" },
+        "disableGeoliteUpdate": { "type": "boolean" },
+        "command": { "type": "array", "items": { "type": "string" } },
+        "args": { "type": "array", "items": { "type": "string" } },
+        "env": { "$ref": "#/definitions/env" },
+        "envFrom": { "type": "array", "items": { "type": "object" } },
+        "config": { "type": "object" },
+        "auth": { "type": "object" },
+        "store": { "type": "object" },
+        "service": { "$ref": "#/definitions/serverService" }
+      }
+    },
+    "dashboard": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "$ref": "#/definitions/image" },
+        "replicaCount": { "type": "integer", "minimum": 1 },
+        "env": { "$ref": "#/definitions/env" },
+        "envFrom": { "type": "array", "items": { "type": "object" } },
+        "auth": { "type": "object" },
+        "securityContext": { "type": "object" },
+        "service": { "$ref": "#/definitions/dashboardService" }
+      }
+    },
+    "serverService": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "httpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "stunPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "metricsPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "healthPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "dashboardService": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "annotations": { "type": "object" },
+        "ipFamilyPolicy": { "type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"] },
+        "ipFamilies": { "type": "array", "items": { "type": "string", "enum": ["IPv4", "IPv6"] } }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "size": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessModes": { "type": "array", "items": { "type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"] } },
+        "existingClaim": { "type": "string" },
+        "mountPath": { "type": "string" }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressClassName": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array", "items": { "type": "object" } },
+        "tls": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "httpRoutes": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "apiVersion": { "type": "string" },
+        "refreshInterval": { "type": "string" },
+        "items": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "properties": {
+        "startup": { "$ref": "#/definitions/probe" },
+        "liveness": { "$ref": "#/definitions/probe" },
+        "readiness": { "$ref": "#/definitions/probe" }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "string" }] }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "ingressFrom": { "type": "array", "items": { "type": "object" } },
+        "extraEgress": { "type": "array", "items": { "type": "object" } }
+      }
+    }
+  }
+}

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# -- Override the chart name used in Kubernetes object names.
+nameOverride: ""
+
+# -- Override the full release name used in Kubernetes object names.
+fullnameOverride: ""
+
+# -- Extra labels applied to all Kubernetes objects rendered by this chart.
+commonLabels: {}
+
+server:
+  image:
+    # -- Official NetBird server container image repository.
+    repository: netbirdio/netbird-server
+    # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
+    tag: "0.74.4"
+    # -- Kubernetes image pull policy.
+    pullPolicy: IfNotPresent
+  # -- Number of NetBird server pods. Keep 1 with the default sqlite store.
+  replicaCount: 1
+  # -- Public URL used by NetBird peers, dashboard, APIs, gRPC, signal, and relay.
+  publicUrl: https://netbird.example.com
+  # -- Shared authentication secret used by the NetBird server. Override for production.
+  authSecret: change-me-in-production
+  # -- Disable anonymous upstream telemetry from the NetBird server.
+  disableAnonymousMetrics: true
+  # -- Disable GeoLite database updates when outbound internet access is restricted.
+  disableGeoliteUpdate: true
+  # -- Optional command override. Leave empty to use the upstream image entrypoint.
+  command: []
+  # -- Optional argument override. Defaults to loading the rendered config file.
+  args:
+    - --config
+    - /etc/netbird/config.yaml
+  # -- Additional environment variables.
+  env: []
+  # -- Additional envFrom sources such as Secret or ConfigMap references.
+  envFrom: []
+  probes:
+    # -- Enable NetBird server health probes. Disabled by default because first boot can initialize geolocation data longer than default Helm wait timeouts.
+    enabled: false
+  config:
+    # -- Existing Secret containing config.yaml. When set, the chart does not render its generated config Secret.
+    existingSecret: ""
+    # -- Key inside existingSecret that stores the NetBird config file.
+    existingSecretKey: config.yaml
+    # -- Extra raw YAML appended under the top-level server config.
+    extraYaml: ""
+  auth:
+    # -- OIDC issuer URL. The default is suitable only for chart validation and must be replaced for production.
+    issuer: https://netbird.example.com/oauth2
+    # -- Disable local authentication when an external OIDC provider is configured.
+    localAuthDisabled: false
+    # -- Enable NetBird sign-key refresh.
+    signKeyRefreshEnabled: false
+    owner:
+      # -- Optional initial owner email for local authentication bootstrap.
+      email: ""
+      # -- Optional initial owner password for local authentication bootstrap. Prefer externalSecrets in production.
+      password: ""
+  store:
+    # -- NetBird store engine. Supported by upstream: sqlite, postgres, mysql.
+    engine: sqlite
+    # -- Store DSN. Empty uses sqlite under /var/lib/netbird.
+    dsn: ""
+    # -- Optional encryption key for stored secrets. Prefer externalSecrets in production.
+    encryptionKey: ""
+  service:
+    # -- Service type for NetBird server HTTP/gRPC and STUN UDP traffic.
+    type: ClusterIP
+    # -- HTTP/gRPC service port.
+    httpPort: 80
+    # -- UDP STUN service port.
+    stunPort: 3478
+    # -- Metrics service port.
+    metricsPort: 9090
+    # -- Health service port.
+    healthPort: 9000
+    # -- Service annotations.
+    annotations: {}
+    # -- IP family policy. Options: SingleStack, PreferDualStack, RequireDualStack.
+    ipFamilyPolicy: ""
+    # -- Ordered list of IP families, for example ["IPv4", "IPv6"].
+    ipFamilies: []
+
+dashboard:
+  # -- Deploy the NetBird dashboard UI.
+  enabled: true
+  image:
+    # -- Official NetBird dashboard container image repository.
+    repository: netbirdio/dashboard
+    # -- Pinned NetBird dashboard image tag. This follows dashboard's own upstream versioning.
+    tag: "v2.90.3"
+    # -- Kubernetes image pull policy.
+    pullPolicy: IfNotPresent
+  # -- Number of dashboard pods.
+  replicaCount: 1
+  # -- Additional dashboard environment variables.
+  env: []
+  # -- Additional envFrom sources such as Secret or ConfigMap references.
+  envFrom: []
+  auth:
+    # -- Dashboard OIDC client ID.
+    clientId: netbird
+    # -- Dashboard OIDC audience.
+    audience: netbird
+    # -- Dashboard OIDC scopes.
+    supportedScopes: openid profile email offline_access api
+    # -- Dashboard token source.
+    tokenSource: accessToken
+    # -- Whether the dashboard should use Auth0 mode.
+    useAuth0: "false"
+  # -- Dashboard container security context. Upstream supervisord starts as root and drops privileges internally.
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - CHOWN
+        - SETGID
+        - SETUID
+    readOnlyRootFilesystem: false
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault
+  service:
+    # -- Service type for the dashboard.
+    type: ClusterIP
+    # -- Dashboard service port.
+    port: 80
+    # -- Service annotations.
+    annotations: {}
+    # -- IP family policy. Options: SingleStack, PreferDualStack, RequireDualStack.
+    ipFamilyPolicy: ""
+    # -- Ordered list of IP families, for example ["IPv4", "IPv6"].
+    ipFamilies: []
+
+# -- Optional image pull secrets for private registries or mirrored images.
+imagePullSecrets: []
+
+persistence:
+  # -- Persist NetBird sqlite data, embedded configuration state, and generated assets.
+  enabled: true
+  # -- PersistentVolumeClaim size for /var/lib/netbird.
+  size: 10Gi
+  # -- StorageClass for the generated PersistentVolumeClaim. Empty uses the cluster default.
+  storageClass: ""
+  # -- Access modes for the generated PersistentVolumeClaim.
+  accessModes:
+    - ReadWriteOnce
+  # -- Existing PersistentVolumeClaim to mount instead of creating a new claim.
+  existingClaim: ""
+  # -- Container data directory used by upstream NetBird.
+  mountPath: /var/lib/netbird
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- ServiceAccount name. Defaults to the release fullname when create=true.
+  name: ""
+  # -- Annotations for the ServiceAccount.
+  annotations: {}
+  # -- Mount the ServiceAccount token in the pod.
+  automountServiceAccountToken: false
+
+ingress:
+  # -- Enable Kubernetes Ingress for dashboard and server HTTP/gRPC endpoints.
+  enabled: false
+  # -- IngressClassName for the generated Ingress.
+  ingressClassName: traefik
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Ingress hosts and paths. Use service: server or dashboard per path.
+  hosts: []
+  # -- Ingress TLS blocks.
+  tls: []
+
+gatewayAPI:
+  # -- Enable Gateway API HTTPRoute templates.
+  enabled: false
+  # -- List of HTTPRoute definitions. Each item is rendered as one HTTPRoute.
+  httpRoutes: []
+
+externalSecrets:
+  # -- Render external-secrets.io ExternalSecret resources.
+  enabled: false
+  # -- ExternalSecret apiVersion.
+  apiVersion: external-secrets.io/v1
+  # -- Default sync interval applied to items without their own value.
+  refreshInterval: 1h
+  # -- List of ExternalSecret definitions. Each item carries a complete spec.
+  items: []
+
+probes:
+  startup:
+    # -- Enable startup probes.
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 30
+  liveness:
+    # -- Enable liveness probes.
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    # -- Enable readiness probes.
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+# -- Container resource requests and limits.
+resources: {}
+
+# -- Pod security context.
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+
+# -- NetBird server container security context.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+pdb:
+  # -- Create PodDisruptionBudgets for enabled components.
+  enabled: false
+  # -- Minimum available pods during voluntary disruptions.
+  minAvailable: 1
+
+networkPolicy:
+  # -- Create a NetworkPolicy that restricts inbound traffic to NetBird.
+  enabled: false
+  # -- Custom ingress peers. Empty allows ingress from any namespace.
+  ingressFrom: []
+  # -- Additional egress rules. When set, the policy also isolates egress while preserving DNS, HTTP, HTTPS, and UDP 3478 access.
+  extraEgress: []
+
+# -- Node selector for scheduling pods.
+nodeSelector: {}
+
+# -- Tolerations for scheduling pods.
+tolerations: []
+
+# -- Affinity rules for scheduling pods.
+affinity: {}
+
+# -- Topology spread constraints for scheduling pods.
+topologySpreadConstraints: []
+
+# -- Optional PriorityClass name.
+priorityClassName: ""
+
+# -- Pod termination grace period in seconds.
+terminationGracePeriodSeconds: 30
+
+# -- Extra labels applied to pod templates.
+podLabels: {}
+
+# -- Extra annotations applied to pod templates.
+podAnnotations: {}
+
+# -- Extra volumes mounted into pods.
+extraVolumes: []
+
+# -- Extra volume mounts added to containers.
+extraVolumeMounts: []
+
+# -- Additional Kubernetes manifests rendered with the chart.
+extraManifests: []


### PR DESCRIPTION
## Summary

- Add production-ready NetBird chart using the current combined self-hosted architecture.
- Deploys `netbird-server` plus dashboard with official pinned images.
- Includes generated Secret-backed config.yaml, persistence, Services for HTTP/gRPC and UDP STUN, Ingress/Gateway API, ESO, NetworkPolicy, PDB, dual-stack scenarios, docs, examples, and unit tests.

## Upstream evidence

- `netbirdio/netbird-server:0.74.4` verified by manifest for linux/amd64, linux/arm64, linux/arm.
- `netbirdio/dashboard:v2.90.3` verified by manifest for linux/amd64, linux/arm64, linux/arm.
- Upstream self-hosted docs use combined `netbird-server` plus dashboard architecture for new installs.

## Validation

- `make image-verify IMAGE=netbirdio/netbird-server:0.74.4`
- `make image-verify IMAGE=netbirdio/dashboard:v2.90.3`
- `helm lint charts/netbird --strict`
- `helm unittest charts/netbird` -> 29/29 passing
- `make standards-check CHART=netbird`
- `make deps-check CHART=netbird`
- `node scripts/charts/template-standards-check.js --chart netbird`
- `make validate-chart CHART=netbird` -> FULLY VALIDATED, 17 layers including k3d default and all ci scenarios
- `make site-sync-check CHART=netbird JSON=1`
- `make org-check`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Linked work

- Resolves #778
- Parent request: #777
- Site PR: helmforgedev/site#418
- Org profile sync PR: helmforgedev/.github#14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm chart to deploy NetBird’s server with optional dashboard, including services, health checks, security settings, generated config, and enhanced install/upgrade notes.
  * Added routing options (Ingress and Gateway API), dual-stack networking guidance, and UDP STUN exposure.
  * Added persistence/storage options, External Secrets integration, and configurable NetworkPolicy and PodDisruptionBudget support.
  * Introduced a values schema plus updated examples and chart documentation.
* **Tests**
  * Expanded Helm rendering and added validation tests to catch common misconfigurations (routing, storage/replicas, external secrets setup, and label overrides).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->