### PR TITLE
fix(certimate): update image to 0.4.28

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -4,7 +4,7 @@ name: certimate
 description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
 type: application
 version: 1.0.1
-appVersion: "0.4.27"
+appVersion: "0.4.28"
 home: https://helmforge.dev/docs/charts/certimate
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/certimate

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -2,7 +2,7 @@
 
 Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
 
-This chart packages the official `certimate/certimate:v0.4.27` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+This chart packages the official `certimate/certimate:v0.4.28` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
 
 ## Production Defaults
 
@@ -71,6 +71,10 @@ Back up the PersistentVolumeClaim before upgrades. Certimate stores its
 PocketBase database, uploaded certificate material, ACME account state, workflow
 definitions, and provider credentials under `/app/pb_data`.
 
+Certimate 0.4.28 fixes repeated Tencent EdgeOne deployment workflows when no
+domains remain to be updated. It does not change the container port, storage
+path, or chart configuration contract.
+
 Certimate's upstream deployment uses PocketBase-local state. This chart does not
 ship PostgreSQL, MySQL, or Redis subcharts because the product does not expose an
 official external database mode for its application state. Treat the PVC as the
@@ -85,7 +89,7 @@ ACME endpoints required by your workflows.
 Local security scan:
 
 ```text
-Image: certimate/certimate:v0.4.27
+Image: certimate/certimate:v0.4.28
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 93.93939 compliance score
 ```

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: certimate/certimate:v0.4.27
+          value: certimate/certimate:v0.4.28
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "certimate/certimate" },
-        "tag": { "type": "string", "default": "v0.4.27", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "v0.4.28", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Certimate container image repository.
   repository: certimate/certimate
   # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
-  tag: "v0.4.27"
+  tag: "v0.4.28"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official Certimate image from `certimate/certimate:v0.4.27` to `v0.4.28`
- keep `Chart.yaml`, values, JSON schema, README, and unit expectations in sync
- document the upstream fix for repeated Tencent EdgeOne workflows with no pending domains
- preserve the existing runtime contract: HTTP `8090`, PocketBase data at `/app/pb_data`, and no new chart configuration

## Upstream review

- latest stable release: https://github.com/certimate-go/certimate/releases/tag/v0.4.28
- fixed upstream issue: https://github.com/certimate-go/certimate/issues/1381
- official image manifest verified for `linux/amd64`, `linux/arm64`, and `linux/arm`
- no breaking container, storage, port, or migration contract change found

## Local validation

- regression test first failed against `v0.4.27`, then passed after the bump
- `make image-verify IMAGE=certimate/certimate:v0.4.28`
- `make deps-check CHART=certimate`
- `make validate-chart CHART=certimate`: 17/17 layers passed
- 8 k3d scenarios passed: default, default-values, dual-stack, External Secrets, Gateway API, Ingress, NetworkPolicy, and ephemeral storage
- every scenario: Ready workload, active service endpoint, zero restarts, clean logs, no Warning events, clean namespace teardown
- Helm unittest: 33/33 tests passed
- Kubescape 4.0.9: 93.93939%, no critical or high findings
- `make preflight`, standards, markdown, release, and attribution checks passed without blockers

## Self-review

Reviewed the full upstream diff and the complete PR diff for version drift, missing defaults, schema mismatch, unsupported upgrade claims, runtime regressions, security changes, generated files, and attribution. The change is correctly scoped as a patch release and no blocker was found.

## Site

- https://github.com/helmforgedev/site/pull/460

Closes #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Helm chart to deploy Certimate version `v0.4.28` by default.
  * Documented the `0.4.28` fix for repeated Tencent EdgeOne deployments when no domains remain to update.
* **Documentation**
  * Updated container image references and security scan documentation to `v0.4.28`.
* **Tests**
  * Updated chart validation to expect the `v0.4.28` container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->