### PR TITLE
chore(uptime-kuma): bump image to 2.5.0

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -4,7 +4,7 @@ name: uptime-kuma
 description: Uptime Kuma self-hosted monitoring with HTTP/TCP/DNS/Ping checks, notifications, status pages, and optional MariaDB
 type: application
 version: 1.5.9
-appVersion: "2.4.0"
+appVersion: "2.5.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/uptime-kuma.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#592)"
+      description: "bump uptime kuma to 2.5.0 (#909)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -126,7 +126,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/louislam/uptime-kuma` | Uptime Kuma container image |
-| `image.tag` | `2.4.0` | Uptime Kuma image tag |
+| `image.tag` | `2.5.0` | Uptime Kuma image tag |
 | `uptimeKuma.port` | `3001` | Application port |
 | `database.type` | `sqlite` | Database type (sqlite, mariadb) |
 | `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.0`) |
@@ -141,11 +141,11 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Uptime Kuma `2.4.0` adds notification providers, incident RSS support, monitor
-improvements, bug fixes, and an authenticated admin security fix. The default
-`database.type=sqlite` path remains aligned with upstream behavior. Keep
-persistence enabled for production SQLite deployments and back up `/app/data`
-before upgrading live instances.
+Uptime Kuma `2.5.0` adds NTP monitoring and notification providers, widens
+daily statistics counters, and includes dependency security updates. The
+default `database.type=sqlite` path remains aligned with upstream behavior.
+Keep persistence enabled and back up `/app/data` before upgrading live
+instances.
 
 ## More Information
 

--- a/charts/uptime-kuma/examples/gateway-api/values.yaml
+++ b/charts/uptime-kuma/examples/gateway-api/values.yaml
@@ -8,9 +8,3 @@ gatewayAPI:
           namespace: gateway-system
       hostnames:
         - status.example.com
-      rules:
-        - matches:
-            - path:
-                type: PathPrefix
-                value: /
-

--- a/charts/uptime-kuma/templates/_helpers.tpl
+++ b/charts/uptime-kuma/templates/_helpers.tpl
@@ -151,3 +151,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "uptime-kuma.backupSecretSecretKeyKey" -}}
 {{- .Values.backup.s3.existingSecretSecretKeyKey | default "secret-key" -}}
 {{- end -}}
+
+{{/* Validate values that must fail before rendering workloads. */}}
+{{- define "uptime-kuma.validate" -}}
+{{- if has .Values.image.tag (list "latest" "stable" "main" "master" "edge") -}}
+{{- fail "image.tag must be an immutable release tag" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/uptime-kuma/templates/validate.yaml
+++ b/charts/uptime-kuma/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "uptime-kuma.validate" . -}}

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/louislam/uptime-kuma:2.4.0"
+          value: "docker.io/louislam/uptime-kuma:2.5.0"
 
   - it: should set custom image tag
     set:

--- a/charts/uptime-kuma/values.schema.json
+++ b/charts/uptime-kuma/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag",
-          "default": "2.4.0"
+          "default": "2.5.0"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Uptime Kuma container image
   repository: docker.io/louislam/uptime-kuma
   # -- Image tag
-  tag: "2.4.0"
+  tag: "2.5.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Uptime Kuma from `2.4.0` to `2.5.0`
- update schema defaults, metadata, tests, and upgrade notes
- add immutable-tag validation and let the chart generate Gateway API backend rules

## Upstream review

Uptime Kuma 2.5.0 adds NTP monitoring and notification providers, widens daily statistics counters, and updates security-sensitive dependencies. The statistics schema change affects both supported database paths.

## Validation

- image verified for amd64, arm64, and arm
- full static validation across all fixtures
- SQLite default runtime passed in 77 seconds
- MariaDB runtime passed in 61 seconds
- all workloads were stable with zero restarts or fatal logs

Ingress, Gateway API, backup, ESO, external DB, and dual-stack contracts were statically validated but did not require duplicate runtime coverage.

Resolves #909
