### PR TITLE
chore(adguard-home): bump adguard home to 0.107.78

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -4,7 +4,7 @@ name: adguard-home
 description: AdGuard Home network-wide ad and tracker blocking DNS server with sync and S3 backup
 type: application
 version: 1.4.13
-appVersion: "0.107.77"
+appVersion: "0.107.78"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,8 +25,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/adguard-home.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "support service externalTrafficPolicy setting  (#727)"
+    - kind: security
+      description: "update AdGuard Home to 0.107.78 with upstream DNS and QUIC security fixes"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -35,10 +35,9 @@ To skip the wizard and deploy a pre-configured instance, provide `config.adGuard
 
 ## Upstream Version Notes
 
-AdGuard Home `0.107.77` is an upstream security and bugfix release. It fixes a
-GLiNET-mode authorization path traversal issue (CVE-2026-41448), adds the
-`reason` query parameter for query log filtering, and deprecates the older
-`response_status` query parameter.
+AdGuard Home `0.107.78` is an upstream security and bugfix release. It improves
+resistance to JIGGLE attacks, validates responses from DNS-over-HTTPS upstreams
+more strictly, and protects QUIC connections from unbounded reads.
 
 The `0.107.76` release notes also state that YAML duration values now support
 `d` day units. If you roll back to a version below `v0.107.76`, convert any `d`
@@ -188,7 +187,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/adguard/adguardhome` | Container image |
-| `image.tag` | `v0.107.77` | Image tag |
+| `image.tag` | `v0.107.78` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### General Configuration

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/adguard/adguardhome:v0.107.77"
+          value: "docker.io/adguard/adguardhome:v0.107.78"
 
   - it: should expose setup wizard port 3000 by default (no config)
     template: templates/deployment.yaml

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- AdGuard Home container image
   repository: docker.io/adguard/adguardhome
   # -- Image tag
-  tag: "v0.107.77"
+  tag: "v0.107.78"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update AdGuard Home from 0.107.77 to 0.107.78
- refresh the rendered-image unit test and configuration reference
- document the upstream DNS and QUIC security fixes in the release metadata

## Upstream evidence

- Image: `docker.io/adguard/adguardhome:v0.107.78`
- Manifest platforms: `linux/386`, `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/ppc64le`
- Release notes: https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.78
- No chart-facing breaking configuration change identified

## Validation

- `make image-verify IMAGE=docker.io/adguard/adguardhome:v0.107.78`
- `make deps-check CHART=adguard-home`
- `make validate-chart CHART=adguard-home` — 18 layers passed, including nine isolated k3d scenarios
- `node scripts/charts/template-standards-check.js --chart adguard-home`
- `make standards-check CHART=adguard-home`
- `make md-lint REPO=charts`
- `make preflight`

## Site sync

Site PR: helmforgedev/site#427

Closes #787.
