### PR TITLE
feat(poznote): update app to 6.45.0

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.0.4
-appVersion: "6.35.0"
+appVersion: "6.45.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,9 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update to 6.35.0 (#826)"
+      description: "update Poznote to 6.45.0 (#849)"
+    - kind: added
+      description: "add a typed option to hide user restriction controls in sharing dialogs"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,10 +14,16 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.35.0
+ghcr.io/timothepoznanski/poznote:6.45.0
 ```
 
-The tag maps to the upstream `6.35.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.45.0` release and publishes Linux `amd64` and `arm64` manifests.
+
+Upstream also publishes a `6.45.0-rootless` variant. It is not the chart
+default because its startup script requires the mounted data directory itself
+to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
+default image do not guarantee that ownership without a privileged recursive
+ownership migration.
 
 ## Database
 

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.35.0` |
+| `image.tag` | Image tag | `6.45.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -108,6 +108,7 @@ ingress:
 | `secrets.oidcClientId` | Inline OIDC client ID | `""` |
 | `secrets.oidcClientSecret` | Inline OIDC client secret | `""` |
 | `poznote.oidc.disableNormalLogin` | Force SSO-only login | `false` |
+| `poznote.sharing.hideRestrictUsers` | Hide user restriction controls in sharing dialogs | `false` |
 
 ## Examples
 
@@ -140,10 +141,14 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.35.0` adds the optional AI assistant and improves the mobile
-navigation. No Kubernetes-facing configuration changes are required by this
-chart, but back up the `data` PVC
-before upgrading because it stores the SQLite database, notes, attachments, and
+Poznote `6.45.0` adds the Diary, user quotas, safer concurrent REST writes,
+expanded user administration, per-user display controls, and many editor and
+sharing improvements introduced since `6.35.0`. The chart now exposes
+`poznote.sharing.hideRestrictUsers` for deployments that should hide user
+restriction controls in sharing dialogs.
+
+No upstream storage migration is required. Back up the `data` PVC before
+upgrading because it stores the SQLite database, notes, attachments, and
 application configuration.
 
 ## Security Scan

--- a/charts/poznote/ci/sharing-values.yaml
+++ b/charts/poznote/ci/sharing-values.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+poznote:
+  sharing:
+    hideRestrictUsers: true

--- a/charts/poznote/templates/_helpers.tpl
+++ b/charts/poznote/templates/_helpers.tpl
@@ -117,6 +117,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
 {{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
 {{- end -}}
+{{- $reservedEnv := list "HTTP_WEB_PORT" "TZ" "POZNOTE_DEBUG" "POZNOTE_OIDC_CLIENT_ID" "POZNOTE_OIDC_CLIENT_SECRET" "POZNOTE_OIDC_DISABLE_NORMAL_LOGIN" "POZNOTE_HIDE_RESTRICT_USERS" -}}
+{{- range .Values.app.env -}}
+{{- if has .name $reservedEnv -}}
+{{- fail (printf "app.env must not override chart-managed environment variable %s" .name) -}}
+{{- end -}}
+{{- end -}}
 {{- if .Values.podLabels -}}
 {{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
 {{- fail "podLabels must not override the selector label app.kubernetes.io/name" -}}

--- a/charts/poznote/templates/deployment.yaml
+++ b/charts/poznote/templates/deployment.yaml
@@ -87,6 +87,10 @@ spec:
             - name: POZNOTE_OIDC_DISABLE_NORMAL_LOGIN
               value: "true"
             {{- end }}
+            {{- if .Values.poznote.sharing.hideRestrictUsers }}
+            - name: POZNOTE_HIDE_RESTRICT_USERS
+              value: "true"
+            {{- end }}
             {{- range .Values.app.env }}
             - name: {{ .name }}
               {{- if hasKey . "valueFrom" }}

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.35.0"
+          value: "ghcr.io/timothepoznanski/poznote:6.45.0"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml
@@ -97,6 +97,28 @@ tests:
           content:
             name: POZNOTE_OIDC_DISABLE_NORMAL_LOGIN
             value: "true"
+
+  - it: should hide user restriction controls when enabled
+    template: templates/deployment.yaml
+    set:
+      poznote.sharing.hideRestrictUsers: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POZNOTE_HIDE_RESTRICT_USERS
+            value: "true"
+
+  - it: should reject overrides of chart-managed environment variables
+    template: templates/deployment.yaml
+    set:
+      app:
+        env:
+          - name: POZNOTE_HIDE_RESTRICT_USERS
+            value: "false"
+    asserts:
+      - failedTemplate:
+          errorMessage: app.env must not override chart-managed environment variable POZNOTE_HIDE_RESTRICT_USERS
 
   - it: should mount data volume at upstream data path
     template: templates/deployment.yaml

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -109,6 +109,15 @@ tests:
             name: POZNOTE_HIDE_RESTRICT_USERS
             value: "true"
 
+  - it: should not hide user restriction controls by default
+    template: templates/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POZNOTE_HIDE_RESTRICT_USERS
+            value: "true"
+
   - it: should reject overrides of chart-managed environment variables
     template: templates/deployment.yaml
     set:

--- a/charts/poznote/values.schema.json
+++ b/charts/poznote/values.schema.json
@@ -68,7 +68,23 @@
         },
         "env": {
           "type": "array",
-          "description": "Additional environment variables"
+          "description": "Additional environment variables",
+          "items": {
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "value": {
+                "type": ["string", "number", "boolean"]
+              },
+              "valueFrom": {
+                "type": "object"
+              }
+            }
+          }
         },
         "envFrom": {
           "type": "array",
@@ -112,6 +128,15 @@
             "disableNormalLogin": {
               "type": "boolean",
               "description": "Disable local login and force SSO-only"
+            }
+          }
+        },
+        "sharing": {
+          "type": "object",
+          "properties": {
+            "hideRestrictUsers": {
+              "type": "boolean",
+              "description": "Hide user restriction controls in sharing dialogs"
             }
           }
         }

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.35.0"
+  tag: "6.45.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 
@@ -53,6 +53,9 @@ poznote:
   oidc:
     # -- Disable the local username/password login form and force SSO-only mode.
     disableNormalLogin: false
+  sharing:
+    # -- Hide "Restrict to specific users" controls in sharing dialogs.
+    hideRestrictUsers: false
 
 persistence:
   data:


### PR DESCRIPTION
## Summary

- update Poznote from 6.35.0 to the latest stable 6.45.0 release
- add typed `poznote.sharing.hideRestrictUsers` support for `POZNOTE_HIDE_RESTRICT_USERS`
- prevent `app.env` from duplicating chart-managed environment variables
- add a dedicated runtime scenario and update schema, tests, design notes, and upgrade guidance
- retain the standard upstream image after evaluating the exact rootless variant, because its UID 1000 volume ownership requirement is not safe for new PVCs or upgrades without a privileged recursive migration

## Upstream evidence

- Release: https://github.com/timothepoznanski/poznote/releases/tag/6.45.0
- Source tag commit: `9e2fe2b3a476deb4fe124a59c58ab4d5380ce1c8`
- Image: `ghcr.io/timothepoznanski/poznote:6.45.0`
- Manifest verified for `linux/amd64` and `linux/arm64`
- Reviewed every upstream release from 6.35.0 through 6.45.0; no manual storage migration or breaking Kubernetes change is documented

## Local validation

- `make validate-chart CHART=poznote TIMEOUT=600`: 17/17 layers passed
- k3d scenarios: default, default values, External Secrets, Gateway API, Ingress, NetworkPolicy, persistence disabled, and sharing restriction controls
- all runtime scenarios: ready workload, live service endpoints, zero restarts, clean logs, zero Warning events, blocking cleanup
- upgrade test: chart 1.0.4 / Poznote 6.35.0 to the local chart / 6.45.0 using `--reset-then-reuse-values`; the effective image changed, the SQLite database and PVC marker survived, and health reported 6.45.0
- feature test: `POZNOTE_HIDE_RESTRICT_USERS=true` confirmed in the upgraded pod
- REST concurrency test: first conditional PATCH succeeded; a stale version was rejected with `409 version_conflict`
- Kubescape MITRE + NSA + SOC2: `87.878784%`
- `make preflight`, standards, dependency, markdown, Artifact Hub, kubeconform, site sync, and organization parity checks passed

## Site

Site PR: helmforgedev/site#476

Closes #849.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to hide user restriction controls in sharing dialogs.
  - Added validation for environment variable configuration and protected chart-managed settings.
  - Improved configuration schema support for environment variable values and sources.

- **Updates**
  - Updated the bundled Poznote image and chart version from 6.35.0 to 6.45.0.
  - Refreshed deployment documentation and upgrade notes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->