### PR TITLE
chore(gitea): bump gitea to 1.27.0

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -4,7 +4,7 @@ name: gitea
 description: Gitea self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.14
-appVersion: "1.26.4"
+appVersion: "1.27.0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh chart subchart dependencies (#587)"
+      description: "bump Gitea rootless image to 1.27.0 (#793)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/gitea/DESIGN.md
+++ b/charts/gitea/DESIGN.md
@@ -9,7 +9,7 @@ ClusterIP HTTP and SSH services, and restricted-compatible pod defaults.
 
 ## Goals
 
-- Run the official `docker.io/gitea/gitea:1.26.4-rootless` image without Bitnami
+- Run the official `docker.io/gitea/gitea:1.27.0-rootless` image without Bitnami
   or third-party runtime substitutions.
 - Keep the default install zero-config through SQLite while making PostgreSQL,
   MySQL, and external database modes explicit.

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -4,8 +4,8 @@
 
 Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
 
-- **Current application version** `1.26.4`
-- **Default image** `docker.io/gitea/gitea:1.26.4-rootless`
+- **Current application version** `1.27.0`
+- **Default image** `docker.io/gitea/gitea:1.27.0-rootless`
 - **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
 - **Rootless storage** PVC paths are prepared for UID/GID 1000 by a small initContainer
 
@@ -137,7 +137,7 @@ gitea:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `gitea/gitea` | Container image repository |
-| `image.tag` | `"1.26.4-rootless"` | Image tag |
+| `image.tag` | `"1.27.0-rootless"` | Image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
 | `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
@@ -191,8 +191,12 @@ Only one database source can be active. The chart fails with a clear error if mu
 
 ## Upgrade Notes
 
-This update moves the default rootless image from `1.26.2-rootless` to `1.26.4-rootless`. Review upstream
-Gitea release notes before upgrading production instances, especially for repository, SSH, and database migration behavior.
+This update moves the default rootless image to `1.27.0-rootless`. Gitea 1.27
+changes reusable Actions workflow behavior and
+enforces per-request Content Security Policy nonces for inline scripts. Review
+custom workflows, templates, themes, and embeds before upgrading. Back up the
+database and repositories first; Gitea runs required database migrations during
+the first startup.
 
 ## SSH Access
 

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -6,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.26.4-rootless"
+  tag: "1.27.0-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- update Gitea from `1.26.4-rootless` to `1.27.0-rootless`
- document the breaking Actions and Content Security Policy changes
- synchronize chart design and site documentation

Closes #793.

Companion site PR: helmforgedev/site#433.

## Upstream verification

- image: `docker.io/gitea/gitea:1.27.0-rootless`
- platforms: `linux/amd64`, `linux/arm64`, `linux/riscv64`
- release: https://github.com/go-gitea/gitea/releases/tag/v1.27.0
- Kubernetes impact: existing chart values remain valid; operators must review reusable workflows, inline-script customizations, and first-start database migrations

## Validation

- `make image-verify IMAGE=docker.io/gitea/gitea:1.27.0-rootless`
- `make deps-check CHART=gitea`
- `make validate-chart CHART=gitea` (17 layers, including 8 behavioral k3d scenarios)
- `make standards-check CHART=gitea`
- `make md-lint REPO=charts`
- `make site-sync-check CHART=gitea`
- `make org-check`
- `make preflight`
