### PR TITLE
chore(drupal): bump drupal to 11.4.4

### DIFF
--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.10
-appVersion: "11.4.1"
+appVersion: "11.4.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 11.4.1 (#757)"
+      description: "bump image to 11.4.4 (#790)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.4.1-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.4.4-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.4.1-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.4.4-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,16 +53,15 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.4.1` is a production-ready patch release that fixes three regressions
-found in 11.4.0. The 11.4 line changes the
-Composer dependency policy for `drupal/core-recommended`: Guzzle, Twig, and
-Symfony polyfills are no longer pinned there, so security and patch updates can
-be applied without waiting for a new Drupal core release.
+Drupal `11.4.4` is a security release that fixes moderately critical
+information-disclosure and cross-site scripting vulnerabilities. Drupal
+recommends updating 11.4.x sites immediately; no unrelated fixes are included
+in this release.
 
 Before upgrading production workloads, test the site in staging with the same
 PHP extensions, Composer dependency set, storage class, and database mode used
-in production. Review Drupal's 11.4.1 known issues, especially the documented
-search-module update path, before running database updates.
+in production. Review the Drupal 11.4.4 release notes and security advisories
+before running database updates.
 
 ## Production Example
 
@@ -150,7 +149,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.4.1-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.4.4-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.4.1-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.4-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.4.1-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.4-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.4.1-php8.5-apache-bookworm"
+  tag: "11.4.4-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update Drupal from `11.4.1` to `11.4.4`
- document the upstream security fixes
- update deployment tests and the HelmForge site documentation

Closes #790.

Companion site PR: helmforgedev/site#430.

## Upstream verification

- image: `docker.io/library/drupal:11.4.4-php8.5-apache-bookworm`
- platforms: `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/386`, `linux/ppc64le`, `linux/s390x`
- release: https://www.drupal.org/project/drupal/releases/11.4.4
- security impact: fixes moderately critical information-disclosure and cross-site scripting vulnerabilities
- Kubernetes impact: no chart contract changes required

## Validation

- `make image-verify IMAGE=docker.io/library/drupal:11.4.4-php8.5-apache-bookworm`
- `make deps-check CHART=drupal`
- `make validate-chart CHART=drupal` (17 layers, including 8 behavioral k3d scenarios)
- `node scripts/charts/template-standards-check.js --chart drupal`
- `make standards-check CHART=drupal`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=drupal`
- `make org-check`
- `make preflight`
