### PR TITLE
chore(notediscovery): bump image to 0.30.0

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.1.0
-appVersion: "0.28.4"
+appVersion: "0.30.0"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 0.28.4 (#876)"
+      description: "upgrade to 0.30.0 (#904)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.28.4` image.
+official `ghcr.io/gamosoft/notediscovery:0.30.0` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.28.4` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.30.0` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -151,10 +151,10 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.28.4` adds a configurable default theme and fixes Markdown
-links to sibling notes. Set `notediscovery.defaultTheme` to a built-in or
-operator-mounted theme ID; a theme already stored in the browser continues to
-take precedence, and invalid IDs fall back to `light`.
+NoteDiscovery `0.30.0` serves browser libraries locally, adds cache-safe asset
+versioning, gzip and conditional responses, and fixes first-load Mermaid
+rendering. Releases 0.29.x also correct share-link schemes behind reverse
+proxies and raise normal editing rate limits.
 
 Generated configuration now stores plugin state under the writable data volume
 and bootstraps the official bundled plugins there. Existing Secrets should use

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.28.4
+          value: ghcr.io/gamosoft/notediscovery:0.30.0
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -24,7 +24,7 @@ tests:
           value: plugin-bootstrap
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.28.4
+          value: ghcr.io/gamosoft/notediscovery:0.30.0
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "if \\[ -d /app/plugins \\]"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.28.4", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.30.0", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.28.4"
+  tag: "0.30.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump NoteDiscovery from `0.28.4` to `0.30.0`
- update schema defaults, metadata, tests, and upgrade notes
- cover the reverse-proxy fixes introduced in the intermediate 0.29 releases

## Upstream review

Version 0.30.0 serves browser libraries locally, adds cache-safe asset versions, gzip/304 responses, and fixes Mermaid startup. The 0.29 line fixes share-link schemes behind reverse proxies and normal editing rate limits.

## Validation

- image verified for amd64 and arm64
- full static validation across all fixtures
- default runtime passed in 27 seconds
- Ingress runtime passed in 17 seconds
- both deployments had zero restarts, fatal logs, or warning events

Gateway API, network policy, ESO, and theme/auth variants were statically rendered but not repeated in k3d because the changelog does not affect them.

Resolves #904
