### PR TITLE
fix(ntfy): support PostgreSQL database secrets

### DIFF
--- a/charts/ntfy/DESIGN.md
+++ b/charts/ntfy/DESIGN.md
@@ -20,7 +20,7 @@ flowchart LR
   route --> svc[Service]
   svc --> pod[ntfy pod]
   pod --> cfg[ConfigMap server.yml]
-  pod --> pvc[(PVC /var/cache/ntfy)]
+  pod -. optional persistence .-> pvc[(PVC or emptyDir /var/cache/ntfy)]
   pod -. optional database URL Secret .-> secret[Secret]
   pod -. optional external database .-> postgres[(PostgreSQL)]
   pod -. optional ban feed .-> pvc

--- a/charts/ntfy/DESIGN.md
+++ b/charts/ntfy/DESIGN.md
@@ -8,7 +8,7 @@ Supported use cases:
 
 - personal or team notification endpoints
 - script-driven push notifications
-- single-instance deployments backed by persistent SQLite storage
+- single-instance deployments backed by persistent SQLite or external PostgreSQL
 - ingress or Gateway API exposure for public HTTPS access
 - optional Prometheus scraping through the ntfy metrics endpoint
 
@@ -21,6 +21,8 @@ flowchart LR
   svc --> pod[ntfy pod]
   pod --> cfg[ConfigMap server.yml]
   pod --> pvc[(PVC /var/cache/ntfy)]
+  pod -. optional database URL Secret .-> secret[Secret]
+  pod -. optional external database .-> postgres[(PostgreSQL)]
   pod -. optional ban feed .-> pvc
   pvc -. external consumer .-> ban[fail2ban or equivalent]
   prom[Prometheus] -. optional .-> svc
@@ -30,6 +32,8 @@ flowchart LR
 
 - Use the upstream `binwiederhier/ntfy` image.
 - Keep the workload single-replica because ntfy stores cache and auth data in local SQLite files.
+- Allow PostgreSQL to replace all SQLite stores without placing its connection URL in the ConfigMap.
+- Consume the PostgreSQL URL from a Kubernetes Secret and optionally reconcile it with External Secrets Operator.
 - Keep persistence enabled by default so message cache, attachments, and auth data survive restarts.
 - Render Gateway API HTTPRoutes as an opt-in exposure path alongside Ingress.
 - Keep Service dual-stack fields opt-in so clusters without dual-stack support use their defaults.
@@ -43,6 +47,7 @@ Recommended production controls:
 - set `ntfy.baseUrl` to the public HTTPS URL clients will use
 - enable authentication and set `ntfy.authDefaultAccess: deny-all` for private deployments
 - keep persistence enabled with a durable storage class
+- use a provider-managed Secret for PostgreSQL credentials
 - back up the PVC before upgrades
 - expose the service only through trusted ingress or Gateway policy
 - set explicit resources for shared clusters
@@ -51,6 +56,7 @@ Recommended production controls:
 ## Non-Goals
 
 - multi-replica SQLite coordination
+- automatic multi-replica or shared-attachment configuration for PostgreSQL deployments
 - user account reconciliation
 - installing Gateway API CRDs or controllers
 - installing Prometheus Operator CRDs

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -10,6 +10,8 @@ to phones and desktops via scripts — no signup, no fees.
 - **HTTP pub-sub** — send notifications via simple HTTP PUT/POST requests
 - **Cross-platform** — native Android, iOS apps and web push support
 - **Persistent storage** — SQLite cache and auth databases on PVC
+- **PostgreSQL support** — load the connection URL from a Kubernetes Secret
+- **External Secrets** — materialize database credentials through External Secrets Operator
 - **Prometheus metrics** — opt-in `/metrics` endpoint with ServiceMonitor
 - **Behind proxy** — trusts X-Forwarded-For headers by default
 - **Attachment support** — configurable file size and expiry limits
@@ -65,6 +67,9 @@ curl -s http://localhost:8080/test/json
 | `ntfy.enableMetrics` | `false` | Enable Prometheus `/metrics` endpoint |
 | `ntfy.banFeed.enabled` | `false` | Append confirmed abusive visitors to a ban-feed file |
 | `ntfy.banFeed.file` | `/var/cache/ntfy/ban.log` | Writable ban-feed file on the data volume |
+| `ntfy.database.enabled` | `false` | Use PostgreSQL instead of SQLite stores |
+| `ntfy.database.existingSecret` | `""` | Secret containing the PostgreSQL URL |
+| `ntfy.database.existingSecretKey` | `database-url` | Secret key containing the PostgreSQL URL |
 | `persistence.enabled` | `true` | Enable persistence for cache and auth |
 | `persistence.size` | `2Gi` | PVC size |
 | `service.type` | `ClusterIP` | Service type |
@@ -90,6 +95,68 @@ Then restrict default access:
 ntfy:
   authDefaultAccess: "deny-all"
 ```
+
+## PostgreSQL
+
+Create a Secret containing the complete PostgreSQL connection URL, then enable
+the database integration:
+
+```bash
+kubectl create secret generic ntfy-database \
+  --from-literal=database-url="$NTFY_DATABASE_URL"
+```
+
+```yaml
+ntfy:
+  database:
+    enabled: true
+    existingSecret: ntfy-database
+    existingSecretKey: database-url
+
+persistence:
+  enabled: false
+```
+
+The chart exposes the Secret key as `NTFY_DATABASE_URL` and omits ntfy's
+SQLite-only `cache-file`, `auth-file`, and `web-push-file` options. PostgreSQL
+stores messages, access control, and web push subscriptions. Keep persistence
+enabled if local attachments, the abuse ban-feed, or other file-backed options
+need to survive pod replacement.
+
+PostgreSQL alone does not make this chart highly available. The Deployment
+remains single-replica, and local attachment storage is not shared between
+pods. Configure and validate shared attachment storage before designing an HA
+deployment.
+
+### External Secrets Operator
+
+The same target Secret can be reconciled from a provider:
+
+```yaml
+ntfy:
+  database:
+    enabled: true
+    existingSecret: ntfy-database
+
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: ntfy-database
+      spec:
+        secretStoreRef:
+          name: production-secrets
+          kind: ClusterSecretStore
+        target:
+          name: ntfy-database
+        data:
+          - secretKey: database-url
+            remoteRef:
+              key: ntfy/database
+              property: url
+```
+
+See the [External Secrets Operator documentation](https://external-secrets.io/latest/)
+for provider and SecretStore configuration.
 
 ## Prometheus Metrics
 
@@ -152,8 +219,8 @@ service:
 
 ## Limitations
 
-- **Single instance** — SQLite does not support concurrent writers
-- **No clustering** — designed as a single-node service
+- **Single replica** — the Deployment currently uses one replica regardless of database backend
+- **Local attachments** — filesystem attachment storage is not shared across pods
 
 ## More Information
 

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -233,6 +233,6 @@ service:
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **72.72727%** |
+| MITRE + NSA + SOC2 | **74.242424%** |
 
 > Security posture acceptable.

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -158,6 +158,11 @@ externalSecrets:
 See the [External Secrets Operator documentation](https://external-secrets.io/latest/)
 for provider and SecretStore configuration.
 
+Because Kubernetes does not refresh environment variables in running
+containers, rotating the target Secret does not update `NTFY_DATABASE_URL` in
+an existing ntfy pod. Trigger a Deployment rollout after rotation, or configure
+a compatible restart controller to restart the workload when the Secret changes.
+
 ## Prometheus Metrics
 
 Enable the built-in Prometheus metrics endpoint:

--- a/charts/ntfy/ci/external-secrets-values.yaml
+++ b/charts/ntfy/ci/external-secrets-values.yaml
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+ntfy:
+  extraEnv:
+    - name: HELMFORGE_TEST_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: ntfy-database
+          key: database-url
+
+externalSecrets:
+  enabled: true
+  items:
+    - fullnameOverride: ntfy-database
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        target:
+          name: ntfy-database
+          creationPolicy: Owner
+        data:
+          - secretKey: database-url
+            remoteRef:
+              key: test/password

--- a/charts/ntfy/ci/postgresql-values.yaml
+++ b/charts/ntfy/ci/postgresql-values.yaml
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+ntfy:
+  database:
+    enabled: true
+    existingSecret: ntfy-database
+
+persistence:
+  enabled: false
+
+extraManifests:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ntfy-database
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "-10"
+        helm.sh/hook-delete-policy: before-hook-creation
+    type: Opaque
+    stringData:
+      database-url: postgres://ntfy:ci-password@ntfy-postgresql:5432/ntfy?sslmode=disable
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ntfy-postgresql
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "-10"
+        helm.sh/hook-delete-policy: before-hook-creation
+    spec:
+      selector:
+        app.kubernetes.io/name: ntfy-postgresql
+      ports:
+        - name: postgresql
+          port: 5432
+          targetPort: postgresql
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: ntfy-postgresql
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "-5"
+        helm.sh/hook-delete-policy: before-hook-creation
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: ntfy-postgresql
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: ntfy-postgresql
+        spec:
+          containers:
+            - name: postgresql
+              image: docker.io/library/postgres:18.4-alpine3.24
+              imagePullPolicy: IfNotPresent
+              ports:
+                - name: postgresql
+                  containerPort: 5432
+              env:
+                - name: POSTGRES_DB
+                  value: ntfy
+                - name: POSTGRES_USER
+                  value: ntfy
+                - name: POSTGRES_PASSWORD
+                  value: ci-password
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ntfy-postgresql-ready
+      annotations:
+        helm.sh/hook: pre-install
+        helm.sh/hook-weight: "0"
+        helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: wait
+              image: docker.io/library/postgres:18.4-alpine3.24
+              imagePullPolicy: IfNotPresent
+              command:
+                - sh
+                - -ec
+                - until pg_isready -h ntfy-postgresql -p 5432 -U ntfy -d ntfy; do sleep 1; done

--- a/charts/ntfy/ci/postgresql-values.yaml
+++ b/charts/ntfy/ci/postgresql-values.yaml
@@ -75,6 +75,7 @@ extraManifests:
         helm.sh/hook-weight: "0"
         helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     spec:
+      activeDeadlineSeconds: 120
       backoffLimit: 3
       template:
         spec:

--- a/charts/ntfy/docs/configuration.md
+++ b/charts/ntfy/docs/configuration.md
@@ -39,6 +39,65 @@ metrics:
 
 `ServiceMonitor` requires Prometheus Operator CRDs to exist in the cluster.
 
+## PostgreSQL
+
+ntfy can use PostgreSQL for its message cache, access control, and web push
+subscriptions. The connection URL is read from an existing Kubernetes Secret
+and is never stored in the ConfigMap:
+
+```yaml
+ntfy:
+  database:
+    enabled: true
+    existingSecret: ntfy-database
+    existingSecretKey: database-url
+
+persistence:
+  enabled: false
+```
+
+The Secret must contain a `database-url` key with a PostgreSQL connection URL.
+When PostgreSQL is enabled, the chart omits `cache-file`, `auth-file`, and
+`web-push-file`, as required by ntfy.
+
+Disabling persistence is appropriate only when no local file-backed features
+need durable storage. Keep it enabled for filesystem attachments, the ban-feed,
+or custom configuration that writes beneath `/var/cache/ntfy`.
+
+PostgreSQL does not by itself make the chart highly available. The chart keeps
+one replica, and local filesystem attachments are not shared.
+
+## External Secrets
+
+Use External Secrets Operator to reconcile the database Secret from a provider:
+
+```yaml
+ntfy:
+  database:
+    enabled: true
+    existingSecret: ntfy-database
+
+externalSecrets:
+  enabled: true
+  refreshInterval: 1h
+  items:
+    - fullnameOverride: ntfy-database
+      spec:
+        secretStoreRef:
+          name: production-secrets
+          kind: ClusterSecretStore
+        target:
+          name: ntfy-database
+        data:
+          - secretKey: database-url
+            remoteRef:
+              key: ntfy/database
+              property: url
+```
+
+See the [External Secrets Operator documentation](https://external-secrets.io/latest/)
+for provider setup.
+
 ## Abuse Ban-Feed
 
 ntfy 2.26.3 can emit confirmed abusive visitors to a file consumed by fail2ban

--- a/charts/ntfy/docs/configuration.md
+++ b/charts/ntfy/docs/configuration.md
@@ -98,6 +98,11 @@ externalSecrets:
 See the [External Secrets Operator documentation](https://external-secrets.io/latest/)
 for provider setup.
 
+Secret rotation does not update `NTFY_DATABASE_URL` inside a running pod because
+Kubernetes injects environment variables only when containers start. Trigger a
+Deployment rollout after rotation, or use a compatible restart controller that
+restarts the workload when the target Secret changes.
+
 ## Abuse Ban-Feed
 
 ntfy 2.26.3 can emit confirmed abusive visitors to a file consumed by fail2ban

--- a/charts/ntfy/templates/NOTES.txt
+++ b/charts/ntfy/templates/NOTES.txt
@@ -9,6 +9,9 @@ AppVersion: {{ .Chart.AppVersion }}
 Release:    {{ .Release.Name }}
 Namespace:  {{ .Release.Namespace }}
 
+Database:   {{ if .Values.ntfy.database.enabled }}PostgreSQL (Secret: {{ .Values.ntfy.database.existingSecret }}){{ else }}SQLite{{ end }}
+Persistence: {{ if .Values.persistence.enabled }}enabled{{ else }}disabled{{ end }}
+
 --------------------------------------------------------------------
 ACCESS INFORMATION
 --------------------------------------------------------------------
@@ -53,6 +56,9 @@ TROUBLESHOOTING
   kubectl logs -l app.kubernetes.io/name=ntfy -n {{ .Release.Namespace }} --all-containers --tail=100
   kubectl get all -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
   kubectl get pvc -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+{{- if .Values.ntfy.database.enabled }}
+  kubectl get secret {{ .Values.ntfy.database.existingSecret }} -n {{ .Release.Namespace }}
+{{- end }}
 
 --------------------------------------------------------------------
 WARNINGS
@@ -62,6 +68,11 @@ WARNINGS
 
 NOTE: Ingress is not enabled. Access via port-forward (see above).
 For push notifications to mobile apps, ntfy needs a public HTTPS endpoint.
+{{- end }}
+{{- if and .Values.ntfy.database.enabled (not .Values.persistence.enabled) }}
+
+NOTE: Persistence is disabled. PostgreSQL stores database-backed state, but
+filesystem attachments and other local files will not survive pod replacement.
 {{- end }}
 
 --------------------------------------------------------------------

--- a/charts/ntfy/templates/configmap.yaml
+++ b/charts/ntfy/templates/configmap.yaml
@@ -11,8 +11,10 @@ data:
     base-url: {{ . | quote }}
     {{- end }}
     listen-http: ":80"
+    {{- if not .Values.ntfy.database.enabled }}
     cache-file: /var/cache/ntfy/cache.db
     auth-file: /var/cache/ntfy/auth.db
+    {{- end }}
     auth-default-access: {{ .Values.ntfy.authDefaultAccess | quote }}
     behind-proxy: {{ .Values.ntfy.behindProxy }}
     {{- if .Values.ntfy.enableMetrics }}

--- a/charts/ntfy/templates/deployment.yaml
+++ b/charts/ntfy/templates/deployment.yaml
@@ -51,6 +51,16 @@ spec:
               containerPort: 80
               protocol: TCP
           env:
+            {{- if .Values.ntfy.database.enabled }}
+            {{- if not .Values.ntfy.database.existingSecret }}
+            {{- fail "ntfy.database.enabled requires ntfy.database.existingSecret" }}
+            {{- end }}
+            - name: NTFY_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ntfy.database.existingSecret }}
+                  key: {{ .Values.ntfy.database.existingSecretKey }}
+            {{- end }}
             {{- with .Values.ntfy.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/ntfy/templates/externalsecret.yaml
+++ b/charts/ntfy/templates/externalsecret.yaml
@@ -1,0 +1,45 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- range $index, $item := .Values.externalSecrets.items | default list }}
+{{- $name := $item.fullnameOverride | default (printf "%s-%s" (include "ntfy.fullname" $) ($item.name | default (printf "external-secret-%d" $index))) }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $name }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := ne (dig "secretStoreRef" "name" "" $spec) "" }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail (printf "externalSecrets.items[%d] requires spec.secretStoreRef or a dataFrom sourceRef" $index) }}
+{{- end }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "ntfy.labels" $ | nindent 4 }}
+    {{- with $item.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/ntfy/templates/externalsecret.yaml
+++ b/charts/ntfy/templates/externalsecret.yaml
@@ -1,7 +1,12 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.externalSecrets.enabled }}
+{{- $seenNames := dict }}
 {{- range $index, $item := .Values.externalSecrets.items | default list }}
 {{- $name := $item.fullnameOverride | default (printf "%s-%s" (include "ntfy.fullname" $) ($item.name | default (printf "external-secret-%d" $index))) }}
+{{- if hasKey $seenNames $name }}
+{{- fail (printf "externalSecrets.items resolve to duplicate name %s" $name) }}
+{{- end }}
+{{- $_ := set $seenNames $name true }}
 {{- $spec := deepCopy ($item.spec | default dict) }}
 {{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
 {{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
@@ -23,7 +28,7 @@
 {{- end }}
 {{- end }}
 {{- if not $hasStoreRef }}
-{{- fail (printf "externalSecrets.items[%d] requires spec.secretStoreRef or a dataFrom sourceRef" $index) }}
+{{- fail (printf "externalSecrets.items[%d] requires spec.secretStoreRef or a spec.data[].sourceRef/spec.dataFrom[].sourceRef" $index) }}
 {{- end }}
 ---
 apiVersion: external-secrets.io/v1

--- a/charts/ntfy/tests/configmap_test.yaml
+++ b/charts/ntfy/tests/configmap_test.yaml
@@ -40,6 +40,21 @@ tests:
           path: data["server.yml"]
           pattern: "base-url.*ntfy.example.com"
 
+  - it: should omit SQLite file settings when PostgreSQL is enabled
+    set:
+      ntfy.database.enabled: true
+      ntfy.database.existingSecret: ntfy-database
+    asserts:
+      - notMatchRegex:
+          path: data["server.yml"]
+          pattern: "cache-file"
+      - notMatchRegex:
+          path: data["server.yml"]
+          pattern: "auth-file"
+      - notMatchRegex:
+          path: data["server.yml"]
+          pattern: "web-push-file"
+
   - it: should enable metrics when configured
     set:
       ntfy.enableMetrics: true

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -101,3 +101,28 @@ tests:
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: should load the PostgreSQL URL from an existing Secret
+    template: templates/deployment.yaml
+    set:
+      ntfy.database.enabled: true
+      ntfy.database.existingSecret: ntfy-database
+      ntfy.database.existingSecretKey: database-url
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NTFY_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: ntfy-database
+                key: database-url
+
+  - it: should reject PostgreSQL without an existing Secret
+    template: templates/deployment.yaml
+    set:
+      ntfy.database.enabled: true
+      ntfy.database.existingSecret: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "ntfy.database.enabled requires ntfy.database.existingSecret"

--- a/charts/ntfy/tests/externalsecret_test.yaml
+++ b/charts/ntfy/tests/externalsecret_test.yaml
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: ExternalSecret
+templates:
+  - templates/externalsecret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: should not render ExternalSecrets by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a database ExternalSecret
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: ntfy-database
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+              kind: ClusterSecretStore
+            target:
+              name: ntfy-database
+            data:
+              - secretKey: database-url
+                remoteRef:
+                  key: ntfy/database
+                  property: url
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: ntfy-database
+      - equal:
+          path: spec.target.name
+          value: ntfy-database
+      - equal:
+          path: spec.secretStoreRef.name
+          value: helmforge-fake-store
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+
+  - it: should default the target name from the item name
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: database
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+              kind: ClusterSecretStore
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-ntfy-database
+      - equal:
+          path: spec.target.name
+          value: test-ntfy-database
+
+  - it: should render multiple ExternalSecrets
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: database
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+              kind: ClusterSecretStore
+        - name: integration
+          spec:
+            dataFrom:
+              - sourceRef:
+                  generatorRef:
+                    apiVersion: generators.external-secrets.io/v1alpha1
+                    kind: Password
+                    name: generated-password
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: test-ntfy-integration
+        documentIndex: 1
+
+  - it: should require a store reference
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: ntfy-database
+          spec:
+            target:
+              name: ntfy-database
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items[0] requires spec.secretStoreRef or a dataFrom sourceRef"

--- a/charts/ntfy/tests/externalsecret_test.yaml
+++ b/charts/ntfy/tests/externalsecret_test.yaml
@@ -98,4 +98,36 @@ tests:
               name: ntfy-database
     asserts:
       - failedTemplate:
-          errorMessage: "externalSecrets.items[0] requires spec.secretStoreRef or a dataFrom sourceRef"
+          errorMessage: "externalSecrets.items[0] requires spec.secretStoreRef or a spec.data[].sourceRef/spec.dataFrom[].sourceRef"
+
+  - it: should reject duplicate item names
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: database
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+        - name: database
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items resolve to duplicate name test-ntfy-database"
+
+  - it: should reject duplicate fullname overrides
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: shared-secret
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+        - fullnameOverride: shared-secret
+          spec:
+            secretStoreRef:
+              name: helmforge-fake-store
+    asserts:
+      - failedTemplate:
+          errorMessage: "externalSecrets.items resolve to duplicate name shared-secret"

--- a/charts/ntfy/values.schema.json
+++ b/charts/ntfy/values.schema.json
@@ -57,7 +57,39 @@
           ]
         },
         "extraConfig": { "type": "string", "default": "" },
-        "extraEnv": { "type": "array", "items": { "type": "object" } }
+        "extraEnv": { "type": "array", "items": { "type": "object" } },
+        "database": {
+          "type": "object",
+          "description": "PostgreSQL configuration",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean", "default": false },
+            "existingSecret": { "type": "string", "default": "" },
+            "existingSecretKey": { "type": "string", "minLength": 1, "default": "database-url" }
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "description": "External Secrets Operator resources for database credentials",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "refreshInterval": { "type": "string", "minLength": 1, "default": "1h" },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "fullnameOverride": { "type": "string" },
+              "labels": { "type": "object" },
+              "annotations": { "type": "object" },
+              "spec": { "type": "object" }
+            }
+          }
+        }
       }
     },
     "persistence": {

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -61,6 +61,26 @@ ntfy:
   # -- Extra environment variables for the container
   # -- @default -- `[]`
   extraEnv: []
+  # -- PostgreSQL configuration. When enabled, SQLite file options are omitted.
+  database:
+    # -- Use PostgreSQL for the message cache, access control, and web push stores
+    enabled: false
+    # -- Existing Secret containing the PostgreSQL connection URL
+    existingSecret: ""
+    # -- Key in the existing Secret containing the PostgreSQL connection URL
+    existingSecretKey: database-url
+
+# =============================================================================
+# External Secrets Operator
+# =============================================================================
+
+externalSecrets:
+  # -- Render ExternalSecret resources
+  enabled: false
+  # -- Default refresh interval for ExternalSecret resources
+  refreshInterval: 1h
+  # -- ExternalSecret definitions with complete spec blocks
+  items: []
 
 # =============================================================================
 # Persistence


### PR DESCRIPTION
## Summary

- add first-class ntfy PostgreSQL configuration using an existing Kubernetes Secret
- omit cache-file, auth-file, and web-push-file whenever PostgreSQL is enabled
- add canonical External Secrets Operator resources, schema coverage, tests, CI scenarios, and operational documentation
- clarify that persistence may be disabled only when local file-backed features are not needed and that PostgreSQL alone does not provide HA

Resolves #932

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body
- [x] New-chart labels are not applicable

## Checklist

- [x] Branch created from updated main
- [x] PR targets main
- [x] Commit messages and PR title follow Conventional Commits
- [x] Chart.yaml version was not edited manually
- [x] values.schema.json covers the new values
- [x] Chart documentation was updated

## Upstream Verification

- [x] Confirmed in the official ntfy documentation that database-url replaces all SQLite-backed stores
- [x] Confirmed NTFY_DATABASE_URL is the supported environment variable
- [x] Image and appVersion are unchanged

## Site Sync (GR-007)

- [x] Companion site PR: helmforgedev/site#488

## Local Validation

- [x] kubectl context: k3d-helmforge-tests-wsl
- [x] make validate-chart CHART=ntfy passed all 17 layers
- [x] helm unittest passed 31 tests
- [x] ExternalSecret passed strict kubeconform using the real CRD schema
- [x] ExternalSecret reached Ready=True with reason SecretSynced using helmforge-fake-store
- [x] PostgreSQL scenario deployed both workloads Ready with zero restarts and clean logs
- [x] Kubescape MITRE, NSA, and SOC2 score: 74.242424 percent
- [x] make preflight passed

## Notes

The PostgreSQL CI fixture uses the official pinned postgres:18.4-alpine3.24 image and a pre-install readiness Job to prevent startup races. The chart remains single-replica; shared attachment storage is outside this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional PostgreSQL-backed storage for single-instance deployments.
  * Added support for sourcing database credentials from Kubernetes Secrets.
  * Added External Secrets Operator integration for managing database credentials.
  * Added configuration validation and deployment guidance for database and persistence settings.

* **Documentation**
  * Expanded configuration, architecture, limitations, and troubleshooting documentation.
  * Added guidance for PostgreSQL persistence, availability, and external secret providers.

* **Tests**
  * Added coverage for PostgreSQL, Secret validation, and ExternalSecret rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->