### PR TITLE
chore(hoppscotch): bump hoppscotch to 2026.7.0

### DIFF
--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
 version: 1.1.8
-appVersion: "2026.6.1"
+appVersion: "2026.7.0"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -30,7 +30,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump hoppscotch to 2026.6.1 (#818)"
+      description: "update Hoppscotch to 2026.7.0 (#895)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -77,7 +77,7 @@ backend process inside the AIO image.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.6.1` |
+| `image.tag` | Hoppscotch image tag | `2026.7.0` |
 | `namespaceOverride` | Namespace for chart-managed resources. Use with an external database; bundled PostgreSQL remains in the Helm release namespace. | `""` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
@@ -105,10 +105,9 @@ backend process inside the AIO image.
 
 ## Upgrade Notes
 
-Hoppscotch `2026.6.1` fixes Desktop App authentication with self-hosted instances, supports arbitrary non-root container
-UIDs, captures response cookies for Agent-routed requests, and reduces JSON renderer overhead. This release is specifically
-published for self-hosted deployments. Back up the PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before
-upgrading.
+Hoppscotch `2026.7.0` fixes collection data loss in personal workspaces and request loss when importing large team
+collections, adds fallback to initial values for empty environment variables, and includes security fixes. Back up the
+PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
 The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
 user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs
 a pre-upgrade hook to apply `pg_trgm` to existing bundled PostgreSQL PVCs before

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/hoppscotch/hoppscotch:2026.6.1
+          value: docker.io/hoppscotch/hoppscotch:2026.7.0
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -53,7 +53,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: docker.io/hoppscotch/hoppscotch:2026.6.1
+          value: docker.io/hoppscotch/hoppscotch:2026.7.0
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
@@ -87,7 +87,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: docker.io/hoppscotch/hoppscotch:2026.6.1
+          value: docker.io/hoppscotch/hoppscotch:2026.7.0
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].command[0]

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.6.1"
+  tag: "2026.7.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update Hoppscotch from `2026.6.1` to `2026.7.0`
- refresh pinned-image assertions, Artifact Hub metadata, and upgrade guidance

## Upstream evidence

- Release notes: https://github.com/hoppscotch/hoppscotch/releases/tag/2026.7.0
- Image manifest: `docker.io/hoppscotch/hoppscotch:2026.7.0` is available for `linux/amd64` and `linux/arm64`
- The release fixes collection/request data loss, adds environment-value fallback behavior, and includes security fixes; it documents no required environment-variable, port, probe, or container-path change

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| Collection persistence and backend fixes | Database-backed default deployment must start and migrate cleanly | `default` exercises bundled PostgreSQL, startup migrations, HTTP readiness, and persisted signing/encryption secrets |
| No external database or exposure contract change | Other profiles are not specifically impacted | Covered by static render and kubeconform validation |

## Validation

- `make image-verify IMAGE=docker.io/hoppscotch/hoppscotch:2026.7.0`
- `make deps-check CHART=hoppscotch`
- `make validate-chart CHART=hoppscotch K3D_SCENARIOS="default" TIMEOUT=300`
- `make standards-check CHART=hoppscotch`
- `node scripts/charts/template-standards-check.js --chart hoppscotch`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: Hoppscotch and PostgreSQL became ready in 100 seconds; both workloads rolled out with zero restarts, all Services had endpoints, logs and events were clean, and cleanup completed. Static validation covered every `ci/*.yaml` scenario.

Site sync was reviewed. This patch changes only the pinned application image and does not alter the chart or playground contract, so no companion site change is required.

Resolves #895
