### PR TITLE
chore(metabase): bump metabase to v0.63.5

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.22
-appVersion: "v0.63.2"
+appVersion: "v0.63.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.63.2 (#920)"
+      description: "bump image to 0.63.5 security release (#944)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.63.2
+  tag: v0.63.5
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.63.2` | Metabase container image tag |
+| `image.tag` | `v0.63.5` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,11 +184,10 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.63.2` updates the application to the latest upstream release and
-repairs the chart's validation scenarios for single-stack clusters, external
-database fixtures, and External Secrets. Back up the Metabase application
-database before upgrading, keep the encryption key stable, and validate the
-`/api/health` endpoint after rollout.
+Metabase `v0.63.5` includes upstream security fixes. Back up the Metabase
+application database and review the official security advisory before upgrading.
+Keep the encryption key stable and validate the `/api/health` endpoint after
+rollout.
 
 ## Examples
 

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.63.2"
+          value: "docker.io/metabase/metabase:v0.63.5"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.63.2"
+  tag: "v0.63.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- upgrade Metabase from v0.63.2 to v0.63.5
- update image expectations and release metadata
- keep the chart on the upstream-supported secure patch for the 0.63 series

## Upstream impact

| Upstream change | Chart impact | Runtime coverage |
| --- | --- | --- |
| 0.63 patch and security fixes | image defaults and tests only; no port, path, or probe contract change | default |

## Validation

- official image manifest verified for amd64 and arm64
- make validate-chart CHART=metabase K3D_SCENARIOS="default"
- 10 validation layers passed; workloads ready with no restarts or fatal logs
- release, standards, preflight, and attribution checks passed

Site companion: helmforgedev/site#503

Resolves #944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Metabase to version `v0.63.5`.

* **Security**
  * Includes upstream security fixes from the `v0.63.5` release.
  * Added guidance to review the related security advisory before upgrading.

* **Documentation**
  * Updated deployment examples and configuration references to use the new version.
  * Retained backup, encryption-key, and health-check recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->