### PR TITLE
chore(homarr): bump homarr to 1.74.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.2.1
-appVersion: "1.73.0"
+appVersion: "1.74.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump homarr to 1.73.0 (#915)"
+      description: "bump homarr to 1.74.0 (#939)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.73.0`.
+Current application version: `v1.74.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.73.0"` | Homarr image tag |
+| `image.tag` | `"v1.74.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,9 +265,9 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image from `v1.72.0` to `v1.73.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.73.0` adds OIDC account linking, Navidrome media-server integration, widget improvements, and
-Beszel session recovery fixes. No breaking changes or new required environment variables were identified in the upstream
+This update moves the default image to `v1.74.0`. Review upstream release notes before upgrading production
+environments. Homarr `v1.74.0` adds persistent widget layouts, custom URI schemes, and integration reliability fixes.
+No breaking changes or new required environment variables were identified in the upstream
 release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.73.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.74.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.73.0"
+  tag: "v1.74.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- bump the official Homarr image from `v1.73.0` to `v1.74.0`
- align metadata, tests, README defaults, and upgrade guidance

## Upstream evidence

- Release: https://github.com/homarr-labs/homarr/releases/tag/v1.74.0
- Compare: https://github.com/homarr-labs/homarr/compare/v1.73.0...v1.74.0
- Manifest: `ghcr.io/homarr-labs/homarr:v1.74.0` supports `linux/amd64` and `linux/arm64`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| Persistent widget layouts and custom URI schemes | Application behavior only | `default` |
| Integration reliability and permission fixes | No container contract change | `default` startup and HTTP smoke |

Only `default` is selected because the release adds application features and fixes without changing ports, database settings, storage, or probes. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=ghcr.io/homarr-labs/homarr:v1.74.0 JSON=1`
- `make deps-check CHART=homarr`
- `make validate-chart CHART=homarr K3D_SCENARIOS="default"` — 10 layers passed, including behavioral k3d validation
- `make standards-check CHART=homarr`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

No site file contains the old image version, so no companion site change is required.

Resolves #939
