### PR TITLE
feat(minecraft): upgrade to 2026.7.2

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.4.15
-appVersion: "2026.7.0"
+appVersion: "2026.7.2"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump minecraft to 2026.7.0 (#717)"
+      description: "upgrade minecraft server image to 2026.7.2"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/DESIGN.md
+++ b/charts/minecraft/DESIGN.md
@@ -5,6 +5,8 @@
 This chart deploys Minecraft Java Edition servers using the official community-standard
 `docker.io/itzg/minecraft-server` image. It supports vanilla, Paper, Forge, Fabric, Quilt, Geyser/Floodgate cross-play,
 RCON operations, persistent worlds, metrics, External Secrets, and S3-compatible backups.
+The 2026.7.2 runtime also exposes IPv6 stack preference, a replaceable process
+runner, and layered generic packs distributed as OCI artifacts.
 
 ## Architecture
 
@@ -33,6 +35,10 @@ world data at a time.
 - Keep RCON enabled for operational automation, backups, and graceful save coordination.
 - Use External Secrets only when explicitly enabled and require an existing RCON secret to avoid credential drift.
 - Use the same `itzg/minecraft-server` image for backup worker jobs so RCON tooling stays aligned with the server image.
+- Map `server.preferIPv6` and `server.runner` directly to the upstream runtime
+  contract while preserving safe defaults.
+- Pass generic pack OCI references and optional registry authentication paths
+  without copying credentials into Helm values.
 
 ## Production Boundary
 

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -155,6 +155,8 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 | `server.eula` | `true` | Accept the Minecraft EULA (required) |
 | `server.type` | `VANILLA` | Server type (VANILLA, PAPER, FORGE, FABRIC, etc.) |
 | `server.version` | `LATEST` | Minecraft version |
+| `server.preferIPv6` | `false` | Prefer the IPv6 Java network stack and addresses |
+| `server.runner` | `mc-server-runner` | Process supervisor command |
 | `server.motd` | `A Minecraft Server powered by HelmForge` | Message of the day |
 | `server.difficulty` | `normal` | Game difficulty |
 | `server.gameMode` | `survival` | Default game mode |
@@ -255,11 +257,11 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.7.0` updates the upstream server image from
-`2026.6.1`. The upstream release adds Purpur support for ServerLibraryCleaner,
-fixes start-utils extraction for non-specific file types, fixes Paper boolean
-flag handling, improves GTNH pack version handling, and reloads
-`LOAD_ENV_FROM_FILE` after the packwiz installer runs.
+`docker.io/itzg/minecraft-server:2026.7.2` adds native `PREFER_IPv6` and
+custom `SERVER_RUNNER` support, moves Vanilla installation to
+`mc-image-helper`, adds OCI generic-pack references, and includes GTNH,
+CurseForge HTTP, Java 17 compatibility, and dependency fixes. Configure the
+first two features with `server.preferIPv6` and `server.runner`.
 Review the upstream release notes before upgrading production servers, take a
 world backup, and verify plugins, mods, datapacks, proxy settings, and pinned
 `server.version` values in a staging environment before reusing existing PVCs.
@@ -272,6 +274,8 @@ Security Scan: Kubescape local scan against `MITRE,NSA,SOC2` reports a 78.79% re
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `mods.genericPacks` | `""` | Generic pack URLs or OCI references, applied in order |
+| `mods.genericPacksOciAuthFile` | `""` | Registry auth file path for private OCI packs |
 | `mods.modrinthProjects` | `""` | Modrinth project slugs (comma-separated) |
 | `mods.curseforgeApiKey` | `""` | CurseForge API key |
 | `mods.autoCurseforgeSlug` | `""` | Auto CurseForge modpack slug |

--- a/charts/minecraft/ci/ipv6-preference-values.yaml
+++ b/charts/minecraft/ci/ipv6-preference-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+server:
+  eula: true
+  preferIPv6: true

--- a/charts/minecraft/templates/NOTES.txt
+++ b/charts/minecraft/templates/NOTES.txt
@@ -53,6 +53,9 @@
   Aikar flags:        {{ .Values.jvm.useAikarFlags }}
   View distance:      {{ .Values.server.viewDistance }}
   Simulation distance: {{ .Values.server.simulationDistance }}
+  Prefer IPv6:        {{ .Values.server.preferIPv6 }}
+  Server runner:      {{ .Values.server.runner }}
+  Generic packs:      {{ if .Values.mods.genericPacks }}configured{{ else }}none{{ end }}
   Geyser:             {{ .Values.geyser.enabled }}
   Metrics:            {{ .Values.metrics.enabled }}
   Backup:             {{ .Values.backup.enabled }}

--- a/charts/minecraft/templates/_helpers.tpl
+++ b/charts/minecraft/templates/_helpers.tpl
@@ -137,3 +137,12 @@ Image string with tag fallback to appVersion.
 {{- define "minecraft.image" -}}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}
+
+{{/*
+Validate required runtime settings before rendering workloads.
+*/}}
+{{- define "minecraft.validate" -}}
+{{- if not .Values.server.eula -}}
+{{- fail "server.eula must be true to accept the Minecraft EULA" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/minecraft/templates/deployment.yaml
+++ b/charts/minecraft/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
               value: {{ .Values.server.type | quote }}
             - name: VERSION
               value: {{ .Values.server.version | quote }}
+            - name: PREFER_IPv6
+              value: {{ .Values.server.preferIPv6 | quote }}
+            - name: SERVER_RUNNER
+              value: {{ .Values.server.runner | quote }}
             - name: MOTD
               value: {{ .Values.server.motd | quote }}
             - name: DIFFICULTY
@@ -141,6 +145,14 @@ spec:
               value: "false"
             {{- end }}
             # -- Mods & Plugins
+            {{- if .Values.mods.genericPacks }}
+            - name: GENERIC_PACKS
+              value: {{ .Values.mods.genericPacks | quote }}
+            {{- end }}
+            {{- if .Values.mods.genericPacksOciAuthFile }}
+            - name: GENERIC_PACKS_OCI_AUTH_FILE
+              value: {{ .Values.mods.genericPacksOciAuthFile | quote }}
+            {{- end }}
             {{- if .Values.mods.modrinthProjects }}
             - name: MODRINTH_PROJECTS
               value: {{ .Values.mods.modrinthProjects | quote }}

--- a/charts/minecraft/templates/validate.yaml
+++ b/charts/minecraft/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "minecraft.validate" . -}}

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.7.0
+          value: docker.io/itzg/minecraft-server:2026.7.2
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.7.0
+          value: docker.io/itzg/minecraft-server:2026.7.2
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.7.0
+          value: docker.io/itzg/minecraft-server:2026.7.2
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.7.0
+          value: docker.io/itzg/minecraft-server:2026.7.2
 
   - it: should set EULA to true
     asserts:
@@ -49,6 +49,38 @@ tests:
           content:
             name: TYPE
             value: PAPER
+
+  - it: should configure IPv6 preference and a custom server runner
+    set:
+      server.preferIPv6: true
+      server.runner: /opt/minecraft/custom-runner
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PREFER_IPv6
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SERVER_RUNNER
+            value: /opt/minecraft/custom-runner
+
+  - it: should configure OCI generic packs
+    set:
+      mods.genericPacks: oci://ghcr.io/example/base:1,oci://ghcr.io/example/mods:1
+      mods.genericPacksOciAuthFile: /run/secrets/registry/config.json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERIC_PACKS
+            value: oci://ghcr.io/example/base:1,oci://ghcr.io/example/mods:1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GENERIC_PACKS_OCI_AUTH_FILE
+            value: /run/secrets/registry/config.json
 
   - it: should set JVM memory
     set:

--- a/charts/minecraft/tests/validate_test.yaml
+++ b/charts/minecraft/tests/validate_test.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: rejects an unaccepted EULA
+    set:
+      server.eula: false
+    asserts:
+      - failedTemplate:
+          errorMessage: server.eula must be true to accept the Minecraft EULA

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.7.0"
+          "default": "2026.7.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -69,6 +69,17 @@
           "type": "string",
           "description": "Minecraft version (LATEST, SNAPSHOT, or specific like 1.21.4)",
           "default": "LATEST"
+        },
+        "preferIPv6": {
+          "type": "boolean",
+          "description": "Prefer the IPv6 Java network stack and addresses",
+          "default": false
+        },
+        "runner": {
+          "type": "string",
+          "description": "Command used to supervise the Minecraft server process",
+          "minLength": 1,
+          "default": "mc-server-runner"
         },
         "motd": {
           "type": "string",
@@ -634,7 +645,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.7.0"
+              "default": "docker.io/itzg/minecraft-server:2026.7.2"
             },
             "uploader": {
               "type": "string",
@@ -706,6 +717,16 @@
       "description": "Mods and plugins configuration",
       "additionalProperties": false,
       "properties": {
+        "genericPacks": {
+          "type": "string",
+          "description": "Comma-separated generic pack URLs or OCI references applied in order",
+          "default": ""
+        },
+        "genericPacksOciAuthFile": {
+          "type": "string",
+          "description": "Container path to a registry auth file for private OCI generic packs",
+          "default": ""
+        },
         "modrinthProjects": {
           "type": "string",
           "description": "Modrinth project slugs or IDs (comma-separated)",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.7.0"
+  tag: "2026.7.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -45,6 +45,12 @@ server:
 
   # -- Minecraft version (LATEST, SNAPSHOT, or specific like 1.21.4)
   version: LATEST
+
+  # -- Prefer the IPv6 Java network stack and addresses.
+  preferIPv6: false
+
+  # -- Command used to supervise the Minecraft server process.
+  runner: mc-server-runner
 
   # -- Message of the day displayed in the server list
   motd: "A Minecraft Server powered by HelmForge"
@@ -381,7 +387,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.7.0
+    worker: docker.io/itzg/minecraft-server:2026.7.2
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 
@@ -421,6 +427,12 @@ backup:
 # =============================================================================
 
 mods:
+  # -- Comma-separated generic pack URLs or OCI references applied in order
+  genericPacks: ""
+
+  # -- Container path to a registry auth file used for private OCI generic packs
+  genericPacksOciAuthFile: ""
+
   # -- Modrinth project slugs or IDs (comma-separated)
   # modrinthProjects: "geyser:beta"
   modrinthProjects: ""


### PR DESCRIPTION
## Summary

- upgrade the official Minecraft server image from 2026.7.0 to 2026.7.2
- expose upstream `PREFER_IPv6` and `SERVER_RUNNER` controls with safe defaults
- add OCI generic-pack references and optional registry auth-file support
- align the backup worker image and document the upstream compatibility fixes
- enforce EULA acceptance during rendering and add dedicated unit and k3d coverage

## Local validation

- official image manifests verified for `2026.7.2`, `2026.7.2-java21`, and `2026.7.2-java17` on their published architectures
- `make validate-chart CHART=minecraft TIMEOUT=600`: 18/18 layers passed
- k3d scenarios: default, backup, dual-stack, External Secrets, Forge, Geyser, IPv6 preference, Paper, and Vanilla
- every scenario Ready with zero restarts, clean logs, and only justified transient startup-probe warnings
- real upgrade 1.4.15 / app 2026.7.0 to local 2026.7.2: PVC UID preserved, zero restarts, clean logs, no Warning events
- Helm unittest: 74 passed
- Kubescape: Overall 78.79%, MITRE 100%, NSA 70%, SOC2 80%
- `make preflight`

## Compatibility notes

The Vanilla installer now runs through `mc-image-helper`. Back up production worlds and validate pinned Minecraft versions, plugins, mods, datapacks, proxies, and custom runners before upgrading existing PVCs.

Site PR: helmforgedev/site#469

Closes #842.