### PR TITLE
chore(qdrant): bump image to 1.19.0

### DIFF
--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -4,7 +4,7 @@ name: qdrant
 description: Qdrant vector database
 type: application
 version: 1.0.3
-appVersion: "1.18.3"
+appVersion: "1.19.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/qdrant.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "update to 1.18.3 (#827)"
+      description: "update to 1.19.0 (#952)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/qdrant/README.md
+++ b/charts/qdrant/README.md
@@ -2,7 +2,7 @@
 
 Qdrant is a vector database and similarity search engine for embeddings, payload filters, semantic search, retrieval-augmented generation,
 recommendation, and matching workloads.
-This HelmForge chart deploys the official `docker.io/qdrant/qdrant:v1.18.3` image with persistent storage, HTTP and gRPC services,
+This HelmForge chart deploys the official `docker.io/qdrant/qdrant:v1.19.0` image with persistent storage, HTTP and gRPC services,
 optional API key authentication, snapshot storage, Prometheus scraping, and guarded distributed-mode settings.
 
 ## Install

--- a/charts/qdrant/tests/templates_test.yaml
+++ b/charts/qdrant/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/qdrant/qdrant:v1.18.3
+          value: docker.io/qdrant/qdrant:v1.19.0
   - it: renders service
     template: templates/service.yaml
     asserts:

--- a/charts/qdrant/values.schema.json
+++ b/charts/qdrant/values.schema.json
@@ -13,7 +13,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/qdrant/qdrant" },
-        "tag": { "type": "string", "default": "v1.18.3" },
+        "tag": { "type": "string", "default": "v1.19.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official Qdrant image repository.
   repository: docker.io/qdrant/qdrant
   # -- Official Qdrant image tag. Do not use a floating tag.
-  tag: "v1.18.3"
+  tag: "v1.19.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the official `qdrant/qdrant` image from `v1.18.3` to `v1.19.0`
- update chart metadata, schema defaults, tests, and documentation

## Upstream review

Qdrant 1.19.0 is stable. The release adds memory tiers, TurboQuant storage, quotas and read-affinity routing, while changing storage defaults and fixing consensus reinitialization, resharding, WAL recovery, readiness, snapshots, and a path-traversal vulnerability in S3 snapshots.

Upstream release: https://github.com/qdrant/qdrant/releases/tag/v1.19.0

## Validation

- image manifest verified for `qdrant/qdrant:v1.19.0`
- dependency, chart, and template standards: pass
- `make validate-chart CHART=qdrant K3D_SCENARIOS="default ci/cluster-values.yaml"`: pass, 11 layers
- standalone and three-node distributed workloads ready; endpoints populated; no restarts, crash terminations, fatal logs, or warning events
- companion site PR: https://github.com/helmforgedev/site/pull/500

Resolves #952
