### PR TITLE
feat(ghost): upgrade to 6.54.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.1.20
-appVersion: "6.53.0"
+appVersion: "6.54.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ghost to 6.53.0 (#815)"
+      description: "bump ghost to 6.54.0 (#838)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -92,7 +92,8 @@ externalSecrets:
 ```
 
 The chart renders `external-secrets.io/v1`, defaults the target to the rendered
-ExternalSecret name, and supports multiple items. The legacy
+ExternalSecret name, and supports multiple items. Every item must set either
+`name` or `fullnameOverride` so each resource has a unique identity. The legacy
 `secretStoreRef`/`data` surface remains compatible for existing releases, but
 new configurations should use `externalSecrets.items`.
 

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -7,7 +7,7 @@ for building blogs, newsletters, and membership-based content with built-in mone
 ## Features
 
 - **MySQL backend** — bundled via HelmForge subchart or external database
-- **Content persistence** — images, media, and files on PVC
+- **Content persistence** — images, media, themes, routes, and redirects on PVC
 - **S3 backup** — scheduled content backups to S3-compatible storage
 - **Headless CMS** — REST and Content API for headless usage
 - **Memberships** — built-in subscriptions, newsletters, and payments
@@ -60,12 +60,69 @@ database:
     password: "secure-password"
 ```
 
+## External Secrets
+
+External Secrets Operator can project the external MySQL password into the
+Secret consumed by Ghost. Install the operator separately, disable the bundled
+MySQL chart, and keep the item target aligned with
+`database.external.existingSecret`:
+
+```yaml
+mysql:
+  enabled: false
+
+database:
+  external:
+    host: mysql.database.svc
+    existingSecret: ghost-db-credentials
+
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: ghost-db-credentials
+      spec:
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        data:
+          - secretKey: password
+            remoteRef:
+              key: ghost/database
+              property: password
+```
+
+The chart renders `external-secrets.io/v1`, defaults the target to the rendered
+ExternalSecret name, and supports multiple items. The legacy
+`secretStoreRef`/`data` surface remains compatible for existing releases, but
+new configurations should use `externalSecrets.items`.
+
+## Custom Adapter Images
+
+Ghost 6.54.0 can load adapters installed outside the content directory. For a
+custom image that installs adapters in `/opt/ghost/adapters`, expose the path
+through Ghost's environment-based configuration:
+
+```yaml
+image:
+  repository: registry.example.com/ghost-with-adapters
+  tag: "6.54.0"
+
+ghost:
+  extraEnv:
+    - name: paths__installedAdaptersPath
+      value: /opt/ghost/adapters
+```
+
+Bake the adapter directory into the custom image. Keeping it outside
+`/var/lib/ghost/content` prevents the content PVC from shadowing installed
+adapters when the container starts.
+
 ## Key Values
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.53.0` | Ghost image tag |
+| `image.tag` | `6.54.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -74,15 +131,23 @@ database:
 | `ingress.enabled` | `false` | Enable ingress |
 | `gateway.enabled` | `false` | Enable Gateway API HTTPRoute |
 | `externalSecrets.enabled` | `false` | Render ExternalSecret for database password |
+| `externalSecrets.refreshInterval` | `1h` | Default sync interval for ExternalSecret items |
+| `externalSecrets.items` | `[]` | Complete ExternalSecret definitions |
 
 ## Upgrade Notes
 
-Ghost `6.53.0` adds adapter boot-time validation and strengthens protection
-against spam member signups. It also improves author selection and analytics
-performance and fixes expired-session and editor-state issues. Review the
-upstream Ghost release notes before upgrading production sites, take a content
-and database backup, and verify themes, custom integrations, newsletter flows,
-comments, and member signup paths in staging before reusing existing PVCs.
+Ghost `6.54.0` adds inline editing for `routes.yaml` and `redirects.yaml`,
+support for adapters installed outside the content directory, member labels,
+complimentary subscriptions, and theme access to member avatars. It also
+hardens filename generation and fixes unsafe split-helper output and several
+CSV import edge cases. Files edited in Ghost Admin remain under
+`/var/lib/ghost/content/data`, so the chart's content PVC and S3 content backup
+already cover them. Review the upstream Ghost release notes before upgrading
+production sites, take a content and database backup, and verify themes, custom
+integrations, newsletter flows, comments, and member signup paths in staging
+before reusing existing PVCs. The External Secrets contract now follows
+`externalSecrets.items[]`; the previous single-secret fields remain supported
+for compatibility.
 
 ## S3 Backup
 
@@ -106,7 +171,7 @@ backup:
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **86.580086%** |
+| MITRE + NSA + SOC2 | **89.393936%** |
 
 > Security posture acceptable.
 

--- a/charts/ghost/ci/external-secrets.yaml
+++ b/charts/ghost/ci/external-secrets.yaml
@@ -20,13 +20,19 @@ database:
 
 externalSecrets:
   enabled: true
-  secretStoreRef:
-    name: helmforge-fake-store
-    kind: ClusterSecretStore
-  data:
-    - secretKey: password
-      remoteRef:
-        key: test/password
+  items:
+    - fullnameOverride: ghost-db-credentials
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        target:
+          name: ghost-db-credentials
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: test/password
 
 extraManifests:
   - apiVersion: apps/v1

--- a/charts/ghost/ci/installed-adapters-path.yaml
+++ b/charts/ghost/ci/installed-adapters-path.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ghost:
+  extraEnv:
+    - name: paths__installedAdaptersPath
+      value: /opt/ghost/adapters
+
+extraVolumes:
+  - name: installed-adapters
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: installed-adapters
+    mountPath: /opt/ghost/adapters

--- a/charts/ghost/templates/NOTES.txt
+++ b/charts/ghost/templates/NOTES.txt
@@ -1,6 +1,10 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- $fullname := include "ghost.fullname" . -}}
 {{- $namespace := .Release.Namespace -}}
+{{- $externalSecretItemCount := len (.Values.externalSecrets.items | default list) -}}
+{{- if and (eq $externalSecretItemCount 0) .Values.externalSecrets.data -}}
+{{- $externalSecretItemCount = 1 -}}
+{{- end -}}
 
 1. Ghost has been installed
 ---------------------------
@@ -115,7 +119,7 @@
 ------------------------
 {{- if .Values.externalSecrets.enabled }}
   External Secrets Operator is enabled.
-  ExternalSecret items: {{ len (.Values.externalSecrets.items | default list) }}
+  ExternalSecret items: {{ $externalSecretItemCount }}
   Target Secret: {{ include "ghost.dbSecretName" . }}
   Verify synchronization:
     kubectl get externalsecret -n {{ $namespace }}

--- a/charts/ghost/templates/NOTES.txt
+++ b/charts/ghost/templates/NOTES.txt
@@ -115,8 +115,11 @@
 ------------------------
 {{- if .Values.externalSecrets.enabled }}
   External Secrets Operator is enabled.
-  SecretStore: {{ .Values.externalSecrets.secretStoreRef.kind }}/{{ .Values.externalSecrets.secretStoreRef.name }}
+  ExternalSecret items: {{ len (.Values.externalSecrets.items | default list) }}
   Target Secret: {{ include "ghost.dbSecretName" . }}
+  Verify synchronization:
+    kubectl get externalsecret -n {{ $namespace }}
+    kubectl get secret {{ include "ghost.dbSecretName" . }} -n {{ $namespace }}
 {{- else }}
   External Secrets Operator is disabled.
 {{- end }}

--- a/charts/ghost/templates/_helpers.tpl
+++ b/charts/ghost/templates/_helpers.tpl
@@ -11,6 +11,19 @@
 {{- end -}}
 {{- end -}}
 
+{{/* ExternalSecret resource name */}}
+{{- define "ghost.externalSecretName" -}}
+{{- $root := index . "root" -}}
+{{- $item := index . "item" -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $fullname := include "ghost.fullname" $root -}}
+{{- $itemName := $item.name | default "external" | trunc 32 | trimSuffix "-" -}}
+{{- printf "%s-%s" ($fullname | trunc (int (sub 62 (len $itemName))) | trimSuffix "-") $itemName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "ghost.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -68,11 +81,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.externalSecrets.enabled (not .Values.database.external.existingSecret) -}}
 {{- fail "database.external.existingSecret is required when externalSecrets.enabled is true" -}}
 {{- end -}}
-{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.secretStoreRef.name) -}}
-{{- fail "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled is true" -}}
-{{- end -}}
-{{- if and .Values.externalSecrets.enabled (not .Values.externalSecrets.data) -}}
-{{- fail "externalSecrets.data must contain at least one entry when externalSecrets.enabled is true" -}}
+{{- if and .Values.externalSecrets.enabled (not (or .Values.externalSecrets.items .Values.externalSecrets.data)) -}}
+{{- fail "externalSecrets.items or externalSecrets.data is required when externalSecrets.enabled=true" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/ghost/templates/_helpers.tpl
+++ b/charts/ghost/templates/_helpers.tpl
@@ -19,7 +19,7 @@
 {{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $fullname := include "ghost.fullname" $root -}}
-{{- $itemName := $item.name | default "external" | trunc 32 | trimSuffix "-" -}}
+{{- $itemName := required "externalSecrets.items[].name is required when fullnameOverride is not set" $item.name | trunc 32 | trimSuffix "-" -}}
 {{- printf "%s-%s" ($fullname | trunc (int (sub 62 (len $itemName))) | trimSuffix "-") $itemName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/ghost/templates/externalsecret.yaml
+++ b/charts/ghost/templates/externalsecret.yaml
@@ -1,37 +1,85 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
-{{- /*
-  Guard: when externalSecrets.enabled=true the chart-managed database Secret is still rendered
-  unless database.external.existingSecret is set. Without this guard, both resources target the same
-  Secret name, creating credential drift. Require database.external.existingSecret explicitly.
-*/}}
 {{- if not .Values.database.external.existingSecret }}
-  {{- fail "externalSecrets.enabled requires database.external.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." }}
+{{- fail "database.external.existingSecret is required when externalSecrets.enabled is true" }}
 {{- end }}
-{{- $passKey := .Values.database.external.existingSecretPasswordKey | default "password" -}}
-{{- $hasPasswordKey := false }}
-{{- range .Values.externalSecrets.data }}
-  {{- if eq .secretKey $passKey }}
-    {{- $hasPasswordKey = true }}
-  {{- end }}
+{{- if and .Values.externalSecrets.apiVersion (ne .Values.externalSecrets.apiVersion "external-secrets.io/v1") }}
+{{- fail "externalSecrets.apiVersion is deprecated; Ghost renders external-secrets.io/v1 only. Upgrade External Secrets Operator CRDs or remove this value." }}
 {{- end }}
-{{- if not $hasPasswordKey }}
-  {{- fail (printf "externalSecrets.data must contain an entry with secretKey '%s' when externalSecrets.enabled=true to populate the database password." $passKey) }}
+{{- $items := .Values.externalSecrets.items | default list }}
+{{- $legacyCreationPolicy := "Owner" }}
+{{- with .Values.externalSecrets.target }}
+{{- $legacyCreationPolicy = .creationPolicy | default "Owner" }}
 {{- end }}
-apiVersion: {{ .Values.externalSecrets.apiVersion }}
+{{- if and (not $items) .Values.externalSecrets.data }}
+{{- $items = list (dict "name" "db" "spec" (dict "secretStoreRef" .Values.externalSecrets.secretStoreRef "target" (dict "name" .Values.database.external.existingSecret "creationPolicy" $legacyCreationPolicy) "data" .Values.externalSecrets.data)) }}
+{{- end }}
+{{- if not $items }}
+{{- fail "externalSecrets.items or externalSecrets.data is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- $passwordKey := .Values.database.external.existingSecretPasswordKey | default "password" }}
+{{- $hasDatabaseTarget := false }}
+{{- $hasPasswordSource := false }}
+{{- range $items }}
+{{- $externalSecretName := include "ghost.externalSecretName" (dict "root" $ "item" .) }}
+{{- $spec := deepCopy (.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- if eq (get $target "name") $.Values.database.external.existingSecret }}
+{{- $hasDatabaseTarget = true }}
+{{- if $spec.dataFrom }}
+{{- $hasPasswordSource = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if eq .secretKey $passwordKey }}
+{{- $hasPasswordSource = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: {{ include "ghost.fullname" . }}-db
+  name: {{ $externalSecretName }}
   labels:
-    {{- include "ghost.labels" . | nindent 4 }}
+    {{- include "ghost.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  refreshInterval: {{ .Values.externalSecrets.refreshInterval | quote }}
-  secretStoreRef:
-    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" .Values.externalSecrets.secretStoreRef.name | quote }}
-    kind: {{ .Values.externalSecrets.secretStoreRef.kind | quote }}
-  target:
-    name: {{ .Values.database.external.existingSecret | quote }}
-    creationPolicy: {{ .Values.externalSecrets.target.creationPolicy | quote }}
-  data:
-    {{- toYaml .Values.externalSecrets.data | nindent 4 }}
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- if not $hasDatabaseTarget }}
+{{- fail "externalSecrets.items must include a spec.target.name matching database.external.existingSecret" }}
+{{- end }}
+{{- if not $hasPasswordSource }}
+{{- fail (printf "the ExternalSecret targeting database.external.existingSecret must provide secretKey %q in spec.data or use spec.dataFrom" $passwordKey) }}
+{{- end }}
 {{- end }}

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.53.0"
+          value: "docker.io/library/ghost:6.54.0"
 
   - it: should expose port 2368
     asserts:
@@ -80,6 +80,35 @@ tests:
           content:
             name: database__connection__host
             value: "test-mysql"
+
+  - it: should support installed adapters outside the content volume
+    set:
+      ghost:
+        extraEnv:
+          - name: paths__installedAdaptersPath
+            value: /opt/ghost/adapters
+      extraVolumes:
+        - name: installed-adapters
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: installed-adapters
+          mountPath: /opt/ghost/adapters
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: paths__installedAdaptersPath
+            value: /opt/ghost/adapters
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: installed-adapters
+            mountPath: /opt/ghost/adapters
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: installed-adapters
+            emptyDir: {}
 
   - it: should mount content volume
     asserts:

--- a/charts/ghost/tests/externalsecret_test.yaml
+++ b/charts/ghost/tests/externalsecret_test.yaml
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: does not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders database credentials with the canonical items contract
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        items:
+          - fullnameOverride: ghost-db
+            labels:
+              team: platform
+            annotations:
+              example.com/managed: "true"
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+                kind: ClusterSecretStore
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/database
+                    property: password
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: ghost-db
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.annotations["example.com/managed"]
+          value: "true"
+      - equal:
+          path: spec.target.name
+          value: ghost-db
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: defaults the target name to the rendered ExternalSecret name
+    set:
+      database.external.existingSecret: test-ghost-db
+      externalSecrets:
+        enabled: true
+        items:
+          - name: db
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+                kind: ClusterSecretStore
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/database
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-ghost-db
+      - equal:
+          path: spec.target.name
+          value: test-ghost-db
+
+  - it: preserves an item-specific refresh interval
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        refreshInterval: 1h
+        items:
+          - fullnameOverride: ghost-db
+            spec:
+              refreshInterval: 15m
+              secretStoreRef:
+                name: platform-secrets
+              dataFrom:
+                - extract:
+                    key: ghost/database
+    asserts:
+      - equal:
+          path: spec.refreshInterval
+          value: 15m
+
+  - it: renders multiple ExternalSecret items
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        items:
+          - fullnameOverride: ghost-db
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/database
+          - name: smtp
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+              data:
+                - secretKey: token
+                  remoteRef:
+                    key: ghost/smtp
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: ghost-db
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: test-ghost-smtp
+        documentIndex: 1
+
+  - it: preserves the legacy single ExternalSecret surface
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        secretStoreRef:
+          name: platform-secrets
+          kind: ClusterSecretStore
+        target:
+          creationPolicy: Owner
+        data:
+          - secretKey: password
+            remoteRef:
+              key: ghost/database
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-ghost-db
+      - equal:
+          path: spec.target.name
+          value: ghost-db
+      - equal:
+          path: spec.target.creationPolicy
+          value: Owner
+
+  - it: requires a SecretStore reference
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        items:
+          - fullnameOverride: ghost-db
+            spec:
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/database
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true"
+
+  - it: rejects items that do not target the consumed database Secret
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        items:
+          - fullnameOverride: another-secret
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/database
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.items must include a spec.target.name matching database.external.existingSecret
+
+  - it: requires the configured password key in the database Secret
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        items:
+          - fullnameOverride: ghost-db
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+              data:
+                - secretKey: username
+                  remoteRef:
+                    key: ghost/database
+    asserts:
+      - failedTemplate:
+          errorMessage: 'the ExternalSecret targeting database.external.existingSecret must provide secretKey "password" in spec.data or use spec.dataFrom'
+
+  - it: rejects deprecated non-v1 apiVersion values
+    set:
+      database.external.existingSecret: ghost-db
+      externalSecrets:
+        enabled: true
+        apiVersion: external-secrets.io/v1beta1
+        items:
+          - fullnameOverride: ghost-db
+            spec:
+              secretStoreRef:
+                name: platform-secrets
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/database
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.apiVersion is deprecated; Ghost renders external-secrets.io/v1 only. Upgrade External Secrets Operator CRDs or remove this value."

--- a/charts/ghost/tests/validation_test.yaml
+++ b/charts/ghost/tests/validation_test.yaml
@@ -96,37 +96,29 @@ tests:
       - failedTemplate:
           errorMessage: database.external.existingSecret is required when externalSecrets.enabled is true
 
-  - it: fails when external secrets has no secret store name
+  - it: fails when external secrets has no items
     set:
       database.external.existingSecret: ghost-db
       externalSecrets.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: externalSecrets.secretStoreRef.name is required when externalSecrets.enabled is true
-
-  - it: fails when external secrets has no data entries
-    set:
-      database.external.existingSecret: ghost-db
-      externalSecrets:
-        enabled: true
-        secretStoreRef:
-          name: fake-store
-    asserts:
-      - failedTemplate:
-          errorMessage: externalSecrets.data must contain at least one entry when externalSecrets.enabled is true
+          errorMessage: externalSecrets.items or externalSecrets.data is required when externalSecrets.enabled=true
 
   - it: passes with complete external secrets settings
     set:
       database.external.existingSecret: ghost-db
       externalSecrets:
         enabled: true
-        secretStoreRef:
-          name: fake-store
-        data:
-          - secretKey: password
-            remoteRef:
-              key: ghost/db
-              property: password
+        items:
+          - fullnameOverride: ghost-db
+            spec:
+              secretStoreRef:
+                name: fake-store
+              data:
+                - secretKey: password
+                  remoteRef:
+                    key: ghost/db
+                    property: password
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -325,6 +325,10 @@
                                                        "description": "ExternalSecret definitions with complete spec blocks.",
                                                        "items": {
                                                            "type": "object",
+                                                           "anyOf": [
+                                                               { "required": ["name"] },
+                                                               { "required": ["fullnameOverride"] }
+                                                           ],
                                                            "properties": {
                                                                "name": { "type": "string" },
                                                                "fullnameOverride": { "type": "string" },

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.53.0"
+                                                                    "default":  "6.54.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",
@@ -306,11 +306,34 @@
                                    },
                        "externalSecrets":  {
                                                "type":  "object",
-                                               "description":  "ExternalSecrets Operator configuration.",
+                                               "description":  "External Secrets Operator resources for database credentials.",
+                                               "additionalProperties": false,
                                                "properties": {
                                                    "enabled": { "type": "boolean", "default": false },
-                                                   "apiVersion": { "type": "string" },
-                                                   "refreshInterval": { "type": "string" },
+                                                   "apiVersion": {
+                                                       "type": "string",
+                                                       "description": "Deprecated compatibility field; Ghost always renders external-secrets.io/v1.",
+                                                       "enum": ["external-secrets.io/v1", "external-secrets.io/v1beta1"]
+                                                   },
+                                                   "refreshInterval": {
+                                                       "type": "string",
+                                                       "description": "Default sync interval for items without spec.refreshInterval.",
+                                                       "default": "1h"
+                                                   },
+                                                   "items": {
+                                                       "type": "array",
+                                                       "description": "ExternalSecret definitions with complete spec blocks.",
+                                                       "items": {
+                                                           "type": "object",
+                                                           "properties": {
+                                                               "name": { "type": "string" },
+                                                               "fullnameOverride": { "type": "string" },
+                                                               "labels": { "type": "object" },
+                                                               "annotations": { "type": "object" },
+                                                               "spec": { "type": "object" }
+                                                           }
+                                                       }
+                                                   },
                                                    "secretStoreRef": { "type": "object" },
                                                    "target": { "type": "object" },
                                                    "data": { "type": "array" }

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.53.0"
+  tag: "6.54.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -297,20 +297,23 @@ gateway:
 # =============================================================================
 
 externalSecrets:
-  # -- Render ExternalSecret for the Ghost database password Secret.
-  # Requires database.external.existingSecret to be set to prevent credential drift
-  # between the chart-managed Secret and the ExternalSecret.
+  # -- Render ExternalSecret resources. One item must target database.external.existingSecret.
   enabled: false
-  apiVersion: external-secrets.io/v1
-  refreshInterval: "0"
-  secretStoreRef:
-    name: ""
-    kind: SecretStore
-  target:
-    creationPolicy: Owner
-  # -- Data entries mapping remote keys to the database password key.
-  data: []
-  #   - secretKey: password
-  #     remoteRef:
-  #       key: ghost/db
-  #       property: password
+  # -- Default sync interval for items without spec.refreshInterval
+  refreshInterval: 1h
+  # -- ExternalSecret definitions. Each item requires a complete spec.
+  # @default -- `[]`
+  items: []
+    # - fullnameOverride: ghost-db-credentials
+    #   spec:
+    #     secretStoreRef:
+    #       name: platform-secrets
+    #       kind: ClusterSecretStore
+    #     target:
+    #       name: ghost-db-credentials
+    #       creationPolicy: Owner
+    #     data:
+    #       - secretKey: password
+    #         remoteRef:
+    #           key: ghost/database
+    #           property: password


### PR DESCRIPTION
## Summary

- upgrade the official Ghost image from 6.53.0 to 6.54.0
- document and validate the new installed-adapters path for custom images
- migrate External Secrets to the canonical `externalSecrets.items[]` contract while preserving the existing single-secret fields
- expand schema validation, unit coverage, k3d scenarios, NOTES, upgrade guidance, and the recorded security score

Closes #838

Companion site PR: https://github.com/helmforgedev/site/pull/465

## Upstream and image verification

- Release: https://github.com/TryGhost/Ghost/releases/tag/v6.54.0
- Adapter path change: https://github.com/TryGhost/Ghost/pull/29487
- Image: `docker.io/library/ghost:6.54.0`
- Manifest digest: `sha256:35198555737cb26003bb8de6c680f0647a3882ab70c44e0e7bf2620388673f7c`
- Verified platforms: amd64, arm, arm64
- Runtime package version: 6.54.0

## Local validation

- `make validate-chart CHART=ghost TIMEOUT=600`: fully validated, 17 layers
- eight sequential k3d scenarios: default, default-values, dual-stack, external database, External Secrets, Gateway API, Ingress, installed adapters
- all workloads ready, endpoints populated, zero restarts, clean logs, no critical events
- dedicated External Secrets Operator run: ExternalSecret Ready=True, exact password synchronized, Ghost consumed `ghost-db-credentials/password`, Ghost and MySQL ready with zero restarts
- Helm unittest: 8 suites / 47 tests
- Kubescape 4.0.9: 89.393936%, no critical or high findings
- `make preflight`
- `make standards-check CHART=ghost`
- `make deps-check CHART=ghost`
- `make site-sync-check CHART=ghost`
- `make org-check`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Maintainer review

- verified the immutable upstream release and official image architecture set
- reviewed all rendered-resource changes, failure guards, legacy compatibility, and target/password alignment
- reviewed the full diff for secrets leakage, floating tags, unexpected version edits, and unrelated changes
- confirmed the MySQL dependency remains current and on Ghost-supported MySQL 8
- confirmed site documentation covers every new/defaulted user-facing value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple External Secrets with per-secret specifications.
  * Added support for mounting Ghost adapters outside the content directory.
  * Added clearer validation and deployment guidance for External Secrets.

* **Updates**
  * Upgraded Ghost to version 6.54.0.
  * Preserved compatibility with the previous single-secret configuration format.
  * Updated configuration documentation, examples, and schema defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->