### PR TITLE
chore(ghost): bump ghost to 6.53.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.19
-appVersion: "6.52.1"
+appVersion: "6.53.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 6.52.1 (#758)"
+      description: "bump image to 6.53.0 (#792)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -65,7 +65,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.52.1` | Ghost image tag |
+| `image.tag` | `6.53.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -77,11 +77,12 @@ database:
 
 ## Upgrade Notes
 
-Ghost `6.52.1` is the current upstream patch release and fixes link selection
-in the automations email editor. Review the upstream Ghost release notes before
-upgrading production sites, take a content and database backup, and verify
-themes, custom integrations, newsletter flows, comments, and member signup
-paths in staging before reusing existing PVCs.
+Ghost `6.53.0` adds adapter boot-time validation and strengthens protection
+against spam member signups. It also improves author selection and analytics
+performance and fixes expired-session and editor-state issues. Review the
+upstream Ghost release notes before upgrading production sites, take a content
+and database backup, and verify themes, custom integrations, newsletter flows,
+comments, and member signup paths in staging before reusing existing PVCs.
 
 ## S3 Backup
 

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.52.1"
+          value: "docker.io/library/ghost:6.53.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.52.1"
+                                                                    "default":  "6.53.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.52.1"
+  tag: "6.53.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update Ghost from `6.52.1` to `6.53.0`
- synchronize schema defaults, unit tests, and documentation
- document adapter validation, spam protection, performance improvements, and fixes

Closes #792.

Companion site PR: helmforgedev/site#432.

## Upstream verification

- image: `docker.io/library/ghost:6.53.0`
- platforms: `linux/amd64`, `linux/arm`, `linux/arm64`
- release: https://github.com/TryGhost/Ghost/releases/tag/v6.53.0
- Kubernetes impact: no chart contract changes required

## Validation

- `make image-verify IMAGE=docker.io/library/ghost:6.53.0`
- `make deps-check CHART=ghost`
- `make validate-chart CHART=ghost` (16 layers, including 7 behavioral k3d scenarios)
- `node scripts/charts/template-standards-check.js --chart ghost`
- `make standards-check CHART=ghost`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=ghost`
- `make org-check`
- `make preflight`
