### PR TITLE
feat(umami): configure database wait init container

### DIFF
--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -266,6 +266,9 @@ For production, test restore procedures outside Helm. Backups without restore va
 | `pdb.enabled` | `false` | Render PodDisruptionBudget. |
 | `backup.enabled` | `false` | Enable S3-compatible backup CronJob. |
 | `serviceAccount.automountServiceAccountToken` | `false` | Control service account token mounting. |
+| `initContainers.waitForDatabase.enabled` | `true` | Wait for the database socket before starting Umami. |
+| `initContainers.waitForDatabase.image` | `docker.io/library/busybox:1.37` | Image used by the database readiness check. |
+| `initContainers.waitForDatabase.pullPolicy` | `IfNotPresent` | Pull policy for the database readiness image. |
 | `extraInitContainers` | `[]` | Additional init containers for preparing shared volumes before Umami starts. |
 | `extraVolumes` / `extraVolumeMounts` | `[]` | Additional pod volumes and Umami container mounts, such as GeoIP databases or custom assets. |
 
@@ -292,7 +295,7 @@ Back up PostgreSQL before upgrading live deployments, especially when migrating 
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **81.818184%** |
+| MITRE + NSA + SOC2 | **84.85%** |
 
 > ✅ Security posture acceptable.
 

--- a/charts/umami/ci/custom-wait-for-db.yaml
+++ b/charts/umami/ci/custom-wait-for-db.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+initContainers:
+  waitForDatabase:
+    image: docker.io/library/busybox:1.36
+    pullPolicy: IfNotPresent

--- a/charts/umami/ci/wait-for-db-disabled.yaml
+++ b/charts/umami/ci/wait-for-db-disabled.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+initContainers:
+  waitForDatabase:
+    enabled: false
+
+extraInitContainers:
+  - name: platform-database-readiness
+    image: docker.io/library/busybox:1.37
+    command:
+      - sh
+      - -ec
+    args:
+      - |
+        until nc -z -w2 umami-ci-wait-for-db-disabled-postgresql 5432; do
+          sleep 2
+        done

--- a/charts/umami/docs/configuration.md
+++ b/charts/umami/docs/configuration.md
@@ -46,6 +46,18 @@ Change the default admin password immediately after first login.
 
 ## Custom initialization
 
+The built-in database readiness check is enabled by default. Mirror or replace
+its image when public-registry access is restricted, or disable it when
+database readiness is enforced elsewhere:
+
+```yaml
+initContainers:
+  waitForDatabase:
+    enabled: true
+    image: registry.example.com/platform/busybox:1.37
+    pullPolicy: IfNotPresent
+```
+
 Use `extraInitContainers` with `extraVolumes` and `extraVolumeMounts` when Umami
 needs files prepared before the application starts, such as a GeoIP database,
 custom tracker assets, or organization-owned configuration mounted from a
@@ -71,9 +83,9 @@ extraVolumeMounts:
     mountPath: /app/geoip
 ```
 
-The chart renders custom init containers after the built-in database readiness
-check and optional external database preparation. Keep external downloads pinned
-to trusted URLs or use an internal artifact mirror for reproducible installs.
+The chart renders custom init containers after the enabled internal init
+containers. Keep external downloads pinned to trusted URLs or use an internal
+artifact mirror for reproducible installs.
 
 ## Scaling
 

--- a/charts/umami/examples/production.yaml
+++ b/charts/umami/examples/production.yaml
@@ -6,6 +6,11 @@
 
 replicaCount: 2
 
+initContainers:
+  waitForDatabase:
+    image: docker.io/library/busybox:1.36
+    pullPolicy: IfNotPresent
+
 umami:
   existingSecret: umami-app
   clientIpHeader: X-Forwarded-For

--- a/charts/umami/templates/deployment.yaml
+++ b/charts/umami/templates/deployment.yaml
@@ -41,9 +41,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if or .Values.initContainers.waitForDatabase.enabled .Values.database.external.init.enabled .Values.extraInitContainers }}
       initContainers:
+        {{- if .Values.initContainers.waitForDatabase.enabled }}
         - name: wait-for-db
-          image: docker.io/library/busybox:1.37
+          image: {{ .Values.initContainers.waitForDatabase.image | quote }}
+          imagePullPolicy: {{ .Values.initContainers.waitForDatabase.pullPolicy }}
           command:
             - sh
             - -c
@@ -58,6 +61,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
         {{- if .Values.database.external.init.enabled }}
         - name: prepare-external-db
           image: {{ .Values.database.external.init.image | quote }}
@@ -100,6 +104,7 @@ spec:
         {{- with .Values.extraInitContainers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       containers:
         - name: umami
           image: {{ include "umami.image" . | quote }}

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -101,6 +101,42 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-db
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/busybox:1.37
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should configure the wait-for-db image and pull policy
+    set:
+      initContainers.waitForDatabase.image: registry.example.com/platform/busybox:1.37
+      initContainers.waitForDatabase.pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/platform/busybox:1.37
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always
+
+  - it: should disable the wait-for-db init container
+    set:
+      initContainers.waitForDatabase.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: should append extra init containers when wait-for-db is disabled
+    set:
+      initContainers.waitForDatabase.enabled: false
+      extraInitContainers:
+        - name: prepare-assets
+          image: docker.io/library/busybox:1.37
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-assets
 
   - it: should append extra init containers after internal init containers
     set:

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -478,6 +478,39 @@
       "type": "object",
       "description": "Additional annotations for the pod"
     },
+    "initContainers": {
+      "type": "object",
+      "description": "Internal init container settings",
+      "additionalProperties": false,
+      "required": ["waitForDatabase"],
+      "properties": {
+        "waitForDatabase": {
+          "type": "object",
+          "description": "Database availability check that runs before Umami",
+          "additionalProperties": false,
+          "required": ["enabled", "image", "pullPolicy"],
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Wait for the database socket before starting Umami",
+              "default": true
+            },
+            "image": {
+              "type": "string",
+              "description": "Container image used to check database connectivity",
+              "minLength": 1,
+              "default": "docker.io/library/busybox:1.37"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "Image pull policy for the database wait container",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "default": "IfNotPresent"
+            }
+          }
+        }
+      }
+    },
     "extraVolumes": {
       "type": "array",
       "description": "Additional volumes for the pod",

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -390,6 +390,16 @@ podAnnotations: {}
 # Extra
 # =============================================================================
 
+# -- Internal init containers
+initContainers:
+  waitForDatabase:
+    # -- Wait for the database socket before starting Umami
+    enabled: true
+    # -- Container image used to check database connectivity
+    image: docker.io/library/busybox:1.37
+    # -- Image pull policy for the database wait container
+    pullPolicy: IfNotPresent
+
 extraVolumes: []
 extraVolumeMounts: []
 extraInitContainers: []


### PR DESCRIPTION
## Summary

- makes the built-in `wait-for-db` init container configurable
- preserves existing behavior with `enabled: true`, BusyBox 1.37, and `IfNotPresent`
- supports custom image mirrors and pull policies
- allows the built-in init container to be disabled when platform readiness is supplied elsewhere
- adds unit and k3d scenarios for custom and disabled configurations

Resolves #784

## Type Of Change

- [x] Existing chart change
- [ ] New chart
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] Existing issue linked
- [x] Branch created from updated `main`
- [x] PR targets `main`
- [x] Conventional commit and PR title
- [x] `Chart.yaml` version was not edited manually
- [x] `values.schema.json` and chart documentation updated

## Site Sync (GR-007)

- [x] Site documentation and playground updated in https://github.com/helmforgedev/site/pull/454

## Local Validation

- [x] `make validate-chart CHART=umami` — FULLY VALIDATED (21 layers)
- [x] 70 Helm unit tests passed
- [x] 12 k3d scenarios passed sequentially, including `custom-wait-for-db` and `wait-for-db-disabled`
- [x] All workloads reached Ready with service endpoints
- [x] Zero restarts/crash terminations and clean logs/events in the successful full run
- [x] `make standards-check CHART=umami`
- [x] `make standards-guard`
- [x] `make release-check REPO=charts`
- [x] `make attribution-check REPO=charts`
- [x] `make md-lint REPO=charts`
- [x] Kubescape MITRE + NSA + SOC2 aggregate score: 84.85% (threshold 80)

## Notes

- The disabled k3d scenario supplies a platform-owned readiness init container, proving the built-in container is absent while database readiness remains guaranteed.
- `NOTES.txt` is unchanged because access instructions and post-install operations are unaffected.
- Upstream application version and image tag are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable database readiness check that runs before Umami starts.
  * Enabled the check by default, with configurable container image and pull policy.
  * Added support for disabling the built-in check and supplying custom initialization containers.

* **Documentation**
  * Updated configuration guidance, production examples, and available settings.
  * Improved the documented security scan score.

* **Bug Fixes**
  * Corrected initialization behavior when built-in and custom readiness checks are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->