### PR TITLE
fix(mongodb): upgrade to 8.3.7

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -4,7 +4,7 @@ name: mongodb
 description: MongoDB Helm Chart - standalone, replica set, or sharded cluster using the official MongoDB image
 type: application
 version: 1.7.15
-appVersion: "8.3.4"
+appVersion: "8.3.7"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,8 +22,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "bump mongodb to 8.3.4 (#552)"
+    - kind: security
+      description: "upgrade MongoDB to 8.3.7 with upstream security and reliability fixes"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -129,7 +129,7 @@ user initialization path.
 |-----------|-------------|---------|
 | `architecture` | `standalone`, `replicaset`, or `sharded` | `standalone` |
 | `image.repository` | MongoDB image | `mongo` |
-| `image.tag` | Image tag | `8.3.4` |
+| `image.tag` | Image tag | `8.3.7` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -260,13 +260,15 @@ See the [`examples/`](examples/) directory:
 
 ## Upgrade Notes
 
-MongoDB `8.3.4` is a patch-level update within the MongoDB `8.3` release line.
-Review the MongoDB 8.3 release notes before upgrading production clusters,
-take a backup, and verify the data files are compatible with the target
-`mongod` version before reusing existing PVCs. Keep replica set keyFiles and
-root credentials stable across `helm upgrade`; those values are initialized by
-MongoDB and should be rotated with MongoDB administrative commands instead of
-changing chart values.
+MongoDB `8.3.7` is a security and reliability patch within the MongoDB `8.3`
+release line. It addresses upstream CVEs plus authorization, input validation,
+memory-bound, query-planning, and crash fixes. Review the
+[MongoDB 8.3 release notes](https://www.mongodb.com/docs/manual/release-notes/8.3/)
+before upgrading production clusters, take a backup, and verify the data files
+are compatible with the target `mongod` version before reusing existing PVCs.
+Keep replica set keyFiles and root credentials stable across `helm upgrade`;
+those values are initialized by MongoDB and should be rotated with MongoDB
+administrative commands instead of changing chart values.
 
 ## Security Scan
 

--- a/charts/mongodb/examples/replicaset-production.yaml
+++ b/charts/mongodb/examples/replicaset-production.yaml
@@ -5,7 +5,7 @@
 architecture: replicaset
 
 image:
-  tag: "8.3.4"
+  tag: "8.3.7"
 
 auth:
   enabled: true

--- a/charts/mongodb/templates/_helpers.tpl
+++ b/charts/mongodb/templates/_helpers.tpl
@@ -7,6 +7,15 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Validate cross-field settings that JSON Schema cannot express.
+*/}}
+{{- define "mongodb.validate" -}}
+{{- if and .Values.persistence.existingClaim (ne .Values.architecture "standalone") -}}
+{{- fail "persistence.existingClaim is supported only when architecture is standalone" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Fully qualified app name.
 */}}
 {{- define "mongodb.fullname" -}}

--- a/charts/mongodb/templates/validate.yaml
+++ b/charts/mongodb/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "mongodb.validate" . -}}

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mongo:8.3.4"
+          value: "docker.io/library/mongo:8.3.7"
 
   - it: should have 1 replica in standalone mode
     template: statefulset.yaml

--- a/charts/mongodb/tests/validate_test.yaml
+++ b/charts/mongodb/tests/validate_test.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: rejects an existing PVC outside standalone mode
+    set:
+      architecture: replicaset
+      persistence.existingClaim: mongodb-data
+    asserts:
+      - failedTemplate:
+          errorMessage: persistence.existingClaim is supported only when architecture is standalone

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -39,7 +39,7 @@
         "tag": {
           "type": "string",
           "description": "MongoDB image tag",
-          "default": "8.3.4"
+          "default": "8.3.7"
         },
         "pullPolicy": {
           "type": "string",
@@ -662,7 +662,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "8.3.4"
+                  "default": "8.3.7"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/mongo
-  tag: "8.3.4"
+  tag: "8.3.7"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -315,7 +315,7 @@ backup:
       pullPolicy: IfNotPresent
     mongodb:
       repository: docker.io/library/mongo
-      tag: "8.3.4"
+      tag: "8.3.7"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary

- upgrades the official MongoDB image from 8.3.4 to 8.3.7
- documents upstream security, authorization, input-validation, memory, query-planning, and crash fixes
- adds cross-field validation preventing `persistence.existingClaim` on non-standalone architectures
- updates defaults, schema, example, tests, and Artifact Hub release metadata

## Local validation

- verified `docker.io/library/mongo:8.3.7` manifest for linux/amd64, linux/arm64, and windows/amd64
- `make validate-chart CHART=mongodb TIMEOUT=600` passed all 18 layers
- k3d scenarios: default, authenticated users, backup, dual-stack, External Secrets, no-auth, replica set, sharded, and standalone
- every workload became Ready with zero restarts and clean steady-state logs/events
- real persisted upgrade from MongoDB 8.3.4 to 8.3.7 preserved the PVC UID and marker document, with zero restarts and no warning events
- Helm unittest: 24/24 passed
- Kubescape: overall 72.73, MITRE 100, NSA 60, SOC 2 80
- `make preflight REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Site

- helmforgedev/site#470

Closes #843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent using an existing persistent volume claim with replica set deployments.
* **Bug Fixes**
  * Updated MongoDB and backup images to version 8.3.7, including documented examples and defaults.
  * Includes upstream security and reliability fixes.
* **Documentation**
  * Expanded upgrade guidance, including backup, compatibility, and credential considerations.
* **Tests**
  * Added coverage for invalid persistence configuration and updated image expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->