### PR TITLE
chore(mysql): bump mysql lts to 9.7.2

### DIFF
--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -4,7 +4,7 @@ name: mysql
 description: MySQL for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.0.2
-appVersion: "9.7.1"
+appVersion: "9.7.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump mysql to 9.7.1 (#583)"
+      description: "bump MySQL LTS to 9.7.2 (#946)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -209,7 +209,7 @@ Operational documents:
 |-----------|-------------|---------|
 | `architecture` | `standalone` or `replication` | `standalone` |
 | `image.repository` | MySQL image repository | `docker.io/library/mysql` |
-| `image.tag` | MySQL image tag | `9.7.1` |
+| `image.tag` | MySQL image tag | `9.7.2` |
 | `auth.database` | App database created at bootstrap | `app` |
 | `auth.username` | App user created at bootstrap | `app` |
 | `auth.existingSecret` | Existing secret for passwords | `""` |

--- a/charts/mysql/templates/networkpolicy.yaml
+++ b/charts/mysql/templates/networkpolicy.yaml
@@ -70,5 +70,8 @@ spec:
     - to:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mysql/tests/networkpolicy_test.yaml
+++ b/charts/mysql/tests/networkpolicy_test.yaml
@@ -70,3 +70,27 @@ tests:
       - equal:
           path: spec.egress[2].to[0].podSelector.matchLabels.app
           value: external-secrets
+
+  - it: should append complete extra egress rules
+    set:
+      networkPolicy:
+        enabled: true
+        egress:
+          enabled: true
+        extraEgress:
+          - to:
+              - namespaceSelector:
+                  matchLabels:
+                    environment: shared
+            ports:
+              - protocol: TCP
+                port: 5432
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].namespaceSelector.matchLabels.environment
+          value: shared
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            protocol: TCP
+            port: 5432

--- a/charts/mysql/tests/statefulset_source_test.yaml
+++ b/charts/mysql/tests/statefulset_source_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mysql:9.7.1"
+          value: "docker.io/library/mysql:9.7.2"
 
   - it: should always have 1 replica
     template: statefulset-source.yaml

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -44,7 +44,7 @@
         "tag": {
           "type": "string",
           "description": "MySQL image tag",
-          "default": "9.7.1"
+          "default": "9.7.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -719,7 +719,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "9.7.1"
+                  "default": "9.7.2"
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -805,6 +805,12 @@
           "type": "boolean",
           "description": "Create an ingress-only NetworkPolicy for MySQL pods",
           "default": false
+        },
+        "extraEgress": {
+          "type": "array",
+          "description": "Additional complete egress rules appended when egress is enabled",
+          "items": { "type": "object" },
+          "default": []
         },
         "ingress": {
           "type": "object",

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- MySQL image repository
   repository: docker.io/library/mysql
   # -- MySQL image tag
-  tag: "9.7.1"
+  tag: "9.7.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -277,7 +277,7 @@ backup:
       pullPolicy: IfNotPresent
     mysql:
       repository: docker.io/library/mysql
-      tag: "9.7.1"
+      tag: "9.7.2"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com
@@ -309,6 +309,8 @@ backup:
 networkPolicy:
   # -- Create a NetworkPolicy for MySQL pods
   enabled: false
+  # -- Additional complete egress rules appended when egress.enabled=true.
+  extraEgress: []
   ingress:
     # -- Allow ingress from the same namespace
     allowSameNamespace: true


### PR DESCRIPTION
## Summary

- upgrade MySQL on the existing LTS track from 9.7.1 to 9.7.2
- keep the chart on LTS instead of switching to the separate 26.7 Innovation line
- add the missing top-level networkPolicy.extraEgress contract and coverage

## Upstream impact

| Upstream change | Chart impact | Runtime coverage |
| --- | --- | --- |
| MySQL 9.7.2 LTS patch | runtime and backup image defaults/tests | default |
| replication, TLS, and policy-sensitive operation | no breaking contract found; validate production topology and restricted networking | production-hardening, tls-networkpolicy |

## Validation

- official image manifest verified for amd64 and arm64
- make validate-chart CHART=mysql K3D_SCENARIOS="default ci/production-hardening.yaml ci/tls-networkpolicy.yaml"
- 12 validation layers passed; all workloads stable with clean logs
- release, standards, preflight, and attribution checks passed

Site companion: helmforgedev/site#504

Resolves #946