### PR TITLE
chore(ghost): bump ghost to 6.55.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.2.0
-appVersion: "6.54.0"
+appVersion: "6.55.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,8 +24,8 @@ sources:
   - https://github.com/TryGhost/Ghost
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "upgrade to 6.54.0 (#867)"
+    - kind: changed
+      description: "update Ghost to 6.55.0 (#892)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -99,14 +99,14 @@ new configurations should use `externalSecrets.items`.
 
 ## Custom Adapter Images
 
-Ghost 6.54.0 can load adapters installed outside the content directory. For a
+Ghost 6.55.0 can load adapters installed outside the content directory. For a
 custom image that installs adapters in `/opt/ghost/adapters`, expose the path
 through Ghost's environment-based configuration:
 
 ```yaml
 image:
   repository: registry.example.com/ghost-with-adapters
-  tag: "6.54.0"
+  tag: "6.55.0"
 
 ghost:
   extraEnv:
@@ -123,7 +123,7 @@ adapters when the container starts.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.54.0` | Ghost image tag |
+| `image.tag` | `6.55.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -137,13 +137,12 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.54.0` adds inline editing for `routes.yaml` and `redirects.yaml`,
-support for adapters installed outside the content directory, member labels,
-complimentary subscriptions, and theme access to member avatars. It also
-hardens filename generation and fixes unsafe split-helper output and several
-CSV import edge cases. Files edited in Ghost Admin remain under
-`/var/lib/ghost/content/data`, so the chart's content PVC and S3 content backup
-already cover them. Review the upstream Ghost release notes before upgrading
+Ghost `6.55.0` includes Admin, member import/export, routing, comments, and
+email automation fixes. The release does not change the official image's port,
+content path, database contract, probes, or required environment variables.
+Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the
+chart's content PVC and S3 content backup already cover them. Review the
+upstream Ghost release notes before upgrading
 production sites, take a content and database backup, and verify themes, custom
 integrations, newsletter flows, comments, and member signup paths in staging
 before reusing existing PVCs. The External Secrets contract now follows

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.54.0"
+          value: "docker.io/library/ghost:6.55.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.54.0"
+                                                                    "default":  "6.55.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.54.0"
+  tag: "6.55.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update Ghost from `6.54.0` to `6.55.0`
- refresh the schema default, unit-test assertion, Artifact Hub change note, examples, and upgrade guidance
- preserve the existing image contract, MySQL integration, content path, and probes

## Upstream evidence

- Source comparison: https://github.com/TryGhost/Ghost/compare/v6.54.0...v6.55.0
- Image manifest: `docker.io/library/ghost:6.55.0` is available for `linux/amd64`, `linux/arm`, and `linux/arm64`
- The release contains Admin, members, routing, comments, and email automation changes; no container port, content path, database contract, probe, or required environment-variable change was identified

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| Application and Admin fixes | No chart contract change | `default` exercises Ghost with the bundled MySQL dependency and persistent content volume |
| No image runtime contract change | Optional profiles are not behaviorally affected | All profiles remain covered by render, unit, and kubeconform validation |

## Validation

- `make image-verify IMAGE=docker.io/library/ghost:6.55.0`
- `make deps-check CHART=ghost`
- `make validate-chart CHART=ghost K3D_SCENARIOS="default" TIMEOUT=240`
- `make standards-check CHART=ghost`
- `node scripts/charts/template-standards-check.js --chart ghost`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: Ghost and MySQL became ready in 137 seconds; both workloads rolled out with zero restarts, all three Services had endpoints, logs were clean, transient startup warnings were resolved on the healthy workloads, and cleanup completed. Static validation covered every `ci/*.yaml` scenario.

Site sync was reviewed. This patch changes only the pinned application image and does not alter the values contract, examples, install path, or playground configuration, so no companion site change is required.

Resolves #892


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Ghost Helm Chart to deploy Ghost version 6.55.0 by default.
  - Documented improvements in Admin, member import/export, routing, comments, and email automation.

- **Documentation**
  - Updated configuration examples, version references, and upgrade notes for Ghost 6.55.0.

- **Tests**
  - Updated deployment validation to confirm the Ghost 6.55.0 container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->