### PR TITLE
feat(envoy-gateway): support listener allowed routes

### DIFF
--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -222,12 +222,14 @@ highAvailability:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `gateway.create` | `false` | Create a default Gateway resource (triggers proxy provisioning) |
+| `gateway.create` | `true` | Create a default Gateway resource (triggers proxy provisioning) |
 | `gateway.name` | `""` | Gateway name (defaults to release name) |
 | `gateway.listeners.http.enabled` | `true` | Enable HTTP listener |
 | `gateway.listeners.http.port` | `80` | HTTP listener port |
+| `gateway.listeners.http.allowedRoutes` | `{}` | Route kinds and namespaces allowed to attach; empty uses the same-namespace Gateway API default |
 | `gateway.listeners.https.enabled` | `false` | Enable HTTPS listener |
 | `gateway.listeners.https.port` | `443` | HTTPS listener port |
+| `gateway.listeners.https.allowedRoutes` | `{}` | Route kinds and namespaces allowed to attach; empty uses the same-namespace Gateway API default |
 | `gateway.listeners.https.tls.mode` | `Terminate` | TLS mode (Terminate or Passthrough) |
 | `gateway.listeners.https.tls.certificateRef.name` | `""` | TLS Secret name (must be created separately) |
 
@@ -485,6 +487,6 @@ This chart intentionally does not support:
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **72.22223%** |
+| MITRE + NSA + SOC2 | **71.63059%** |
 
 > Security posture acceptable.

--- a/charts/envoy-gateway/examples/multi-tenancy.yaml
+++ b/charts/envoy-gateway/examples/multi-tenancy.yaml
@@ -7,6 +7,16 @@ profile: production-ha
 gatewayClass:
   name: platform-gateway
 
+gateway:
+  listeners:
+    http:
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              shared-gateway-access: "true"
+
 gatewayAPI:
   examples:
     enabled: false

--- a/charts/envoy-gateway/templates/gateway.yaml
+++ b/charts/envoy-gateway/templates/gateway.yaml
@@ -25,11 +25,13 @@ spec:
     port: {{ .Values.gateway.listeners.https.port }}
     tls:
       mode: {{ .Values.gateway.listeners.https.tls.mode }}
+      {{- if eq .Values.gateway.listeners.https.tls.mode "Terminate" }}
       certificateRefs:
       - name: {{ .Values.gateway.listeners.https.tls.certificateRef.name }}
         {{- if .Values.gateway.listeners.https.tls.certificateRef.namespace }}
         namespace: {{ .Values.gateway.listeners.https.tls.certificateRef.namespace }}
         {{- end }}
+      {{- end }}
     {{- with .Values.gateway.listeners.https.allowedRoutes }}
     allowedRoutes:
       {{- toYaml . | nindent 6 }}

--- a/charts/envoy-gateway/templates/gateway.yaml
+++ b/charts/envoy-gateway/templates/gateway.yaml
@@ -14,6 +14,10 @@ spec:
   - name: http
     protocol: HTTP
     port: {{ .Values.gateway.listeners.http.port }}
+    {{- with .Values.gateway.listeners.http.allowedRoutes }}
+    allowedRoutes:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.gateway.listeners.https.enabled }}
   - name: https
@@ -26,5 +30,9 @@ spec:
         {{- if .Values.gateway.listeners.https.tls.certificateRef.namespace }}
         namespace: {{ .Values.gateway.listeners.https.tls.certificateRef.namespace }}
         {{- end }}
+    {{- with .Values.gateway.listeners.https.allowedRoutes }}
+    allowedRoutes:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/envoy-gateway/tests/gateway_test.yaml
+++ b/charts/envoy-gateway/tests/gateway_test.yaml
@@ -84,3 +84,60 @@ tests:
       - equal:
           path: spec.gatewayClassName
           value: my-class
+
+  - it: should allow HTTP routes from all namespaces
+    set:
+      gateway:
+        listeners:
+          http:
+            allowedRoutes:
+              namespaces:
+                from: All
+    asserts:
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.from
+          value: All
+
+  - it: should restrict HTTP routes with a namespace selector
+    set:
+      gateway:
+        listeners:
+          http:
+            allowedRoutes:
+              namespaces:
+                from: Selector
+                selector:
+                  matchLabels:
+                    shared-gateway-access: "true"
+    asserts:
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchLabels.shared-gateway-access
+          value: "true"
+
+  - it: should configure allowed route kinds on the HTTPS listener
+    set:
+      gateway:
+        listeners:
+          https:
+            enabled: true
+            tls:
+              certificateRef:
+                name: my-tls-secret
+            allowedRoutes:
+              kinds:
+                - kind: HTTPRoute
+                  group: gateway.networking.k8s.io
+              namespaces:
+                from: Same
+    asserts:
+      - equal:
+          path: spec.listeners[1].allowedRoutes.kinds[0].kind
+          value: HTTPRoute
+      - equal:
+          path: spec.listeners[1].allowedRoutes.namespaces.from
+          value: Same
+
+  - it: should omit allowedRoutes when no policy is configured
+    asserts:
+      - notExists:
+          path: spec.listeners[0].allowedRoutes

--- a/charts/envoy-gateway/tests/gateway_test.yaml
+++ b/charts/envoy-gateway/tests/gateway_test.yaml
@@ -141,3 +141,18 @@ tests:
     asserts:
       - notExists:
           path: spec.listeners[0].allowedRoutes
+
+  - it: should omit certificateRefs for HTTPS passthrough
+    set:
+      gateway:
+        listeners:
+          https:
+            enabled: true
+            tls:
+              mode: Passthrough
+    asserts:
+      - equal:
+          path: spec.listeners[1].tls.mode
+          value: Passthrough
+      - notExists:
+          path: spec.listeners[1].tls.certificateRefs

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -791,6 +791,37 @@
         }
       }
     },
+    "gateway": {
+      "type": "object",
+      "description": "Default Gateway resource configuration",
+      "additionalProperties": false,
+      "required": ["create", "name", "listeners"],
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create a default Gateway resource",
+          "default": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Gateway name; defaults to the Helm release name",
+          "default": ""
+        },
+        "listeners": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["http", "https"],
+          "properties": {
+            "http": {
+              "$ref": "#/definitions/httpListener"
+            },
+            "https": {
+              "$ref": "#/definitions/httpsListener"
+            }
+          }
+        }
+      }
+    },
     "cleanup": {
       "type": "object",
       "description": "Cleanup hook configuration",
@@ -842,6 +873,103 @@
         "secretStoreRef": { "type": "object" },
         "target": { "type": "object" },
         "data": { "type": "array" }
+      }
+    }
+  },
+  "definitions": {
+    "allowedRoutes": {
+      "type": "object",
+      "description": "Gateway API constraints for Routes attaching to a listener",
+      "additionalProperties": false,
+      "properties": {
+        "kinds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind"],
+            "properties": {
+              "group": { "type": "string" },
+              "kind": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "namespaces": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "from": {
+              "type": "string",
+              "enum": ["All", "Same", "Selector"]
+            },
+            "selector": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "matchLabels": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                },
+                "matchExpressions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["key", "operator"],
+                    "properties": {
+                      "key": { "type": "string", "minLength": 1 },
+                      "operator": {
+                        "type": "string",
+                        "enum": ["In", "NotIn", "Exists", "DoesNotExist"]
+                      },
+                      "values": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "httpListener": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "port", "allowedRoutes"],
+      "properties": {
+        "enabled": { "type": "boolean", "default": true },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 80 },
+        "allowedRoutes": { "$ref": "#/definitions/allowedRoutes" }
+      }
+    },
+    "httpsListener": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "port", "tls", "allowedRoutes"],
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 443 },
+        "allowedRoutes": { "$ref": "#/definitions/allowedRoutes" },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "certificateRef"],
+          "properties": {
+            "mode": { "type": "string", "enum": ["Terminate", "Passthrough"] },
+            "certificateRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name", "namespace"],
+              "properties": {
+                "name": { "type": "string" },
+                "namespace": { "type": "string" }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -926,12 +926,35 @@
                         "type": "array",
                         "items": { "type": "string" }
                       }
-                    }
+                    },
+                    "allOf": [
+                      {
+                        "if": {
+                          "properties": { "operator": { "enum": ["In", "NotIn"] } },
+                          "required": ["operator"]
+                        },
+                        "then": {
+                          "required": ["values"],
+                          "properties": { "values": { "minItems": 1 } }
+                        },
+                        "else": { "not": { "required": ["values"] } }
+                      }
+                    ]
                   }
                 }
               }
             }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "from": { "const": "Selector" } },
+                "required": ["from"]
+              },
+              "then": { "required": ["selector"] },
+              "else": { "not": { "required": ["selector"] } }
+            }
+          ]
         }
       }
     },
@@ -956,7 +979,7 @@
         "tls": {
           "type": "object",
           "additionalProperties": false,
-          "required": ["mode", "certificateRef"],
+          "required": ["mode"],
           "properties": {
             "mode": { "type": "string", "enum": ["Terminate", "Passthrough"] },
             "certificateRef": {
@@ -970,7 +993,34 @@
             }
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": { "const": true },
+              "tls": {
+                "properties": { "mode": { "const": "Terminate" } },
+                "required": ["mode"]
+              }
+            },
+            "required": ["enabled", "tls"]
+          },
+          "then": {
+            "properties": {
+              "tls": {
+                "required": ["certificateRef"],
+                "properties": {
+                  "certificateRef": {
+                    "required": ["name"],
+                    "properties": { "name": { "minLength": 1 } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -173,6 +173,8 @@ gateway:
     http:
       enabled: true
       port: 80
+      # -- Controls which Routes may attach to the HTTP listener (empty uses Gateway API same-namespace default)
+      allowedRoutes: {}
     https:
       enabled: false
       port: 443
@@ -182,6 +184,8 @@ gateway:
           # -- Name of the TLS secret (must be in same namespace)
           name: ""
           namespace: ""
+      # -- Controls which Routes may attach to the HTTPS listener (empty uses Gateway API same-namespace default)
+      allowedRoutes: {}
 
 ## SecurityPolicy - EG-native auth (JWT, OIDC, API Key, CORS)
 securityPolicy:


### PR DESCRIPTION
## Summary

- add per-listener `allowedRoutes` support to the chart-managed Gateway
- validate `Same`, `All`, and `Selector` namespace policies plus Route kinds
- add unit coverage and a multi-tenancy example
- synchronize the chart README, values schema, and security scan evidence

## Impact

Gateway owners can allow HTTPRoutes from different namespaces using Gateway API
namespace selectors while preserving the existing same-namespace behavior when
the option is omitted.

## Site synchronization

Site PR: helmforgedev/site#486

## Validation

- `make preflight`
- `make validate-chart CHART=envoy-gateway VALUES=examples/multi-tenancy.yaml`
- 21 validation layers passed, including default, every CI profile, and the
  multi-tenancy scenario on `k3d-helmforge-tests-wsl`
- 131 Helm unit tests passed
- Kubescape MITRE + NSA + SOC2: `71.63059%`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Resolves #888


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable route-namespace restrictions for HTTP and HTTPS Gateway listeners.
  * Added support for restricting routes to namespaces with specific labels.
  * Added validation for Gateway creation, listener, TLS, certificate, and route-attachment settings.
* **Documentation**
  * Updated configuration defaults and examples, including multi-tenancy setup guidance.
* **Bug Fixes**
  * Gateway listener settings now render correctly when route policies are configured, while preserving defaults when omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->