### PR TITLE
chore(netbird): update image to 0.74.7

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -4,7 +4,7 @@ name: netbird
 description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
 type: application
 version: 1.0.0
-appVersion: "0.74.4"
+appVersion: "0.74.7"
 home: https://helmforge.dev/docs/charts/netbird
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/netbird
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: add PostgreSQL production store"
+      description: "bump image to 0.74.7 (#800)"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -4,7 +4,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 
 This chart packages the current upstream combined architecture:
 
-- `netbirdio/netbird-server:0.74.4` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/netbird-server:0.74.7` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.3` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
@@ -85,7 +85,7 @@ Use `externalSecrets.items[]` to synchronize sensitive values such as `config.ya
 Local security scan:
 
 ```text
-Image: netbirdio/netbird-server:0.74.4
+Image: netbirdio/netbird-server:0.74.7
 Image: netbirdio/dashboard:v2.90.3
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 86.86869 compliance score

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/netbird-server:0.74.4
+          value: netbirdio/netbird-server:0.74.7
         template: templates/deployment.yaml
         documentIndex: 0
   - it: renders the official pinned dashboard image

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -14,7 +14,7 @@ server:
     # -- Official NetBird server container image repository.
     repository: netbirdio/netbird-server
     # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
-    tag: "0.74.4"
+    tag: "0.74.7"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of NetBird server pods. Keep 1 with the default sqlite store.


### PR DESCRIPTION
## Summary

- update the NetBird server image from `0.74.4` to `0.74.7`
- synchronize chart defaults, tests, and documentation

## Validation

- verified the image for linux/amd64, linux/arm64, and linux/arm
- `make deps-check CHART=netbird`
- `make validate-chart CHART=netbird` (18 layers, including 9 k3d scenarios)
- `make standards-check CHART=netbird`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Closes #800

Site synchronization: helmforgedev/site#440
