### PR TITLE
chore(karakeep): bump karakeep to 0.33.1

### DIFF
--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -5,7 +5,7 @@ description: AI-powered bookmark manager with full-text search and web archiving
 icon: https://helmforge.dev/icons/charts/karakeep.png
 type: application
 version: 1.2.7
-appVersion: "0.32.0"
+appVersion: "0.33.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -22,8 +22,8 @@ sources:
   - https://github.com/karakeep-app/karakeep
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#495)"
+    - kind: changed
+      description: "update Karakeep to 0.33.1 (#896)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/karakeep/README.md
+++ b/charts/karakeep/README.md
@@ -5,11 +5,11 @@ the official `ghcr.io/karakeep-app/karakeep` container image. Karakeep provides
 bookmark management, full-text archive search, web page capture, and optional AI
 tagging in a single-writer application pod.
 
-Current application version: `0.32.0`.
+Current application version: `0.33.1`.
 
 ## Features
 
-- Official Karakeep image pinned to `0.32.0`
+- Official Karakeep image pinned to `0.33.1`
 - Optional Meilisearch sidecar for full-text search
 - Optional browserless Chromium sidecar for screenshots and page archiving
 - SQLite and uploaded content stored on a PersistentVolumeClaim
@@ -125,7 +125,7 @@ chromium:
 | Key | Default | Description |
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/karakeep-app/karakeep` | Main Karakeep image |
-| `image.tag` | `"0.32.0"` | Main Karakeep image tag |
+| `image.tag` | `"0.33.1"` | Main Karakeep image tag |
 | `karakeep.nextAuthUrl` | `""` | Public URL of the Karakeep instance |
 | `karakeep.browserConnectOnDemand` | `true` | Connect to Chromium only when crawling needs it |
 | `karakeep.existingSecret` | `""` | Existing secret with auth and Meilisearch keys |
@@ -154,6 +154,16 @@ resource limits, container hardening context, service account token mounting, an
 NetworkPolicy boundaries. Set `resources`, `securityContext`,
 `podSecurityContext`, and platform NetworkPolicies according to your cluster
 baseline.
+
+## Upgrade Notes
+
+Karakeep `0.33.1` adds experimental semantic search and embedding-based
+auto-tagging, database indexes, crawler and security fixes, and new optional AI
+settings. The bundled Meilisearch `v1.41.0` exceeds the upstream `1.13` minimum
+for embeddings. Custom AI providers can pass `EMBEDDING_TEXT_MODEL`,
+`EMBEDDING_DIMENSIONS`, and `EMBEDDING_ENABLE_AUTO_INDEXING` through
+`karakeep.extraEnv`. Back up the `/data` PVC before upgrading because the
+application applies database changes during startup.
 
 ## Quality Gates
 

--- a/charts/karakeep/docs/operations.md
+++ b/charts/karakeep/docs/operations.md
@@ -14,7 +14,7 @@ make validate-chart CHART=karakeep
 Verify that every image tag is pinned:
 
 ```bash
-make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.32.0
+make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.33.1
 make image-verify IMAGE=docker.io/getmeili/meilisearch:v1.41.0
 make image-verify IMAGE=ghcr.io/browserless/chromium:v2.46.0
 ```

--- a/charts/karakeep/templates/NOTES.txt
+++ b/charts/karakeep/templates/NOTES.txt
@@ -1,14 +1,14 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 Karakeep has been deployed.
 
-Release:
+1. Release
   Chart:      {{ .Chart.Name }}
   Version:    {{ .Chart.Version }}
   AppVersion: {{ .Chart.AppVersion }}
   Release:    {{ .Release.Name }}
   Namespace:  {{ .Release.Namespace }}
 
-Access:
+2. Access
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   Web UI: http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}/
@@ -25,7 +25,7 @@ Access:
   Web UI: http://localhost:3000/
 {{- end }}
 
-Configuration:
+3. Configuration
   Karakeep image: {{ include "karakeep.image" . }}
   Meilisearch enabled: {{ .Values.meilisearch.enabled }}
   Chromium enabled: {{ .Values.chromium.enabled }}
@@ -39,17 +39,17 @@ Configuration:
   Service IP family policy: {{ . }}{{ with $.Values.service.ipFamilies }} (families: {{ join ", " . }}){{ end }}
 {{- end }}
 
-Validation:
+4. Validation
   kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --timeout=300s
   kubectl get pods -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=50
 
-Troubleshooting:
+5. Troubleshooting
   kubectl describe pod -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }}
   kubectl logs -l app.kubernetes.io/name=karakeep -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
 
-Warnings:
+6. Warnings
 {{- if not .Values.karakeep.nextAuthUrl }}
   - karakeep.nextAuthUrl is not set. Set it to the exact URL users open in the browser before production use.
 {{- end }}
@@ -60,8 +60,9 @@ Warnings:
   - chromium.resources is empty. Set resource requests and limits for production.
 {{- end }}
 
-Documentation:
+7. Documentation
   https://helmforge.dev/docs/charts/karakeep
   https://karakeep.app
 
+8. Completion
 Happy Helmforging :)

--- a/charts/karakeep/templates/_helpers.tpl
+++ b/charts/karakeep/templates/_helpers.tpl
@@ -87,3 +87,9 @@ Generate MEILI_MASTER_KEY: lookup existing secret or generate a new one.
 {{- randAlphaNum 32 -}}
 {{- end -}}
 {{- end -}}
+{{/* Validate cross-field configuration before rendering workloads. */}}
+{{- define "karakeep.validate" -}}
+{{- if and .Values.externalSecrets.enabled (not .Values.karakeep.existingSecret) -}}
+{{- fail "externalSecrets.enabled requires karakeep.existingSecret to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/karakeep/templates/deployment.yaml
+++ b/charts/karakeep/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "karakeep.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/karakeep/tests/deployment_test.yaml
+++ b/charts/karakeep/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/karakeep-app/karakeep:0.32.0"
+          value: "ghcr.io/karakeep-app/karakeep:0.33.1"
 
   - it: should set DATA_DIR env
     template: templates/deployment.yaml

--- a/charts/karakeep/values.yaml
+++ b/charts/karakeep/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Karakeep container image
   repository: ghcr.io/karakeep-app/karakeep
   # -- Image tag
-  tag: "0.32.0"
+  tag: "0.33.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update Karakeep from `0.32.0` to `0.33.1`
- document semantic-search prerequisites and the new optional embedding settings
- refresh image assertions and operations guidance
- align NOTES and the cross-field validate helper with current chart standards

## Upstream evidence

- Release notes: https://github.com/karakeep-app/karakeep/releases/tag/v0.33.1
- Image manifest: `ghcr.io/karakeep-app/karakeep:0.33.1` is available for `linux/amd64` and `linux/arm64`
- The release adds semantic search, embedding-based tagging, database indexes, crawler/security fixes, optional AI settings, and requires Meilisearch 1.13+ for embeddings; the chart already pins Meilisearch `v1.41.0`

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| Database indexes and startup migrations | Existing `/data` PVC must upgrade cleanly | `default` plus explicit `0.32.0 → 0.33.1` in-place upgrade |
| Semantic search and Meilisearch vector store | Bundled Meilisearch must be compatible and discovered | `default` includes Meilisearch and confirms `MeiliSearchVector` startup |
| Crawler changes | Bundled Chromium must start with the application | `default` includes Chromium |
| Optional custom embedding settings | Passed through the existing `karakeep.extraEnv` contract | Static validation; no new chart value required |

## Validation

- `make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.33.1`
- `make deps-check CHART=karakeep`
- `make validate-chart CHART=karakeep K3D_SCENARIOS="default" TIMEOUT=300`
- in-place Helm upgrade on the same PVC from image `0.32.0` to `0.33.1` using `--reset-then-reuse-values`
- `make standards-check CHART=karakeep`
- `node scripts/charts/template-standards-check.js --chart karakeep`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: the default three-container pod became ready with zero restarts; application, Meilisearch, and Chromium were healthy and cleanup completed. The in-place upgrade also rolled out with image `0.33.1`, zero restarts, successful database migration, and the `MeiliSearchVector` plugin loaded. Static validation covered every `ci/*.yaml` scenario.

Site sync was reviewed. The new settings use the existing `karakeep.extraEnv` surface and no site/playground contract changes are required.

Resolves #896
