### PR TITLE
chore(netbird): upgrade to 0.75.0

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -4,7 +4,7 @@ name: netbird
 description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
 type: application
 version: 1.0.2
-appVersion: "0.74.7"
+appVersion: "0.75.0"
 home: https://helmforge.dev/docs/charts/netbird
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/netbird
@@ -25,8 +25,10 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
+    - kind: changed
+      description: "bump NetBird server image to 0.75.0 (#845)"
     - kind: fixed
-      description: "align embedded idp dashboard defaults (#858)"
+      description: "make the Helm test use the server when the dashboard is disabled"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -4,7 +4,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 
 This chart packages the current upstream combined architecture:
 
-- `netbirdio/netbird-server:0.74.7` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/netbird-server:0.75.0` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.3` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
@@ -110,7 +110,7 @@ Use `externalSecrets.items[]` to synchronize sensitive values such as `config.ya
 Local security scan:
 
 ```text
-Image: netbirdio/netbird-server:0.74.7
+Image: netbirdio/netbird-server:0.75.0
 Image: netbirdio/dashboard:v2.90.3
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 86.86869 compliance score
@@ -120,6 +120,26 @@ The local scan reported no critical failures and an overall score above the
 repository security gate. Remaining findings are tracked as hardening trade-offs
 for optional NetworkPolicy enablement, upstream dashboard startup model, and
 operator-owned resource limit tuning across the database-backed topology.
+
+## Upgrade from 0.74.7
+
+NetBird `0.75.0` improves the combined server's management, relay, and
+self-hosting paths. The redesigned desktop client announced in the upstream
+release is distributed separately and is not part of this server chart.
+
+Back up the configured database and `/var/lib/netbird`, then apply the new chart
+defaults while preserving your explicit overrides:
+
+```bash
+helm repo update helmforge
+helm upgrade netbird helmforge/netbird \
+  --version 1.0.3 \
+  --namespace netbird \
+  --reset-then-reuse-values
+```
+
+Using `--reuse-values` alone retains the previous default image tag. Remove any
+explicit `server.image.tag` override if you want the chart default `0.75.0`.
 
 ## Validation
 

--- a/charts/netbird/templates/tests/test-connection.yaml
+++ b/charts/netbird/templates/tests/test-connection.yaml
@@ -12,13 +12,25 @@ spec:
   restartPolicy: Never
   automountServiceAccountToken: false
   containers:
-    - name: wget
+    - name: connectivity
+      {{- if .Values.dashboard.enabled }}
       image: busybox:1.37.0
       command:
         - wget
       args:
         - -qO-
         - http://{{ include "netbird.dashboardServiceName" . }}:{{ .Values.dashboard.service.port }}/
+      {{- else }}
+      image: busybox:1.37.0
+      command:
+        - nc
+      args:
+        - -z
+        - -w
+        - "10"
+        - {{ include "netbird.serverServiceName" . }}
+        - {{ .Values.server.service.httpPort | quote }}
+      {{- end }}
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/netbird-server:0.74.7
+          value: netbirdio/netbird-server:0.75.0
         template: templates/deployment.yaml
         documentIndex: 0
   - it: renders the official pinned dashboard image

--- a/charts/netbird/tests/test_connection_test.yaml
+++ b/charts/netbird/tests/test_connection_test.yaml
@@ -19,3 +19,21 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.containers[0].args[1]
+          value: http://test-netbird-dashboard:80/
+  - it: should test the server port when the dashboard is disabled
+    set:
+      dashboard.enabled: false
+    asserts:
+      - equal:
+          path: spec.containers[0].command[0]
+          value: nc
+      - equal:
+          path: spec.containers[0].args
+          value:
+            - -z
+            - -w
+            - "10"
+            - test-netbird-server
+            - "80"

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -14,7 +14,7 @@ server:
     # -- Official NetBird server container image repository.
     repository: netbirdio/netbird-server
     # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
-    tag: "0.74.7"
+    tag: "0.75.0"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of NetBird server pods. Keep 1 with the default sqlite store.


### PR DESCRIPTION
## Summary

- upgrade the official NetBird combined server image from `0.74.7` to `0.75.0`
- synchronize `appVersion`, defaults, tests, README, and Artifact Hub release notes
- fix the Helm test hook so dashboard-disabled installations probe the server port instead of a nonexistent dashboard Service
- document the safe upgrade command that applies the new image default

## Upstream review

NetBird `0.75.0` includes management, relay, and self-hosting improvements. The headline desktop client redesign is distributed separately and does not change this server chart. The release did not introduce a chart value migration.

Official release: https://github.com/netbirdio/netbird/releases/tag/v0.75.0

## Validation

- verified `netbirdio/netbird-server:0.75.0` on linux/amd64, linux/arm64, and linux/arm
- `make validate-chart CHART=netbird TIMEOUT=600` (19 layers; 10 k3d scenarios)
- 38 Helm unit tests passed
- all k3d workloads had zero restarts, clean logs, and no critical events
- installed published chart `1.0.2` / NetBird `0.74.7` with SQLite persistence, wrote a PVC marker, and upgraded locally with `--reset-then-reuse-values`
- confirmed live image `0.75.0`, unchanged PVC UID, preserved marker, zero restarts, no Warning events, clean server logs, and successful `helm test` with dashboard disabled
- `make standards-check CHART=netbird`
- `make deps-check CHART=netbird`
- `make preflight`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=netbird`
- `make org-check`

## Self-review

Reviewed the complete diff for runtime correctness, security, upgrade behavior, documentation consistency, and regression coverage. Two findings were fixed before opening this PR: the dashboard-disabled Helm test target and missing chart-level upgrade guidance. No unresolved findings remain.

Closes #845.

Site synchronization: helmforgedev/site#472.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded the NetBird Helm chart and default server image to version 0.75.0.
  * Added upgrade guidance for installations moving from version 0.74.7.

* **Bug Fixes**
  * Helm connectivity checks now validate the dashboard when enabled and the server when it is disabled.

* **Tests**
  * Updated image-version checks and added coverage for server connectivity testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->