### PR TITLE
chore(matomo): bump matomo to 5.12.0

### DIFF
--- a/charts/matomo/Chart.yaml
+++ b/charts/matomo/Chart.yaml
@@ -4,7 +4,7 @@ name: matomo
 description: Privacy-focused web analytics platform with MySQL and production archiving support
 type: application
 version: 1.0.0
-appVersion: "5.11.2"
+appVersion: "5.12.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/matomo.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: add matomo and clickhouse (#706)"
+      description: "bump Matomo to 5.12.0 (#797)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/matomo/README.md
+++ b/charts/matomo/README.md
@@ -16,7 +16,7 @@ helm install matomo oci://ghcr.io/helmforgedev/helm/matomo
 
 ## Features
 
-- Official Matomo Apache image pinned to `5.11.2-apache`.
+- Official Matomo Apache image pinned to `5.12.0-apache`.
 - Bundled HelmForge MySQL subchart for simple deployments.
 - External MySQL/MariaDB mode for production.
 - CronJob-based `core:archive` execution.
@@ -64,7 +64,7 @@ ingress:
 | --- | --- | --- |
 | `replicaCount` | Matomo web replicas | `1` |
 | `image.repository` | Official Matomo image repository | `docker.io/library/matomo` |
-| `image.tag` | Official Matomo image tag | `5.11.2-apache` |
+| `image.tag` | Official Matomo image tag | `5.12.0-apache` |
 | `database.mode` | `auto`, `external`, or `mysql` | `auto` |
 | `mysql.enabled` | Deploy HelmForge MySQL subchart | `true` |
 | `persistence.enabled` | Persist `/var/www/html` | `true` |

--- a/charts/matomo/tests/deployment_test.yaml
+++ b/charts/matomo/tests/deployment_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/matomo:5.11.2-apache
+          value: docker.io/library/matomo:5.12.0-apache
   - it: wires Matomo database environment variables
     template: deployment.yaml
     asserts:

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official Matomo image repository
   repository: docker.io/library/matomo
   # -- Official Matomo image tag. The apache variant includes the web server.
-  tag: "5.11.2-apache"
+  tag: "5.12.0-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Matomo Apache image from `5.11.2-apache` to `5.12.0-apache`
- update chart metadata, defaults, tests, and documentation

## Upstream evidence

- Image: `docker.io/library/matomo:5.12.0-apache`
- Seven Linux architectures verified
- Release: https://github.com/matomo-org/matomo/releases/tag/5.12.0
- Stable release; no breaking changes identified

## Validation

- manifest and dependencies verified
- `make validate-chart CHART=matomo` passed all 18 layers, including 9 k3d scenarios
- chart and template standards passed

Site PR: helmforgedev/site#437

Closes #797
