### PR TITLE
fix(redis): upgrade to 8.8.1 security release

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -4,7 +4,7 @@ name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 1.6.19
-appVersion: "8.8.0"
+appVersion: "8.8.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -26,8 +26,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "honor service type in cluster mode (#572)"
+    - kind: security
+      description: "upgrade Redis to 8.8.1 to address crafted RESTORE payload handling in RedisBloom and TDigest"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -221,7 +221,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Redis topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Redis image repository | `docker.io/library/redis` |
-| `image.tag` | Redis image tag | `8.8.0` |
+| `image.tag` | Redis image tag | `8.8.1` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Redis password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Redis password | `""` |
@@ -289,6 +289,7 @@ See `examples/`:
 - Redis Sentinel: <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>
 - Redis Cluster: <https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/>
 - Redis security: <https://redis.io/docs/latest/operate/oss_and_stack/management/security/>
+- Redis 8.8.1 security release: <https://github.com/redis/redis/releases/tag/8.8.1>
 
 ### 🟢 Security Scan: `redis`
 

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/redis:8.8.0"
+          value: "docker.io/library/redis:8.8.1"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -28,7 +28,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/redis
-  tag: "8.8.0"
+  tag: "8.8.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary  - upgrade the official Redis image from 8.8.0 to the stable 8.8.1 security release - update Artifact Hub release notes to identify the security impact - align the chart README and rendered-image unit assertion with the new pinned tag  Closes #851  Site PR: helmforgedev/site#478  ## Upstream evidence  - Redis 8.8.1 release notes: https://github.com/redis/redis/releases/tag/8.8.1 - Official image manifest: `docker.io/library/redis:8.8.1` - Platforms verified: linux/amd64, linux/arm, linux/arm64, linux/386, linux/ppc64le, linux/riscv64, linux/s390x - Upstream classifies 8.8.1 as a security release; it fixes crafted `RESTORE` payload handling in RedisBloom and TDigest that could cause out-of-bounds writes and potential remote code execution - No breaking changes or new configuration requirements are documented for this patch release  ## Local validation  - `make validate-chart CHART=redis TIMEOUT=600`: 18/18 layers passed - k3d: default plus all 8 `ci/` scenarios passed; every workload had zero restarts, no Warning events, and clean logs - `helm unittest`: 38 tests passed across 8 suites - `make image-verify IMAGE=docker.io/library/redis:8.8.1` - `make deps-check CHART=redis` - `make standards-check CHART=redis` - `make site-sync-check CHART=redis` - `make org-check` - `make preflight`  ## Upgrade and security validation  Validated the published chart `1.6.19` / Redis 8.8.0 to this chart with `--reset-then-reuse-values`:  - live StatefulSet image changed to `docker.io/library/redis:8.8.1` - `INFO server` returned `redis_version:8.8.1` - a pre-upgrade key and the existing PVC survived the rollout - Redis 8.8.1 loaded the AOF base produced by Redis 8.8.0 without errors - zero pod restarts and zero Warning events after the upgrade - a malformed `RESTORE` payload was rejected with the expected checksum error; the server remained ready and returned `PONG` - authenticated runtime logs contained no warning, error, crash, panic, or corruption patterns  ## Self-review  Reviewed the exact head `c8e4ded65a30ae75a6611bc34ad324f458efa604`. The change is limited to the upstream security patch, keeps the official image pinned, updates the release metadata and assertions, and does not edit the CI-managed chart package version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated Redis to version 8.8.1, including fixes for crafted RESTORE payload handling in RedisBloom and TDigest.

* **Documentation**
  * Updated the documented Redis image version and release notes to reflect Redis 8.8.1.

* **Tests**
  * Updated deployment validation to expect Redis 8.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->