### PR TITLE
chore(n8n): bump image to 2.33.3

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.11
-appVersion: "2.32.5"
+appVersion: "2.33.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#889)"
+      description: "bump n8n to 2.33.3 (#901)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.32.5` | n8n container image tag |
+| `image.tag` | `2.33.3` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,10 +186,11 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.32.5` adds public API, workflow export, and editor capabilities, and
-includes fixes across queue-mode MCP executions, S3 path signing, AI Assistant
-runs, credentials, and integrations. Review the
-[upstream 2.32.5 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.32.5)
+n8n `2.33.3` adds instance credentials, workflow review and publishing APIs,
+OpenTelemetry configuration APIs, scheduler controls, and database migrations
+for new execution and review data. It also fixes security-audit imports and MCP
+Server Trigger execution persistence. Review the
+[upstream 2.33.3 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.33.3)
 before upgrading, back up the database, and keep the encryption key stable
 before upgrading live deployments. This chart keeps the hardened non-root
 container defaults with resource requests and limits. Queue mode fails fast
@@ -198,7 +199,7 @@ must share the same PostgreSQL, MySQL, or external database as the main pod.
 Validate database and queue mode in a staging namespace before reusing
 production PVCs.
 
-When upgrading with `--reuse-values`, explicitly set `image.tag=2.32.5`.
+When upgrading with `--reuse-values`, explicitly set `image.tag=2.33.3`.
 Helm preserves the previous image override in that mode; also update
 `taskRunners.image.tag` when it was pinned separately.
 

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.32.5"
+          value: "docker.io/n8nio/n8n:2.33.3"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.32.5"
+          value: "docker.io/n8nio/runners:2.33.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.32.5"
+          value: "docker.io/n8nio/runners:2.33.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.32.5"
+          "default": "2.33.3"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.32.5"
+  tag: "2.33.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump n8n and its task-runner image from `2.32.5` to `2.33.3`
- update schema defaults, tests, metadata, and upgrade guidance
- document the upstream database and scheduler changes

## Upstream review

The 2.33 series adds instance credentials, workflow review/publishing APIs, scheduler controls, OpenTelemetry APIs, and database migrations for new review and execution data. Patch 2.33.3 fixes security-audit imports and MCP Server Trigger persistence.

## Validation

- both image manifests verified for amd64 and arm64
- full static validation across every values fixture
- default k3d runtime passed in 99 seconds
- queue runtime with PostgreSQL, Redis, two workers, and external task runners passed in 77 seconds
- all five queue-mode pods were stable with no fatal logs or crash restarts

Ingress, Gateway API, ESO, and dual-stack runtimes were not repeated because the upstream changes do not alter those contracts. No site contract changed.

Resolves #901
