### PR TITLE
fix(vaultwarden): upgrade to 1.37.1 security release

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -4,7 +4,7 @@ name: vaultwarden
 description: Vaultwarden for Kubernetes with persistent SQLite storage and explicit ingress/domain configuration
 type: application
 version: 1.12.10
-appVersion: "1.36.0"
+appVersion: "1.37.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,8 +21,10 @@ sources:
 icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#592)"
+    - kind: security
+      description: "upgrade Vaultwarden to 1.37.1 with security fixes, 2026.7.0+ client support, and the invite hotfix"
+    - kind: added
+      description: "expose trusted proxy and unauthenticated endpoint rate-limit settings"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -59,6 +59,8 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 
 - Vaultwarden repository: <https://github.com/dani-garcia/vaultwarden>
 - Vaultwarden configuration template: <https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/.env.template>
+- Vaultwarden 1.37.0 security release: <https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0>
+- Vaultwarden 1.37.1 hotfix release: <https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1>
 
 ## Best practices
 
@@ -100,6 +102,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 - terminate TLS at ingress or reverse proxy
 - keep ingress hosts and `domain` aligned
 - if Vaultwarden is exposed behind a path or non-default HTTPS port, keep that full external URL in `domain`
+- health probes automatically include the path component from `domain`
 - keep `vaultwarden.proxy.ipHeader` aligned with your ingress controller or reverse proxy behavior
 - review ingress/controller timeouts if websocket notifications are important for your users
 
@@ -155,6 +158,9 @@ This chart intentionally maps the most important operational settings from the o
 - `ROCKET_ADDRESS`
 - `ROCKET_PORT`
 - `IP_HEADER`
+- `IP_HEADER_TRUSTED_PROXIES`
+- `UNAUTHENTICATED_RATELIMIT_SECONDS`
+- `UNAUTHENTICATED_RATELIMIT_MAX_BURST`
 - `ENABLE_DB_WAL`
 - `DB_CONNECTION_RETRIES`
 - `DATABASE_TIMEOUT`
@@ -176,7 +182,7 @@ The admin page should not use a plain-text `ADMIN_TOKEN` in real environments. P
 Simple generation options:
 
 ```bash
-docker run --rm -it vaultwarden/server:1.36.0 /vaultwarden hash
+docker run --rm -it vaultwarden/server:1.37.1 /vaultwarden hash
 ```
 
 ```bash
@@ -212,7 +218,7 @@ Official reference:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Vaultwarden image repository | `docker.io/vaultwarden/server` |
-| `image.tag` | Vaultwarden image tag | `1.36.0` |
+| `image.tag` | Vaultwarden image tag | `1.37.1` |
 | `domain` | Public Vaultwarden domain | `""` |
 | `database.mode` | `auto`, `sqlite`, `external`, `postgresql`, or `mysql` | `auto` |
 | `database.external.vendor` | External database vendor | `postgres` |
@@ -241,6 +247,9 @@ Official reference:
 | `vaultwarden.showPasswordHint` | Show password hints directly in the web UI | `false` |
 | `vaultwarden.websocket.enabled` | Enable websocket notifications | `true` |
 | `vaultwarden.proxy.ipHeader` | Header used to detect the client IP behind a reverse proxy | `X-Real-IP` |
+| `vaultwarden.proxy.trustedProxies` | Addresses allowed to supply the configured client IP header | `local` |
+| `vaultwarden.rateLimit.unauthenticated.seconds` | Average seconds between rate-limited unauthenticated requests from one IP | `60` |
+| `vaultwarden.rateLimit.unauthenticated.maxBurst` | Shared burst budget for rate-limited unauthenticated endpoints | `50` |
 | `admin.token` | Inline admin token | `""` |
 | `admin.existingSecret` | Existing secret containing the admin token | `""` |
 | `smtp.enabled` | Enable SMTP configuration | `false` |

--- a/charts/vaultwarden/ci/database-external-secret.yaml
+++ b/charts/vaultwarden/ci/database-external-secret.yaml
@@ -2,5 +2,6 @@
 database:
   mode: external
   external:
+    host: vaultwarden-external-postgresql
     existingSecret: vaultwarden-database
     existingSecretUrlKey: database-url

--- a/charts/vaultwarden/ci/database-external.yaml
+++ b/charts/vaultwarden/ci/database-external.yaml
@@ -3,7 +3,7 @@ database:
   mode: external
   external:
     vendor: postgres
-    host: postgresql.example.svc
+    host: vaultwarden-external-postgresql
     name: vaultwarden
     username: vaultwarden
     password: change-me

--- a/charts/vaultwarden/ci/existing-secret.yaml
+++ b/charts/vaultwarden/ci/existing-secret.yaml
@@ -6,4 +6,5 @@ smtp:
   enabled: true
   host: smtp.example.com
   from: vaultwarden@example.com
+  username: vaultwarden
   existingSecret: vaultwarden-smtp

--- a/charts/vaultwarden/ci/external-secrets.yaml
+++ b/charts/vaultwarden/ci/external-secrets.yaml
@@ -7,10 +7,11 @@ admin:
 externalSecrets:
   enabled: true
   secretStoreRef:
-    name: my-store
+    name: helmforge-fake-store
     kind: ClusterSecretStore
+  target:
+    creationPolicy: Owner
   data:
     - secretKey: admin-token
       remoteRef:
-        key: vaultwarden/auth
-        property: token
+        key: test/token

--- a/charts/vaultwarden/ci/fixtures/database-external-secret.yaml
+++ b/charts/vaultwarden/ci/fixtures/database-external-secret.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vaultwarden-external-postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vaultwarden-external-postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vaultwarden-external-postgresql
+        helmforge.dev/runtime-fixture: "true"
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/library/postgres:18.4-trixie
+          env:
+            - name: POSTGRES_DB
+              value: vaultwarden
+            - name: POSTGRES_USER
+              value: vaultwarden
+            - name: POSTGRES_PASSWORD
+              value: change-me
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - --username=vaultwarden
+                - --dbname=vaultwarden
+            periodSeconds: 2
+            timeoutSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vaultwarden-external-postgresql
+spec:
+  selector:
+    app.kubernetes.io/name: vaultwarden-external-postgresql
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-database
+type: Opaque
+stringData:
+  database-url: postgres://vaultwarden:change-me@vaultwarden-external-postgresql:5432/vaultwarden

--- a/charts/vaultwarden/ci/fixtures/database-external.yaml
+++ b/charts/vaultwarden/ci/fixtures/database-external.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vaultwarden-external-postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vaultwarden-external-postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vaultwarden-external-postgresql
+        helmforge.dev/runtime-fixture: "true"
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/library/postgres:18.4-trixie
+          env:
+            - name: POSTGRES_DB
+              value: vaultwarden
+            - name: POSTGRES_USER
+              value: vaultwarden
+            - name: POSTGRES_PASSWORD
+              value: change-me
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - --username=vaultwarden
+                - --dbname=vaultwarden
+            periodSeconds: 2
+            timeoutSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vaultwarden-external-postgresql
+spec:
+  selector:
+    app.kubernetes.io/name: vaultwarden-external-postgresql
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql

--- a/charts/vaultwarden/ci/fixtures/existing-claim.yaml
+++ b/charts/vaultwarden/ci/fixtures/existing-claim.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vaultwarden-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/charts/vaultwarden/ci/fixtures/existing-secret.yaml
+++ b/charts/vaultwarden/ci/fixtures/existing-secret.yaml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-admin
+type: Opaque
+stringData:
+  admin-token: vaultwarden-test-admin-token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-smtp
+type: Opaque
+stringData:
+  smtp-password: vaultwarden-test-smtp-password

--- a/charts/vaultwarden/ci/fixtures/hardening.yaml
+++ b/charts/vaultwarden/ci/fixtures/hardening.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-admin
+type: Opaque
+stringData:
+  admin-token: helmforge-runtime-validation-token

--- a/charts/vaultwarden/ci/fixtures/restore-selector.yaml
+++ b/charts/vaultwarden/ci/fixtures/restore-selector.yaml
@@ -13,6 +13,8 @@ spec:
         helmforge.dev/runtime-fixture: "true"
     spec:
       restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/hostname: k3d-helmforge-tests-wsl-server-0
       containers:
         - name: prepare
           image: docker.io/library/busybox:1.37
@@ -21,6 +23,7 @@ spec:
             - -c
             - chown 1000:1000 /restore && chmod 0770 /restore
           securityContext:
+            readOnlyRootFilesystem: true
             runAsUser: 0
             runAsGroup: 0
             runAsNonRoot: false
@@ -53,6 +56,14 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Delete
   storageClassName: local-path
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - k3d-helmforge-tests-wsl-server-0
   hostPath:
     path: /tmp/helmforge-vaultwarden-runtime-restore
     type: DirectoryOrCreate

--- a/charts/vaultwarden/ci/fixtures/restore-selector.yaml
+++ b/charts/vaultwarden/ci/fixtures/restore-selector.yaml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vaultwarden-runtime-restore-prepare
+  labels:
+    helmforge.dev/runtime-fixture: "true"
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        helmforge.dev/runtime-fixture: "true"
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: prepare
+          image: docker.io/library/busybox:1.37
+          command:
+            - sh
+            - -c
+            - chown 1000:1000 /restore && chmod 0770 /restore
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - CHOWN
+                - FOWNER
+          volumeMounts:
+            - name: restore
+              mountPath: /restore
+      volumes:
+        - name: restore
+          hostPath:
+            path: /tmp/helmforge-vaultwarden-runtime-restore
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vaultwarden-runtime-restore
+  labels:
+    restore-id: vaultwarden-prod-restore
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-path
+  hostPath:
+    path: /tmp/helmforge-vaultwarden-runtime-restore
+    type: DirectoryOrCreate

--- a/charts/vaultwarden/ci/fixtures/smtp-complete.yaml
+++ b/charts/vaultwarden/ci/fixtures/smtp-complete.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-smtp
+type: Opaque
+stringData:
+  smtp-password: helmforge-runtime-validation-password

--- a/charts/vaultwarden/ci/fixtures/smtp.yaml
+++ b/charts/vaultwarden/ci/fixtures/smtp.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vaultwarden-smtp
+type: Opaque
+stringData:
+  smtp-password: helmforge-runtime-validation-password

--- a/charts/vaultwarden/ci/hardening.yaml
+++ b/charts/vaultwarden/ci/hardening.yaml
@@ -2,6 +2,14 @@
 admin:
   existingSecret: vaultwarden-admin
 
+vaultwarden:
+  proxy:
+    trustedProxies: 10.0.0.0/8
+  rateLimit:
+    unauthenticated:
+      seconds: 120
+      maxBurst: 25
+
 networkPolicy:
   enabled: true
   ingress:

--- a/charts/vaultwarden/ci/restore-selector.yaml
+++ b/charts/vaultwarden/ci/restore-selector.yaml
@@ -4,3 +4,6 @@ data:
     enabled: true
     selectorLabels:
       restore-id: vaultwarden-prod-restore
+
+nodeSelector:
+  kubernetes.io/hostname: k3d-helmforge-tests-wsl-server-0

--- a/charts/vaultwarden/docs/admin-access-and-hardening.md
+++ b/charts/vaultwarden/docs/admin-access-and-hardening.md
@@ -21,7 +21,7 @@ In this chart:
 Using the Vaultwarden image:
 
 ```bash
-docker run --rm -it vaultwarden/server:1.36.0 /vaultwarden hash
+docker run --rm -it vaultwarden/server:1.37.1 /vaultwarden hash
 ```
 
 Using the `argon2` CLI:

--- a/charts/vaultwarden/docs/ingress-and-domain.md
+++ b/charts/vaultwarden/docs/ingress-and-domain.md
@@ -10,6 +10,7 @@ Vaultwarden relies on a correct public domain for features such as attachment li
 - enable ingress with the same hostname
 - terminate TLS at ingress or reverse proxy
 - if the public URL includes a path or non-default port, keep that exact external URL in `domain`
+- the chart automatically prefixes health probe paths with the path component from `domain`
 
 ## Domain examples
 
@@ -73,6 +74,12 @@ Keep `vaultwarden.proxy.ipHeader` aligned with the actual reverse proxy behavior
 - `X-Real-IP` is a common default
 - use `X-Forwarded-For` only when that is what your ingress controller actually forwards
 - use `none` if you want Vaultwarden to rely only on the direct remote address
+
+Vaultwarden 1.37.0 and newer also require the direct peer to match
+`vaultwarden.proxy.trustedProxies` before accepting that header. The secure default
+`local` trusts non-global addresses, which covers most in-cluster ingress paths.
+Use explicit IP or CIDR entries when the proxy reaches Vaultwarden from a public
+address. Avoid `all` unless every path to the pod is controlled by a trusted proxy.
 
 <!-- @AI-METADATA
 type: chart-docs

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -48,7 +48,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $parsedDomain := urlParse $domain -}}
 {{- $basePath = get $parsedDomain "path" | default "" | trimSuffix "/" -}}
 {{- end -}}
-{{- if and $basePath (not (hasPrefix $basePath $configuredPath)) -}}
+{{- if and $basePath (not (or (eq $configuredPath $basePath) (hasPrefix (printf "%s/" $basePath) $configuredPath))) -}}
 {{- printf "%s%s" $basePath $configuredPath -}}
 {{- else -}}
 {{- $configuredPath -}}

--- a/charts/vaultwarden/templates/_helpers.tpl
+++ b/charts/vaultwarden/templates/_helpers.tpl
@@ -40,6 +40,21 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "vaultwarden.probePath" -}}
+{{- $configuredPath := .path -}}
+{{- $domain := include "vaultwarden.domain" .root -}}
+{{- $basePath := "" -}}
+{{- if $domain -}}
+{{- $parsedDomain := urlParse $domain -}}
+{{- $basePath = get $parsedDomain "path" | default "" | trimSuffix "/" -}}
+{{- end -}}
+{{- if and $basePath (not (hasPrefix $basePath $configuredPath)) -}}
+{{- printf "%s%s" $basePath $configuredPath -}}
+{{- else -}}
+{{- $configuredPath -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "vaultwarden.adminSecretName" -}}
 {{- if .Values.admin.existingSecret -}}
 {{- .Values.admin.existingSecret -}}

--- a/charts/vaultwarden/templates/deployment.yaml
+++ b/charts/vaultwarden/templates/deployment.yaml
@@ -120,6 +120,12 @@ spec:
               value: {{ .Values.vaultwarden.logLevel | quote }}
             - name: IP_HEADER
               value: {{ .Values.vaultwarden.proxy.ipHeader | quote }}
+            - name: IP_HEADER_TRUSTED_PROXIES
+              value: {{ .Values.vaultwarden.proxy.trustedProxies | quote }}
+            - name: UNAUTHENTICATED_RATELIMIT_SECONDS
+              value: {{ .Values.vaultwarden.rateLimit.unauthenticated.seconds | quote }}
+            - name: UNAUTHENTICATED_RATELIMIT_MAX_BURST
+              value: {{ .Values.vaultwarden.rateLimit.unauthenticated.maxBurst | quote }}
             {{- if eq (include "vaultwarden.databaseMode" .) "sqlite" }}
             - name: ENABLE_DB_WAL
               value: {{ ternary "true" "false" .Values.database.sqlite.enableWal | quote }}
@@ -201,7 +207,7 @@ spec:
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.probes.liveness.path }}
+              path: {{ include "vaultwarden.probePath" (dict "root" . "path" .Values.probes.liveness.path) }}
               port: http
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
@@ -211,7 +217,7 @@ spec:
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.probes.readiness.path }}
+              path: {{ include "vaultwarden.probePath" (dict "root" . "path" .Values.probes.readiness.path) }}
               port: http
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
@@ -221,7 +227,7 @@ spec:
           {{- if .Values.probes.startup.enabled }}
           startupProbe:
             httpGet:
-              path: {{ .Values.probes.startup.path }}
+              path: {{ include "vaultwarden.probePath" (dict "root" . "path" .Values.probes.startup.path) }}
               port: http
             initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}

--- a/charts/vaultwarden/tests/deployment_test.yaml
+++ b/charts/vaultwarden/tests/deployment_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/vaultwarden/server:1.36.0"
+          value: "docker.io/vaultwarden/server:1.37.1"
 
   - it: should have 1 replica
     template: deployment.yaml
@@ -67,6 +67,33 @@ tests:
       - isNotNull:
           path: spec.template.spec.containers[0].startupProbe
 
+  - it: should prefix probe paths with the domain subpath
+    template: deployment.yaml
+    set:
+      domain: https://example.com/vaultwarden
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /vaultwarden/alive
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /vaultwarden/alive
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /vaultwarden/alive
+
+  - it: should not duplicate the domain subpath in a custom probe path
+    template: deployment.yaml
+    set:
+      domain: https://example.com/vaultwarden
+      probes:
+        liveness:
+          path: /vaultwarden/health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /vaultwarden/health
+
   - it: should mount data volume
     template: deployment.yaml
     asserts:
@@ -93,6 +120,29 @@ tests:
           content:
             name: ENABLE_WEBSOCKET
             value: "true"
+
+  - it: should configure trusted proxies and unauthenticated rate limits
+    template: deployment.yaml
+    set:
+      vaultwarden.proxy.trustedProxies: "10.0.0.0/8,192.168.0.0/16"
+      vaultwarden.rateLimit.unauthenticated.seconds: 120
+      vaultwarden.rateLimit.unauthenticated.maxBurst: 25
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IP_HEADER_TRUSTED_PROXIES
+            value: "10.0.0.0/8,192.168.0.0/16"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UNAUTHENTICATED_RATELIMIT_SECONDS
+            value: "120"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UNAUTHENTICATED_RATELIMIT_MAX_BURST
+            value: "25"
 
   - it: should bind Rocket to a non-privileged port by default
     template: deployment.yaml

--- a/charts/vaultwarden/tests/deployment_test.yaml
+++ b/charts/vaultwarden/tests/deployment_test.yaml
@@ -94,6 +94,18 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /vaultwarden/health
 
+  - it: should prefix a similar path that is not at the domain path boundary
+    template: deployment.yaml
+    set:
+      domain: https://example.com/vault
+      probes:
+        liveness:
+          path: /vaultish/health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /vault/vaultish/health
+
   - it: should mount data volume
     template: deployment.yaml
     asserts:

--- a/charts/vaultwarden/values.schema.json
+++ b/charts/vaultwarden/values.schema.json
@@ -144,6 +144,33 @@
             "ipHeader": {
               "type": "string",
               "description": "Header used by Vaultwarden to identify the client IP behind a reverse proxy"
+            },
+            "trustedProxies": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Addresses allowed to supply the client IP header: local, all, or comma-separated IP/CIDR entries"
+            }
+          }
+        },
+        "rateLimit": {
+          "type": "object",
+          "description": "Vaultwarden request rate-limit settings",
+          "properties": {
+            "unauthenticated": {
+              "type": "object",
+              "description": "Shared rate limit for unauthenticated endpoints such as password hints, account recovery, and Send access",
+              "properties": {
+                "seconds": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Average seconds between unauthenticated requests from the same IP"
+                },
+                "maxBurst": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Shared burst budget for rate-limited unauthenticated endpoints"
+                }
+              }
             }
           }
         }

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Vaultwarden image repository
   repository: docker.io/vaultwarden/server
   # -- Vaultwarden image tag
-  tag: "1.36.0"
+  tag: "1.37.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -72,6 +72,14 @@ vaultwarden:
   proxy:
     # -- Header used by Vaultwarden to identify the client IP behind a reverse proxy
     ipHeader: X-Real-IP
+    # -- Addresses allowed to supply ipHeader: "local", "all", or comma-separated IP/CIDR entries
+    trustedProxies: local
+  rateLimit:
+    unauthenticated:
+      # -- Average seconds between requests from one IP to rate-limited unauthenticated endpoints
+      seconds: 60
+      # -- Shared burst budget for rate-limited unauthenticated endpoints
+      maxBurst: 50
 
 # =============================================================================
 # Admin
@@ -80,7 +88,7 @@ vaultwarden:
 admin:
   # -- Admin token value. Prefer an Argon2 PHC string for production.
   # -- Example with the container image:
-  # --   docker run --rm -it vaultwarden/server:1.36.0 /vaultwarden hash
+  # --   docker run --rm -it vaultwarden/server:1.37.1 /vaultwarden hash
   # -- Example with the argon2 CLI:
   # --   echo -n 'change-me' | argon2 "$(openssl rand -base64 32)" -e -id -k 65540 -t 3 -p 4
   # -- Official reference:


### PR DESCRIPTION
Upgrades Vaultwarden from 1.36.0 to 1.37.1, covering the 1.37.0 security fixes and the 1.37.1 invitation/Alpine follow-up. Adds trusted-proxy and unauthenticated rate-limit settings, automatically prefixes health probes for domain subpaths, and makes every CI runtime scenario self-contained with local fixtures. Local validation: make validate-chart CHART=vaultwarden passed all 30 layers and 21 k3d profiles; published 1.12.10 to local upgrade preserved PVC/data; rate-limit behavior returned 429 on the second request; logs, restarts, and events were clean. Site companion: https://github.com/helmforgedev/site/pull/480. Closes #853.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Vaultwarden to version 1.37.1.
  * Added trusted proxy configuration and unauthenticated request rate limiting.
  * Health probes now support deployments configured under a domain subpath.
  * Added configuration support for external PostgreSQL and SMTP credentials.

* **Documentation**
  * Updated setup guidance, configuration reference, and security recommendations for the new settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->