### PR TITLE
fix(valkey): upgrade to 9.1.1 security release

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -4,7 +4,7 @@ name: valkey
 description: Valkey Helm chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 2.0.2
-appVersion: "9.1.0"
+appVersion: "9.1.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,8 +27,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "seed on the current master, not a reachable replica (#687)"
+    - kind: security
+      description: "upgrade Valkey to 9.1.1 to address TLS CLIENT KILL and corrupt stream RDB vulnerabilities"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -218,7 +218,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Valkey topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Valkey image repository | `docker.io/valkey/valkey` |
-| `image.tag` | Valkey image tag | `9.1.0` |
+| `image.tag` | Valkey image tag | `9.1.1` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Valkey password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Valkey password | `""` |
@@ -245,7 +245,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `metrics.serviceMonitor.enabled` | Create ServiceMonitor | `false` |
 | `tests.enabled` | Render Helm test connection pod | `true` |
 | `tests.image.repository` | Helm test image repository | `docker.io/valkey/valkey` |
-| `tests.image.tag` | Helm test image tag | `9.1.0` |
+| `tests.image.tag` | Helm test image tag | `9.1.1` |
 | `automountServiceAccountToken` | Mount Kubernetes API service account token into pods | `false` |
 | `podSecurityContext.seccompProfile.type` | Pod seccomp profile | `RuntimeDefault` |
 | `securityContext.capabilities.drop` | Linux capabilities dropped by default | `["ALL"]` |
@@ -313,3 +313,4 @@ See `examples/`:
 - Valkey Sentinel: <https://valkey.io/docs/latest/operate/oss_and_stack/management/sentinel/>
 - Valkey Cluster: <https://valkey.io/docs/latest/operate/oss_and_stack/management/scaling/>
 - Valkey security: <https://valkey.io/docs/latest/operate/oss_and_stack/management/security/>
+- Valkey 9.1.1 security release: <https://github.com/valkey-io/valkey/releases/tag/9.1.1>

--- a/charts/valkey/tests/standalone_statefulset_test.yaml
+++ b/charts/valkey/tests/standalone_statefulset_test.yaml
@@ -43,7 +43,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/valkey/valkey:9.1.0"
+          value: "docker.io/valkey/valkey:9.1.1"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -11,6 +11,9 @@ tests:
       - isKind:
           of: Pod
       - equal:
+          path: spec.containers[0].image
+          value: "docker.io/valkey/valkey:9.1.1"
+      - equal:
           path: metadata.name
           value: test-valkey-test-connection
       - equal:

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -30,7 +30,7 @@ image:
   # -- Container image repository
   repository: docker.io/valkey/valkey
   # -- Container image tag
-  tag: "9.1.0"
+  tag: "9.1.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -370,7 +370,7 @@ tests:
     # -- Helm test image repository
     repository: docker.io/valkey/valkey
     # -- Helm test image tag
-    tag: "9.1.0"
+    tag: "9.1.1"
     # -- Helm test image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrade the official Valkey runtime and Helm test images from 9.1.0 to 9.1.1
- classify the release as a security update in Artifact Hub metadata
- update chart documentation and pin both rendered image paths in unit tests

## Upstream evidence

- Release notes: https://github.com/valkey-io/valkey/releases/tag/9.1.1
- Image: `docker.io/valkey/valkey:9.1.1`
- Verified platforms: linux/amd64, linux/arm64, linux/arm, linux/ppc64le
- Valkey classifies 9.1.1 as an urgent security release. It fixes CVE-2026-56684 in authenticated TLS `CLIENT KILL` handling and CVE-2026-63639 while loading a corrupt stream RDB, plus Sentinel failover, ACL, RDB/RESTORE validation, replication, and concurrency fixes.

## Local validation

- `make validate-chart CHART=valkey TIMEOUT=600`: 21/21 layers passed
- `helm unittest charts/valkey`: 16 suites, 111 tests passed
- k3d: default plus all 11 CI scenarios passed, including cluster, replication, Sentinel, and both TLS topologies; zero crash/fatal log patterns
- upgrade path: chart 2.0.2 / Valkey 9.1.0 to local / 9.1.1 preserved the same PVC UID and persisted data; effective workload image and server version were 9.1.1
- corrupt `RESTORE` payload was rejected and the server remained Ready with zero restarts
- authenticated TLS client was terminated using `CLIENT KILL ID`; the server remained healthy with PONG, two connected replicas, zero restarts, and clean logs
- coordinated Sentinel failover elected the other data node in 5 seconds with three usable Sentinels, all five pods Ready, zero restarts, and clean logs
- standards, dependencies, Markdown, site sync, organization consistency, release semantics, attribution, and preflight gates passed

Site PR: helmforgedev/site#479

Closes #852.