### PR TITLE
feat(ntfy): upgrade to 2.26.3

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -4,7 +4,7 @@ name: ntfy
 description: ntfy self-hosted push notification service with HTTP-based pub-sub
 type: application
 version: 1.1.12
-appVersion: "v2.26.0"
+appVersion: "v2.26.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,8 +23,10 @@ sources:
   - https://github.com/binwiederhier/ntfy
 annotations:
   artifacthub.io/changes: |
+    - kind: added
+      description: "expose the ntfy 2.26.3 abuse ban-feed with persistent, opt-in defaults"
     - kind: changed
-      description: "bump image to 2.26.0 (#770)"
+      description: "upgrade the official ntfy image from 2.26.0 to 2.26.3"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ntfy/DESIGN.md
+++ b/charts/ntfy/DESIGN.md
@@ -21,6 +21,8 @@ flowchart LR
   svc --> pod[ntfy pod]
   pod --> cfg[ConfigMap server.yml]
   pod --> pvc[(PVC /var/cache/ntfy)]
+  pod -. optional ban feed .-> pvc
+  pvc -. external consumer .-> ban[fail2ban or equivalent]
   prom[Prometheus] -. optional .-> svc
 ```
 
@@ -32,6 +34,7 @@ flowchart LR
 - Render Gateway API HTTPRoutes as an opt-in exposure path alongside Ingress.
 - Keep Service dual-stack fields opt-in so clusters without dual-stack support use their defaults.
 - Keep authentication user lifecycle out of the chart; ntfy users are managed with the upstream CLI.
+- Keep the 2.26.3 abuse ban-feed opt-in, persist its default file on the existing data volume, and leave firewall enforcement to an external consumer.
 
 ## Production Boundary
 
@@ -43,6 +46,7 @@ Recommended production controls:
 - back up the PVC before upgrades
 - expose the service only through trusted ingress or Gateway policy
 - set explicit resources for shared clusters
+- rotate the ban-feed with copy-truncate semantics when it is enabled
 
 ## Non-Goals
 
@@ -50,6 +54,7 @@ Recommended production controls:
 - user account reconciliation
 - installing Gateway API CRDs or controllers
 - installing Prometheus Operator CRDs
+- installing fail2ban or changing node firewall rules
 
 ## Validation
 
@@ -60,6 +65,7 @@ The chart is expected to pass:
 - helm-unittest coverage for deployment, service, persistence, ingress, Gateway API, and metrics
 - kubeconform validation for Kubernetes-native default manifests
 - local k3d deployment smoke tests with pod logs and namespace events checked
+- an opt-in k3d scenario that renders and starts with the upstream ban-feed settings
 
 <!-- @AI-METADATA
 type: design

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -13,6 +13,7 @@ to phones and desktops via scripts — no signup, no fees.
 - **Prometheus metrics** — opt-in `/metrics` endpoint with ServiceMonitor
 - **Behind proxy** — trusts X-Forwarded-For headers by default
 - **Attachment support** — configurable file size and expiry limits
+- **Abuse ban-feed** — opt-in weighted offender feed for fail2ban or equivalent tooling
 - **Ingress support** — TLS with cert-manager
 - **Dual-stack** — `ipFamilyPolicy`/`ipFamilies` on the Service for IPv4/IPv6 clusters
 - **Gateway API** — opt-in `HTTPRoute` (alternative to Ingress; requires Gateway API CRDs)
@@ -62,6 +63,8 @@ curl -s http://localhost:8080/test/json
 | `ntfy.authDefaultAccess` | `"read-write"` | Default access for unauthenticated users |
 | `ntfy.behindProxy` | `true` | Trust X-Forwarded-For headers |
 | `ntfy.enableMetrics` | `false` | Enable Prometheus `/metrics` endpoint |
+| `ntfy.banFeed.enabled` | `false` | Append confirmed abusive visitors to a ban-feed file |
+| `ntfy.banFeed.file` | `/var/cache/ntfy/ban.log` | Writable ban-feed file on the data volume |
 | `persistence.enabled` | `true` | Enable persistence for cache and auth |
 | `persistence.size` | `2Gi` | PVC size |
 | `service.type` | `ClusterIP` | Service type |
@@ -100,6 +103,28 @@ metrics:
   serviceMonitor:
     enabled: true
 ```
+
+## Abuse Ban-Feed
+
+ntfy 2.26.3 can append confirmed abusive visitor IPs to a weighted ban-feed for
+an external fail2ban or equivalent consumer. The chart keeps this disabled by
+default. When enabled, the default file is stored on the writable data volume:
+
+```yaml
+ntfy:
+  banFeed:
+    enabled: true
+    file: /var/cache/ntfy/ban.log
+    window: 10m
+    threshold: 100
+    weights:
+      - "42909:10"
+```
+
+The chart configures the feed only; it does not install fail2ban or modify node
+firewall rules. The external consumer must be able to read the file, and the
+operator must rotate it with a copy-truncate strategy so it cannot grow without
+bound.
 
 ## Gateway API
 

--- a/charts/ntfy/ci/ban-feed-values.yaml
+++ b/charts/ntfy/ci/ban-feed-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: ntfy 2.26.3 abuse ban-feed on the writable data volume
+ntfy:
+  banFeed:
+    enabled: true
+    file: /var/cache/ntfy/ban.log
+    window: 10m
+    threshold: 1
+    weights:
+      - "404*:1"
+      - "*:0"

--- a/charts/ntfy/docs/configuration.md
+++ b/charts/ntfy/docs/configuration.md
@@ -39,6 +39,26 @@ metrics:
 
 `ServiceMonitor` requires Prometheus Operator CRDs to exist in the cluster.
 
+## Abuse Ban-Feed
+
+ntfy 2.26.3 can emit confirmed abusive visitors to a file consumed by fail2ban
+or equivalent enforcement:
+
+```yaml
+ntfy:
+  banFeed:
+    enabled: true
+    file: /var/cache/ntfy/ban.log
+    window: 10m
+    threshold: 100
+    weights:
+      - "42909:10"
+```
+
+The default path is on the chart's writable data volume. Configure an external
+consumer and rotate the file with copy-truncate semantics. The chart does not
+install fail2ban or modify node firewall rules.
+
 ## Gateway API
 
 ```yaml

--- a/charts/ntfy/templates/configmap.yaml
+++ b/charts/ntfy/templates/configmap.yaml
@@ -30,6 +30,17 @@ data:
     {{- with .Values.ntfy.attachmentExpiryDuration }}
     attachment-expiry-duration: {{ . | quote }}
     {{- end }}
+    {{- if .Values.ntfy.banFeed.enabled }}
+    ban-file: {{ .Values.ntfy.banFeed.file | quote }}
+    ban-window: {{ .Values.ntfy.banFeed.window | quote }}
+    ban-threshold: {{ .Values.ntfy.banFeed.threshold }}
+    {{- with .Values.ntfy.banFeed.weights }}
+    ban-weights:
+      {{- range . }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
     {{- with .Values.ntfy.extraConfig }}
     {{ . | nindent 4 }}
     {{- end }}

--- a/charts/ntfy/tests/configmap_test.yaml
+++ b/charts/ntfy/tests/configmap_test.yaml
@@ -28,6 +28,9 @@ tests:
       - matchRegex:
           path: data["server.yml"]
           pattern: "behind-proxy.*true"
+      - notMatchRegex:
+          path: data["server.yml"]
+          pattern: "ban-file"
 
   - it: should set base-url when configured
     set:
@@ -44,3 +47,29 @@ tests:
       - matchRegex:
           path: data["server.yml"]
           pattern: "enable-metrics.*true"
+
+  - it: should render the abuse ban-feed when enabled
+    set:
+      ntfy.banFeed.enabled: true
+      ntfy.banFeed.file: /var/cache/ntfy/ban.log
+      ntfy.banFeed.window: 5m
+      ntfy.banFeed.threshold: 20
+      ntfy.banFeed.weights:
+        - "42909:10"
+        - "*:1"
+    asserts:
+      - matchRegex:
+          path: data["server.yml"]
+          pattern: "ban-file.*var/cache/ntfy/ban.log"
+      - matchRegex:
+          path: data["server.yml"]
+          pattern: "ban-window.*5m"
+      - matchRegex:
+          path: data["server.yml"]
+          pattern: "ban-threshold: 20"
+      - matchRegex:
+          path: data["server.yml"]
+          pattern: "ban-weights:[\\s\\S]*42909:10"
+      - matchRegex:
+          path: data["server.yml"]
+          pattern: "ban-weights:[\\s\\S]*\\*:1"

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/binwiederhier/ntfy:v2.26.0"
+          value: "docker.io/binwiederhier/ntfy:v2.26.3"
 
   - it: should pass serve argument
     template: templates/deployment.yaml

--- a/charts/ntfy/values.schema.json
+++ b/charts/ntfy/values.schema.json
@@ -42,14 +42,17 @@
               "default": ["42909:10"],
               "items": {
                 "type": "string",
-                "pattern": "^(?:\\*|[1-5](?:\\*|[0-9]{2}\\*?|[0-9]{4})):[0-9]+$"
+                "pattern": "^(?:\\*|[0-9]+\\*?):[0-9]+$"
               }
             }
           },
           "allOf": [
             {
-              "if": { "properties": { "enabled": { "const": true } } },
-              "then": { "properties": { "file": { "minLength": 1, "pattern": "^/" } } }
+              "if": { "properties": { "enabled": { "const": true } }, "required": ["enabled"] },
+              "then": {
+                "properties": { "file": { "minLength": 1, "pattern": "^/" } },
+                "required": ["file"]
+              }
             }
           ]
         },

--- a/charts/ntfy/values.schema.json
+++ b/charts/ntfy/values.schema.json
@@ -29,6 +29,30 @@
         "attachmentTotalSizeLimit": { "type": "string", "default": "" },
         "attachmentFileSizeLimit": { "type": "string", "default": "" },
         "attachmentExpiryDuration": { "type": "string", "default": "" },
+        "banFeed": {
+          "type": "object",
+          "description": "Opt-in abuse ban-feed for an external fail2ban or equivalent consumer",
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "file": { "type": "string", "default": "/var/cache/ntfy/ban.log" },
+            "window": { "type": "string", "minLength": 1, "default": "10m" },
+            "threshold": { "type": "integer", "minimum": 1, "default": 100 },
+            "weights": {
+              "type": "array",
+              "default": ["42909:10"],
+              "items": {
+                "type": "string",
+                "pattern": "^(?:\\*|[1-5](?:\\*|[0-9]{2}\\*?|[0-9]{4})):[0-9]+$"
+              }
+            }
+          },
+          "allOf": [
+            {
+              "if": { "properties": { "enabled": { "const": true } } },
+              "then": { "properties": { "file": { "minLength": 1, "pattern": "^/" } } }
+            }
+          ]
+        },
         "extraConfig": { "type": "string", "default": "" },
         "extraEnv": { "type": "array", "items": { "type": "object" } }
       }

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
   # -- Image tag
-  tag: "v2.26.0"
+  tag: "v2.26.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -42,6 +42,19 @@ ntfy:
   attachmentFileSizeLimit: ""
   # -- Attachment expiry duration (e.g. 3h)
   attachmentExpiryDuration: ""
+  # -- Abuse ban-feed configuration for an external fail2ban or equivalent consumer
+  banFeed:
+    # -- Enable the abuse ban-feed
+    enabled: false
+    # -- Writable file where confirmed abusive visitors are appended
+    file: /var/cache/ntfy/ban.log
+    # -- Rolling window used to count weighted strikes per visitor prefix
+    window: 10m
+    # -- Weighted strikes per window before a visitor prefix is written to the ban file
+    threshold: 100
+    # -- Per-code weights in KEY:WEIGHT format; longest match wins
+    weights:
+      - "42909:10"
   # -- Extra server.yml configuration lines (appended to ConfigMap)
   # -- @default -- `""`
   extraConfig: ""


### PR DESCRIPTION
## Summary

- upgrade the official ntfy image from 2.26.0 to 2.26.3
- expose the 2.26.3 weighted abuse ban-feed as an opt-in chart contract
- validate absolute ban-file paths, positive thresholds, and upstream weight syntax
- add unit coverage, a dedicated CI values scenario, and operator documentation

## Upstream evidence

- release: https://github.com/binwiederhier/ntfy/releases/tag/v2.26.3
- immutable tag commit: `311138ef7b3314a140d8385e6f4549e1454fa97c`
- official image verified for linux/amd64, linux/arm64, and linux/arm

## Local validation

- `make validate-chart CHART=ntfy TIMEOUT=600` — all 15 layers passed, including six k3d scenarios
- dedicated functional k3d test — weighted publish failures emitted the expected ban-feed record
- persistent upgrade from chart 1.1.12 / ntfy 2.26.0 — PVC UID and marker preserved; workload reached 2.26.3
- all pods Ready with zero restarts, clean application logs, and no Warning events
- schema negative tests reject relative ban paths and malformed weights
- `make preflight`, `make standards-check CHART=ntfy`, `make deps-check CHART=ntfy`, and `make site-sync-check CHART=ntfy`

## Site synchronization

- helmforgedev/site#474

Closes #847.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an opt-in abuse ban-feed that records confirmed abusive activity for external enforcement tools.
  - Added configurable feed path, detection window, threshold, and event weights.
  - Added validation requiring an absolute path when the feed is enabled.

- **Updates**
  - Upgraded the bundled ntfy image from v2.26.0 to v2.26.3.

- **Documentation**
  - Added configuration and operational guidance, including log rotation and external firewall enforcement responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->