### PR TITLE
chore(certimate): bump certimate to 0.4.29

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -4,7 +4,7 @@ name: certimate
 description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
 type: application
 version: 1.0.2
-appVersion: "0.4.28"
+appVersion: "0.4.29"
 home: https://helmforge.dev/docs/charts/certimate
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/certimate
@@ -24,8 +24,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/certimate.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "update image to 0.4.28 (#862)"
+    - kind: changed
+      description: "update Certimate to 0.4.29 (#890)"
   artifacthub.io/category: security
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -2,7 +2,7 @@
 
 Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
 
-This chart packages the official `certimate/certimate:v0.4.28` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+This chart packages the official `certimate/certimate:v0.4.29` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
 
 ## Production Defaults
 
@@ -71,9 +71,9 @@ Back up the PersistentVolumeClaim before upgrades. Certimate stores its
 PocketBase database, uploaded certificate material, ACME account state, workflow
 definitions, and provider credentials under `/app/pb_data`.
 
-Certimate 0.4.28 fixes repeated Tencent EdgeOne deployment workflows when no
-domains remain to be updated. It does not change the container port, storage
-path, or chart configuration contract.
+Certimate 0.4.29 adds reverse-proxy subpath support, new Yandex Cloud providers,
+and several provider fixes. It does not change the container port, storage path,
+or chart configuration contract.
 
 Certimate's upstream deployment uses PocketBase-local state. This chart does not
 ship PostgreSQL, MySQL, or Redis subcharts because the product does not expose an
@@ -89,7 +89,7 @@ ACME endpoints required by your workflows.
 Local security scan:
 
 ```text
-Image: certimate/certimate:v0.4.28
+Image: certimate/certimate:v0.4.29
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 93.93939 compliance score
 ```

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: certimate/certimate:v0.4.28
+          value: certimate/certimate:v0.4.29
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "certimate/certimate" },
-        "tag": { "type": "string", "default": "v0.4.28", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "v0.4.29", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Certimate container image repository.
   repository: certimate/certimate
   # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
-  tag: "v0.4.28"
+  tag: "v0.4.29"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update Certimate from `v0.4.28` to `v0.4.29`
- refresh the schema default, unit-test assertion, Artifact Hub change note, and operational documentation
- preserve the existing port, storage path, and chart configuration contract

## Upstream evidence

- Release notes: https://github.com/certimate-go/certimate/releases/tag/v0.4.29
- Image manifest: `certimate/certimate:v0.4.29` is available for `linux/amd64`, `linux/arm64`, and `linux/arm`
- Upstream changes relevant to this chart: reverse-proxy subpath support, new Yandex Cloud integrations, provider fixes, and a panic fix; no documented container port, storage path, probe, or required environment-variable change

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| Reverse-proxy subpath support | No default contract change; ingress/Gateway templates are unchanged | `default` smoke verifies the application still starts and serves HTTP |
| Provider additions and fixes | Application-only behavior | `default` |
| No port, storage, probe, or required environment change | Other `ci/` profiles are not behaviorally impacted | Covered by static render and kubeconform validation |

## Validation

- `make image-verify IMAGE=certimate/certimate:v0.4.29`
- `make deps-check CHART=certimate`
- `make validate-chart CHART=certimate K3D_SCENARIOS="default" TIMEOUT=180`
- `make standards-check CHART=certimate`
- `node scripts/charts/template-standards-check.js --chart certimate`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: the default install became ready in 17 seconds; rollout, Service endpoint smoke, restart checks, container logs, events, and blocking cleanup all passed. Static validation covered the default and every `ci/*.yaml` scenario.

Site sync was reviewed. This patch changes only the pinned application image and does not alter the values contract, examples, install path, or playground configuration, so no companion site change is required.

Resolves #890
