### PR TITLE
chore(metabase): update image to v0.63.1

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.20
-appVersion: "v0.62.4"
+appVersion: "v0.63.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.62.4 (#767)"
+      description: "bump image to 0.63.1 (#798)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.62.4
+  tag: v0.63.1
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.62.4` | Metabase container image tag |
+| `image.tag` | `v0.63.1` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,7 +184,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.62.4` updates the application to the latest upstream release and
+Metabase `v0.63.1` updates the application to the latest upstream release and
 repairs the chart's validation scenarios for single-stack clusters, external
 database fixtures, and External Secrets. Back up the Metabase application
 database before upgrading, keep the encryption key stable, and validate the

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -206,9 +206,6 @@ true
 {{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
 {{- end -}}
-{{- if and .Values.gatewayAPI .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.httpRoutes) -}}
-{{- fail "gatewayAPI.httpRoutes must contain at least one route when gatewayAPI.enabled=true" -}}
-{{- end -}}
 {{- if .Values.podLabels -}}
 {{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}{{- fail "podLabels must not override app.kubernetes.io/name" -}}{{- end -}}
 {{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}{{- fail "podLabels must not override app.kubernetes.io/instance" -}}{{- end -}}

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -200,3 +200,17 @@ true
 {{- "encryption-secret-key" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Validate cross-field configuration contracts. */}}
+{{- define "metabase.validate" -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.gatewayAPI .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.httpRoutes) -}}
+{{- fail "gatewayAPI.httpRoutes must contain at least one route when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- if .Values.podLabels -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}{{- fail "podLabels must not override app.kubernetes.io/name" -}}{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}{{- fail "podLabels must not override app.kubernetes.io/instance" -}}{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/metabase/templates/validate.yaml
+++ b/charts/metabase/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "metabase.validate" . -}}

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.62.4"
+          value: "docker.io/metabase/metabase:v0.63.1"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.62.4"
+  tag: "v0.63.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update the Metabase image from `v0.63.0` to `v0.63.1`
- synchronize chart defaults, tests, and documentation
- add template-time validation for ingress, Gateway API, and protected pod labels

## Validation

- `make image-verify IMAGE=docker.io/metabase/metabase:v0.63.1`
- `make deps-check CHART=metabase`
- `make validate-chart CHART=metabase` (17 layers, including 8 k3d scenarios)
- `make standards-check CHART=metabase`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Closes #798

Site synchronization: helmforgedev/site#438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added render-time validation to require ingress hosts when ingress is enabled.
  * Added safeguards to prevent overriding standard Kubernetes label keys.

* **Updates**
  * Updated the Metabase container image to **v0.63.1** (including chart version metadata and default values).

* **Documentation**
  * Refreshed README configuration examples and upgrade notes to reference **v0.63.1**.

* **Tests**
  * Updated deployment test expectations to verify **v0.63.1** image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->