### PR TITLE
chore(kubernetes-mcp-server): bump image to 0.0.66

### DIFF
--- a/charts/kubernetes-mcp-server/Chart.yaml
+++ b/charts/kubernetes-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ name: kubernetes-mcp-server
 description: Kubernetes and OpenShift MCP server in HTTP mode
 type: application
 version: 1.0.5
-appVersion: "0.0.65"
+appVersion: "0.0.66"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/kubernetes-mcp-server.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.0.65 (#819)"
+      description: "update Kubernetes MCP Server to 0.0.66 (#897)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/kubernetes-mcp-server/README.md
+++ b/charts/kubernetes-mcp-server/README.md
@@ -1,7 +1,7 @@
 # Kubernetes MCP Server Helm Chart
 
 Kubernetes MCP Server exposes Kubernetes cluster inspection and automation through the Model Context Protocol.
-This chart deploys the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.65` image in HTTP mode with in-cluster authentication,
+This chart deploys the official `ghcr.io/containers/kubernetes-mcp-server:v0.0.66` image in HTTP mode with in-cluster authentication,
 read-only safety flags, and least-privilege RBAC by default.
 
 ## Install
@@ -39,6 +39,15 @@ Ingress class rendering is optional. Set `ingress.ingressClassName: ""` to omit 
 When `networkPolicy.enabled=true`, ingress is restricted to the configured peers.
 Setting `networkPolicy.enabled=true` enables egress isolation with built-in DNS and HTTPS allowances; `networkPolicy.extraEgress` appends API server or proxy rules.
 Set `networkPolicy.dnsEgressPeers` when your cluster DNS pods do not use the default kube-system/kube-dns labels.
+
+## Upgrade Notes
+
+Version `0.0.66` adds MCP specification `2026-07-28` support, optional TLS
+minimum-version and cipher-suite environment variables, an environment-based
+config file path, and additional tool capabilities. Existing clients should be
+verified against the new MCP specification. Optional upstream environment
+variables can be supplied through `app.extraEnv`; the default HTTP port and
+read-only chart profile are unchanged.
 
 ## Security Scan: `kubernetes-mcp-server`
 

--- a/charts/kubernetes-mcp-server/tests/templates_test.yaml
+++ b/charts/kubernetes-mcp-server/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.65
+          value: ghcr.io/containers/kubernetes-mcp-server:v0.0.66
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: kubernetes-mcp-server

--- a/charts/kubernetes-mcp-server/values.schema.json
+++ b/charts/kubernetes-mcp-server/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/containers/kubernetes-mcp-server" },
-        "tag": { "type": "string", "default": "v0.0.65" },
+        "tag": { "type": "string", "default": "v0.0.66" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/kubernetes-mcp-server/values.yaml
+++ b/charts/kubernetes-mcp-server/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 commonLabels: {}
 image:
   repository: ghcr.io/containers/kubernetes-mcp-server
-  tag: "v0.0.65"
+  tag: "v0.0.66"
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 replicaCount: 1


### PR DESCRIPTION
## Summary

- update Kubernetes MCP Server from `v0.0.65` to `v0.0.66`
- refresh the schema default, image assertion, Artifact Hub note, and upgrade guidance

## Upstream evidence

- Release notes: https://github.com/containers/kubernetes-mcp-server/releases/tag/v0.0.66
- Image manifest: `ghcr.io/containers/kubernetes-mcp-server:v0.0.66` is available for `linux/amd64`, `linux/arm64`, `linux/s390x`, and `linux/ppc64le`
- The release adds MCP specification `2026-07-28`, optional TLS/config environment settings, and new tool capabilities; the HTTP port and default read-only deployment contract are unchanged

## Validation scope

| Upstream change | Chart impact | Runtime scenario |
|---|---|---|
| MCP protocol and HTTP proxy changes | Default HTTP server and probes must remain healthy | `default` |
| Config-file path and tool configuration changes | Existing chart-managed TOML config must still load | `ci/config-values.yaml` |
| Optional TLS environment settings | Supported through existing `app.extraEnv` | Static validation; disabled by default |

## Validation

- `make image-verify IMAGE=ghcr.io/containers/kubernetes-mcp-server:v0.0.66`
- `make deps-check CHART=kubernetes-mcp-server`
- `make validate-chart CHART=kubernetes-mcp-server K3D_SCENARIOS="default ci/config-values.yaml" TIMEOUT=180`
- `make standards-check CHART=kubernetes-mcp-server`
- `node scripts/charts/template-standards-check.js --chart kubernetes-mcp-server`
- `make md-lint REPO=charts`
- `make preflight`

K3d result: both the default and chart-managed config scenarios became ready in 12–13 seconds with zero restarts, healthy Service endpoints, clean logs/events, and complete cleanup. Static validation covered every `ci/*.yaml` scenario.

Site sync was reviewed. New optional upstream settings use the existing `app.extraEnv` surface, so no site/playground contract change is required.

Resolves #897
