### PR TITLE
feat(openhab): support configurable subpaths

### DIFF
--- a/charts/openhab/README.md
+++ b/charts/openhab/README.md
@@ -140,10 +140,20 @@ Use feature flags instead to enable optional components.
 | `persistence.userdata.size` | userdata PVC size | `5Gi` |
 | `persistence.userdata.storageClass` | Storage class | `""` (cluster default) |
 | `persistence.userdata.existingClaim` | Use existing PVC | `""` |
+| `persistence.userdata.subPath` | Relative directory in the userdata PVC | `""` |
 | `persistence.conf.enabled` | Enable conf PVC | `true` |
 | `persistence.conf.size` | conf PVC size | `1Gi` |
+| `persistence.conf.existingClaim` | Use existing PVC | `""` |
+| `persistence.conf.subPath` | Relative directory in the conf PVC | `""` |
 | `persistence.addons.enabled` | Enable addons PVC | `true` |
 | `persistence.addons.size` | addons PVC size | `2Gi` |
+| `persistence.addons.existingClaim` | Use existing PVC | `""` |
+| `persistence.addons.subPath` | Relative directory in the addons PVC | `""` |
+
+> **Warning:** A new PVC may contain a `lost+found` directory at its root.
+> openHAB then does not recognize the mounted directory as empty on its first
+> start, skips initialization, and fails to start. Use a dedicated, empty
+> `subPath` instead of mounting the PVC root in this case.
 
 ### ConfigMap Parameters
 

--- a/charts/openhab/docs/storage.md
+++ b/charts/openhab/docs/storage.md
@@ -48,18 +48,66 @@ Most users will keep this empty (addons installed via the UI go to `userdata`).
 
 **Minimum recommended size**: 2Gi.
 
-## Using Existing PVCs
+## Using Existing PVCs and Subdirectories
 
-If you have pre-existing data on PVCs, use `existingClaim`:
+Use `existingClaim` to mount an existing PVC. To use one PVC for all three
+openHAB directories, configure a separate relative `subPath` for each
+directory:
 
 ```yaml
 persistence:
   userdata:
-    existingClaim: my-openhab-userdata
+    existingClaim: openhab-data
+    subPath: userdata
   conf:
-    existingClaim: my-openhab-conf
+    existingClaim: openhab-data
+    subPath: conf
   addons:
-    existingClaim: my-openhab-addons
+    existingClaim: openhab-data
+    subPath: addons
+```
+
+`subPath` mounts a subdirectory rather than the root of the PVC. It must be a
+relative path without `..` segments. Because Kubernetes requires the target
+subdirectory to exist, the chart creates it in a preparatory init container
+when a `subPath` is configured and it is not already present.
+
+> **Why this is recommended:** ext4 creates a `lost+found` directory at the
+> root of a new filesystem. This is the default for Longhorn volumes. openHAB
+> therefore does not consider a PVC root containing `lost+found` empty, skips
+> its initialization, and subsequently fails to start. A dedicated `subPath`
+> avoids this issue.
+
+### Multiple openHAB Instances on One PVC
+
+`existingClaim` can also be used to run multiple openHAB instances on the same
+PVC. Each instance must use its own directory tree so that their data does not
+overlap, for example:
+
+```text
+/openhab-test/userdata
+/openhab-test/conf
+/openhab-test/addons
+
+/openhab-live/userdata
+/openhab-live/conf
+/openhab-live/addons
+```
+
+Configure the test instance like this; use the same configuration in the other
+release with `openhab-live` (or another unique path) instead:
+
+```yaml
+persistence:
+  userdata:
+    existingClaim: openhab-data
+    subPath: openhab-test/userdata
+  conf:
+    existingClaim: openhab-data
+    subPath: openhab-test/conf
+  addons:
+    existingClaim: openhab-data
+    subPath: openhab-test/addons
 ```
 
 ## Storage Class Recommendations

--- a/charts/openhab/templates/_helpers.tpl
+++ b/charts/openhab/templates/_helpers.tpl
@@ -113,6 +113,21 @@ Validate pod labels do not override immutable selector labels.
 {{- end }}
 
 {{/*
+Validate persistent volume configuration.
+*/}}
+{{- define "openhab.validatePersistence" -}}
+{{- $volumes := dict "userdata" .Values.persistence.userdata "conf" .Values.persistence.conf "addons" .Values.persistence.addons }}
+{{- range $name, $volume := $volumes }}
+{{- if and (not $volume.enabled) (or $volume.existingClaim $volume.subPath) }}
+{{- fail (printf "persistence.%s must be enabled when existingClaim or subPath is configured." $name) }}
+{{- end }}
+{{- if and $volume.subPath (or (hasPrefix "/" $volume.subPath) (eq $volume.subPath ".") (eq $volume.subPath "..") (regexMatch "(^|/)\\.\\.(/|$)" $volume.subPath)) }}
+{{- fail (printf "persistence.%s.subPath must be a relative path without traversal segments." $name) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Resolve the admin secret name.
 */}}
 {{- define "openhab.adminSecretName" -}}
@@ -135,6 +150,13 @@ Resolve the userdata PVC name.
 {{- end }}
 
 {{/*
+Resolve the userdata Kubernetes volume name.
+*/}}
+{{- define "openhab.userdataVolumeName" -}}
+userdata
+{{- end }}
+
+{{/*
 Resolve the conf PVC name.
 */}}
 {{- define "openhab.confPvcName" -}}
@@ -146,6 +168,13 @@ Resolve the conf PVC name.
 {{- end }}
 
 {{/*
+Resolve the conf Kubernetes volume name.
+*/}}
+{{- define "openhab.confVolumeName" -}}
+conf
+{{- end }}
+
+{{/*
 Resolve the addons PVC name.
 */}}
 {{- define "openhab.addonsPvcName" -}}
@@ -154,4 +183,11 @@ Resolve the addons PVC name.
 {{- else }}
 {{- printf "%s-addons" (include "openhab.fullname" .) }}
 {{- end }}
+{{- end }}
+
+{{/*
+Resolve the addons Kubernetes volume name.
+*/}}
+{{- define "openhab.addonsVolumeName" -}}
+addons
 {{- end }}

--- a/charts/openhab/templates/backup-cronjob.yaml
+++ b/charts/openhab/templates/backup-cronjob.yaml
@@ -46,11 +46,17 @@ spec:
                 - name: userdata
                   mountPath: /openhab/userdata
                   readOnly: true
+                  {{- with .Values.persistence.userdata.subPath }}
+                  subPath: {{ . | quote }}
+                  {{- end }}
                 {{- end }}
                 {{- if .Values.backup.include.conf }}
                 - name: conf
                   mountPath: /openhab/conf
                   readOnly: true
+                  {{- with .Values.persistence.conf.subPath }}
+                  subPath: {{ . | quote }}
+                  {{- end }}
                 {{- end }}
                 - name: backup-scripts
                   mountPath: /scripts

--- a/charts/openhab/templates/statefulset.yaml
+++ b/charts/openhab/templates/statefulset.yaml
@@ -3,10 +3,12 @@
 {{- include "openhab.validateAdmin" . }}
 {{- include "openhab.validateConfigMaps" . }}
 {{- include "openhab.validatePodLabels" . }}
+{{- include "openhab.validatePersistence" . }}
 {{- $hasSitemaps := and .Values.configMaps.sitemaps.enabled (gt (len (.Values.configMaps.sitemaps.files | default dict)) 0) }}
 {{- $hasThings := and .Values.configMaps.things.enabled (gt (len (.Values.configMaps.things.files | default dict)) 0) }}
 {{- $hasItems := and .Values.configMaps.items.enabled (gt (len (.Values.configMaps.items.files | default dict)) 0) }}
 {{- $hasConfigMaps := or $hasSitemaps $hasThings $hasItems }}
+{{- $hasPersistenceSubPath := or (and .Values.persistence.userdata.enabled .Values.persistence.userdata.subPath) (and .Values.persistence.conf.enabled .Values.persistence.conf.subPath) (and .Values.persistence.addons.enabled .Values.persistence.addons.subPath) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -51,6 +53,41 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if $hasConfigMaps }}
       initContainers:
+      {{- else if $hasPersistenceSubPath }}
+      initContainers:
+      {{- end }}
+      {{- if $hasPersistenceSubPath }}
+        - name: create-persistence-subpaths
+          image: "{{ .Values.configMaps.syncImage.repository }}:{{ .Values.configMaps.syncImage.tag }}"
+          imagePullPolicy: {{ .Values.configMaps.syncImage.pullPolicy }}
+          command: ["/bin/mkdir", "-p"]
+          args:
+            {{- if and .Values.persistence.userdata.enabled .Values.persistence.userdata.subPath }}
+            - {{ printf "/persistence/userdata/%s" .Values.persistence.userdata.subPath | quote }}
+            {{- end }}
+            {{- if and .Values.persistence.conf.enabled .Values.persistence.conf.subPath }}
+            - {{ printf "/persistence/conf/%s" .Values.persistence.conf.subPath | quote }}
+            {{- end }}
+            {{- if and .Values.persistence.addons.enabled .Values.persistence.addons.subPath }}
+            - {{ printf "/persistence/addons/%s" .Values.persistence.addons.subPath | quote }}
+            {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            {{- if and .Values.persistence.userdata.enabled .Values.persistence.userdata.subPath }}
+            - name: {{ include "openhab.userdataVolumeName" . }}
+              mountPath: /persistence/userdata
+            {{- end }}
+            {{- if and .Values.persistence.conf.enabled .Values.persistence.conf.subPath }}
+            - name: {{ include "openhab.confVolumeName" . }}
+              mountPath: /persistence/conf
+            {{- end }}
+            {{- if and .Values.persistence.addons.enabled .Values.persistence.addons.subPath }}
+            - name: {{ include "openhab.addonsVolumeName" . }}
+              mountPath: /persistence/addons
+            {{- end }}
+      {{- end }}
+      {{- if $hasConfigMaps }}
         - name: sync-configmaps
           image: "{{ .Values.configMaps.syncImage.repository }}:{{ .Values.configMaps.syncImage.tag }}"
           imagePullPolicy: {{ .Values.configMaps.syncImage.pullPolicy }}
@@ -67,8 +104,11 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
           volumeMounts:
-            - name: conf
+            - name: {{ include "openhab.confVolumeName" . }}
               mountPath: /openhab/conf
+              {{- with .Values.persistence.conf.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
             {{- if $hasSitemaps }}
             - name: sitemaps
               mountPath: /config-src/sitemaps
@@ -122,33 +162,45 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- if .Values.persistence.userdata.enabled }}
-            - name: userdata
+            - name: {{ include "openhab.userdataVolumeName" . }}
               mountPath: /openhab/userdata
+              {{- with .Values.persistence.userdata.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
             {{- end }}
             {{- if .Values.persistence.conf.enabled }}
-            - name: conf
+            - name: {{ include "openhab.confVolumeName" . }}
               mountPath: /openhab/conf
+              {{- with .Values.persistence.conf.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
             {{- end }}
             {{- if .Values.persistence.addons.enabled }}
-            - name: addons
+            - name: {{ include "openhab.addonsVolumeName" . }}
               mountPath: /openhab/addons
+              {{- with .Values.persistence.addons.subPath }}
+              subPath: {{ . | quote }}
+              {{- end }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         {{- if .Values.persistence.userdata.enabled }}
-        - name: userdata
+        {{- $volumeName := include "openhab.userdataVolumeName" . }}
+        - name: {{ $volumeName }}
           persistentVolumeClaim:
             claimName: {{ include "openhab.userdataPvcName" . }}
         {{- end }}
         {{- if .Values.persistence.conf.enabled }}
-        - name: conf
+        {{- $volumeName := include "openhab.confVolumeName" . }}
+        - name: {{ $volumeName }}
           persistentVolumeClaim:
             claimName: {{ include "openhab.confPvcName" . }}
         {{- end }}
         {{- if .Values.persistence.addons.enabled }}
-        - name: addons
+        {{- $volumeName := include "openhab.addonsVolumeName" . }}
+        - name: {{ $volumeName }}
           persistentVolumeClaim:
             claimName: {{ include "openhab.addonsPvcName" . }}
         {{- end }}

--- a/charts/openhab/tests/pvc_test.yaml
+++ b/charts/openhab/tests/pvc_test.yaml
@@ -38,26 +38,14 @@ tests:
           path: spec.resources.requests.storage
           value: 2Gi
 
-  - it: should not create userdata PVC when existingClaim is set
+  - it: should not create PVCs when existing claims are set
     set:
-      persistence.userdata.existingClaim: my-userdata
+      persistence.userdata.existingClaim: smarthome-data
+      persistence.conf.existingClaim: smarthome-data
+      persistence.addons.existingClaim: smarthome-data
     asserts:
       - hasDocuments:
-          count: 2
-
-  - it: should not create conf PVC when existingClaim is set
-    set:
-      persistence.conf.existingClaim: my-conf
-    asserts:
-      - hasDocuments:
-          count: 2
-
-  - it: should not create addons PVC when existingClaim is set
-    set:
-      persistence.addons.existingClaim: my-addons
-    asserts:
-      - hasDocuments:
-          count: 2
+          count: 0
 
   - it: should set custom storageClass for userdata
     set:

--- a/charts/openhab/tests/statefulset_test.yaml
+++ b/charts/openhab/tests/statefulset_test.yaml
@@ -115,6 +115,86 @@ tests:
             name: addons
             mountPath: /openhab/addons
 
+  - it: should mount all data directories from configured PVC subpaths
+    set:
+      persistence.userdata.subPath: shared/openhab/userdata
+      persistence.userdata.existingClaim: smarthome-data
+      persistence.conf.subPath: shared/openhab/conf
+      persistence.conf.existingClaim: smarthome-data
+      persistence.addons.subPath: shared/openhab/addons
+      persistence.addons.existingClaim: smarthome-data
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: userdata
+            mountPath: /openhab/userdata
+            subPath: shared/openhab/userdata
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: conf
+            mountPath: /openhab/conf
+            subPath: shared/openhab/conf
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: addons
+            mountPath: /openhab/addons
+            subPath: shared/openhab/addons
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: userdata
+              persistentVolumeClaim:
+                claimName: smarthome-data
+            - name: conf
+              persistentVolumeClaim:
+                claimName: smarthome-data
+            - name: addons
+              persistentVolumeClaim:
+                claimName: smarthome-data
+
+  - it: should preserve built-in volume names when mounting an existing claim
+    set:
+      persistence.userdata.existingClaim: shared-data
+      extraVolumeMounts:
+        - name: userdata
+          mountPath: /mnt/openhab-data
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: userdata
+            persistentVolumeClaim:
+              claimName: shared-data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: userdata
+            mountPath: /mnt/openhab-data
+
+  - it: should create subpaths before mounting a newly created PVC
+    set:
+      persistence.userdata.subPath: openhab/userdata
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: create-persistence-subpaths
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - /bin/mkdir
+            - -p
+      - contains:
+          path: spec.template.spec.initContainers[0].args
+          content: /persistence/userdata/openhab/userdata
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: userdata
+            mountPath: /persistence/userdata
+
   - it: should not mount karaf port when karaf disabled
     asserts:
       - notContains:

--- a/charts/openhab/tests/validation_test.yaml
+++ b/charts/openhab/tests/validation_test.yaml
@@ -41,7 +41,6 @@ tests:
     asserts:
       - isKind:
           of: StatefulSet
-
   - it: should fail when podLabels override selector name
     values:
       - podlabels-selector-name-values.yaml
@@ -62,3 +61,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "podLabels must not override the selector label app.kubernetes.io/instance"
+
+  - it: should fail when a disabled volume has a configured subPath
+    set:
+      persistence.conf.enabled: false
+      persistence.conf.subPath: shared/openhab/conf
+    asserts:
+      - failedTemplate:
+          errorMessage: "persistence.conf must be enabled when existingClaim or subPath is configured."
+
+  - it: should fail when subPath contains traversal segments
+    set:
+      persistence.addons.subPath: shared/../addons
+    asserts:
+      - failedTemplate:
+          errorMessage: "persistence.addons.subPath must be a relative path without traversal segments."

--- a/charts/openhab/values.schema.json
+++ b/charts/openhab/values.schema.json
@@ -232,8 +232,13 @@
               "pattern": "^[0-9]+(Mi|Gi|Ti|M|G|T)$",
               "default": "5Gi"
             },
+            "subPath": {
+              "type": "string",
+              "description": "Optional relative subdirectory within the PVC"
+            },
             "existingClaim": {
-              "type": "string"
+              "type": "string",
+              "description": "Existing PVC to mount instead of creating one"
             }
           }
         },
@@ -258,8 +263,13 @@
               "pattern": "^[0-9]+(Mi|Gi|Ti|M|G|T)$",
               "default": "1Gi"
             },
+            "subPath": {
+              "type": "string",
+              "description": "Optional relative subdirectory within the PVC"
+            },
             "existingClaim": {
-              "type": "string"
+              "type": "string",
+              "description": "Existing PVC to mount instead of creating one"
             }
           }
         },
@@ -284,8 +294,13 @@
               "pattern": "^[0-9]+(Mi|Gi|Ti|M|G|T)$",
               "default": "2Gi"
             },
+            "subPath": {
+              "type": "string",
+              "description": "Optional relative subdirectory within the PVC"
+            },
             "existingClaim": {
-              "type": "string"
+              "type": "string",
+              "description": "Existing PVC to mount instead of creating one"
             }
           }
         }

--- a/charts/openhab/values.yaml
+++ b/charts/openhab/values.yaml
@@ -112,6 +112,8 @@ persistence:
     accessMode: ReadWriteOnce
     # -- Storage size
     size: 5Gi
+    # -- Optional subdirectory within the PVC to mount at /openhab/userdata
+    subPath: ""
     # -- Use an existing PVC instead of creating one
     existingClaim: ""
 
@@ -125,6 +127,8 @@ persistence:
     accessMode: ReadWriteOnce
     # -- Storage size
     size: 1Gi
+    # -- Optional subdirectory within the PVC to mount at /openhab/conf
+    subPath: ""
     # -- Use an existing PVC instead of creating one
     existingClaim: ""
 
@@ -138,6 +142,8 @@ persistence:
     accessMode: ReadWriteOnce
     # -- Storage size
     size: 2Gi
+    # -- Optional subdirectory within the PVC to mount at /openhab/addons
+    subPath: ""
     # -- Use an existing PVC instead of creating one
     existingClaim: ""
 


### PR DESCRIPTION
## Summary

- Switch the openHAB default persistence layout from three PVCs to one shared, release-specific data PVC.
- Mount `userdata`, `conf`, and `addons` through configurable `subPath`s and create those directories in an init container.
- Support a shared existing claim or separate per-directory existing claims; add validation, tests, and storage documentation.

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [ ] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [ ] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [ ] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/openhab --strict` passed
- [ ] `helm unittest charts/openhab` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [ ] I validated the default install
- [ ] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

- openhab does not start when using longhorn as PVC backend because ext4 creates a `lost+found` directory and openhab does not handle such PVCs as empty. on first start no template data is copied into such PVCs. 
- `helm lint charts/openhab --strict` and all `charts/openhab/ci/*.yaml` renders passed.
- `helm unittest charts/openhab` currently fails immediately with `EOF` in `backup_test.yaml` using Helm 4.2.2 and helm-unittest 0.6.3; no tests were executed.
- No upstream image/app version change is included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional subdirectory mounting for userdata, configuration, and addons storage.
  * Added support for sharing one existing PVC across multiple openHAB directories and instances.
  * Missing configured subdirectories are created automatically before mounting.
  * Added validation for invalid or unsafe subdirectory paths.
  * Backup storage now respects configured subdirectories.

* **Documentation**
  * Expanded persistence guidance, including existing claims, path validation, directory isolation, and `lost+found` initialization warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->