### PR TITLE
chore(medikeep): bump image to 0.69.0

### DIFF
--- a/charts/medikeep/Chart.yaml
+++ b/charts/medikeep/Chart.yaml
@@ -4,7 +4,7 @@ name: medikeep
 description: Self-hosted personal medical records manager with PostgreSQL persistence
 type: application
 version: 1.0.3
-appVersion: "0.68.0"
+appVersion: "0.69.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/medikeep
 sources:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/medikeep.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump medikeep to 0.68.0 (#716)"
+      description: "bump medikeep to 0.69.0 (#898)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/medikeep/DESIGN.md
+++ b/charts/medikeep/DESIGN.md
@@ -14,10 +14,10 @@ Scaling above one pod is blocked because MediKeep writes uploads and generated b
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/afairgiant/medikeep:v0.68.0
+ghcr.io/afairgiant/medikeep:v0.69.0
 ```
 
-The tag maps to the upstream `v0.68.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `v0.69.0` release and publishes Linux `amd64` and `arm64` manifests.
 
 ## Database
 

--- a/charts/medikeep/README.md
+++ b/charts/medikeep/README.md
@@ -2,17 +2,15 @@
 
 Deploy [MediKeep](https://github.com/afairgiant/MediKeep), a self-hosted personal medical records application built with React and FastAPI.
 
-This chart packages the official `ghcr.io/afairgiant/medikeep:v0.68.0` image with PostgreSQL, persistent uploads and backups,
+This chart packages the official `ghcr.io/afairgiant/medikeep:v0.69.0` image with PostgreSQL, persistent uploads and backups,
 Kubernetes Ingress, Gateway API, NetworkPolicy, and External Secrets Operator integration.
 
 ## Upgrade Notes
 
-MediKeep `v0.68.0` adds medication reminder configuration and test reminders,
-new clinical data options such as Chikungunya vaccine support, stacked lab
-result views, and practitioner entry improvements. It also includes fixes for
-reference range validation, immunization history linking, condition lab results,
-and a migration file ID overlap. Back up PostgreSQL and uploaded records before
-upgrading.
+MediKeep `v0.69.0` adds advanced lab-result entry and relationships, vaccine
+library synchronization, and a database migration that merges lab-result text
+values and backfills missing vaccines. Back up PostgreSQL and uploaded records
+before upgrading.
 
 ## Install
 

--- a/charts/medikeep/tests/templates_test.yaml
+++ b/charts/medikeep/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/afairgiant/medikeep:v0.68.0
+          value: ghcr.io/afairgiant/medikeep:v0.69.0
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/medikeep/values.yaml
+++ b/charts/medikeep/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official MediKeep container image repository.
   repository: ghcr.io/afairgiant/medikeep
   # -- Pinned MediKeep image tag. Floating tags such as latest are not used by default.
-  tag: "v0.68.0"
+  tag: "v0.69.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official MediKeep image from `v0.68.0` to `v0.69.0`
- refresh chart metadata, tests, design notes, and upgrade guidance
- document the upstream database migration and vaccine backfill

## Upstream review

The official `v0.69.0` release adds advanced lab-result handling, vaccine-library synchronization, and a database migration that merges lab-result textual values and backfills missing vaccines. No ingress, Gateway API, NetworkPolicy, or secret contract changed.

## Validation

- `make image-verify IMAGE=ghcr.io/afairgiant/medikeep:v0.69.0`
- `make validate-chart CHART=medikeep K3D_SCENARIOS="default" TIMEOUT=600`
- default deployment with PostgreSQL became ready in 67 seconds with no restarts, fatal logs, or warning events
- `make standards-check CHART=medikeep`
- `make md-lint REPO=charts`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

The site-sync detector reports generic defaults/install-path guidance because the pinned image default changed. No user-facing values contract, install path, or site example changed, so a companion site PR is not applicable.

Resolves #898
