### PR TITLE
chore(clickhouse): bump clickhouse to 26.7.3

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -4,7 +4,7 @@ name: clickhouse
 description: Fast column-oriented OLAP database with production-safe standalone defaults
 type: application
 version: 1.0.2
-appVersion: "26.7.1"
+appVersion: "26.7.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/clickhouse.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade image to 26.7.1 (#863)"
+      description: "upgrade image to 26.7.3 (#936)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -15,7 +15,7 @@ helm install clickhouse oci://ghcr.io/helmforgedev/helm/clickhouse
 
 ## Features
 
-- Official ClickHouse image pinned to `26.7.1`.
+- Official ClickHouse image pinned to `26.7.3`.
 - StatefulSet with persistent data volume.
 - Client Service exposing HTTP `8123` and native TCP `9000`.
 - Headless Service for stable pod DNS.
@@ -55,7 +55,7 @@ networkPolicy:
 | --- | --- | --- |
 | `replicaCount` | ClickHouse pod count. Must remain `1` | `1` |
 | `image.repository` | Official image repository | `docker.io/clickhouse/clickhouse-server` |
-| `image.tag` | Official full-version tag | `26.7.1` |
+| `image.tag` | Official full-version tag | `26.7.3` |
 | `clickhouse.database` | Initial database | `default` |
 | `clickhouse.user` | Initial user | `default` |
 | `clickhouse.password` | Initial password | `""` |
@@ -104,7 +104,7 @@ clusters.
 ## Upgrade Notes
 
 This release moves ClickHouse from 26.6 to 26.7 stable. Review the upstream
-[ClickHouse 26.7 release notes](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.1.1315-stable)
+[ClickHouse 26.7 release notes](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.3.19-stable)
 and backward-incompatible changes before upgrading production workloads.
 Important changes include explicit credentials for user SQL that accesses S3,
 rejection of ZIP/ZIPX backups on object storage, stricter

--- a/charts/clickhouse/tests/statefulset_test.yaml
+++ b/charts/clickhouse/tests/statefulset_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/clickhouse/clickhouse-server:26.7.1
+          value: docker.io/clickhouse/clickhouse-server:26.7.3
   - it: exposes HTTP and native TCP ports
     template: statefulset.yaml
     asserts:

--- a/charts/clickhouse/tests/test_connection_test.yaml
+++ b/charts/clickhouse/tests/test_connection_test.yaml
@@ -17,7 +17,7 @@ tests:
           path: spec.containers[0].env
           content:
             name: CLICKHOUSE_EXPECTED_VERSION
-            value: "26.7.1"
+            value: "26.7.3"
       - contains:
           path: spec.containers[0].env
           content:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official ClickHouse image repository
   repository: docker.io/clickhouse/clickhouse-server
   # -- Official full-version tag
-  tag: "26.7.1"
+  tag: "26.7.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official ClickHouse image from `26.7.1` to `26.7.3`
- align chart metadata, tests, README, and the upstream release reference

## Upstream evidence

- 26.7.2 release: https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.2.59-stable
- 26.7.3 release: https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.3.19-stable
- Manifest: `docker.io/clickhouse/clickhouse-server:26.7.3` supports `linux/amd64` and `linux/arm64`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| Stable 26.7 patch releases | No documented container contract, port, storage, or configuration migration | `default` |
| Upstream fixes since 26.7.1 | Runtime startup and service availability | `default` rollout and service smoke |

Only `default` is selected because this is a patch update within the 26.7 stable series with no chart-facing contract change. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=docker.io/clickhouse/clickhouse-server:26.7.3 JSON=1`
- `make deps-check CHART=clickhouse`
- `make validate-chart CHART=clickhouse K3D_SCENARIOS="default"` — 10 layers passed, including behavioral k3d validation
- `make standards-check CHART=clickhouse`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Related site update: helmforgedev/site#493

Resolves #936
