### PR TITLE
chore(kubernetes-mcp-server): bump image to 0.0.65

### DIFF
--- a/charts/kubernetes-mcp-server/Chart.yaml
+++ b/charts/kubernetes-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ name: kubernetes-mcp-server
 description: Kubernetes and OpenShift MCP server in HTTP mode
 type: application
 version: 1.0.4
-appVersion: "0.0.64"
+appVersion: "0.0.65"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/kubernetes-mcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.0.64 (#763)"
+      description: "bump image to 0.0.65 (#796)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -1,7 +1,7 @@
 # Kubernetes MCP Server Helm Chart
 
 Kubernetes MCP Server exposes Kubernetes cluster inspection and automation through the Model Context Protocol.
-This chart deploys the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.64` image in HTTP mode with in-cluster authentication,
+This chart deploys the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.65` image in HTTP mode with in-cluster authentication,
 read-only safety flags, and least-privilege RBAC by default.
 
 ## Install

--- a/charts/kubernetes-mcp-server/tests/templates_test.yaml
+++ b/charts/kubernetes-mcp-server/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.64
+          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.65
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: kubernetes-mcp-server

--- a/charts/kubernetes-mcp-server/values.schema.json
+++ b/charts/kubernetes-mcp-server/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/containers/kubernetes-mcp-server" },
-        "tag": { "type": "string", "default": "v0.0.64" },
+        "tag": { "type": "string", "default": "v0.0.65" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 commonLabels: {}
 image:
   repository: ghcr.io/containers/kubernetes-mcp-server
-  tag: "v0.0.64"
+  tag: "v0.0.65"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 replicaCount: 1


### PR DESCRIPTION
## Summary

- bump Kubernetes MCP Server from `v0.0.64` to `v0.0.65`
- update metadata, defaults, schema, documentation, and pinned-image tests

## Upstream evidence

- Image: `ghcr.io/containers/kubernetes-mcp-server:v0.0.65`
- Platforms: `linux/amd64`, `linux/arm64`, `linux/s390x`, `linux/ppc64le`
- Release: https://github.com/containers/kubernetes-mcp-server/releases/tag/v0.0.65
- Stable release; no breaking changes identified

## Validation

- image manifest and dependencies verified
- `make validate-chart CHART=kubernetes-mcp-server` passed all 16 layers, including 7 k3d scenarios
- chart and template standards passed

Site PR: helmforgedev/site#436

Closes #796
