### PR TITLE
chore(minecraft): bump server image to 2026.8.0

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.5.0
-appVersion: "2026.7.2"
+appVersion: "2026.8.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 2026.7.2 (#871)"
+      description: "upgrade to 2026.8.0 (#945)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/DESIGN.md
+++ b/charts/minecraft/DESIGN.md
@@ -5,7 +5,7 @@
 This chart deploys Minecraft Java Edition servers using the official community-standard
 `docker.io/itzg/minecraft-server` image. It supports vanilla, Paper, Forge, Fabric, Quilt, Geyser/Floodgate cross-play,
 RCON operations, persistent worlds, metrics, External Secrets, and S3-compatible backups.
-The 2026.7.2 runtime also exposes IPv6 stack preference, a replaceable process
+The 2026.8.0 runtime also exposes IPv6 stack preference, a replaceable process
 runner, and layered generic packs distributed as OCI artifacts.
 
 ## Architecture

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -257,7 +257,7 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.7.2` adds native `PREFER_IPv6` and
+`docker.io/itzg/minecraft-server:2026.8.0` adds GTNH daily-build support, Java 25 knockd fixes, and retains native `PREFER_IPv6` and
 custom `SERVER_RUNNER` support, moves Vanilla installation to
 `mc-image-helper`, adds OCI generic-pack references, and includes GTNH,
 CurseForge HTTP, Java 17 compatibility, and dependency fixes. Configure the

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.7.2
+          value: docker.io/itzg/minecraft-server:2026.8.0
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.7.2
+          value: docker.io/itzg/minecraft-server:2026.8.0
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.7.2
+          value: docker.io/itzg/minecraft-server:2026.8.0
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.7.2
+          value: docker.io/itzg/minecraft-server:2026.8.0
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.7.2"
+          "default": "2026.8.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -645,7 +645,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.7.2"
+              "default": "docker.io/itzg/minecraft-server:2026.8.0"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.7.2"
+  tag: "2026.8.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -387,7 +387,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.7.2
+    worker: docker.io/itzg/minecraft-server:2026.8.0
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
## Summary

- bump the official Minecraft server and backup worker image from `2026.7.2` to `2026.8.0`
- align metadata, schema, tests, design notes, and README

## Upstream evidence

- Release: https://github.com/itzg/docker-minecraft-server/releases/tag/2026.8.0
- Compare: https://github.com/itzg/docker-minecraft-server/compare/2026.7.2...2026.8.0
- Manifests verified for `2026.8.0`, `2026.8.0-java21`, and `2026.8.0-java17`

| Upstream change | Chart impact | k3d coverage |
| --- | --- | --- |
| GTNH daily-build support and Java 25 knockd changes | Main server startup | `default` |
| mc-image-helper and mc-monitor updates | Runtime health and helper operations | `default` |
| Backup worker uses the same updated image | Backup CronJob image contract | `ci/backup-values.yaml` |

Other server-type profiles are unaffected by the changelog and remain covered by static rendering.

## Validation

- image manifests verified for default, Java 21, and Java 17 variants
- `make deps-check CHART=minecraft`
- `make validate-chart CHART=minecraft K3D_SCENARIOS="default ci/backup-values.yaml"` — 11 layers passed, including both behavioral k3d scenarios
- `make standards-check CHART=minecraft`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

Related site update: helmforgedev/site#498

Resolves #945
