### PR TITLE
fix(netbird): align embedded idp dashboard defaults

### DIFF
--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -62,6 +62,31 @@ geolocation data before opening the health endpoint.
 
 Use `server.config.existingSecret` when you need to provide a full upstream `config.yaml` directly. Otherwise the chart renders one from values and stores it in a Kubernetes Secret.
 
+## Embedded identity provider
+
+The default dashboard authentication settings match the identity provider
+embedded in `netbird-server`:
+
+```yaml
+server:
+  publicUrl: https://netbird.example.com
+  auth:
+    issuer: https://netbird.example.com/oauth2
+
+dashboard:
+  auth:
+    clientId: netbird-dashboard
+    audience: netbird-dashboard
+    supportedScopes: openid profile email groups
+    redirectUri: /nb-auth
+    silentRedirectUri: /nb-silent-auth
+```
+
+The generated server configuration allows the corresponding absolute callback
+URLs below `server.publicUrl`. Keep the dashboard and server on the same public
+hostname when using the embedded provider. Override all dashboard auth values
+when integrating an external OIDC provider.
+
 ## Storage
 
 The default store mode is `auto`, which selects the PostgreSQL subchart unless

--- a/charts/netbird/ci/embedded-idp-ingress-values.yaml
+++ b/charts/netbird/ci/embedded-idp-ingress-values.yaml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  publicUrl: https://netbird.example.com
+  auth:
+    issuer: https://netbird.example.com/oauth2
+
+ingress:
+  enabled: true
+  ingressClassName: traefik
+  hosts:
+    - host: netbird.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: dashboard
+        - path: /api
+          pathType: Prefix
+          service: server
+  tls:
+    - secretName: netbird-tls
+      hosts:
+        - netbird.example.com

--- a/charts/netbird/templates/deployment.yaml
+++ b/charts/netbird/templates/deployment.yaml
@@ -259,6 +259,10 @@ spec:
               value: {{ .Values.dashboard.auth.audience | quote }}
             - name: AUTH_SUPPORTED_SCOPES
               value: {{ .Values.dashboard.auth.supportedScopes | quote }}
+            - name: AUTH_REDIRECT_URI
+              value: {{ .Values.dashboard.auth.redirectUri | quote }}
+            - name: AUTH_SILENT_REDIRECT_URI
+              value: {{ .Values.dashboard.auth.silentRedirectUri | quote }}
             - name: NETBIRD_TOKEN_SOURCE
               value: {{ .Values.dashboard.auth.tokenSource | quote }}
             - name: USE_AUTH0

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -21,6 +21,72 @@ tests:
           value: netbirdio/dashboard:v2.90.3
         template: templates/deployment.yaml
         documentIndex: 1
+  - it: configures dashboard defaults for the embedded identity provider
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_CLIENT_ID
+            value: netbird-dashboard
+        template: templates/deployment.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_AUDIENCE
+            value: netbird-dashboard
+        template: templates/deployment.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_SUPPORTED_SCOPES
+            value: openid profile email groups
+        template: templates/deployment.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_REDIRECT_URI
+            value: /nb-auth
+        template: templates/deployment.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_SILENT_REDIRECT_URI
+            value: /nb-silent-auth
+        template: templates/deployment.yaml
+        documentIndex: 1
+  - it: supports external identity provider dashboard overrides
+    set:
+      dashboard.auth.clientId: custom-dashboard
+      dashboard.auth.audience: custom-audience
+      dashboard.auth.supportedScopes: openid profile email
+      dashboard.auth.redirectUri: https://vpn.example.com/auth/callback
+      dashboard.auth.silentRedirectUri: https://vpn.example.com/auth/silent
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_CLIENT_ID
+            value: custom-dashboard
+        template: templates/deployment.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_REDIRECT_URI
+            value: https://vpn.example.com/auth/callback
+        template: templates/deployment.yaml
+        documentIndex: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_SILENT_REDIRECT_URI
+            value: https://vpn.example.com/auth/silent
+        template: templates/deployment.yaml
+        documentIndex: 1
   - it: renders separate server and dashboard services
     asserts:
       - equal:

--- a/charts/netbird/values.schema.json
+++ b/charts/netbird/values.schema.json
@@ -84,7 +84,20 @@
         "replicaCount": { "type": "integer", "minimum": 1 },
         "env": { "$ref": "#/definitions/env" },
         "envFrom": { "type": "array", "items": { "type": "object" } },
-        "auth": { "type": "object" },
+        "auth": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["clientId", "audience", "supportedScopes", "redirectUri", "silentRedirectUri", "tokenSource", "useAuth0"],
+          "properties": {
+            "clientId": { "type": "string", "minLength": 1, "default": "netbird-dashboard" },
+            "audience": { "type": "string", "minLength": 1, "default": "netbird-dashboard" },
+            "supportedScopes": { "type": "string", "minLength": 1, "default": "openid profile email groups" },
+            "redirectUri": { "type": "string", "minLength": 1, "default": "/nb-auth" },
+            "silentRedirectUri": { "type": "string", "minLength": 1, "default": "/nb-silent-auth" },
+            "tokenSource": { "type": "string", "enum": ["accessToken", "idToken"], "default": "accessToken" },
+            "useAuth0": { "type": "string", "enum": ["true", "false"], "default": "false" }
+          }
+        },
         "securityContext": { "type": "object" },
         "service": { "$ref": "#/definitions/dashboardService" }
       }

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -102,11 +102,15 @@ dashboard:
   envFrom: []
   auth:
     # -- Dashboard OIDC client ID.
-    clientId: netbird
+    clientId: netbird-dashboard
     # -- Dashboard OIDC audience.
-    audience: netbird
+    audience: netbird-dashboard
     # -- Dashboard OIDC scopes.
-    supportedScopes: openid profile email offline_access api
+    supportedScopes: openid profile email groups
+    # -- Dashboard authentication callback URI. Relative paths use server.publicUrl.
+    redirectUri: /nb-auth
+    # -- Dashboard silent authentication callback URI. Relative paths use server.publicUrl.
+    silentRedirectUri: /nb-silent-auth
     # -- Dashboard token source.
     tokenSource: accessToken
     # -- Whether the dashboard should use Auth0 mode.


### PR DESCRIPTION
## Summary

- aligns dashboard client ID and audience with the embedded `netbird-server` identity provider
- uses the official embedded-provider scopes
- renders interactive and silent dashboard redirect URI environment variables
- preserves full override support for external OIDC providers
- adds a same-host production Ingress k3d scenario

Resolves #830

## Type Of Change

- [x] Existing chart change
- [ ] New chart
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] Existing issue linked
- [x] Branch created from updated `main`
- [x] PR targets `main`
- [x] Conventional commit and PR title
- [x] `Chart.yaml` version was not edited manually
- [x] `values.schema.json` and chart documentation updated

## Site Sync (GR-007)

- [x] Site documentation updated in https://github.com/helmforgedev/site/pull/456

## Local Validation

- [x] `make validate-chart CHART=netbird` — FULLY VALIDATED (19 layers)
- [x] 37 Helm unit tests passed
- [x] 10 k3d scenarios passed sequentially, including `embedded-idp-ingress-values`
- [x] Three workloads and four Service endpoints validated in PostgreSQL profiles
- [x] Zero restarts/crash terminations and clean logs/events
- [x] `make standards-check CHART=netbird`
- [x] `make standards-guard`
- [x] `make release-check REPO=charts`
- [x] `make attribution-check REPO=charts`
- [x] `make md-lint REPO=charts`
- [x] Kubescape MITRE + NSA + SOC2 score: 86.87% (threshold 80)

## Notes

- `NOTES.txt` is unchanged because it covers access operations rather than the full OIDC value reference.
- Upstream application and image versions are unchanged.