### PR TITLE
chore(generic): bump nginx to 1.31.3

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,14 +7,14 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 version: 3.1.2
-appVersion: "1.31.2"
+appVersion: "1.31.3"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#667)"
+    - kind: changed
+      description: "bump default nginx image to 1.31.3 (#791)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -3,6 +3,10 @@
 A single chart that handles **Deployments**, **StatefulSets**, **DaemonSets**, **Jobs**, and **CronJobs** with a unified values
 interface. Designed for teams that deploy many services and want one chart to rule them all.
 
+The default `nginx:1.31.3` image includes upstream fixes for CVE-2026-42533,
+CVE-2026-60005, and CVE-2026-56434. Existing Generic chart configuration
+remains compatible with this image update.
+
 ## Install
 
 ### HTTPS repository
@@ -366,7 +370,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Image** | | |
 | `global.imageRegistry` | Optional registry prefix for unqualified repositories | `""` |
 | `image.repository` | Container image repository | `docker.io/library/nginx` |
-| `image.tag` | Image tag | `1.27.5` |
+| `image.tag` | Image tag | `1.31.3` |
 | `image.digest` | Image digest, takes precedence over tag | `""` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Registry pull secrets | `[]` |

--- a/charts/generic/ci/deployment-values.yaml
+++ b/charts/generic/ci/deployment-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.2"
+  tag: "1.31.3"
   pullPolicy: IfNotPresent
 
 containers:

--- a/charts/generic/ci/multi-container-values.yaml
+++ b/charts/generic/ci/multi-container-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.2"
+  tag: "1.31.3"
 
 containers:
   - name: api

--- a/charts/generic/ci/platform-values.yaml
+++ b/charts/generic/ci/platform-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.2"
+  tag: "1.31.3"
   pullPolicy: IfNotPresent
 
 containers:

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -15,4 +15,4 @@ tests:
           of: DaemonSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/nginx:1.31.2
+          value: docker.io/library/nginx:1.31.3

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -56,7 +56,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/nginx:1.31.2"
+          value: "docker.io/library/nginx:1.31.3"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -88,7 +88,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/nginx:1.31.2"
+          value: "registry.example.com/nginx:1.31.3"
 
   - it: should apply global registry to namespaced unqualified repositories
     set:
@@ -97,7 +97,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/team/app:1.31.2"
+          value: "registry.example.com/team/app:1.31.3"
 
   - it: should not apply global registry to fully qualified repositories
     set:
@@ -106,7 +106,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/team/app:1.31.2"
+          value: "ghcr.io/team/app:1.31.3"
 
   - it: should allow per-container image digest override
     set:

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -81,7 +81,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "1.31.2"
+          "default": "1.31.3"
         },
         "digest": {
           "type": "string",

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -52,7 +52,7 @@ global:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.2"
+  tag: "1.31.3"
   digest: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the Generic chart default nginx image from `1.31.2` to `1.31.3`
- synchronize schema defaults, CI scenarios, unit tests, and documentation
- document the upstream security fixes included in the release

Closes #791.

Companion site PR: helmforgedev/site#431.

## Upstream verification

- image: `docker.io/library/nginx:1.31.3`
- platforms: `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/386`, `linux/ppc64le`, `linux/riscv64`, `linux/s390x`
- release: https://nginx.org/2026.html
- security impact: fixes CVE-2026-42533, CVE-2026-60005, and CVE-2026-56434
- Kubernetes impact: no chart contract changes required

## Validation

- `make image-verify IMAGE=docker.io/library/nginx:1.31.3`
- `make deps-check CHART=generic`
- `make validate-chart CHART=generic` (18 layers, including 9 behavioral k3d scenarios)
- `node scripts/charts/template-standards-check.js --chart generic`
- `make standards-check CHART=generic`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=generic`
- `make org-check`
- `make preflight`
