### PR TITLE
feat(homarr): upgrade to 1.72.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.1.23
-appVersion: "1.71.0"
+appVersion: "1.72.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump homarr to 1.71.0 (#817)"
+      description: "upgrade Homarr to 1.72.0"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.71.0`.
+Current application version: `v1.72.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.71.0"` | Homarr image tag |
+| `image.tag` | `"v1.72.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,9 +265,10 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.70.0` to `v1.71.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.71.0` restores database migration journal entries, improves integrations and widgets, and fixes
-container image builds. No breaking changes were identified in the upstream release metadata.
+This update moves the default image from `v1.71.0` to `v1.72.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.72.0` adds album-free random photos for Immich, humidity and animated weather in clock widgets,
+and fixes permission visibility, media integrations, response caching, and Beszel subscription memory growth. No breaking
+changes or new required environment variables were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.71.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.72.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.71.0"
+  tag: "v1.72.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- upgrade the official Homarr image from `v1.71.0` to `v1.72.0`
- update `appVersion`, Artifact Hub change metadata, README, and the image assertion
- document the 1.72.0 integration/widget improvements without adding unsupported chart settings

## Upstream review

Homarr 1.72.0 adds album-free random Immich photos, humidity and animated weather for clock widgets, and fixes permissions, media integrations, response caching, and Beszel subscription memory growth. The upstream release contains no breaking change or new required environment variable.

The registry tag is `v1.72.0` (the unprefixed `1.72.0` tag does not exist). Manifest verification passed for `linux/amd64` and `linux/arm64`.

## Validation

- `make validate-chart CHART=homarr TIMEOUT=600`: fully validated, 19 layers
- ten sequential k3d scenarios: default, backup, dual-stack, external DB, External Secrets, Gateway API, Kubernetes integration, MySQL, and PostgreSQL
- all workloads Ready with zero restarts; service endpoint smoke passed; logs had no crash/fatal patterns
- `make standards-check CHART=homarr`
- `make deps-check CHART=homarr`
- `make site-sync-check CHART=homarr`
- `make org-check`
- `make md-lint REPO=charts`

## Review

Maintainer self-review completed. The chart version remains CI-owned, the official upstream image stays pinned, the image prefix is correct, and all version references/tests/docs are consistent. No blocking findings.

Companion site PR: helmforgedev/site#466

Closes #839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Homarr Helm chart to application version **1.72.0**.
  * Updated the default container image tag and chart documentation to match the new release.

* **Tests**
  * Updated deployment validation to confirm use of the Homarr 1.72.0 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->