### PR TITLE
chore(cloudflared): bump cloudflared to 2026.7.2

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.11
-appVersion: "2026.7.1"
+appVersion: "2026.7.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2026.7.1 (#756)"
+      description: "update cloudflared to 2026.7.2"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.7.1"
+  tag: "2026.7.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update Cloudflared from `2026.7.1` to `2026.7.2`
- record the upstream release in Artifact Hub annotations
- synchronize the HelmForge site documentation

Closes #789.

Companion site PR: helmforgedev/site#429.

## Upstream verification

- image: `docker.io/cloudflare/cloudflared:2026.7.2`
- platforms: `linux/amd64`, `linux/arm64`
- release: https://github.com/cloudflare/cloudflared/releases/tag/2026.7.2
- Kubernetes impact: no chart contract changes required; the upstream change affects macOS service token-file handling

## Validation

- `make image-verify IMAGE=docker.io/cloudflare/cloudflared:2026.7.2`
- `make deps-check CHART=cloudflared`
- `make validate-chart CHART=cloudflared` (16 layers, including 7 behavioral k3d scenarios)
- `node scripts/charts/template-standards-check.js --chart cloudflared`
- `make standards-check CHART=cloudflared`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=cloudflared`
- `make org-check`
- `make preflight`
