### PR TITLE
chore(notediscovery): update image to 0.28.3

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.0.4
-appVersion: "0.28.2"
+appVersion: "0.28.3"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.28.2 (#769)"
+      description: "bump image to 0.28.3 (#801)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.28.2` image.
+official `ghcr.io/gamosoft/notediscovery:0.28.3` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.2` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.3` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -149,8 +149,8 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.28.2` fixes rendering of nested code blocks inside GFM and
-GLFM alerts. The chart continues to render `storage.notes_dir` from
+NoteDiscovery `0.28.3` adds pane visibility shortcuts and custom image sizes.
+The chart continues to render `storage.notes_dir` from
 `persistence.mountPath`; keep that path stable across upgrades and back up the
 PVC before upgrading production vaults.
 

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.28.2
+          value: ghcr.io/gamosoft/notediscovery:0.28.3
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.28.2", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.28.3", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.28.2"
+  tag: "0.28.3"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the NoteDiscovery image from `0.28.2` to `0.28.3`
- synchronize chart defaults, schema, tests, design notes, and upgrade guidance

## Validation

- verified the image for linux/amd64 and linux/arm64
- `make deps-check CHART=notediscovery`
- `make validate-chart CHART=notediscovery` (19 layers, including 10 k3d scenarios)
- `make standards-check CHART=notediscovery`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Closes #801

Site synchronization: helmforgedev/site#441
