### PR TITLE
chore(strava-statistics): update to 5.0.0

### DIFF
--- a/charts/strava-statistics/Chart.yaml
+++ b/charts/strava-statistics/Chart.yaml
@@ -4,7 +4,7 @@ name: strava-statistics
 description: Statistics for Strava self-hosted fitness dashboard with SQLite and Strava OAuth
 type: application
 version: 1.1.15
-appVersion: "4.8.8"
+appVersion: "5.0.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to v4.8.8 (#550)"
+      description: "bump image to v5.0.0 (#806)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strava-statistics/README.md
+++ b/charts/strava-statistics/README.md
@@ -105,7 +105,7 @@ gatewayAPI:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.tag` | `v4.8.8` | Statistics for Strava image tag |
+| `image.tag` | `v5.0.0` | Dreeve image tag |
 | `strava.port` | `8080` | Application port |
 | `strava.clientId` | `""` | Strava OAuth Client ID |
 | `strava.clientSecret` | `""` | Strava OAuth Client Secret |
@@ -126,7 +126,12 @@ gatewayAPI:
 
 ## Upgrade Notes
 
-Statistics for Strava `v4.8.8` moves database migrations into the container
+Statistics for Strava was renamed to Dreeve in `v5.0.0`. This major release
+adds local activity uploads and an admin panel, and migrates YAML settings into
+the database. Back up both `storage/database` and the `config` directory, then
+follow the [upstream v4 migration guide](https://docs.dreeve.app/#/getting-started/migrating-from-v4).
+The chart continues to prepare the storage layout introduced in v4.8.8 and
+moves database migrations into the container
 entrypoint and refreshes the onboarding flow. Upstream now reads SQLite data
 from `/var/www/storage/database`, so this chart mounts the PVC on the upstream
 path and bootstraps compatibility symlinks for legacy root-level `strava.db`
@@ -139,12 +144,13 @@ should still keep a current PVC backup before rollout.
 
 - **Single instance only** — SQLite is single-writer, horizontal scaling is not supported
 - **ReadWriteOnce** — PVC must be ReadWriteOnce due to SQLite limitations
-- **Strava API** — requires valid Strava OAuth credentials to fetch activity data
+- **Strava API imports** — require valid Strava OAuth credentials; Dreeve 5 also supports local FIT, TCX, and GPX uploads
 - **OAuth callback** — `strava.config.general.appUrl` must match the public URL configured in the Strava app
 
 ## More Information
 
-- [Statistics for Strava documentation](https://github.com/robiningelbrecht/statistics-for-strava)
+- [Dreeve documentation](https://docs.dreeve.app)
+- [Dreeve source](https://github.com/dreeveapp/dreeve)
 - [Source code](https://github.com/helmforgedev/charts/tree/main/charts/strava-statistics)
 
 ### Security Scan: `strava-statistics`

--- a/charts/strava-statistics/tests/deployment_test.yaml
+++ b/charts/strava-statistics/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/robiningelbrecht/strava-statistics:v4.8.8"
+          value: "docker.io/robiningelbrecht/strava-statistics:v5.0.0"
 
   - it: should allow custom image tag
     set:

--- a/charts/strava-statistics/values.schema.json
+++ b/charts/strava-statistics/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "v4.8.8"
+                                                                    "default":  "v5.0.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/strava-statistics/values.yaml
+++ b/charts/strava-statistics/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Statistics for Strava container image
   repository: docker.io/robiningelbrecht/strava-statistics
   # -- Image tag
-  tag: "v4.8.8"
+  tag: "v5.0.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update Statistics for Strava to upstream Dreeve `5.0.0`
- refresh all pinned image references and document the Dreeve rebrand
- add major-version migration guidance for the database, configuration backup, settings migration, and new administration capabilities

## Validation

- upstream image manifest verified for `linux/amd64` and `linux/arm64`
- official stable `v5.0.0` release verified
- dependency policy check passed
- `make validate-chart CHART=strava-statistics` passed all 15 layers
- 6 behavioral k3d scenarios passed
- explicit k3d upgrade from `v4.8.8` to `v5.0.0` passed
- the upgrade retained the same PVC, rolled out the `v5.0.0` image with zero restarts, and passed an in-cluster HTTP smoke test
- standards, release, and attribution checks passed

Operators using `--reuse-values` must explicitly override the image tag during this major upgrade; using the new chart defaults selects `v5.0.0`.

Site documentation sync: helmforgedev/site#446

Closes #806


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the application release to version 5.0.0.
  * Added documentation for local activity uploads, the admin panel, and database-based settings migration.
* **Documentation**
  * Updated product references from “Statistics for Strava” to “Dreeve.”
  * Added revised upgrade and migration guidance.
  * Updated links to the Dreeve documentation and source repository.
* **Chores**
  * Updated the default deployment image to version 5.0.0 across supported configuration and validation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->