### PR TITLE
chore(strapi): bump image to 5.51.1

### DIFF
--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -4,7 +4,7 @@ name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
 version: 2.3.10
-appVersion: "5.50.2"
+appVersion: "5.51.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update to 5.50.2 (#828)"
+      description: "update to 5.51.1 (#908)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strapi/README.md
+++ b/charts/strapi/README.md
@@ -18,9 +18,9 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 
 ## HelmForge Base Image
 
-This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.50.2`) which provides:
+This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.51.1`) which provides:
 
-- **Strapi 5.50.2** with all official plugins pre-installed
+- **Strapi 5.51.1** with all official plugins pre-installed
 - **Multi-database support** — SQLite, PostgreSQL, MySQL ready to use
 - **Health check endpoint** — HTTP health checks on `/_health` for proper Kubernetes integration
 - **Security hardened** — Non-root user (UID 1000), minimal attack surface
@@ -107,7 +107,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `helmforge/strapi-base` | Container image for the Strapi project |
-| `image.tag` | `5.50.2` | HelmForge Strapi base image version |
+| `image.tag` | `5.51.1` | HelmForge Strapi base image version |
 | `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
 | `strapi.port` | `1337` | Container port |
 | `strapi.telemetryDisabled` | `true` | Disable telemetry |
@@ -141,17 +141,18 @@ database:
 
 ## Notes
 
-- The default image is `helmforge/strapi-base:5.50.2`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
+- The default image is `helmforge/strapi-base:5.51.1`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
 - SQLite is supported for simple deployments, but server-based databases are recommended for production workloads.
 - Horizontal scaling is intentionally out of scope for this v1 chart because default local uploads persistence is single-writer oriented.
 - For ingress, set `ingress.ingressClassName` to the class used in your cluster, such as `traefik`, `nginx`, or another supported controller.
 
 ## Upgrade Notes
 
-Strapi `5.50.2` adds configurable admin auth cookie names and Korean
-translations, fixes admin, content, database, and upload behavior, and updates
-the WebSocket dependency for CVE-2026-48779. Back up the database and uploads PVC before
-upgrading production workloads.
+Strapi `5.51.1` fixes document relation validation, database morph relations,
+admin audit filtering, recent-document serialization, and duplicate public
+assets. It also includes security-oriented dependency updates. The HelmForge
+base image preserves the existing runtime and database contract. Back up the
+database and uploads PVC before upgrading production workloads.
 
 ## More Information
 

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:5.50.2"
+          value: "docker.io/helmforge/strapi-base:5.51.1"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -26,7 +26,7 @@ replicaCount: 1
 # Image
 # =============================================================================
 # HelmForge provides a production-ready Strapi base image (helmforge/strapi-base)
-# that includes Strapi 5.50.2 with all official plugins, multi-database support,
+# that includes Strapi 5.51.1 with all official plugins, multi-database support,
 # security hardening, and health check endpoints. This image is multi-arch
 # (amd64/arm64), regularly updated, and optimized for Kubernetes deployments.
 #
@@ -38,7 +38,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "5.50.2"
+  tag: "5.51.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the HelmForge Strapi base image from `5.50.2` to `5.51.1`
- update chart metadata, tests, values comments, and upgrade notes

## Upstream review

Strapi 5.51.1 fixes document relation validation, database morph relations, audit filtering, recent-document serialization, and duplicate assets, and updates security-sensitive dependencies. The corresponding HelmForge base image is already published for both supported architectures.

## Validation

- `helmforge/strapi-base:5.51.1` verified for amd64 and arm64
- full static validation across all fixtures
- default Strapi plus PostgreSQL runtime passed in 67 seconds
- both pods were stable with zero restarts, fatal logs, or warning events

The default topology exercises startup and database behavior. External DB, ingress, backup, ESO, and dual-stack contracts are unchanged and were covered statically.

Resolves #908


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Strapi deployment to version 5.51.1.
  * Included the latest Strapi fixes and security dependency updates.
  * Confirmed continued runtime and database compatibility.

* **Documentation**
  * Updated version references, image tags, and upgrade guidance to reflect Strapi 5.51.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->