### PR TITLE
chore(metabase): bump image to 0.63.2

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.21
-appVersion: "v0.63.1"
+appVersion: "v0.63.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update image to v0.63.1 (#821)"
+      description: "update image to v0.63.2 (#899)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.63.1
+  tag: v0.63.2
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.63.1` | Metabase container image tag |
+| `image.tag` | `v0.63.2` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,7 +184,7 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.63.1` updates the application to the latest upstream release and
+Metabase `v0.63.2` updates the application to the latest upstream release and
 repairs the chart's validation scenarios for single-stack clusters, external
 database fixtures, and External Secrets. Back up the Metabase application
 database before upgrading, keep the encryption key stable, and validate the

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.63.1"
+          value: "docker.io/metabase/metabase:v0.63.2"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.63.1"
+  tag: "v0.63.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Metabase from `v0.63.1` to `v0.63.2`
- update chart metadata, values, tests, and upgrade documentation
- keep the change isolated from the unrelated Metabase customization request

## Upstream review

Metabase 63.2 is a corrective release with administration, querying, and dashboard fixes. Upstream requires backing up the application database before every upgrade; no Helm-facing configuration or network contract changed.

## Validation

- image manifest verified for `linux/amd64` and `linux/arm64`
- `make validate-chart CHART=metabase K3D_SCENARIOS="default" TIMEOUT=600`
- Metabase and PostgreSQL became ready in 177 seconds with no restarts or fatal logs
- targeted standards and Markdown checks passed

The default scenario exercises startup and application-database migrations against PostgreSQL. Other entry-point scenarios were not repeated because the changelog does not affect those contracts. The site-sync detector's generic defaults signal is not applicable because no user-facing values contract or install path changed.

Resolves #899
