### PR TITLE
chore(openhab): bump image to 5.2.1

### DIFF
--- a/charts/openhab/Chart.yaml
+++ b/charts/openhab/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: openhab
 type: application
 version: 1.1.4
-appVersion: "5.2.0"
+appVersion: "5.2.1"
 kubeVersion: ">=1.26.0-0"
 description: Production-ready openHAB home automation platform for Kubernetes
 icon: https://helmforge.dev/icons/charts/openhab.png
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump openhab to 5.2.0 (#721)"
+      description: "bump openhab to 5.2.1 (#905)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/openhab/README.md
+++ b/charts/openhab/README.md
@@ -102,7 +102,7 @@ Use feature flags instead to enable optional components.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.tag` | openHAB image tag | `5.2.0` |
+| `image.tag` | openHAB image tag | `5.2.1` |
 | `image.repository` | Image repository | `docker.io/openhab/openhab` |
 | `replicaCount` | Must be 1 — no clustering support | `1` |
 | `namespaceOverride` | Namespace for chart-managed resources | `""` |
@@ -237,13 +237,11 @@ See [Prometheus Metrics Guide](docs/metrics.md) for full details.
 
 ## Upgrade Notes
 
-openHAB `5.2.0` is a stable feature release for the 5.x line. The upstream
-release notes list new add-ons, runtime/UI enhancements, and several breaking
-changes that may require manual action after upgrade. Back up the `userdata`,
-`conf`, and `addons` PVCs before upgrading. Review any affected rules, UI
-layouts, persistence queries, voice IDs, and add-ons before rolling production
-deployments. openHAB 5.x still requires Java 21, which is provided by the
-official container image used by this chart.
+openHAB `5.2.1` is a stable patch release for the 5.x line. It fixes runtime,
+UI, connectivity, scripting, voice, and add-on regressions without changing the
+container contract. Back up the `userdata`, `conf`, and `addons` PVCs before
+upgrading. openHAB 5.x still requires Java 21, which is provided by the official
+container image used by this chart.
 
 ### Security Scan: openhab
 

--- a/charts/openhab/examples/production.yaml
+++ b/charts/openhab/examples/production.yaml
@@ -5,7 +5,7 @@
 #           Karaf console for administration, larger storage.
 
 image:
-  tag: "5.2.0"
+  tag: "5.2.1"
 
 service:
   type: ClusterIP

--- a/charts/openhab/examples/simple.yaml
+++ b/charts/openhab/examples/simple.yaml
@@ -3,7 +3,7 @@
 # Use case: Single-node cluster or home server, basic persistence, port-forward access
 
 image:
-  tag: "5.2.0"
+  tag: "5.2.1"
 
 persistence:
   userdata:

--- a/charts/openhab/examples/with-configmaps.yaml
+++ b/charts/openhab/examples/with-configmaps.yaml
@@ -5,7 +5,7 @@
 #           into the writable conf PVC before openHAB starts.
 
 image:
-  tag: "5.2.0"
+  tag: "5.2.1"
 
 env:
   TZ: "America/Sao_Paulo"

--- a/charts/openhab/examples/with-ingress.yaml
+++ b/charts/openhab/examples/with-ingress.yaml
@@ -4,7 +4,7 @@
 # Requirements: nginx-ingress-controller, cert-manager (for TLS)
 
 image:
-  tag: "5.2.0"
+  tag: "5.2.1"
 
 service:
   type: ClusterIP

--- a/charts/openhab/tests/statefulset_test.yaml
+++ b/charts/openhab/tests/statefulset_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/openhab/openhab:5.2.0
+          value: docker.io/openhab/openhab:5.2.1
 
   # The openHAB entrypoint must start as root to create the openhab user/group
   # (groupadd/useradd/chown) before dropping to UID 9001 via gosu.

--- a/charts/openhab/values.schema.json
+++ b/charts/openhab/values.schema.json
@@ -23,7 +23,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag. Never use 'latest'.",
-          "default": "5.2.0"
+          "default": "5.2.1"
         }
       }
     },

--- a/charts/openhab/values.yaml
+++ b/charts/openhab/values.yaml
@@ -6,7 +6,7 @@ image:
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Image tag (defaults to chart appVersion). Never use 'latest'.
-  tag: "5.2.0"
+  tag: "5.2.1"
 
 # -- Image pull secrets
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump openHAB from `5.2.0` to `5.2.1`
- update schema, examples, tests, metadata, and upgrade notes

## Upstream review

OpenHAB 5.2.1 is a patch release with runtime, UI, scripting, voice, connectivity, and add-on fixes. It introduces no container or Helm-facing breaking change and retains Java 21.

## Validation

- image verified for amd64 and arm64
- full static validation across all chart fixtures and examples
- default StatefulSet became ready in 93 seconds
- no restarts, fatal logs, or warning events

Only the default persistent runtime was repeated because the patch does not alter ingress, Gateway API, configuration maps, backup, ESO, or networking contracts.

Resolves #905
