### PR TITLE
chore(netbird): bump image to 0.76.3

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -4,7 +4,7 @@ name: netbird
 description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
 type: application
 version: 1.0.4
-appVersion: "0.76.1"
+appVersion: "0.76.3"
 home: https://helmforge.dev/docs/charts/netbird
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/netbird
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.76.1 (#922)"
+      description: "bump image to 0.76.3 (#948)"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -4,7 +4,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 
 This chart packages the current upstream combined architecture:
 
-- `netbirdio/netbird-server:0.76.1` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/netbird-server:0.76.3` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.3` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
@@ -110,7 +110,7 @@ Use `externalSecrets.items[]` to synchronize sensitive values such as `config.ya
 Local security scan:
 
 ```text
-Image: netbirdio/netbird-server:0.76.1
+Image: netbirdio/netbird-server:0.76.3
 Image: netbirdio/dashboard:v2.90.3
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 86.86869 compliance score
@@ -121,11 +121,12 @@ repository security gate. Remaining findings are tracked as hardening trade-offs
 for optional NetworkPolicy enablement, upstream dashboard startup model, and
 operator-owned resource limit tuning across the database-backed topology.
 
-## Upgrade from 0.75.0
+## Upgrade from 0.76.1
 
-NetBird `0.76.1` adds management-owned LLM pricing data and requires management
-and proxy components to move together. The chart's combined server image keeps
-those components on the same version. It also includes client and proxy fixes.
+NetBird `0.76.3` includes management fixes for posture-check caching, user update
+propagation, reverse-proxy authorization, and agent-network group references.
+The chart's combined server image keeps management, signal, relay, and proxy
+components on the same version.
 
 Back up the configured database and `/var/lib/netbird`, then apply the new chart
 defaults while preserving your explicit overrides:
@@ -139,7 +140,7 @@ helm upgrade netbird helmforge/netbird \
 ```
 
 Using `--reuse-values` alone retains the previous default image tag. Remove any
-explicit `server.image.tag` override if you want the chart default `0.76.1`.
+explicit `server.image.tag` override if you want the chart default `0.76.3`.
 
 ## Validation
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -134,7 +134,6 @@ defaults while preserving your explicit overrides:
 ```bash
 helm repo update helmforge
 helm upgrade netbird helmforge/netbird \
-  --version 1.0.3 \
   --namespace netbird \
   --reset-then-reuse-values
 ```

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/netbird-server:0.76.1
+          value: netbirdio/netbird-server:0.76.3
         template: templates/deployment.yaml
         documentIndex: 0
   - it: renders the official pinned dashboard image

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -14,7 +14,7 @@ server:
     # -- Official NetBird server container image repository.
     repository: netbirdio/netbird-server
     # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
-    tag: "0.76.1"
+    tag: "0.76.3"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of NetBird server pods. Keep 1 with the default sqlite store.


### PR DESCRIPTION
## Summary

- bump the official `netbirdio/netbird-server` image from `0.76.1` to `0.76.3`
- update chart metadata, tests, and upgrade guidance
- keep management, signal, relay, and proxy components aligned on the combined server image

## Upstream review

| Release | Status | Relevant changes |
|---|---|---|
| `0.76.2` | Stable | management agent-network fixes, group-reference integrity, self-hosted session-key setup |
| `0.76.3` | Stable | posture-check cache warmup, user update propagation, reverse-proxy authorization fixes |

Upstream releases: https://github.com/netbirdio/netbird/releases/tag/v0.76.2 and https://github.com/netbirdio/netbird/releases/tag/v0.76.3

## Validation

- image manifest verified for `netbirdio/netbird-server:0.76.3`
- dependency policy: pass
- chart standards: pass
- template standards: pass
- `make validate-chart CHART=netbird`: pass, 19 layers
- k3d behavioral validation: default plus all 9 CI profiles passed; workloads ready, endpoints populated, no restarts, crash terminations, or fatal log patterns
- site scan: no stale `0.76.1` references; no companion site PR required

Resolves #948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the NetBird Helm chart to version 0.76.3.
  * Updated the default server image to 0.76.3.
  * Revised upgrade guidance and security scan references for the new release.
  * Updated chart validation expectations to match the latest image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->