### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -56,6 +56,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -62,6 +62,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: ""
     condition: crds.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     condition: postgresql.enabled
   - name: redis
     alias: valkey
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: valkey.internal.enabled

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/pimcore/Chart.yaml
+++ b/charts/pimcore/Chart.yaml
@@ -56,7 +56,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
   - name: rabbitmq

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -57,6 +57,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -55,6 +55,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.20
+    version: 1.6.21
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled
   - name: memcached


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- appwrite: redis 1.6.20 -> 1.6.21
- authelia: redis 1.6.20 -> 1.6.21
- automatisch: redis 1.6.20 -> 1.6.21
- castopod: redis 1.6.20 -> 1.6.21
- ckan: redis 1.6.20 -> 1.6.21
- docmost: redis 1.6.20 -> 1.6.21
- envoy-gateway: redis 1.6.20 -> 1.6.21
- flowise: redis 1.6.20 -> 1.6.21
- immich: redis 1.6.20 -> 1.6.21
- middleware: redis 1.6.20 -> 1.6.21
- n8n: redis 1.6.20 -> 1.6.21
- netbox: redis 1.6.20 -> 1.6.21
- open-webui: redis 1.6.20 -> 1.6.21
- opencut: redis 1.6.20 -> 1.6.21
- pimcore: redis 1.6.20 -> 1.6.21
- superset: redis 1.6.20 -> 1.6.21
- wallabag: redis 1.6.20 -> 1.6.21
- wordpress: redis 1.6.20 -> 1.6.21

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Redis and Valkey chart dependencies from version 1.6.20 to 1.6.21 across supported application deployments.
  * Brings the latest dependency patch update to improve consistency and maintenance across charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->