### PR TITLE
chore(notediscovery): bump image to 0.30.1

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.1.1
-appVersion: "0.30.0"
+appVersion: "0.30.1"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.30.0 (#924)"
+      description: "bump image to 0.30.1 (#949)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.30.0` image.
+official `ghcr.io/gamosoft/notediscovery:0.30.1` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.30.0` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.30.1` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -151,7 +151,8 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.30.0` serves browser libraries locally, adds cache-safe asset
+NoteDiscovery `0.30.1` adds interactive task checkboxes while retaining the
+locally served browser libraries and cache-safe asset
 versioning, gzip and conditional responses, and fixes first-load Mermaid
 rendering. Releases 0.29.x also correct share-link schemes behind reverse
 proxies and raise normal editing rate limits.

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.30.0
+          value: ghcr.io/gamosoft/notediscovery:0.30.1
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -24,7 +24,7 @@ tests:
           value: plugin-bootstrap
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.30.0
+          value: ghcr.io/gamosoft/notediscovery:0.30.1
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "if \\[ -d /app/plugins \\]"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.30.0", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.30.1", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.30.0"
+  tag: "0.30.1"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official `ghcr.io/gamosoft/notediscovery` image from `0.30.0` to `0.30.1`
- update chart metadata, schema defaults, tests, design notes, and upgrade guidance

## Upstream review

NoteDiscovery 0.30.1 is a stable release that adds interactive task-checkbox toggling. No breaking configuration or storage changes are documented.

Upstream release: https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.30.1

## Validation

- image manifest verified for `ghcr.io/gamosoft/notediscovery:0.30.1`
- dependency, chart, and template standards: pass
- `make validate-chart CHART=notediscovery`: pass, 20 layers
- k3d behavioral validation: default plus all 10 CI profiles passed; workloads ready, endpoints populated, no restarts, crash terminations, fatal logs, or warning events
- site scan: no NoteDiscovery `0.30.0` reference; no companion site PR required

Resolves #949