### PR TITLE
feat(appwrite): upgrade appwrite to 1.9.6

### DIFF
--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -4,7 +4,7 @@ name: appwrite
 description: Appwrite self-hosted backend-as-a-service platform with MariaDB and Redis
 type: application
 version: 1.2.4
-appVersion: "1.9.5"
+appVersion: "1.9.6"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/appwrite.png
 home: https://helmforge.dev

--- a/charts/appwrite/README.md
+++ b/charts/appwrite/README.md
@@ -5,6 +5,7 @@ Self-hosted backend-as-a-service platform for web, mobile, and Flutter developer
 ## Features
 
 - Appwrite API server, console, and realtime WebSocket service
+- Side-effect-free API health probes using `/v1/health/version`
 - 12 background workers for audits, webhooks, deletes, databases, builds, certificates, functions, mails, messaging, migrations, and stats
 - Schedulers for functions, messages, and executions
 - Maintenance task for automated housekeeping
@@ -58,10 +59,10 @@ When ingress is enabled, requests are routed by path:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `image.repository` | `appwrite/appwrite` | Appwrite server image |
-| `image.tag` | `""` (uses appVersion) | Image tag |
-| `console.image.repository` | `appwrite/console` | Console image |
-| `console.image.tag` | `8.7.5` | Console image tag |
+| `image.repository` | `docker.io/appwrite/appwrite` | Appwrite server image |
+| `image.tag` | `1.9.6` | Image tag |
+| `console.image.repository` | `docker.io/appwrite/console` | Console image |
+| `console.image.tag` | `8.7.30` | Console image tag |
 | `appwrite.locale` | `en` | Application locale |
 | `appwrite.domain` | `""` (auto-detected) | Appwrite domain |
 | `appwrite.openSslKeyV1` | `""` (auto-generated) | 64-char hex encryption key |
@@ -78,11 +79,12 @@ See [`values.yaml`](values.yaml) for the full configuration reference.
 
 ## Upgrade Notes
 
-Appwrite 1.9.5 requires the upstream database migration step even when upgrading
-from Appwrite 1.9.0. After `helm upgrade`, run the Appwrite migrate command
-against an Appwrite API pod before returning production traffic to the release,
-for example with `kubectl exec deploy/<release>-appwrite-api -- appwrite migrate`
-adjusted to the release name and namespace.
+Appwrite 1.9.6 repairs missing Functions and Sites Git-provider attributes left
+by upgrades from 1.9.5 and makes migration batches idempotent. After
+`helm upgrade`, run the Appwrite migrate command against an Appwrite API pod
+before returning production traffic to the release, for example with
+`kubectl exec deploy/<release>-appwrite-api -- appwrite migrate` adjusted to the
+release name and namespace.
 
 ## External Database
 

--- a/charts/appwrite/templates/_helpers.tpl
+++ b/charts/appwrite/templates/_helpers.tpl
@@ -468,6 +468,55 @@ startupProbe:
 {{- end }}
 {{- end -}}
 
+{{/* ---- Side-effect-free HTTP probes for the Appwrite API ---- */}}
+{{- define "appwrite.apiLivenessProbe" -}}
+{{- if .Values.livenessProbe.enabled }}
+livenessProbe:
+  httpGet:
+    path: /v1/health/version
+    port: http
+    httpHeaders:
+      - name: Host
+        value: {{ include "appwrite.domain" . | quote }}
+  initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+  failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
+{{- end -}}
+
+{{- define "appwrite.apiReadinessProbe" -}}
+{{- if .Values.readinessProbe.enabled }}
+readinessProbe:
+  httpGet:
+    path: /v1/health/version
+    port: http
+    httpHeaders:
+      - name: Host
+        value: {{ include "appwrite.domain" . | quote }}
+  initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+  failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+{{- end -}}
+
+{{- define "appwrite.apiStartupProbe" -}}
+{{- if .Values.startupProbe.enabled }}
+startupProbe:
+  httpGet:
+    path: /v1/health/version
+    port: http
+    httpHeaders:
+      - name: Host
+        value: {{ include "appwrite.domain" . | quote }}
+  initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+  periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+  timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+  failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+{{- end }}
+{{- end -}}
+
 {{/* ---- Backup helpers ---- */}}
 
 {{- define "appwrite.backupSecretName" -}}

--- a/charts/appwrite/templates/deployment-api.yaml
+++ b/charts/appwrite/templates/deployment-api.yaml
@@ -42,9 +42,9 @@ spec:
             {{- include "appwrite.commonEnv" . | nindent 12 }}
           volumeMounts:
             {{- include "appwrite.sharedVolumeMounts" . | nindent 12 }}
-          {{- include "appwrite.httpLivenessProbe" . | nindent 10 }}
-          {{- include "appwrite.httpReadinessProbe" . | nindent 10 }}
-          {{- include "appwrite.httpStartupProbe" . | nindent 10 }}
+          {{- include "appwrite.apiLivenessProbe" . | nindent 10 }}
+          {{- include "appwrite.apiReadinessProbe" . | nindent 10 }}
+          {{- include "appwrite.apiStartupProbe" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- with .Values.api.resources }}

--- a/charts/appwrite/tests/deployment_api_test.yaml
+++ b/charts/appwrite/tests/deployment_api_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/appwrite/appwrite:1.9.5"
+          value: "docker.io/appwrite/appwrite:1.9.6"
 
   - it: should run http.php entrypoint
     template: templates/deployment-api.yaml
@@ -37,15 +37,35 @@ tests:
             containerPort: 80
             protocol: TCP
 
-  - it: should have probes by default
+  - it: should use the side-effect-free version endpoint for API probes
     template: templates/deployment-api.yaml
+    set:
+      appwrite.domain: appwrite.example.com
     asserts:
-      - isNotNull:
-          path: spec.template.spec.containers[0].livenessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[0].readinessProbe
-      - isNotNull:
-          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+          value:
+            path: /v1/health/version
+            port: http
+            httpHeaders:
+              - name: Host
+                value: appwrite.example.com
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+          value:
+            path: /v1/health/version
+            port: http
+            httpHeaders:
+              - name: Host
+                value: appwrite.example.com
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet
+          value:
+            path: /v1/health/version
+            port: http
+            httpHeaders:
+              - name: Host
+                value: appwrite.example.com
 
   - it: should wait for database and redis before starting
     template: templates/deployment-api.yaml

--- a/charts/appwrite/tests/deployment_console_test.yaml
+++ b/charts/appwrite/tests/deployment_console_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/appwrite/console:8.7.5"
+          value: "docker.io/appwrite/console:8.7.30"
 
   - it: should have component label
     asserts:

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Appwrite server image repository
   repository: docker.io/appwrite/appwrite
   # -- Appwrite image tag. Defaults to appVersion.
-  tag: "1.9.5"
+  tag: "1.9.6"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -36,7 +36,7 @@ console:
     # -- Appwrite console image repository
     repository: docker.io/appwrite/console
     # -- Console image tag
-    tag: "8.7.5"
+    tag: "8.7.30"
     # -- Console image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrades Appwrite from `1.9.5` to `1.9.6`
- upgrades the companion Appwrite Console image from `8.7.5` to `8.7.30`
- changes API probes from TCP to the public, side-effect-free `/v1/health/version` endpoint with the required `Host` header
- preserves TCP probes for the separate Realtime entrypoint
- updates upgrade and migration guidance

Closes #832.

## Upstream review

- release: https://github.com/appwrite/appwrite/releases/tag/1.9.6
- comparison: https://github.com/appwrite/appwrite/compare/1.9.5...1.9.6
- healthcheck change: https://github.com/appwrite/appwrite/pull/12765
- `docker.io/appwrite/appwrite:1.9.6`: verified for `linux/amd64` and `linux/arm64`
- `docker.io/appwrite/console:8.7.30`: verified for `linux/amd64` and `linux/arm64`

Appwrite 1.9.6 repairs missing Functions and Sites Git-provider attributes, makes migration batches idempotent, improves database/queue diagnostics, and replaces a side-effecting healthcheck. Operators must still run the documented Appwrite migration after upgrading.

## Validation

- `make image-verify` for both official images
- `make deps-check CHART=appwrite`
- `make validate-chart CHART=appwrite`
  - 19 layers passed
  - 10 behavioral k3d scenarios passed
  - up to 21 workloads per scenario, all Ready with zero restarts
  - logs clean across every inspected pod
  - default, backup, dual-stack, external database, External Secrets, Gateway API, Ingress, minimal workers, and no-persistence coverage
  - live API response confirmed as `{"version":"1.9.6"}`
- `make standards-check CHART=appwrite`
- `node scripts/charts/template-standards-check.js --chart appwrite`
- `make site-sync-check CHART=appwrite`
- `make preflight`

## Self-review

- reviewed every changed line against `main`
- confirmed package `version` remains CI-owned and untouched
- confirmed API probes match the upstream public endpoint and required host routing
- confirmed Realtime retains its compatible TCP probe
- confirmed migration guidance and companion Console version match the release
- confirmed no unrelated changes or attribution trailers

Companion site documentation: helmforgedev/site#459.
