### PR TITLE
chore(redis): bump image to 8.10.0

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -4,7 +4,7 @@ name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 1.6.20
-appVersion: "8.8.1"
+appVersion: "8.10.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,7 +27,7 @@ icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "upgrade to 8.8.1 security release (#882)"
+      description: "upgrade to redis 8.10.0 (#907)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -221,7 +221,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Redis topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Redis image repository | `docker.io/library/redis` |
-| `image.tag` | Redis image tag | `8.8.1` |
+| `image.tag` | Redis image tag | `8.10.0` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Redis password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Redis password | `""` |
@@ -289,7 +289,7 @@ See `examples/`:
 - Redis Sentinel: <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>
 - Redis Cluster: <https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/>
 - Redis security: <https://redis.io/docs/latest/operate/oss_and_stack/management/security/>
-- Redis 8.8.1 security release: <https://github.com/redis/redis/releases/tag/8.8.1>
+- Redis 8.10.0 release: <https://github.com/redis/redis/releases/tag/8.10.0>
 
 ### 🟢 Security Scan: `redis`
 

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/* Validate values that must fail before rendering workloads. */}}
+{{- define "redis.validate" -}}
+{{- if has .Values.image.tag (list "latest" "stable" "main" "master" "edge") -}}
+{{- fail "image.tag must be an immutable release tag" -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 */}}

--- a/charts/redis/templates/validate.yaml
+++ b/charts/redis/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "redis.validate" . -}}

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/redis:8.8.1"
+          value: "docker.io/library/redis:8.10.0"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -28,7 +28,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/redis
-  tag: "8.8.1"
+  tag: "8.10.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Redis from `8.8.1` to GA `8.10.0`
- update metadata, tests, and release documentation
- add the standard immutable-tag validation helper

## Upstream review

Redis 8.10 adds compact hashes, backup support, TLS peer authentication, new commands, and fixes affecting full synchronization, replica clients, AOF restore, ACLs, and cluster bus parsing. This justified direct runtime coverage of all three supported topologies.

## Validation

- official image verified across seven Linux architectures
- full static validation across all fixtures
- standalone passed in 27 seconds with one stable pod
- six-node cluster passed in 32 seconds with all pods stable
- primary/replica mode passed in 34 seconds with three pods stable
- no restarts, fatal logs, or warning events in any topology

Sentinel, metrics, TLS, ESO, and dual-stack contracts were statically validated but not repeated because the changelog did not require separate runtime evidence.

Resolves #907
