### PR TITLE
chore(cloudflared): upgrade image to 2026.7.3

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.12
-appVersion: "2026.7.2"
+appVersion: "2026.7.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -176,6 +176,18 @@ topologySpreadConstraints:
 - **Routing is dashboard-managed** — this chart does not configure ingress rules; use the Cloudflare dashboard to map public hostnames to internal services
 - **No ingress template** — cloudflared replaces traditional ingress controllers
 
+## Upgrade Notes
+
+Cloudflared 2026.7.3 is a security and connectivity maintenance release. It
+updates `golang.org/x/text` and related dependencies for a CVE fix, aligns
+connectivity prechecks with the curves used for edge connections, and protects
+Windows service tokens with `--token-file`. The Kubernetes tunnel command and
+chart values contract are unchanged.
+
+Review the
+[official 2026.7.3 release](https://github.com/cloudflare/cloudflared/releases/tag/2026.7.3)
+before production rollout.
+
 ## Security Scan
 
 🟢 Security Scan: `cloudflared`

--- a/charts/cloudflared/tests/deployment_test.yaml
+++ b/charts/cloudflared/tests/deployment_test.yaml
@@ -35,9 +35,9 @@ tests:
   - it: should set the correct image
     template: templates/deployment.yaml
     asserts:
-      - matchRegex:
+      - equal:
           path: spec.template.spec.containers[0].image
-          pattern: "docker.io/cloudflare/cloudflared:.*"
+          value: "docker.io/cloudflare/cloudflared:2026.7.3"
 
   - it: should use custom image tag
     template: templates/deployment.yaml

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.7.2"
+  tag: "2026.7.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- upgrade the official Cloudflared image from 2026.7.2 to 2026.7.3
- replace the permissive image regex test with an exact default-image assertion
- document the security and connectivity maintenance changes from the official release

Resolves #835

## Type Of Change

- [x] Existing chart change
- [ ] New chart
- [ ] Documentation only
- [ ] CI / repository workflow

## Upstream Verification

- [x] Official release `2026.7.3` reviewed; published and not a prerelease
- [x] `docker.io/cloudflare/cloudflared:2026.7.3` pulled successfully
- [x] linux/amd64 and linux/arm64 manifests verified
- [x] Binary reports `cloudflared version 2026.7.3`
- [x] Image commit verified as `3a2b45c2a511fcdd81b68c190938e4ffadbea5dc`
- [x] Digest observed locally: `sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf`

## Site Sync (GR-007)

- [x] Companion documentation PR: helmforgedev/site#462

## Local Validation

- [x] `make validate-chart CHART=cloudflared` passed all 16 layers
- [x] Default plus all 6 `ci/*.yaml` k3d scenarios passed
- [x] HA scenario validated 3 stable replicas
- [x] Quick tunnel, External Secrets, monitoring, and IP family scenarios passed
- [x] Workloads had zero restarts, clean logs, ready endpoints, and no Warning events
- [x] `make release-check REPO=charts` and attribution check passed

## Self-review

Reviewed the full diff against the official changelog and commit range. The release fixes a dependency CVE, aligns connection precheck curves, and protects Windows service tokens. It does not change the Kubernetes tunnel command, metrics endpoints, probes, security context, or public values contract. The chart version was not edited; CI owns the patch release bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Cloudflared Helm chart to package client version 2026.7.3.
  * Added upgrade notes covering security and connectivity maintenance updates.

* **Documentation**
  * Clarified that Kubernetes tunnel commands and chart values remain unchanged.

* **Tests**
  * Improved deployment validation to verify the exact Cloudflared container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->