### PR TITLE
chore(poznote): bump image to 6.57.1

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.1.1
-appVersion: "6.51.0"
+appVersion: "6.57.1"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 6.51.0 (#926)"
+      description: "bump image to 6.57.1 (#951)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.51.0
+ghcr.io/timothepoznanski/poznote:6.57.1
 ```
 
-The tag maps to the upstream `6.51.0` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.57.1` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.51.0-rootless` variant. It is not the chart
+Upstream also publishes a `6.57.1-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.51.0` |
+| `image.tag` | Image tag | `6.57.1` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -141,10 +141,10 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.51.0` adds multiple diaries per workspace, checklist conversion for
-HTML notes, per-user Markdown colors, and pinned settings cards. It also removes
-fixed container names from upstream Compose examples, which does not affect the
-Kubernetes workload.
+Poznote `6.57.1` adds user webhooks, tenant-isolation controls, task management,
+optional S3 attachment and backup storage, an administrator activity log, and
+safer account deletion. The default local SQLite and filesystem deployment
+remains compatible; S3 integration is configured inside Poznote when needed.
 
 No upstream storage migration is required. Back up the `data` PVC before
 upgrading because it stores the SQLite database, notes, attachments, and

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.51.0"
+          value: "ghcr.io/timothepoznanski/poznote:6.57.1"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.51.0"
+  tag: "6.57.1"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official `ghcr.io/timothepoznanski/poznote` image from `6.51.0` to `6.57.1`
- update chart metadata, tests, design notes, and upgrade guidance
- retain the standard image while documenting the verified matching rootless variant

## Upstream review

Reviewed stable releases 6.52.0 through 6.57.1. Highlights include user webhooks, tenant isolation, task management, optional S3 attachment/backup storage, activity logging, and safer account deletion. No required change to the chart's default local SQLite/filesystem contract is documented.

Upstream releases: https://github.com/timothepoznanski/poznote/releases

## Validation

- manifests verified for `6.57.1` and `6.57.1-rootless` (the chart retains the standard image)
- dependency, chart, and template standards: pass
- `make validate-chart CHART=poznote K3D_SCENARIOS=default`: pass, 10 layers
- k3d workload ready, endpoint populated, no restarts, crash terminations, fatal logs, or warning events
- site scan: no stale `6.51.0` reference; no companion site PR required

Resolves #951