### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled
   - name: memcached
-    version: 1.0.7
+    version: 1.0.8
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.memcached.subchart.enabled


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- wordpress: memcached 1.0.7 -> 1.0.8

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled Memcached chart to version 1.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->