### PR TITLE
chore(homarr): bump homarr to 1.73.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.2.0
-appVersion: "1.72.0"
+appVersion: "1.73.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -22,8 +22,8 @@ sources:
   - https://github.com/homarr-labs/homarr
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "upgrade to 1.72.0 (#868)"
+    - kind: changed
+      description: "update Homarr to 1.73.0 (#894)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.72.0`.
+Current application version: `v1.73.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.72.0"` | Homarr image tag |
+| `image.tag` | `"v1.73.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,10 +265,10 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.71.0` to `v1.72.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.72.0` adds album-free random photos for Immich, humidity and animated weather in clock widgets,
-and fixes permission visibility, media integrations, response caching, and Beszel subscription memory growth. No breaking
-changes or new required environment variables were identified in the upstream release metadata.
+This update moves the default image from `v1.72.0` to `v1.73.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.73.0` adds OIDC account linking, Navidrome media-server integration, widget improvements, and
+Beszel session recovery fixes. No breaking changes or new required environment variables were identified in the upstream
+release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.72.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.73.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.72.0"
+  tag: "v1.73.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- update Homarr from `v1.72.0` to `v1.73.0`
- refresh the Artifact Hub note, pinned-image assertion, values documentation, and upgrade guidance

## Upstream evidence

- Release notes: https://github.com/homarr-labs/homarr/releases/tag/v1.73.0
- Image manifest: `ghcr.io/homarr-labs/homarr:v1.73.0` is available for `linux/amd64` and `linux/arm64`
- The release adds OIDC account linking and Navidrome integration plus Beszel and widget fixes; no required environment-variable, database, port, probe, or image-contract change is documented

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| Authentication, integration, and widget features | Application-only behavior with no chart contract change | `default` validates SQLite startup, persistence, and HTTP readiness |
| No database or deployment contract change | PostgreSQL, MySQL, backup, and Kubernetes integration profiles are not specifically impacted | Covered by static render and kubeconform validation |

## Validation

- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.73.0`
- `make deps-check CHART=homarr`
- `make validate-chart CHART=homarr K3D_SCENARIOS="default" TIMEOUT=240`
- `make standards-check CHART=homarr`
- `node scripts/charts/template-standards-check.js --chart homarr`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: Homarr became ready in 57 seconds with zero restarts, the Service had endpoints, logs and events were clean, and cleanup completed. Static validation covered every `ci/*.yaml` scenario.

Site sync was reviewed. This patch changes only the pinned application image and does not alter the values contract or playground configuration, so no companion site change is required.

Resolves #894
