### PR TITLE
chore(charts): refresh upstream images and dependencies

### DIFF
--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -4,7 +4,7 @@ name: alfio
 description: Open-source event management and ticketing platform with PostgreSQL backend
 type: application
 version: 1.2.10
-appVersion: "2.0-M5-2509-1"
+appVersion: "2.0-M5-2606"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/alfio/tests/deployment_test.yaml
+++ b/charts/alfio/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/alfio/alf.io:2.0-M5-2509-1"
+          value: "docker.io/alfio/alf.io:2.0-M5-2606"
 
   - it: should set custom image tag
     set:

--- a/charts/alfio/values.yaml
+++ b/charts/alfio/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- alf.io container image
   repository: docker.io/alfio/alf.io
   # -- Image tag
-  tag: "2.0-M5-2509-1"
+  tag: "2.0-M5-2606"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/answer/README.md
+++ b/charts/answer/README.md
@@ -5,8 +5,8 @@ Deploy [Apache Answer](https://answer.apache.org/) on Kubernetes — an open-sou
 ## Features
 
 - **SQLite by default** — zero database configuration needed
-- **PostgreSQL subchart** — bundled via HelmForge dependency (`2.0.2`)
-- **MySQL subchart** — bundled via HelmForge dependency (`2.0.0`)
+- **PostgreSQL subchart** — bundled via HelmForge dependency (`2.0.4`)
+- **MySQL subchart** — bundled via HelmForge dependency (`2.0.3`)
 - **External database** — connect to existing PostgreSQL or MySQL
 - **Auto-install** — unattended setup via environment variables
 - **Scheduled backups** — database-aware CronJob with S3 upload

--- a/charts/apache/templates/NOTES.txt
+++ b/charts/apache/templates/NOTES.txt
@@ -119,7 +119,7 @@ Check the Service and endpoints:
 
 Probe the health endpoint through a temporary curl pod:
 
-  kubectl run {{ .Release.Name }}-curl -n {{ .Release.Namespace }} --rm -i --restart=Never --image=curlimages/curl:8.17.0 -- \
+  kubectl run {{ .Release.Name }}-curl -n {{ .Release.Namespace }} --rm -i --restart=Never --image=curlimages/curl:8.21.0 -- \
     curl -fsS http://{{ include "apache.fullname" . }}:{{ .Values.service.port }}/healthz
 
 8. Troubleshooting

--- a/charts/apache/templates/test-connection.yaml
+++ b/charts/apache/templates/test-connection.yaml
@@ -12,7 +12,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -56,6 +56,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/appwrite/README.md
+++ b/charts/appwrite/README.md
@@ -62,7 +62,7 @@ When ingress is enabled, requests are routed by path:
 | `image.repository` | `docker.io/appwrite/appwrite` | Appwrite server image |
 | `image.tag` | `1.9.6` | Image tag |
 | `console.image.repository` | `docker.io/appwrite/console` | Console image |
-| `console.image.tag` | `8.7.30` | Console image tag |
+| `console.image.tag` | `8.7.38` | Console image tag |
 | `appwrite.locale` | `en` | Application locale |
 | `appwrite.domain` | `""` (auto-detected) | Appwrite domain |
 | `appwrite.openSslKeyV1` | `""` (auto-generated) | 64-char hex encryption key |

--- a/charts/appwrite/tests/deployment_console_test.yaml
+++ b/charts/appwrite/tests/deployment_console_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/appwrite/console:8.7.30"
+          value: "docker.io/appwrite/console:8.7.38"
 
   - it: should have component label
     asserts:

--- a/charts/appwrite/values.yaml
+++ b/charts/appwrite/values.yaml
@@ -36,7 +36,7 @@ console:
     # -- Appwrite console image repository
     repository: docker.io/appwrite/console
     # -- Console image tag
-    tag: "8.7.30"
+    tag: "8.7.38"
     # -- Console image pull policy
     pullPolicy: IfNotPresent
 

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -58,10 +58,10 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -150,9 +150,9 @@ The chart uses HelmForge-maintained subcharts for optional stateful services:
 
 | Dependency | Version | Usage |
 |------------|---------|-------|
-| PostgreSQL | `2.0.2` | Production storage backend |
-| MySQL | `2.0.0` | Production storage backend alternative |
-| Redis | `1.6.16` | Session storage for distributed/HA deployments |
+| PostgreSQL | `2.0.4` | Production storage backend |
+| MySQL | `2.0.3` | Production storage backend alternative |
+| Redis | `2.0.0` | Session storage for distributed/HA deployments |
 
 ## Forward Auth Configuration
 

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ckan/README.md
+++ b/charts/ckan/README.md
@@ -67,7 +67,7 @@ StatefulSet: solr (port 8983)
 | `postgresql.enabled` | `true` | Enable PostgreSQL subchart |
 | `redis.enabled` | `true` | Enable Redis subchart |
 
-This chart currently deploys CKAN `2.11.5` with HelmForge PostgreSQL `1.10.0` and Redis `1.6.14`.
+This chart currently deploys CKAN `2.11.5` with HelmForge PostgreSQL `2.0.4` and Redis `2.0.0`.
 It intentionally does not keep `Chart.lock`; dependencies are resolved by the release workflow.
 
 ## External Database

--- a/charts/clickhouse/templates/NOTES.txt
+++ b/charts/clickhouse/templates/NOTES.txt
@@ -32,7 +32,7 @@ Wait for readiness:
   kubectl -n {{ include "clickhouse.namespace" . }} rollout status statefulset/{{ include "clickhouse.fullname" . }} --timeout=5m
 
 Run an HTTP query:
-  kubectl -n {{ include "clickhouse.namespace" . }} run {{ include "clickhouse.fullname" . }}-query --rm -i --restart=Never --image=docker.io/curlimages/curl:8.17.0 -- curl -fsS "http://{{ include "clickhouse.fullname" . }}:{{ .Values.service.ports.http }}/?query=SELECT%201"
+  kubectl -n {{ include "clickhouse.namespace" . }} run {{ include "clickhouse.fullname" . }}-query --rm -i --restart=Never --image=docker.io/curlimages/curl:8.21.0 -- curl -fsS "http://{{ include "clickhouse.fullname" . }}:{{ .Values.service.ports.http }}/?query=SELECT%201"
 
 4. Credentials
 ==============

--- a/charts/clickhouse/templates/tests/test-connection.yaml
+++ b/charts/clickhouse/templates/tests/test-connection.yaml
@@ -14,7 +14,7 @@ spec:
   activeDeadlineSeconds: 60
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/charts/discount-bandit/Chart.yaml
+++ b/charts/discount-bandit/Chart.yaml
@@ -53,6 +53,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/docmost/DESIGN.md
+++ b/charts/docmost/DESIGN.md
@@ -22,7 +22,7 @@ User
 
 ## Design Choices
 
-- Default installs use HelmForge PostgreSQL `2.0.2` and Redis `1.6.16`
+- Default installs use HelmForge PostgreSQL `2.0.4` and Redis `2.0.0`
   subcharts so database/cache lifecycle stays inside the HelmForge ecosystem.
 - `replicaCount` defaults to one because local uploaded-file storage is
   single-writer. Values greater than one are allowed only with S3-compatible

--- a/charts/docmost/README.md
+++ b/charts/docmost/README.md
@@ -21,8 +21,8 @@ helm install docmost oci://ghcr.io/helmforgedev/helm/docmost
 ## Features
 
 - **Official Docmost image** based on `docmost/docmost`
-- **PostgreSQL subchart** bundled PostgreSQL `2.0.2` for default installs
-- **Redis subchart** bundled Redis `1.6.16` for default installs
+- **PostgreSQL subchart** bundled PostgreSQL `2.0.4` for default installs
+- **Redis subchart** bundled Redis `2.0.0` for default installs
 - **External services** support for managed PostgreSQL and Redis
 - **Local or S3 storage** for uploaded files
 - **Ingress support** configurable ingress with TLS

--- a/charts/docmost/ci/external-secrets.yaml
+++ b/charts/docmost/ci/external-secrets.yaml
@@ -93,7 +93,7 @@ extraManifests:
         spec:
           containers:
             - name: redis
-              image: docker.io/library/redis:8.8.0
+              image: docker.io/library/redis:8.10.0
               imagePullPolicy: IfNotPresent
               ports:
                 - name: redis

--- a/charts/docmost/ci/external-services.yaml
+++ b/charts/docmost/ci/external-services.yaml
@@ -91,7 +91,7 @@ extraManifests:
         spec:
           containers:
             - name: redis
-              image: docker.io/library/redis:8.8.0
+              image: docker.io/library/redis:8.10.0
               imagePullPolicy: IfNotPresent
               command: ["redis-server"]
               args:

--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -50,6 +50,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/druid/ci/external-metadata-values.yaml
+++ b/charts/druid/ci/external-metadata-values.yaml
@@ -100,7 +100,7 @@ extraManifests:
         spec:
           containers:
             - name: zookeeper
-              image: docker.io/library/zookeeper:3.9.4
+              image: docker.io/library/zookeeper:3.9.5
               imagePullPolicy: IfNotPresent
               env:
                 - name: ZOO_4LW_COMMANDS_WHITELIST

--- a/charts/druid/ci/external-secrets.yaml
+++ b/charts/druid/ci/external-secrets.yaml
@@ -141,7 +141,7 @@ extraManifests:
         spec:
           containers:
             - name: zookeeper
-              image: docker.io/library/zookeeper:3.9.4
+              image: docker.io/library/zookeeper:3.9.5
               imagePullPolicy: IfNotPresent
               env:
                 - name: ZOO_4LW_COMMANDS_WHITELIST

--- a/charts/druid/tests/zookeeper_test.yaml
+++ b/charts/druid/tests/zookeeper_test.yaml
@@ -28,7 +28,7 @@ tests:
         documentIndex: 0
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/zookeeper:3.9.4
+          value: docker.io/library/zookeeper:3.9.5
         documentIndex: 3
       - notMatchRegex:
           path: data["zoo.cfg"]

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -463,7 +463,7 @@ zookeeper:
     # -- ZooKeeper container image repository
     repository: docker.io/library/zookeeper
     # -- ZooKeeper container image tag
-    tag: "3.9.4"
+    tag: "3.9.5"
     # -- ZooKeeper image pull policy
     pullPolicy: IfNotPresent
   # -- Number of ZooKeeper replicas

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -4,7 +4,7 @@ name: drupal
 description: Production-ready Drupal CMS with seeded sites persistence, S3 backups, and safe horizontal scaling controls
 type: application
 version: 1.2.11
-appVersion: "11.4.4"
+appVersion: "11.4.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump drupal to 11.4.4 (#813)"
+      description: "bump drupal to 11.4.5 (#813)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/drupal/Chart.yaml
+++ b/charts/drupal/Chart.yaml
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/drupal.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump drupal to 11.4.5 (#813)"
+      description: "bump drupal to 11.4.4 (#813)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -6,7 +6,7 @@ Important runtime note:
 
 - This chart uses `docker.io/library/drupal`.
 - Drupal upstream does not currently publish its own upstream-maintained runtime container image.
-- HelmForge pins the Docker Official Apache image explicitly to `11.4.4-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
+- HelmForge pins the Docker Official Apache image explicitly to `11.4.5-php8.5-apache-bookworm`, which is published by the Docker Official Drupal image repository.
 - The chart prepares runtime, persistence, ingress, backup automation, and database connectivity, then guides the final site installation through Drupal's web installer.
 
 ## Install
@@ -44,7 +44,7 @@ Then:
 
 ## Why This Chart Is Different
 
-- **Pinned production image** — uses `drupal:11.4.4-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
+- **Pinned production image** — uses `drupal:11.4.5-php8.5-apache-bookworm`, keeping the Drupal release, PHP runtime, and Debian base explicit
 - **Seeded `sites/` persistence** — preserves installer output and uploads without masking Drupal core files from the image
 - **Built-in backup automation** — archives `sites/` and backs up either MySQL or SQLite to S3-compatible storage
 - **Safe scaling model** — single replica by default, with fail-fast guardrails for multi-replica or HPA use
@@ -53,14 +53,14 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.4.4` is a security release that fixes moderately critical
+Drupal `11.4.5` is a security release that fixes moderately critical
 information-disclosure and cross-site scripting vulnerabilities. Drupal
 recommends updating 11.4.x sites immediately; no unrelated fixes are included
 in this release.
 
 Before upgrading production workloads, test the site in staging with the same
 PHP extensions, Composer dependency set, storage class, and database mode used
-in production. Review the Drupal 11.4.4 release notes and security advisories
+in production. Review the Drupal 11.4.5 release notes and security advisories
 before running database updates.
 
 ## Production Example
@@ -149,7 +149,7 @@ mysql:
 |-----|---------|-------------|
 | `replicaCount` | `1` | Number of Drupal replicas. |
 | `image.repository` | `docker.io/library/drupal` | Drupal image repository. |
-| `image.tag` | `11.4.4-php8.5-apache-bookworm` | Drupal image tag. |
+| `image.tag` | `11.4.5-php8.5-apache-bookworm` | Drupal image tag. |
 | `database.mode` | `auto` | Database mode: `auto`, `external`, `mysql`, or `sqlite`. |
 | `mysql.enabled` | `true` | Deploy bundled MySQL. |
 | `mysql.auth.database` | `drupal` | Database name created by the MySQL subchart. |

--- a/charts/drupal/README.md
+++ b/charts/drupal/README.md
@@ -53,15 +53,13 @@ Then:
 
 ## Upstream Version Notes
 
-Drupal `11.4.5` is a security release that fixes moderately critical
-information-disclosure and cross-site scripting vulnerabilities. Drupal
-recommends updating 11.4.x sites immediately; no unrelated fixes are included
-in this release.
+Drupal `11.4.5` is a patch release with upstream bug fixes. Review the upstream
+release notes for the complete list of resolved issues and any known regressions.
 
 Before upgrading production workloads, test the site in staging with the same
 PHP extensions, Composer dependency set, storage class, and database mode used
-in production. Review the Drupal 11.4.5 release notes and security advisories
-before running database updates.
+in production. Review the Drupal 11.4.5 release notes before running database
+updates.
 
 ## Production Example
 

--- a/charts/drupal/tests/deployment_test.yaml
+++ b/charts/drupal/tests/deployment_test.yaml
@@ -52,7 +52,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/drupal:11.4.4-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.5-php8.5-apache-bookworm
 
   - it: should include the seed-sites init container
     template: templates/deployment.yaml
@@ -62,7 +62,7 @@ tests:
           value: seed-sites
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/drupal:11.4.4-php8.5-apache-bookworm
+          value: docker.io/library/drupal:11.4.5-php8.5-apache-bookworm
 
   - it: should mount the sites directory
     template: templates/deployment.yaml

--- a/charts/drupal/values.yaml
+++ b/charts/drupal/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Drupal container image repository
   repository: docker.io/library/drupal
   # -- Drupal container image tag
-  tag: "11.4.4-php8.5-apache-bookworm"
+  tag: "11.4.5-php8.5-apache-bookworm"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -27,7 +27,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade stack to 9.5.1 (#865)"
+      description: "upgrade stack to 9.4.4 (#865)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.1.5
-appVersion: "9.4.4"
+appVersion: "9.5.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev
@@ -27,7 +27,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade stack to 9.4.4 (#865)"
+      description: "upgrade stack to 9.5.1 (#865)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -161,7 +161,7 @@ dataTiers:
 | `namespaceOverride` | Namespace for chart-managed namespaced resources | `""` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.4.4` |
+| `image.tag` | Image tag | `9.5.1` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -262,7 +262,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.4.4` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.5.1` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -311,11 +311,11 @@ Security posture acceptable.
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.4.4` is an upstream image update from
+`docker.io/library/elasticsearch:9.5.1` is an upstream image update from
 `9.4.3`. It improves aggregation memory accounting, search timeout enforcement,
 data stream authorization, snapshot handling on CIFS shares, ML model validation,
 and ES|QL reliability. Review the
-[upstream Elasticsearch 9.4.4 release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.4.4-release-notes)
+[upstream Elasticsearch 9.5.1 release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.1-release-notes)
 before upgrading production clusters, take a snapshot backup, and verify Kibana
 compatibility, plugins, ILM policies, and index templates in a staging
 environment before reusing existing PVCs.

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.4.4
+          value: docker.io/library/kibana:9.5.1
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.4.4
+          value: docker.io/library/elasticsearch:9.5.1
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -37,7 +37,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.4.4"
+          "default": "9.5.1"
         },
         "pullPolicy": {
           "type": "string",
@@ -247,7 +247,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.4.4"
+              "default": "9.5.1"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.4.4"
+  tag: "9.5.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -324,7 +324,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.4.4"
+    tag: "9.5.1"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.2.2
-appVersion: "6.56.0"
+appVersion: "6.57.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ghost to 6.56.0 (#957)"
+      description: "bump ghost to 6.57.1 (#957)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump ghost to 6.57.1 (#957)"
+      description: "bump ghost to 6.56.0 (#957)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -106,7 +106,7 @@ through Ghost's environment-based configuration:
 ```yaml
 image:
   repository: registry.example.com/ghost-with-adapters
-  tag: "6.56.0"
+  tag: "6.57.1"
 
 ghost:
   extraEnv:
@@ -123,9 +123,9 @@ adapters when the container starts.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.56.0` | Ghost image tag |
+| `image.tag` | `6.57.1` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
-| `mysql.image.tag` | `8.4.7` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
+| `mysql.image.tag` | `8.4.11` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
 | `persistence.size` | `10Gi` | Content PVC size |
 | `backup.enabled` | `false` | Enable S3 content backups |
@@ -137,7 +137,7 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.56.0` adds tier-specific editor previews and fixes newsletter links,
+Ghost `6.57.1` adds tier-specific editor previews and fixes newsletter links,
 bookmark cards, comments, and managed Stripe checkout. The release does not change the official image's port,
 content path, database contract, probes, or required environment variables.
 Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -137,9 +137,10 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.57.1` adds tier-specific editor previews and fixes newsletter links,
-bookmark cards, comments, and managed Stripe checkout. The release does not change the official image's port,
-content path, database contract, probes, or required environment variables.
+Ghost `6.57.1` fixes member webhook payloads, subdirectory redirect loops,
+theme-setting resets, and related presentation issues. The release does not
+change the official image's port, content path, database contract, probes, or
+required environment variables.
 Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the
 chart's content PVC and S3 content backup already cover them. Review the
 upstream Ghost release notes before upgrading

--- a/charts/ghost/ci/external-db-values.yaml
+++ b/charts/ghost/ci/external-db-values.yaml
@@ -42,7 +42,7 @@ extraManifests:
         spec:
           containers:
             - name: mysql
-              image: docker.io/library/mysql:8.4.7
+              image: docker.io/library/mysql:8.4.11
               imagePullPolicy: IfNotPresent
               ports:
                 - name: mysql

--- a/charts/ghost/ci/external-secrets.yaml
+++ b/charts/ghost/ci/external-secrets.yaml
@@ -59,7 +59,7 @@ extraManifests:
         spec:
           containers:
             - name: mysql
-              image: docker.io/library/mysql:8.4.7
+              image: docker.io/library/mysql:8.4.11
               imagePullPolicy: IfNotPresent
               ports:
                 - name: mysql

--- a/charts/ghost/docs/database.md
+++ b/charts/ghost/docs/database.md
@@ -8,7 +8,7 @@ The default configuration deploys Ghost with the HelmForge MySQL dependency:
 mysql:
   enabled: true
   image:
-    tag: "8.4.7"
+    tag: "8.4.11"
   auth:
     database: ghost
     username: ghost

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.56.0"
+          value: "docker.io/library/ghost:6.57.1"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/tests/mysql_subchart_test.yaml
+++ b/charts/ghost/tests/mysql_subchart_test.yaml
@@ -12,4 +12,4 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mysql:8.4.7"
+          value: "docker.io/library/mysql:8.4.11"

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.56.0"
+                                                                    "default":  "6.57.1"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.56.0"
+  tag: "6.57.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -259,7 +259,7 @@ mysql:
   image:
     # -- Ghost production supports MySQL 8; keep the HelmForge MySQL dependency on the supported image major.
     repository: docker.io/library/mysql
-    tag: "8.4.7"
+    tag: "8.4.11"
     pullPolicy: IfNotPresent
   architecture: standalone
   auth:

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -54,6 +54,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/github-mcp-server/Chart.yaml
+++ b/charts/github-mcp-server/Chart.yaml
@@ -4,7 +4,7 @@ name: github-mcp-server
 description: GitHub official MCP server in HTTP mode
 type: application
 version: 1.0.2
-appVersion: "1.2.0"
+appVersion: "1.9.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/github-mcp-server/README.md
+++ b/charts/github-mcp-server/README.md
@@ -1,7 +1,7 @@
 # GitHub MCP Server Helm Chart
 
 The GitHub MCP Server exposes GitHub APIs through the Model Context Protocol.
-This chart deploys the official `ghcr.io/github/github-mcp-server:v1.2.0` image in streamable HTTP mode for internal agent platforms,
+This chart deploys the official `ghcr.io/github/github-mcp-server:v1.9.0` image in streamable HTTP mode for internal agent platforms,
 IDE integrations, and automation gateways.
 
 ## Install

--- a/charts/github-mcp-server/tests/templates_test.yaml
+++ b/charts/github-mcp-server/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/github/github-mcp-server:v1.2.0
+          value: ghcr.io/github/github-mcp-server:v1.9.0
   - it: renders service
     template: templates/service.yaml
     asserts:

--- a/charts/github-mcp-server/values.schema.json
+++ b/charts/github-mcp-server/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/github/github-mcp-server" },
-        "tag": { "type": "string", "default": "v1.2.0" },
+        "tag": { "type": "string", "default": "v1.9.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/github-mcp-server/values.yaml
+++ b/charts/github-mcp-server/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official GitHub MCP Server image repository.
   repository: ghcr.io/github/github-mcp-server
   # -- Official GitHub MCP Server image tag. Do not use a floating tag.
-  tag: "v1.2.0"
+  tag: "v1.9.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/gophish/Chart.yaml
+++ b/charts/gophish/Chart.yaml
@@ -47,6 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -56,6 +56,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: heimdall
 type: application
 version: 1.1.12
-appVersion: "2.8.1"
+appVersion: "2.8.2"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Heimdall application dashboard on Kubernetes
 maintainers:
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/heimdall.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2.8.1 (#759)"
+      description: "bump image to 2.8.2 (#759)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/heimdall/Chart.yaml
+++ b/charts/heimdall/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/heimdall.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2.8.2 (#759)"
+      description: "bump image to 2.8.1 (#759)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/heimdall/tests/deployment_test.yaml
+++ b/charts/heimdall/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/linuxserver/heimdall:2.8.1"
+          value: "docker.io/linuxserver/heimdall:2.8.2"
 
   - it: should set PUID, PGID, and TZ env vars
     asserts:

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- Container image repository
   repository: docker.io/linuxserver/heimdall
   # -- Image tag
-  tag: "2.8.1"
+  tag: "2.8.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -54,6 +54,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -11,7 +11,7 @@ Current application version: `v1.74.0`.
 
 - **Official Homarr image** from `ghcr.io/homarr-labs/homarr`
 - **Database backends** SQLite3 (default), PostgreSQL, or MySQL with auto-detection
-- **PostgreSQL and MySQL subcharts** optional bundled database deployments using HelmForge PostgreSQL `2.0.4` and MySQL `2.0.1`
+- **PostgreSQL and MySQL subcharts** optional bundled database deployments using HelmForge PostgreSQL `2.0.4` and MySQL `2.0.3`
 - **Encryption key management** auto-generated or existing secret for `SECRET_ENCRYPTION_KEY`
 - **Kubernetes integration** optional workload discovery via `ENABLE_KUBERNETES`
 - **External Redis** optional external Redis for multi-instance setups

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -4,7 +4,7 @@ name: immich
 description: Immich photo and video management with HelmForge PostgreSQL, Redis-compatible cache, and machine learning
 type: application
 version: 1.2.5
-appVersion: "2.7.5"
+appVersion: "3.1.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -59,6 +59,6 @@ dependencies:
     condition: postgresql.enabled
   - name: redis
     alias: valkey
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: valkey.internal.enabled

--- a/charts/immich/README.md
+++ b/charts/immich/README.md
@@ -30,14 +30,17 @@ the k3d values file.
 
 ## Upgrading to Immich 3
 
-Immich 3 removes support for `pgvecto.rs`. Before upgrading an installation
-older than Immich `1.133.0`, complete the upstream VectorChord migration. Back
-up the database and uploads first, then upgrade normally; the server performs
-its application database migrations during startup. This chart's bundled
-PostgreSQL image already uses VectorChord.
+Immich 3 removes support for `pgvecto.rs`. Check the active database extension
+and effective `DB_VECTOR_EXTENSION` setting (`vectorchord` or `pgvector`). If
+the database still uses `pgvecto.rs`, complete the upstream migration before
+upgrading. Back up the database and uploads first; external PostgreSQL
+migrations must be performed outside Helm. The server performs its application
+database migrations during startup, and this chart's bundled PostgreSQL image
+already uses VectorChord.
 
 See the [Immich 3 migration guide](https://immich.app/blog/v3-migration) and
-[VectorChord upgrade instructions](https://docs.immich.app/install/upgrading/#migrating-to-vectorchord).
+[VectorChord upgrade instructions](https://docs.immich.app/install/upgrading/#migrating-to-vectorchord). External
+databases should follow the [standalone PostgreSQL migration guide](https://docs.immich.app/administration/postgres-standalone).
 
 ## Extra Server Volumes
 

--- a/charts/immich/README.md
+++ b/charts/immich/README.md
@@ -6,7 +6,7 @@ and the upstream VectorChord PostgreSQL image recommended by Immich.
 
 ## Highlights
 
-- Official Immich images pinned to `v2.7.5`.
+- Official Immich images pinned to `v3.1.0`.
 - Internal PostgreSQL uses `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0`.
 - Internal cache uses the HelmForge Redis chart aliased as `valkey` for
   Redis/Valkey-compatible protocol support.
@@ -27,6 +27,17 @@ helm install immich oci://ghcr.io/helmforgedev/helm/immich
 Persistent storage is enabled by default for uploads, PostgreSQL, internal cache, and
 machine-learning model cache. For local smoke tests, disable persistence with
 the k3d values file.
+
+## Upgrading to Immich 3
+
+Immich 3 removes support for `pgvecto.rs`. Before upgrading an installation
+older than Immich `1.133.0`, complete the upstream VectorChord migration. Back
+up the database and uploads first, then upgrade normally; the server performs
+its application database migrations during startup. This chart's bundled
+PostgreSQL image already uses VectorChord.
+
+See the [Immich 3 migration guide](https://immich.app/blog/v3-migration) and
+[VectorChord upgrade instructions](https://docs.immich.app/install/upgrading/#migrating-to-vectorchord).
 
 ## Extra Server Volumes
 

--- a/charts/immich/tests/deployment_test.yaml
+++ b/charts/immich/tests/deployment_test.yaml
@@ -12,7 +12,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/immich-app/immich-server:v2.7.5
+          value: ghcr.io/immich-app/immich-server:v3.1.0
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].env[7].name

--- a/charts/immich/values.yaml
+++ b/charts/immich/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Immich server image repository.
   repository: ghcr.io/immich-app/immich-server
   # -- Immich server image tag.
-  tag: "v2.7.5"
+  tag: "v3.1.0"
   # -- Immich server image pull policy.
   pullPolicy: IfNotPresent
 
@@ -28,7 +28,7 @@ machineLearning:
     # -- Machine-learning image repository.
     repository: ghcr.io/immich-app/immich-machine-learning
     # -- Machine-learning image tag.
-    tag: "v2.7.5"
+    tag: "v3.1.0"
     # -- Machine-learning image pull policy.
     pullPolicy: IfNotPresent
   service:

--- a/charts/jenkins/templates/tests/test-connection.yaml
+++ b/charts/jenkins/templates/tests/test-connection.yaml
@@ -12,7 +12,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/charts/jupyterhub/templates/deployment-hub.yaml
+++ b/charts/jupyterhub/templates/deployment-hub.yaml
@@ -69,7 +69,7 @@ spec:
               readOnly: true
         {{- end }}
         - name: wait-for-proxy-api
-          image: docker.io/curlimages/curl:8.17.0
+          image: docker.io/curlimages/curl:8.21.0
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/jupyterhub/templates/tests/test-connection.yaml
+++ b/charts/jupyterhub/templates/tests/test-connection.yaml
@@ -16,7 +16,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -59,7 +59,7 @@ proxy:
     # -- configurable-http-proxy image repository.
     repository: docker.io/jupyterhub/configurable-http-proxy
     # -- configurable-http-proxy image tag.
-    tag: "4.6.3"
+    tag: "5.3.0"
     # -- configurable-http-proxy image pull policy.
     pullPolicy: IfNotPresent
   # -- Proxy auth token. Empty generates or reuses a Secret token.

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -5,7 +5,7 @@ description: AI-powered bookmark manager with full-text search and web archiving
 icon: https://helmforge.dev/icons/charts/karakeep.png
 type: application
 version: 1.2.8
-appVersion: "0.33.1"
+appVersion: "0.33.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump karakeep to 0.33.1 (#917)"
+      description: "bump karakeep to 0.33.2 (#917)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/karakeep/Chart.yaml
+++ b/charts/karakeep/Chart.yaml
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump karakeep to 0.33.2 (#917)"
+      description: "bump karakeep to 0.33.1 (#917)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/karakeep/README.md
+++ b/charts/karakeep/README.md
@@ -5,11 +5,11 @@ the official `ghcr.io/karakeep-app/karakeep` container image. Karakeep provides
 bookmark management, full-text archive search, web page capture, and optional AI
 tagging in a single-writer application pod.
 
-Current application version: `0.33.1`.
+Current application version: `0.33.2`.
 
 ## Features
 
-- Official Karakeep image pinned to `0.33.1`
+- Official Karakeep image pinned to `0.33.2`
 - Optional Meilisearch sidecar for full-text search
 - Optional browserless Chromium sidecar for screenshots and page archiving
 - SQLite and uploaded content stored on a PersistentVolumeClaim
@@ -125,7 +125,7 @@ chromium:
 | Key | Default | Description |
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/karakeep-app/karakeep` | Main Karakeep image |
-| `image.tag` | `"0.33.1"` | Main Karakeep image tag |
+| `image.tag` | `"0.33.2"` | Main Karakeep image tag |
 | `karakeep.nextAuthUrl` | `""` | Public URL of the Karakeep instance |
 | `karakeep.browserConnectOnDemand` | `true` | Connect to Chromium only when crawling needs it |
 | `karakeep.existingSecret` | `""` | Existing secret with auth and Meilisearch keys |
@@ -157,9 +157,9 @@ baseline.
 
 ## Upgrade Notes
 
-Karakeep `0.33.1` adds experimental semantic search and embedding-based
+Karakeep `0.33.2` adds experimental semantic search and embedding-based
 auto-tagging, database indexes, crawler and security fixes, and new optional AI
-settings. The bundled Meilisearch `v1.41.0` exceeds the upstream `1.13` minimum
+settings. The bundled Meilisearch `v1.53.0` exceeds the upstream `1.13` minimum
 for embeddings. Custom AI providers can pass `EMBEDDING_TEXT_MODEL`,
 `EMBEDDING_DIMENSIONS`, and `EMBEDDING_ENABLE_AUTO_INDEXING` through
 `karakeep.extraEnv`. Back up the `/data` PVC before upgrading because the

--- a/charts/karakeep/README.md
+++ b/charts/karakeep/README.md
@@ -157,13 +157,10 @@ baseline.
 
 ## Upgrade Notes
 
-Karakeep `0.33.2` adds experimental semantic search and embedding-based
-auto-tagging, database indexes, crawler and security fixes, and new optional AI
-settings. The bundled Meilisearch `v1.53.0` exceeds the upstream `1.13` minimum
-for embeddings. Custom AI providers can pass `EMBEDDING_TEXT_MODEL`,
-`EMBEDDING_DIMENSIONS`, and `EMBEDDING_ENABLE_AUTO_INDEXING` through
-`karakeep.extraEnv`. Back up the `/data` PVC before upgrading because the
-application applies database changes during startup.
+Karakeep `0.33.2` improves SingleFile archive handling, custom Chrome migration,
+favicon extraction, CLI uploads, and completion-token configuration. Back up
+the `/data` PVC before upgrading and review the upstream release notes for the
+complete migration guidance.
 
 ## Quality Gates
 

--- a/charts/karakeep/docs/operations.md
+++ b/charts/karakeep/docs/operations.md
@@ -14,9 +14,9 @@ make validate-chart CHART=karakeep
 Verify that every image tag is pinned:
 
 ```bash
-make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.33.1
-make image-verify IMAGE=docker.io/getmeili/meilisearch:v1.41.0
-make image-verify IMAGE=ghcr.io/browserless/chromium:v2.46.0
+make image-verify IMAGE=ghcr.io/karakeep-app/karakeep:0.33.2
+make image-verify IMAGE=docker.io/getmeili/meilisearch:v1.53.0
+make image-verify IMAGE=ghcr.io/browserless/chromium:v2.55.4
 ```
 
 ## Installation

--- a/charts/karakeep/tests/deployment_test.yaml
+++ b/charts/karakeep/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/karakeep-app/karakeep:0.33.1"
+          value: "ghcr.io/karakeep-app/karakeep:0.33.2"
 
   - it: should set DATA_DIR env
     template: templates/deployment.yaml

--- a/charts/karakeep/values.schema.json
+++ b/charts/karakeep/values.schema.json
@@ -38,7 +38,7 @@
           "type": "object",
           "properties": {
             "repository": { "type": "string", "default": "docker.io/getmeili/meilisearch" },
-            "tag": { "type": "string", "default": "v1.41.0" },
+            "tag": { "type": "string", "default": "v1.53.0" },
             "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
           }
         },
@@ -55,7 +55,7 @@
           "type": "object",
           "properties": {
             "repository": { "type": "string", "default": "ghcr.io/browserless/chromium" },
-            "tag": { "type": "string", "default": "v2.46.0" },
+            "tag": { "type": "string", "default": "v2.55.4" },
             "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
           }
         },

--- a/charts/karakeep/values.yaml
+++ b/charts/karakeep/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Karakeep container image
   repository: ghcr.io/karakeep-app/karakeep
   # -- Image tag
-  tag: "0.33.1"
+  tag: "0.33.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -51,7 +51,7 @@ meilisearch:
     # -- Meilisearch container image
     repository: docker.io/getmeili/meilisearch
     # -- Meilisearch image tag
-    tag: "v1.41.0"
+    tag: "v1.53.0"
     pullPolicy: IfNotPresent
   # -- Resources for the Meilisearch container
   resources: {}
@@ -69,7 +69,7 @@ chromium:
     # -- Chromium container image
     repository: ghcr.io/browserless/chromium
     # -- Chromium image tag
-    tag: "v2.46.0"
+    tag: "v2.55.4"
     pullPolicy: IfNotPresent
   # -- Resources for the Chromium container
   resources: {}

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -4,7 +4,7 @@ name: kibana
 description: Production-ready Kibana with secure Elasticsearch connectivity, Wolfi image support, Gateway API, and dual-stack services
 type: application
 version: 1.1.4
-appVersion: "9.4.2"
+appVersion: "9.5.1"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/kibana.png
 home: https://helmforge.dev

--- a/charts/kibana/README.md
+++ b/charts/kibana/README.md
@@ -21,7 +21,7 @@ helm install kibana helmforge/kibana
 ```
 
 Elastic recommends running the same Elastic Stack version across Kibana and
-Elasticsearch. The default chart version targets Kibana `9.4.2`.
+Elasticsearch. The default chart version targets Kibana `9.5.1`.
 
 ## HelmForge Elasticsearch Subchart
 
@@ -34,7 +34,7 @@ bundledElasticsearch:
 
 bundled-elasticsearch:
   image:
-    tag: "9.4.2"
+    tag: "9.5.1"
 ```
 
 For production, keep `bundledElasticsearch.enabled=false` and connect to an
@@ -98,7 +98,7 @@ gateway:
 | `image.repository` | Official Elastic Kibana image repository | `docker.elastic.co/kibana/kibana` |
 | `image.wolfiRepository` | Official Elastic Kibana Wolfi image repository | `docker.elastic.co/kibana/kibana-wolfi` |
 | `image.flavor` | Image flavor: `default` or `wolfi` | `default` |
-| `image.tag` | Kibana image tag | `9.4.2` |
+| `image.tag` | Kibana image tag | `9.5.1` |
 | `replicaCount` | Number of Kibana replicas | `1` |
 | `elasticsearch.hosts` | External Elasticsearch URLs used when bundled mode is disabled | `[http://elasticsearch:9200]` |
 | `bundledElasticsearch.enabled` | Enable HelmForge Elasticsearch dependency | `true` |

--- a/charts/kibana/ci/bundled-elasticsearch-values.yaml
+++ b/charts/kibana/ci/bundled-elasticsearch-values.yaml
@@ -10,7 +10,7 @@ bundled-elasticsearch:
   fullnameOverride: kibana-ci-elasticsearch
   clusterProfile: dev
   image:
-    tag: "9.4.2"
+    tag: "9.5.1"
   master:
     persistence:
       enabled: false

--- a/charts/kibana/examples/bundled-elasticsearch.yaml
+++ b/charts/kibana/examples/bundled-elasticsearch.yaml
@@ -5,7 +5,7 @@ bundledElasticsearch:
 bundled-elasticsearch:
   clusterProfile: dev
   image:
-    tag: "9.4.2"
+    tag: "9.5.1"
   kibana:
     enabled: false
   master:

--- a/charts/kibana/tests/deployment_test.yaml
+++ b/charts/kibana/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.elastic.co/kibana/kibana:9.4.2
+          value: docker.elastic.co/kibana/kibana:9.5.1
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 5601
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.elastic.co/kibana/kibana-wolfi:9.4.2
+          value: docker.elastic.co/kibana/kibana-wolfi:9.5.1
 
   - it: wires basic Elasticsearch authentication from a Secret
     template: templates/deployment.yaml

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -36,7 +36,7 @@ image:
   # -- Image flavor. Valid values: default, wolfi
   flavor: default
   # -- Kibana image tag. Defaults to the chart appVersion.
-  tag: "9.4.2"
+  tag: "9.5.1"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -94,7 +94,7 @@ bundled-elasticsearch:
   clusterProfile: dev
   image:
     # -- Keep bundled Elasticsearch aligned with the Kibana appVersion.
-    tag: "9.4.2"
+    tag: "9.5.1"
   # -- Disable nested Kibana from the Elasticsearch chart.
   kibana:
     enabled: false

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -4,7 +4,7 @@ name: komga
 description: Komga media server for comics and manga with persistent SQLite storage, library management, and S3 backup
 type: application
 version: 1.4.14
-appVersion: "1.26.1"
+appVersion: "1.26.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump komga to 1.26.1 (#961)"
+      description: "bump komga to 1.26.3 (#961)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/komga/Chart.yaml
+++ b/charts/komga/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/komga.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump komga to 1.26.3 (#961)"
+      description: "bump komga to 1.26.1 (#961)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/komga/README.md
+++ b/charts/komga/README.md
@@ -54,10 +54,9 @@ kubectl port-forward svc/<release>-komga 25600:80
 
 ## Upgrade Notes
 
-Komga `1.26.3` adds a beta NextUI, native RAR5 support, and referential API v2 while preserving Kobo content
-restrictions more consistently, flattens hierarchical OpenAPI schemas, and
-updates application dependencies including Spring Boot. Back up the `/config`
-PVC before upgrading because Komga stores its SQLite databases there.
+Komga `1.26.3` is a maintenance release with build and translation updates.
+Back up the `/config` PVC before upgrading because Komga stores its SQLite
+databases there.
 
 ## Production Example
 

--- a/charts/komga/README.md
+++ b/charts/komga/README.md
@@ -54,7 +54,7 @@ kubectl port-forward svc/<release>-komga 25600:80
 
 ## Upgrade Notes
 
-Komga `1.26.1` adds a beta NextUI, native RAR5 support, and referential API v2 while preserving Kobo content
+Komga `1.26.3` adds a beta NextUI, native RAR5 support, and referential API v2 while preserving Kobo content
 restrictions more consistently, flattens hierarchical OpenAPI schemas, and
 updates application dependencies including Spring Boot. Back up the `/config`
 PVC before upgrading because Komga stores its SQLite databases there.
@@ -105,7 +105,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/gotson/komga` | Image repository |
-| `image.tag` | `"1.26.1"` | Image tag |
+| `image.tag` | `"1.26.3"` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### Komga Configuration

--- a/charts/komga/tests/deployment_test.yaml
+++ b/charts/komga/tests/deployment_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/gotson/komga:1.26.1"
+          value: "docker.io/gotson/komga:1.26.3"
 
   - it: should set container port to 25600
     asserts:

--- a/charts/komga/values.yaml
+++ b/charts/komga/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Komga image repository
   repository: docker.io/gotson/komga
   # -- Komga image tag
-  tag: "1.26.1"
+  tag: "1.26.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump langflow to 1.11.3 (#962)"
+      description: "bump langflow to 1.11.2 (#962)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.1.1
-appVersion: "1.11.2"
+appVersion: "1.11.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump langflow to 1.11.2 (#962)"
+      description: "bump langflow to 1.11.3 (#962)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,11 +1,11 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.2` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.3` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
 
 Langflow 1.11 adds native v2 workflow execution, trusted JWT authentication with just-in-time user mapping, RBAC-aware interfaces, A2A and
-human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.2 also includes upstream fixes for authentication,
+human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.3 also includes upstream fixes for authentication,
 tracing, MCP, SSRF protections, and component loading. Advanced runtime settings for these capabilities can be supplied through `app.env` or
 `app.envFrom`.
 

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.11.2
+          value: docker.io/langflowai/langflow:1.11.3
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.11.2" },
+        "tag": { "type": "string", "default": "1.11.3" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.11.2"
+  tag: "1.11.3"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/matomo/Chart.yaml
+++ b/charts/matomo/Chart.yaml
@@ -51,6 +51,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/matomo/templates/NOTES.txt
+++ b/charts/matomo/templates/NOTES.txt
@@ -67,7 +67,7 @@ Service endpoints:
   kubectl -n {{ include "matomo.namespace" . }} get endpoints {{ include "matomo.fullname" . }}
 
 HTTP smoke test:
-  kubectl -n {{ include "matomo.namespace" . }} run {{ include "matomo.fullname" . }}-curl --rm -i --restart=Never --image=docker.io/curlimages/curl:8.17.0 -- curl -fsS http://{{ include "matomo.fullname" . }}:{{ .Values.service.port }}/matomo.php
+  kubectl -n {{ include "matomo.namespace" . }} run {{ include "matomo.fullname" . }}-curl --rm -i --restart=Never --image=docker.io/curlimages/curl:8.21.0 -- curl -fsS http://{{ include "matomo.fullname" . }}:{{ .Values.service.port }}/matomo.php
 
 Helm test:
   helm test {{ .Release.Name }} -n {{ include "matomo.namespace" . }}

--- a/charts/matomo/templates/tests/test-connection.yaml
+++ b/charts/matomo/templates/tests/test-connection.yaml
@@ -14,7 +14,7 @@ spec:
   activeDeadlineSeconds: 60
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       imagePullPolicy: IfNotPresent
       command:
         - sh

--- a/charts/metrics-server/Chart.yaml
+++ b/charts/metrics-server/Chart.yaml
@@ -4,7 +4,7 @@ name: metrics-server
 description: Kubernetes Metrics Server chart for autoscaling metrics with secure RBAC and k3d-friendly validation controls
 type: application
 version: 1.0.3
-appVersion: "0.8.1"
+appVersion: "0.9.0"
 kubeVersion: ">=1.31.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/metrics-server/DESIGN.md
+++ b/charts/metrics-server/DESIGN.md
@@ -6,7 +6,7 @@ This chart installs Metrics Server and the Kubernetes API aggregation resources 
 
 ## Decisions
 
-The chart uses Metrics Server `v0.8.1`, the latest upstream application release found during implementation.
+The chart uses Metrics Server `v0.9.0`, the latest upstream application release found during implementation.
 The official upstream Helm chart was still published at app version `0.8.0`, so this chart intentionally follows the newer application release while keeping the same upstream operational contract.
 
 Kubelet TLS verification is secure by default.

--- a/charts/metrics-server/README.md
+++ b/charts/metrics-server/README.md
@@ -20,7 +20,7 @@ helm install metrics-server oci://ghcr.io/helmforgedev/helm/metrics-server -n ku
 
 ## What this chart covers
 
-- official Metrics Server image pinned to `v0.8.1`
+- official Metrics Server image pinned to `v0.9.0`
 - Kubernetes Metrics API `APIService`
 - required ServiceAccount, ClusterRole, ClusterRoleBinding, and delegated authentication RoleBinding
 - typed kubelet flag modeling instead of a single unstructured args list
@@ -77,7 +77,7 @@ This avoids ownership conflicts while still deploying the Metrics Server workloa
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `registry.k8s.io/metrics-server/metrics-server` | Official image repository |
-| `image.tag` | `v0.8.1` | Metrics Server image tag |
+| `image.tag` | `v0.9.0` | Metrics Server image tag |
 | `replicaCount` | `1` | Deployment replicas |
 | `apiService.create` | `true` | Create `v1beta1.metrics.k8s.io` APIService |
 | `apiService.insecureSkipTLSVerify` | `true` | Skip APIService backend TLS verification unless `caBundle` is set |

--- a/charts/metrics-server/tests/deployment_test.yaml
+++ b/charts/metrics-server/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
           value: test-metrics-server
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+          value: registry.k8s.io/metrics-server/metrics-server:v0.9.0
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true

--- a/charts/metrics-server/values.yaml
+++ b/charts/metrics-server/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Official Metrics Server image repository
   repository: registry.k8s.io/metrics-server/metrics-server
   # -- Metrics Server image tag
-  tag: "v0.8.1"
+  tag: "v0.9.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -4,7 +4,7 @@ name: mongodb
 description: MongoDB Helm Chart - standalone, replica set, or sharded cluster using the official MongoDB image
 type: application
 version: 1.7.16
-appVersion: "8.3.7"
+appVersion: "8.3.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "upgrade to 8.3.7 (#872)"
+      description: "upgrade to 8.3.8 (#872)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/mongodb.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "upgrade to 8.3.8 (#872)"
+      description: "upgrade to 8.3.7 (#872)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -129,7 +129,7 @@ user initialization path.
 |-----------|-------------|---------|
 | `architecture` | `standalone`, `replicaset`, or `sharded` | `standalone` |
 | `image.repository` | MongoDB image | `mongo` |
-| `image.tag` | Image tag | `8.3.7` |
+| `image.tag` | Image tag | `8.3.8` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -260,7 +260,7 @@ See the [`examples/`](examples/) directory:
 
 ## Upgrade Notes
 
-MongoDB `8.3.7` is a security and reliability patch within the MongoDB `8.3`
+MongoDB `8.3.8` is a security and reliability patch within the MongoDB `8.3`
 release line. It addresses upstream CVEs plus authorization, input validation,
 memory-bound, query-planning, and crash fixes. Review the
 [MongoDB 8.3 release notes](https://www.mongodb.com/docs/manual/release-notes/8.3/)

--- a/charts/mongodb/examples/replicaset-production.yaml
+++ b/charts/mongodb/examples/replicaset-production.yaml
@@ -5,7 +5,7 @@
 architecture: replicaset
 
 image:
-  tag: "8.3.7"
+  tag: "8.3.8"
 
 auth:
   enabled: true

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mongo:8.3.7"
+          value: "docker.io/library/mongo:8.3.8"
 
   - it: should have 1 replica in standalone mode
     template: statefulset.yaml

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -39,7 +39,7 @@
         "tag": {
           "type": "string",
           "description": "MongoDB image tag",
-          "default": "8.3.7"
+          "default": "8.3.8"
         },
         "pullPolicy": {
           "type": "string",
@@ -662,7 +662,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "8.3.7"
+                  "default": "8.3.8"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -21,7 +21,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/mongo
-  tag: "8.3.7"
+  tag: "8.3.8"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -315,7 +315,7 @@ backup:
       pullPolicy: IfNotPresent
     mongodb:
       repository: docker.io/library/mongo
-      tag: "8.3.7"
+      tag: "8.3.8"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.13
-appVersion: "2.34.4"
+appVersion: "2.34.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.34.4 (#976)"
+      description: "bump n8n to 2.34.5 (#976)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -55,7 +55,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump n8n to 2.34.5 (#976)"
+      description: "bump n8n to 2.34.4 (#976)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.34.4` | n8n container image tag |
+| `image.tag` | `2.34.5` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,14 +186,14 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.34.4` includes task-runner health-check fixes and the 2.34 maintenance
+n8n `2.34.5` includes task-runner health-check fixes and the 2.34 maintenance
 updates. Review the
-[upstream 2.34.4 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.34.4)
+[upstream 2.34.5 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.34.5)
 before upgrading. Back up the database, keep the encryption key stable, and
 validate task runners and queue workers in a staging namespace. This update also
 moves the bundled Redis dependency to HelmForge Redis `2.0.0`.
 
-When upgrading with `--reuse-values`, explicitly set `image.tag=2.34.4`.
+When upgrading with `--reuse-values`, explicitly set `image.tag=2.34.5`.
 Helm preserves the previous image override in that mode; also update
 `taskRunners.image.tag` when it was pinned separately.
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -153,7 +153,7 @@ externalSecrets:
 | `database.mode` | `auto` | Database mode (auto, sqlite, external, postgresql, mysql) |
 | `postgresql.enabled` | `false` | Deploy PostgreSQL subchart (`helmforge/postgresql` `2.0.4`) |
 | `postgresql.initdb.scripts` | n8n extension bootstrap | Creates PostgreSQL extensions required by n8n migrations |
-| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.1`) |
+| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.3`) |
 | `queue.enabled` | `false` | Enable queue mode (requires Redis and a non-SQLite database) |
 | `queue.workers` | `1` | Number of worker replicas |
 | `queue.concurrency` | `10` | Concurrent workflows per worker |

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.34.4"
+          value: "docker.io/n8nio/n8n:2.34.5"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.34.4"
+          value: "docker.io/n8nio/runners:2.34.5"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.34.4"
+          value: "docker.io/n8nio/runners:2.34.5"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.34.4"
+          "default": "2.34.5"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.34.4"
+  tag: "2.34.5"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -5,7 +5,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 This chart packages the current upstream combined architecture:
 
 - `netbirdio/netbird-server:0.76.3` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
-- `netbirdio/dashboard:v2.90.3` for the web UI
+- `netbirdio/dashboard:v2.90.10` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
 - optional persistent storage under `/var/lib/netbird`
@@ -111,7 +111,7 @@ Local security scan:
 
 ```text
 Image: netbirdio/netbird-server:0.76.3
-Image: netbirdio/dashboard:v2.90.3
+Image: netbirdio/dashboard:v2.90.10
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 86.86869 compliance score
 ```

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -18,7 +18,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/dashboard:v2.90.3
+          value: netbirdio/dashboard:v2.90.10
         template: templates/deployment.yaml
         documentIndex: 1
   - it: configures dashboard defaults for the embedded identity provider

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -91,7 +91,7 @@ dashboard:
     # -- Official NetBird dashboard container image repository.
     repository: netbirdio/dashboard
     # -- Pinned NetBird dashboard image tag. This follows dashboard's own upstream versioning.
-    tag: "v2.90.3"
+    tag: "v2.90.10"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of dashboard pods.

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/netbox/DESIGN.md
+++ b/charts/netbox/DESIGN.md
@@ -13,7 +13,7 @@ pods can never accidentally receive HTTP traffic.
 
 ## Image choice
 
-The default `v4.6.7-5.0.2` tag combines an exact NetBox application release
+The default `v4.6.8-5.0.2` tag combines an exact NetBox application release
 with an exact netbox-docker support release. It is published for amd64 and
 arm64. NetBox 4.6.7 existed when the chart was authored, but no matching exact
 5.0.2 image was published, so the chart does not invent or use a moving tag.

--- a/charts/netbox/templates/tests/test-connection.yaml
+++ b/charts/netbox/templates/tests/test-connection.yaml
@@ -18,7 +18,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       args:
         - --fail
         - --show-error

--- a/charts/netbox/tests/deployment_test.yaml
+++ b/charts/netbox/tests/deployment_test.yaml
@@ -16,7 +16,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/netboxcommunity/netbox:v4.6.7-5.0.2
+          value: docker.io/netboxcommunity/netbox:v4.6.8-5.0.2
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official NetBox Docker image repository.
   repository: docker.io/netboxcommunity/netbox
   # -- Immutable NetBox and netbox-docker release combination.
-  tag: "v4.6.7-5.0.2"
+  tag: "v4.6.8-5.0.2"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 # -- Image pull secrets.

--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.31.0 (#965)"
+      description: "bump image to 0.30.1 (#965)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.1.2
-appVersion: "0.30.1"
+appVersion: "0.31.0"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 0.30.1 (#965)"
+      description: "bump image to 0.31.0 (#965)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.30.1` image.
+official `ghcr.io/gamosoft/notediscovery:0.31.0` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.30.1` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.0` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -151,7 +151,7 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.30.1` adds interactive task checkboxes while retaining the
+NoteDiscovery `0.31.0` adds interactive task checkboxes while retaining the
 locally served browser libraries and cache-safe asset
 versioning, gzip and conditional responses, and fixes first-load Mermaid
 rendering. Releases 0.29.x also correct share-link schemes behind reverse

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.30.1
+          value: ghcr.io/gamosoft/notediscovery:0.31.0
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -24,7 +24,7 @@ tests:
           value: plugin-bootstrap
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.30.1
+          value: ghcr.io/gamosoft/notediscovery:0.31.0
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "if \\[ -d /app/plugins \\]"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.30.1", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.31.0", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.30.1"
+  tag: "0.31.0"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -4,7 +4,7 @@ name: olivetin
 description: OliveTin web interface for running predefined shell commands
 type: application
 version: 1.2.0
-appVersion: "3000.18.1"
+appVersion: "3000.19.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 3000.18.1 (#879)"
+      description: "upgrade to 3000.19.0 (#879)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 3000.19.0 (#879)"
+      description: "upgrade to 3000.18.1 (#879)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/olivetin/README.md
+++ b/charts/olivetin/README.md
@@ -60,7 +60,7 @@ kubectl port-forward svc/<release>-olivetin 1337:80
 | `configInit.enabled` | `true` | Prepare writable OliveTin runtime files before startup |
 | `configInit.resources` | requests/limits set | Resource guardrails for the config bootstrap init container |
 | `configInit.securityContext` | non-root | Security context for the config bootstrap init container |
-| `image.tag` | `3000.18.1` | OliveTin image tag |
+| `image.tag` | `3000.19.0` | OliveTin image tag |
 | `securityContext` | non-root | Security context for the OliveTin application container |
 | `olivetin.port` | `1337` | Application port, propagated through OliveTin's `PORT` environment variable |
 | `config` | `""` | OliveTin YAML configuration. Empty uses the chart-managed default config. |
@@ -106,7 +106,7 @@ See the [OliveTin documentation](https://docs.olivetin.app) for all available op
 ## Upgrade Notes
 
 OliveTin `3000.18.0` added `dnsname` action arguments and configuration issues
-in diagnostics. OliveTin `3000.18.1` adds dashboard categories, persistent log
+in diagnostics. OliveTin `3000.19.0` adds dashboard categories, persistent log
 filters, and support for the `PORT` environment variable. It also fixes
 `shellAfterCompleted` output injection, HTTP timeout and path traversal
 weaknesses, and unsafe theme permissions. Upstream reports no breaking changes.

--- a/charts/olivetin/tests/deployment_test.yaml
+++ b/charts/olivetin/tests/deployment_test.yaml
@@ -100,7 +100,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/jamesread/olivetin:3000.18.1"
+          value: "docker.io/jamesread/olivetin:3000.19.0"
 
   - it: should mount writable config directory with read-only config file
     template: templates/deployment.yaml

--- a/charts/olivetin/values.schema.json
+++ b/charts/olivetin/values.schema.json
@@ -32,7 +32,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/jamesread/olivetin" },
-        "tag": { "type": "string", "default": "3000.18.1" },
+        "tag": { "type": "string", "default": "3000.19.0" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/olivetin/values.yaml
+++ b/charts/olivetin/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- OliveTin container image
   repository: docker.io/jamesread/olivetin
   # -- Image tag
-  tag: "3000.18.1"
+  tag: "3000.19.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -4,7 +4,7 @@ name: open-webui
 description: Open WebUI â€” self-hosted AI chat platform with Ollama and OpenAI support, RAG, multi-model conversations, and extensible plugin system
 type: application
 version: 1.4.3
-appVersion: "0.8.12"
+appVersion: "0.11.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/open-webui.png
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -55,6 +55,16 @@ Open WebUI supports three database modes controlled by `database.mode`:
 | `sqlite` | Always uses embedded SQLite (single instance only) |
 | `external` | Uses `database.url` or `database.existingSecret` for an external PostgreSQL |
 
+## Upgrading from 0.8
+
+Open WebUI 0.9 introduced database schema changes. Back up the database and
+persistent data before upgrading to this chart version. Multi-replica or
+load-balanced installations must update all Open WebUI instances together;
+upstream does not support a rolling update across the incompatible schemas.
+
+Review the [Open WebUI 0.9 release notes](https://github.com/open-webui/open-webui/releases/tag/v0.9.0)
+before upgrading production installations.
+
 ### External PostgreSQL
 
 ```yaml

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Open WebUI container image
   repository: ghcr.io/open-webui/open-webui
   # -- Image tag
-  tag: "v0.8.12"
+  tag: "v0.11.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/pimcore/Chart.yaml
+++ b/charts/pimcore/Chart.yaml
@@ -4,7 +4,7 @@ name: pimcore
 description: Pimcore data and experience management platform with PHP-FPM, Messenger workers, and maintenance automation
 type: application
 version: 1.0.0
-appVersion: "2026.2.5"
+appVersion: "2026.2.8"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -56,7 +56,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
   - name: rabbitmq

--- a/charts/pimcore/README.md
+++ b/charts/pimcore/README.md
@@ -3,7 +3,7 @@
 Production-oriented deployment of [Pimcore](https://pimcore.com), the
 PHP/Symfony platform for PIM, MDM, DAM, CDP, DXP/CMS, and digital commerce.
 
-This chart targets Pimcore `2026.2.5` and pins the official multi-architecture
+This chart targets Pimcore `2026.2.8` and pins the official multi-architecture
 PHP 8.5 runtime `pimcore/pimcore:php8.5.9-max-v5.2-hardened`. It models the
 upstream topology instead of treating the runtime image as a complete
 application:
@@ -120,7 +120,7 @@ Deploy it with bootstrap and project persistence disabled:
 ```yaml
 image:
   repository: registry.example.com/platform/pimcore-project
-  tag: "2026.2.5-1"
+  tag: "2026.2.8-1"
 
 project:
   bootstrap:

--- a/charts/pimcore/examples/production.yaml
+++ b/charts/pimcore/examples/production.yaml
@@ -2,7 +2,7 @@
 ---
 image:
   repository: registry.example.com/platform/pimcore-project
-  tag: "2026.2.5-1"
+  tag: "2026.2.8-1"
 
 project:
   bootstrap:

--- a/charts/pimcore/templates/tests/test-connection.yaml
+++ b/charts/pimcore/templates/tests/test-connection.yaml
@@ -18,7 +18,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: curl
-      image: docker.io/curlimages/curl:8.17.0
+      image: docker.io/curlimages/curl:8.21.0
       args:
         - --fail
         - --show-error

--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.1.2
-appVersion: "6.57.1"
+appVersion: "6.59.2"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 6.57.1 (#967)"
+      description: "bump image to 6.59.2 (#967)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 6.59.2 (#967)"
+      description: "bump image to 6.57.1 (#967)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.57.1
+ghcr.io/timothepoznanski/poznote:6.59.2
 ```
 
-The tag maps to the upstream `6.57.1` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.59.2` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.57.1-rootless` variant. It is not the chart
+Upstream also publishes a `6.59.2-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.57.1` |
+| `image.tag` | Image tag | `6.59.2` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -141,7 +141,7 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.57.1` adds user webhooks, tenant-isolation controls, task management,
+Poznote `6.59.2` adds user webhooks, tenant-isolation controls, task management,
 optional S3 attachment and backup storage, an administrator activity log, and
 safer account deletion. The default local SQLite and filesystem deployment
 remains compatible; S3 integration is configured inside Poznote when needed.

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.57.1"
+          value: "ghcr.io/timothepoznanski/poznote:6.59.2"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.57.1"
+  tag: "6.59.2"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -4,7 +4,7 @@ name: sonarqube
 description: SonarQube Community Build Helm chart with plugin automation and production controls
 type: application
 version: 1.0.4
-appVersion: "26.4.0.121862"
+appVersion: "26.8.0.126808"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/sonarqube/DESIGN.md
+++ b/charts/sonarqube/DESIGN.md
@@ -10,7 +10,7 @@ The chart uses a Deployment with `Recreate` strategy because a single SonarQube 
 Production deployments should back the application with PostgreSQL and persistent volumes.
 The chart can either connect to an external PostgreSQL endpoint or deploy the HelmForge PostgreSQL chart as an optional dependency.
 
-The default image is pinned to `docker.io/library/sonarqube:26.4.0.121862-community`.
+The default image is pinned to `docker.io/library/sonarqube:26.8.0.126808-community`.
 This line matches the default `communityBranchPlugin.version` of `26.4.0`, allowing the plugin automation to be enabled without version guesswork.
 
 `sonarqube.databaseMode=auto` chooses an external database when external settings are provided, then the HelmForge PostgreSQL subchart when `postgresql.enabled=true`.

--- a/charts/sonarqube/DESIGN.md
+++ b/charts/sonarqube/DESIGN.md
@@ -11,7 +11,8 @@ Production deployments should back the application with PostgreSQL and persisten
 The chart can either connect to an external PostgreSQL endpoint or deploy the HelmForge PostgreSQL chart as an optional dependency.
 
 The default image is pinned to `docker.io/library/sonarqube:26.8.0.126808-community`.
-This line matches the default `communityBranchPlugin.version` of `26.4.0`, allowing the plugin automation to be enabled without version guesswork.
+The optional community branch plugin is pinned independently to `26.4.0`; the
+`ci/plugins.yaml` scenario validates this combination before release.
 
 `sonarqube.databaseMode=auto` chooses an external database when external settings are provided, then the HelmForge PostgreSQL subchart when `postgresql.enabled=true`.
 If neither is configured, it falls back to embedded evaluation mode.

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -101,7 +101,7 @@ communityBranchPlugin:
   version: "26.4.0"
 ```
 
-Keep the plugin major and minor version aligned with the SonarQube version. The default chart image is pinned to `26.4.0.121862-community` to match the default plugin line.
+Keep the plugin major and minor version aligned with the SonarQube version. The default chart image is pinned to `26.8.0.126808-community` to match the default plugin line.
 
 See [Community Branch Plugin](docs/community-branch-plugin.md).
 
@@ -165,7 +165,7 @@ networkPolicy:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/library/sonarqube` | Official SonarQube image repository |
-| `image.tag` | `26.4.0.121862-community` | SonarQube Community Build image tag |
+| `image.tag` | `26.8.0.126808-community` | SonarQube Community Build image tag |
 | `sonarqube.databaseMode` | `auto` | `auto`, `embedded`, `postgresql`, or `external` |
 | `postgresql.enabled` | `false` | Deploy HelmForge PostgreSQL as a subchart |
 | `waitForDatabase.enabled` | `true` | Wait for bundled PostgreSQL before starting SonarQube |

--- a/charts/sonarqube/README.md
+++ b/charts/sonarqube/README.md
@@ -101,7 +101,9 @@ communityBranchPlugin:
   version: "26.4.0"
 ```
 
-Keep the plugin major and minor version aligned with the SonarQube version. The default chart image is pinned to `26.8.0.126808-community` to match the default plugin line.
+The chart pins plugin `26.4.0` independently from the SonarQube image release.
+This combination is covered by the chart's plugin validation scenario; review
+upstream compatibility notes before selecting another plugin or image version.
 
 See [Community Branch Plugin](docs/community-branch-plugin.md).
 

--- a/charts/sonarqube/docs/community-branch-plugin.md
+++ b/charts/sonarqube/docs/community-branch-plugin.md
@@ -25,7 +25,9 @@ communityBranchPlugin:
   webappUrl: https://artifacts.example.com/sonarqube-webapp.zip
 ```
 
-Keep the plugin major and minor version aligned with the SonarQube major and minor version.
+The chart validates plugin `26.4.0` with its default SonarQube image. When
+changing either version, consult the plugin compatibility notes and rerun the
+`ci/plugins.yaml` scenario before deployment.
 
 ## Additional Plugins
 

--- a/charts/sonarqube/tests/deployment_test.yaml
+++ b/charts/sonarqube/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
           value: false
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/sonarqube:26.4.0.121862-community
+          value: docker.io/library/sonarqube:26.8.0.126808-community
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true

--- a/charts/sonarqube/values.yaml
+++ b/charts/sonarqube/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- SonarQube image repository. Uses the official Docker image.
   repository: docker.io/library/sonarqube
   # -- SonarQube Community Build image tag.
-  tag: "26.4.0.121862-community"
+  tag: "26.8.0.126808-community"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -4,7 +4,7 @@ name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
 version: 2.3.11
-appVersion: "5.51.1"
+appVersion: "5.52.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/strapi/README.md
+++ b/charts/strapi/README.md
@@ -18,9 +18,9 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 
 ## HelmForge Base Image
 
-This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.51.1`) which provides:
+This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.52.0`) which provides:
 
-- **Strapi 5.51.1** with all official plugins pre-installed
+- **Strapi 5.52.0** with all official plugins pre-installed
 - **Multi-database support** — SQLite, PostgreSQL, MySQL ready to use
 - **Health check endpoint** — HTTP health checks on `/_health` for proper Kubernetes integration
 - **Security hardened** — Non-root user (UID 1000), minimal attack surface
@@ -107,7 +107,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `helmforge/strapi-base` | Container image for the Strapi project |
-| `image.tag` | `5.51.1` | HelmForge Strapi base image version |
+| `image.tag` | `5.52.0` | HelmForge Strapi base image version |
 | `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
 | `strapi.port` | `1337` | Container port |
 | `strapi.telemetryDisabled` | `true` | Disable telemetry |
@@ -141,14 +141,14 @@ database:
 
 ## Notes
 
-- The default image is `helmforge/strapi-base:5.51.1`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
+- The default image is `helmforge/strapi-base:5.52.0`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
 - SQLite is supported for simple deployments, but server-based databases are recommended for production workloads.
 - Horizontal scaling is intentionally out of scope for this v1 chart because default local uploads persistence is single-writer oriented.
 - For ingress, set `ingress.ingressClassName` to the class used in your cluster, such as `traefik`, `nginx`, or another supported controller.
 
 ## Upgrade Notes
 
-Strapi `5.51.1` fixes document relation validation, database morph relations,
+Strapi `5.52.0` fixes document relation validation, database morph relations,
 admin audit filtering, recent-document serialization, and duplicate public
 assets. It also includes security-oriented dependency updates. The HelmForge
 base image preserves the existing runtime and database contract. Back up the

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:5.51.1"
+          value: "docker.io/helmforge/strapi-base:5.52.0"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -26,7 +26,7 @@ replicaCount: 1
 # Image
 # =============================================================================
 # HelmForge provides a production-ready Strapi base image (helmforge/strapi-base)
-# that includes Strapi 5.51.1 with all official plugins, multi-database support,
+# that includes Strapi 5.52.0 with all official plugins, multi-database support,
 # security hardening, and health check endpoints. This image is multi-arch
 # (amd64/arm64), regularly updated, and optimized for Kubernetes deployments.
 #
@@ -38,7 +38,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "5.51.1"
+  tag: "5.52.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -4,7 +4,7 @@ name: superset
 description: Apache Superset BI platform with web, worker, and beat deployments backed by PostgreSQL and Redis
 type: application
 version: 1.3.3
-appVersion: "4.1.4"
+appVersion: "6.1.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -57,6 +57,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/superset/README.md
+++ b/charts/superset/README.md
@@ -31,6 +31,19 @@ helm install superset helmforge/superset -f values.yaml
 helm install superset oci://ghcr.io/helmforgedev/helm/superset --version <version> -f values.yaml
 ```
 
+## Upgrading from Superset 4
+
+This chart crosses the Superset 5 and 6 major releases. Back up the metadata
+database before upgrading and plan for migration downtime. The chart's init Job
+runs `superset db upgrade` and `superset init` before the application workloads
+become ready. Superset 6 removes `AUTH_OID`; installations using it must move to
+OAuth, LDAP, or database authentication first. Custom frontend extensions may
+also need changes for the React upgrade introduced in Superset 5.
+
+Review the upstream [Superset 5 update notes](https://github.com/apache/superset/blob/5.0.0/UPDATING.md)
+and [Superset 6 update notes](https://github.com/apache/superset/blob/6.1.0/UPDATING.md)
+before upgrading production installations.
+
 ## Architecture
 
 ```text

--- a/charts/superset/templates/beat-deployment.yaml
+++ b/charts/superset/templates/beat-deployment.yaml
@@ -55,7 +55,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              uv pip install --target /tmp/superset-python psycopg2-binary redis --quiet
+              export PYTHONPATH="/tmp/superset-python${PYTHONPATH:+:$PYTHONPATH}"
               celery --app=superset.tasks.celery_app:app beat --pidfile=/tmp/celerybeat.pid --schedule=/tmp/celerybeat-schedule --loglevel=INFO
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/superset/templates/deployment.yaml
+++ b/charts/superset/templates/deployment.yaml
@@ -54,7 +54,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              uv pip install --target /tmp/superset-python psycopg2-binary redis --quiet
+              export PYTHONPATH="/tmp/superset-python${PYTHONPATH:+:$PYTHONPATH}"
               {{- if not .Values.init.enabled }}
               {{- /* No managed init Job: this pod must initialize the DB itself.
                      Keep web.replicaCount=1 to avoid a Flask-AppBuilder schema race. */}}

--- a/charts/superset/templates/init-job.yaml
+++ b/charts/superset/templates/init-job.yaml
@@ -42,7 +42,8 @@ spec:
             - -c
             - |
               set -e
-              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              uv pip install --target /tmp/superset-python psycopg2-binary redis --quiet
+              export PYTHONPATH="/tmp/superset-python${PYTHONPATH:+:$PYTHONPATH}"
               echo "Running database migrations..."
               superset db upgrade
               echo "Initializing Superset..."

--- a/charts/superset/templates/worker-deployment.yaml
+++ b/charts/superset/templates/worker-deployment.yaml
@@ -55,7 +55,8 @@ spec:
             - /bin/sh
             - -c
             - |
-              pip install psycopg2-binary redis --quiet --disable-pip-version-check
+              uv pip install --target /tmp/superset-python psycopg2-binary redis --quiet
+              export PYTHONPATH="/tmp/superset-python${PYTHONPATH:+:$PYTHONPATH}"
               celery --app=superset.tasks.celery_app:app worker --pool=prefork --concurrency={{ .Values.worker.concurrency }} -Ofair --loglevel=INFO
           {{- with .Values.securityContext }}
           securityContext:

--- a/charts/superset/tests/deployment_test.yaml
+++ b/charts/superset/tests/deployment_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "apache/superset:4\\.1\\.4"
+          pattern: "apache/superset:6\\.1\\.0"
 
   - it: should expose port 8088
     template: templates/deployment.yaml

--- a/charts/superset/values.yaml
+++ b/charts/superset/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Superset container image repository
   repository: docker.io/apache/superset
   # -- Superset image tag. Defaults to appVersion.
-  tag: "4.1.4"
+  tag: "6.1.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -4,7 +4,7 @@ name: umami
 description: Umami privacy-first web analytics with PostgreSQL, Gateway API, External Secrets, backups, and production controls
 type: application
 version: 2.3.0
-appVersion: "3.2.0"
+appVersion: "3.3.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/umami-software/umami:3.2.0"
+          value: "ghcr.io/umami-software/umami:3.3.0"
 
   - it: should set custom image tag
     set:

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Umami container image
   repository: ghcr.io/umami-software/umami
   # -- Image tag
-  tag: "3.2.0"
+  tag: "3.3.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -48,6 +48,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -50,7 +50,7 @@ kubectl port-forward svc/<release>-uptime-kuma 3001:80
 
 ## MariaDB Mode
 
-The optional local database path uses the HelmForge MySQL subchart `2.0.0`
+The optional local database path uses the HelmForge MySQL subchart `2.0.3`
 as a MariaDB-compatible backend.
 
 ```yaml
@@ -129,7 +129,7 @@ externalSecrets:
 | `image.tag` | `2.5.0` | Uptime Kuma image tag |
 | `uptimeKuma.port` | `3001` | Application port |
 | `database.type` | `sqlite` | Database type (sqlite, mariadb) |
-| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.0`) |
+| `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.3`) |
 | `persistence.enabled` | `true` | Enable persistence for /app/data |
 | `persistence.size` | `2Gi` | PVC size |
 | `ingress.enabled` | `false` | Enable ingress |

--- a/charts/uptime-kuma/docs/database.md
+++ b/charts/uptime-kuma/docs/database.md
@@ -18,7 +18,7 @@ persistence:
 
 ## MariaDB via MySQL Subchart
 
-Use the HelmForge MySQL subchart `2.0.0` as a MariaDB-compatible backend:
+Use the HelmForge MySQL subchart `2.0.3` as a MariaDB-compatible backend:
 
 ```yaml
 database:

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -85,7 +85,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 ### Database selection
 
 - for production, prefer `database.external` or one of the optional subcharts
-- optional local database subcharts are vendored from HelmForge dependencies: PostgreSQL chart `2.0.2` and MySQL chart `2.0.0`
+- optional local database subcharts are vendored from HelmForge dependencies: PostgreSQL chart `2.0.4` and MySQL chart `2.0.3`
 - `database.mode=auto` uses this precedence:
 - `database.external.host` or `database.external.existingSecret`
 - `postgresql.enabled=true`
@@ -227,8 +227,8 @@ Official reference:
 | `database.external.username` | External database username | `vaultwarden` |
 | `database.external.existingSecret` | Existing secret containing a complete `DATABASE_URL` | `""` |
 | `database.external.existingSecretUrlKey` | Secret key containing the `DATABASE_URL` value | `database-url` |
-| `postgresql.enabled` | Enable the local PostgreSQL subchart (`helmforge/postgresql` `2.0.2`) | `false` |
-| `mysql.enabled` | Enable the local MySQL subchart (`helmforge/mysql` `2.0.0`) | `false` |
+| `postgresql.enabled` | Enable the local PostgreSQL subchart (`helmforge/postgresql` `2.0.4`) | `false` |
+| `mysql.enabled` | Enable the local MySQL subchart (`helmforge/mysql` `2.0.3`) | `false` |
 | `vaultwarden.signupsAllowed` | Allow new user signups | `false` |
 | `vaultwarden.signupsVerify` | Require email verification for new signups | `false` |
 | `vaultwarden.signupsVerifyResendTime` | Seconds before another verification email can be sent | `3600` |

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -55,6 +55,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "upgrade to 7.0.4 security release (#885)"
+      description: "upgrade to 7.0.2 security release (#885)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: wordpress
 type: application
 version: 3.0.3
-appVersion: "7.0.2"
+appVersion: "7.0.4"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying WordPress on Kubernetes with MySQL support and S3 backup
 maintainers:
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "upgrade to 7.0.2 security release (#885)"
+      description: "upgrade to 7.0.4 security release (#885)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -50,11 +50,11 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/mysql
 dependencies:
   - name: mysql
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 1.6.20
+    version: 2.0.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled
   - name: memcached

--- a/charts/wordpress/ci/memcached-subchart-values.yaml
+++ b/charts/wordpress/ci/memcached-subchart-values.yaml
@@ -17,6 +17,9 @@ objectCache:
       enabled: true
 
 memcached:
+  # Keep the dependency Service distinct when the validation release name
+  # itself contains "memcached".
+  nameOverride: mcserver
   architecture: standalone
   memcached:
     memoryLimitMB: 128

--- a/charts/wordpress/ci/redis-external-values.yaml
+++ b/charts/wordpress/ci/redis-external-values.yaml
@@ -54,7 +54,7 @@ extraManifests:
         spec:
           containers:
             - name: redis
-              image: docker.io/library/redis:8.8.0
+              image: docker.io/library/redis:8.10.0
               imagePullPolicy: IfNotPresent
               args:
                 - redis-server

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -7,7 +7,7 @@ release:
   name: test
   namespace: default
 chart:
-  appVersion: "7.0.2"
+  appVersion: "7.0.4"
 tests:
   - it: should not render backup by default
     template: templates/backup-cronjob.yaml

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Container image repository
   repository: docker.io/library/wordpress
   # -- Container image tag
-  tag: "7.0.2-apache"
+  tag: "7.0.4-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -426,7 +426,7 @@ wpCron:
     backoffLimit: 1
     image:
       repository: docker.io/curlimages/curl
-      tag: "8.17.0"
+      tag: "8.21.0"
       pullPolicy: IfNotPresent
     resources: {}
 


### PR DESCRIPTION
## Summary

- refreshes official pinned images across 52 charts
- updates dependency documentation and corrects upstream release notes found during review
- restores CI-owned Artifact Hub change metadata and documents the independently pinned SonarQube community plugin
- updates Strapi to the published HelmForge base image 5.52.0

## Validation

- `make preflight`
- `make validate-chart CHART=<chart>` passed end-to-end for all 52 changed charts, including the k3d behavioral gate
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`

## Related

- Site image and upgrade documentation: helmforgedev/site#506
- Strapi documentation: helmforgedev/site#507
- Strapi base image release: helmforgedev/strapi-base#17