### PR TITLE
feat(adguard-home): support additional dns service ports

### DIFF
--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -220,6 +220,7 @@ backup:
 | `service.web.ipFamilies` | `[]` | IP families (`IPv4`, `IPv6`) |
 | `service.dns.type` | `LoadBalancer` | DNS service type |
 | `service.dns.port` | `53` | DNS port |
+| `service.dns.extraPorts` | `[]` | Additional named DNS service ports, such as DNS-over-TLS on TCP 853 |
 | `service.dns.loadBalancerIP` | `""` | Fixed IP for DNS stability |
 | `service.dns.externalTrafficPolicy` | `Cluster` | Traffic policy for external traffic (`Cluster`, `Local`). Set to `Local` to preserve client source IP |
 | `service.dns.ipFamilyPolicy` | `~` | Dual-stack policy (`SingleStack`, `PreferDualStack`, `RequireDualStack`) |

--- a/charts/adguard-home/ci/extra-dns-ports.yaml
+++ b/charts/adguard-home/ci/extra-dns-ports.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  dns:
+    extraPorts:
+      - name: dns-tls
+        port: 853
+        targetPort: 853
+        protocol: TCP

--- a/charts/adguard-home/examples/production.yaml
+++ b/charts/adguard-home/examples/production.yaml
@@ -58,6 +58,11 @@ service:
   dns:
     type: LoadBalancer
     loadBalancerIP: "192.168.1.53"
+    extraPorts:
+      - name: dns-tls
+        port: 853
+        targetPort: 853
+        protocol: TCP
 
 ingress:
   enabled: true

--- a/charts/adguard-home/templates/_helpers.tpl
+++ b/charts/adguard-home/templates/_helpers.tpl
@@ -87,6 +87,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "adguard-home.validate" -}}
+{{- $dnsPortNames := dict "dns-tcp" true "dns-udp" true -}}
+{{- range .Values.service.dns.extraPorts -}}
+  {{- if hasKey $dnsPortNames .name -}}
+    {{- fail "service.dns.extraPorts names must be unique and cannot use the reserved names dns-tcp or dns-udp." -}}
+  {{- end -}}
+  {{- $_ := set $dnsPortNames .name true -}}
+{{- end -}}
 {{- if .Values.externalSecrets.enabled -}}
   {{- if not .Values.config.existingSecret -}}
     {{- fail "externalSecrets.enabled requires config.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." -}}

--- a/charts/adguard-home/templates/service.yaml
+++ b/charts/adguard-home/templates/service.yaml
@@ -64,5 +64,8 @@ spec:
       port: {{ .Values.service.dns.port }}
       targetPort: dns-udp
       protocol: UDP
+    {{- with .Values.service.dns.extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "adguard-home.selectorLabels" . | nindent 4 }}

--- a/charts/adguard-home/tests/service_test.yaml
+++ b/charts/adguard-home/tests/service_test.yaml
@@ -55,6 +55,9 @@ tests:
   - it: should have DNS TCP and UDP ports
     documentIndex: 1
     asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 2
       - contains:
           path: spec.ports
           content:
@@ -68,6 +71,37 @@ tests:
             name: dns-udp
             port: 53
             targetPort: dns-udp
+            protocol: UDP
+
+  - it: should append explicitly configured DNS service ports
+    documentIndex: 1
+    set:
+      service.dns.extraPorts:
+        - name: dns-tls
+          port: 853
+          targetPort: 853
+          protocol: TCP
+        - name: dns-alt
+          port: 5353
+          targetPort: dns-tcp
+          protocol: UDP
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 4
+      - contains:
+          path: spec.ports
+          content:
+            name: dns-tls
+            port: 853
+            targetPort: 853
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            name: dns-alt
+            port: 5353
+            targetPort: dns-tcp
             protocol: UDP
 
   - it: should set loadBalancerIP when specified

--- a/charts/adguard-home/tests/validation_test.yaml
+++ b/charts/adguard-home/tests/validation_test.yaml
@@ -30,3 +30,29 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: externalSecrets.data must contain an entry with secretKey 'AdGuardHome.yaml' when externalSecrets.enabled=true to populate the initial configuration.
+
+  - it: should reject an extra DNS port that reuses a built-in name
+    set:
+      service.dns.extraPorts:
+        - name: dns-tcp
+          port: 853
+          targetPort: 853
+          protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: service.dns.extraPorts names must be unique and cannot use the reserved names dns-tcp or dns-udp.
+
+  - it: should reject duplicate extra DNS port names
+    set:
+      service.dns.extraPorts:
+        - name: dns-tls
+          port: 853
+          targetPort: 853
+          protocol: TCP
+        - name: dns-tls
+          port: 8853
+          targetPort: 8853
+          protocol: TCP
+    asserts:
+      - failedTemplate:
+          errorMessage: service.dns.extraPorts names must be unique and cannot use the reserved names dns-tcp or dns-udp.

--- a/charts/adguard-home/values.schema.json
+++ b/charts/adguard-home/values.schema.json
@@ -212,11 +212,66 @@
               "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
               "default": "LoadBalancer"
             },
-            "port": {
-              "type": "integer",
-              "description": "DNS service port",
-              "default": 53
-            },
+        "port": {
+          "type": "integer",
+          "description": "DNS service port",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 53
+        },
+        "extraPorts": {
+          "type": "array",
+          "description": "Additional ports exposed by the DNS service, such as DNS-over-TLS",
+          "default": [],
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "port",
+              "targetPort",
+              "protocol"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Unique Kubernetes Service port name",
+                "minLength": 1,
+                "maxLength": 15,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "port": {
+                "type": "integer",
+                "description": "Service port",
+                "minimum": 1,
+                "maximum": 65535
+              },
+              "targetPort": {
+                "description": "Container port number or named container port",
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535
+                  },
+                  {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                ]
+              },
+              "protocol": {
+                "type": "string",
+                "description": "Transport protocol",
+                "enum": [
+                  "TCP",
+                  "UDP",
+                  "SCTP"
+                ]
+              }
+            }
+          }
+        },
             "annotations": {
               "type": "object",
               "description": "Annotations for the DNS service"

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -134,6 +134,13 @@ service:
     # -- Service type - use LoadBalancer for external DNS access
     type: LoadBalancer
     port: 53
+    # -- Additional ports exposed by the DNS service, for example DNS-over-TLS on TCP 853.
+    # -- Names must be unique across this list and the built-in dns-tcp/dns-udp ports.
+    extraPorts: []
+      # - name: dns-tls
+      #   port: 853
+      #   targetPort: 853
+      #   protocol: TCP
     annotations: {}
     # -- Load balancer IP (optional, for static IP assignment)
     loadBalancerIP: ""


### PR DESCRIPTION
## Summary

- adds `service.dns.extraPorts` for additional named DNS Service ports
- supports TCP, UDP, and SCTP with schema validation
- rejects reserved and duplicate port names
- includes a DNS-over-TLS 853 example and dedicated k3d scenario

Resolves #785

## Type Of Change

- [x] Existing chart change
- [ ] New chart
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] Existing issue linked
- [x] Branch created from updated `main`
- [x] PR targets `main`
- [x] Conventional commit and PR title
- [x] `Chart.yaml` version was not edited manually
- [x] `values.schema.json` and chart documentation updated

## Site Sync (GR-007)

- [x] Site documentation updated in https://github.com/helmforgedev/site/pull/455

## Local Validation

- [x] `make validate-chart CHART=adguard-home` — FULLY VALIDATED (19 layers)
- [x] 54 Helm unit tests passed
- [x] 10 k3d scenarios passed sequentially, including `extra-dns-ports`
- [x] All workloads reached Ready with service endpoints
- [x] Zero restarts/crash terminations and clean logs in the successful full run
- [x] `make standards-check CHART=adguard-home`
- [x] `make standards-guard`
- [x] `make release-check REPO=charts`
- [x] `make attribution-check REPO=charts`
- [x] `make md-lint REPO=charts`
- [x] Kubescape score: 72.72727%, matching the documented baseline

## Notes

- `NOTES.txt` is unchanged because access and troubleshooting instructions do not enumerate individual DNS Service ports.
- Upstream application version and image tag are unchanged.