### PR TITLE
chore(certimate): bump certimate to 0.4.30

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -4,7 +4,7 @@ name: certimate
 description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
 type: application
 version: 1.0.3
-appVersion: "0.4.29"
+appVersion: "0.4.30"
 home: https://helmforge.dev/docs/charts/certimate
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/certimate
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/certimate.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump certimate to 0.4.29 (#912)"
+      description: "bump certimate to 0.4.30 (#935)"
   artifacthub.io/category: security
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -2,7 +2,7 @@
 
 Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
 
-This chart packages the official `certimate/certimate:v0.4.29` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+This chart packages the official `certimate/certimate:v0.4.30` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
 
 ## Production Defaults
 
@@ -71,9 +71,9 @@ Back up the PersistentVolumeClaim before upgrades. Certimate stores its
 PocketBase database, uploaded certificate material, ACME account state, workflow
 definitions, and provider credentials under `/app/pb_data`.
 
-Certimate 0.4.29 adds reverse-proxy subpath support, new Yandex Cloud providers,
-and several provider fixes. It does not change the container port, storage path,
-or chart configuration contract.
+Certimate 0.4.30 adds AxisNow and Proxmox Backup Server deployment providers and
+fixes Kubernetes Secret certificate deployment. It does not change the container
+port, storage path, or chart configuration contract.
 
 Certimate's upstream deployment uses PocketBase-local state. This chart does not
 ship PostgreSQL, MySQL, or Redis subcharts because the product does not expose an
@@ -89,7 +89,7 @@ ACME endpoints required by your workflows.
 Local security scan:
 
 ```text
-Image: certimate/certimate:v0.4.29
+Image: certimate/certimate:v0.4.30
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 93.93939 compliance score
 ```

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: certimate/certimate:v0.4.29
+          value: certimate/certimate:v0.4.30
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "certimate/certimate" },
-        "tag": { "type": "string", "default": "v0.4.29", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "v0.4.30", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Certimate container image repository.
   repository: certimate/certimate
   # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
-  tag: "v0.4.29"
+  tag: "v0.4.30"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Certimate image from `v0.4.29` to `v0.4.30`
- align the chart metadata, schema, unit assertion, README, and security scan reference
- document the upstream provider additions and Kubernetes Secret deployment fix

## Upstream evidence

- Release: https://github.com/certimate-go/certimate/releases/tag/v0.4.30
- Compare: https://github.com/certimate-go/certimate/compare/v0.4.29...v0.4.30
- Manifest: `certimate/certimate:v0.4.30` supports `linux/amd64`, `linux/arm64`, and `linux/arm`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| AxisNow and Proxmox Backup Server providers | No container contract change | `default` |
| Kubernetes Secret deployment fix | Improves an in-app integration; no template change | `default` startup and HTTP smoke |
| Dependency and UI maintenance | No ports, storage, probes, or values change | `default` |

Only `default` is selected for behavioral runtime because the release does not change the container port, persistence path, probes, or optional chart integrations. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=certimate/certimate:v0.4.30 JSON=1`
- `make deps-check CHART=certimate`
- `make validate-chart CHART=certimate K3D_SCENARIOS="default"` — 10 layers passed, including behavioral k3d validation
- `make standards-check CHART=certimate`
- `make site-sync-check CHART=certimate` — existing site surfaces present; no site version reference required an update
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Resolves #935


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AxisNow and Proxmox Backup Server deployment providers.
* **Bug Fixes**
  * Fixed certificate deployment through Kubernetes Secrets.
* **Updates**
  * Updated the Certimate container image to version 0.4.30.
  * Updated the Helm chart metadata, defaults, validation, and release documentation to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->