### PR TITLE
feat(notediscovery): upgrade to 0.28.4

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.0.5
-appVersion: "0.28.3"
+appVersion: "0.28.4"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -23,8 +23,10 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "update image to 0.28.3 (#824)"
+    - kind: added
+      description: "expose the configurable default theme introduced in 0.28.4 (#846)"
+    - kind: fixed
+      description: "fix sibling note links and persist writable plugin configuration on 0.28.4 (#846)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.28.3` image.
+official `ghcr.io/gamosoft/notediscovery:0.28.4` image.
 
 ## Product Model
 
@@ -25,6 +25,13 @@ Upstream NoteDiscovery reads `config.yaml`. The chart renders that file in two m
 The chart does not split individual auth keys into separate environment
 variables because the upstream contract is file-based. Keeping the full file
 together avoids partially duplicated configuration paths.
+
+Generated configuration places plugins under the writable data volume. An init
+container copies the upstream bundled plugins there before application startup,
+preserving plugin configuration without running the application as root or
+hiding the official plugin bundle. `PLUGINS_DIR` is set to the same effective
+path for generated and externally supplied config files, and bootstrap never
+overwrites a plugin already present on the volume.
 
 ## Default Topology
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.3` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.4` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -50,6 +50,7 @@ Then open `http://127.0.0.1:8000`.
 notediscovery:
   allowedOrigins:
     - https://notes.example.com
+  defaultTheme: dracula
 
 auth:
   enabled: true
@@ -113,11 +114,12 @@ stringData:
       debug: false
     storage:
       notes_dir: "/app/data"
-      plugins_dir: "./plugins"
+      plugins_dir: "/app/data/plugins"
     search:
       enabled: true
     ui:
       autosave_delay_ms: 1000
+      default_theme: "dracula"
     authentication:
       enabled: true
       secret_key: "replace-with-a-long-random-secret"
@@ -149,10 +151,29 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.28.3` adds pane visibility shortcuts and custom image sizes.
-The chart continues to render `storage.notes_dir` from
-`persistence.mountPath`; keep that path stable across upgrades and back up the
-PVC before upgrading production vaults.
+NoteDiscovery `0.28.4` adds a configurable default theme and fixes Markdown
+links to sibling notes. Set `notediscovery.defaultTheme` to a built-in or
+operator-mounted theme ID; a theme already stored in the browser continues to
+take precedence, and invalid IDs fall back to `light`.
+
+Generated configuration now stores plugin state under the writable data volume
+and bootstraps the official bundled plugins there. Existing Secrets should use
+`storage.plugins_dir: "/app/data/plugins"` (or another writable directory).
+The chart sets `PLUGINS_DIR` to `notediscovery.pluginsDir`, derived from
+`persistence.mountPath` when empty, so the effective path stays consistent for
+generated config, existing Secrets, and External Secrets. Bootstrap preserves
+files already present on the volume.
+
+Back up the PVC and keep `persistence.mountPath` stable, then apply the new
+chart defaults while preserving explicit overrides:
+
+```bash
+helm repo update helmforge
+helm upgrade notediscovery helmforge/notediscovery \
+  --version 1.1.0 \
+  --namespace notediscovery \
+  --reset-then-reuse-values
+```
 
 ## Network Policy
 

--- a/charts/notediscovery/ci/default-theme-values.yaml
+++ b/charts/notediscovery/ci/default-theme-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+notediscovery:
+  defaultTheme: dracula

--- a/charts/notediscovery/ci/existing-config-secret.yaml
+++ b/charts/notediscovery/ci/existing-config-secret.yaml
@@ -21,7 +21,7 @@ extraManifests:
           debug: false
         storage:
           notes_dir: "/app/data"
-          plugins_dir: "./plugins"
+          plugins_dir: "/app/data/plugins"
         search:
           enabled: true
         ui:

--- a/charts/notediscovery/ci/external-secrets.yaml
+++ b/charts/notediscovery/ci/external-secrets.yaml
@@ -26,7 +26,7 @@ externalSecrets:
                   debug: false
                 storage:
                   notes_dir: "/app/data"
-                  plugins_dir: "./plugins"
+                  plugins_dir: "/app/data/plugins"
                 search:
                   enabled: true
                 ui:

--- a/charts/notediscovery/templates/_helpers.tpl
+++ b/charts/notediscovery/templates/_helpers.tpl
@@ -104,6 +104,17 @@ Configuration checksum for pod rollouts.
 {{- end -}}
 
 {{/*
+Writable plugin directory colocated with the persistent data volume.
+*/}}
+{{- define "notediscovery.pluginsDir" -}}
+{{- if .Values.notediscovery.pluginsDir -}}
+{{- .Values.notediscovery.pluginsDir -}}
+{{- else -}}
+{{- printf "%s/plugins" (trimSuffix "/" .Values.persistence.mountPath) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 HTTPRoute name helper.
 */}}
 {{- define "notediscovery.httpRouteName" -}}

--- a/charts/notediscovery/templates/configmap.yaml
+++ b/charts/notediscovery/templates/configmap.yaml
@@ -20,11 +20,12 @@ data:
       debug: {{ .Values.notediscovery.debug }}
     storage:
       notes_dir: {{ .Values.persistence.mountPath | quote }}
-      plugins_dir: "./plugins"
+      plugins_dir: {{ include "notediscovery.pluginsDir" . | quote }}
     search:
       enabled: {{ .Values.notediscovery.searchEnabled }}
     ui:
       autosave_delay_ms: {{ .Values.notediscovery.autosaveDelayMs }}
+      default_theme: {{ .Values.notediscovery.defaultTheme | quote }}
     authentication:
       enabled: false
       secret_key: ""

--- a/charts/notediscovery/templates/deployment.yaml
+++ b/charts/notediscovery/templates/deployment.yaml
@@ -39,6 +39,25 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: plugin-bootstrap
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - -ec
+            - |
+              mkdir -p {{ include "notediscovery.pluginsDir" . | quote }}
+              if [ -d /app/plugins ]; then
+                cp -Rn /app/plugins/. {{ include "notediscovery.pluginsDir" . | quote }}/
+              fi
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath | quote }}
       containers:
         - name: {{ include "notediscovery.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -64,6 +83,8 @@ spec:
               value: {{ .Values.app.timezone | quote }}
             - name: PORT
               value: {{ .Values.app.port | quote }}
+            - name: PLUGINS_DIR
+              value: {{ include "notediscovery.pluginsDir" . | quote }}
             {{- range .Values.app.env }}
             - name: {{ .name }}
               {{- if hasKey . "valueFrom" }}

--- a/charts/notediscovery/templates/secret.yaml
+++ b/charts/notediscovery/templates/secret.yaml
@@ -21,11 +21,12 @@ stringData:
       debug: {{ .Values.notediscovery.debug }}
     storage:
       notes_dir: {{ .Values.persistence.mountPath | quote }}
-      plugins_dir: "./plugins"
+      plugins_dir: {{ include "notediscovery.pluginsDir" . | quote }}
     search:
       enabled: {{ .Values.notediscovery.searchEnabled }}
     ui:
       autosave_delay_ms: {{ .Values.notediscovery.autosaveDelayMs }}
+      default_theme: {{ .Values.notediscovery.defaultTheme | quote }}
     authentication:
       enabled: true
       secret_key: {{ .Values.auth.secretKey | quote }}

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -5,6 +5,7 @@ templates:
   - templates/deployment.yaml
   - templates/ingress.yaml
   - templates/pvc.yaml
+  - templates/secret.yaml
   - templates/service.yaml
 tests:
   - it: renders the official pinned image
@@ -14,10 +15,28 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.28.3
+          value: ghcr.io/gamosoft/notediscovery:0.28.4
       - equal:
           path: spec.strategy.type
           value: Recreate
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: plugin-bootstrap
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/gamosoft/notediscovery:0.28.4
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "if \\[ -d /app/plugins \\]"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "cp -Rn /app/plugins"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: PLUGINS_DIR
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: /app/data/plugins
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/config"]
           pattern: "^[a-f0-9]{64}$"
@@ -45,6 +64,37 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "enabled: false"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'default_theme: "light"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'plugins_dir: "/app/data/plugins"'
+  - it: renders a custom default theme in generated config
+    template: templates/configmap.yaml
+    set:
+      notediscovery.defaultTheme: dracula
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'default_theme: "dracula"'
+  - it: renders theme and plugin path in generated authenticated config
+    template: templates/secret.yaml
+    set:
+      auth.enabled: true
+      auth.secretKey: test-session-secret
+      auth.password: test-password
+      notediscovery.defaultTheme: nord
+      notediscovery.pluginsDir: /plugins
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'default_theme: "nord"'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'plugins_dir: "/plugins"'
   - it: renders ingress TLS
     template: templates/ingress.yaml
     values:

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.28.3", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.28.4", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -47,7 +47,9 @@
         "allowedOrigins": { "type": "array", "items": { "type": "string" } },
         "debug": { "type": "boolean", "default": false },
         "searchEnabled": { "type": "boolean", "default": true },
-        "autosaveDelayMs": { "type": "integer", "minimum": 0, "default": 1000 }
+        "autosaveDelayMs": { "type": "integer", "minimum": 0, "default": 1000 },
+        "defaultTheme": { "type": "string", "minLength": 1, "default": "light" },
+        "pluginsDir": { "type": "string", "default": "" }
       }
     },
     "auth": {

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.28.3"
+  tag: "0.28.4"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 
@@ -49,6 +49,10 @@ notediscovery:
   searchEnabled: true
   # -- Autosave debounce in milliseconds.
   autosaveDelayMs: 1000
+  # -- Theme shown to browsers without a saved preference. Invalid upstream theme IDs fall back to light.
+  defaultTheme: light
+  # -- Writable plugin directory. Empty derives <persistence.mountPath>/plugins.
+  pluginsDir: ""
 
 auth:
   # -- Require login before users can access notes.


### PR DESCRIPTION
## Summary

- upgrade the official NoteDiscovery image from 0.28.3 to 0.28.4
- expose `notediscovery.defaultTheme` through generated ConfigMap and Secret configuration
- add a dedicated default-theme runtime scenario
- move generated plugin state to the writable data volume and bootstrap official bundled plugins with a non-root init container
- document the safe persistent upgrade path and the corrected sibling-note links from upstream

## Upstream review

NoteDiscovery 0.28.4 adds a configurable default theme for fresh browser sessions and fixes Markdown links to sibling notes. Saved browser preferences still take precedence, and invalid theme IDs fall back to `light` upstream.

Image manifest verified for linux/amd64 and linux/arm64.

## Validation

- 34 Helm unit tests passed
- `make validate-chart CHART=notediscovery TIMEOUT=600`: fully validated in 20 layers
- 12 k3d scenarios passed, including auth, default theme, dual stack, existing Secret, External Secrets, Gateway API, Ingress, NetworkPolicy, and persistence disabled
- persistent upgrade 1.0.5/0.28.3 to local 0.28.4 passed with the same PVC UID and marker note preserved
- runtime API returned `defaultTheme=dracula`
- official plugin and `plugin_config.json` persisted under `/app/data/plugins` with UID/GID 1000
- Helm test passed; workloads Ready; zero restarts; no Warning events; application logs contained no error/fatal/traceback/exception patterns
- standards, dependency, markdown, site-sync, org consistency, release, and attribution checks passed

## Site sync

- helmforgedev/site#473

Closes #846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded NoteDiscovery to version 0.28.4.
  * Added configurable default themes, including support for custom theme values.
  * Preserved plugin configuration and state across restarts using persistent storage.
* **Bug Fixes**
  * Fixed sibling note links.
* **Documentation**
  * Updated chart configuration, upgrade guidance, and examples for the new release and plugin behavior.
* **Tests**
  * Added coverage for default themes, plugin paths, and startup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->