### PR TITLE
feat(rabbitmq): upgrade to 4.3.4 and harden management ui

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -4,7 +4,7 @@ name: rabbitmq
 description: RabbitMQ for Kubernetes with explicit single-node and cluster modes
 type: application
 version: 1.6.1
-appVersion: "4.3.2"
+appVersion: "4.3.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -187,7 +187,9 @@ externalSecrets:
 
 ### Runtime efficiency
 
-- the default image is `docker.io/library/rabbitmq:4.3.2-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
+- the default image is `docker.io/library/rabbitmq:4.3.4-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
+- RabbitMQ 4.3.4 removes `unsafe-eval` and `unsafe-inline` from the Management UI Content Security Policy
+- `management.referrerPolicy=no-referrer` enables the upstream Referrer-Policy support with a privacy-preserving default; set it to `""` to defer to the browser default
 - `runtime.disableSchedulerBusyWait=true` is enabled by default to reduce idle CPU from Erlang scheduler spin-wait in containers
 - default Kubernetes probes use lightweight TCP checks against the active AMQP listener instead of recurring `rabbitmq-diagnostics` commands
 - use `runtime.additionalErlArgs` for extra Erlang VM flags and reserve `extraEnv` for explicit upstream environment variables or full overrides
@@ -197,14 +199,15 @@ externalSecrets:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `architecture` | `single-node` or `cluster` | `single-node` |
-| `image.repository` | RabbitMQ image repository | `rabbitmq` |
-| `image.tag` | RabbitMQ image tag | `4.3.2-alpine` |
+| `image.repository` | RabbitMQ image repository | `docker.io/library/rabbitmq` |
+| `image.tag` | RabbitMQ image tag | `4.3.4-alpine` |
 | `auth.username` | Application username | `user` |
 | `auth.password` | Application password | `""` |
 | `auth.erlangCookie` | Erlang cookie | `""` |
 | `auth.existingSecret` | Existing secret for credentials | `""` |
 | `queueDefaults.type` | `quorum` or `classic` | `quorum` |
 | `management.enabled` | Enable management plugin/UI | `true` |
+| `management.referrerPolicy` | Management UI Referrer-Policy header; empty uses browser default | `no-referrer` |
 | `management.ingress.enabled` | Enable management ingress | `false` |
 | `management.ingress.ingressClassName` | Ingress class for the Management UI | `traefik` |
 | `tls.enabled` | Enable TLS listeners | `false` |

--- a/charts/rabbitmq/templates/_helpers.tpl
+++ b/charts/rabbitmq/templates/_helpers.tpl
@@ -32,6 +32,15 @@ app.kubernetes.io/name: {{ include "rabbitmq.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{- define "rabbitmq.validateAll" -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+  {{- fail "podLabels must not override the app.kubernetes.io/name selector label" -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+  {{- fail "podLabels must not override the app.kubernetes.io/instance selector label" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "rabbitmq.secretName" -}}
 {{- if .Values.auth.existingSecret -}}
 {{- .Values.auth.existingSecret -}}

--- a/charts/rabbitmq/templates/configmap.yaml
+++ b/charts/rabbitmq/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
     loopback_users.guest = false
     default_vhost = {{ .Values.auth.vhost }}
     default_queue_type = {{ .Values.queueDefaults.type }}
+    {{- if .Values.management.referrerPolicy }}
+    management.headers.referrer_policy = {{ .Values.management.referrerPolicy }}
+    {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.disableNonTLSListeners }}
     listeners.tcp = none
     {{- else }}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "rabbitmq.validateAll" . -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/rabbitmq/tests/configmap_test.yaml
+++ b/charts/rabbitmq/tests/configmap_test.yaml
@@ -22,6 +22,28 @@ tests:
           value: |
             [].
 
+  - it: should set a secure Referrer-Policy by default
+    asserts:
+      - matchRegex:
+          path: data["rabbitmq.conf"]
+          pattern: "management.headers.referrer_policy = no-referrer"
+
+  - it: should allow a custom Referrer-Policy
+    set:
+      management.referrerPolicy: same-origin
+    asserts:
+      - matchRegex:
+          path: data["rabbitmq.conf"]
+          pattern: "management.headers.referrer_policy = same-origin"
+
+  - it: should omit Referrer-Policy when explicitly empty
+    set:
+      management.referrerPolicy: ""
+    asserts:
+      - notMatchRegex:
+          path: data["rabbitmq.conf"]
+          pattern: "management.headers.referrer_policy"
+
   - it: should enable metrics plugin when metrics are enabled
     set:
       metrics.enabled: true

--- a/charts/rabbitmq/tests/statefulset_test.yaml
+++ b/charts/rabbitmq/tests/statefulset_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/rabbitmq:4.3.2-alpine"
+          value: "docker.io/library/rabbitmq:4.3.4-alpine"
 
   - it: should have 1 replica in single-node mode
     template: statefulset.yaml

--- a/charts/rabbitmq/tests/validation_test.yaml
+++ b/charts/rabbitmq/tests/validation_test.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validations
+templates:
+  - statefulset.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should reject an overridden name selector label
+    set:
+      podLabels:
+        app.kubernetes.io/name: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the app.kubernetes.io/name selector label"
+
+  - it: should reject an overridden instance selector label
+    set:
+      podLabels:
+        app.kubernetes.io/instance: invalid
+    asserts:
+      - failedTemplate:
+          errorMessage: "podLabels must not override the app.kubernetes.io/instance selector label"

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -107,6 +107,21 @@
           "type": "boolean",
           "description": "Enable the management plugin/UI"
         },
+        "referrerPolicy": {
+          "type": "string",
+          "description": "Referrer-Policy header for the Management UI. Empty uses the browser default.",
+          "enum": [
+            "",
+            "no-referrer",
+            "no-referrer-when-downgrade",
+            "origin",
+            "origin-when-cross-origin",
+            "same-origin",
+            "strict-origin",
+            "strict-origin-when-cross-origin",
+            "unsafe-url"
+          ]
+        },
           "ingress": {
             "type": "object",
             "description": "Ingress configuration for the Management UI",

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- RabbitMQ image repository
   repository: docker.io/library/rabbitmq
   # -- RabbitMQ image tag
-  tag: "4.3.2-alpine"
+  tag: "4.3.4-alpine"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -67,6 +67,8 @@ queueDefaults:
 management:
   # -- Enable the management plugin/UI
   enabled: true
+  # -- Referrer-Policy header for the Management UI. Empty uses the browser default.
+  referrerPolicy: no-referrer
   ingress:
     # -- Enable ingress for the Management UI
     enabled: false


### PR DESCRIPTION
## Summary

- upgrade the official RabbitMQ Alpine image from 4.3.2 to 4.3.4
- expose the new upstream `management.headers.referrer_policy` setting as typed `management.referrerPolicy`, defaulting securely to `no-referrer`
- preserve the upstream 4.3.4 CSP hardening that removes `unsafe-eval` and `unsafe-inline`
- add unit coverage for the image, default/custom/disabled Referrer-Policy behavior, and immutable StatefulSet selector labels
- align chart documentation and eliminate the stale short image repository reference

Closes #850

Site PR: helmforgedev/site#477

## Upstream evidence

- RabbitMQ 4.3.3 release notes: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.3
- RabbitMQ 4.3.4 release notes: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.4
- Official image manifest: `docker.io/library/rabbitmq:4.3.4-alpine`
- Platforms verified: linux/amd64, linux/arm, linux/arm64, linux/386, linux/ppc64le, linux/riscv64, linux/s390x
- No upstream breaking change in this 4.3.x maintenance upgrade; the official image runs Erlang 27.3.4.15, satisfying RabbitMQ 4.3.3+'s Erlang 27 minimum

## Local validation

- `make validate-chart CHART=rabbitmq TIMEOUT=600`: passed twice after the final chart change, 18 layers each
- k3d: default plus all 8 `ci/` scenarios passed; workloads had zero restarts and no crash/fatal log findings
- `helm unittest`: 46 tests passed across 9 suites
- `make image-verify IMAGE=docker.io/library/rabbitmq:4.3.4-alpine`
- `make deps-check CHART=rabbitmq`
- `make standards-check CHART=rabbitmq`
- template standards: zero warnings for RabbitMQ
- Kubescape MITRE + NSA + SOC2: 74.24%, unchanged
- `make preflight`, `make site-sync-check CHART=rabbitmq`, and `make org-check`

## Upgrade and feature validation

Validated the published chart `1.6.1` / RabbitMQ 4.3.2 to this chart with `--reset-then-reuse-values`:

- live StatefulSet image changed to `docker.io/library/rabbitmq:4.3.4-alpine`
- `rabbitmq-diagnostics server_version` returned 4.3.4
- a pre-upgrade vhost and PVC marker survived the rollout
- zero pod restarts and zero Warning events after the upgrade
- Management UI returned `referrer-policy: no-referrer`
- Content Security Policy was `script-src 'self'; object-src 'self'`, with neither unsafe directive
- definitions export returned HTTP 200 using chunked transfer and included the preserved vhost
- the three-node TLS scenario converged with all nodes running, no alarms, and no network partitions

The External Secrets scenario emitted the known initial SecretStore reconciliation race and then became healthy; the validator classified both transient events with justification and completed green.

## Self-review

Reviewed the exact head `16530795269146cca8dfdcd4c1473161266ede06`. The schema constrains the new value to valid Referrer-Policy tokens, the empty-string escape omits the upstream setting, selector-label validation prevents immutable StatefulSet drift, and no chart package version was edited.
