### PR TITLE
chore(netbox): bump image to 4.6.7

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -4,7 +4,7 @@ name: netbox
 description: NetBox infrastructure resource modeling with web, worker, and housekeeping workloads
 type: application
 version: 1.0.0
-appVersion: "4.6.5"
+appVersion: "4.6.7"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/netbox.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: add netbox chart (#886)"
+      description: "bump netbox to 4.6.7 (#903)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/netbox/DESIGN.md
+++ b/charts/netbox/DESIGN.md
@@ -13,7 +13,7 @@ pods can never accidentally receive HTTP traffic.
 
 ## Image choice
 
-The default `v4.6.5-5.0.2` tag combines an exact NetBox application release
+The default `v4.6.7-5.0.2` tag combines an exact NetBox application release
 with an exact netbox-docker support release. It is published for amd64 and
 arm64. NetBox 4.6.7 existed when the chart was authored, but no matching exact
 5.0.2 image was published, so the chart does not invent or use a moving tag.

--- a/charts/netbox/tests/deployment_test.yaml
+++ b/charts/netbox/tests/deployment_test.yaml
@@ -16,7 +16,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/netboxcommunity/netbox:v4.6.5-5.0.2
+          value: docker.io/netboxcommunity/netbox:v4.6.7-5.0.2
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official NetBox Docker image repository.
   repository: docker.io/netboxcommunity/netbox
   # -- Immutable NetBox and netbox-docker release combination.
-  tag: "v4.6.5-5.0.2"
+  tag: "v4.6.7-5.0.2"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 # -- Image pull secrets.


### PR DESCRIPTION
## Summary

- bump NetBox from `4.6.5` to `4.6.7`
- use the immutable NetBox Docker tag `v4.6.7-5.0.2`
- update metadata, design documentation, and tests

## Upstream review

NetBox 4.6.6 and 4.6.7 contain security, permission, API, correctness, and performance fixes. The container packaging release remains 5.0.2 and supports NetBox 4.6.x. No Helm-facing configuration changed.

## Validation

- image verified for amd64 and arm64
- full static validation across all fixtures
- default runtime completed fresh migrations and became ready in 217 seconds
- web, worker, PostgreSQL, and Redis were stable with zero restarts or fatal logs

The default topology covers the affected application and persistence paths; external service and secret scenarios are unchanged.

Resolves #903
