### PR TITLE
chore(n8n): bump n8n to 2.34.4

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.12
-appVersion: "2.33.3"
+appVersion: "2.34.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2.33.3 (#921)"
+      description: "bump n8n to 2.34.4 and Redis to 2.0.0 (#947)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.33.3` | n8n container image tag |
+| `image.tag` | `2.34.4` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -159,7 +159,7 @@ externalSecrets:
 | `queue.concurrency` | `10` | Concurrent workflows per worker |
 | `queue.persistence.shareMainVolume` | `true` | Mount the main n8n data PVC into worker pods |
 | `terminationGracePeriodSeconds` | `75` | Kubernetes pod shutdown grace period |
-| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `1.6.19`) |
+| `redis.enabled` | `false` | Deploy Redis subchart (`helmforge/redis` `2.0.0`) |
 | `taskRunners.mode` | `external` | Task runner mode (`internal` or `external`) |
 | `taskRunners.image.repository` | `docker.io/n8nio/runners` | External task runner sidecar image repository |
 | `taskRunners.image.tag` | `""` | External task runner sidecar tag (defaults to `image.tag`) |
@@ -186,20 +186,14 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.33.3` adds instance credentials, workflow review and publishing APIs,
-OpenTelemetry configuration APIs, scheduler controls, and database migrations
-for new execution and review data. It also fixes security-audit imports and MCP
-Server Trigger execution persistence. Review the
-[upstream 2.33.3 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.33.3)
-before upgrading, back up the database, and keep the encryption key stable
-before upgrading live deployments. This chart keeps the hardened non-root
-container defaults with resource requests and limits. Queue mode fails fast
-when it resolves to SQLite or when Redis is not configured, because workers
-must share the same PostgreSQL, MySQL, or external database as the main pod.
-Validate database and queue mode in a staging namespace before reusing
-production PVCs.
+n8n `2.34.4` includes task-runner health-check fixes and the 2.34 maintenance
+updates. Review the
+[upstream 2.34.4 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.34.4)
+before upgrading. Back up the database, keep the encryption key stable, and
+validate task runners and queue workers in a staging namespace. This update also
+moves the bundled Redis dependency to HelmForge Redis `2.0.0`.
 
-When upgrading with `--reuse-values`, explicitly set `image.tag=2.33.3`.
+When upgrading with `--reuse-values`, explicitly set `image.tag=2.34.4`.
 Helm preserves the previous image override in that mode; also update
 `taskRunners.image.tag` when it was pinned separately.
 

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.33.3"
+          value: "docker.io/n8nio/n8n:2.34.4"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.33.3"
+          value: "docker.io/n8nio/runners:2.34.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.33.3"
+          value: "docker.io/n8nio/runners:2.34.4"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.33.3"
+          "default": "2.34.4"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.33.3"
+  tag: "2.34.4"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrade n8n from 2.33.3 to 2.34.4
- align the task runner image expectation
- update the HelmForge Redis dependency to the current release

## Upstream impact

| Upstream change | Chart impact | Runtime coverage |
| --- | --- | --- |
| n8n 2.34 patch fixes, including task runner health handling | main and runner image defaults/tests | default |
| queue worker and runner behavior | validate n8n, worker, PostgreSQL, and Redis together | queue-values |

## Validation

- n8n and runner manifests verified for amd64 and arm64
- make validate-chart CHART=n8n K3D_SCENARIOS="default ci/queue-values.yaml"
- 11 validation layers passed; five queue-mode pods stable with clean logs
- release, standards, preflight, and attribution checks passed

Site companion: helmforgedev/site#505

Resolves #947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the n8n deployment image to version 2.34.4.
  - Upgraded the bundled Redis component to version 2.0.0.

- **Documentation**
  - Added upgrade guidance, validation steps, and instructions for preserving existing values during upgrades.
  - Updated documented image and component versions.

- **Tests**
  - Updated deployment and task-runner validation expectations for n8n 2.34.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->