### PR TITLE
chore(keycloak): bump keycloak to 26.7.1

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 3.0.7
-appVersion: "26.7.0"
+appVersion: "26.7.1"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - keycloak
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 26.7.0 (#762)"
+      description: "bump image to 26.7.1 (#941)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -88,11 +88,11 @@ Recommended reading before installation:
 
 ## Keycloak 26.7.x alignment
 
-This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.0`.
+This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.1`.
 
 Relevant 26.7.x operational changes to account for during rollout:
 
-- 26.7.0 includes security fixes and new administration capabilities; review the upstream migration guide before production rollout
+- 26.7.1 includes security and authentication fixes; review the upstream migration guide before production rollout
 - zero-downtime patch releases are supported within the same minor stream, but still require readiness, proxy, and database validation
 - the HTTP stack supports graceful shutdown, so keep `terminationGracePeriodSeconds` aligned with connection draining at the proxy layer
 - Kubernetes and OpenShift truststore initialization improved upstream; keep custom `truststore` and database CA mounts explicit when the platform uses private CAs
@@ -245,7 +245,7 @@ postgresql:
 |-----------|-------------|---------|
 | `mode` | `dev` or `production` | `dev` |
 | `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `26.7.0` |
+| `image.tag` | Keycloak image tag | `26.7.1` |
 | `admin.existingSecret` | Existing secret for bootstrap admin credentials | `""` |
 | `http.port` | Application HTTP port | `8080` |
 | `http.managementPort` | Management port for health and metrics | `9000` |

--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -157,11 +157,11 @@ When an ExternalSecret owns a target Secret, the native generated Secret for tha
 
 ## Keycloak 26.7.x rollout notes
 
-The default image is `quay.io/keycloak/keycloak:26.7.0`.
+The default image is `quay.io/keycloak/keycloak:26.7.1`.
 
 Before rolling this version into production:
 
-- read the official [26.7.0 release notes](https://www.keycloak.org/2026/07/keycloak-2670-released)
+- read the official [26.7.1 release notes](https://github.com/keycloak/keycloak/releases/tag/26.7.1)
 - validate database startup and migration logs
 - validate readiness and liveness on the management service
 - validate login, token refresh, logout, and admin console access through the real reverse proxy path

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.7.0"
+          value: "quay.io/keycloak/keycloak:26.7.1"
 
   - it: should have 1 replica by default
     template: deployment.yaml

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # -- Keycloak image tag
-  tag: "26.7.0"
+  tag: "26.7.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the official Keycloak image from `26.7.0` to `26.7.1`
- align metadata, tests, README, and production guidance

## Upstream evidence

- Release: https://github.com/keycloak/keycloak/releases/tag/26.7.1
- Migration guide: https://www.keycloak.org/docs/latest/upgrading/#migration-changes
- Manifest: `quay.io/keycloak/keycloak:26.7.1` supports `linux/amd64`, `linux/arm64`, and `linux/ppc64le`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| OIDC, SAML, DCR, LDAP, FGAP, and admin API security fixes | No chart values contract change | `default` startup and service smoke |
| Authentication and Liquibase lock fixes | Existing database/bootstrap path | `default` |

Only `default` is selected because the patch contains security and application fixes without changing ports, hostname configuration, storage, or required environment variables. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=quay.io/keycloak/keycloak:26.7.1 JSON=1`
- `make deps-check CHART=keycloak`
- `make validate-chart CHART=keycloak K3D_SCENARIOS="default"` — 10 layers passed, including behavioral k3d validation
- `make standards-check CHART=keycloak`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Related site update: helmforgedev/site#495

Resolves #941
