### PR TITLE
chore(komga): bump komga to 1.26.1

### DIFF
--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -4,7 +4,7 @@ name: komga
 description: Komga media server for comics and manga with persistent SQLite storage, library management, and S3 backup
 type: application
 version: 1.4.13
-appVersion: "1.25.0"
+appVersion: "1.26.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump komga to 1.25.0 (#715)"
+      description: "bump komga to 1.26.1 (#942)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/komga/README.md
+++ b/charts/komga/README.md
@@ -54,7 +54,7 @@ kubectl port-forward svc/<release>-komga 25600:80
 
 ## Upgrade Notes
 
-Komga `1.25.0` adds support for solid RAR4 archives, enforces Kobo content
+Komga `1.26.1` adds a beta NextUI, native RAR5 support, and referential API v2 while preserving Kobo content
 restrictions more consistently, flattens hierarchical OpenAPI schemas, and
 updates application dependencies including Spring Boot. Back up the `/config`
 PVC before upgrading because Komga stores its SQLite databases there.
@@ -105,7 +105,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/gotson/komga` | Image repository |
-| `image.tag` | `"1.25.0"` | Image tag |
+| `image.tag` | `"1.26.1"` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### Komga Configuration

--- a/charts/komga/templates/NOTES.txt
+++ b/charts/komga/templates/NOTES.txt
@@ -1,7 +1,7 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 Komga has been deployed.
 
-Access:
+1. Access
 
   Internal service:
     http://{{ include "komga.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
@@ -24,11 +24,11 @@ Access:
 {{- end }}
 {{- end }}
 
-Storage:
+2. Storage
   Config/database volume: {{ if .Values.persistence.config.enabled }}persistent{{ else }}ephemeral{{ end }}
   Library volume: {{ if .Values.persistence.data.enabled }}persistent{{ else }}ephemeral{{ end }}
 
-Runtime:
+3. Runtime
   Timezone: {{ .Values.komga.timezone }}
   Context path: {{ .Values.komga.contextPath }}
   Session timeout: {{ .Values.komga.sessionTimeout }}
@@ -37,7 +37,7 @@ Runtime:
   Java options: {{ $javaToolOptions }}
 {{- end }}
 
-Backup:
+4. Backup
 {{- if .Values.backup.enabled }}
   CronJob enabled on schedule {{ .Values.backup.schedule }}.
   Target bucket: {{ .Values.backup.s3.bucket }}
@@ -46,7 +46,7 @@ Backup:
   Disabled. Enable backup.enabled and configure backup.s3 for S3-compatible backups.
 {{- end }}
 
-Next steps:
+5. Next steps
   1. Open Komga and create the first admin account.
   2. Add libraries that point to subdirectories under /data.
   3. For production, set resource requests and limits and verify backups.

--- a/charts/komga/templates/_helpers.tpl
+++ b/charts/komga/templates/_helpers.tpl
@@ -43,6 +43,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
 {{- end -}}
 
+{{- define "komga.validate" -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hosts) -}}
+{{- fail "ingress.enabled requires at least one ingress.hosts entry" -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (not .Values.gateway.parentRefs) -}}
+{{- fail "gateway.enabled requires at least one gateway.parentRefs entry" -}}
+{{- end -}}
+{{- if and .Values.backup.enabled (not .Values.backup.s3.bucket) -}}
+{{- fail "backup.enabled requires backup.s3.bucket" -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Config PVC claim name */}}
 {{- define "komga.configClaimName" -}}
 {{- if .Values.persistence.config.existingClaim -}}

--- a/charts/komga/templates/validate.yaml
+++ b/charts/komga/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "komga.validate" . -}}

--- a/charts/komga/tests/deployment_test.yaml
+++ b/charts/komga/tests/deployment_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/gotson/komga:1.25.0"
+          value: "docker.io/gotson/komga:1.26.1"
 
   - it: should set container port to 25600
     asserts:

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Komga image repository
   repository: docker.io/gotson/komga
   # -- Komga image tag
-  tag: "1.25.0"
+  tag: "1.26.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the official Komga image from `1.25.0` to `1.26.1`
- align metadata, tests, README defaults, and upgrade guidance
- bring the touched chart to zero template-standard warnings with numbered NOTES sections and centralized values validation

## Upstream evidence

- 1.26.0 release: https://github.com/gotson/komga/releases/tag/1.26.0
- 1.26.1 release: https://github.com/gotson/komga/releases/tag/1.26.1
- Manifest: `docker.io/gotson/komga:1.26.1` supports `linux/amd64`, `linux/arm`, and `linux/arm64`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| Beta NextUI and referential API v2 | Existing HTTP service | `default` |
| Native Java RAR5 support and removal of libarchive | No Kubernetes dependency or mount change | `default` startup and HTTP smoke |
| Configuration escaping and NextUI CSS fixes | No values contract migration | `default` |

Only `default` is selected because ports, `/config` and `/data` mounts, probes, and required environment variables remain unchanged. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=docker.io/gotson/komga:1.26.1 JSON=1`
- `make deps-check CHART=komga`
- `make validate-chart CHART=komga K3D_SCENARIOS="default"` — 10 layers passed, including behavioral k3d validation
- `make standards-check CHART=komga`
- `node scripts/charts/template-standards-check.js --chart komga` — zero warnings
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Related site update: helmforgedev/site#496

Resolves #942
