### PR TITLE
chore(hoppscotch): bump hoppscotch to 2026.6.1

### DIFF
--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
 version: 1.1.7
-appVersion: "2026.6.0"
+appVersion: "2026.6.1"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -30,7 +30,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump hoppscotch to 2026.6.0 (#714)"
+      description: "bump hoppscotch to 2026.6.1 (#795)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -77,7 +77,7 @@ backend process inside the AIO image.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.6.0` |
+| `image.tag` | Hoppscotch image tag | `2026.6.1` |
 | `namespaceOverride` | Namespace for chart-managed resources. Use with an external database; bundled PostgreSQL remains in the Helm release namespace. | `""` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
@@ -105,10 +105,10 @@ backend process inside the AIO image.
 
 ## Upgrade Notes
 
-Hoppscotch `2026.6.0` adds OAuth2 `id_token` support, fixes mock server URL handling for subpath deployments, adds Thai
-language support, improves self-hosted admin validation messages, and includes backend ownership, SMTP URL validation, and
-dependency security hardening. The upstream release notes mention a rollback for Hoppscotch Cloud only; self-hosted
-deployments are not affected. Back up the PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
+Hoppscotch `2026.6.1` fixes Desktop App authentication with self-hosted instances, supports arbitrary non-root container
+UIDs, captures response cookies for Agent-routed requests, and reduces JSON renderer overhead. This release is specifically
+published for self-hosted deployments. Back up the PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before
+upgrading.
 The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
 user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs
 a pre-upgrade hook to apply `pg_trgm` to existing bundled PostgreSQL PVCs before

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/hoppscotch/hoppscotch:2026.6.0
+          value: docker.io/hoppscotch/hoppscotch:2026.6.1
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -53,7 +53,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: docker.io/hoppscotch/hoppscotch:2026.6.0
+          value: docker.io/hoppscotch/hoppscotch:2026.6.1
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
@@ -87,7 +87,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: docker.io/hoppscotch/hoppscotch:2026.6.0
+          value: docker.io/hoppscotch/hoppscotch:2026.6.1
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].command[0]

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.6.0"
+  tag: "2026.6.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Hoppscotch image from `2026.6.0` to `2026.6.1`
- update chart metadata, defaults, pinned-image tests, and upgrade guidance
- document the self-hosted authentication, arbitrary non-root UID, Agent cookie, and JSON renderer fixes

## Upstream evidence

- Image: `docker.io/hoppscotch/hoppscotch:2026.6.1`
- Platforms verified: `linux/amd64`, `linux/arm64`
- Release notes: https://github.com/hoppscotch/hoppscotch/releases/tag/2026.6.1
- Stable self-hosted release: not a draft or prerelease

## Validation

- `make image-verify IMAGE=hoppscotch/hoppscotch:2026.6.1`
- `make deps-check CHART=hoppscotch`
- `make validate-chart CHART=hoppscotch` — passed all 18 layers, including 9 behavioral k3d scenarios
- `make standards-check CHART=hoppscotch`
- `node scripts/charts/template-standards-check.js --chart hoppscotch`

All k3d workloads became ready with healthy endpoints, no restarts or crash terminations, no fatal log patterns, and no critical events.

Site PR: helmforgedev/site#435

Closes #795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Helm chart to deploy Hoppscotch version 2026.6.1 by default.

* **Documentation**
  * Updated chart configuration and upgrade guidance for version 2026.6.1.

* **Tests**
  * Updated deployment checks to validate the 2026.6.1 container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->