### PR TITLE
feat(netbird)!: add PostgreSQL production store

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -16,6 +16,7 @@ keywords:
   - zero-trust
   - mesh
   - networking
+  - postgresql
   - self-hosted
   - kubernetes
 maintainers:
@@ -25,8 +26,15 @@ icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: add chart (#781)"
+      description: "BREAKING: default to PostgreSQL-backed production store"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"
-  helmforge.dev/maturity: alpha
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+  helmforge.dev/maturity: stable
+dependencies:
+  - name: postgresql
+    version: 2.0.4
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled

--- a/charts/netbird/DESIGN.md
+++ b/charts/netbird/DESIGN.md
@@ -26,7 +26,14 @@ The default store engine is `sqlite`, stored under `/var/lib/netbird`.
 With sqlite, `server.replicaCount` must remain `1` because concurrent writers are unsafe.
 The validation helper blocks sqlite scale-out.
 
-For high availability, configure an external `postgres` or `mysql` DSN through `server.store` and then increase `server.replicaCount`.
+For high availability, use the default PostgreSQL subchart for self-contained
+installs or configure an external `postgres` or `mysql` database through
+`database.external`. PostgreSQL is the only bundled database dependency in v1
+because upstream documents it as the recommended production store. MySQL remains
+available as an external store for organizations standardized on it.
+
+SQLite is still supported, but only for single-replica lab or small installs.
+Set `database.mode=sqlite` and `postgresql.enabled=false` explicitly.
 
 ## Exposure
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -7,6 +7,7 @@ This chart packages the current upstream combined architecture:
 - `netbirdio/netbird-server:0.74.4` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.3` for the web UI
 - a generated or externally supplied `config.yaml`
+- HelmForge PostgreSQL subchart as the default production store
 - optional persistent storage under `/var/lib/netbird`
 - dashboard OIDC environment derived from chart values
 - Ingress and Gateway API HTTPRoute support for HTTP/gRPC front doors
@@ -32,6 +33,16 @@ helm upgrade --install netbird helmforge/netbird \
   --set server.authSecret="$(openssl rand -hex 32)"
 ```
 
+The v1 chart defaults to PostgreSQL-backed storage through the HelmForge
+PostgreSQL subchart. For disposable or single-node lab installs, explicitly set:
+
+```yaml
+database:
+  mode: sqlite
+postgresql:
+  enabled: false
+```
+
 ## Production notes
 
 NetBird peers need a stable public endpoint. Expose:
@@ -53,9 +64,17 @@ Use `server.config.existingSecret` when you need to provide a full upstream `con
 
 ## Storage
 
-The default store engine is `sqlite`, so the server Deployment defaults to one replica and
-uses a `Recreate` strategy. For horizontal server scaling, configure an external
-`postgres` or `mysql` store and set `server.replicaCount` above one.
+The default store mode is `auto`, which selects the PostgreSQL subchart unless
+an external database is configured. This follows upstream guidance that
+PostgreSQL is the production store for concurrent access and high availability.
+
+Use `database.mode=external` with `database.external.engine=postgres` or `mysql`
+when your platform owns the database. MySQL is supported as an external database
+because upstream supports it, but this chart does not add a MySQL subchart in v1;
+PostgreSQL is the recommended bundled production path.
+
+SQLite remains available for lab installs with `database.mode=sqlite` and
+`postgresql.enabled=false`. Keep `server.replicaCount: 1` in sqlite mode.
 
 ## External secrets
 
@@ -69,13 +88,13 @@ Local security scan:
 Image: netbirdio/netbird-server:0.74.4
 Image: netbirdio/dashboard:v2.90.3
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
-Result: 83.83838 compliance score
+Result: 86.86869 compliance score
 ```
 
 The local scan reported no critical failures and an overall score above the
 repository security gate. Remaining findings are tracked as hardening trade-offs
-for default resource limits, optional NetworkPolicy enablement, and the
-dashboard image startup model.
+for optional NetworkPolicy enablement, upstream dashboard startup model, and
+operator-owned resource limit tuning across the database-backed topology.
 
 ## Validation
 

--- a/charts/netbird/ci/sqlite-values.yaml
+++ b/charts/netbird/ci/sqlite-values.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+database:
+  mode: sqlite
+postgresql:
+  enabled: false

--- a/charts/netbird/docs/storage.md
+++ b/charts/netbird/docs/storage.md
@@ -2,6 +2,47 @@
 
 The chart persists NetBird server data under `/var/lib/netbird` by default.
 
-With the default sqlite store, keep `server.replicaCount: 1`. Use an external `postgres` or `mysql` store before scaling the server Deployment horizontally.
+The v1 chart defaults to PostgreSQL through the HelmForge PostgreSQL subchart.
+This gives new production installs a network database by default while keeping a
+self-contained Helm install experience.
+
+Use the bundled PostgreSQL store:
+
+```yaml
+database:
+  mode: postgresql
+postgresql:
+  enabled: true
+```
+
+Use an external PostgreSQL or MySQL database when your platform owns database
+backups, HA, TLS, and maintenance:
+
+```yaml
+postgresql:
+  enabled: false
+database:
+  mode: external
+  external:
+    engine: postgres
+    host: postgres.example.com
+    name: netbird
+    username: netbird
+    existingSecret: netbird-database
+    existingSecretPasswordKey: database-password
+```
+
+Use SQLite only for disposable or small single-replica installs:
+
+```yaml
+database:
+  mode: sqlite
+postgresql:
+  enabled: false
+```
+
+Keep `server.replicaCount: 1` in sqlite mode. Even with PostgreSQL or MySQL,
+scaling the combined NetBird server requires protocol-aware routing and HA
+planning for management, signal, relay, and STUN traffic.
 
 Back up the PersistentVolumeClaim before chart upgrades. If you use an external database, include the database backup and the mounted NetBird data directory in the same recovery plan.

--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -84,6 +84,139 @@ NetBird config secret name.
 {{- end -}}
 
 {{/*
+Database/store mode selection.
+*/}}
+{{- define "netbird.databaseMode" -}}
+{{- $mode := .Values.database.mode | default "auto" -}}
+{{- if not (has $mode (list "auto" "sqlite" "postgresql" "external")) -}}
+{{- fail (printf "database.mode must be one of: auto, sqlite, postgresql, external (got %s)" $mode) -}}
+{{- end -}}
+{{- $external := .Values.database.external | default dict -}}
+{{- $hasExternal := or (ne ($external.host | default "") "") (ne ($external.existingSecret | default "") "") (ne ($external.dsn | default "") "") -}}
+{{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
+{{- if eq $mode "auto" -}}
+  {{- if and $hasExternal $hasPostgresql -}}
+    {{- fail "netbird database selection is ambiguous: configure only one of database.external.* or postgresql.enabled" -}}
+  {{- end -}}
+  {{- if $hasExternal -}}external
+  {{- else if $hasPostgresql -}}postgresql
+  {{- else -}}sqlite
+  {{- end -}}
+{{- else -}}
+  {{- if and (eq $mode "external") (not $hasExternal) -}}
+    {{- fail "database.mode=external requires database.external.host, database.external.existingSecret, or database.external.dsn" -}}
+  {{- end -}}
+  {{- if and (eq $mode "external") $hasPostgresql -}}
+    {{- fail "database.mode=external cannot be combined with postgresql.enabled" -}}
+  {{- end -}}
+  {{- if and (eq $mode "postgresql") (not $hasPostgresql) -}}
+    {{- fail "database.mode=postgresql requires postgresql.enabled=true" -}}
+  {{- end -}}
+  {{- if and (eq $mode "postgresql") $hasExternal -}}
+    {{- fail "database.mode=postgresql cannot be combined with database.external.*" -}}
+  {{- end -}}
+  {{- if and (eq $mode "sqlite") $hasPostgresql -}}
+    {{- fail "database.mode=sqlite requires postgresql.enabled=false" -}}
+  {{- end -}}
+  {{- if and (eq $mode "sqlite") $hasExternal -}}
+    {{- fail "database.mode=sqlite cannot be combined with database.external.*" -}}
+  {{- end -}}
+  {{- $mode -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.storeEngine" -}}
+{{- if .Values.server.store.engine -}}
+{{- .Values.server.store.engine -}}
+{{- else -}}
+{{- $mode := include "netbird.databaseMode" . -}}
+{{- if eq $mode "sqlite" -}}sqlite
+{{- else if eq $mode "postgresql" -}}postgres
+{{- else -}}{{ .Values.database.external.engine | default "postgres" }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.postgresqlSecretName" -}}
+{{- printf "%s-postgresql-auth" .Release.Name -}}
+{{- end -}}
+
+{{- define "netbird.databasePasswordSecretName" -}}
+{{- $mode := include "netbird.databaseMode" . -}}
+{{- if eq $mode "postgresql" -}}
+{{- include "netbird.postgresqlSecretName" . -}}
+{{- else if .Values.database.external.existingSecret -}}
+{{- .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- printf "%s-database" (include "netbird.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.databasePasswordSecretKey" -}}
+{{- if eq (include "netbird.databaseMode" .) "postgresql" -}}
+user-password
+{{- else -}}
+{{- .Values.database.external.existingSecretPasswordKey | default "database-password" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.databaseHost" -}}
+{{- if eq (include "netbird.databaseMode" .) "postgresql" -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- else -}}
+{{- .Values.database.external.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.databasePort" -}}
+{{- if eq (include "netbird.databaseMode" .) "postgresql" -}}5432{{- else -}}{{ .Values.database.external.port | toString }}{{- end -}}
+{{- end -}}
+
+{{- define "netbird.databaseName" -}}
+{{- if eq (include "netbird.databaseMode" .) "postgresql" -}}{{ .Values.postgresql.auth.database }}{{- else -}}{{ .Values.database.external.name }}{{- end -}}
+{{- end -}}
+
+{{- define "netbird.databaseUsername" -}}
+{{- if eq (include "netbird.databaseMode" .) "postgresql" -}}{{ .Values.postgresql.auth.username }}{{- else -}}{{ .Values.database.external.username }}{{- end -}}
+{{- end -}}
+
+{{- define "netbird.storeConfigDsn" -}}
+{{- if .Values.server.store.dsn -}}
+{{- .Values.server.store.dsn -}}
+{{- else if and (eq (include "netbird.databaseMode" .) "external") .Values.database.external.dsn -}}
+{{- .Values.database.external.dsn -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.storeDsnEnvName" -}}
+{{- if eq (include "netbird.storeEngine" .) "mysql" -}}NETBIRD_STORE_ENGINE_MYSQL_DSN{{- else -}}NETBIRD_STORE_ENGINE_POSTGRES_DSN{{- end -}}
+{{- end -}}
+
+{{- define "netbird.storeDsnTemplate" -}}
+{{- $mode := include "netbird.databaseMode" . -}}
+{{- if eq (include "netbird.storeEngine" .) "mysql" -}}
+{{- printf "%s:%s@tcp(%s:%s)/%s" (include "netbird.databaseUsername" .) "$(NETBIRD_DATABASE_PASSWORD)" (include "netbird.databaseHost" .) (include "netbird.databasePort" .) (include "netbird.databaseName" .) -}}
+{{- else -}}
+{{- printf "host=%s user=%s password=%s dbname=%s port=%s sslmode=%s" (include "netbird.databaseHost" .) (include "netbird.databaseUsername" .) "$(NETBIRD_DATABASE_PASSWORD)" (include "netbird.databaseName" .) (include "netbird.databasePort" .) (ternary "disable" (.Values.database.external.sslMode | default "disable") (eq $mode "postgresql")) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "netbird.storeEnv" -}}
+{{- $mode := include "netbird.databaseMode" . -}}
+{{- if and (ne $mode "sqlite") (not .Values.server.store.dsn) (not .Values.database.external.dsn) }}
+- name: NETBIRD_DATABASE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "netbird.databasePasswordSecretName" . }}
+      key: {{ include "netbird.databasePasswordSecretKey" . }}
+- name: {{ include "netbird.storeDsnEnvName" . }}
+  value: {{ include "netbird.storeDsnTemplate" . | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 ServiceAccount name.
 */}}
 {{- define "netbird.serviceAccountName" -}}
@@ -140,11 +273,18 @@ ExternalSecret name helper.
 Validate chart values.
 */}}
 {{- define "netbird.validate" -}}
+{{- $_ := include "netbird.databaseMode" . -}}
 {{- if and (gt (int .Values.server.replicaCount) 1) (eq .Values.server.store.engine "sqlite") -}}
 {{- fail "server.replicaCount > 1 requires server.store.engine other than sqlite" -}}
 {{- end -}}
-{{- if and (ne .Values.server.store.engine "sqlite") (empty .Values.server.store.dsn) -}}
-{{- fail "server.store.dsn is required when server.store.engine is postgres or mysql" -}}
+{{- if and (gt (int .Values.server.replicaCount) 1) (eq (include "netbird.databaseMode" .) "sqlite") -}}
+{{- fail "server.replicaCount > 1 requires database.mode other than sqlite" -}}
+{{- end -}}
+{{- if and (eq (include "netbird.databaseMode" .) "external") (not .Values.database.external.dsn) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
+{{- fail "database.external.password, database.external.existingSecret, or database.external.dsn is required when database.mode=external" -}}
+{{- end -}}
+{{- if and .Values.server.store.engine (not (has .Values.server.store.engine (list "sqlite" "postgres" "mysql"))) -}}
+{{- fail "server.store.engine must be one of: sqlite, postgres, mysql" -}}
 {{- end -}}
 {{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}

--- a/charts/netbird/templates/_helpers.tpl
+++ b/charts/netbird/templates/_helpers.tpl
@@ -92,7 +92,7 @@ Database/store mode selection.
 {{- fail (printf "database.mode must be one of: auto, sqlite, postgresql, external (got %s)" $mode) -}}
 {{- end -}}
 {{- $external := .Values.database.external | default dict -}}
-{{- $hasExternal := or (ne ($external.host | default "") "") (ne ($external.existingSecret | default "") "") (ne ($external.dsn | default "") "") -}}
+{{- $hasExternal := or (ne ($external.host | default "") "") (ne ($external.existingSecret | default "") "") (ne ($external.dsn | default "") "") (ne ($external.password | default "") "") -}}
 {{- $hasPostgresql := .Values.postgresql.enabled | default false -}}
 {{- if eq $mode "auto" -}}
   {{- if and $hasExternal $hasPostgresql -}}
@@ -104,7 +104,7 @@ Database/store mode selection.
   {{- end -}}
 {{- else -}}
   {{- if and (eq $mode "external") (not $hasExternal) -}}
-    {{- fail "database.mode=external requires database.external.host, database.external.existingSecret, or database.external.dsn" -}}
+    {{- fail "database.mode=external requires database.external.host, database.external.existingSecret, database.external.password, or database.external.dsn" -}}
   {{- end -}}
   {{- if and (eq $mode "external") $hasPostgresql -}}
     {{- fail "database.mode=external cannot be combined with postgresql.enabled" -}}
@@ -205,7 +205,8 @@ user-password
 
 {{- define "netbird.storeEnv" -}}
 {{- $mode := include "netbird.databaseMode" . -}}
-{{- if and (ne $mode "sqlite") (not .Values.server.store.dsn) (not .Values.database.external.dsn) }}
+{{- $configDsn := include "netbird.storeConfigDsn" . -}}
+{{- if and (ne $mode "sqlite") (not .Values.server.store.dsn) (not $configDsn) }}
 - name: NETBIRD_DATABASE_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -283,8 +284,21 @@ Validate chart values.
 {{- if and (eq (include "netbird.databaseMode" .) "external") (not .Values.database.external.dsn) (not .Values.database.external.existingSecret) (not .Values.database.external.password) -}}
 {{- fail "database.external.password, database.external.existingSecret, or database.external.dsn is required when database.mode=external" -}}
 {{- end -}}
+{{- if and (eq (include "netbird.databaseMode" .) "external") (not .Values.database.external.dsn) (not .Values.database.external.host) -}}
+{{- fail "database.external.host or database.external.dsn is required when database.mode=external" -}}
+{{- end -}}
 {{- if and .Values.server.store.engine (not (has .Values.server.store.engine (list "sqlite" "postgres" "mysql"))) -}}
 {{- fail "server.store.engine must be one of: sqlite, postgres, mysql" -}}
+{{- end -}}
+{{- $mode := include "netbird.databaseMode" . -}}
+{{- if and .Values.server.store.engine (eq $mode "sqlite") (ne .Values.server.store.engine "sqlite") -}}
+{{- fail "server.store.engine must be sqlite when database.mode resolves to sqlite" -}}
+{{- end -}}
+{{- if and .Values.server.store.engine (eq $mode "postgresql") (ne .Values.server.store.engine "postgres") -}}
+{{- fail "server.store.engine must be postgres when database.mode resolves to postgresql" -}}
+{{- end -}}
+{{- if and .Values.server.store.engine (eq $mode "external") (ne .Values.server.store.engine (.Values.database.external.engine | default "postgres")) -}}
+{{- fail "server.store.engine must match database.external.engine when database.mode resolves to external" -}}
 {{- end -}}
 {{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}

--- a/charts/netbird/templates/deployment.yaml
+++ b/charts/netbird/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- if ne (include "netbird.databaseMode" .) "sqlite" }}
+      {{- if and (ne (include "netbird.databaseMode" .) "sqlite") (not (include "netbird.storeConfigDsn" .)) (include "netbird.databaseHost" .) (include "netbird.databasePort" .) }}
       initContainers:
         - name: wait-for-database
           image: busybox:1.37.0

--- a/charts/netbird/templates/deployment.yaml
+++ b/charts/netbird/templates/deployment.yaml
@@ -43,6 +43,37 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if ne (include "netbird.databaseMode" .) "sqlite" }}
+      initContainers:
+        - name: wait-for-database
+          image: busybox:1.37.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -ec
+            - |
+              until nc -z {{ include "netbird.databaseHost" . | quote }} {{ include "netbird.databasePort" . | quote }}; do
+                sleep 2
+              done
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+      {{- end }}
       containers:
         - name: server
           image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
@@ -72,9 +103,11 @@ spec:
             - name: health
               containerPort: 9000
               protocol: TCP
-          {{- with .Values.server.env }}
+          {{- $storeEnv := include "netbird.storeEnv" . }}
+          {{- if or $storeEnv .Values.server.env }}
           env:
-            {{- range . }}
+            {{- $storeEnv | nindent 12 }}
+            {{- range .Values.server.env }}
             - name: {{ .name }}
               {{- if hasKey . "valueFrom" }}
               valueFrom:

--- a/charts/netbird/templates/secret-config.yaml
+++ b/charts/netbird/templates/secret-config.yaml
@@ -44,8 +44,8 @@ stringData:
           password: {{ .Values.server.auth.owner.password | quote }}
         {{- end }}
       store:
-        engine: {{ .Values.server.store.engine | quote }}
-        dsn: {{ .Values.server.store.dsn | quote }}
+        engine: {{ include "netbird.storeEngine" . | quote }}
+        dsn: {{ include "netbird.storeConfigDsn" . | quote }}
         encryptionKey: {{ .Values.server.store.encryptionKey | quote }}
 {{- with .Values.server.config.extraYaml }}
 {{ . | nindent 6 }}

--- a/charts/netbird/templates/secret-database.yaml
+++ b/charts/netbird/templates/secret-database.yaml
@@ -1,0 +1,12 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and (eq (include "netbird.databaseMode" .) "external") (not .Values.database.external.existingSecret) (not .Values.database.external.dsn) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "netbird.databasePasswordSecretName" . }}
+  labels:
+    {{- include "netbird.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ include "netbird.databasePasswordSecretKey" . }}: {{ .Values.database.external.password | quote }}
+{{- end }}

--- a/charts/netbird/tests/database-ambiguous-values.yaml
+++ b/charts/netbird/tests/database-ambiguous-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+postgresql:
+  enabled: true
+database:
+  external:
+    host: postgres.example.com
+    password: external-password

--- a/charts/netbird/tests/database_test.yaml
+++ b/charts/netbird/tests/database_test.yaml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbird database
+templates:
+  - templates/deployment.yaml
+  - templates/secret-config.yaml
+  - templates/secret-database.yaml
+  - templates/validate.yaml
+tests:
+  - it: defaults to the PostgreSQL subchart store
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NETBIRD_DATABASE_PASSWORD
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+          value: RELEASE-NAME-postgresql-auth
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: NETBIRD_STORE_ENGINE_POSTGRES_DSN
+        documentIndex: 0
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[1].value
+          pattern: "host=RELEASE-NAME-postgresql.*dbname=netbird.*sslmode=disable"
+        documentIndex: 0
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-database
+        documentIndex: 0
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "RELEASE-NAME-postgresql"
+        documentIndex: 0
+  - it: renders sqlite without database env vars
+    template: templates/deployment.yaml
+    values:
+      - sqlite-values.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env
+        documentIndex: 0
+      - notExists:
+          path: spec.template.spec.initContainers
+        documentIndex: 0
+  - it: renders external postgres password Secret and DSN env
+    values:
+      - external-postgres-values.yaml
+    asserts:
+      - isKind:
+          of: Secret
+        template: templates/secret-database.yaml
+      - equal:
+          path: stringData.database-password
+          value: external-password
+        template: templates/secret-database.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[1].value
+          pattern: "host=postgres.example.com.*sslmode=require"
+        template: templates/deployment.yaml
+        documentIndex: 0
+  - it: renders external mysql DSN env
+    template: templates/deployment.yaml
+    values:
+      - external-mysql-values.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: NETBIRD_STORE_ENGINE_MYSQL_DSN
+        documentIndex: 0
+      - matchRegex:
+          path: spec.template.spec.containers[0].env[1].value
+          pattern: "netbird:\\$\\(NETBIRD_DATABASE_PASSWORD\\)@tcp\\(mysql.example.com:3306\\)/netbird"
+        documentIndex: 0

--- a/charts/netbird/tests/external-mysql-values.yaml
+++ b/charts/netbird/tests/external-mysql-values.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+postgresql:
+  enabled: false
+database:
+  mode: external
+  external:
+    engine: mysql
+    host: mysql.example.com
+    port: 3306
+    name: netbird
+    username: netbird
+    password: external-password

--- a/charts/netbird/tests/external-postgres-values.yaml
+++ b/charts/netbird/tests/external-postgres-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+postgresql:
+  enabled: false
+database:
+  mode: external
+  external:
+    engine: postgres
+    host: postgres.example.com
+    port: 5432
+    name: netbird
+    username: netbird
+    password: external-password
+    sslMode: require

--- a/charts/netbird/tests/sqlite-values.yaml
+++ b/charts/netbird/tests/sqlite-values.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+database:
+  mode: sqlite
+postgresql:
+  enabled: false

--- a/charts/netbird/tests/validation_test.yaml
+++ b/charts/netbird/tests/validation_test.yaml
@@ -10,12 +10,26 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "server.replicaCount > 1 requires server.store.engine other than sqlite"
+  - it: fails when scaling database.mode sqlite server replicas
+    set:
+      server.replicaCount: 2
+      database.mode: sqlite
+      postgresql.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "server.replicaCount > 1 requires database.mode other than sqlite"
   - it: fails when ingress is enabled without hosts
     set:
       ingress.enabled: true
     asserts:
       - failedTemplate:
           errorMessage: "ingress.hosts must contain at least one host when ingress.enabled=true"
+  - it: fails when database selection is ambiguous
+    values:
+      - database-ambiguous-values.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "netbird database selection is ambiguous: configure only one of database.external.* or postgresql.enabled"
   - it: fails when ExternalSecrets is enabled without items
     set:
       externalSecrets.enabled: true

--- a/charts/netbird/values.schema.json
+++ b/charts/netbird/values.schema.json
@@ -138,7 +138,7 @@
             "password": { "type": "string", "default": "" },
             "existingSecret": { "type": "string", "default": "" },
             "existingSecretPasswordKey": { "type": "string", "default": "database-password" },
-            "sslMode": { "type": "string", "default": "disable" },
+            "sslMode": { "type": "string", "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"], "default": "prefer" },
             "dsn": { "type": "string", "default": "" }
           }
         }

--- a/charts/netbird/values.schema.json
+++ b/charts/netbird/values.schema.json
@@ -11,6 +11,8 @@
     "server": { "$ref": "#/definitions/server" },
     "dashboard": { "$ref": "#/definitions/dashboard" },
     "imagePullSecrets": { "type": "array", "items": { "type": "object" } },
+    "database": { "$ref": "#/definitions/database" },
+    "postgresql": { "$ref": "#/definitions/postgresql" },
     "persistence": { "$ref": "#/definitions/persistence" },
     "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
     "ingress": { "$ref": "#/definitions/ingress" },
@@ -119,6 +121,37 @@
         "accessModes": { "type": "array", "items": { "type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"] } },
         "existingClaim": { "type": "string" },
         "mountPath": { "type": "string" }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "mode": { "type": "string", "enum": ["auto", "sqlite", "postgresql", "external"], "default": "auto" },
+        "external": {
+          "type": "object",
+          "properties": {
+            "engine": { "type": "string", "enum": ["postgres", "mysql"], "default": "postgres" },
+            "host": { "type": "string", "default": "" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 5432 },
+            "name": { "type": "string", "default": "netbird" },
+            "username": { "type": "string", "default": "netbird" },
+            "password": { "type": "string", "default": "" },
+            "existingSecret": { "type": "string", "default": "" },
+            "existingSecretPasswordKey": { "type": "string", "default": "database-password" },
+            "sslMode": { "type": "string", "default": "disable" },
+            "dsn": { "type": "string", "default": "" }
+          }
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "architecture": { "type": "string", "default": "standalone" },
+        "auth": { "type": "object" },
+        "standalone": { "type": "object" }
       }
     },
     "serviceAccount": {

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -60,9 +60,9 @@ server:
       # -- Optional initial owner password for local authentication bootstrap. Prefer externalSecrets in production.
       password: ""
   store:
-    # -- NetBird store engine. Supported by upstream: sqlite, postgres, mysql.
-    engine: sqlite
-    # -- Store DSN. Empty uses sqlite under /var/lib/netbird.
+    # -- Legacy direct NetBird store engine override. Prefer database.mode for new installs.
+    engine: ""
+    # -- Legacy direct store DSN override. Prefer database.external for new installs.
     dsn: ""
     # -- Optional encryption key for stored secrets. Prefer externalSecrets in production.
     encryptionKey: ""
@@ -140,8 +140,53 @@ dashboard:
 # -- Optional image pull secrets for private registries or mirrored images.
 imagePullSecrets: []
 
+database:
+  # -- Store mode: auto | sqlite | postgresql | external. Auto selects external when configured, then PostgreSQL subchart, then sqlite.
+  mode: auto
+  external:
+    # -- External database engine. Upstream supports postgres and mysql.
+    engine: postgres
+    # -- External database hostname.
+    host: ""
+    # -- External database port.
+    port: 5432
+    # -- External database name.
+    name: netbird
+    # -- External database username.
+    username: netbird
+    # -- External database password. Ignored when existingSecret is set.
+    password: ""
+    # -- Existing Secret containing the external database password.
+    existingSecret: ""
+    # -- Key in existingSecret containing the database password.
+    existingSecretPasswordKey: database-password
+    # -- PostgreSQL sslmode when external.engine=postgres.
+    sslMode: disable
+    # -- Raw upstream DSN. When set, it is used directly and host/user/password fields are ignored.
+    dsn: ""
+
+postgresql:
+  # -- Deploy HelmForge PostgreSQL as the default production store.
+  enabled: true
+  architecture: standalone
+  auth:
+    # -- PostgreSQL database name created on first run.
+    database: netbird
+    # -- PostgreSQL username created on first run.
+    username: netbird
+    # -- PostgreSQL application user password. Auto-generated if empty.
+    password: ""
+    # -- PostgreSQL superuser password. Auto-generated if empty.
+    postgresPassword: ""
+  standalone:
+    persistence:
+      # -- Enable persistence for PostgreSQL data.
+      enabled: true
+      # -- PVC size for PostgreSQL.
+      size: 8Gi
+
 persistence:
-  # -- Persist NetBird sqlite data, embedded configuration state, and generated assets.
+  # -- Persist NetBird sqlite data, embedded configuration state, and generated assets. PostgreSQL mode still uses this for non-database runtime assets.
   enabled: true
   # -- PersistentVolumeClaim size for /var/lib/netbird.
   size: 10Gi

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -148,7 +148,7 @@ database:
     engine: postgres
     # -- External database hostname.
     host: ""
-    # -- External database port.
+    # -- External database port. MySQL users must override this to 3306.
     port: 5432
     # -- External database name.
     name: netbird
@@ -161,7 +161,7 @@ database:
     # -- Key in existingSecret containing the database password.
     existingSecretPasswordKey: database-password
     # -- PostgreSQL sslmode when external.engine=postgres.
-    sslMode: disable
+    sslMode: prefer
     # -- Raw upstream DSN. When set, it is used directly and host/user/password fields are ignored.
     dsn: ""
 


### PR DESCRIPTION
## Summary
- Promotes NetBird to stable with a production-oriented PostgreSQL-backed default store.
- Adds the HelmForge PostgreSQL subchart, `database.mode`, external PostgreSQL/MySQL contracts, generated DSN helpers, and a database readiness init container.
- Keeps SQLite available explicitly for lab/small installs and adds rendered tests for bundled PostgreSQL, SQLite, external PostgreSQL, external MySQL, and invalid ambiguous database selection.
- Updates README/DESIGN/storage docs and the Kubescape security scan evidence.

Related to #777

## Breaking change
The default NetBird store changes from SQLite to bundled PostgreSQL. Existing SQLite users should opt in explicitly:

```yaml
database:
  mode: sqlite
postgresql:
  enabled: false
```

## Product/subchart assessment
- NetBird officially supports `sqlite`, `postgres`, and `mysql` store engines.
- PostgreSQL is the correct HelmForge v1 production default because it supports the HA/production path better than SQLite and matches mature HelmForge charts that include first-party database subcharts when the app has a real database contract.
- MySQL remains supported as an external database in this PR, but is not added as a second bundled subchart to avoid dual bundled database complexity in v1.
- Redis is not added: NetBird does not require it for the chart's production store contract.

## Linked PRs
- Site sync: helmforgedev/site#420
- Org profile sync: helmforgedev/.github#16

## Validation
- `make validate-chart CHART=netbird` PASS, 18 layers including k3d default PostgreSQL and `ci/sqlite-values.yaml`.
- `make standards-check CHART=netbird`
- `make deps-check CHART=netbird`
- `node scripts/charts/template-standards-check.js --chart netbird`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=netbird JSON=1`
- `make org-check`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`