### PR TITLE
chore(poznote): update to 6.35.0

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.0.3
-appVersion: "6.33.0"
+appVersion: "6.35.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 6.33.0 (#773)"
+      description: "bump image to 6.35.0 (#803)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,10 +14,10 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.33.0
+ghcr.io/timothepoznanski/poznote:6.35.0
 ```
 
-The tag maps to the upstream `6.33.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.35.0` release and publishes Linux `amd64` and `arm64` manifests.
 
 ## Database
 

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.33.0` |
+| `image.tag` | Image tag | `6.35.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -140,7 +140,7 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.33.0` adds the graph view and improves dashboard and mobile
+Poznote `6.35.0` adds the optional AI assistant and improves the mobile
 navigation. No Kubernetes-facing configuration changes are required by this
 chart, but back up the `data` PVC
 before upgrading because it stores the SQLite database, notes, attachments, and

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.33.0"
+          value: "ghcr.io/timothepoznanski/poznote:6.35.0"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.33.0"
+  tag: "6.35.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update Poznote to upstream version `6.35.0`
- refresh every pinned image reference and the chart documentation
- document the optional AI assistant and mobile-related upstream changes

## Validation

- upstream image manifest verified for `linux/amd64` and `linux/arm64`
- dependency policy check passed
- `make validate-chart CHART=poznote` passed all 16 layers
- 7 behavioral k3d scenarios passed
- standards, release, and attribution checks passed

Site documentation sync: helmforgedev/site#443

Closes #803
