### PR TITLE
chore(olivetin): update to 3000.17.2

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.15
-appVersion: "3000.17.0"
+appVersion: "3000.17.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 3000.17.0 (#771)"
+      description: "bump image to 3000.17.2 (#802)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -58,7 +58,7 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.resources` | requests/limits set | Resource guardrails for the config bootstrap init container |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.17.0` | OliveTin image tag |
+| `image.tag` | `3000.17.2` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
 | `olivetin.port` | `1337` | Application port |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |
@@ -103,7 +103,7 @@ See the [OliveTin documentation](https://docs.olivetin.app) for all available op
 
 ## Upgrade Notes
 
-OliveTin `3000.17.0` adds checklist and entity UI support and includes security
+OliveTin `3000.17.2` fixes dashboard ACLs and includes security
 hardening for shell execution, argument types, log access control, and OAuth2
 state growth. Upstream reports no upgrade warnings or breaking changes; keep
 the chart-managed config and persistent data paths unchanged when rolling

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.17.0"
+          value: "docker.io/jamesread/olivetin:3000.17.2"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.17.0" },
+        "tag": { "type": "string", "default": "3000.17.2" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.17.0"
+  tag: "3000.17.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update OliveTin from `3000.17.0` to `3000.17.2`
- refresh all pinned image references and chart documentation
- document the upstream dashboard ACL correction included in this release

## Validation

- upstream image manifest verified for `linux/amd64` and `linux/arm64`
- dependency policy check passed
- `make validate-chart CHART=olivetin` passed all 15 layers
- 6 behavioral k3d scenarios passed
- standards, release, and attribution checks passed

Site documentation sync: helmforgedev/site#442

Closes #802
