### PR TITLE
feat(guacamole): configurable initContainers

### DIFF
--- a/charts/guacamole/README.md
+++ b/charts/guacamole/README.md
@@ -112,7 +112,7 @@ See [OIDC with Keycloak guide](docs/oidc-keycloak.md) for detailed setup instruc
 | Key | Default | Description |
 |-----|---------|-------------|
 | `database.type` | `postgresql` | Database type (postgresql, mysql) |
-| `database.waitForConnection.enabled` | `enabled` | Wait for successful database connection before starting |
+| `database.waitForConnection.enabled` | `true` | Wait for successful database connection before starting |
 | `database.waitForConnection.resources` | `{}` | Optional resource definitions for waitForConnection |
 | `database.external.host` | `""` | External database host |
 | `database.external.name` | `guacamole_db` | Database name |
@@ -161,6 +161,15 @@ See [OIDC with Keycloak guide](docs/oidc-keycloak.md) for detailed setup instruc
 | `backup.schedule` | `0 2 * * *` | Cron schedule |
 | `backup.s3.endpoint` | `""` | S3 endpoint URL |
 | `backup.s3.bucket` | `""` | S3 bucket |
+
+### Extra
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `extraInitContainers` | `[]` | Additional init containers for the pod |
+| `extraVolumes` | `[]` | Additional volumes for the pod |
+| `extraVolumeMounts` | `[]` | Additional volume mounts for the container |
+| `extraManifests` | `[]` | Extra manifests to deploy alongside the chart |
 
 ## Architecture
 

--- a/charts/guacamole/README.md
+++ b/charts/guacamole/README.md
@@ -112,6 +112,8 @@ See [OIDC with Keycloak guide](docs/oidc-keycloak.md) for detailed setup instruc
 | Key | Default | Description |
 |-----|---------|-------------|
 | `database.type` | `postgresql` | Database type (postgresql, mysql) |
+| `database.waitForConnection.enabled` | `enabled` | Wait for successful database connection before starting |
+| `database.waitForConnection.resources` | `{}` | Optional resource definitions for waitForConnection |
 | `database.external.host` | `""` | External database host |
 | `database.external.name` | `guacamole_db` | Database name |
 | `database.external.username` | `guacamole_user` | Database username |

--- a/charts/guacamole/docs/database.md
+++ b/charts/guacamole/docs/database.md
@@ -70,7 +70,7 @@ The chart includes a post-install Job (`initdb-job`) that:
 
 Set `initDb.enabled: false` to skip automatic initialization (useful with external databases that already have the schema).
 
-Set `database.waitForConnection.enabled: false` to skip waiting for successful database connection (useful with already existing external databases).
+Set `database.waitForConnection.enabled: false` to skip waiting for successful database connection in the main pod (useful with already existing external databases). The `initdb-job` still waits for the database before initialization.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/guacamole/docs/database.md
+++ b/charts/guacamole/docs/database.md
@@ -70,6 +70,8 @@ The chart includes a post-install Job (`initdb-job`) that:
 
 Set `initDb.enabled: false` to skip automatic initialization (useful with external databases that already have the schema).
 
+Set `database.waitForConnection.enabled: false` to skip waiting for successful database connection (useful with already existing external databases).
+
 <!-- @AI-METADATA
 type: chart-docs
 title: Guacamole Database Configuration

--- a/charts/guacamole/docs/database.md
+++ b/charts/guacamole/docs/database.md
@@ -70,7 +70,8 @@ The chart includes a post-install Job (`initdb-job`) that:
 
 Set `initDb.enabled: false` to skip automatic initialization (useful with external databases that already have the schema).
 
-Set `database.waitForConnection.enabled: false` to skip waiting for successful database connection in the main pod (useful with already existing external databases). The `initdb-job` still waits for the database before initialization.
+Set `database.waitForConnection.enabled: false` to skip waiting for successful database connection in the main pod (useful with already existing external databases).
+Note: this does not disable waiting in `initdb-job`.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/guacamole/templates/deployment.yaml
+++ b/charts/guacamole/templates/deployment.yaml
@@ -35,9 +35,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or .Values.database.waitForConnection.enabled .Values.extraInitContainers }}
       initContainers:
+        {{- if .Values.database.waitForConnection.enabled }}
         - name: wait-for-db
           image: docker.io/library/busybox:1.37
+          {{- with .Values.database.waitForConnection.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - sh
             - -c
@@ -46,6 +52,11 @@ spec:
                 echo "waiting for database..."
                 sleep 2
               done
+        {{- end }}
+        {{- with .Values.extraInitContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: guacamole
           image: {{ include "guacamole.image" . | quote }}

--- a/charts/guacamole/tests/deployment_test.yaml
+++ b/charts/guacamole/tests/deployment_test.yaml
@@ -92,6 +92,53 @@ tests:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-db
 
+  - it: should have custom resources for wait-for-db init container when set
+    set:
+      database.waitForConnection.resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.cpu
+          value: "100m"
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.limits.memory
+          value: "128Mi"
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: "50m"
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.memory
+          value: "64Mi"
+
+  - it: should not have wait-for-db init container when waitForConnection is disabled
+    set:
+      database.waitForConnection.enabled: false
+    template: templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: should also have a custom init container when extraInitContainers is set
+    set:
+      extraInitContainers:
+        - name: custom-init
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - echo "Custom init container"
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[-1].name
+          value: custom-init      
+
   - it: should set OIDC env vars when enabled
     template: templates/deployment.yaml
     set:

--- a/charts/guacamole/values.schema.json
+++ b/charts/guacamole/values.schema.json
@@ -230,6 +230,16 @@
           "description": "Database type: postgresql or mysql.",
           "enum": ["postgresql", "mysql"]
         },
+        "waitForConnection": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          },
+          "resources": {
+            "type": "object",
+            "description": "Resources for the `wait-for-db` init container."
+          }
+        },
         "external": {
           "type": "object",
           "description": "External database configuration (used when neither subchart is enabled).",

--- a/charts/guacamole/values.schema.json
+++ b/charts/guacamole/values.schema.json
@@ -233,11 +233,11 @@
         "waitForConnection": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" }
-          },
-          "resources": {
-            "type": "object",
-            "description": "Resources for the `wait-for-db` init container."
+            "enabled": { "type": "boolean" },
+            "resources": {
+              "type": "object",
+              "description": "Resources for the `wait-for-db` init container."
+            }
           }
         },
         "external": {
@@ -532,6 +532,11 @@
           }
         }
       }
+    },
+    "extraInitContainers": {
+      "type": "array",
+      "description": "Additional init containers for the pod.",
+      "items": { "type": "object" }
     },
     "extraVolumes": {
       "type": "array",

--- a/charts/guacamole/values.yaml
+++ b/charts/guacamole/values.yaml
@@ -131,6 +131,10 @@ totp:
 database:
   # -- Database type: postgresql or mysql
   type: postgresql
+  waitForConnection:
+    # -- Wait for the configured database socket before starting Guacamole.
+    enabled: true
+    resources: {}
   # -- External database configuration (used when neither subchart is enabled)
   external:
     host: ""
@@ -309,6 +313,7 @@ backup:
 # Extra
 # =============================================================================
 
+extraInitContainers: []
 extraVolumes: []
 extraVolumeMounts: []
 


### PR DESCRIPTION
## Summary
- Add `database.waitForConnection.enabled` toggle to conditionally include the wait-for-db init container
- Add `database.waitForConnection.resources` for custom resource limits and requests
- Add `extraInitContainers` for additional user-defined init containers

Resolves #808.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [ ] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [ ] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation

- [ ] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [ ] I validated this change on a local `k3d` cluster when required
- [ ] I validated the default install
- [ ] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

- I also documented the `Extra` section in `values.yaml` besides adding **extraInitContainers** there.

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to enable or disable waiting for database connectivity before startup.
  * Added optional resource settings for the database wait init container.
  * Added support for injecting extra init containers.

* **Bug Fixes**
  * Prevented the database wait init container from being created when database waiting is disabled.

* **Documentation**
  * Updated chart values and database initialization docs with the new wait-for-connection and extra init container options.

* **Tests**
  * Added coverage for conditional init-container rendering, resource propagation, and extra init container injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->