### PR TITLE
chore(n8n): update image to 2.31.4

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.8
-appVersion: "2.30.4"
+appVersion: "2.31.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2.30.4 (#768)"
+      description: "bump image to 2.31.4 (#799)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.30.4` | n8n container image tag |
+| `image.tag` | `2.31.4` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,7 +186,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.30.4` is the upstream stable release used by the chart defaults. Review
+n8n `2.31.4` is the upstream stable release used by the chart defaults. Review
 the upstream release notes before upgrading, back up the database, and keep the
 encryption key stable before upgrading live deployments. This chart keeps the
 hardened non-root container defaults with resource requests and limits. Queue

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.30.4"
+          value: "docker.io/n8nio/n8n:2.31.4"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.30.4"
+          value: "docker.io/n8nio/runners:2.31.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.30.4"
+          value: "docker.io/n8nio/runners:2.31.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.30.4"
+          "default": "2.31.4"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.30.4"
+  tag: "2.31.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the n8n and task runner images from `2.30.4` to `2.31.4`
- synchronize chart defaults, schema, tests, and documentation
- retain the existing SQLite, PostgreSQL, MySQL, Redis queue, and runner contracts

## Validation

- verified both images for linux/amd64 and linux/arm64
- `make deps-check CHART=n8n`
- `make validate-chart CHART=n8n` (20 layers, including 11 k3d scenarios)
- `make standards-check CHART=n8n`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Closes #799

Site synchronization: helmforgedev/site#439
