### PR TITLE
chore(n8n): upgrade to 2.32.5

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.9
-appVersion: "2.31.4"
+appVersion: "2.32.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to 2.31.4 (#822)"
+      description: "upgrade n8n and external task runners to 2.32.5"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.31.4` | n8n container image tag |
+| `image.tag` | `2.32.5` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,17 +186,21 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.31.4` is the upstream stable release used by the chart defaults. Review
-the upstream release notes before upgrading, back up the database, and keep the
-encryption key stable before upgrading live deployments. This chart keeps the
-hardened non-root container defaults with resource requests and limits. Queue
-mode fails fast when it resolves to SQLite or when Redis is not configured,
-because workers must share the same PostgreSQL, MySQL, or external database as
-the main pod. Validate database and queue mode in a staging namespace before
-reusing production PVCs.
+n8n `2.32.5` adds public API, workflow export, and editor capabilities, and
+includes fixes across queue-mode MCP executions, S3 path signing, AI Assistant
+runs, credentials, and integrations. Review the
+[upstream 2.32.5 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.32.5)
+before upgrading, back up the database, and keep the encryption key stable
+before upgrading live deployments. This chart keeps the hardened non-root
+container defaults with resource requests and limits. Queue mode fails fast
+when it resolves to SQLite or when Redis is not configured, because workers
+must share the same PostgreSQL, MySQL, or external database as the main pod.
+Validate database and queue mode in a staging namespace before reusing
+production PVCs.
 
-This release includes fixes for execution visibility, webhook error handling,
-and compatibility with earlier versions of the Notion node.
+When upgrading with `--reuse-values`, explicitly set `image.tag=2.32.5`.
+Helm preserves the previous image override in that mode; also update
+`taskRunners.image.tag` when it was pinned separately.
 
 The chart defaults to `N8N_RUNNERS_MODE=external`. It creates a shared auth
 token, opens the broker port, and runs a `docker.io/n8nio/runners` sidecar next

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.31.4"
+          value: "docker.io/n8nio/n8n:2.32.5"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.31.4"
+          value: "docker.io/n8nio/runners:2.32.5"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.31.4"
+          value: "docker.io/n8nio/runners:2.32.5"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.31.4"
+          "default": "2.32.5"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.31.4"
+  tag: "2.32.5"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrades n8n and external task runners from 2.31.4 to 2.32.5
- updates version expectations and upgrade guidance
- documents the `--reuse-values` image pinning requirement found during a persisted upgrade test

## Upstream review

The 2.32 release line adds public API, workflow export, and editor capabilities, and fixes queue-mode MCP executions, AI Assistant runs, credentials, integrations, and strict RFC 3986 S3 path signing. No chart-facing breaking change was identified. Agent-level OpenTelemetry tracing was deliberately excluded because upstream documents it as available only from n8n 2.33.0.

## Local validation

- image manifests verified for `n8nio/n8n:2.32.5` and `n8nio/runners:2.32.5` on linux/amd64 and linux/arm64
- `make validate-chart CHART=n8n TIMEOUT=600`: all 20 layers and 11 k3d scenarios passed on the final head
- Helm unit tests: 78/78 passed
- queue scenario: main and 2 workers Ready, zero restarts, clean application logs
- persisted upgrade from chart 1.6.9/app 2.31.4: PVC UID and SQLite marker preserved, upgraded workload 2/2 Ready with zero restarts
- Kubescape: overall 87.289566 (threshold 87), MITRE 100, NSA 81.25, SOC2 91.11111
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Site

Companion documentation: helmforgedev/site#471

Closes #844