### PR TITLE
chore(ntfy): bump image to 2.27.0

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -4,7 +4,7 @@ name: ntfy
 description: ntfy self-hosted push notification service with HTTP-based pub-sub
 type: application
 version: 1.2.0
-appVersion: "v2.26.3"
+appVersion: "v2.27.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 2.26.3 (#878)"
+      description: "upgrade to 2.27.0 (#950)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ntfy/templates/_helpers.tpl
+++ b/charts/ntfy/templates/_helpers.tpl
@@ -3,6 +3,16 @@
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/* Validate chart values before rendering resources. */}}
+{{- define "ntfy.validate" -}}
+{{- if and .Values.ntfy.database.enabled (empty .Values.ntfy.database.existingSecret) -}}
+{{- fail "ntfy.database.enabled requires ntfy.database.existingSecret" -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) -}}
+{{- fail "externalSecrets.items must contain at least one item when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "ntfy.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}

--- a/charts/ntfy/templates/deployment.yaml
+++ b/charts/ntfy/templates/deployment.yaml
@@ -52,9 +52,6 @@ spec:
               protocol: TCP
           env:
             {{- if .Values.ntfy.database.enabled }}
-            {{- if not .Values.ntfy.database.existingSecret }}
-            {{- fail "ntfy.database.enabled requires ntfy.database.existingSecret" }}
-            {{- end }}
             - name: NTFY_DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/charts/ntfy/templates/validate.yaml
+++ b/charts/ntfy/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "ntfy.validate" . -}}

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -3,6 +3,7 @@ suite: Deployment
 templates:
   - templates/deployment.yaml
   - templates/configmap.yaml
+  - templates/validate.yaml
 release:
   name: test
   namespace: default
@@ -28,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/binwiederhier/ntfy:v2.26.3"
+          value: "docker.io/binwiederhier/ntfy:v2.27.0"
 
   - it: should pass serve argument
     template: templates/deployment.yaml
@@ -119,7 +120,7 @@ tests:
                 key: database-url
 
   - it: should reject PostgreSQL without an existing Secret
-    template: templates/deployment.yaml
+    template: templates/validate.yaml
     set:
       ntfy.database.enabled: true
       ntfy.database.existingSecret: ""

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
   # -- Image tag
-  tag: "v2.26.3"
+  tag: "v2.27.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump the official `binwiederhier/ntfy` image from `v2.26.3` to `v2.27.0`
- centralize chart value validation in the standard `ntfy.validate` helper
- preserve the existing abuse ban-feed contract and PostgreSQL profile

## Upstream review

ntfy 2.27.0 is stable. It hardens message-template resource limits, removes secrets from the web config hash, adds verified-email login, fixes Twilio errors and SQLite migration integrity, and graduates PostgreSQL support from experimental.

Upstream release: https://github.com/binwiederhier/ntfy/releases/tag/v2.27.0

## Validation

- image manifest verified for `binwiederhier/ntfy:v2.27.0`
- dependency, chart, and template standards: pass with zero template warnings
- full initial gate: pass, 17 layers and all 8 k3d profiles
- post-validation-helper gate: pass, 11 layers with default and PostgreSQL k3d profiles
- workloads ready, endpoints populated, no restarts, crash terminations, fatal logs, or warning events
- companion site PR: https://github.com/helmforgedev/site/pull/499

Resolves #950
