### PR TITLE
chore(jenkins): bump jenkins to 2.568.2

### DIFF
--- a/charts/jenkins/Chart.yaml
+++ b/charts/jenkins/Chart.yaml
@@ -4,7 +4,7 @@ name: jenkins
 description: Jenkins Helm Chart with secure controller defaults, JCasC, plugin bootstrap, Gateway API, and Kubernetes agent RBAC
 type: application
 version: 1.0.6
-appVersion: "2.568.1"
+appVersion: "2.568.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -28,7 +28,7 @@ icon: https://helmforge.dev/icons/charts/jenkins.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2.568.1 (#761)"
+      description: "bump image to 2.568.2 (#940)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/jenkins/README.md
+++ b/charts/jenkins/README.md
@@ -3,7 +3,7 @@
 Jenkins is an open source automation server for continuous integration and delivery.
 
 This HelmForge chart deploys the official `jenkins/jenkins` controller image
-at the pinned `2.568.1-lts-jdk21` release with production-oriented Kubernetes
+at the pinned `2.568.2-lts-jdk21` release with production-oriented Kubernetes
 defaults. It includes a StatefulSet
 controller, persistent Jenkins home, secure initial admin bootstrap, optional
 Jenkins Configuration as Code, optional plugin installation with

--- a/charts/jenkins/values.yaml
+++ b/charts/jenkins/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Jenkins controller image repository.
   repository: docker.io/jenkins/jenkins
   # -- Jenkins controller image tag.
-  tag: "2.568.1-lts-jdk21"
+  tag: "2.568.2-lts-jdk21"
   # -- Jenkins controller image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Jenkins LTS JDK 21 image from `2.568.1-lts-jdk21` to `2.568.2-lts-jdk21`
- align chart metadata and README

## Upstream evidence

- LTS changelog: https://www.jenkins.io/changelog-stable/
- Image metadata: https://hub.docker.com/r/jenkins/jenkins/tags?name=2.568.2-lts-jdk21
- Manifest: `docker.io/jenkins/jenkins:2.568.2-lts-jdk21` supports amd64, arm64, s390x, ppc64le, and riscv64

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| Jenkins 2.568 LTS patch update | No JDK, port, `JENKINS_HOME`, or values contract change | `default` |

Only `default` is selected because this is a patch update in the same LTS/JDK line. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=docker.io/jenkins/jenkins:2.568.2-lts-jdk21 JSON=1`
- minimal k3d image command: `java -version` returned Temurin 21.0.11
- `make deps-check CHART=jenkins`
- `make validate-chart CHART=jenkins K3D_SCENARIOS="default"` — 10 layers passed with no Warning events
- `make standards-check CHART=jenkins`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Related site update: helmforgedev/site#494

Resolves #940
