### PR TITLE
chore(qdrant): update to 1.18.3

### DIFF
--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -4,7 +4,7 @@ name: qdrant
 description: Qdrant vector database
 type: application
 version: 1.0.2
-appVersion: "1.18.2"
+appVersion: "1.18.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/qdrant.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#673)"
+    - kind: changed
+      description: "bump image to v1.18.3 (#804)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/qdrant/README.md
+++ b/charts/qdrant/README.md
@@ -2,7 +2,7 @@
 
 Qdrant is a vector database and similarity search engine for embeddings, payload filters, semantic search, retrieval-augmented generation,
 recommendation, and matching workloads.
-This HelmForge chart deploys the official `docker.io/qdrant/qdrant:v1.18.2` image with persistent storage, HTTP and gRPC services,
+This HelmForge chart deploys the official `docker.io/qdrant/qdrant:v1.18.3` image with persistent storage, HTTP and gRPC services,
 optional API key authentication, snapshot storage, Prometheus scraping, and guarded distributed-mode settings.
 
 ## Install

--- a/charts/qdrant/tests/templates_test.yaml
+++ b/charts/qdrant/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/qdrant/qdrant:v1.18.2
+          value: docker.io/qdrant/qdrant:v1.18.3
   - it: renders service
     template: templates/service.yaml
     asserts:

--- a/charts/qdrant/values.schema.json
+++ b/charts/qdrant/values.schema.json
@@ -13,7 +13,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/qdrant/qdrant" },
-        "tag": { "type": "string", "default": "v1.18.2" },
+        "tag": { "type": "string", "default": "v1.18.3" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official Qdrant image repository.
   repository: docker.io/qdrant/qdrant
   # -- Official Qdrant image tag. Do not use a floating tag.
-  tag: "v1.18.2"
+  tag: "v1.18.3"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update Qdrant to upstream version `1.18.3`
- refresh every pinned image reference and chart documentation
- document the upstream shard-key and resharding fixes

## Validation

- upstream image manifest verified for `linux/amd64` and `linux/arm64`
- dependency policy check passed
- `make validate-chart CHART=qdrant` passed all 18 layers
- 9 behavioral k3d scenarios passed, including the three-node cluster
- standards, release, and attribution checks passed

Site documentation sync: helmforgedev/site#444

Closes #804


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Qdrant deployment image to version **v1.18.3**.
  * Updated chart metadata, default configuration, and deployment documentation to reflect the new version.

* **Tests**
  * Updated deployment validation to expect Qdrant image version **v1.18.3**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->