### PR TITLE
chore(envoy-gateway): update to v1.8.3

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 1.8.0
-appVersion: "v1.8.2"
+appVersion: "v1.8.3"
 kubeVersion: ">=1.24.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,7 +1,7 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.8.2 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
+v1.8.3 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
 Envoy proxy pods automatically in response to Gateway API resources.
 
 ## Installation
@@ -24,7 +24,7 @@ helm install envoy-gateway oci://ghcr.io/helmforgedev/helm/envoy-gateway
 
 Envoy Gateway and Gateway API experimental v1.5.1 CRDs are bundled in the local
 `crds` subchart and installed automatically by default. This includes
-`ListenerSet`, which Envoy Gateway v1.8.2 requires. Set `crds.enabled=false`
+`ListenerSet`, which Envoy Gateway v1.8.3 requires. Set `crds.enabled=false`
 only when a platform operator, GitOps controller, or another release manages
 all required CRDs. Helm installs CRDs on first install but does not upgrade or
 delete them automatically; review upstream CRD changes before chart upgrades.
@@ -164,7 +164,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.8.2` | Controller image tag |
+| `controller.image.tag` | `v1.8.3` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -182,7 +182,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.8.2` | Certgen image tag |
+| `certgen.image.tag` | `v1.8.3` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -201,7 +201,7 @@ highAvailability:
 | `proxy.image.tag` | `distroless-v1.38.0` | Proxy image tag |
 | `proxy.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `proxy.shutdownManager.image.repository` | `docker.io/envoyproxy/gateway` | Shutdown manager sidecar image repository |
-| `proxy.shutdownManager.image.tag` | `v1.8.2` | Shutdown manager sidecar image tag |
+| `proxy.shutdownManager.image.tag` | `v1.8.3` | Shutdown manager sidecar image tag |
 | `proxy.shutdownManager.image.pullPolicy` | `IfNotPresent` | Shutdown manager image pull policy |
 | `proxy.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `proxy.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -277,6 +277,8 @@ highAvailability:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `rateLimiting.enabled` | `false` | Enable rate limiting |
+| `rateLimiting.service.image.repository` | `docker.io/envoyproxy/ratelimit` | Rate limit service image repository |
+| `rateLimiting.service.image.tag` | `1e50889b` | Rate limit service image tag aligned with Envoy Gateway v1.8.3 |
 | `rateLimiting.externalRedis.host` | `""` | External Redis host |
 | `rateLimiting.externalRedis.port` | `6379` | External Redis port |
 | `rateLimiting.externalRedis.auth.enabled` | `false` | Enable Redis authentication |
@@ -320,7 +322,7 @@ highAvailability:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `serviceAccount.create` | `true` | Create ServiceAccount |
-| `serviceAccount.name` | `""` | ServiceAccount name (generated if empty) |
+| `serviceAccount.name` | `""` | ServiceAccount name (generated if empty; must be `envoy-gateway` when rate limiting is enabled) |
 | `serviceAccount.annotations` | `{}` | ServiceAccount annotations |
 | `rbac.create` | `true` | Create RBAC resources |
 
@@ -436,21 +438,34 @@ Major architectural redesign to align with the EG operator model.
 
 ## Upgrade Notes
 
-`docker.io/envoyproxy/gateway:v1.8.2` is the upstream patch update from
-`v1.8.1`. The automatically generated issue referenced `1.8.2`, but Docker Hub
+`docker.io/envoyproxy/gateway:v1.8.3` is the upstream patch update from
+`v1.8.2`. The automatically generated issue referenced `1.8.3`, but Docker Hub
 publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
 keeps the managed Envoy proxy image pinned to
 `docker.io/envoyproxy/envoy:distroless-v1.38.0`, which remains aligned with the
-upstream v1.8 compatibility matrix.
+upstream v1.8 compatibility matrix. The rate limit deployment now uses the
+upstream v1.8.3 default `docker.io/envoyproxy/ratelimit:1e50889b` and honors the
+`rateLimiting.service.image` override through the EnvoyGateway configuration.
+When rate limiting is enabled, the chart also uses the upstream-required
+`envoy-gateway` names for the controller Deployment and ServiceAccount. If the
+ServiceAccount is externally managed, set
+`serviceAccount.create=false,serviceAccount.name=envoy-gateway`.
+The controller Service exposes the rate-limit xDS port `18001`, bundled Redis
+uses its `-redis-client` endpoint, and Redis authentication is injected into the
+managed rate-limit Deployment through `REDIS_AUTH` from either the bundled or
+external Secret.
 
-Envoy Gateway v1.8.2 includes upstream bug fixes for Gateway API conditions,
-Backend TLS ALPN handling, ExternalName backends, Kubernetes 1.36 rate limit
-validation, EnvoyGateway config hot reload, and route timeout handling. It also
-tightens admission validation for `SecurityPolicy.spec.apiKeyAuth.extractFrom`:
-each entry must specify exactly one of `headers`, `params`, or `cookies`, and
-source names must be non-empty. Before upgrading production controllers, verify
-Gateway API and Envoy Gateway CRDs in staging, and test existing Gateway,
-HTTPRoute, EnvoyProxy, `BackendTrafficPolicy`, and `SecurityPolicy` resources.
+Envoy Gateway v1.8.3 updates its distroless base and fixes backend TLS 1.3
+defaults, mismatched or malformed listener certificates, IPv6 literal OIDC
+endpoints, translator status races, and Wasm fetch retries. It also moves
+EnvoyExtensionPolicy Lua source from per-route overrides to listener-level
+filters. This changes generated xDS Lua filter names and layout; update any
+EnvoyPatchPolicy or extension server that matches the previous
+`envoy.filters.http.lua/` keys. Review the
+[upstream v1.8.3 release notes](https://gateway.envoyproxy.io/news/releases/notes/v1.8.3)
+before upgrading, verify Gateway API and Envoy Gateway CRDs in staging, and test
+existing Gateway, HTTPRoute, EnvoyProxy, `BackendTrafficPolicy`,
+`SecurityPolicy`, EnvoyExtensionPolicy, and EnvoyPatchPolicy resources.
 
 ### Version 1.0.0
 

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -308,6 +308,8 @@ highAvailability:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `security.networkPolicies` | `false` | Enable rendering of NetworkPolicy resources |
+| `security.networkPolicy.dns.namespace` | `kube-system` | Namespace containing cluster DNS pods allowed by NetworkPolicies |
+| `security.networkPolicy.dns.podLabels` | `{"k8s-app":"kube-dns"}` | Labels selecting cluster DNS pods allowed by NetworkPolicies |
 | `security.podSecurityStandards` | `true` | Enable PodSecurityStandards (restricted mode) |
 
 ### High Availability

--- a/charts/envoy-gateway/ci/external-secrets.yaml
+++ b/charts/envoy-gateway/ci/external-secrets.yaml
@@ -1,15 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # CI scenario: ExternalSecrets with drift guard (GR-061)
 redis:
-  enabled: false
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: true
+    password: helmforge-test-password
+  standalone:
+    persistence:
+      enabled: false
 
 rateLimiting:
   enabled: true
   externalRedis:
-    host: "redis-external"
+    host: "envoy-gateway-ci-external-secrets-redis-client"
     auth:
       enabled: true
       secretName: envoy-redis-credentials
+      secretKey: redis-password
 
 externalSecrets:
   enabled: true

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -34,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.8.2
+    tag: v1.8.3
   resources:
     requests:
       cpu: 10m

--- a/charts/envoy-gateway/docs/rate-limiting.md
+++ b/charts/envoy-gateway/docs/rate-limiting.md
@@ -211,7 +211,7 @@ kubectl exec -it envoy-gateway-redis-0 -- redis-cli ping
 
 ```bash
 # Port-forward to the managed rate-limit service
-kubectl port-forward svc/envoy-ratelimit 19001:19001
+kubectl -n <namespace> port-forward svc/envoy-ratelimit 19001:19001
 
 # Check rate limit metrics
 curl http://localhost:19001/metrics | grep ratelimit

--- a/charts/envoy-gateway/docs/rate-limiting.md
+++ b/charts/envoy-gateway/docs/rate-limiting.md
@@ -24,15 +24,17 @@ Deploy Redis StatefulSet with the chart:
 ```yaml
 rateLimiting:
   enabled: true
-  redis:
-    enabled: true
-    resources:
-      requests:
-        cpu: 100m
-        memory: 128Mi
-      limits:
-        cpu: 500m
-        memory: 512Mi
+
+redis:
+  enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  standalone:
     persistence:
       enabled: true
       size: 2Gi
@@ -51,8 +53,6 @@ Use an existing Redis instance:
 ```yaml
 rateLimiting:
   enabled: true
-  redis:
-    enabled: false
   externalRedis:
     host: redis.example.com
     port: 6379
@@ -60,6 +60,9 @@ rateLimiting:
       enabled: true
       secretName: redis-auth
       secretKey: password
+
+redis:
+  enabled: false
 ```
 
 Create the secret:
@@ -87,7 +90,8 @@ Creates `BackendTrafficPolicy` with a `targetRef.kind: Gateway` targeting the ac
 - **Scope**: Per client IP (x-real-ip header)
 - **Type**: Global (distributed across all proxy instances)
 
-Usage:
+Routes attached to that Gateway inherit the policy. No `ExtensionRef` filter is
+required:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -95,16 +99,12 @@ kind: HTTPRoute
 metadata:
   name: my-api
 spec:
+  parentRefs:
+  - name: envoy-gateway
   rules:
   - backendRefs:
     - name: api-service
       port: 80
-    filters:
-    - type: ExtensionRef
-      extensionRef:
-        group: gateway.envoyproxy.io
-        kind: BackendTrafficPolicy
-        name: envoy-gateway-ratelimit-api
 ```
 
 ### Strict Preset (10 requests/minute)
@@ -210,18 +210,18 @@ kubectl exec -it envoy-gateway-redis-0 -- redis-cli ping
 ### View Rate Limit Metrics
 
 ```bash
-# Port-forward to controller
-kubectl port-forward svc/envoy-gateway-controller 8081:8081
+# Port-forward to the managed rate-limit service
+kubectl port-forward svc/envoy-ratelimit 19001:19001
 
 # Check rate limit metrics
-curl http://localhost:8081/metrics | grep ratelimit
+curl http://localhost:19001/metrics | grep ratelimit
 ```
 
 Key metrics:
 
-- `envoy_cluster_ratelimit_over_limit` — requests rejected by rate limiter
-- `envoy_cluster_ratelimit_ok` — requests allowed by rate limiter
-- `envoy_cluster_ratelimit_error` — rate limiter errors
+- `ratelimit_service_total_requests` — rate-limit gRPC checks
+- `ratelimit_service_response_time_seconds` — check latency
+- `ratelimit_service_should_rate_limit_error` — rate-limit service errors
 
 ## Troubleshooting
 
@@ -238,14 +238,15 @@ kubectl get pods -l app.kubernetes.io/component=redis
 # Check rate limit policy
 kubectl get backendtrafficpolicy
 
-# Verify HTTPRoute has ExtensionRef filter
-kubectl get httproute <route-name> -o yaml | grep -A 10 filters
+# Verify the policy target and that the route uses the same Gateway
+kubectl get backendtrafficpolicy <policy-name> -o yaml
+kubectl get httproute <route-name> -o yaml
 ```
 
 **Common Causes**:
 
 1. Redis pod not running
-2. Rate limit policy not attached to HTTPRoute
+2. Rate limit policy and HTTPRoute target different Gateways
 3. Wrong header selector (x-real-ip vs x-forwarded-for)
 4. External Redis not reachable
 

--- a/charts/envoy-gateway/docs/rate-limiting.md
+++ b/charts/envoy-gateway/docs/rate-limiting.md
@@ -69,7 +69,8 @@ Create the secret:
 
 ```bash
 kubectl create secret generic redis-auth \
-  --from-literal=password=your-redis-password
+  --from-literal=password=your-redis-password \
+  -n <namespace>
 ```
 
 ## Rate Limit Presets
@@ -236,11 +237,11 @@ Key metrics:
 kubectl get pods -l app.kubernetes.io/component=redis
 
 # Check rate limit policy
-kubectl get backendtrafficpolicy
+kubectl get backendtrafficpolicy -n <namespace>
 
 # Verify the policy target and that the route uses the same Gateway
-kubectl get backendtrafficpolicy <policy-name> -o yaml
-kubectl get httproute <route-name> -o yaml
+kubectl get backendtrafficpolicy <policy-name> -n <namespace> -o yaml
+kubectl get httproute <route-name> -n <namespace> -o yaml
 ```
 
 **Common Causes**:

--- a/charts/envoy-gateway/templates/NOTES.txt
+++ b/charts/envoy-gateway/templates/NOTES.txt
@@ -172,7 +172,7 @@ Rate Limiting: Enabled
 
 {{- if .Values.redis.enabled }}
 Redis Backend: helmforge/redis subchart (standalone)
-  Service: {{ .Release.Name }}-redis.{{ .Release.Namespace }}.svc.cluster.local:6379
+  Service: {{ .Release.Name }}-redis-client.{{ .Release.Namespace }}.svc.cluster.local:6379
 
 Check Redis status:
   kubectl get statefulset {{ .Release.Name }}-redis -n {{ .Release.Namespace }}

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -76,10 +76,24 @@ app.kubernetes.io/component: controller
 Create the name of the service account to use
 */}}
 {{- define "envoy-gateway.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if .Values.rateLimiting.enabled }}
+{{- "envoy-gateway" }}
+{{- else if .Values.serviceAccount.create }}
 {{- default (include "envoy-gateway.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Controller Deployment name. Envoy Gateway's global rate-limit infrastructure
+requires its owning controller Deployment to use the upstream canonical name.
+*/}}
+{{- define "envoy-gateway.controllerName" -}}
+{{- if .Values.rateLimiting.enabled }}
+{{- "envoy-gateway" }}
+{{- else }}
+{{- printf "%s-controller" (include "envoy-gateway.fullname" .) }}
 {{- end }}
 {{- end }}
 
@@ -206,14 +220,14 @@ SecurityPolicy target name - returns targetName or gateway name
 
 {{/*
 Rate limit Redis URL - returns subchart or external Redis URL.
-Subchart (redis.enabled=true): redis service is named "<release>-redis" by the helmforge/redis chart.
+Subchart (redis.enabled=true): redis service is named "<release>-redis-client" by the helmforge/redis chart.
 External (rateLimiting.externalRedis.host set): use the provided host/port.
 */}}
 {{- define "envoy-gateway.ratelimit.redisUrl" -}}
-{{- if .Values.redis.enabled }}
-{{- printf "redis://%s-redis.%s.svc.cluster.local:6379" .Release.Name .Release.Namespace }}
-{{- else if .Values.rateLimiting.externalRedis.host }}
-{{- printf "redis://%s:%d" .Values.rateLimiting.externalRedis.host (.Values.rateLimiting.externalRedis.port | int) }}
+{{- if .Values.rateLimiting.externalRedis.host }}
+{{- printf "%s:%d" .Values.rateLimiting.externalRedis.host (.Values.rateLimiting.externalRedis.port | int) }}
+{{- else if .Values.redis.enabled }}
+{{- printf "%s-redis-client.%s.svc.cluster.local:6379" .Release.Name .Release.Namespace }}
 {{- end }}
 {{- end }}
 
@@ -248,6 +262,12 @@ Central fail-fast validation entrypoint.
 {{- end -}}
 {{- if and .Values.rateLimiting.enabled (not .Values.redis.enabled) .Values.rateLimiting.externalRedis.host .Values.rateLimiting.externalRedis.auth.enabled (not .Values.rateLimiting.externalRedis.auth.secretName) -}}
 {{- fail "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName" -}}
+{{- end -}}
+{{- if and .Values.rateLimiting.enabled .Values.serviceAccount.create .Values.serviceAccount.name (ne .Values.serviceAccount.name "envoy-gateway") -}}
+{{- fail "rateLimiting.enabled requires serviceAccount.name to be empty or envoy-gateway" -}}
+{{- end -}}
+{{- if and .Values.rateLimiting.enabled (not .Values.serviceAccount.create) (ne .Values.serviceAccount.name "envoy-gateway") -}}
+{{- fail "rateLimiting.enabled with serviceAccount.create=false requires serviceAccount.name=envoy-gateway" -}}
 {{- end -}}
 {{- $podLabels := .Values.podLabels | default dict -}}
 {{- $selectorLabels := include "envoy-gateway.controller.selectorLabels" . | fromYaml -}}

--- a/charts/envoy-gateway/templates/configmap.yaml
+++ b/charts/envoy-gateway/templates/configmap.yaml
@@ -34,7 +34,7 @@ data:
                               secretKeyRef:
                                 name: {{ .Values.rateLimiting.externalRedis.auth.secretName }}
                                 key: {{ .Values.rateLimiting.externalRedis.auth.secretKey }}
-          {{- else if and .Values.rateLimiting.enabled .Values.redis.enabled .Values.redis.auth.enabled }}
+          {{- else if and .Values.rateLimiting.enabled (not .Values.rateLimiting.externalRedis.host) .Values.redis.enabled .Values.redis.auth.enabled }}
           patch:
             type: StrategicMerge
             value:

--- a/charts/envoy-gateway/templates/configmap.yaml
+++ b/charts/envoy-gateway/templates/configmap.yaml
@@ -16,6 +16,40 @@ data:
       type: Kubernetes
       kubernetes:
         envoyDeploymentSpec: {}
+        rateLimitDeployment:
+          container:
+            image: {{ printf "%s:%s" .Values.rateLimiting.service.image.repository .Values.rateLimiting.service.image.tag }}
+          {{- if and .Values.rateLimiting.enabled .Values.rateLimiting.externalRedis.host .Values.rateLimiting.externalRedis.auth.enabled }}
+          patch:
+            type: StrategicMerge
+            value:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: envoy-ratelimit
+                        env:
+                          - name: REDIS_AUTH
+                            valueFrom:
+                              secretKeyRef:
+                                name: {{ .Values.rateLimiting.externalRedis.auth.secretName }}
+                                key: {{ .Values.rateLimiting.externalRedis.auth.secretKey }}
+          {{- else if and .Values.rateLimiting.enabled .Values.redis.enabled .Values.redis.auth.enabled }}
+          patch:
+            type: StrategicMerge
+            value:
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: envoy-ratelimit
+                        env:
+                          - name: REDIS_AUTH
+                            valueFrom:
+                              secretKeyRef:
+                                name: {{ printf "%s-redis-auth" .Release.Name }}
+                                key: redis-password
+          {{- end }}
     {{- if .Values.rateLimiting.enabled }}
     rateLimit:
       backend:

--- a/charts/envoy-gateway/templates/deployment-controller.yaml
+++ b/charts/envoy-gateway/templates/deployment-controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "envoy-gateway.fullname" . }}-controller
+  name: {{ include "envoy-gateway.controllerName" . }}
   namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
     {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
@@ -59,6 +59,11 @@ spec:
         - name: xds
           containerPort: 18000
           protocol: TCP
+        {{- if .Values.rateLimiting.enabled }}
+        - name: ratelimit
+          containerPort: 18001
+          protocol: TCP
+        {{- end }}
         - name: wasm
           containerPort: 18002
           protocol: TCP

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -33,6 +33,10 @@ spec:
       port: 18000
     - protocol: TCP
       port: 18002
+    {{- if .Values.rateLimiting.enabled }}
+    - protocol: TCP
+      port: 18001
+    {{- end }}
   egress:
   - to:
     - namespaceSelector: {}
@@ -74,7 +78,8 @@ spec:
   - from:
     - podSelector:
         matchLabels:
-          {{- include "envoy-gateway.selectorLabels" . | nindent 10 }}
+          app.kubernetes.io/name: envoy-ratelimit
+          app.kubernetes.io/managed-by: envoy-gateway
           app.kubernetes.io/component: ratelimit
     ports:
     - protocol: TCP
@@ -93,7 +98,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "envoy-gateway.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: envoy-ratelimit
+      app.kubernetes.io/managed-by: envoy-gateway
       app.kubernetes.io/component: ratelimit
   policyTypes:
   - Ingress
@@ -124,5 +130,13 @@ spec:
     - protocol: TCP
       port: {{ .Values.rateLimiting.externalRedis.port }}
   {{- end }}
+  - to:
+    - namespaceSelector: {}
+      podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
 {{- end }}
 {{- end }}

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -46,8 +46,12 @@ spec:
     - protocol: TCP
       port: 6443
   - to:
-    - namespaceSelector: {}
-      podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Values.security.networkPolicy.dns.namespace | quote }}
+      podSelector:
+        matchLabels:
+          {{- toYaml .Values.security.networkPolicy.dns.podLabels | nindent 10 }}
     ports:
     - protocol: TCP
       port: 53
@@ -131,8 +135,12 @@ spec:
       port: {{ .Values.rateLimiting.externalRedis.port }}
   {{- end }}
   - to:
-    - namespaceSelector: {}
-      podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Values.security.networkPolicy.dns.namespace | quote }}
+      podSelector:
+        matchLabels:
+          {{- toYaml .Values.security.networkPolicy.dns.podLabels | nindent 10 }}
     ports:
     - protocol: TCP
       port: 53

--- a/charts/envoy-gateway/templates/service-controller.yaml
+++ b/charts/envoy-gateway/templates/service-controller.yaml
@@ -51,6 +51,12 @@ spec:
     port: 18000
     targetPort: 18000
     protocol: TCP
+  {{- if .Values.rateLimiting.enabled }}
+  - name: ratelimit
+    port: 18001
+    targetPort: 18001
+    protocol: TCP
+  {{- end }}
   - name: wasm
     port: 18002
     targetPort: 18002

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -77,9 +77,9 @@ tests:
 
   - it: should use controller image by default
     asserts:
-      - matchRegex:
+      - equal:
           path: spec.template.spec.containers[0].image
-          pattern: "envoyproxy/gateway:v1.8.2"
+          value: docker.io/envoyproxy/gateway:v1.8.3
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
+++ b/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
@@ -40,7 +40,7 @@ tests:
           value: shutdown-manager
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.2
+          value: docker.io/envoyproxy/gateway:v1.8.3
 
   - it: should configure DaemonSet mode when kind is DaemonSet
     set:
@@ -53,7 +53,7 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment
       - equal:
           path: spec.provider.kubernetes.envoyDaemonSet.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.2
+          value: docker.io/envoyproxy/gateway:v1.8.3
 
   - it: should set proxy service type
     set:

--- a/charts/envoy-gateway/tests/monitoring_test.yaml
+++ b/charts/envoy-gateway/tests/monitoring_test.yaml
@@ -112,7 +112,24 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "redis://"
+          pattern: "redis-client\\."
+        template: configmap.yaml
+      - matchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "image: docker.io/envoyproxy/ratelimit:1e50889b"
+        template: configmap.yaml
+
+  - it: should configure a custom rate limit service image
+    set:
+      rateLimiting:
+        service:
+          image:
+            repository: registry.example.com/platform/ratelimit
+            tag: "custom"
+    asserts:
+      - matchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "image: registry.example.com/platform/ratelimit:custom"
         template: configmap.yaml
 
   - it: should not have rateLimit section in configmap when rate limiting disabled
@@ -122,5 +139,5 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "rateLimit"
+          pattern: "(?m)^rateLimit:$"
         template: configmap.yaml

--- a/charts/envoy-gateway/tests/rate-limiting_test.yaml
+++ b/charts/envoy-gateway/tests/rate-limiting_test.yaml
@@ -3,6 +3,9 @@ suite: Rate Limiting
 templates:
   - ratelimit-policies.yaml
   - configmap.yaml
+  - deployment-controller.yaml
+  - serviceaccount.yaml
+  - service-controller.yaml
 tests:
   # Redis subchart is rendered by Helm, not by helm-unittest.
   # Tests here cover configmap URL generation and rate limit policies.
@@ -20,8 +23,29 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "redis://RELEASE-NAME-redis\."
+          pattern: "url: RELEASE-NAME-redis-client\."
         template: configmap.yaml
+      - equal:
+          path: metadata.name
+          value: envoy-gateway
+        template: deployment-controller.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: envoy-gateway
+        template: deployment-controller.yaml
+      - equal:
+          path: metadata.name
+          value: envoy-gateway
+        template: serviceaccount.yaml
+      - contains:
+          path: spec.ports
+          content:
+            name: ratelimit
+            port: 18001
+            targetPort: 18001
+            protocol: TCP
+        template: service-controller.yaml
+        documentIndex: 1
 
   - it: should use external redis url when externalRedis host set
     set:
@@ -35,7 +59,33 @@ tests:
     asserts:
       - matchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "redis://my-redis\.infra\.svc\.cluster\.local:6379"
+          pattern: "url: my-redis\.infra\.svc\.cluster\.local:6379"
+        template: configmap.yaml
+
+  - it: should inject external Redis auth from the configured Secret
+    set:
+      rateLimiting:
+        enabled: true
+        externalRedis:
+          host: my-redis.infra.svc.cluster.local
+          auth:
+            enabled: true
+            secretName: redis-credentials
+            secretKey: redis-password
+      redis:
+        enabled: false
+    asserts:
+      - matchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "name: REDIS_AUTH"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "name: redis-credentials"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "key: redis-password"
         template: configmap.yaml
 
   - it: should not have rateLimit section in configmap when rate limiting disabled
@@ -45,7 +95,7 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "rateLimit"
+          pattern: "(?m)^rateLimit:$"
         template: configmap.yaml
 
   - it: should create rate limit policies with api preset

--- a/charts/envoy-gateway/tests/rate-limiting_test.yaml
+++ b/charts/envoy-gateway/tests/rate-limiting_test.yaml
@@ -23,7 +23,7 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "url: RELEASE-NAME-redis-client\."
+          pattern: 'url: RELEASE-NAME-redis-client\.'
         template: configmap.yaml
       - equal:
           path: metadata.name
@@ -59,7 +59,31 @@ tests:
     asserts:
       - matchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "url: my-redis\.infra\.svc\.cluster\.local:6379"
+          pattern: 'url: my-redis\.infra\.svc\.cluster\.local:6379'
+        template: configmap.yaml
+
+  - it: should not inject bundled Redis auth for an external Redis host
+    set:
+      rateLimiting:
+        enabled: true
+        externalRedis:
+          host: my-redis.infra.svc.cluster.local
+      redis:
+        enabled: true
+        auth:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: 'url: my-redis\.infra\.svc\.cluster\.local:6379'
+        template: configmap.yaml
+      - notMatchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "name: REDIS_AUTH"
+        template: configmap.yaml
+      - notMatchRegex:
+          path: data["envoy-gateway.yaml"]
+          pattern: "RELEASE-NAME-redis-auth"
         template: configmap.yaml
 
   - it: should inject external Redis auth from the configured Secret

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -32,6 +32,13 @@ tests:
             port: 18002
         template: networkpolicy.yaml
         documentIndex: 0
+      - notContains:
+          path: spec.ingress[2].ports
+          content:
+            protocol: TCP
+            port: 18001
+        template: networkpolicy.yaml
+        documentIndex: 0
 
   - it: should not create NetworkPolicies when disabled
     set:
@@ -107,12 +114,12 @@ tests:
         documentIndex: 1
       - equal:
           path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/name"]
-          value: envoy-gateway
+          value: envoy-ratelimit
         template: networkpolicy.yaml
         documentIndex: 1
       - equal:
-          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/instance"]
-          value: RELEASE-NAME
+          path: spec.ingress[0].from[0].podSelector.matchLabels["app.kubernetes.io/managed-by"]
+          value: envoy-gateway
         template: networkpolicy.yaml
         documentIndex: 1
       - equal:
@@ -131,6 +138,25 @@ tests:
         template: networkpolicy.yaml
         documentIndex: 2
       - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: envoy-ratelimit
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/managed-by"]
+          value: envoy-gateway
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: ratelimit
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - notExists:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/instance"]
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
           path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: NAMESPACE
         template: networkpolicy.yaml
@@ -145,6 +171,26 @@ tests:
           value: RELEASE-NAME
         template: networkpolicy.yaml
         documentIndex: 2
+      - contains:
+          path: spec.egress
+          content:
+            to:
+              - namespaceSelector: {}
+                podSelector: {}
+            ports:
+              - protocol: TCP
+                port: 53
+              - protocol: UDP
+                port: 53
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - contains:
+          path: spec.ingress[2].ports
+          content:
+            protocol: TCP
+            port: 18001
+        template: networkpolicy.yaml
+        documentIndex: 0
 
   - it: should create PrometheusRule when enabled
     set:

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -39,6 +39,16 @@ tests:
             port: 18001
         template: networkpolicy.yaml
         documentIndex: 0
+      - equal:
+          path: spec.egress[1].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: kube-system
+        template: networkpolicy.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels["k8s-app"]
+          value: kube-dns
+        template: networkpolicy.yaml
+        documentIndex: 0
 
   - it: should not create NetworkPolicies when disabled
     set:
@@ -175,8 +185,12 @@ tests:
           path: spec.egress
           content:
             to:
-              - namespaceSelector: {}
-                podSelector: {}
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: kube-system
+                podSelector:
+                  matchLabels:
+                    k8s-app: kube-dns
             ports:
               - protocol: TCP
                 port: 53
@@ -189,6 +203,41 @@ tests:
           content:
             protocol: TCP
             port: 18001
+        template: networkpolicy.yaml
+        documentIndex: 0
+
+  - it: should allow a custom cluster DNS selector for ratelimit
+    set:
+      security:
+        networkPolicies: true
+        networkPolicy:
+          dns:
+            namespace: openshift-dns
+            podLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      rateLimiting:
+        enabled: true
+      redis:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[1].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: openshift-dns
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels["dns.operator.openshift.io/daemonset-dns"]
+          value: default
+        template: networkpolicy.yaml
+        documentIndex: 2
+      - equal:
+          path: spec.egress[1].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: openshift-dns
+        template: networkpolicy.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels["dns.operator.openshift.io/daemonset-dns"]
+          value: default
         template: networkpolicy.yaml
         documentIndex: 0
 

--- a/charts/envoy-gateway/tests/validation_test.yaml
+++ b/charts/envoy-gateway/tests/validation_test.yaml
@@ -33,6 +33,31 @@ tests:
       - failedTemplate:
           errorMessage: "rateLimiting.externalRedis.auth.enabled requires rateLimiting.externalRedis.auth.secretName"
 
+  - it: should reject a non-canonical ServiceAccount for rate limiting
+    set:
+      rateLimiting:
+        enabled: true
+      redis:
+        enabled: true
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - failedTemplate:
+          errorMessage: "rateLimiting.enabled requires serviceAccount.name to be empty or envoy-gateway"
+
+  - it: should reject an implicit default ServiceAccount for rate limiting
+    set:
+      rateLimiting:
+        enabled: true
+      redis:
+        enabled: true
+      serviceAccount:
+        create: false
+        name: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "rateLimiting.enabled with serviceAccount.create=false requires serviceAccount.name=envoy-gateway"
+
   - it: should allow unused external redis auth settings
     set:
       rateLimiting:

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -111,7 +111,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.8.2"
+              "default": "v1.8.3"
             },
             "pullPolicy": {
               "type": "string",
@@ -262,7 +262,7 @@
                 "tag": {
                   "type": "string",
                   "description": "Shutdown manager sidecar image tag",
-                  "default": "v1.8.2"
+                  "default": "v1.8.3"
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -525,6 +525,28 @@
           "description": "Enable rate limiting",
           "default": false
         },
+        "service": {
+          "type": "object",
+          "description": "Envoy global rate limit service configuration",
+          "properties": {
+            "image": {
+              "type": "object",
+              "description": "Rate limit service image deployed by Envoy Gateway",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "Rate limit service image repository",
+                  "default": "docker.io/envoyproxy/ratelimit"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Rate limit service image tag",
+                  "default": "1e50889b"
+                }
+              }
+            }
+          }
+        },
         "redis": {
           "type": "object",
           "description": "Redis configuration for rate limiting backend",
@@ -714,7 +736,7 @@
         },
         "name": {
           "type": "string",
-          "description": "Service account name (generated if not set)",
+          "description": "Service account name (generated if not set; must be envoy-gateway when rate limiting is enabled)",
           "default": ""
         },
         "annotations": {

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -687,6 +687,25 @@
           "type": "object",
           "description": "NetworkPolicy rule extensions used when security.networkPolicies is enabled",
           "properties": {
+            "dns": {
+              "type": "object",
+              "description": "Cluster DNS selector used by controller and rate-limit NetworkPolicies",
+              "properties": {
+                "namespace": {
+                  "type": "string",
+                  "description": "Namespace containing cluster DNS pods",
+                  "minLength": 1,
+                  "default": "kube-system"
+                },
+                "podLabels": {
+                  "type": "object",
+                  "description": "Labels selecting cluster DNS pods",
+                  "additionalProperties": { "type": "string" },
+                  "minProperties": 1,
+                  "default": { "k8s-app": "kube-dns" }
+                }
+              }
+            },
             "extraEgress": {
               "type": "array",
               "description": "Additional complete egress rules appended to the controller NetworkPolicy",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -392,6 +392,12 @@ security:
   # -- Enable rendering of NetworkPolicy resources
   networkPolicies: false
   networkPolicy:
+    dns:
+      # -- Namespace containing the cluster DNS pods allowed by NetworkPolicies
+      namespace: kube-system
+      # -- Pod labels selecting the cluster DNS endpoints allowed by NetworkPolicies
+      podLabels:
+        k8s-app: kube-dns
     # -- Additional complete egress rules appended to the controller NetworkPolicy when security.networkPolicies is enabled
     extraEgress: []
   # -- Enable PodSecurityStandard restricted

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -33,7 +33,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.8.2"
+    tag: "v1.8.3"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -75,7 +75,7 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.8.2"
+    tag: "v1.8.3"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:
@@ -99,7 +99,7 @@ proxy:
       # -- Shutdown manager sidecar image repository
       repository: docker.io/envoyproxy/gateway
       # -- Shutdown manager sidecar image tag
-      tag: "v1.8.2"
+      tag: "v1.8.3"
       # -- Shutdown manager image pull policy
       pullPolicy: IfNotPresent
 
@@ -324,7 +324,7 @@ rateLimiting:
   service:
     image:
       repository: docker.io/envoyproxy/ratelimit
-      tag: "19f2079f"
+      tag: "1e50889b"
   # -- Use an external Redis instead of the bundled subchart
   # Set this if redis.enabled=false and you want to point to your own Redis.
   externalRedis:
@@ -418,7 +418,7 @@ gatewayAPI:
 serviceAccount:
   # -- Create service account
   create: true
-  # -- Service account name (generated if not set)
+  # -- Service account name (generated if not set; must be envoy-gateway when rate limiting is enabled)
   name: ""
   # -- Annotations for service account
   annotations: {}


### PR DESCRIPTION
## Summary

- update Envoy Gateway controller, certgen, and shutdown manager from v1.8.2 to v1.8.3
- align the global rate-limit service with upstream image `docker.io/envoyproxy/ratelimit:1e50889b`
- restore the upstream runtime contract for the canonical controller Deployment, ServiceAccount, and xDS port 18001
- fix bundled Redis discovery, Redis Secret authentication, and NetworkPolicy selectors/DNS for the dynamically managed rate-limit pod
- correct rate-limit documentation and make the External Secrets scenario exercise authenticated Redis end to end

## Upstream review

Envoy Gateway v1.8.3 is a patch release with fixes for TLS 1.3 defaults, malformed listener certificates, IPv6 OIDC endpoints, translator status races, Wasm retries, and the distroless base. Its Lua extension translation now uses listener-level filters, so the upgrade notes call out the changed generated xDS filter layout for EnvoyPatchPolicy and extension integrations.

## Local validation

- verified official multi-arch manifests for `envoyproxy/gateway:v1.8.3` and `envoyproxy/ratelimit:1e50889b`
- `make validate-chart CHART=envoy-gateway TIMEOUT=600`: all 20 layers passed
- 11 k3d scenarios passed, including authenticated External Secrets, global rate limiting, security NetworkPolicies, HA, monitoring, dual-stack, and namespace override
- all runtime workloads Ready, all Services had endpoints, zero restarts, and logs had no crash/fatal patterns
- functional strict-limit check: 10 allowed responses followed by 2 HTTP 429 responses
- `make standards-check CHART=envoy-gateway`
- `make deps-check CHART=envoy-gateway`
- `make md-lint REPO=charts`
- `make org-check`

## Self-review

- reviewed every rendered/runtime contract changed by the upgrade
- confirmed chart version remains CI-owned; only `appVersion` and image defaults changed
- checked values, schema, README, tests, CI scenarios, templates, and site documentation for parity
- no unresolved local findings

## Site

- helmforgedev/site#464

Closes #837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rate-limiting service images and support for authenticated external or bundled Redis backends.
  * Exposed the rate-limiting service through the controller on port 18001.
  * Added validation and clearer service account requirements when rate limiting is enabled.

* **Bug Fixes**
  * Corrected Redis service discovery, authentication injection, network policies, and generated installation guidance.

* **Documentation**
  * Updated Helm chart documentation, examples, monitoring instructions, troubleshooting guidance, and upgrade notes for Envoy Gateway v1.8.3.

* **Chores**
  * Updated default container images and chart metadata to v1.8.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->