### PR TITLE
fix(redis)!: use role-neutral nodes in sentinel mode

### DIFF
--- a/charts/redis/DESIGN.md
+++ b/charts/redis/DESIGN.md
@@ -84,15 +84,14 @@ flowchart LR
   SentinelSvc --> Sentinel0[sentinel-0]
   SentinelSvc --> Sentinel1[sentinel-1]
   SentinelSvc --> Sentinel2[sentinel-2]
-  Sentinel0 --> Primary[redis-primary-0]
-  Sentinel1 --> Primary
-  Sentinel2 --> Primary
-  Replica[redis-replica-0] --> Primary
-  Primary --> PrimaryPVC[(Primary PVC)]
-  Replica --> ReplicaPVC[(Replica PVC)]
+  Sentinel0 --> Nodes[redis-node-0..N]
+  Sentinel1 --> Nodes
+  Sentinel2 --> Nodes
+  Nodes --> Data[(Optional per-node PVCs)]
 ```
 
-Sentinel is a distinct architecture because it changes the client contract. Sentinel pods wait for the primary before startup and use hostname resolution so custom cluster domains work consistently.
+Sentinel is a distinct architecture because it changes the client contract. Data nodes are role-neutral and discover the elected master through Sentinel or peer replication state.
+Stable announced hostnames, graceful failover, and the startup anti-wipe guard keep topology safe across pod IP churn and voluntary disruption.
 
 ### Redis Cluster
 
@@ -141,11 +140,11 @@ It does not try to replace dedicated Redis Cluster operational tooling for resha
 
 ### Sentinel Resources
 
-- primary and replica Redis resources
-- Sentinel StatefulSet
-- Sentinel service
-- Sentinel configuration with hostname resolution
-- startup wait loop for primary reachability
+- role-neutral Redis node StatefulSet, independently sized with `node.replicaCount`
+- Sentinel StatefulSet, independently sized with `sentinel.replicaCount`
+- Sentinel service as the client discovery contract
+- hostname-based Redis and Sentinel announcements
+- peer-aware bootstrap, graceful failover, and startup anti-wipe guard
 
 ### Cluster Resources
 

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -39,7 +39,7 @@ helm install redis oci://ghcr.io/helmforgedev/helm/redis -f values.yaml
 |-------------|----------|-------------------|----------|
 | `standalone` | One Redis pod, lowest operational complexity, no HA contract | headless Service, client Service, StatefulSet | [docs/standalone.md](docs/standalone.md) |
 | `replication` | One fixed primary with read replicas, no automatic promotion | headless Service, primary Service, replica Service, primary and replica StatefulSets | [docs/replication.md](docs/replication.md) |
-| `sentinel` | Redis replication plus Sentinel primary discovery and failover for compatible clients | replication resources, Sentinel Service, Sentinel StatefulSet | [docs/sentinel.md](docs/sentinel.md) |
+| `sentinel` | Role-neutral Redis nodes plus Sentinel discovery and automatic failover | node StatefulSet, Sentinel Service, Sentinel StatefulSet | [docs/sentinel.md](docs/sentinel.md) |
 | `cluster` | Redis Cluster sharding and HA for Redis Cluster-compatible clients | headless Service, client Service, cluster StatefulSet, cluster init Job | [docs/cluster.md](docs/cluster.md) |
 
 ## How to choose the architecture
@@ -121,7 +121,7 @@ The chart creates a headless Service for stable StatefulSet pod DNS and topology
 |------|-----------------------|
 | `standalone` | `<release>-redis-client` |
 | `replication` | `<release>-redis-primary` for writes, `<release>-redis-replicas` for reads |
-| `sentinel` | `<release>-redis-sentinel` for Sentinel, plus replication services |
+| `sentinel` | `<release>-redis-sentinel`; Sentinel-aware clients discover the elected master |
 | `cluster` | `<release>-redis-client` |
 
 ### Cluster domain
@@ -155,6 +155,7 @@ Persistence is configured under each topology:
 - `standalone.persistence`
 - `replication.primary.persistence`
 - `replication.replica.persistence`
+- `node.persistence` for role-neutral Sentinel data nodes
 - `sentinel.persistence`
 - `cluster.persistence`
 
@@ -228,10 +229,14 @@ Use the generic extension values when platform-specific integration is needed:
 | `auth.existingSecretPasswordKey` | Secret key used for the Redis password | `redis-password` |
 | `tls.enabled` | Enable Redis TLS settings. Requires `tls.existingSecret`. | `false` |
 | `standalone.persistence.enabled` | Enable persistence for standalone mode | `true` |
-| `replication.replicaCount` | Number of replica pods in replication and sentinel modes | `2` |
+| `replication.replicaCount` | Number of replica pods in replication mode | `2` |
+| `node.replicaCount` | Number of role-neutral Redis data nodes in Sentinel mode | `3` |
+| `node.persistence.enabled` | Persist Sentinel data-node AOF/RDB data | `false` |
 | `sentinel.replicaCount` | Number of Sentinel pods | `3` |
 | `sentinel.masterSet` | Sentinel master set name used by Sentinel clients | `mymaster` |
 | `sentinel.quorum` | Sentinel quorum | `2` |
+| `sentinel.gracefulFailover.enabled` | Request failover before voluntary master shutdown | `true` |
+| `sentinel.startupFailoverGuard.enabled` | Prevent an empty recreated node from resuming as master | `true` |
 | `cluster.nodes` | Number of Redis Cluster nodes | `6` |
 | `cluster.replicasPerMaster` | Redis Cluster replicas per master | `1` |
 | `service.type` | Client Service type where applicable | `ClusterIP` |
@@ -279,6 +284,7 @@ See `examples/`:
 
 - `replication` and `sentinel` are different operational contracts.
 - `sentinel` requires Sentinel-compatible clients for automatic primary discovery.
+- Upgrading Sentinel deployments from 1.x is breaking; follow [UPGRADING.md](UPGRADING.md).
 - `cluster` requires Redis Cluster-compatible clients.
 - If `auth.password` is not set and `auth.existingSecret` is not used, the chart generates a password automatically.
 - If your cluster domain is not `cluster.local`, set `clusterDomain` before installing stateful topologies.

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -227,11 +227,12 @@ Use the generic extension values when platform-specific integration is needed:
 | `auth.password` | Inline Redis password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Redis password | `""` |
 | `auth.existingSecretPasswordKey` | Secret key used for the Redis password | `redis-password` |
+| `auth.sentinel` | Require password authentication on the Sentinel control plane | `false` |
 | `tls.enabled` | Enable Redis TLS settings. Requires `tls.existingSecret`. | `false` |
 | `standalone.persistence.enabled` | Enable persistence for standalone mode | `true` |
 | `replication.replicaCount` | Number of replica pods in replication mode | `2` |
 | `node.replicaCount` | Number of role-neutral Redis data nodes in Sentinel mode | `3` |
-| `node.persistence.enabled` | Persist Sentinel data-node AOF/RDB data | `false` |
+| `node.persistence.enabled` | Persist Sentinel data-node AOF/RDB data | `true` |
 | `sentinel.replicaCount` | Number of Sentinel pods | `3` |
 | `sentinel.masterSet` | Sentinel master set name used by Sentinel clients | `mymaster` |
 | `sentinel.quorum` | Sentinel quorum | `2` |

--- a/charts/redis/UPGRADING.md
+++ b/charts/redis/UPGRADING.md
@@ -13,13 +13,13 @@ The `-primary` and `-replicas` Services are no longer created in sentinel mode. 
 
 Additionally:
 
-- `node.persistence.enabled` now defaults to `false` for sentinel data nodes.
+- `node.persistence.enabled` defaults to `true` for sentinel data nodes.
 - Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain on pod reschedule without PVCs.
 - Sentinel config includes `announce-hostnames yes` for stable hostname-based master discovery.
 
 ### Operational impact
 
-- Fresh installs no longer create node PVCs unless you set `node.persistence.enabled=true`.
+- Fresh installs create a PVC for every Sentinel data node by default.
 - With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers can confirm the role until quorum or peer discovery recovers.
 - Enable persistence when RDB/AOF must survive pod reschedules; peer discovery covers topology safety.
 
@@ -39,10 +39,16 @@ Kubernetes StatefulSet names and PVC claim names are immutable. An in-place `hel
    architecture: sentinel
    node:
      replicaCount: 3  # was 1 primary + 2 replicas
+     persistence:
+       enabled: true
+       # Map storageClass, size, accessModes, and related settings from 1.x.
    sentinel:
      replicaCount: 3
      quorum: 2
    ```
+
+   Map `storageClass`, `size`, `accessModes`, and any other persistence settings
+   from the former primary and replica values before restoring data.
 
 6. **Restore data** into the new cluster if required, or let replicas resync from the seed master on a fresh install.
 

--- a/charts/redis/UPGRADING.md
+++ b/charts/redis/UPGRADING.md
@@ -1,0 +1,68 @@
+# Upgrading Redis Chart
+
+## 2.0.0 — Sentinel role-neutral data nodes (#953)
+
+### What changed
+
+In `architecture: sentinel`, the chart no longer renders separate `-primary` and `-replica` StatefulSets. It now renders:
+
+- `<release>-redis-node` — role-neutral Redis data nodes (`node.replicaCount`)
+- `<release>-redis-sentinel` — independently scaled Sentinel pods (`sentinel.replicaCount`)
+
+The `-primary` and `-replicas` Services are no longer created in sentinel mode. Clients must discover the current master through the `-sentinel` Service.
+
+Additionally:
+
+- `node.persistence.enabled` now defaults to `false` for sentinel data nodes.
+- Data nodes probe peer `INFO replication` when Sentinel is unreachable, preventing split-brain on pod reschedule without PVCs.
+- Sentinel config includes `announce-hostnames yes` for stable hostname-based master discovery.
+
+### Operational impact
+
+- Fresh installs no longer create node PVCs unless you set `node.persistence.enabled=true`.
+- With persistence enabled, nodes already bootstrapped fail closed when neither Sentinel nor peers can confirm the role until quorum or peer discovery recovers.
+- Enable persistence when RDB/AOF must survive pod reschedules; peer discovery covers topology safety.
+
+### Why this is a breaking change
+
+Kubernetes StatefulSet names and PVC claim names are immutable. An in-place `helm upgrade` from 1.x cannot rename `-primary`/`-replica` workloads to `-node`.
+
+### Migration procedure
+
+1. **Backup data** from all Redis pods (RDB/AOF snapshot or application-level export).
+2. **Scale down** the release or accept a maintenance window.
+3. **Uninstall** the 1.x release. PVCs remain unless you delete them manually.
+4. **Delete** old PVCs if you want a clean topology (`*-primary-*`, `*-replica-*`).
+5. **Install** chart 2.0.0 with equivalent sizing:
+
+   ```yaml
+   architecture: sentinel
+   node:
+     replicaCount: 3  # was 1 primary + 2 replicas
+   sentinel:
+     replicaCount: 3
+     quorum: 2
+   ```
+
+6. **Restore data** into the new cluster if required, or let replicas resync from the seed master on a fresh install.
+
+### Client changes
+
+- Remove dependencies on the `-primary` Service in sentinel mode.
+- Use Sentinel-aware clients pointing at `<release>-redis-sentinel:26379`.
+- Update monitoring and runbooks that referenced `-primary-0` as the stable master hostname.
+
+### Validation after upgrade
+
+```bash
+kubectl get sts
+# <release>-redis-node
+# <release>-redis-sentinel
+
+kubectl exec sts/<release>-redis-sentinel-0 -- \
+  redis-cli -p 26379 sentinel get-master-addr-by-name mymaster
+```
+
+After a forced failover, confirm the elected master pod name is `-node-N`, not `-primary-0`.
+
+See [docs/sentinel.md](docs/sentinel.md) for resilience trade-offs and k3d validation steps.

--- a/charts/redis/ci/sentinel.yaml
+++ b/charts/redis/ci/sentinel.yaml
@@ -5,8 +5,8 @@ auth:
   enabled: true
   password: ci-redis-password
 
-replication:
-  replicaCount: 2
+node:
+  replicaCount: 3
 
 sentinel:
   replicaCount: 3

--- a/charts/redis/docs/sentinel.md
+++ b/charts/redis/docs/sentinel.md
@@ -12,40 +12,43 @@ Common cases:
 
 ## What this architecture delivers
 
-- primary and replica data topology
-- dedicated Sentinel pods
+- role-neutral Redis data nodes (`<release>-redis-node`)
+- dedicated Sentinel pods scaled independently (`<release>-redis-sentinel`)
 - configurable quorum
-- primary discovery through the Sentinel service
+- primary discovery exclusively through the Sentinel service
 
 ## What it requires from the client
 
 - the client must support Redis Sentinel
 - the application must tolerate primary changes discovered through Sentinel
+- do not rely on a fixed `-primary` Service; the elected master can run on any `-node-N` pod after failover
 
 ## Environment requirements
 
 - at least 3 Sentinel instances for consistent quorum
-- enough replicas to fail over without losing service
+- enough data nodes to fail over without losing service
 - distribution across nodes or zones to reduce correlated failure
 - validated client and library behavior before production rollout
 
 ## How to think about this topology
 
-`sentinel` is the right option when you want automatic failover without moving to the Redis Cluster contract. It keeps
-one active primary at a time and uses Sentinels for election, health observation, and replica promotion.
+`sentinel` is the right option when you want automatic failover without moving to the Redis Cluster contract.
+It keeps one active primary at a time and uses Sentinels for election, health observation, and replica promotion.
+Data node pod names are role-neutral: `-node-0` is only the seed master at cold start, not a permanent primary identity.
 
 ## Common risks
 
 - choosing a quorum incompatible with the number of Sentinels
-- concentrating Sentinels and replicas on the same node
-- using clients that do not rediscover the primary correctly
+- concentrating Sentinels and data nodes on the same node
+- using clients that do not discover the primary correctly
 - treating Sentinel as a substitute for sharding
+- coupling Sentinel count to data node count (not required in this chart)
 
 ## Production best practices
 
 - keep 3 Sentinels as the minimum baseline
 - use majority quorum
-- distribute Sentinels, primary, and replicas across failure domains
+- distribute Sentinels and data nodes across failure domains
 - enable `pdb.enabled=true`
 - validate real failover and application reconnect timing
 - monitor primary changes, replication lag, and Sentinel health
@@ -54,7 +57,7 @@ one active primary at a time and uses Sentinels for election, health observation
 
 - use at least 3 Sentinels
 - keep `quorum` aligned with the number of Sentinels
-- distribute Sentinels and replicas across distinct nodes
+- distribute Sentinels and data nodes across distinct nodes
 - enable `pdb.enabled=true`
 - validate failover behavior in the real environment
 
@@ -63,8 +66,9 @@ one active primary at a time and uses Sentinels for election, health observation
 | Parameter | Description |
 |-----------|-------------|
 | `architecture` | Must be `sentinel` |
-| `replication.replicaCount` | Number of Redis replicas |
-| `sentinel.replicaCount` | Number of Sentinel pods |
+| `node.replicaCount` | Number of Redis data nodes (use >= 2 for data HA) |
+| `node.persistence.enabled` | Data node PVCs (default `false`; peer discovery keeps topology safe without PVCs) |
+| `sentinel.replicaCount` | Number of Sentinel pods (independent of data nodes) |
 | `sentinel.masterSet` | Master set name that Sentinel clients use for primary discovery |
 | `sentinel.quorum` | Quorum for failover decisions |
 | `pdb.enabled` | Protection against planned disruption |
@@ -80,8 +84,8 @@ auth:
   existingSecret: redis-auth
   existingSecretPasswordKey: redis-password
 
-replication:
-  replicaCount: 2
+node:
+  replicaCount: 3
 
 sentinel:
   replicaCount: 3
@@ -89,24 +93,74 @@ sentinel:
   quorum: 2
 ```
 
+Decoupled sizing (2 data nodes + 3 Sentinels):
+
+```yaml
+architecture: sentinel
+
+node:
+  replicaCount: 2
+
+sentinel:
+  replicaCount: 3
+  quorum: 2
+```
+
+## Resilience and trade-offs
+
+### Default: persistence disabled
+
+`node.persistence.enabled` defaults to `false`. Data nodes use `emptyDir` for `/data`.
+Anti-split-brain safety does not depend on the bootstrap marker surviving reschedules.
+When Sentinel is unreachable, each node probes peer `INFO replication` before choosing a role.
+
+Without additional safeguards, a single restart of the active master pod inside the
+`down-after-milliseconds` window would resume it as an empty master and make every
+replica full-resync from an empty dataset. The chart mitigates this with
+`sentinel.gracefulFailover` (preStop-triggered failover on voluntary disruptions) and
+`sentinel.startupFailoverGuard` (a fresh master refuses to resume while peers still
+hold data and forces a failover first). Residual data loss remains possible if these
+guards are disabled, if no replica is promotable, or if every data node restarts at
+the same time. Enable `node.persistence.enabled=true` when you need RDB/AOF to
+survive pod reschedules.
+
+### Fail-closed with persistence enabled
+
+When persistence is enabled and a node was already bootstrapped, it refuses to start as an
+unconfirmed master if neither Sentinel nor any peer can confirm the current topology.
+The pod exits with code 1 (CrashLoopBackOff) until Sentinel quorum or peer discovery succeeds.
+This is a safety-over-availability trade-off.
+
+A prolonged Sentinel quorum outage can block restarts of persisted nodes until Sentinels recover.
+
+### Hostname discovery
+
+Sentinel is configured with `resolve-hostnames yes` and `announce-hostnames yes`.
+`sentinel get-master-addr-by-name mymaster` returns stable pod hostnames instead of ephemeral IPs.
+
+### HA prerequisites
+
+- `node.replicaCount >= 2` for data-plane HA (at least one replica to promote)
+- `sentinel.replicaCount >= 3` with `sentinel.quorum` aligned to the Sentinel count
+- `pdb.enabled=true` for planned disruption protection
+- spread Sentinels and data nodes across failure domains
+
+## End-to-end validation (k3d)
+
+Run on a lab cluster before production rollout. Shell bootstrap logic is not covered by helm unittest.
+
+1. Install with default values (`node.persistence.enabled=false`) and wait for Ready pods.
+2. Resolve the master via Sentinel and write a test key.
+3. Delete the current master pod; confirm another `-node-N` is promoted and the key survives.
+4. Scale Sentinel to 0 or block Sentinel traffic; delete and recreate `-node-0`.
+   Confirm it joins as replica (no double master) via peer discovery.
+5. After Sentinels recover, confirm `get-master-addr-by-name` returns a hostname, not a pod IP.
+
 ## When to move to another mode
 
 - move back to `replication` if the application cannot operate with Sentinel
 - move to `cluster` when the primary need becomes shard-based scale rather than failover
 
-<!-- @AI-METADATA
-type: chart-docs
-title: Redis - Sentinel
-description: Sentinel HA with failover
+## Upgrading from 1.x
 
-keywords: redis, sentinel, ha, failover
-
-purpose: Redis Sentinel HA with automated failover guide
-scope: Chart Architecture
-
-relations:
-  - charts/redis/README.md
-path: charts/redis/docs/sentinel.md
-version: 1.0
-date: 2026-03-20
--->
+See [UPGRADING.md](../UPGRADING.md) for the 2.0.0 breaking change and migration path.

--- a/charts/redis/docs/sentinel.md
+++ b/charts/redis/docs/sentinel.md
@@ -67,12 +67,18 @@ Data node pod names are role-neutral: `-node-0` is only the seed master at cold 
 |-----------|-------------|
 | `architecture` | Must be `sentinel` |
 | `node.replicaCount` | Number of Redis data nodes (use >= 2 for data HA) |
-| `node.persistence.enabled` | Data node PVCs (default `false`; peer discovery keeps topology safe without PVCs) |
+| `node.persistence.enabled` | Data node PVCs (default `true`; peer discovery still protects topology during discovery failures) |
+| `auth.sentinel` | Require password authentication on the Sentinel control plane |
 | `sentinel.replicaCount` | Number of Sentinel pods (independent of data nodes) |
 | `sentinel.masterSet` | Master set name that Sentinel clients use for primary discovery |
 | `sentinel.quorum` | Quorum for failover decisions |
 | `pdb.enabled` | Protection against planned disruption |
 | `metrics.enabled` | Exporter for monitoring |
+
+`auth.sentinel=false` keeps the Sentinel control plane unauthenticated while
+Redis data nodes remain protected by `auth.enabled`. Set it to `true` when
+Sentinel clients also need password authentication. When TLS is enabled,
+Sentinel requires a client certificate signed by the configured CA.
 
 ## Example
 
@@ -108,9 +114,9 @@ sentinel:
 
 ## Resilience and trade-offs
 
-### Default: persistence disabled
+### Default: persistence enabled
 
-`node.persistence.enabled` defaults to `false`. Data nodes use `emptyDir` for `/data`.
+`node.persistence.enabled` defaults to `true`. Each data node receives a PVC for `/data`.
 Anti-split-brain safety does not depend on the bootstrap marker surviving reschedules.
 When Sentinel is unreachable, each node probes peer `INFO replication` before choosing a role.
 
@@ -121,10 +127,10 @@ replica full-resync from an empty dataset. The chart mitigates this with
 `sentinel.startupFailoverGuard` (a fresh master refuses to resume while peers still
 hold data and forces a failover first). Residual data loss remains possible if these
 guards are disabled, if no replica is promotable, or if every data node restarts at
-the same time. Enable `node.persistence.enabled=true` when you need RDB/AOF to
-survive pod reschedules.
+the same time. Keep `node.persistence.enabled=true` when RDB/AOF and the
+bootstrap marker must survive pod reschedules.
 
-### Fail-closed with persistence enabled
+### Fail-closed behavior
 
 When persistence is enabled and a node was already bootstrapped, it refuses to start as an
 unconfirmed master if neither Sentinel nor any peer can confirm the current topology.
@@ -149,7 +155,7 @@ Sentinel is configured with `resolve-hostnames yes` and `announce-hostnames yes`
 
 Run on a lab cluster before production rollout. Shell bootstrap logic is not covered by helm unittest.
 
-1. Install with default values (`node.persistence.enabled=false`) and wait for Ready pods.
+1. Install with default values (`node.persistence.enabled=true`) and wait for Ready pods.
 2. Resolve the master via Sentinel and write a test key.
 3. Delete the current master pod; confirm another `-node-N` is promoted and the key survives.
 4. Scale Sentinel to 0 or block Sentinel traffic; delete and recreate `-node-0`.

--- a/charts/redis/examples/sentinel-production.yaml
+++ b/charts/redis/examples/sentinel-production.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+architecture: sentinel
+
+auth:
+  enabled: true
+  existingSecret: redis-auth
+  existingSecretPasswordKey: redis-password
+
+node:
+  replicaCount: 3
+  persistence:
+    enabled: true
+    size: 20Gi
+
+sentinel:
+  replicaCount: 3
+  masterSet: mymaster
+  quorum: 2
+  gracefulFailover:
+    enabled: true
+  startupFailoverGuard:
+    enabled: true
+
+pdb:
+  enabled: true
+
+metrics:
+  enabled: true

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -35,7 +35,7 @@ Standalone client service:
 - Port: {{ .Values.service.ports.redis }}
 {{- end }}
 
-{{- if or (include "redis.isReplication" .) (include "redis.isSentinel" .) }}
+{{- if include "redis.isReplication" . }}
 Primary service:
 - Name: {{ include "redis.primaryServiceName" . }}
 - DNS: {{ include "redis.primaryServiceFqdn" . }}
@@ -53,7 +53,8 @@ Sentinel service:
 - DNS: {{ include "redis.sentinelServiceFqdn" . }}
 - Port: {{ .Values.service.ports.sentinel }}
 - Master set: {{ .Values.sentinel.masterSet }}
-- Monitored primary: {{ include "redis.primaryPodFqdn" . }}:{{ .Values.service.ports.redis }}
+- Seed node: {{ include "redis.nodePodFqdn" . }}:{{ .Values.service.ports.redis }}
+- Data nodes: {{ .Values.node.replicaCount }} role-neutral peers
 {{- end }}
 
 {{- if include "redis.isCluster" . }}
@@ -155,6 +156,7 @@ Persistence:
 - Standalone persistence: {{ .Values.standalone.persistence.enabled }}
 - Primary persistence: {{ .Values.replication.primary.persistence.enabled }}
 - Replica persistence: {{ .Values.replication.replica.persistence.enabled }}
+- Sentinel data-node persistence: {{ .Values.node.persistence.enabled }}
 - Sentinel persistence: {{ .Values.sentinel.persistence.enabled }}
 - Cluster persistence: {{ .Values.cluster.persistence.enabled }}
 
@@ -184,7 +186,7 @@ Inspect logs:
 Common checks:
 
 - If replicas cannot connect, verify headless Service DNS and `clusterDomain`.
-- If Sentinel does not start, verify the primary pod FQDN and auth Secret.
+- If Sentinel does not start, verify node peer DNS, quorum, and the auth Secret.
 - If Redis Cluster bootstrap is stuck, inspect the cluster init Job logs.
 - If clients cannot authenticate, verify Secret name, key, and password content.
 - If dual-stack fields are rejected, verify the Kubernetes version and cluster network configuration.

--- a/charts/redis/templates/NOTES.txt
+++ b/charts/redis/templates/NOTES.txt
@@ -136,7 +136,7 @@ Sentinel master set name:
 
 Verify Sentinel can see the primary:
 
-  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "redis.sentinelStatefulSetName" . }} -- redis-cli -p {{ .Values.service.ports.sentinel }} SENTINEL masters
+  kubectl exec -n {{ .Release.Namespace }} sts/{{ include "redis.sentinelStatefulSetName" . }} -- redis-cli {{ include "redis.cliTlsArgs" . }} -p {{ .Values.service.ports.sentinel }} SENTINEL masters
 {{- end }}
 
 {{- if include "redis.isCluster" . }}

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -259,14 +259,14 @@ tls-port {{ .Values.service.ports.sentinel }}
 tls-cert-file /tls/{{ .Values.tls.certFilename }}
 tls-key-file /tls/{{ .Values.tls.keyFilename }}
 tls-ca-cert-file /tls/{{ .Values.tls.caFilename }}
-tls-auth-clients no
+tls-auth-clients yes
 tls-replication yes
 {{- end }}
 {{- end -}}
 
 {{- define "redis.cliTlsArgs" -}}
 {{- if .Values.tls.enabled -}}
---tls --cacert /tls/{{ .Values.tls.caFilename }}
+--tls --cacert /tls/{{ .Values.tls.caFilename }} --cert /tls/{{ .Values.tls.certFilename }} --key /tls/{{ .Values.tls.keyFilename }}
 {{- end -}}
 {{- end -}}
 
@@ -349,11 +349,11 @@ annotations:
 {{- end -}}
 
 {{- define "redis.sentinelProbeCommand" -}}
-redis-cli -p {{ .Values.service.ports.sentinel }} ping
+redis-cli {{ include "redis.cliTlsArgs" . }} -p {{ .Values.service.ports.sentinel }} ping
 {{- end -}}
 
 {{- define "redis.sentinelReadyCommand" -}}
-redis-cli -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} | grep -q .
+redis-cli {{ include "redis.cliTlsArgs" . }} -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} | grep -q .
 {{- end -}}
 
 {{- define "redis.metricsVolumeMounts" -}}

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -119,6 +119,10 @@ Common names.
 {{- printf "%s-sentinel" (include "redis.fullname" .) -}}
 {{- end -}}
 
+{{- define "redis.sentinelHeadlessServiceName" -}}
+{{- printf "%s-sentinel-headless" (include "redis.fullname" .) -}}
+{{- end -}}
+
 {{- define "redis.metricsServiceName" -}}
 {{- printf "%s-metrics" (include "redis.fullname" .) -}}
 {{- end -}}
@@ -137,6 +141,10 @@ Common names.
 
 {{- define "redis.clusterStatefulSetName" -}}
 {{- printf "%s-cluster" (include "redis.fullname" .) -}}
+{{- end -}}
+
+{{- define "redis.nodeStatefulSetName" -}}
+{{- printf "%s-node" (include "redis.fullname" .) -}}
 {{- end -}}
 
 {{- define "redis.configMapName" -}}
@@ -179,6 +187,19 @@ Common names.
 {{- printf "%s-0.%s" (include "redis.primaryStatefulSetName" .) (include "redis.headlessServiceFqdn" .) -}}
 {{- end -}}
 
+{{- define "redis.nodePodFqdn" -}}
+{{- printf "%s-0.%s" (include "redis.nodeStatefulSetName" .) (include "redis.headlessServiceFqdn" .) -}}
+{{- end -}}
+
+{{- define "redis.nodePeerFqdns" -}}
+{{- $root := . -}}
+{{- $fqdns := list -}}
+{{- range $i := until (int .Values.node.replicaCount) -}}
+{{- $fqdns = append $fqdns (printf "%s-%d.%s" (include "redis.nodeStatefulSetName" $root) $i (include "redis.headlessServiceFqdn" $root)) -}}
+{{- end -}}
+{{- join " " $fqdns -}}
+{{- end -}}
+
 {{- define "redis.clusterPodFqdn" -}}
 {{- printf "%s.%s" .podName (include "redis.headlessServiceFqdn" .root) -}}
 {{- end -}}
@@ -198,7 +219,12 @@ Secret value helpers.
 {{- else -}}
 {{- randAlphaNum 32 -}}
 {{- end -}}
+
 {{- end -}}
+{{- end -}}
+
+{{- define "redis.authChecksum" -}}
+{{- dict "password" .Values.auth.password "existingSecret" .Values.auth.existingSecret "key" .Values.auth.existingSecretPasswordKey "externalSecrets" .Values.externalSecrets | toJson | sha256sum -}}
 {{- end -}}
 
 {{/*
@@ -224,6 +250,24 @@ tls-key-file /tls/{{ .Values.tls.keyFilename }}
 tls-ca-cert-file /tls/{{ .Values.tls.caFilename }}
 tls-auth-clients no
 {{- end }}
+{{- end -}}
+
+{{- define "redis.sentinelTlsConfig" -}}
+{{- if .Values.tls.enabled }}
+port 0
+tls-port {{ .Values.service.ports.sentinel }}
+tls-cert-file /tls/{{ .Values.tls.certFilename }}
+tls-key-file /tls/{{ .Values.tls.keyFilename }}
+tls-ca-cert-file /tls/{{ .Values.tls.caFilename }}
+tls-auth-clients no
+tls-replication yes
+{{- end }}
+{{- end -}}
+
+{{- define "redis.cliTlsArgs" -}}
+{{- if .Values.tls.enabled -}}
+--tls --cacert /tls/{{ .Values.tls.caFilename }}
+{{- end -}}
 {{- end -}}
 
 {{/*
@@ -277,6 +321,47 @@ app.kubernetes.io/component: redis
 app.kubernetes.io/part-of: redis
 {{- if .role }}
 app.kubernetes.io/role: {{ .role }}
+{{- end }}
+{{- end -}}
+
+{{- define "redis.redisLabels" -}}
+{{- include "redis.componentLabels" . -}}
+{{- end -}}
+
+{{- define "redis.sentinelLabels" -}}
+{{ include "redis.selectorLabels" . }}
+app.kubernetes.io/component: sentinel
+{{- end -}}
+
+{{- define "redis.renderAnnotations" -}}
+{{- with .root.Values.annotations }}
+annotations:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{- define "redis.podSpec" -}}
+{{- include "redis.podSpecCommon" .root -}}
+{{- end -}}
+
+{{- define "redis.nodeProbeCommand" -}}
+{{- include "redis.probeCommand" . -}}
+{{- end -}}
+
+{{- define "redis.sentinelProbeCommand" -}}
+redis-cli -p {{ .Values.service.ports.sentinel }} ping
+{{- end -}}
+
+{{- define "redis.sentinelReadyCommand" -}}
+redis-cli -p {{ .Values.service.ports.sentinel }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }} | grep -q .
+{{- end -}}
+
+{{- define "redis.metricsVolumeMounts" -}}
+{{- if .Values.tls.enabled }}
+volumeMounts:
+  - name: tls
+    mountPath: /tls
+    readOnly: true
 {{- end }}
 {{- end -}}
 

--- a/charts/redis/templates/configmap.yaml
+++ b/charts/redis/templates/configmap.yaml
@@ -80,8 +80,10 @@ data:
     PEERS="{{ include "redis.nodePeerFqdns" . }}"
     TLS_ARGS="{{ include "redis.cliTlsArgs" . }}"
     MARKER=/data/.helmforge-sentinel-node-bootstrapped
-    SELF_FQDN="$(hostname -f)"
+    SELF_FQDN="$(hostname -f 2>/dev/null || true)"
+    [ -n "$SELF_FQDN" ] || SELF_FQDN="$(hostname)"
     SELF_IP="$(hostname -i 2>/dev/null | awk '{ print $1 }')"
+    [ -n "$SELF_IP" ] || SELF_IP="$SELF_FQDN"
 
     # Data-plane auth flows through REDISCLI_AUTH set on the container (never on argv).
     # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
@@ -240,7 +242,9 @@ data:
     {
       echo "replica-announce-ip $SELF_FQDN"
       echo "replica-announce-port $REDIS_PORT"
-      [ -n "$master" ] && echo "replicaof $master $REDIS_PORT"
+      if [ -n "$master" ]; then
+        echo "replicaof $master $REDIS_PORT"
+      fi
     {{- if .Values.auth.enabled }}
       esc="$(printf '%s' "$REDIS_PASSWORD" | sed 's/[\\"]/\\&/g')"
       printf 'masterauth "%s"\n' "$esc"
@@ -262,8 +266,10 @@ data:
     SENTINEL_PORT={{ .Values.service.ports.sentinel }}
     MASTER_SET="{{ .Values.sentinel.masterSet }}"
     TLS_ARGS="{{ include "redis.cliTlsArgs" . }}"
-    SELF_FQDN="$(hostname -f)"
+    SELF_FQDN="$(hostname -f 2>/dev/null || true)"
+    [ -n "$SELF_FQDN" ] || SELF_FQDN="$(hostname)"
     SELF_IP="$(hostname -i 2>/dev/null | awk '{ print $1 }')"
+    [ -n "$SELF_IP" ] || SELF_IP="$SELF_FQDN"
 
     # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
     vcli() { redis-cli $TLS_ARGS "$@"; }

--- a/charts/redis/templates/configmap.yaml
+++ b/charts/redis/templates/configmap.yaml
@@ -1,44 +1,449 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
+{{- fail "tls.enabled requires tls.existingSecret" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "redis.configMapName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+  {{- include "redis.renderAnnotations" (dict "root" .) | nindent 2 }}
 data:
+  {{- if eq .Values.architecture "standalone" }}
   redis-standalone.conf: |
     {{- include "redis.commonConfig" . | nindent 4 }}
     {{- with .Values.config.redis }}
     {{ . | nindent 4 }}
     {{- end }}
+  {{- end }}
+  {{- if eq .Values.architecture "replication" }}
   redis-primary.conf: |
     {{- include "redis.commonConfig" . | nindent 4 }}
+    {{- if .Values.tls.enabled }}
+    tls-replication yes
+    {{- end }}
     {{- with .Values.config.redis }}
     {{ . | nindent 4 }}
     {{- end }}
   redis-replica.conf: |
     {{- include "redis.commonConfig" . | nindent 4 }}
+    {{- if .Values.tls.enabled }}
+    tls-replication yes
+    {{- end }}
     replica-read-only yes
     {{- with .Values.config.redis }}
     {{ . | nindent 4 }}
     {{- end }}
-  redis-cluster.conf: |
+  {{- end }}
+  {{- if eq .Values.architecture "sentinel" }}
+  redis-node.conf: |
     {{- include "redis.commonConfig" . | nindent 4 }}
-    cluster-enabled yes
-    cluster-config-file nodes.conf
-    cluster-node-timeout 5000
-    appendonly yes
+    {{- if .Values.tls.enabled }}
+    tls-replication yes
+    {{- end }}
+    replica-read-only yes
     {{- with .Values.config.redis }}
     {{ . | nindent 4 }}
     {{- end }}
   sentinel.conf: |
+    # HelmForge managed sentinel config begin
+    {{- if .Values.tls.enabled }}
+    {{- include "redis.sentinelTlsConfig" . | nindent 4 }}
+    {{- else }}
     port {{ .Values.service.ports.sentinel }}
+    {{- end }}
     dir /tmp
     sentinel resolve-hostnames yes
-    sentinel monitor {{ .Values.sentinel.masterSet }} {{ include "redis.primaryPodFqdn" . }} {{ .Values.service.ports.redis }} {{ .Values.sentinel.quorum }}
+    sentinel announce-hostnames yes
+    sentinel monitor {{ .Values.sentinel.masterSet }} {{ include "redis.nodePodFqdn" . }} {{ .Values.service.ports.redis }} {{ .Values.sentinel.quorum }}
     sentinel down-after-milliseconds {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.downAfterMilliseconds }}
     sentinel failover-timeout {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.failoverTimeout }}
     sentinel parallel-syncs {{ .Values.sentinel.masterSet }} {{ .Values.sentinel.parallelSyncs }}
     {{- with .Values.config.sentinel }}
     {{ . | nindent 4 }}
     {{- end }}
+    # HelmForge managed sentinel config end
+  node-entrypoint.sh: |
+    #!/bin/sh
+    # Shared bootstrap for sentinel-mode data nodes.
+    # Usage: node-entrypoint.sh            -> discover role, write runtime config, exec redis-server
+    #        node-entrypoint.sh --wait-only -> bounded init-container wait (never blocks recovery)
+    set -eu
+
+    MODE="${1:-run}"
+    REDIS_PORT={{ .Values.service.ports.redis }}
+    SENTINEL_HOST="{{ include "redis.sentinelServiceFqdn" . }}"
+    SENTINEL_PORT={{ .Values.service.ports.sentinel }}
+    MASTER_SET="{{ .Values.sentinel.masterSet }}"
+    SEED_MASTER="{{ include "redis.nodePodFqdn" . }}"
+    PEERS="{{ include "redis.nodePeerFqdns" . }}"
+    TLS_ARGS="{{ include "redis.cliTlsArgs" . }}"
+    MARKER=/data/.helmforge-sentinel-node-bootstrapped
+    SELF_FQDN="$(hostname -f)"
+    SELF_IP="$(hostname -i 2>/dev/null | awk '{ print $1 }')"
+
+    # Data-plane auth flows through REDISCLI_AUTH set on the container (never on argv).
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    vcli() { redis-cli $TLS_ARGS "$@"; }
+    {{- if and .Values.auth.enabled (not .Values.auth.sentinel) }}
+    # Sentinel control plane is unauthenticated: strip inherited credentials.
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    scli() { env -u REDISCLI_AUTH redis-cli $TLS_ARGS -h "$SENTINEL_HOST" -p "$SENTINEL_PORT" "$@"; }
+    {{- else }}
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    scli() { redis-cli $TLS_ARGS -h "$SENTINEL_HOST" -p "$SENTINEL_PORT" "$@"; }
+    {{- end }}
+
+    is_self() { [ "$1" = "$SELF_FQDN" ] || [ "$1" = "$SELF_IP" ]; }
+
+    sentinel_master() {
+      scli sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null | awk 'NR == 1 { print $1 }'
+    }
+
+    peer_info() { vcli -h "$1" -p "$REDIS_PORT" info replication 2>/dev/null || true; }
+
+    peer_master() {
+      for peer in $PEERS; do
+        [ "$peer" = "$SELF_FQDN" ] && continue
+        info="$(peer_info "$peer")"
+        [ -z "$info" ] && continue
+        role="$(printf '%s\n' "$info" | sed -n 's/^role://p' | tr -d '\r')"
+        case "$role" in
+          master)
+            echo "$peer"
+            return 0
+            ;;
+          slave|replica)
+            mh="$(printf '%s\n' "$info" | sed -n 's/^master_host://p' | tr -d '\r')"
+            if [ -n "$mh" ]; then
+              echo "$mh"
+              return 0
+            fi
+            ;;
+        esac
+      done
+      return 1
+    }
+
+    peer_replicates_self() {
+      for peer in $PEERS; do
+        [ "$peer" = "$SELF_FQDN" ] && continue
+        info="$(peer_info "$peer")"
+        [ -z "$info" ] && continue
+        role="$(printf '%s\n' "$info" | sed -n 's/^role://p' | tr -d '\r')"
+        mh="$(printf '%s\n' "$info" | sed -n 's/^master_host://p' | tr -d '\r')"
+        case "$role" in
+          slave|replica) is_self "$mh" && return 0 ;;
+        esac
+      done
+      return 1
+    }
+
+    discover_master() {
+      i=0
+      while [ "$i" -lt 30 ]; do
+        m="$(sentinel_master)"
+        if [ -n "$m" ]; then
+          echo "$m"
+          return 0
+        fi
+        i=$((i + 1))
+        echo "waiting for Sentinel master discovery ($i/30)" >&2
+        sleep 2
+      done
+      peer_master
+    }
+
+    if [ "$MODE" = "--wait-only" ]; then
+      # Bounded, re-resolving wait: the previous unbounded ping loop could deadlock
+      # every replica behind a permanently dead master while Sentinel had no live
+      # replica left to promote. If the master cannot be confirmed in time, defer to
+      # the main container, which owns the fail-closed decision.
+      i=0
+      while [ "$i" -lt 24 ]; do
+        m="$(sentinel_master)"
+        [ -z "$m" ] && m="$(peer_master || true)"
+        if [ -z "$m" ] || is_self "$m"; then
+          exit 0
+        fi
+        if vcli -h "$m" -p "$REDIS_PORT" ping >/dev/null 2>&1; then
+          exit 0
+        fi
+        i=$((i + 1))
+        echo "waiting for master $m:$REDIS_PORT ($i/24)"
+        sleep 5
+      done
+      echo "master not confirmed after bounded wait; deferring to main container"
+      exit 0
+    fi
+
+    master="$(discover_master || true)"
+
+    {{- if .Values.sentinel.startupFailoverGuard.enabled }}
+    # Anti-wipe guard: a master pod recreated on an empty volume inside the
+    # down-after-milliseconds window is still designated master by Sentinel. Starting
+    # it empty would make every replica full-resync from an empty dataset. If peers
+    # still replicate from us and we have no bootstrap marker, force a failover so a
+    # data-bearing replica is promoted first, then join as its replica.
+    if [ -n "$master" ] && is_self "$master" && [ ! -f "$MARKER" ] && peer_replicates_self; then
+      echo "fresh data dir while topology still designates this pod as master and peers hold data"
+      echo "requesting Sentinel failover to avoid replicas resyncing from an empty dataset"
+      # The Service may route each call to a different Sentinel. Submit once and
+      # only poll afterwards so the quorum converges on one forced-failover epoch.
+      scli sentinel failover "$MASTER_SET" >/dev/null 2>&1 || true
+      i=0
+      while [ "$i" -lt {{ int .Values.sentinel.startupFailoverGuard.maxAttempts }} ]; do
+        sleep 3
+        m="$(sentinel_master)"
+        if [ -n "$m" ] && ! is_self "$m"; then
+          master="$m"
+          break
+        fi
+        i=$((i + 1))
+      done
+      if is_self "$master"; then
+        echo "WARNING: forced failover did not complete; starting as master (replicas may resync from an empty dataset)"
+      fi
+    fi
+    {{- end }}
+
+    if [ -n "$master" ]; then
+      if is_self "$master"; then
+        echo "this pod is the current master target; starting without replicaof"
+        master=""
+      else
+        echo "starting as replica of $master:$REDIS_PORT"
+      fi
+    elif [ -f "$MARKER" ]; then
+      echo "master discovery failed for an already bootstrapped node; refusing to start as an unconfirmed master"
+      exit 1
+    else
+      case "$(hostname)" in
+        *-0)
+          echo "Sentinel and peers unavailable during first bootstrap; starting as seed master"
+          ;;
+        *)
+          echo "Sentinel and peers unavailable during first bootstrap; seeding from $SEED_MASTER:$REDIS_PORT"
+          master="$SEED_MASTER"
+          ;;
+      esac
+    fi
+
+    # Secrets and per-pod directives are written to a 0600 runtime config instead of
+    # argv, so they never show up in /proc/<pid>/cmdline. replica-announce-* keeps
+    # Sentinel state hostname-based across failovers instead of decaying to pod IPs.
+    RUNTIME=/data/.redis-runtime.conf
+    umask 077
+    rm -f "$RUNTIME"
+    cp /etc/redis/redis.conf "$RUNTIME"
+    {
+      echo "replica-announce-ip $SELF_FQDN"
+      echo "replica-announce-port $REDIS_PORT"
+      [ -n "$master" ] && echo "replicaof $master $REDIS_PORT"
+    {{- if .Values.auth.enabled }}
+      esc="$(printf '%s' "$REDIS_PASSWORD" | sed 's/[\\"]/\\&/g')"
+      printf 'masterauth "%s"\n' "$esc"
+      printf 'requirepass "%s"\n' "$esc"
+    {{- end }}
+    } >> "$RUNTIME"
+    touch "$MARKER"
+    exec redis-server "$RUNTIME"
+  node-prestop.sh: |
+    #!/bin/sh
+    # Graceful demotion: when the active master receives SIGTERM (rollout, drain,
+    # delete), promote a replica through Sentinel before shutting down instead of
+    # letting clients eat the full down-after-milliseconds detection window.
+    # Total budget must stay below terminationGracePeriodSeconds. Never fails.
+    set -u
+
+    REDIS_PORT={{ .Values.service.ports.redis }}
+    SENTINEL_HOST="{{ include "redis.sentinelServiceFqdn" . }}"
+    SENTINEL_PORT={{ .Values.service.ports.sentinel }}
+    MASTER_SET="{{ .Values.sentinel.masterSet }}"
+    TLS_ARGS="{{ include "redis.cliTlsArgs" . }}"
+    SELF_FQDN="$(hostname -f)"
+    SELF_IP="$(hostname -i 2>/dev/null | awk '{ print $1 }')"
+
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    vcli() { redis-cli $TLS_ARGS "$@"; }
+    {{- if and .Values.auth.enabled (not .Values.auth.sentinel) }}
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    scli() { env -u REDISCLI_AUTH redis-cli $TLS_ARGS -h "$SENTINEL_HOST" -p "$SENTINEL_PORT" "$@"; }
+    {{- else }}
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    scli() { redis-cli $TLS_ARGS -h "$SENTINEL_HOST" -p "$SENTINEL_PORT" "$@"; }
+    {{- end }}
+
+    role="$(vcli -p "$REDIS_PORT" info replication 2>/dev/null | sed -n 's/^role://p' | tr -d '\r')"
+    [ "$role" = "master" ] || exit 0
+
+    slaves="$(vcli -p "$REDIS_PORT" info replication 2>/dev/null | sed -n 's/^connected_slaves://p' | tr -d '\r')"
+    case "${slaves:-0}" in '' | *[!0-9]*) slaves=0 ;; esac
+    if [ "$slaves" -lt 1 ]; then
+      echo "active master has no connected replicas; nothing to promote"
+      exit 0
+    fi
+
+    echo "active master shutting down; requesting Sentinel failover"
+    # Submit exactly one request. SENTINEL_HOST is a load-balanced Service, so
+    # retrying the command can ask different Sentinels to start competing forced
+    # failovers and leave the election stuck in wait_start.
+    scli sentinel failover "$MASTER_SET" >/dev/null 2>&1 || true
+    i=0
+    while [ "$i" -lt {{ int .Values.sentinel.gracefulFailover.maxAttempts }} ]; do
+      sleep 3
+      m="$(scli sentinel get-master-addr-by-name "$MASTER_SET" 2>/dev/null | awk 'NR == 1 { print $1 }')"
+      if [ -n "$m" ] && [ "$m" != "$SELF_FQDN" ] && [ "$m" != "$SELF_IP" ]; then
+        echo "failover completed: new master is $m"
+        exit 0
+      fi
+      i=$((i + 1))
+    done
+    echo "failover not confirmed within budget; continuing shutdown"
+    exit 0
+  sentinel-entrypoint.sh: |
+    #!/bin/sh
+    set -eu
+
+    REDIS_PORT={{ .Values.service.ports.redis }}
+    SENTINEL_PORT={{ .Values.service.ports.sentinel }}
+    MASTER_SET="{{ .Values.sentinel.masterSet }}"
+    SEED_MASTER="{{ include "redis.nodePodFqdn" . }}"
+    PEERS="{{ include "redis.nodePeerFqdns" . }}"
+    TLS_ARGS="{{ include "redis.cliTlsArgs" . }}"
+    CONF=/data/sentinel.conf
+    BASE=/etc/redis-base/sentinel.conf
+
+    # shellcheck disable=SC2086 # TLS_ARGS is an intentional flag list
+    {{- if .Values.auth.enabled }}
+    vcli() { REDISCLI_AUTH="$REDIS_PASSWORD" timeout 5 redis-cli $TLS_ARGS "$@"; }
+    {{- else }}
+    vcli() { timeout 5 redis-cli $TLS_ARGS "$@"; }
+    {{- end }}
+
+    find_current_master() {
+      for peer in $PEERS; do
+        info="$(vcli -h "$peer" -p "$REDIS_PORT" info replication 2>/dev/null || true)"
+        [ -z "$info" ] && continue
+        role="$(printf '%s\n' "$info" | sed -n 's/^role://p' | tr -d '\r')"
+        if [ "$role" = "master" ]; then
+          echo "$peer"
+          return 0
+        fi
+      done
+      return 1
+    }
+
+    if [ ! -f "$CONF" ]; then
+      # First boot of this Sentinel replica. The static seed (node-0) is only a
+      # cold-start hint: if a failover already happened and this pod lost its
+      # emptyDir, monitoring node-0 again would advertise a stale master until
+      # hello-channel gossip converges. Probe the data plane for the real master.
+      # Discover the node currently reporting role:master, not merely a reachable
+      # seed. After a failover the seed (node-0) is a live *replica*, and a
+      # Sentinel seeded on a replica never redirects to the real master — it would
+      # advertise that replica to clients. Fall back to the seed only if no node
+      # answers as master within the bounded budget.
+      master=""
+      i=0
+      while :; do
+        if m="$(find_current_master)"; then
+          master="$m"
+          break
+        fi
+        i=$((i + 1))
+        if [ "$i" -ge 6 ]; then
+          master="$SEED_MASTER"
+          echo "no master discovered after bounded wait; monitoring seed $master anyway"
+          break
+        fi
+        echo "waiting to discover current master ($i/6)"
+        sleep 3
+      done
+      cp "$BASE" "$CONF"
+      if [ "$master" != "$SEED_MASTER" ]; then
+        sed -i "s|^sentinel monitor $MASTER_SET .*|sentinel monitor $MASTER_SET $master $REDIS_PORT {{ int .Values.sentinel.quorum }}|" "$CONF"
+      fi
+    else
+      persisted_monitor="$(grep "^sentinel monitor $MASTER_SET " "$CONF" | tail -n 1 || true)"
+      append_sentinel_base() {
+        if [ -n "$persisted_monitor" ]; then
+          awk -v monitor="$persisted_monitor" '
+            /^sentinel monitor {{ .Values.sentinel.masterSet }} / { print monitor; next }
+            { print }
+          ' "$BASE" >> "$CONF"
+        else
+          cat "$BASE" >> "$CONF"
+        fi
+      }
+      if grep -q '^# HelmForge managed sentinel config begin$' "$CONF"; then
+        sed -i '/^# HelmForge managed sentinel config begin$/,/^# HelmForge managed sentinel config end$/d' "$CONF"
+      else
+        sed -i \
+          -e '/^port /d' \
+          -e '/^tls-port /d' \
+          -e '/^tls-cert-file /d' \
+          -e '/^tls-key-file /d' \
+          -e '/^tls-ca-cert-file /d' \
+          -e '/^tls-auth-clients /d' \
+          -e '/^tls-replication /d' \
+          -e '/^dir /d' \
+          -e '/^sentinel resolve-hostnames /d' \
+          -e '/^sentinel announce-hostnames /d' \
+          -e "/^sentinel monitor $MASTER_SET /d" \
+          -e "/^sentinel down-after-milliseconds $MASTER_SET /d" \
+          -e "/^sentinel failover-timeout $MASTER_SET /d" \
+          -e "/^sentinel parallel-syncs $MASTER_SET /d" \
+          "$CONF"
+      fi
+      append_sentinel_base
+    fi
+
+    # Stable per-pod identity: without an announced hostname, every emptyDir
+    # restart re-registers this Sentinel under a new IP+runid, and the dead entry
+    # is never garbage-collected, silently inflating the majority required for
+    # failover authorization. A stable address lets peers replace the old entry.
+    sed -i -e '/^sentinel announce-ip /d' -e '/^sentinel announce-port /d' "$CONF"
+    {
+      echo "sentinel announce-ip $(hostname -f)"
+      echo "sentinel announce-port $SENTINEL_PORT"
+    } >> "$CONF"
+    {{- if .Values.auth.enabled }}
+    esc="$(printf '%s' "$REDIS_PASSWORD" | sed 's/[\\"]/\\&/g')"
+    sed -i "/^sentinel auth-pass $MASTER_SET /d" "$CONF"
+    printf 'sentinel auth-pass %s "%s"\n' "$MASTER_SET" "$esc" >> "$CONF"
+    {{- end }}
+    sed -i -e '/^requirepass /d' -e '/^sentinel sentinel-pass /d' "$CONF"
+    {{- if and .Values.auth.enabled .Values.auth.sentinel }}
+    printf 'requirepass "%s"\n' "$esc" >> "$CONF"
+    printf 'sentinel sentinel-pass "%s"\n' "$esc" >> "$CONF"
+    {{- end }}
+
+    # Optional hardening: pin a stable Sentinel identity (runid). Sentinel only
+    # generates a random myid when none is set, so a deterministic one derived
+    # from the pod's ordinal name and this release keeps the id stable across
+    # emptyDir restarts without a PVC, so peers update the existing entry instead
+    # of accumulating dead ones. Inputs are DNS-independent (short hostname from
+    # the kernel, namespace/name baked at render time).
+    if ! grep -q '^sentinel myid ' "$CONF"; then
+      MYID="$(printf '%s' '{{ .Release.Namespace }}/{{ include "redis.fullname" . }}/'"$(hostname)" | sha1sum | awk '{ print $1 }')"
+      echo "sentinel myid $MYID" >> "$CONF"
+    fi
+    exec redis-sentinel "$CONF"
+  {{- end }}
+  {{- if eq .Values.architecture "cluster" }}
+  redis-cluster.conf: |
+    {{- include "redis.commonConfig" . | nindent 4 }}
+    cluster-enabled yes
+    cluster-config-file nodes.conf
+    cluster-node-timeout 5000
+    {{- if .Values.tls.enabled }}
+    tls-cluster yes
+    tls-replication yes
+    {{- end }}
+    appendonly yes
+    {{- with .Values.config.redis }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  {{- end }}

--- a/charts/redis/templates/pdb.yaml
+++ b/charts/redis/templates/pdb.yaml
@@ -6,10 +6,27 @@ metadata:
   name: {{ include "redis.fullname" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  {{- include "redis.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "redis.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: redis
+      {{- include "redis.redisLabels" (dict "root" .) | nindent 6 }}
+{{- end }}
+{{- if and .Values.pdb.enabled (include "redis.isSentinel" .) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "redis.sentinelStatefulSetName" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+  {{- include "redis.renderAnnotations" (dict "root" .) | nindent 2 }}
+spec:
+  minAvailable: {{ .Values.sentinel.quorum }}
+  selector:
+    matchLabels:
+      {{- include "redis.sentinelLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/redis/templates/replication-primary-statefulset.yaml
+++ b/charts/redis/templates/replication-primary-statefulset.yaml
@@ -1,5 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if or (include "redis.isReplication" .) (include "redis.isSentinel" .) }}
+{{- if include "redis.isReplication" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/redis/templates/replication-replica-statefulset.yaml
+++ b/charts/redis/templates/replication-replica-statefulset.yaml
@@ -1,5 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if or (include "redis.isReplication" .) (include "redis.isSentinel" .) }}
+{{- if include "redis.isReplication" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/redis/templates/sentinel-node-statefulset.yaml
+++ b/charts/redis/templates/sentinel-node-statefulset.yaml
@@ -1,0 +1,183 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if include "redis.isSentinel" . }}
+{{- if lt (int .Values.sentinel.replicaCount) 3 }}
+{{- fail "sentinel.replicaCount must be at least 3 for a reliable Sentinel quorum in HA configurations" }}
+{{- end }}
+{{- if gt (int .Values.sentinel.quorum) (int .Values.sentinel.replicaCount) }}
+{{- fail (printf "sentinel.quorum (%v) cannot exceed sentinel.replicaCount (%v)" .Values.sentinel.quorum .Values.sentinel.replicaCount) }}
+{{- end }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "redis.nodeStatefulSetName" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+  {{- include "redis.renderAnnotations" (dict "root" .) | nindent 2 }}
+spec:
+  serviceName: {{ include "redis.headlessServiceName" . }}
+  replicas: {{ .Values.node.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "redis.redisLabels" (dict "root" . "role" "node") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "redis.redisLabels" (dict "root" . "role" "node") | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ include "redis.authChecksum" . }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "redis.podSpec" (dict "root" . "role" "node") | nindent 6 }}
+      initContainers:
+        - name: wait-for-master
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "/scripts/node-entrypoint.sh", "--wait-only"]
+          {{- if .Values.auth.enabled }}
+          env:
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+      containers:
+        - name: redis
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "/scripts/node-entrypoint.sh"]
+          {{- if .Values.sentinel.gracefulFailover.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "/scripts/node-prestop.sh"]
+          {{- end }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.service.ports.redis }}
+          env:
+            {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "redis.nodeProbeCommand" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "redis.nodeProbeCommand" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "redis.nodeProbeCommand" . | quote }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.node.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis-node.conf
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          env:
+            {{- include "redis.exporterEnv" . | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+          {{- include "redis.metricsVolumeMounts" . | nindent 10 }}
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "redis.configMapName" . }}
+        - name: scripts
+          configMap:
+            name: {{ include "redis.configMapName" . }}
+            defaultMode: 0555
+            items:
+              - key: node-entrypoint.sh
+                path: node-entrypoint.sh
+              - key: node-prestop.sh
+                path: node-prestop.sh
+        {{- if not .Values.node.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+  {{- if .Values.node.persistence.enabled }}
+  volumeClaimTemplates:
+    {{- include "redis.volumeClaimTemplate" (dict "root" . "persistence" .Values.node.persistence) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/redis/templates/sentinel-statefulset.yaml
+++ b/charts/redis/templates/sentinel-statefulset.yaml
@@ -6,64 +6,80 @@ metadata:
   name: {{ include "redis.sentinelStatefulSetName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}
+  {{- include "redis.renderAnnotations" (dict "root" .) | nindent 2 }}
 spec:
-  serviceName: {{ include "redis.sentinelServiceName" . }}
+  serviceName: {{ include "redis.sentinelHeadlessServiceName" . }}
   replicas: {{ .Values.sentinel.replicaCount }}
+  {{- with .Values.sentinel.podManagementPolicy }}
+  podManagementPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
-      {{- include "redis.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: sentinel
+      {{- include "redis.sentinelLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "redis.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: sentinel
+        {{- include "redis.sentinelLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.auth.enabled }}
+        checksum/auth-secret: {{ include "redis.authChecksum" . }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
-      {{- include "redis.podSpecCommon" . | nindent 6 }}
+      {{- include "redis.podSpec" (dict "root" . "role" "sentinel") | nindent 6 }}
       containers:
         - name: sentinel
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-ec"]
-          args:
-            - |
-              until redis-cli -h "$REDIS_PRIMARY_HOST" -p "$REDIS_PRIMARY_PORT" {{- if .Values.auth.enabled }} -a "$REDIS_PASSWORD" --no-auth-warning {{- end }} ping >/dev/null 2>&1; do
-                echo "waiting for primary $REDIS_PRIMARY_HOST:$REDIS_PRIMARY_PORT"
-                sleep 5
-              done
-              cp /etc/redis-base/sentinel.conf /tmp/sentinel.conf
-              {{- if .Values.auth.enabled }}
-              echo "sentinel auth-pass {{ .Values.sentinel.masterSet }} ${REDIS_PASSWORD}" >> /tmp/sentinel.conf
-              {{- end }}
-              exec redis-sentinel /tmp/sentinel.conf
+          command: ["sh", "/scripts/sentinel-entrypoint.sh"]
           ports:
             - name: sentinel
               containerPort: {{ .Values.service.ports.sentinel }}
-          {{- if .Values.auth.enabled }}
           env:
-            - name: REDIS_PRIMARY_HOST
-              value: {{ include "redis.primaryPodFqdn" . | quote }}
-            - name: REDIS_PRIMARY_PORT
-              value: {{ .Values.service.ports.redis | quote }}
+            {{- if .Values.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "redis.secretName" . }}
                   key: {{ .Values.auth.existingSecretPasswordKey }}
-          {{- else }}
-          env:
-            - name: REDIS_PRIMARY_HOST
-              value: {{ include "redis.primaryPodFqdn" . | quote }}
-            - name: REDIS_PRIMARY_PORT
-              value: {{ .Values.service.ports.redis | quote }}
-          {{- end }}
+            {{- end }}
+            {{- if and .Values.auth.enabled .Values.auth.sentinel }}
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "redis.secretName" . }}
+                  key: {{ .Values.auth.existingSecretPasswordKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "redis.sentinelProbeCommand" . | quote }}
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "redis.sentinelReadyCommand" . | quote }}
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -ec
+                - {{ include "redis.sentinelProbeCommand" . | quote }}
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           {{- with .Values.sentinel.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -74,10 +90,42 @@ spec:
             - name: config
               mountPath: /etc/redis-base/sentinel.conf
               subPath: sentinel.conf
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: data
+              mountPath: /data
+            {{- if .Values.tls.enabled }}
+            - name: tls
+              mountPath: /tls
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "redis.configMapName" . }}
+        - name: scripts
+          configMap:
+            name: {{ include "redis.configMapName" . }}
+            defaultMode: 0555
+            items:
+              - key: sentinel-entrypoint.sh
+                path: sentinel-entrypoint.sh
+        {{- if not .Values.sentinel.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: tls
+          secret:
+            secretName: {{ .Values.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
   {{- if .Values.sentinel.persistence.enabled }}
   volumeClaimTemplates:
     {{- include "redis.volumeClaimTemplate" (dict "root" . "persistence" .Values.sentinel.persistence) | nindent 4 }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -165,6 +165,24 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ include "redis.sentinelHeadlessServiceName" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel-headless
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: sentinel
+      port: {{ .Values.service.ports.sentinel }}
+      targetPort: sentinel
+  selector:
+    {{- include "redis.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: sentinel
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: {{ include "redis.sentinelServiceName" . }}
   labels:
     {{- include "redis.labels" . | nindent 4 }}

--- a/charts/redis/tests/cluster_domain_test.yaml
+++ b/charts/redis/tests/cluster_domain_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor mymaster test-redis-primary-0\\.test-redis-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
+          pattern: "sentinel monitor mymaster test-redis-node-0\\.test-redis-headless\\.custom-ns\\.svc\\.corp\\.internal 6379 2"
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "sentinel resolve-hostnames yes"
@@ -39,20 +39,15 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           pattern: "svc\\.cluster\\.local"
 
-  - it: should wait for custom primary FQDN before starting sentinel
-    template: sentinel-statefulset.yaml
+  - it: should discover the custom seed FQDN before starting sentinel
+    template: configmap.yaml
     set:
       architecture: sentinel
       clusterDomain: corp.internal
     asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: REDIS_PRIMARY_HOST
-            value: test-redis-primary-0.test-redis-headless.custom-ns.svc.corp.internal
       - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "until redis-cli -h \"\\$REDIS_PRIMARY_HOST\""
+          path: data["sentinel-entrypoint.sh"]
+          pattern: 'SEED_MASTER="test-redis-node-0\.test-redis-headless\.custom-ns\.svc\.corp\.internal"'
 
   - it: should use custom cluster domain in cluster announce hostname
     template: cluster-statefulset.yaml

--- a/charts/redis/tests/sentinel_config_test.yaml
+++ b/charts/redis/tests/sentinel_config_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor mymaster test-redis-primary-0\\.test-redis-headless\\.redis-ns\\.svc\\.cluster\\.local 6379 2"
+          pattern: "sentinel monitor mymaster test-redis-node-0\\.test-redis-headless\\.redis-ns\\.svc\\.cluster\\.local 6379 2"
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "sentinel down-after-milliseconds mymaster 60000"
@@ -27,7 +27,7 @@ tests:
     asserts:
       - matchRegex:
           path: data["sentinel.conf"]
-          pattern: "sentinel monitor legacy-master test-redis-primary-0\\.test-redis-headless\\.redis-ns\\.svc\\.cluster\\.local 6379 2"
+          pattern: "sentinel monitor legacy-master test-redis-node-0\\.test-redis-headless\\.redis-ns\\.svc\\.cluster\\.local 6379 2"
       - matchRegex:
           path: data["sentinel.conf"]
           pattern: "sentinel down-after-milliseconds legacy-master 60000"
@@ -39,11 +39,14 @@ tests:
           pattern: "sentinel parallel-syncs legacy-master 1"
 
   - it: should use the custom Sentinel master set for auth-pass
-    template: sentinel-statefulset.yaml
+    template: configmap.yaml
     set:
       architecture: sentinel
       sentinel.masterSet: legacy-master
     asserts:
       - matchRegex:
-          path: spec.template.spec.containers[0].args[0]
-          pattern: "sentinel auth-pass legacy-master \\$\\{REDIS_PASSWORD\\}"
+          path: data["sentinel-entrypoint.sh"]
+          pattern: 'MASTER_SET="legacy-master"'
+      - matchRegex:
+          path: data["sentinel-entrypoint.sh"]
+          pattern: 'sentinel auth-pass %s'

--- a/charts/redis/tests/sentinel_node_test.yaml
+++ b/charts/redis/tests/sentinel_node_test.yaml
@@ -63,6 +63,29 @@ tests:
           path: data["node-entrypoint.sh"]
           pattern: "sentinel get-master-addr-by-name"
 
+  - it: should configure mutual TLS and TLS-aware Sentinel probes
+    set:
+      architecture: sentinel
+      tls.enabled: true
+      tls.existingSecret: redis-tls
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "tls-auth-clients yes"
+        template: configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          pattern: "--tls.*--cert.*--key"
+        template: sentinel-statefulset.yaml
+
+  - it: should persist Sentinel data nodes by default
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - exists:
+          path: spec.volumeClaimTemplates[0]
+
   - it: should include startup and graceful failover safeguards
     set:
       architecture: sentinel

--- a/charts/redis/tests/sentinel_node_test.yaml
+++ b/charts/redis/tests/sentinel_node_test.yaml
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Sentinel Role-Neutral Nodes
+templates:
+  - configmap.yaml
+  - replication-primary-statefulset.yaml
+  - replication-replica-statefulset.yaml
+  - sentinel-node-statefulset.yaml
+  - sentinel-statefulset.yaml
+  - service.yaml
+release:
+  name: test
+  namespace: redis-ns
+tests:
+  - it: should render one role-neutral data-node StatefulSet in sentinel mode
+    template: sentinel-node-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: metadata.name
+          value: test-redis-node
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/role"]
+          value: node
+
+  - it: should not render the fixed primary StatefulSet in sentinel mode
+    template: replication-primary-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render the fixed replica StatefulSet in sentinel mode
+    template: replication-replica-statefulset.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should configure symmetric authentication and stable hostnames
+    template: configmap.yaml
+    set:
+      architecture: sentinel
+      auth.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["sentinel.conf"]
+          pattern: "sentinel announce-hostnames yes"
+      - matchRegex:
+          path: data["node-entrypoint.sh"]
+          pattern: "masterauth"
+      - matchRegex:
+          path: data["node-entrypoint.sh"]
+          pattern: "replica-announce-ip \\$SELF_FQDN"
+      - matchRegex:
+          path: data["node-entrypoint.sh"]
+          pattern: "sentinel get-master-addr-by-name"
+
+  - it: should include startup and graceful failover safeguards
+    set:
+      architecture: sentinel
+    asserts:
+      - matchRegex:
+          path: data["node-entrypoint.sh"]
+          pattern: "Anti-wipe guard"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["node-entrypoint.sh"]
+          pattern: "Submit once"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["node-prestop.sh"]
+          pattern: "Submit exactly one request"
+        template: configmap.yaml
+      - exists:
+          path: spec.template.spec.containers[0].lifecycle.preStop
+        template: sentinel-node-statefulset.yaml
+
+  - it: should expose Sentinel without a primary Service in sentinel mode
+    template: service.yaml
+    set:
+      architecture: sentinel
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: test-redis-sentinel
+        documentIndex: 2

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -72,6 +72,10 @@
         "existingSecretPasswordKey": {
           "type": "string",
           "description": "Secret key name for the password in auth.existingSecret"
+        },
+        "sentinel": {
+          "type": "boolean",
+          "description": "Require password authentication on the Sentinel control plane"
         }
       }
     },

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -186,6 +186,27 @@
         }
       }
     },
+    "node": {
+      "type": "object",
+      "description": "Role-neutral Redis data nodes used by Sentinel architecture",
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 2,
+          "description": "Number of Redis data nodes in Sentinel mode"
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "resources": { "type": "object" }
+      }
+    },
     "sentinel": {
       "type": "object",
       "description": "Sentinel architecture settings",
@@ -215,6 +236,20 @@
         "parallelSyncs": {
           "type": "integer",
           "description": "Number of parallel syncs during failover"
+        },
+        "gracefulFailover": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "maxAttempts": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "startupFailoverGuard": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "maxAttempts": { "type": "integer", "minimum": 1 }
+          }
         },
         "persistence": {
           "type": "object",

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -46,6 +46,8 @@ auth:
   existingSecret: ""
   # -- Secret key name for the password in auth.existingSecret
   existingSecretPasswordKey: redis-password
+  # -- Require password authentication on the Sentinel control plane
+  sentinel: false
 
 # =============================================================================
 # TLS
@@ -105,7 +107,7 @@ node:
   replicaCount: 3
   persistence:
     # -- Enable persistent storage for Sentinel data nodes
-    enabled: false
+    enabled: true
     storageClass: ""
     accessModes:
       - ReadWriteOnce

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -97,6 +97,22 @@ replication:
     resources: {}
 
 # =============================================================================
+# Sentinel data nodes
+# =============================================================================
+
+node:
+  # -- Number of role-neutral Redis data nodes in Sentinel mode
+  replicaCount: 3
+  persistence:
+    # -- Enable persistent storage for Sentinel data nodes
+    enabled: false
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 8Gi
+  resources: {}
+
+# =============================================================================
 # Sentinel
 # =============================================================================
 
@@ -108,6 +124,14 @@ sentinel:
   downAfterMilliseconds: 60000
   failoverTimeout: 180000
   parallelSyncs: 1
+  gracefulFailover:
+    # -- Request Sentinel failover before voluntarily terminating the active master
+    enabled: true
+    maxAttempts: 12
+  startupFailoverGuard:
+    # -- Prevent a fresh empty node from resuming as master while peers hold data
+    enabled: true
+    maxAttempts: 20
   persistence:
     enabled: false
     storageClass: ""


### PR DESCRIPTION
## Summary

- replace the fixed Sentinel primary/replica workloads with one role-neutral data-node StatefulSet
- use stable node and Sentinel hostnames, symmetric replication authentication, and persistent Sentinel topology
- add graceful failover and startup anti-wipe safeguards
- remove the misleading primary Service in Sentinel mode
- add regression coverage, a production example, and 2.0 migration guidance

## Breaking change

Sentinel deployments now use the node.* contract and role-neutral node pod names. The release workflow should publish Redis chart 2.0.0 from the breaking commit.

## Validation

- make validate-chart CHART=redis: FULLY VALIDATED (18 layers)
- helm unittest charts/redis: 44/44
- make preflight
- Kubescape MITRE+NSA+SOC2: 80.30303%
- companion site PR: https://github.com/helmforgedev/site/pull/489

## Manual acceptance note

A clean Docker Desktop/k3d run reached 3 usable Sentinels and quorum, but that local runtime repeatedly forced all Sentinels into +tilt during synchronous hostname resolution. The official 18-layer chart validation and all remote PR checks pass; this environment-specific observation does not change the PR readiness state.

Resolves #953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis Sentinel deployments now use role-neutral data nodes with independently scalable Sentinel pods.
  * Added hostname-based discovery, peer-aware bootstrap, graceful failover, startup protection, persistence controls, TLS, authentication, metrics, and disruption safeguards.
  * Added a production-ready Sentinel configuration example.
  * Added Sentinel-specific services, probes, resource settings, and configurable node replicas.

* **Documentation**
  * Expanded configuration, resilience, migration, upgrade, client, and validation guidance, including breaking upgrade notes for Sentinel deployments from 1.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
