### PR TITLE
chore(langflow): bump langflow to 1.11.2

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.1.0
-appVersion: "1.11.1"
+appVersion: "1.11.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 1.11.1 (#869)"
+      description: "upgrade to 1.11.2 (#943)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,11 +1,11 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.1` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.2` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
 
 Langflow 1.11 adds native v2 workflow execution, trusted JWT authentication with just-in-time user mapping, RBAC-aware interfaces, A2A and
-human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.1 also includes upstream fixes for authentication,
+human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.2 also includes upstream fixes for authentication,
 tracing, MCP, SSRF protections, and component loading. Advanced runtime settings for these capabilities can be supplied through `app.env` or
 `app.envFrom`.
 

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.11.1
+          value: docker.io/langflowai/langflow:1.11.2
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.11.1" },
+        "tag": { "type": "string", "default": "1.11.2" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.11.1"
+  tag: "1.11.2"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official Langflow image from `1.11.1` to `1.11.2`
- align metadata, schema, tests, and README

## Upstream evidence

- Release: https://github.com/langflow-ai/langflow/releases/tag/v1.11.2
- Compare: https://github.com/langflow-ai/langflow/compare/v1.11.1...v1.11.2
- Manifest: `docker.io/langflowai/langflow:1.11.2` supports `linux/amd64` and `linux/arm64`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| Writable Docker runtime home fix | Container startup and persisted local state | `default` |
| SQLite locking and startup import fixes | Default SQLite lifecycle | `default` |
| Authentication, SSRF, MCP, and authorization fixes | No values contract change | `default` HTTP health smoke |

Only `default` is selected because it directly exercises the changed Docker home and SQLite path; external database, Gateway, and ingress contracts are unchanged. Static validation still renders every CI profile.

## Validation

- `make image-verify IMAGE=docker.io/langflowai/langflow:1.11.2 JSON=1`
- `make deps-check CHART=langflow`
- `make validate-chart CHART=langflow K3D_SCENARIOS="default"` — 10 layers passed, including behavioral k3d validation
- `make standards-check CHART=langflow`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Related site update: helmforgedev/site#497

Resolves #943
