### PR TITLE
fix(wordpress): upgrade to 7.0.2 security release

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: wordpress
 type: application
 version: 3.0.2
-appVersion: "7.0.1"
+appVersion: "7.0.2"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying WordPress on Kubernetes with MySQL support and S3 backup
 maintainers:
@@ -22,8 +22,12 @@ sources:
 icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
   artifacthub.io/changes: |
+    - kind: security
+      description: "upgrade WordPress to 7.0.2 with fixes for critical and high severity vulnerabilities"
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#786)"
+      description: "bump the HelmForge Redis subchart to 1.6.20"
+    - kind: added
+      description: "support complete custom NetworkPolicy egress rules with optional ports"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -54,7 +58,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled
   - name: memcached

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -417,6 +417,7 @@ The chart creates an `HTTPRoute` that sends traffic to the WordPress Service.
 | `wpCron.cronJob.enabled` | `false` | Create deterministic WordPress cron CronJob |
 | `networkPolicy.enabled` | `false` | Create NetworkPolicy |
 | `networkPolicy.egress.enabled` | `false` | Manage egress allow list |
+| `networkPolicy.egress.extraEgress` | `[]` | Append complete custom egress rules with optional ports |
 | `metrics.enabled` | `false` | Enable Apache exporter sidecar |
 | `metrics.serviceMonitor.enabled` | `false` | Create ServiceMonitor |
 | `plugins.enabled` | `false` | Enable plugin installer support |

--- a/charts/wordpress/docs/production.md
+++ b/charts/wordpress/docs/production.md
@@ -78,6 +78,7 @@ Use either Ingress or Gateway API. Do not enable both for the same hostname unle
 Enable `networkPolicy.enabled` to isolate inbound traffic.
 Enable `networkPolicy.egress.enabled` only after listing required destinations such as DNS, database, HTTPS APIs,
 object storage, and SMTP.
+Use `networkPolicy.egress.extraEgress` for destinations that need complete custom `to` and `ports` rules.
 
 Redis object cache is the recommended provider for the official WordPress image. Memcached can be used with the
 HelmForge Memcached subchart only when the WordPress image includes the required PHP extension.

--- a/charts/wordpress/templates/networkpolicy.yaml
+++ b/charts/wordpress/templates/networkpolicy.yaml
@@ -54,7 +54,7 @@ spec:
     []
     {{- end }}
   {{- if .Values.networkPolicy.egress.enabled }}
-  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespaceDatabase (and .Values.networkPolicy.egress.allowSameNamespaceCache .Values.objectCache.enabled) .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowSMTP .Values.networkPolicy.egress.extraTo }}
+  {{- $allowEgress := or .Values.networkPolicy.egress.allowDNS .Values.networkPolicy.egress.allowSameNamespaceDatabase (and .Values.networkPolicy.egress.allowSameNamespaceCache .Values.objectCache.enabled) .Values.networkPolicy.egress.allowHTTPS .Values.networkPolicy.egress.allowSMTP .Values.networkPolicy.egress.extraTo .Values.networkPolicy.egress.extraEgress }}
   egress:
     {{- if $allowEgress }}
     {{- if .Values.networkPolicy.egress.allowDNS }}
@@ -107,6 +107,9 @@ spec:
     {{- with .Values.networkPolicy.egress.extraTo }}
     - to:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
     {{- else }}
     []

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -7,7 +7,7 @@ release:
   name: test
   namespace: default
 chart:
-  appVersion: "7.0.1"
+  appVersion: "7.0.2"
 tests:
   - it: should not render backup by default
     template: templates/backup-cronjob.yaml

--- a/charts/wordpress/tests/networkpolicy_test.yaml
+++ b/charts/wordpress/tests/networkpolicy_test.yaml
@@ -78,6 +78,30 @@ tests:
             protocol: TCP
             port: 11211
 
+  - it: should append complete custom egress rules
+    set:
+      networkPolicy:
+        enabled: true
+        egress:
+          enabled: true
+          extraEgress:
+            - to:
+                - ipBlock:
+                    cidr: 10.20.0.0/16
+              ports:
+                - protocol: TCP
+                  port: 8443
+    asserts:
+      - equal:
+          path: spec.egress[2]
+          value:
+            to:
+              - ipBlock:
+                  cidr: 10.20.0.0/16
+            ports:
+              - protocol: TCP
+                port: 8443
+
   - it: should render empty ingress list for default deny ingress
     set:
       networkPolicy.enabled: true

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -620,7 +620,8 @@
             "allowHTTPS": { "type": "boolean", "description": "Allow HTTPS egress" },
             "allowSMTP": { "type": "boolean", "description": "Allow SMTP egress" },
             "smtpPort": { "type": "integer", "description": "SMTP egress port" },
-            "extraTo": { "type": "array", "description": "Additional egress destinations", "items": { "type": "object" } }
+            "extraTo": { "type": "array", "description": "Additional egress destinations", "items": { "type": "object" } },
+            "extraEgress": { "type": "array", "description": "Additional complete NetworkPolicy egress rules", "items": { "type": "object" } }
           }
         }
       }

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Container image repository
   repository: docker.io/library/wordpress
   # -- Container image tag
-  tag: "7.0.1-apache"
+  tag: "7.0.2-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -557,6 +557,8 @@ networkPolicy:
     smtpPort: 587
     # -- Additional egress "to" rules
     extraTo: []
+    # -- Additional complete NetworkPolicy egress rules, including optional ports
+    extraEgress: []
 
 # =============================================================================
 # External Secrets Operator


### PR DESCRIPTION
## Summary

- upgrade the official WordPress image from `7.0.1-apache` to `7.0.2-apache`
- bump the HelmForge Redis dependency from 1.6.19 to 1.6.20
- add complete custom NetworkPolicy egress rules through `networkPolicy.egress.extraEgress`
- update tests and production documentation

## Security context

WordPress 7.0.2 is an urgent security release fixing one critical and one high-severity vulnerability. Upstream recommends updating affected installations immediately.

Release notes: https://wordpress.org/news/2026/07/wordpress-7-0-2-release/

## Image verification

`docker.io/library/wordpress:7.0.2-apache` was verified from the registry manifest for Linux amd64, arm, arm64, 386, ppc64le, riscv64, and s390x.

## Local validation

- `make image-verify IMAGE=docker.io/library/wordpress:7.0.2-apache`
- `make deps-check CHART=wordpress`
- `make validate-chart CHART=wordpress`: fully validated, 24 layers
- 127 Helm unit tests passed
- all 15 k3d behavioral profiles passed
- workloads Ready, zero restarts, clean application/database logs and events
- live upgrade from published chart 3.0.2 / WordPress 7.0.1 to the local chart / WordPress 7.0.2 passed
- PVC UID remained unchanged and the persisted marker survived the upgrade
- `make preflight`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- `make site-sync-check CHART=wordpress`
- `make org-check`

## Site synchronization

Companion documentation PR: helmforgedev/site#481

Closes #854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom NetworkPolicy egress rules, including optional destination ports.
  * Added configuration and production guidance for defining additional egress destinations.

* **Bug Fixes**
  * Updated WordPress to version 7.0.2, including the associated security upgrade.
  * Updated the Redis chart dependency to version 1.6.20.

* **Tests**
  * Added coverage confirming custom egress rules render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->