### PR TITLE
chore(certimate): bump certimate to 0.4.27

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -4,7 +4,7 @@ name: certimate
 description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
 type: application
 version: 1.0.0
-appVersion: "0.4.26"
+appVersion: "0.4.27"
 home: https://helmforge.dev/docs/charts/certimate
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/certimate
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/certimate.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: harden production defaults (#782)"
+      description: "update Certimate to 0.4.27 with new DNS and deployment providers"
   artifacthub.io/category: security
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -2,7 +2,7 @@
 
 Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
 
-This chart packages the official `certimate/certimate:v0.4.26` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+This chart packages the official `certimate/certimate:v0.4.27` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
 
 ## Production Defaults
 
@@ -85,7 +85,7 @@ ACME endpoints required by your workflows.
 Local security scan:
 
 ```text
-Image: certimate/certimate:v0.4.26
+Image: certimate/certimate:v0.4.27
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 93.93939 compliance score
 ```

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: certimate/certimate:v0.4.26
+          value: certimate/certimate:v0.4.27
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "certimate/certimate" },
-        "tag": { "type": "string", "default": "v0.4.26", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "v0.4.27", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Certimate container image repository.
   repository: certimate/certimate
   # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
-  tag: "v0.4.26"
+  tag: "v0.4.27"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update Certimate from 0.4.26 to 0.4.27
- synchronize the schema, README, and rendered-image test
- record the upstream provider additions and maintenance release

## Upstream evidence

- Image: `certimate/certimate:v0.4.27`
- Manifest platforms: `linux/amd64`, `linux/arm64`, `linux/arm`
- Release notes: https://github.com/certimate-go/certimate/releases/tag/v0.4.27
- The unprefixed `0.4.27` tag suggested by the automation does not exist; the official stable tag is `v0.4.27`
- No chart-facing breaking change identified

## Validation

- `make image-verify IMAGE=certimate/certimate:v0.4.27`
- `make deps-check CHART=certimate`
- `make validate-chart CHART=certimate` — 17 layers passed, including eight isolated k3d scenarios
- `node scripts/charts/template-standards-check.js --chart certimate`
- `make standards-check CHART=certimate`
- `make md-lint REPO=charts`
- `make preflight`

## Site sync

Site PR: helmforgedev/site#428

Closes #788.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Helm chart and default container image to Certimate `v0.4.27`.
  * Refreshed chart documentation and security scan examples to reference the new image version.
  * Updated validation tests to confirm the `v0.4.27` image is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->