### PR TITLE
chore(strapi): update to 5.50.2

### DIFF
--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -4,7 +4,7 @@ name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
 version: 2.3.9
-appVersion: "5.50.0"
+appVersion: "5.50.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 5.50.0 (#774)"
+      description: "bump image to 5.50.2 (#805)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strapi/README.md
+++ b/charts/strapi/README.md
@@ -18,9 +18,9 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 
 ## HelmForge Base Image
 
-This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.50.0`) which provides:
+This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.50.2`) which provides:
 
-- **Strapi 5.50.0** with all official plugins pre-installed
+- **Strapi 5.50.2** with all official plugins pre-installed
 - **Multi-database support** — SQLite, PostgreSQL, MySQL ready to use
 - **Health check endpoint** — HTTP health checks on `/_health` for proper Kubernetes integration
 - **Security hardened** — Non-root user (UID 1000), minimal attack surface
@@ -107,7 +107,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `helmforge/strapi-base` | Container image for the Strapi project |
-| `image.tag` | `5.50.0` | HelmForge Strapi base image version |
+| `image.tag` | `5.50.2` | HelmForge Strapi base image version |
 | `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
 | `strapi.port` | `1337` | Container port |
 | `strapi.telemetryDisabled` | `true` | Disable telemetry |
@@ -141,17 +141,16 @@ database:
 
 ## Notes
 
-- The default image is `helmforge/strapi-base:5.50.0`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
+- The default image is `helmforge/strapi-base:5.50.2`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
 - SQLite is supported for simple deployments, but server-based databases are recommended for production workloads.
 - Horizontal scaling is intentionally out of scope for this v1 chart because default local uploads persistence is single-writer oriented.
 - For ingress, set `ingress.ingressClassName` to the class used in your cluster, such as `traefik`, `nginx`, or another supported controller.
 
 ## Upgrade Notes
 
-Strapi `5.50.0` adds active device session management, secure scaffold defaults,
-EU SendGrid region support, and AWS credential provider functions. It also
-defaults legacy JWT verification to HS256 and includes admin, relation, upload,
-and dynamic-zone fixes. Back up the database and uploads PVC before
+Strapi `5.50.2` adds configurable admin auth cookie names and Korean
+translations, fixes admin, content, database, and upload behavior, and updates
+the WebSocket dependency for CVE-2026-48779. Back up the database and uploads PVC before
 upgrading production workloads.
 
 ## More Information

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:5.50.0"
+          value: "docker.io/helmforge/strapi-base:5.50.2"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -26,7 +26,7 @@ replicaCount: 1
 # Image
 # =============================================================================
 # HelmForge provides a production-ready Strapi base image (helmforge/strapi-base)
-# that includes Strapi 5.50.0 with all official plugins, multi-database support,
+# that includes Strapi 5.50.2 with all official plugins, multi-database support,
 # security hardening, and health check endpoints. This image is multi-arch
 # (amd64/arm64), regularly updated, and optimized for Kubernetes deployments.
 #
@@ -38,7 +38,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "5.50.0"
+  tag: "5.50.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the HelmForge Strapi base image to upstream version `5.50.2`
- refresh every pinned image reference and chart documentation
- document the configurable admin authentication cookie, Korean localization, upstream fixes, and WebSocket dependency security update

## Validation

- `docker.io/helmforge/strapi-base:5.50.2` manifest verified for `linux/amd64` and `linux/arm64`
- official Strapi `v5.50.2` release verified
- dependency policy check passed
- `make validate-chart CHART=strapi` passed all 18 layers
- 9 behavioral k3d scenarios passed, including bundled and external PostgreSQL
- standards, release, and attribution checks passed

Site documentation sync: helmforgedev/site#445

Closes #805
