### PR TITLE
feat(envoy-gateway): support allowed listeners

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: ""
     condition: crds.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: Production-ready Envoy Gateway operator with Gateway API support, c
 type: application
 version: 1.9.0
 appVersion: "v1.8.3"
-kubeVersion: ">=1.24.0-0"
+kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
   - https://github.com/helmforgedev/charts

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -224,6 +224,7 @@ highAvailability:
 |-----|---------|-------------|
 | `gateway.create` | `true` | Create a default Gateway resource (triggers proxy provisioning) |
 | `gateway.name` | `""` | Gateway name (defaults to release name) |
+| `gateway.allowedListeners` | `{}` | ListenerSet namespace attachment policy; supports `None`, `Same`, `All`, and `Selector` |
 | `gateway.listeners.http.enabled` | `true` | Enable HTTP listener |
 | `gateway.listeners.http.port` | `80` | HTTP listener port |
 | `gateway.listeners.http.allowedRoutes` | `{}` | Route kinds and namespaces allowed to attach; empty uses the same-namespace Gateway API default |

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -254,6 +254,9 @@ affinity:
 Central fail-fast validation entrypoint.
 */}}
 {{- define "envoy-gateway.validate" -}}
+{{- if and .Values.redis.enabled (ne .Values.redis.architecture "standalone") -}}
+{{- fail "redis.architecture must be standalone when the bundled rate-limiting backend is enabled" -}}
+{{- end -}}
 {{- if and .Values.externalSecrets.enabled (not .Values.rateLimiting.externalRedis.auth.secretName) -}}
 {{- fail "externalSecrets.enabled requires rateLimiting.externalRedis.auth.secretName to be set to prevent credential drift between the chart-managed Secret and the ExternalSecret." -}}
 {{- end -}}

--- a/charts/envoy-gateway/templates/gateway.yaml
+++ b/charts/envoy-gateway/templates/gateway.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- include "envoy-gateway.labels" . | nindent 4 }}
 spec:
   gatewayClassName: {{ .Values.gatewayClass.name }}
+  {{- with .Values.gateway.allowedListeners }}
+  allowedListeners:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   listeners:
   {{- if .Values.gateway.listeners.http.enabled }}
   - name: http

--- a/charts/envoy-gateway/tests/gateway_test.yaml
+++ b/charts/envoy-gateway/tests/gateway_test.yaml
@@ -85,6 +85,36 @@ tests:
           path: spec.gatewayClassName
           value: my-class
 
+  - it: should allow ListenerSets from the Gateway namespace
+    set:
+      gateway:
+        allowedListeners:
+          namespaces:
+            from: Same
+    asserts:
+      - equal:
+          path: spec.allowedListeners.namespaces.from
+          value: Same
+
+  - it: should select ListenerSet namespaces by label
+    set:
+      gateway:
+        allowedListeners:
+          namespaces:
+            from: Selector
+            selector:
+              matchLabels:
+                shared-gateway-access: "true"
+    asserts:
+      - equal:
+          path: spec.allowedListeners.namespaces.selector.matchLabels.shared-gateway-access
+          value: "true"
+
+  - it: should omit allowedListeners by default
+    asserts:
+      - notExists:
+          path: spec.allowedListeners
+
   - it: should allow HTTP routes from all namespaces
     set:
       gateway:

--- a/charts/envoy-gateway/tests/validation_test.yaml
+++ b/charts/envoy-gateway/tests/validation_test.yaml
@@ -18,6 +18,15 @@ tests:
       - failedTemplate:
           errorMessage: "rateLimiting.enabled requires redis.enabled=true or rateLimiting.externalRedis.host to be set"
 
+  - it: should reject unsupported bundled Redis topologies
+    set:
+      redis:
+        enabled: true
+        architecture: sentinel
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis.architecture must be standalone when the bundled rate-limiting backend is enabled"
+
   - it: should reject external redis auth without secret
     set:
       rateLimiting:

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -795,7 +795,7 @@
       "type": "object",
       "description": "Default Gateway resource configuration",
       "additionalProperties": false,
-      "required": ["create", "name", "listeners"],
+      "required": ["create", "name", "allowedListeners", "listeners"],
       "properties": {
         "create": {
           "type": "boolean",
@@ -806,6 +806,9 @@
           "type": "string",
           "description": "Gateway name; defaults to the Helm release name",
           "default": ""
+        },
+        "allowedListeners": {
+          "$ref": "#/definitions/allowedListeners"
         },
         "listeners": {
           "type": "object",
@@ -877,6 +880,66 @@
     }
   },
   "definitions": {
+    "allowedListeners": {
+      "type": "object",
+      "description": "Gateway API constraints for ListenerSets attaching to the Gateway",
+      "additionalProperties": false,
+      "properties": {
+        "namespaces": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["from"],
+          "properties": {
+            "from": {
+              "type": "string",
+              "enum": ["All", "None", "Same", "Selector"]
+            },
+            "selector": {
+              "$ref": "#/definitions/labelSelector"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "from": { "const": "Selector" } },
+                "required": ["from"]
+              },
+              "then": { "required": ["selector"] },
+              "else": { "not": { "required": ["selector"] } }
+            }
+          ]
+        }
+      }
+    },
+    "labelSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "matchLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "matchExpressions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["key", "operator"],
+            "properties": {
+              "key": { "type": "string", "minLength": 1 },
+              "operator": {
+                "type": "string",
+                "enum": ["In", "NotIn", "Exists", "DoesNotExist"]
+              },
+              "values": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
     "allowedRoutes": {
       "type": "object",
       "description": "Gateway API constraints for Routes attaching to a listener",

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -935,7 +935,22 @@
                 "type": "array",
                 "items": { "type": "string" }
               }
-            }
+            },
+            "allOf": [
+              {
+                "if": {
+                  "properties": { "operator": { "enum": ["In", "NotIn"] } },
+                  "required": ["operator"]
+                },
+                "then": {
+                  "required": ["values"],
+                  "properties": { "values": { "minItems": 1 } }
+                },
+                "else": {
+                  "properties": { "values": { "maxItems": 0 } }
+                }
+              }
+            ]
           }
         }
       }

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -169,6 +169,8 @@ gateway:
   create: true
   # -- Name of the Gateway (defaults to release name)
   name: ""
+  # -- Controls which ListenerSets may attach to the Gateway (empty uses Gateway API None default)
+  allowedListeners: {}
   listeners:
     http:
       enabled: true


### PR DESCRIPTION
## Summary

- add configurable `gateway.allowedListeners` support for ListenerSet attachment
- validate `None`, `Same`, `All`, and `Selector` namespace policies
- update the Envoy Gateway Redis dependency to the current HelmForge 2.0.0 contract required by preflight

## Validation

- `make validate-chart CHART=envoy-gateway` — PASS, 20 layers including all 11 k3d scenarios
- `make standards-check CHART=envoy-gateway` — PASS
- `make preflight` — PASS

Site PR: helmforgedev/site#501

Resolves #971


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `gateway.allowedListeners` configuration to control which namespaces may attach ListenerSets.
  - Supports same-namespace, all-namespace, and label-selected namespace policies.
  - Added validation for listener namespace selectors and supported values.

- **Bug Fixes**
  - Bundled Redis now rejects unsupported Sentinel architecture configurations with a clear validation error.

- **Compatibility**
  - Updated the chart’s minimum supported Kubernetes version to 1.26.
  - Updated the bundled Redis dependency to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->