### PR TITLE
fix(pihole): update hagezi blocklist paths

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -23,8 +23,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/pihole.png
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "bump image to 2026.07.2 (#772)"
+    - kind: fixed
+      description: "use available Pi-hole v6 HaGeZi blocklist formats (#930)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/pihole/ci/balanced-blocklists.yaml
+++ b/charts/pihole/ci/balanced-blocklists.yaml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: Validate that the balanced preset downloads its upstream blocklists.
+
+dns:
+  preset: balanced

--- a/charts/pihole/templates/_helpers.tpl
+++ b/charts/pihole/templates/_helpers.tpl
@@ -185,16 +185,16 @@ Returns list.
 {{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
 {{- else if eq $preset "balanced" }}
 {{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
-{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/multi.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/multi.txt" }}
 {{- $lists = append $lists "https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts.txt" }}
 {{- else if eq $preset "aggressive" }}
 {{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
-{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/pro.txt" }}
-{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/doh-vpn-proxy-bypass.txt" }}
-{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/tif.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/pro.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/doh-vpn-proxy-bypass.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/tif.txt" }}
 {{- else if eq $preset "gaming-friendly" }}
 {{- $lists = append $lists "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts" }}
-{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/domains/multi.txt" }}
+{{- $lists = append $lists "https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/multi.txt" }}
 {{- end }}
 
 {{- range .Values.dns.adlists }}

--- a/charts/pihole/tests/gravity_init_configmap_test.yaml
+++ b/charts/pihole/tests/gravity_init_configmap_test.yaml
@@ -50,6 +50,45 @@ tests:
           path: data["init-gravity.sh"]
           pattern: "INSERT OR IGNORE INTO adlist \\(address, type, enabled, comment\\) VALUES \\('https://example.com/block.txt', 0, 1, 'Added by Helm chart'\\)"
 
+  - it: should use Pi-hole v6 compatible HaGeZi lists for balanced blocking
+    set:
+      dns.preset: balanced
+    asserts:
+      - matchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/adblock/multi.txt"
+      - notMatchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/domains/"
+
+  - it: should use Pi-hole v6 compatible HaGeZi lists for aggressive blocking
+    set:
+      dns.preset: aggressive
+    asserts:
+      - matchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/adblock/pro.txt"
+      - matchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/adblock/doh-vpn-proxy-bypass.txt"
+      - matchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/adblock/tif.txt"
+      - notMatchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/domains/"
+
+  - it: should use Pi-hole v6 compatible HaGeZi lists for gaming-friendly blocking
+    set:
+      dns.preset: gaming-friendly
+    asserts:
+      - matchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/adblock/multi.txt"
+      - notMatchRegex:
+          path: data["init-gravity.sh"]
+          pattern: "hagezi/dns-blocklists@latest/domains/"
+
   - it: should report that gravity update runs in a follow-up init container
     asserts:
       - matchRegex:


### PR DESCRIPTION
## Summary

- migrate the `balanced`, `aggressive`, and `gaming-friendly` presets from removed HaGeZi `domains/` URLs to Pi-hole v6-compatible `adblock/` sources
- add regression coverage for every affected preset and reject stale `domains/` paths
- add a behavioral `balanced` scenario that runs the real gravity update
- update the Artifact Hub change annotation

## Root cause

HaGeZi moved legacy domain-format lists as part of its repository layout transition. The chart still referenced the old jsDelivr `domains/` paths, so Pi-hole could not download one or more default lists.

## Validation

- `make validate-chart CHART=pihole TIMEOUT=300` (21 layers, including all 12 k3d scenarios)
- `make standards-check CHART=pihole`
- `make standards-guard`
- `make deps-check CHART=pihole`
- `make preflight`
- `make site-sync-check CHART=pihole`
- `make org-check`

Companion site PR: https://github.com/helmforgedev/site/pull/487

Closes #930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Pi-hole DNS presets to use the current HaGeZi blocklist format.
  * Fixed balanced, aggressive, and gaming-friendly presets for Pi-hole v6 compatibility.
  * Preserved specialized lists for aggressive mode under the updated format.

* **Tests**
  * Added validation to confirm supported blocklist URLs download correctly and legacy paths are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->