### PR TITLE
chore(homarr): bump homarr to 1.71.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.22
-appVersion: "1.70.0"
+appVersion: "1.71.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 1.70.0 (#760)"
+      description: "bump image to 1.71.0 (#794)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.70.0`.
+Current application version: `v1.71.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.70.0"` | Homarr image tag |
+| `image.tag` | `"v1.71.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,9 +265,9 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.69.2` to `v1.70.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.70.0` adds integrations and fixes widget secrets, forms, query caching, and layout stacking so the AppShell header renders above indicator
-dots. No breaking changes were identified in the upstream release metadata.
+This update moves the default image from `v1.70.0` to `v1.71.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.71.0` restores database migration journal entries, improves integrations and widgets, and fixes
+container image builds. No breaking changes were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.70.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.71.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.70.0"
+  tag: "v1.71.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- bump the official Homarr image from `v1.70.0` to `v1.71.0`
- update chart metadata, defaults, pinned-image tests, and upgrade documentation
- document the upstream database migration, integration, widget, and container-build fixes

## Upstream evidence

- Image: `ghcr.io/homarr-labs/homarr:v1.71.0`
- Platforms verified: `linux/amd64`, `linux/arm64`
- Release notes: https://github.com/homarr-labs/homarr/releases/tag/v1.71.0
- Stable release: not a draft or prerelease
- No breaking changes identified in the upstream release metadata

## Validation

- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.71.0`
- `make deps-check CHART=homarr`
- `make validate-chart CHART=homarr` — passed all 19 layers, including 10 behavioral k3d scenarios
- `make standards-check CHART=homarr`
- `node scripts/charts/template-standards-check.js --chart homarr`
- `make preflight`

All k3d workloads became ready with healthy service endpoints, no restarts or crash terminations, no fatal log patterns, and no critical events.

Site PR: helmforgedev/site#434

Closes #794
