### PR TITLE
chore(elasticsearch): upgrade stack to 9.4.4

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.1.4
-appVersion: "9.4.3"
+appVersion: "9.4.4"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -161,7 +161,7 @@ dataTiers:
 | `namespaceOverride` | Namespace for chart-managed namespaced resources | `""` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.4.3` |
+| `image.tag` | Image tag | `9.4.4` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -262,7 +262,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.3` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.4` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -311,11 +311,14 @@ Security posture acceptable.
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.3` is an upstream image update from
-`9.4.2` with upstream fixes and enhancements. Review the upstream Elasticsearch
-release notes before upgrading production clusters, take a snapshot backup, and
-verify Kibana compatibility, plugins, ILM policies, and index templates in a
-staging environment before reusing existing PVCs.
+`docker.io/library/elasticsearch:9.4.4` is an upstream image update from
+`9.4.3`. It improves aggregation memory accounting, search timeout enforcement,
+data stream authorization, snapshot handling on CIFS shares, ML model validation,
+and ES|QL reliability. Review the
+[upstream Elasticsearch 9.4.4 release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.4.4-release-notes)
+before upgrading production clusters, take a snapshot backup, and verify Kibana
+compatibility, plugins, ILM policies, and index templates in a staging
+environment before reusing existing PVCs.
 
 ## Resources Generated
 

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.4.3
+          value: docker.io/library/kibana:9.4.4
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.4.3
+          value: docker.io/library/elasticsearch:9.4.4
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -37,7 +37,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.4.3"
+          "default": "9.4.4"
         },
         "pullPolicy": {
           "type": "string",
@@ -247,7 +247,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.4.3"
+              "default": "9.4.4"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.4.3"
+  tag: "9.4.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -324,7 +324,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.4.3"
+    tag: "9.4.4"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
Closes #836.

## Summary

- Upgrade the official Elasticsearch image from 9.4.3 to 9.4.4.
- Upgrade the optional official Kibana image from 9.4.3 to 9.4.4 to preserve Elastic Stack version alignment.
- Update schema defaults, README guidance, and exact image assertions.
- Document notable upstream fixes for aggregation memory accounting, search timeouts, data-stream authorization, CIFS snapshots, ML validation, and ES|QL reliability.

## Upstream evidence

- Official release: https://github.com/elastic/elasticsearch/releases/tag/v9.4.4
- Official release notes: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.4.4-release-notes
- `docker.io/library/elasticsearch:9.4.4`: verified for linux/amd64 and linux/arm64.
- `docker.io/library/kibana:9.4.4`: verified for linux/amd64 and linux/arm64.
- No required chart configuration or breaking change was identified for this patch release.

## Site sync

- helmforgedev/site#463

## Validation

- TDD red: the two exact image tests failed against 9.4.3 before implementation.
- `helm unittest charts/elasticsearch`: 14 suites, 99 tests passed.
- `make validate-chart CHART=elasticsearch`: 17 layers passed, including default plus all 7 CI scenarios on k3d.
- k3d runtime coverage included data tiers, dev, dual-stack, External Secrets, Gateway API, production-ha, and staging; up to 5 pods were exercised with zero restarts, no warning events, and no crash/fatal log patterns.
- Manual Elasticsearch/Kibana integration: both reported 9.4.4, Kibana reported all services/plugins available, two documents were indexed, and an aggregation returned the expected average of 50.0.
- Investigated the two one-time Kibana workflow rollover startup messages: upstream starts the rollover asynchronously before lazy data-stream creation, catches the missing-index response, reached `available`, and emitted no further errors after readiness.
- `make standards-check CHART=elasticsearch`
- `make deps-check CHART=elasticsearch`
- `make site-sync-check CHART=elasticsearch`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Self-review

- Scope is limited to version defaults, matching schema/docs, and exact image tests.
- Elasticsearch and Kibana remain version-aligned everywhere in the chart contract.
- Chart package version was not edited; release automation remains responsible for the patch release.
- No unrelated files, floating tags, new dependencies, or attribution trailers were introduced.