### PR TITLE
feat(certimate)!: harden production defaults

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -25,8 +25,8 @@ icon: https://helmforge.dev/icons/charts/certimate.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: add chart (#780)"
+      description: "BREAKING: require explicit ephemeral storage opt-in and harden production defaults"
   artifacthub.io/category: security
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable

--- a/charts/certimate/DESIGN.md
+++ b/charts/certimate/DESIGN.md
@@ -17,6 +17,17 @@ application data, user accounts, provider credentials, ACME state, workflows,
 and issued certificate material. Backup and restore procedures should treat the
 whole directory as sensitive.
 
+Certimate is PocketBase-backed in the upstream container. The chart deliberately
+does not add PostgreSQL, MySQL, or Redis subcharts because there is no official
+external database contract to wire those dependencies safely. A database subchart
+would create a false production signal without moving Certimate state out of
+`/app/pb_data`.
+
+Disabling persistence is a breaking, explicit choice: users must set
+`persistence.ephemeral=true` together with `persistence.enabled=false`. This
+keeps disposable CI and demo installs available while preventing accidental loss
+of certificates, ACME accounts, provider credentials, and workflow state.
+
 ## Exposure
 
 The chart supports Kubernetes Ingress and Gateway API HTTPRoute. TLS termination is expected at the ingress controller or gateway. Certimate itself remains an internal HTTP service.

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -7,7 +7,9 @@ This chart packages the official `certimate/certimate:v0.4.26` image and follows
 ## Production Defaults
 
 - one Deployment using `Recreate` strategy for single-writer PocketBase storage
-- one PersistentVolumeClaim mounted at `/app/pb_data`
+- one `10Gi` PersistentVolumeClaim mounted at `/app/pb_data`
+- explicit `persistence.ephemeral=true` opt-in for disposable emptyDir installs
+- default resource requests and memory limit for scheduler and Kubescape hygiene
 - restricted ServiceAccount token mounting by default
 - Kubernetes Ingress and Gateway API HTTPRoute support
 - optional NetworkPolicy with explicit additional egress for ACME DNS APIs, DNS, SMTP, webhooks, and target deployment systems
@@ -69,6 +71,11 @@ Back up the PersistentVolumeClaim before upgrades. Certimate stores its
 PocketBase database, uploaded certificate material, ACME account state, workflow
 definitions, and provider credentials under `/app/pb_data`.
 
+Certimate's upstream deployment uses PocketBase-local state. This chart does not
+ship PostgreSQL, MySQL, or Redis subcharts because the product does not expose an
+official external database mode for its application state. Treat the PVC as the
+database and certificate material authority.
+
 For production, enable `networkPolicy.enabled` and add egress rules for the DNS
 providers, certificate deployment targets, SMTP relays, webhook endpoints, and
 ACME endpoints required by your workflows.
@@ -79,13 +86,13 @@ Local security scan:
 
 ```text
 Image: certimate/certimate:v0.4.26
-Scanner: pending local repository security scan
-Result: pending
+Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
+Result: 93.93939 compliance score
 ```
 
-The chart is designed for the HelmForge security scan workflow. Local scan
-evidence must be refreshed before merge with the repository security tooling and
-then pasted into this section if required by the release checklist.
+The local scan reported no critical or high-severity failures. Remaining medium
+findings are expected until operators enable a production NetworkPolicy matching
+their ACME, DNS provider, SMTP, webhook, and deployment destinations.
 
 ## Documentation
 

--- a/charts/certimate/ci/persistence-disabled.yaml
+++ b/charts/certimate/ci/persistence-disabled.yaml
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 persistence:
   enabled: false
+  ephemeral: true

--- a/charts/certimate/docs/storage.md
+++ b/charts/certimate/docs/storage.md
@@ -20,3 +20,15 @@ persistence:
 ```
 
 Do not disable persistence outside ephemeral validation environments.
+
+If you intentionally need disposable storage, opt in explicitly:
+
+```yaml
+persistence:
+  enabled: false
+  ephemeral: true
+```
+
+There is no PostgreSQL, MySQL, or Redis subchart for Certimate. The upstream
+container persists application state through PocketBase under `/app/pb_data`, so
+the PVC is the production data authority.

--- a/charts/certimate/examples/secured.yaml
+++ b/charts/certimate/examples/secured.yaml
@@ -3,6 +3,13 @@ persistence:
   enabled: true
   size: 20Gi
 
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 1Gi
+
 networkPolicy:
   enabled: true
   extraEgress:
@@ -11,11 +18,3 @@ networkPolicy:
       ports:
         - protocol: TCP
           port: 443
-
-resources:
-  requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 1
-    memory: 1Gi

--- a/charts/certimate/templates/_helpers.tpl
+++ b/charts/certimate/templates/_helpers.tpl
@@ -110,6 +110,9 @@ Validate chart values.
 {{- if and (gt (int .Values.replicaCount) 1) (not .Values.persistence.existingClaim) -}}
 {{- fail "replicaCount > 1 requires persistence.existingClaim because Certimate stores PocketBase state on a single writable volume" -}}
 {{- end -}}
+{{- if and (not .Values.persistence.enabled) (not .Values.persistence.ephemeral) -}}
+{{- fail "persistence.enabled=false requires persistence.ephemeral=true because Certimate stores critical PocketBase state under /app/pb_data" -}}
+{{- end -}}
 {{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
 {{- end -}}

--- a/charts/certimate/templates/tests/test-connection.yaml
+++ b/charts/certimate/templates/tests/test-connection.yaml
@@ -30,3 +30,7 @@ spec:
         runAsGroup: 65534
         seccompProfile:
           type: RuntimeDefault
+      {{- with .Values.test.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -65,6 +65,7 @@ tests:
     template: templates/deployment.yaml
     set:
       persistence.enabled: false
+      persistence.ephemeral: true
     asserts:
       - equal:
           path: spec.template.spec.volumes[0].name
@@ -79,4 +80,19 @@ tests:
           of: PersistentVolumeClaim
       - equal:
           path: spec.resources.requests.storage
-          value: 5Gi
+          value: 10Gi
+  - it: renders default production resource requests and limits
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 50m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m

--- a/charts/certimate/tests/test_connection_test.yaml
+++ b/charts/certimate/tests/test_connection_test.yaml
@@ -19,3 +19,9 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.containers[0].resources.limits.memory
+          value: 64Mi

--- a/charts/certimate/tests/validation_test.yaml
+++ b/charts/certimate/tests/validation_test.yaml
@@ -9,6 +9,12 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "replicaCount > 1 requires persistence.existingClaim because Certimate stores PocketBase state on a single writable volume"
+  - it: fails when persistence is disabled without ephemeral opt-in
+    set:
+      persistence.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "persistence.enabled=false requires persistence.ephemeral=true because Certimate stores critical PocketBase state under /app/pb_data"
   - it: fails when ingress is enabled without hosts
     set:
       ingress.enabled: true

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -44,7 +44,8 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean", "default": true },
-        "size": { "type": "string", "default": "5Gi" },
+        "ephemeral": { "type": "boolean", "default": false },
+        "size": { "type": "string", "default": "10Gi" },
         "storageClass": { "type": "string", "default": "" },
         "accessModes": { "type": "array", "items": { "type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"] } },
         "existingClaim": { "type": "string", "default": "" },
@@ -58,6 +59,12 @@
     "externalSecrets": { "$ref": "#/definitions/externalSecrets" },
     "probes": { "$ref": "#/definitions/probes" },
     "resources": { "type": "object" },
+    "test": {
+      "type": "object",
+      "properties": {
+        "resources": { "type": "object" }
+      }
+    },
     "podSecurityContext": { "type": "object" },
     "securityContext": { "type": "object" },
     "pdb": { "$ref": "#/definitions/pdb" },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -40,8 +40,10 @@ app:
 persistence:
   # -- Persist Certimate PocketBase data, certificates, account data, workflows, and provider credentials.
   enabled: true
+  # -- Explicitly allow ephemeral emptyDir storage when persistence.enabled=false. This is intended only for CI and disposable demos.
+  ephemeral: false
   # -- PersistentVolumeClaim size for /app/pb_data.
-  size: 5Gi
+  size: 10Gi
   # -- StorageClass for the generated PersistentVolumeClaim. Empty uses the cluster default.
   storageClass: ""
   # -- Access modes for the generated PersistentVolumeClaim.
@@ -126,7 +128,22 @@ probes:
     failureThreshold: 6
 
 # -- Container resource requests and limits.
-resources: {}
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+test:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
 
 # -- Pod security context.
 podSecurityContext:


### PR DESCRIPTION
## Summary

Promotes Certimate toward a v1 production contract with a breaking hardening release.

## Product and subchart analysis

Certimate upstream persists application state through PocketBase under `/app/pb_data`. Official Docker documentation mounts `./data:/app/pb_data`; no official PostgreSQL, MySQL, or Redis application-state mode is exposed. Because of that, this PR does not add database/cache subcharts. The PVC remains the database and certificate-material authority.

## Changes

- Marks Certimate maturity as stable.
- Requires explicit `persistence.ephemeral=true` when `persistence.enabled=false`.
- Raises default PVC size from `5Gi` to `10Gi`.
- Adds default app resource requests/limits and Helm test hook resources.
- Updates schema, examples, docs, and unit tests for the new storage contract.
- Refreshes Security Scan evidence with Kubescape score `93.93939`.

## Breaking change

Installations that intentionally set `persistence.enabled=false` must now also set:

```yaml
persistence:
  enabled: false
  ephemeral: true
```

This prevents accidental loss of PocketBase data, ACME accounts, provider credentials, workflows, and issued certificate material.

## Validation

- `make validate-chart CHART=certimate` PASS, 17 layers including all k3d scenarios.
- `make standards-check CHART=certimate` PASS.
- `make deps-check CHART=certimate` PASS.
- `make md-lint REPO=charts` PASS.
- `make site-sync-check CHART=certimate JSON=1` PASS.
- `make org-check` PASS with linked sync changes.
- `make release-check REPO=charts` PASS with expected release warning.
- `make attribution-check REPO=charts` PASS.

Site sync PR: helmforgedev/site#419
Org profile PR: helmforgedev/.github#15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default persistent storage allocation to 10Gi.
  * Added explicit opt-in support for ephemeral, disposable storage.
  * Added default CPU and memory settings for application and test workloads.
  * Added configurable resources for connection test workloads.
  * Upgraded the chart maturity designation to stable.

* **Bug Fixes**
  * Added validation to prevent disabling persistence without explicitly enabling ephemeral storage.

* **Documentation**
  * Clarified storage behavior, production defaults, operational guidance, and security scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->