### PR TITLE
feat(olivetin): upgrade to 3000.18.1

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.1.16
-appVersion: "3000.17.2"
+appVersion: "3000.18.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,13 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update to 3000.17.2 (#825)"
+      description: "update OliveTin to 3000.18.1 (#848)"
+    - kind: added
+      description: "make olivetin.port authoritative through the upstream PORT environment variable"
+    - kind: security
+      description: "include upstream shellAfterCompleted injection, HTTP timeout, path traversal, and theme permission fixes"
+    - kind: fixed
+      description: "create the data PersistentVolumeClaim when persistence is enabled"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -105,14 +105,14 @@ See the [OliveTin documentation](https://docs.olivetin.app) for all available op
 
 ## Upgrade Notes
 
-OliveTin `3000.18.1` adds `dnsname` action arguments, configuration issues in
-diagnostics, dashboard categories, persistent log filters, and support for the
-`PORT` environment variable. It also fixes `shellAfterCompleted` output
-injection, HTTP timeout and path traversal weaknesses, and unsafe theme
-permissions. Upstream reports no breaking changes. The chart now propagates
-`olivetin.port` through `PORT`; remove any duplicate `PORT` entry from
-`olivetin.extraEnv` and configure the port only through `olivetin.port`.
-Enabling persistence now creates the data PVC when
+OliveTin `3000.18.0` added `dnsname` action arguments and configuration issues
+in diagnostics. OliveTin `3000.18.1` adds dashboard categories, persistent log
+filters, and support for the `PORT` environment variable. It also fixes
+`shellAfterCompleted` output injection, HTTP timeout and path traversal
+weaknesses, and unsafe theme permissions. Upstream reports no breaking changes.
+The chart now propagates `olivetin.port` through `PORT`; remove any duplicate
+`PORT` entry from `olivetin.extraEnv` and configure the port only through
+`olivetin.port`. Enabling persistence now creates the data PVC when
 `persistence.existingClaim` is empty.
 
 ### Security Scan: olivetin

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -14,6 +14,8 @@ OliveTin gives safe and simple access to predefined shell commands from a web in
 - **Gateway API support** — optional HTTPRoute rendering for modern ingress controllers
 - **External Secrets support** — optional ExternalSecret resources for command credentials
 - **Dual-stack Service support** — optional `ipFamilyPolicy` and `ipFamilies`
+- **Authoritative application port** — `olivetin.port` configures both Kubernetes and OliveTin through `PORT`
+- **Optional persistence** — dynamically provision a data PVC or attach an existing claim
 - **Lightweight** — minimal resource usage
 
 ## Installation
@@ -58,9 +60,9 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.resources` | requests/limits set | Resource guardrails for the config bootstrap init container |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.17.2` | OliveTin image tag |
+| `image.tag` | `3000.18.1` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
-| `olivetin.port` | `1337` | Application port |
+| `olivetin.port` | `1337` | Application port, propagated through OliveTin's `PORT` environment variable |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |
 | `configTpl.enabled` | `false` | Opt in to Helm `tpl` rendering for `config` |
 | `persistence.enabled` | `false` | Enable optional PVC for data |
@@ -103,11 +105,15 @@ See the [OliveTin documentation](https://docs.olivetin.app) for all available op
 
 ## Upgrade Notes
 
-OliveTin `3000.17.2` fixes dashboard ACLs and includes security
-hardening for shell execution, argument types, log access control, and OAuth2
-state growth. Upstream reports no upgrade warnings or breaking changes; keep
-the chart-managed config and persistent data paths unchanged when rolling
-production deployments.
+OliveTin `3000.18.1` adds `dnsname` action arguments, configuration issues in
+diagnostics, dashboard categories, persistent log filters, and support for the
+`PORT` environment variable. It also fixes `shellAfterCompleted` output
+injection, HTTP timeout and path traversal weaknesses, and unsafe theme
+permissions. Upstream reports no breaking changes. The chart now propagates
+`olivetin.port` through `PORT`; remove any duplicate `PORT` entry from
+`olivetin.extraEnv` and configure the port only through `olivetin.port`.
+Enabling persistence now creates the data PVC when
+`persistence.existingClaim` is empty.
 
 ### Security Scan: olivetin
 

--- a/charts/olivetin/ci/persistence-values.yaml
+++ b/charts/olivetin/ci/persistence-values.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: dynamically provisioned persistent data volume
+persistence:
+  enabled: true
+  size: 128Mi

--- a/charts/olivetin/ci/upstream-features-values.yaml
+++ b/charts/olivetin/ci/upstream-features-values.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: OliveTin 3000.18 custom PORT and dnsname argument validation
+olivetin:
+  port: 1447
+
+config: |
+  actions:
+    - title: "Resolve host"
+      shell: "getent hosts {{ hostname }}"
+      arguments:
+        - name: hostname
+          title: "DNS hostname"
+          type: dnsname
+          default: "example.com"

--- a/charts/olivetin/docs/configuration.md
+++ b/charts/olivetin/docs/configuration.md
@@ -13,6 +13,25 @@ config: |
 
 When `config` is empty, the chart renders a safe default action so the application can start and expose the UI.
 
+## Application Port
+
+`olivetin.port` configures the container port, probes, Service target, and the
+upstream `PORT` environment variable. `PORT` is reserved by the chart; do not
+repeat it in `olivetin.extraEnv`.
+
+OliveTin 3000.18 also supports the `dnsname` argument type:
+
+```yaml
+config: |
+  actions:
+    - title: Resolve host
+      shell: "getent hosts {{ hostname }}"
+      arguments:
+        - name: hostname
+          type: dnsname
+          default: example.com
+```
+
 ## Runtime Template Handling
 
 OliveTin supports its own runtime template syntax. For that reason, Helm `tpl` rendering is disabled by default.

--- a/charts/olivetin/templates/deployment.yaml
+++ b/charts/olivetin/templates/deployment.yaml
@@ -70,8 +70,10 @@ spec:
             - name: http
               containerPort: {{ .Values.olivetin.port }}
               protocol: TCP
-          {{- with .Values.olivetin.extraEnv }}
           env:
+            - name: PORT
+              value: {{ .Values.olivetin.port | quote }}
+          {{- with .Values.olivetin.extraEnv }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.probes.startup.enabled }}

--- a/charts/olivetin/templates/pvc.yaml
+++ b/charts/olivetin/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "olivetin.dataClaimName" . }}
+  labels:
+    {{- include "olivetin.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.17.2"
+          value: "docker.io/jamesread/olivetin:3000.18.1"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml
@@ -190,6 +190,25 @@ tests:
             name: http
             containerPort: 1337
             protocol: TCP
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORT
+            value: "1337"
+
+  - it: should propagate a custom application port to OliveTin
+    template: templates/deployment.yaml
+    set:
+      olivetin.port: 1447
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 1447
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PORT
+            value: "1447"
 
   - it: should allow disabling config directory init container
     template: templates/deployment.yaml

--- a/charts/olivetin/tests/pvc_test.yaml
+++ b/charts/olivetin/tests/pvc_test.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a data PVC when persistence is enabled
+    set:
+      persistence.enabled: true
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: test-olivetin-data
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi
+
+  - it: should use a configured storage class
+    set:
+      persistence.enabled: true
+      persistence.storageClass: local-path
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: local-path
+
+  - it: should not render when an existing claim is configured
+    set:
+      persistence.enabled: true
+      persistence.existingClaim: shared-data
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -47,6 +47,7 @@
           "description": "Extra environment variables; PORT is reserved and managed through olivetin.port",
           "items": {
             "type": "object",
+            "required": ["name"],
             "properties": {
               "name": { "type": "string", "not": { "enum": ["PORT"] } }
             }

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.17.2" },
+        "tag": { "type": "string", "default": "3000.18.1" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },
@@ -41,8 +41,17 @@
       "type": "object",
       "description": "OliveTin application configuration",
       "properties": {
-        "port": { "type": "integer", "description": "Application port", "default": 1337 },
-        "extraEnv": { "type": "array", "items": { "type": "object" } }
+        "port": { "type": "integer", "description": "Application port, propagated through OliveTin's PORT environment variable", "minimum": 1, "maximum": 65535, "default": 1337 },
+        "extraEnv": {
+          "type": "array",
+          "description": "Extra environment variables; PORT is reserved and managed through olivetin.port",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string", "not": { "enum": ["PORT"] } }
+            }
+          }
+        }
       }
     },
     "config": {

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.17.2"
+  tag: "3000.18.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -56,9 +56,9 @@ configInit:
 # =============================================================================
 
 olivetin:
-  # -- Application port
+  # -- Application port. The chart sets OliveTin's PORT environment variable to this value.
   port: 1337
-  # -- Extra environment variables for the container
+  # -- Extra environment variables for the container. PORT is reserved and managed through olivetin.port.
   # -- @default -- `[]`
   extraEnv: []
 


### PR DESCRIPTION
## Summary

- upgrade the official OliveTin image from 3000.17.2 to 3000.18.1, superseding the issue's now-obsolete 3000.17.4 target
- make `olivetin.port` authoritative through OliveTin's upstream `PORT` support and reject duplicate reserved `PORT` entries
- exercise the new `dnsname` argument type in a dedicated runtime scenario
- fix persistence-enabled installs by creating the missing data PersistentVolumeClaim

## Upstream evidence

- release: https://github.com/OliveTin/OliveTin/releases/tag/3000.18.1
- immutable tag commit: `1a31c4dee47cc76a2df8c3347307a6ef478a76aa`
- official image verified for linux/amd64 and linux/arm64
- upstream reports no breaking changes; 3000.18.1 includes shellAfterCompleted injection, HTTP timeout, path traversal, and theme permission security fixes

## Local validation

- `make validate-chart CHART=olivetin TIMEOUT=600` — all 17 layers passed, including eight k3d scenarios
- custom-port runtime — service endpoint and OliveTin listener both used 1447; dnsname configuration loaded successfully
- persistent upgrade from chart 1.1.16 / OliveTin 3000.17.2 — marker preserved after upgrade to 3000.18.1, zero restarts, clean logs
- dynamically provisioned PVC scenario — claim bound and workload Ready with no Warning events
- 43 Helm unit tests, including PVC lifecycle and custom PORT coverage
- reserved PORT negative schema test, strict lint, kubeconform, Artifact Hub lint, standards, dependencies, org consistency, and preflight

## Site synchronization

- helmforgedev/site#475

Closes #848.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated OliveTin to version 3000.18.1.
  * Added authoritative application port configuration through `olivetin.port`.
  * Added optional automatic PersistentVolumeClaim creation when persistence is enabled.
  * Added support and documentation for `dnsname` action arguments.

* **Bug Fixes**
  * Prevented conflicting manual `PORT` environment variable configuration.
  * Improved chart handling for persistence and application networking.

* **Documentation**
  * Expanded port, persistence, upgrade, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->