### PR TITLE
chore(gitea): bump gitea to 1.27.1

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -4,7 +4,7 @@ name: gitea
 description: Gitea self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.15
-appVersion: "1.27.0"
+appVersion: "1.27.1"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump gitea to 1.27.0 (#816)"
+      description: "update Gitea to 1.27.1 (#893)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/gitea/DESIGN.md
+++ b/charts/gitea/DESIGN.md
@@ -9,7 +9,7 @@ ClusterIP HTTP and SSH services, and restricted-compatible pod defaults.
 
 ## Goals
 
-- Run the official `docker.io/gitea/gitea:1.27.0-rootless` image without Bitnami
+- Run the official `docker.io/gitea/gitea:1.27.1-rootless` image without Bitnami
   or third-party runtime substitutions.
 - Keep the default install zero-config through SQLite while making PostgreSQL,
   MySQL, and external database modes explicit.

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -4,8 +4,8 @@
 
 Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
 
-- **Current application version** `1.27.0`
-- **Default image** `docker.io/gitea/gitea:1.27.0-rootless`
+- **Current application version** `1.27.1`
+- **Default image** `docker.io/gitea/gitea:1.27.1-rootless`
 - **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
 - **Rootless storage** PVC paths are prepared for UID/GID 1000 by a small initContainer
 
@@ -137,7 +137,7 @@ gitea:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `gitea/gitea` | Container image repository |
-| `image.tag` | `"1.27.0-rootless"` | Image tag |
+| `image.tag` | `"1.27.1-rootless"` | Image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
 | `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
@@ -191,12 +191,11 @@ Only one database source can be active. The chart fails with a clear error if mu
 
 ## Upgrade Notes
 
-This update moves the default rootless image to `1.27.0-rootless`. Gitea 1.27
-changes reusable Actions workflow behavior and
-enforces per-request Content Security Policy nonces for inline scripts. Review
-custom workflows, templates, themes, and embeds before upgrading. Back up the
-database and repositories first; Gitea runs required database migrations during
-the first startup.
+This update moves the default rootless image to `1.27.1-rootless`. Gitea 1.27.1
+contains security, Actions, OAuth2, repository cleanup, API schema, and UI fixes
+without a documented change to the rootless image contract. Back up the database
+and repositories first; Gitea runs required database migrations during the first
+startup.
 
 ## SSH Access
 

--- a/charts/gitea/templates/_helpers.tpl
+++ b/charts/gitea/templates/_helpers.tpl
@@ -371,3 +371,8 @@ Backup database password secret key
   {{- include "gitea.databaseSecretKey" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Validate cross-field configuration before rendering workloads. */}}
+{{- define "gitea.validate" -}}
+{{- $databaseMode := include "gitea.databaseMode" . -}}
+{{- end -}}

--- a/charts/gitea/templates/deployment.yaml
+++ b/charts/gitea/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "gitea.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -6,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.27.0-rootless"
+  tag: "1.27.1-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- update the official rootless Gitea image from `1.27.0-rootless` to `1.27.1-rootless`
- refresh application-version documentation and upgrade guidance
- centralize the chart's existing database validation through the canonical validate helper

## Upstream evidence

- Release notes: https://github.com/go-gitea/gitea/releases/tag/v1.27.1
- Image manifest: `docker.io/gitea/gitea:1.27.1-rootless` is available for `linux/amd64`, `linux/arm64`, and `linux/riscv64`
- The patch release contains security, OAuth2, Actions, repository cleanup, API schema, and UI fixes; it documents no rootless image contract, port, storage, probe, or required environment-variable change

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| Patch-level application and security fixes | No values or workload contract change | `default` validates rootless startup, SQLite persistence, HTTP, and SSH Services |
| No database or image contract change | MySQL/PostgreSQL profiles are not specifically impacted | Covered by static render and kubeconform validation |

## Validation

- `make image-verify IMAGE=docker.io/gitea/gitea:1.27.1-rootless`
- `make deps-check CHART=gitea`
- `make validate-chart CHART=gitea K3D_SCENARIOS="default" TIMEOUT=240`
- `make standards-check CHART=gitea`
- `node scripts/charts/template-standards-check.js --chart gitea`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: the rootless Gitea workload became ready in 26 seconds with zero restarts, both Services had endpoints, logs and events were clean, and cleanup completed. Static validation covered every `ci/*.yaml` scenario.

Site sync was reviewed. The validate helper only centralizes existing render-time checks, and the image bump does not change the user-facing values contract or site configuration, so no companion site change is required.

Resolves #893
