### PR TITLE
chore(ghost): bump ghost to 6.56.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.2.1
-appVersion: "6.55.0"
+appVersion: "6.56.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ghost to 6.55.0 (#913)"
+      description: "bump ghost to 6.56.0 (#938)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -99,14 +99,14 @@ new configurations should use `externalSecrets.items`.
 
 ## Custom Adapter Images
 
-Ghost 6.55.0 can load adapters installed outside the content directory. For a
+Ghost can load adapters installed outside the content directory. For a
 custom image that installs adapters in `/opt/ghost/adapters`, expose the path
 through Ghost's environment-based configuration:
 
 ```yaml
 image:
   repository: registry.example.com/ghost-with-adapters
-  tag: "6.55.0"
+  tag: "6.56.0"
 
 ghost:
   extraEnv:
@@ -123,7 +123,7 @@ adapters when the container starts.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.55.0` | Ghost image tag |
+| `image.tag` | `6.56.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -137,8 +137,8 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.55.0` includes Admin, member import/export, routing, comments, and
-email automation fixes. The release does not change the official image's port,
+Ghost `6.56.0` adds tier-specific editor previews and fixes newsletter links,
+bookmark cards, comments, and managed Stripe checkout. The release does not change the official image's port,
 content path, database contract, probes, or required environment variables.
 Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the
 chart's content PVC and S3 content backup already cover them. Review the

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.55.0"
+          value: "docker.io/library/ghost:6.56.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.55.0"
+                                                                    "default":  "6.56.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.55.0"
+  tag: "6.56.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the official Ghost image from `6.55.0` to `6.56.0`
- align metadata, schema, tests, README defaults, and release notes

## Upstream evidence

- Release: https://github.com/TryGhost/Ghost/releases/tag/v6.56.0
- Compare: https://github.com/TryGhost/Ghost/compare/v6.55.0...v6.56.0
- Manifest: `docker.io/library/ghost:6.56.0` supports `linux/amd64`, `linux/arm`, and `linux/arm64`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| Tier-specific editor preview | Application feature only | `default` |
| Newsletter, bookmark, comment, and Stripe fixes | No container contract change | `default` startup and HTTP smoke |

Only `default` is selected because ports, content storage, database configuration, and probes are unchanged. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=docker.io/library/ghost:6.56.0 JSON=1`
- `make deps-check CHART=ghost`
- `make validate-chart CHART=ghost K3D_SCENARIOS="default"` — 10 layers passed, including Ghost and MySQL on k3d
- `make standards-check CHART=ghost`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

No site file contains the old image version, so no companion site change is required.

Resolves #938
