### PR TITLE
chore(netbird): bump image to 0.76.1

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -4,7 +4,7 @@ name: netbird
 description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
 type: application
 version: 1.0.3
-appVersion: "0.75.0"
+appVersion: "0.76.1"
 home: https://helmforge.dev/docs/charts/netbird
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/netbird
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade to 0.75.0 (#875)"
+      description: "upgrade to 0.76.1 (#902)"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -4,7 +4,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 
 This chart packages the current upstream combined architecture:
 
-- `netbirdio/netbird-server:0.75.0` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/netbird-server:0.76.1` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.3` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
@@ -110,7 +110,7 @@ Use `externalSecrets.items[]` to synchronize sensitive values such as `config.ya
 Local security scan:
 
 ```text
-Image: netbirdio/netbird-server:0.75.0
+Image: netbirdio/netbird-server:0.76.1
 Image: netbirdio/dashboard:v2.90.3
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 86.86869 compliance score
@@ -121,11 +121,11 @@ repository security gate. Remaining findings are tracked as hardening trade-offs
 for optional NetworkPolicy enablement, upstream dashboard startup model, and
 operator-owned resource limit tuning across the database-backed topology.
 
-## Upgrade from 0.74.7
+## Upgrade from 0.75.0
 
-NetBird `0.75.0` improves the combined server's management, relay, and
-self-hosting paths. The redesigned desktop client announced in the upstream
-release is distributed separately and is not part of this server chart.
+NetBird `0.76.1` adds management-owned LLM pricing data and requires management
+and proxy components to move together. The chart's combined server image keeps
+those components on the same version. It also includes client and proxy fixes.
 
 Back up the configured database and `/var/lib/netbird`, then apply the new chart
 defaults while preserving your explicit overrides:
@@ -139,7 +139,7 @@ helm upgrade netbird helmforge/netbird \
 ```
 
 Using `--reuse-values` alone retains the previous default image tag. Remove any
-explicit `server.image.tag` override if you want the chart default `0.75.0`.
+explicit `server.image.tag` override if you want the chart default `0.76.1`.
 
 ## Validation
 

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/netbird-server:0.75.0
+          value: netbirdio/netbird-server:0.76.1
         template: templates/deployment.yaml
         documentIndex: 0
   - it: renders the official pinned dashboard image

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -14,7 +14,7 @@ server:
     # -- Official NetBird server container image repository.
     repository: netbirdio/netbird-server
     # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
-    tag: "0.75.0"
+    tag: "0.76.1"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of NetBird server pods. Keep 1 with the default sqlite store.


### PR DESCRIPTION
## Summary

- bump the combined NetBird server from `0.75.0` to `0.76.1`
- update metadata, tests, and upgrade guidance
- keep management and proxy functionality on one coherent image version

## Upstream review

NetBird 0.76.0 fixes a client-daemon local privilege escalation and includes management/proxy fixes. Version 0.76.1 makes LLM pricing management-owned and warns that management and proxy must be upgraded together. This chart uses the combined server image, so both move atomically.

## Validation

- image verified for amd64, arm64, and arm
- full static validation across every fixture
- default runtime passed in 37 seconds
- combined server, dashboard, and PostgreSQL were ready with zero restarts, fatal logs, or warnings

No separate ingress/network runtime was needed because their Helm contracts are unchanged.

Resolves #902
