### PR TITLE
feat(langflow): upgrade to 1.11.1

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -20,14 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "upgrade Langflow with v2 workflows, trusted JWT authentication, RBAC, A2A, HITL, and new provider bundles"
     - kind: changed
-      description: "bump the official Langflow image to 1.11.1 (#840)"
-    - kind: changed
-      description: "generate stable initial credentials and use the reliable /health_check endpoint for probes"
-    - kind: fixed
-      description: "include upstream authentication, tracing, MCP, SSRF, and component-loading fixes from 1.11.1"
+      description: "bump image to 1.10.2 (#764)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.0.4
-appVersion: "1.10.2"
+appVersion: "1.11.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,14 @@ sources:
 icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "upgrade Langflow with v2 workflows, trusted JWT authentication, RBAC, A2A, HITL, and new provider bundles"
     - kind: changed
-      description: "bump image to 1.10.2 (#764)"
+      description: "bump the official Langflow image to 1.11.1 (#840)"
+    - kind: changed
+      description: "generate stable initial credentials and use the reliable /health_check endpoint for probes"
+    - kind: fixed
+      description: "include upstream authentication, tracing, MCP, SSRF, and component-loading fixes from 1.11.1"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,8 +1,17 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.10.2` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.1` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
+
+Langflow 1.11 adds native v2 workflow execution, trusted JWT authentication with just-in-time user mapping, RBAC-aware interfaces, A2A and
+human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.1 also includes upstream fixes for authentication,
+tracing, MCP, SSRF protections, and component loading. Advanced runtime settings for these capabilities can be supplied through `app.env` or
+`app.envFrom`.
+
+The chart generates a strong Langflow secret key and initial superuser password on first install when `auth.existingSecret` and inline
+credentials are empty. These values are reused on upgrades. Runtime probes use Langflow's `/health_check` endpoint so a pod is not marked ready
+until application services and the database are healthy.
 
 ## Install
 
@@ -19,7 +28,7 @@ Set `networkPolicy.dnsEgressPeers` when your cluster DNS pods do not use the def
 
 ## Production Configuration
 
-Set a stable `LANGFLOW_SECRET_KEY` so encrypted provider credentials and JWT signing survive pod restarts:
+For production, use an existing Secret so credentials remain under your secret-management lifecycle:
 
 ```yaml
 auth:

--- a/charts/langflow/templates/NOTES.txt
+++ b/charts/langflow/templates/NOTES.txt
@@ -34,14 +34,18 @@ Langflow has been deployed.
 
 4. Authentication
 
-{{- if or .Values.auth.secretKey .Values.auth.existingSecret }}
 - Auth Secret: {{ default (include "langflow.fullname" .) .Values.auth.existingSecret }}
 - Secret key entry: {{ .Values.auth.secretKeyKey }}
 - Superuser entry: {{ .Values.auth.superuserKey }}
 - Superuser password entry: {{ .Values.auth.superuserPasswordKey }}
+{{- if .Values.auth.existingSecret }}
+- Credentials are read from the existing Secret.
 {{- else }}
-- No chart-managed Langflow auth Secret is configured.
-- Set auth.existingSecret before exposing Langflow to users.
+- Missing credentials are generated on first install and preserved across upgrades.
+- Retrieve the generated superuser:
+  kubectl get secret {{ include "langflow.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.superuserKey }}}" | base64 --decode
+- Retrieve the generated password:
+  kubectl get secret {{ include "langflow.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.{{ .Values.auth.superuserPasswordKey }}}" | base64 --decode
 {{- end }}
 
 5. Scaling

--- a/charts/langflow/templates/deployment.yaml
+++ b/charts/langflow/templates/deployment.yaml
@@ -64,29 +64,21 @@ spec:
               value: "true"
             - name: LANGFLOW_OPEN_BROWSER
               value: "false"
-            {{- if or .Values.auth.secretKey .Values.auth.existingSecret }}
             - name: LANGFLOW_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ default (include "langflow.fullname" .) .Values.auth.existingSecret }}
                   key: {{ .Values.auth.secretKeyKey }}
-            {{- end }}
-            {{- if or .Values.auth.superuser .Values.auth.existingSecret }}
             - name: LANGFLOW_SUPERUSER
               valueFrom:
                 secretKeyRef:
                   name: {{ default (include "langflow.fullname" .) .Values.auth.existingSecret }}
                   key: {{ .Values.auth.superuserKey }}
-                  optional: true
-            {{- end }}
-            {{- if or .Values.auth.superuserPassword .Values.auth.existingSecret }}
             - name: LANGFLOW_SUPERUSER_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ default (include "langflow.fullname" .) .Values.auth.existingSecret }}
                   key: {{ .Values.auth.superuserPasswordKey }}
-                  optional: true
-            {{- end }}
             {{- if or .Values.database.url .Values.database.existingSecret }}
             - name: LANGFLOW_DATABASE_URL
               valueFrom:
@@ -111,7 +103,9 @@ spec:
           {{- end }}
           {{- if .Values.probes.startup.enabled }}
           startupProbe:
-            tcpSocket: { port: http }
+            httpGet:
+              path: {{ .Values.probes.startup.path | quote }}
+              port: http
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
@@ -119,7 +113,9 @@ spec:
           {{- end }}
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
-            tcpSocket: { port: http }
+            httpGet:
+              path: {{ .Values.probes.liveness.path | quote }}
+              port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -127,7 +123,9 @@ spec:
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
-            tcpSocket: { port: http }
+            httpGet:
+              path: {{ .Values.probes.readiness.path | quote }}
+              port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/charts/langflow/templates/secret.yaml
+++ b/charts/langflow/templates/secret.yaml
@@ -1,5 +1,18 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if and (not .Values.auth.existingSecret) (or .Values.auth.secretKey .Values.auth.superuser .Values.auth.superuserPassword) }}
+{{- if not .Values.auth.existingSecret }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (include "langflow.fullname" .) }}
+{{- $existingData := dict }}
+{{- if $existingSecret }}
+{{- $existingData = get $existingSecret "data" | default dict }}
+{{- end }}
+{{- $secretKey := .Values.auth.secretKey }}
+{{- if and (not $secretKey) (hasKey $existingData .Values.auth.secretKeyKey) }}
+{{- $secretKey = get $existingData .Values.auth.secretKeyKey | b64dec }}
+{{- end }}
+{{- $superuserPassword := .Values.auth.superuserPassword }}
+{{- if and (not $superuserPassword) (hasKey $existingData .Values.auth.superuserPasswordKey) }}
+{{- $superuserPassword = get $existingData .Values.auth.superuserPasswordKey | b64dec }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,15 +21,9 @@ metadata:
     {{- include "langflow.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{- if .Values.auth.secretKey }}
-  {{ .Values.auth.secretKeyKey }}: {{ .Values.auth.secretKey | quote }}
-  {{- end }}
-  {{- if .Values.auth.superuser }}
-  {{ .Values.auth.superuserKey }}: {{ .Values.auth.superuser | quote }}
-  {{- end }}
-  {{- if .Values.auth.superuserPassword }}
-  {{ .Values.auth.superuserPasswordKey }}: {{ .Values.auth.superuserPassword | quote }}
-  {{- end }}
+  {{ .Values.auth.secretKeyKey }}: {{ if $secretKey }}{{ $secretKey | quote }}{{ else }}{{ randAlphaNum 64 | quote }}{{ end }}
+  {{ .Values.auth.superuserKey }}: {{ default "langflow" .Values.auth.superuser | quote }}
+  {{ .Values.auth.superuserPasswordKey }}: {{ if $superuserPassword }}{{ $superuserPassword | quote }}{{ else }}{{ randAlphaNum 32 | quote }}{{ end }}
 {{- end }}
 ---
 {{- if and (not .Values.database.existingSecret) .Values.database.url }}

--- a/charts/langflow/tests/security_database_test.yaml
+++ b/charts/langflow/tests/security_database_test.yaml
@@ -22,6 +22,24 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: LANGFLOW_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-langflow
+                key: secret-key
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFLOW_SUPERUSER
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-langflow
+                key: superuser
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: LANGFLOW_SUPERUSER_PASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/langflow/tests/security_database_test.yaml
+++ b/charts/langflow/tests/security_database_test.yaml
@@ -4,6 +4,30 @@ templates:
   - templates/deployment.yaml
   - templates/secret.yaml
 tests:
+  - it: generates required credentials and wires them by default
+    asserts:
+      - isKind:
+          of: Secret
+        template: templates/secret.yaml
+      - isNotEmpty:
+          path: stringData.secret-key
+        template: templates/secret.yaml
+      - equal:
+          path: stringData.superuser
+          value: langflow
+        template: templates/secret.yaml
+      - isNotEmpty:
+          path: stringData.superuser-password
+        template: templates/secret.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LANGFLOW_SUPERUSER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-langflow
+                key: superuser-password
+        template: templates/deployment.yaml
   - it: renders auth secret and wires Langflow secret env vars
     values:
       - secure-values.yaml

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.10.2
+          value: docker.io/langflowai/langflow:1.11.1
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow
@@ -119,3 +119,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 9
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health_check

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.10.2" },
+        "tag": { "type": "string", "default": "1.11.1" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -150,6 +150,7 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
+        "path": { "type": "string", "pattern": "^/" },
         "initialDelaySeconds": { "type": "integer", "minimum": 0 },
         "periodSeconds": { "type": "integer", "minimum": 1 },
         "timeoutSeconds": { "type": "integer", "minimum": 1 },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.10.2"
+  tag: "1.11.1"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 
@@ -37,13 +37,13 @@ app:
   extraEnv: []
 
 auth:
-  # -- Langflow secret key used for sensitive data encryption and JWT signing. Prefer existingSecret for production.
+  # -- Langflow secret key used for sensitive data encryption and JWT signing. Generated and preserved when empty.
   secretKey: ""
-  # -- Initial superuser username.
+  # -- Initial superuser username. Defaults to langflow when empty.
   superuser: ""
-  # -- Initial superuser password. Prefer existingSecret for production.
+  # -- Initial superuser password. Generated and preserved when empty.
   superuserPassword: ""
-  # -- Existing Secret containing auth data.
+  # -- Existing Secret containing all auth data. Disables chart-managed credential generation.
   existingSecret: ""
   # -- Secret key containing LANGFLOW_SECRET_KEY.
   secretKeyKey: secret-key
@@ -149,11 +149,11 @@ networkPolicy:
 
 probes:
   # -- Startup probe settings.
-  startup: { enabled: true, initialDelaySeconds: 5, periodSeconds: 10, timeoutSeconds: 3, failureThreshold: 60 }
+  startup: { enabled: true, path: /health_check, initialDelaySeconds: 5, periodSeconds: 10, timeoutSeconds: 3, failureThreshold: 60 }
   # -- Liveness probe settings.
-  liveness: { enabled: true, initialDelaySeconds: 0, periodSeconds: 20, timeoutSeconds: 5, failureThreshold: 3 }
+  liveness: { enabled: true, path: /health_check, initialDelaySeconds: 0, periodSeconds: 20, timeoutSeconds: 5, failureThreshold: 3 }
   # -- Readiness probe settings.
-  readiness: { enabled: true, initialDelaySeconds: 0, periodSeconds: 10, timeoutSeconds: 5, failureThreshold: 6 }
+  readiness: { enabled: true, path: /health_check, initialDelaySeconds: 0, periodSeconds: 10, timeoutSeconds: 5, failureThreshold: 6 }
 
 # -- Container resources.
 resources: {}


### PR DESCRIPTION
## Summary

- upgrade the official Langflow image from `1.10.2` to the current stable `1.11.1`
- add stable chart-managed secret key and initial superuser credentials when no existing Secret is supplied
- preserve generated credentials across Helm upgrades using the existing release Secret
- replace TCP-only probes with Langflow's reliable `/health_check` endpoint
- document Langflow 1.11 v2 workflows, trusted JWT auth, RBAC, A2A, HITL, provider bundles, and 1.11.1 fixes
- synchronize tests, schema, README, NOTES, Artifact Hub changes, playground, and site documentation

The issue originally detected `1.11.0`; upstream released the stable `1.11.1` maintenance version before implementation, so this PR includes its authentication, tracing, MCP, SSRF, dependency, and component-loading fixes.

## Upstream evidence

- Image: `docker.io/langflowai/langflow:1.11.1`
- Manifest: verified for `linux/amd64` and `linux/arm64`
- 1.11.0 release: https://github.com/langflow-ai/langflow/releases/tag/v1.11.0
- 1.11.1 release: https://github.com/langflow-ai/langflow/releases/tag/v1.11.1
- Site PR: https://github.com/helmforgedev/site/pull/467

## Validation

- `make image-verify IMAGE=docker.io/langflowai/langflow:1.11.1`
- `make deps-check CHART=langflow`
- `make validate-chart CHART=langflow TIMEOUT=600` — fully validated, 17 layers
- eight behavioral k3d scenarios: default, default values, dual stack, external database, Gateway API, ingress, NetworkPolicy, and secure credentials
- every scenario: application/database health ready, service endpoints populated, zero restarts, clean crash/fatal logs, and full cleanup
- directed k3d feature validation: `/health_check` returned `chat`, `db`, and `status` as `ok`; six `/api/v2/workflows` routes present in runtime OpenAPI
- generated credential preservation verified across `helm upgrade`; zero runtime error/traceback/fatal lines
- `helm unittest` — 21 tests passed
- template standards, chart standards, dependency policy, Markdown lint, site sync, org consistency, and `make preflight` passed
- site lint, format, 162-page build, 367 full Playwright tests, and 76 final targeted browser tests passed

## Review

Self-review completed for upgrade compatibility, secret lifecycle, existing Secret behavior, health semantics, release metadata, schema/tests, security posture, generated manifests, and runtime logs/events. No unresolved findings.

Closes #840.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Langflow chart to version 1.11.1, including support for new workflow, authentication, and access-control capabilities.
  * Added HTTP health checks using the configurable `/health_check` endpoint.
  * Added automatic generation and preservation of authentication credentials across upgrades.
  * Added support for using an existing Secret to manage production credentials.

* **Bug Fixes**
  * Improved credential wiring and deployment readiness behavior.
  * Added validation requiring probe paths to begin with `/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->