### PR TITLE
feat(answer): upgrade apache answer to 2.0.2

### DIFF
--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -4,7 +4,7 @@ name: answer
 description: Apache Answer Q&A platform with SQLite, MySQL, or PostgreSQL support
 type: application
 version: 1.4.16
-appVersion: "2.0.1"
+appVersion: "2.0.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/answer/README.md
+++ b/charts/answer/README.md
@@ -94,6 +94,8 @@ database:
 | `answer.externalContentDisplay` | `ask_before_display` | External content display policy used by auto-install |
 | `answer.autoInstall` | `true` | Enable unattended setup |
 | `answer.logLevel` | `INFO` | Log level (DEBUG, INFO, WARN, ERROR) |
+| `answer.notifications.newQuestionEmail.queueSize` | `1024` | Maximum buffered new-question email tasks |
+| `answer.notifications.newQuestionEmail.sendIntervalSeconds` | `0` | Delay between new-question email attempts; 0 disables throttling |
 | `admin.name` | `admin` | Admin username |
 | `admin.password` | `""` | Admin password (auto-generated) |
 | `admin.email` | `admin@example.com` | Admin email |

--- a/charts/answer/ci/new-question-email-worker.yaml
+++ b/charts/answer/ci/new-question-email-worker.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+answer:
+  notifications:
+    newQuestionEmail:
+      queueSize: 2048
+      sendIntervalSeconds: 15

--- a/charts/answer/templates/deployment.yaml
+++ b/charts/answer/templates/deployment.yaml
@@ -124,6 +124,10 @@ spec:
             {{- end }}
             - name: LOG_LEVEL
               value: {{ .Values.answer.logLevel | quote }}
+            - name: NEW_QUESTION_NOTIFICATION_EMAIL_QUEUE_SIZE
+              value: {{ .Values.answer.notifications.newQuestionEmail.queueSize | quote }}
+            - name: NEW_QUESTION_NOTIFICATION_EMAIL_SEND_INTERVAL_SECONDS
+              value: {{ .Values.answer.notifications.newQuestionEmail.sendIntervalSeconds | quote }}
             {{- with .Values.answer.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/answer/tests/deployment_test.yaml
+++ b/charts/answer/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/apache/answer:2.0.1"
+          value: "docker.io/apache/answer:2.0.2"
 
   - it: should allow custom image tag
     template: templates/deployment.yaml
@@ -357,6 +357,23 @@ tests:
           content:
             name: TIMEZONE
             value: "UTC"
+
+  - it: should configure the new question email worker
+    template: templates/deployment.yaml
+    set:
+      answer.notifications.newQuestionEmail.queueSize: 2048
+      answer.notifications.newQuestionEmail.sendIntervalSeconds: 15
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEW_QUESTION_NOTIFICATION_EMAIL_QUEUE_SIZE
+            value: "2048"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEW_QUESTION_NOTIFICATION_EMAIL_SEND_INTERVAL_SECONDS
+            value: "15"
 
   - it: should set pod labels
     template: templates/deployment.yaml

--- a/charts/answer/values.schema.json
+++ b/charts/answer/values.schema.json
@@ -78,6 +78,34 @@
           "description": "Log level: DEBUG, INFO, WARN, ERROR.",
           "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
         },
+        "notifications": {
+          "type": "object",
+          "description": "Answer notification worker configuration.",
+          "additionalProperties": false,
+          "required": ["newQuestionEmail"],
+          "properties": {
+            "newQuestionEmail": {
+              "type": "object",
+              "description": "New-question email worker settings introduced in Answer 2.0.2.",
+              "additionalProperties": false,
+              "required": ["queueSize", "sendIntervalSeconds"],
+              "properties": {
+                "queueSize": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65536,
+                  "description": "Maximum number of new-question email tasks buffered by the Answer worker."
+                },
+                "sendIntervalSeconds": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 300,
+                  "description": "Delay in seconds between new-question email attempts; 0 disables throttling."
+                }
+              }
+            }
+          }
+        },
         "extraEnv": {
           "type": "array",
           "description": "Additional environment variables for the Answer container.",

--- a/charts/answer/values.yaml
+++ b/charts/answer/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/apache/answer
   # -- Container image tag
-  tag: "2.0.1"
+  tag: "2.0.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -59,6 +59,13 @@ answer:
 
   # -- Log level: DEBUG, INFO, WARN, ERROR
   logLevel: INFO
+
+  notifications:
+    newQuestionEmail:
+      # -- Maximum number of new-question email tasks buffered by the Answer worker
+      queueSize: 1024
+      # -- Delay in seconds between new-question email attempts (0 disables throttling)
+      sendIntervalSeconds: 0
 
   # -- Additional environment variables for the Answer container
   # extraEnv:


### PR DESCRIPTION
## Summary

- upgrades the official Apache Answer image from `2.0.1` to `2.0.2`
- exposes the new-question email queue size and send interval as typed chart values
- validates the new values with unit, schema, template, and behavioral k3d scenarios
- updates the chart README and synchronizes the site documentation in helmforgedev/site#458

Closes #831.

## Upstream review

- release: https://github.com/apache/answer/releases/tag/v2.0.2
- comparison: https://github.com/apache/answer/compare/v2.0.1...v2.0.2
- image: `docker.io/apache/answer:2.0.2`, verified for `linux/amd64` and `linux/arm64`

Answer 2.0.2 adds reasoning content in AI chat, optional email verification, recovery middleware, configurable new-question email delivery, and several authorization and account-hardening fixes. The release does not change the chart's port, storage path, or database contract.

## User impact

The upgrade is backward compatible with the existing defaults. Operators may now configure:

- `answer.notifications.newQuestionEmail.queueSize` (`1` to `65536`, default `1024`)
- `answer.notifications.newQuestionEmail.sendIntervalSeconds` (`0` to `300`, default `0`)

## Validation

- `make image-verify IMAGE=docker.io/apache/answer:2.0.2`
- `make deps-check CHART=answer`
- `make validate-chart CHART=answer`
  - 19 layers passed
  - 10 behavioral k3d scenarios passed
  - all workloads Ready, zero restarts, clean crash/fatal log scan
  - default, backup, external database, External Secrets, Gateway API, Ingress, MySQL, PostgreSQL, and new email-worker scenarios covered
- schema rejection verified for queue size `0` and interval `301`
- `make standards-check CHART=answer`
- `node scripts/charts/template-standards-check.js --chart answer`
- `make site-sync-check CHART=answer`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make preflight`

## Self-review

- reviewed every changed line against `main`
- confirmed the image and `appVersion` match the latest stable upstream release
- confirmed no chart package version was edited
- confirmed the new schema bounds match the upstream constants
- confirmed the new values render the exact upstream environment variables
- confirmed no stale `2.0.1` reference remains under `charts/answer`
- confirmed the diff contains no unrelated changes or attribution trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for new-question email delivery, including queue capacity and sending intervals.
  * Added support for disabling email throttling by setting the interval to zero.
  * Exposed the new settings through Helm chart values and deployment configuration.

* **Documentation**
  * Updated chart documentation with the new notification settings.

* **Chores**
  * Updated the application image and chart version to 2.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->