### PR TITLE
chore(poznote): bump image to 6.51.0

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.1.0
-appVersion: "6.45.0"
+appVersion: "6.51.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "update app to 6.45.0 (#880)"
+      description: "update app to 6.51.0 (#906)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.45.0
+ghcr.io/timothepoznanski/poznote:6.51.0
 ```
 
-The tag maps to the upstream `6.45.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.51.0` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.45.0-rootless` variant. It is not the chart
+Upstream also publishes a `6.51.0-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.45.0` |
+| `image.tag` | Image tag | `6.51.0` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -141,11 +141,10 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.45.0` adds the Diary, user quotas, safer concurrent REST writes,
-expanded user administration, per-user display controls, and many editor and
-sharing improvements introduced since `6.35.0`. The chart now exposes
-`poznote.sharing.hideRestrictUsers` for deployments that should hide user
-restriction controls in sharing dialogs.
+Poznote `6.51.0` adds multiple diaries per workspace, checklist conversion for
+HTML notes, per-user Markdown colors, and pinned settings cards. It also removes
+fixed container names from upstream Compose examples, which does not affect the
+Kubernetes workload.
 
 No upstream storage migration is required. Back up the `data` PVC before
 upgrading because it stores the SQLite database, notes, attachments, and

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.45.0"
+          value: "ghcr.io/timothepoznanski/poznote:6.51.0"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.45.0"
+  tag: "6.51.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Poznote from `6.45.0` to `6.51.0`
- update metadata, image documentation, tests, and upgrade notes

## Upstream review

Poznote 6.51.0 adds multiple diaries, HTML checklist conversion, per-user Markdown colors, and pinned settings cards. These changes persist in the existing data volume; the removal of fixed names from Compose examples does not affect Kubernetes.

## Validation

- image verified for amd64 and arm64
- full static validation across all fixtures
- default persistent runtime passed in 50 seconds
- no restarts, fatal logs, or warning events

Ingress, Gateway API, sharing, ESO, and network variants were not repeated because their contracts are unchanged.

Resolves #906
