### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -56,6 +56,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -62,6 +62,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/Countly/countly-server
 dependencies:
   - name: mongodb
-    version: 1.7.15
+    version: 1.7.16
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: ""
     condition: crds.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     condition: postgresql.enabled
   - name: redis
     alias: valkey
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: valkey.internal.enabled

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -54,6 +54,6 @@ annotations:
 dependencies:
   - name: elasticsearch
     alias: bundled-elasticsearch
-    version: 1.1.4
+    version: 1.1.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: bundledElasticsearch.enabled

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -57,6 +57,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -55,6 +55,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.19
+    version: 1.6.20
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- appwrite: redis 1.6.19 -> 1.6.20
- authelia: redis 1.6.19 -> 1.6.20
- automatisch: redis 1.6.19 -> 1.6.20
- castopod: redis 1.6.19 -> 1.6.20
- ckan: redis 1.6.19 -> 1.6.20
- countly: mongodb 1.7.15 -> 1.7.16
- docmost: redis 1.6.19 -> 1.6.20
- envoy-gateway: redis 1.6.19 -> 1.6.20
- flowise: redis 1.6.19 -> 1.6.20
- immich: redis 1.6.19 -> 1.6.20
- kibana: elasticsearch 1.1.4 -> 1.1.5
- middleware: redis 1.6.19 -> 1.6.20
- n8n: redis 1.6.19 -> 1.6.20
- open-webui: redis 1.6.19 -> 1.6.20
- opencut: redis 1.6.19 -> 1.6.20
- superset: redis 1.6.19 -> 1.6.20
- wallabag: redis 1.6.19 -> 1.6.20

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Redis dependency to version 1.6.20 across supported application charts.
  * Updated the MongoDB dependency used by Countly to version 1.7.16.
  * Updated the Elasticsearch dependency used by Kibana to version 1.1.5.
  * These updates provide the latest compatible dependency versions for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->