### PR TITLE
chore(clickhouse): upgrade image to 26.7.1

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -4,7 +4,7 @@ name: clickhouse
 description: Fast column-oriented OLAP database with production-safe standalone defaults
 type: application
 version: 1.0.1
-appVersion: "26.6.1"
+appVersion: "26.7.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -15,7 +15,7 @@ helm install clickhouse oci://ghcr.io/helmforgedev/helm/clickhouse
 
 ## Features
 
-- Official ClickHouse image pinned to `26.6.1`.
+- Official ClickHouse image pinned to `26.7.1`.
 - StatefulSet with persistent data volume.
 - Client Service exposing HTTP `8123` and native TCP `9000`.
 - Headless Service for stable pod DNS.
@@ -55,7 +55,7 @@ networkPolicy:
 | --- | --- | --- |
 | `replicaCount` | ClickHouse pod count. Must remain `1` | `1` |
 | `image.repository` | Official image repository | `docker.io/clickhouse/clickhouse-server` |
-| `image.tag` | Official full-version tag | `26.6.1` |
+| `image.tag` | Official full-version tag | `26.7.1` |
 | `clickhouse.database` | Initial database | `default` |
 | `clickhouse.user` | Initial user | `default` |
 | `clickhouse.password` | Initial password | `""` |
@@ -103,10 +103,19 @@ clusters.
 
 ## Upgrade Notes
 
-This release moves ClickHouse from the 25.8 LTS line to 26.6 stable. Review the
-upstream release notes and test application queries, persisted data, and backup
-restore procedures before upgrading production workloads. StatefulSet rolling
-updates reuse the existing data volume; take a verified backup first.
+This release moves ClickHouse from 26.6 to 26.7 stable. Review the upstream
+[ClickHouse 26.7 release notes](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.1.1315-stable)
+and backward-incompatible changes before upgrading production workloads.
+Important changes include explicit credentials for user SQL that accesses S3,
+rejection of ZIP/ZIPX backups on object storage, stricter
+`AggregatingMergeTree` dimensions, removal of XML `resources` and
+`workload_classifiers`, and startup rejection of legacy
+`insert_deduplication_version` values. StatefulSet rolling updates reuse the
+existing data volume; take a verified backup and test application queries and
+restore procedures first.
+
+The Helm test now authenticates through the configured Secret, verifies the
+running version, and executes an `EXPLAIN ANALYZE` query introduced in 26.7.
 
 <!-- @AI-METADATA
 type: chart-readme

--- a/charts/clickhouse/templates/tests/test-connection.yaml
+++ b/charts/clickhouse/templates/tests/test-connection.yaml
@@ -19,7 +19,33 @@ spec:
       command:
         - sh
         - -ec
-        - curl -fsS --connect-timeout 5 --max-time 15 "http://{{ include "clickhouse.fullname" . }}:{{ .Values.service.ports.http }}/ping" | grep -q Ok
+        - |-
+          endpoint="http://{{ include "clickhouse.fullname" . }}:{{ .Values.service.ports.http }}"
+          auth="${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD:-}"
+          curl -fsS --connect-timeout 5 --max-time 15 "${endpoint}/ping" | grep -q Ok
+          actual_version="$(curl -fsS --connect-timeout 5 --max-time 15 --user "${auth}" --get --data-urlencode "query=SELECT version()" "${endpoint}/")"
+          case "${actual_version}" in
+            "${CLICKHOUSE_EXPECTED_VERSION}"*) ;;
+            *)
+              echo "unexpected ClickHouse version: expected ${CLICKHOUSE_EXPECTED_VERSION}, got ${actual_version}" >&2
+              exit 1
+              ;;
+          esac
+          curl -fsS --connect-timeout 5 --max-time 15 --user "${auth}" --get \
+            --data-urlencode "query=EXPLAIN ANALYZE SELECT number FROM numbers(10) WHERE number % 2 = 0" \
+            "${endpoint}/" | grep -q .
+      env:
+        - name: CLICKHOUSE_EXPECTED_VERSION
+          value: {{ .Chart.AppVersion | quote }}
+        - name: CLICKHOUSE_USER
+          value: {{ .Values.clickhouse.user | quote }}
+        {{- if or .Values.clickhouse.password .Values.clickhouse.existingSecret .Values.externalSecrets.enabled }}
+        - name: CLICKHOUSE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "clickhouse.secretName" . }}
+              key: {{ .Values.clickhouse.existingSecretPasswordKey }}
+        {{- end }}
       resources:
         requests:
           cpu: 10m

--- a/charts/clickhouse/tests/statefulset_test.yaml
+++ b/charts/clickhouse/tests/statefulset_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/clickhouse/clickhouse-server:26.6.1
+          value: docker.io/clickhouse/clickhouse-server:26.7.1
   - it: exposes HTTP and native TCP ports
     template: statefulset.yaml
     asserts:

--- a/charts/clickhouse/tests/test_connection_test.yaml
+++ b/charts/clickhouse/tests/test_connection_test.yaml
@@ -12,7 +12,30 @@ tests:
           value: test
       - matchRegex:
           path: spec.containers[0].command[2]
-          pattern: --max-time 15.*/ping
+          pattern: EXPLAIN ANALYZE
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: CLICKHOUSE_EXPECTED_VERSION
+            value: "26.7.1"
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: CLICKHOUSE_USER
+            value: default
       - equal:
           path: spec.activeDeadlineSeconds
           value: 60
+  - it: authenticates queries with the configured Secret
+    set:
+      clickhouse:
+        password: test-password
+    asserts:
+      - contains:
+          path: spec.containers[0].env
+          content:
+            name: CLICKHOUSE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-clickhouse-auth
+                key: clickhouse-password

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official ClickHouse image repository
   repository: docker.io/clickhouse/clickhouse-server
   # -- Official full-version tag
-  tag: "26.6.1"
+  tag: "26.7.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrade the official ClickHouse image from 26.6.1 to 26.7.1
- strengthen the Helm test to authenticate with the configured Secret, verify the running version, and execute `EXPLAIN ANALYZE`
- document the upstream 26.7 backward-incompatible changes and production migration precautions

Resolves #834

## Type Of Change

- [x] Existing chart change
- [ ] New chart
- [ ] Documentation only
- [ ] CI / repository workflow

## Upstream Verification

- [x] Official release `v26.7.1.1315-stable` reviewed
- [x] `docker.io/clickhouse/clickhouse-server:26.7.1` pulled successfully
- [x] linux/amd64 and linux/arm64 manifests verified
- [x] Image build version verified as `26.7.1.1315`
- [x] Digest observed locally: `sha256:d7556a3841027651307b5aa08d72b5c467d0241d3db5b67d9e158ef3975626f5`

## Site Sync (GR-007)

- [x] Companion documentation PR: helmforgedev/site#461

## Local Validation

- [x] `make validate-chart CHART=clickhouse` passed all 18 layers
- [x] Default plus all 8 `ci/*.yaml` k3d scenarios passed
- [x] Workloads had zero restarts, clean logs, ready endpoints, and no Warning events while active
- [x] `helm test` passed against a passwordless deployment
- [x] `helm test` passed against a password-backed Secret deployment
- [x] Direct upstream image probe returned `26.7.1.1315` and executed `EXPLAIN ANALYZE`
- [x] `make release-check REPO=charts` and attribution check passed

## Self-review

Reviewed the full diff for runtime compatibility, authentication, secret naming, shell failure handling, documentation accuracy, and release semantics. Ports, storage paths, probes, security contexts, and public values remain unchanged. The chart version was not edited; CI owns the patch release bump.