### PR TITLE
feat(ente)!: add chart

### DIFF
--- a/charts/ente/.helmignore
+++ b/charts/ente/.helmignore
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+.DS_Store
+Thumbs.db
+.git/
+.gitignore
+.gitattributes
+.helmignore
+.idea/
+.project
+.tmp/
+.vscode/
+*.swp
+*.tmp
+*.orig
+*.rej
+*.log
+*.bak
+PLAN.md
+RESEARCH.md

--- a/charts/ente/Chart.yaml
+++ b/charts/ente/Chart.yaml
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: ente
+description: Production-ready Ente Photos with Museum, web applications, PostgreSQL, and external S3 storage
+type: application
+version: 1.0.0
+appVersion: "0472c929b6070e61fecaf2013d47efce2dcda462"
+kubeVersion: ">=1.26.0-0"
+icon: https://helmforge.dev/icons/charts/ente.png
+home: https://helmforge.dev
+keywords:
+  - ente
+  - photos
+  - backup
+  - encryption
+  - s3
+  - postgresql
+maintainers:
+  - name: helmforgedev
+  - name: mberlofa
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/ente
+  - https://github.com/ente/ente
+  - https://help.ente.io/self-hosting
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "initial production-ready Ente Photos chart (#980)"
+  artifacthub.io/maintainers: |
+    - name: HelmForge
+      email: berlofa@helmforge.dev
+    - name: Maicon Berlofa
+      email: maicon.berloffa@gmail.com
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: storage
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://ente.io
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/ente
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/ente
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  helmforge.dev/maturity: stable
+  helmforge.dev/signed: gpg+cosign
+  artifacthub.io/signKey: |
+    fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
+    url: https://repo.helmforge.dev/pgp-public-key.asc
+  helmforge.dev/repository: https://repo.helmforge.dev
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/helmforge/postgresql
+dependencies:
+  - name: postgresql
+    version: 2.0.4
+    repository: oci://ghcr.io/helmforgedev/helm
+    condition: postgresql.enabled

--- a/charts/ente/DESIGN.md
+++ b/charts/ente/DESIGN.md
@@ -1,0 +1,126 @@
+# Ente Chart Design
+
+This chart packages Ente's Museum API and official web applications with a
+HelmForge PostgreSQL dependency or an external PostgreSQL service. Object data
+is always stored in an external S3-compatible service.
+
+## Architecture
+
+```text
+Web and mobile clients
+  |
+  +-- Ingress or Gateway API
+        |
+        +-- Museum Service
+        |     |
+        |     +-- Museum API Deployment
+        |     +-- PostgreSQL subchart or external PostgreSQL
+        |     +-- External S3-compatible object storage
+        |
+        +-- Web Services
+              |
+              +-- One hardened web Deployment
+                    +-- Photos, Accounts, Albums, and optional Ente apps
+
+Optional application HA topology
+  +-- Museum API replicas with background jobs disabled
+  +-- One Museum worker replica with background jobs enabled
+```
+
+## Design Choices
+
+- The chart uses immutable official Museum and web image tags. Ente does not
+  publish server semantic releases, so the Museum tag follows the exact commit
+  deployed by the upstream production service and the web tag follows the
+  official weekly build.
+- S3-compatible object storage is external and mandatory. Ente clients upload
+  and download through presigned URLs, so the endpoint must be reachable by
+  clients and configured with the required CORS policy. Bundling a test object
+  store would obscure this production requirement.
+- The default is one Museum API replica with background jobs enabled. Scaling
+  the API requires disabling its background jobs and enabling exactly one
+  singleton worker Deployment. This prevents duplicate cron and cleanup work.
+- A single web Deployment exposes the enabled applications on their upstream
+  ports. Separate Services and routes retain independent public hostnames
+  without duplicating the same image and static assets across Deployments.
+- PostgreSQL can be installed through the HelmForge dependency or supplied by
+  a managed service or operator. Museum performs database migrations during
+  startup. HA pods use a PostgreSQL advisory-lock sidecar that polls without an
+  active transaction and releases the next Museum only after port 8080 opens.
+  This is required because concurrent upstream startup can leave migrations
+  dirty, including migrations that create indexes concurrently.
+- Encryption, hash, and JWT keys are generated only on first installation and
+  retained with Helm `lookup`, or supplied through an existing Secret. They are
+  never intentionally regenerated during an upgrade.
+- External Secrets support follows the generic `items[]` contract. It creates
+  Secrets but does not bypass the chart's explicit `existingSecret` wiring.
+
+## Security And Operations
+
+Museum runs as an arbitrary non-root user with a read-only root filesystem.
+The web image requires a writable copy of its static output for upstream
+runtime origin replacement, so an init container copies the assets into an
+`emptyDir`; the serving container remains non-root and read-only outside the
+declared writable mounts. Both workloads disable privilege escalation, drop
+Linux capabilities, and do not mount service account tokens.
+
+The Museum readiness and startup probes use `/ping`, which verifies PostgreSQL.
+The liveness probe uses TCP so a database outage does not cause restart loops.
+Upstream `/ping` does not verify S3, so production monitoring must include an
+object upload and download check in addition to pod readiness.
+
+NetworkPolicy, PodDisruptionBudget, autoscaling, ServiceMonitor,
+PrometheusRule, Ingress, Gateway API, dual-stack Services, backup, and
+scheduling controls are opt-in. Their defaults do not assume cluster CRDs or a
+specific network environment.
+
+## Durability Model
+
+An Ente recovery set consists of the Museum keys and configuration, PostgreSQL
+data, and all object-storage data. The optional backup CronJob creates
+PostgreSQL dumps in separate S3-compatible storage. It does not copy the photo
+objects or Secret material, so operators must back up all three parts and run
+complete restore drills.
+
+Ente's object replication feature is disabled by default. Replication is not a
+backup and its workers can run in every Museum process. This chart does not
+claim a safe general-purpose replication topology until upstream exposes a
+dedicated worker lifecycle.
+
+## Non-Goals
+
+- Provisioning or managing an S3-compatible object store
+- Treating an embedded database replica as automatic PostgreSQL failover
+- Making the web applications available without a public Museum origin
+- Claiming that Kubernetes readiness proves object-storage availability
+- Backing up object data or external Secret provider contents
+- Enabling upstream object replication by default
+
+## Validation Focus
+
+- Default Museum, web, and HelmForge PostgreSQL rendering
+- External PostgreSQL and existing Secret wiring
+- Generated key stability across Helm upgrades
+- External Secrets Operator resources using `items[]`
+- Safe multi-replica API plus singleton worker topology
+- Serialized first install and upgrade migrations across all Museum pods
+- Ingress and Gateway API routing for Museum and individual web apps
+- Non-root, read-only runtime behavior for Museum and web
+- Dual-stack Services, NetworkPolicy, PDB, HPA, and metrics resources
+- PostgreSQL dump upload to external S3-compatible backup storage
+- Real Museum `/ping`, web HTTP, and S3 object operations in k3d
+
+## Related Files
+
+- `charts/ente/README.md`
+- `charts/ente/docs/architecture.md`
+- `charts/ente/docs/object-storage.md`
+- `charts/ente/docs/high-availability.md`
+- `charts/ente/docs/backup-restore.md`
+- `charts/ente/examples/production.yaml`
+- `charts/ente/examples/production-ha.yaml`
+
+---
+
+keywords: ente, museum, photos, postgresql, s3, gateway-api, external-secrets
+path: charts/ente/DESIGN.md

--- a/charts/ente/PLAN.md
+++ b/charts/ente/PLAN.md
@@ -1,0 +1,216 @@
+# Ente - Implementation Plan
+
+**Chart:** `ente`
+**Issue:** [#980](https://github.com/helmforgedev/charts/issues/980)
+**Target chart version:** `1.0.0`
+**Target maturity:** `stable`
+**Complexity:** High
+
+## Executive Summary
+
+Create a production-ready Ente Photos chart around the official Museum and web
+images. The chart will provide a secure single-instance default, an explicit HA
+topology, HelmForge PostgreSQL, external PostgreSQL support, mandatory external
+S3 configuration, stable cryptographic secrets, modern Kubernetes exposure,
+observability, backup automation, and complete operational documentation.
+
+## Scope
+
+The chart deploys:
+
+- Museum API and its optional singleton background worker.
+- One web Deployment serving the selected Ente Photos applications.
+- A HelmForge PostgreSQL dependency by default or an external PostgreSQL service.
+- Services, Ingress, Gateway API routes, policy, observability, and backup jobs.
+
+The chart does not deploy an S3 server, SMTP server, or Ente's Paste and Locker
+products. These are separate operational domains and should not be hidden inside
+an Ente Photos release.
+
+## Priority 1: Functional MVP
+
+### P1-1: Museum API
+
+- Render a complete upstream `museum.yaml`.
+- Source credentials from a stable generated Secret or an existing Secret.
+- Configure `/ping` startup/readiness and TCP liveness probes.
+- Apply non-root, read-only runtime security.
+
+### P1-2: PostgreSQL
+
+- Depend on HelmForge PostgreSQL `2.0.4` by default.
+- Support external PostgreSQL with TLS mode and Secret key mapping.
+- Wait for the database before Museum starts.
+
+### P1-3: External S3
+
+- Require endpoint, region, bucket, access key, and secret key.
+- Support path-style addressing for compatible providers.
+- Keep MinIO outside the chart and use it only as a k3d fixture.
+
+### P1-4: Web applications
+
+- Run one official web image with Photos, Accounts, and Albums enabled.
+- Expose selected application ports through Kubernetes Services.
+- Configure `ENTE_API_ORIGIN` consistently.
+
+### P1 validation gate
+
+Before production templates are added:
+
+1. Resolve dependencies and run strict lint/schema rendering.
+2. Install the chart in k3d with an external MinIO fixture.
+3. Confirm PostgreSQL, Museum `/ping`, and each default web app are ready.
+4. Confirm secrets remain unchanged after `helm upgrade`.
+5. Exercise an S3 write/read operation using chart credentials.
+
+## Priority 2: Production Features
+
+### P2-1: Safe high availability
+
+- Provide API replicas with cron disabled.
+- Provide exactly one cron-enabled worker Deployment with `Recreate` strategy.
+- Add API PDB, HPA, topology spread, affinity, and anti-affinity controls.
+- Fail rendering for unsafe combinations.
+
+### P2-2: Exposure
+
+- Support per-application Ingress hosts with TLS.
+- Support Gateway API HTTPRoutes and reusable parent references.
+- Support dual-stack Service settings.
+
+### P2-3: Secret management
+
+- Support one existing Secret contract for all Museum credentials.
+- Support External Secrets Operator `items[]` with complete specs.
+- Detect duplicate generated ExternalSecret names.
+
+### P2-4: Network security
+
+- Add NetworkPolicy for Museum and web workloads.
+- Model DNS, PostgreSQL, S3, SMTP, ingress-controller, monitoring, and custom
+  egress without making public-network assumptions.
+
+### P2-5: Observability
+
+- Expose Museum metrics through a separate Service.
+- Add opt-in ServiceMonitor and PrometheusRule.
+- Document logs and actionable alerts.
+
+### P2-6: Backup
+
+- Add an opt-in PostgreSQL dump-to-S3 CronJob.
+- Reuse external backup credentials without conflating them with Ente storage.
+- Document S3 object backup and complete restore ordering.
+
+## Priority 3: Quality And Operations
+
+- Full `values.schema.json` coverage.
+- At least 40 focused helm-unittest cases.
+- Eight to ten CI values scenarios.
+- Five or more complete examples.
+- Dedicated guides for architecture, S3, HA, security, backup, and operations.
+- A 150-200 line `NOTES.txt` with eight operational sections.
+- A comprehensive chart README.
+- Stable site catalog entry, official icon, playground scenarios, and an
+  800-line minimum documentation page with all required sections.
+
+## Planned Chart Structure
+
+```text
+charts/ente/
+|-- Chart.yaml
+|-- Chart.lock
+|-- values.yaml
+|-- values.schema.json
+|-- README.md
+|-- RESEARCH.md
+|-- PLAN.md
+|-- ci/
+|-- docs/
+|-- examples/
+|-- tests/
+`-- templates/
+    |-- _helpers.tpl
+    |-- validate.yaml
+    |-- configmap.yaml
+    |-- secret.yaml
+    |-- externalsecret.yaml
+    |-- museum-api-deployment.yaml
+    |-- museum-worker-deployment.yaml
+    |-- web-deployment.yaml
+    |-- services.yaml
+    |-- ingress.yaml
+    |-- gateway-httproute.yaml
+    |-- networkpolicy.yaml
+    |-- pdb.yaml
+    |-- hpa.yaml
+    |-- servicemonitor.yaml
+    |-- prometheusrule.yaml
+    |-- backup-cronjob.yaml
+    |-- serviceaccount.yaml
+    |-- extra-manifests.yaml
+    `-- NOTES.txt
+```
+
+## Validation Strategy
+
+### Static gates
+
+- `helm dependency build`
+- `helm lint --strict` for defaults and every `ci/*.yaml`
+- `helm template` and JSON schema validation
+- `helm unittest`
+- `kubeconform` against installed CRD schemas
+- Artifact Hub lint
+- SPDX and HelmForge standards checks
+
+### Behavioral gates
+
+- Default single-instance install.
+- External PostgreSQL render and connection contract.
+- ESO render against the installed fake ClusterSecretStore.
+- Ingress and Gateway API routes.
+- HA API plus singleton worker rollout.
+- Metrics discovery.
+- NetworkPolicy-enabled startup and S3 access.
+- Backup CronJob execution against the fixture.
+- Secret preservation across upgrade.
+- API and web smoke checks.
+
+The final mandatory gate is:
+
+```shell
+make validate-chart CHART=ente
+```
+
+## Documentation Plan
+
+Chart documentation will cover:
+
+1. Architecture.
+2. Installation.
+3. Initial secret preparation.
+4. PostgreSQL modes.
+5. S3 providers and CORS.
+6. SMTP and one-time codes.
+7. Web application hosts.
+8. Ingress.
+9. Gateway API.
+10. High availability.
+11. Security and NetworkPolicy.
+12. Observability.
+13. Backup and restore.
+14. Upgrade procedures.
+15. Troubleshooting with at least ten cases.
+
+## Acceptance Criteria
+
+- The chart is marked `helmforge.dev/maturity: stable`.
+- All images are official, pinned, and verified multi-architecture images.
+- No critical credential changes during an ordinary upgrade.
+- Default and production examples pass the full local validation gate.
+- HA never runs more than one cron-enabled worker.
+- S3 is clearly external and validated as a production dependency.
+- Chart and site documentation satisfy the new-chart requirements.
+- No unresolved validation warnings remain.

--- a/charts/ente/README.md
+++ b/charts/ente/README.md
@@ -100,7 +100,9 @@ A production installation needs:
 4. HTTPS hosts for Photos, Accounts, and Albums.
 5. Durable Museum cryptographic secrets.
 6. Durable PostgreSQL.
-7. SMTP for one-time login codes.
+7. SMTP is strongly recommended for one-time login codes. Without SMTP, Museum
+   writes the codes to its logs and the installation is not suitable for normal
+   production authentication.
 
 Set `productionMode=true` to reject evaluation placeholders and local-bucket
 workarounds.
@@ -148,13 +150,13 @@ Create `values-production.yaml`:
 productionMode: true
 
 museum:
-  externalUrl: https://api.ente.example.com
+  externalUrl: https://api.ente.company.tld
   existingSecret: ente-museum
   config:
     webauthn:
-      rpid: accounts.ente.example.com
+      rpid: accounts.ente.company.tld
       rporigins:
-        - https://accounts.ente.example.com
+        - https://accounts.ente.company.tld
 
 storage:
   s3:
@@ -165,9 +167,9 @@ storage:
 
 smtp:
   enabled: true
-  host: smtp.example.com
+  host: smtp.company.tld
   port: 587
-  email: ente@example.com
+  email: ente@company.tld
   senderName: Ente
   encryption: tls
   existingSecret: ente-smtp
@@ -175,32 +177,32 @@ smtp:
 web:
   apps:
     photos:
-      externalUrl: https://photos.ente.example.com
+      externalUrl: https://photos.ente.company.tld
     accounts:
-      externalUrl: https://accounts.ente.example.com
+      externalUrl: https://accounts.ente.company.tld
     albums:
-      externalUrl: https://albums.ente.example.com
+      externalUrl: https://albums.ente.company.tld
 
 ingress:
   enabled: true
   ingressClassName: nginx
   hosts:
-    - host: api.ente.example.com
+    - host: api.ente.company.tld
       service: museum
       paths:
         - path: /
           pathType: Prefix
-    - host: photos.ente.example.com
+    - host: photos.ente.company.tld
       service: photos
       paths:
         - path: /
           pathType: Prefix
-    - host: accounts.ente.example.com
+    - host: accounts.ente.company.tld
       service: accounts
       paths:
         - path: /
           pathType: Prefix
-    - host: albums.ente.example.com
+    - host: albums.ente.company.tld
       service: albums
       paths:
         - path: /
@@ -208,10 +210,10 @@ ingress:
   tls:
     - secretName: ente-tls
       hosts:
-        - api.ente.example.com
-        - photos.ente.example.com
-        - accounts.ente.example.com
-        - albums.ente.example.com
+        - api.ente.company.tld
+        - photos.ente.company.tld
+        - accounts.ente.company.tld
+        - albums.ente.company.tld
 ```
 
 ## PostgreSQL modes
@@ -426,9 +428,18 @@ networkPolicy:
     allowDNS: true
     allowSameNamespacePostgresql: true
     allowObjectStorage: true
+    objectStoragePorts:
+      - 443
 ```
 
-For external PostgreSQL, private S3, or restricted SMTP, add shared rules to
+The default object-storage rule permits public IPv4 and IPv6 destinations on
+TCP 443 while excluding private and link-local ranges. For a private or
+in-cluster S3 endpoint, replace
+`networkPolicy.egress.objectStorageDestinations` with explicit `ipBlock`,
+`namespaceSelector`, or `podSelector` peers. Add plaintext ports such as 80 or
+9000 to `objectStoragePorts` only when the endpoint and network are trusted.
+
+For external PostgreSQL or restricted SMTP, add shared rules to
 `networkPolicy.extraEgress` or Museum-only rules to
 `networkPolicy.egress.museumExtraRules`. NetworkPolicy cannot authorize a DNS
 hostname directly; use stable provider CIDRs or a controlled egress gateway.

--- a/charts/ente/README.md
+++ b/charts/ente/README.md
@@ -1,0 +1,574 @@
+# Ente
+
+A production-ready Helm chart for [Ente](https://ente.io), the end-to-end
+encrypted photo platform. The chart deploys Museum, Ente's web applications,
+and HelmForge PostgreSQL while using durable external S3-compatible object
+storage.
+
+## Status
+
+- Maturity: stable
+- Kubernetes: 1.26 or newer
+- Architectures: amd64 and arm64
+- Museum image: official `ghcr.io/ente/server`, pinned to the upstream
+  production commit
+- Web image: official `ghcr.io/ente/web`, pinned to an immutable commit
+- License: Apache-2.0 for the chart; Ente is AGPL-3.0
+
+### Security Scan: `ente`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **89.11616%** |
+
+> Security posture acceptable. Kubescape 4.0.9 reported no critical failures.
+
+## Architecture
+
+Ente clients encrypt photos before upload. Museum stores metadata and encryption
+material in PostgreSQL and returns presigned object-storage URLs. Clients then
+transfer encrypted objects directly to S3.
+
+```text
+Browser / mobile client
+        | HTTPS
+        +--------------------> Ente web applications
+        |
+        +--------------------> Museum API
+                                  | PostgreSQL protocol
+                                  +------> PostgreSQL
+                                  |
+                                  | S3 control operations
+                                  +------> external S3
+        |
+        | presigned S3 URLs
+        +------------------------> external S3
+```
+
+The S3 endpoint must be reachable from both the cluster and end-user clients.
+The chart deliberately does not bundle MinIO because upstream recommends an
+external provider for long-lived self-hosted installations.
+
+## Features
+
+- Official, immutable, multi-architecture Museum and web images
+- Stable cryptographic keys preserved through Helm upgrades
+- Existing Secret and External Secrets Operator integration
+- HelmForge PostgreSQL dependency or external PostgreSQL
+- Museum API and singleton job-worker HA topology
+- PostgreSQL advisory-lock gate for serialized HA migrations
+- Photos, Accounts, and Albums enabled by default
+- Auth, Cast, Share, Embed, and Memories optional
+- One hardened web Deployment instead of duplicated images
+- Non-root containers and read-only root filesystems
+- Restricted service accounts without API tokens
+- Startup, readiness, and liveness probes
+- Ingress with per-application hosts and TLS
+- Gateway API HTTPRoutes
+- Dual-stack Services
+- PDB and HPA for API and web workloads
+- NetworkPolicy with S3, SMTP, and private-network extension points
+- Native Museum metrics, ServiceMonitor, and PrometheusRule
+- PostgreSQL dump-to-S3 CronJob
+- Helm test hook for API and enabled web applications
+- Complete JSON schema, CI scenarios, and unit tests
+
+## Installation
+
+### Helm repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install ente helmforge/ente -f values-production.yaml
+```
+
+### OCI registry
+
+```bash
+helm install ente oci://ghcr.io/helmforgedev/helm/ente \
+  -f values-production.yaml
+```
+
+## Required production inputs
+
+A production installation needs:
+
+1. An S3-compatible bucket without object lock or versioning.
+2. CORS configured for the Ente web origins.
+3. A public HTTPS Museum API origin.
+4. HTTPS hosts for Photos, Accounts, and Albums.
+5. Durable Museum cryptographic secrets.
+6. Durable PostgreSQL.
+7. SMTP for one-time login codes.
+
+Set `productionMode=true` to reject evaluation placeholders and local-bucket
+workarounds.
+
+## Production quick start
+
+Create Museum, S3, and SMTP Secrets before installation:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ente-museum
+type: Opaque
+stringData:
+  encryption-key: REPLACE_WITH_32_BYTE_STANDARD_BASE64
+  hash-key: REPLACE_WITH_64_BYTE_STANDARD_BASE64
+  jwt-secret: REPLACE_WITH_32_BYTE_URL_SAFE_BASE64
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ente-s3
+type: Opaque
+stringData:
+  access-key: REPLACE_WITH_ACCESS_KEY
+  secret-key: REPLACE_WITH_SECRET_KEY
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ente-smtp
+type: Opaque
+stringData:
+  username: REPLACE_WITH_SMTP_USERNAME
+  password: REPLACE_WITH_SMTP_PASSWORD
+```
+
+Generate Ente key material with a cryptographically secure tool. Do not use the
+fixed development values from upstream `local.yaml`.
+
+Create `values-production.yaml`:
+
+```yaml
+productionMode: true
+
+museum:
+  externalUrl: https://api.ente.example.com
+  existingSecret: ente-museum
+  config:
+    webauthn:
+      rpid: accounts.ente.example.com
+      rporigins:
+        - https://accounts.ente.example.com
+
+storage:
+  s3:
+    endpoint: https://s3.us-east-1.amazonaws.com
+    region: us-east-1
+    bucket: company-ente-photos
+    existingSecret: ente-s3
+
+smtp:
+  enabled: true
+  host: smtp.example.com
+  port: 587
+  email: ente@example.com
+  senderName: Ente
+  encryption: tls
+  existingSecret: ente-smtp
+
+web:
+  apps:
+    photos:
+      externalUrl: https://photos.ente.example.com
+    accounts:
+      externalUrl: https://accounts.ente.example.com
+    albums:
+      externalUrl: https://albums.ente.example.com
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: api.ente.example.com
+      service: museum
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: photos.ente.example.com
+      service: photos
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: accounts.ente.example.com
+      service: accounts
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: albums.ente.example.com
+      service: albums
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: ente-tls
+      hosts:
+        - api.ente.example.com
+        - photos.ente.example.com
+        - accounts.ente.example.com
+        - albums.ente.example.com
+```
+
+## PostgreSQL modes
+
+The default `database.mode=auto` chooses the external configuration when set,
+otherwise the HelmForge PostgreSQL dependency.
+
+### Bundled PostgreSQL
+
+```yaml
+postgresql:
+  enabled: true
+  architecture: standalone
+  auth:
+    database: ente
+    username: ente
+  standalone:
+    persistence:
+      enabled: true
+      size: 100Gi
+```
+
+The bundled architecture is durable but does not provide automatic database
+failover. Use managed PostgreSQL or a Kubernetes database operator for HA.
+
+### External PostgreSQL
+
+```yaml
+database:
+  mode: external
+  external:
+    host: ente-rw.database.svc.cluster.local
+    port: 5432
+    name: ente
+    username: ente
+    existingSecret: ente-postgresql
+    existingSecretPasswordKey: database-password
+    sslMode: verify-full
+
+postgresql:
+  enabled: false
+```
+
+Museum supports PostgreSQL 14 and newer and applies migrations during startup.
+
+## High availability
+
+Museum runs scheduled and background work inside the API process. Multiple
+cron-enabled replicas are unsafe. The chart rejects that configuration.
+
+Use API replicas with jobs disabled plus one singleton worker:
+
+```yaml
+museum:
+  api:
+    replicaCount: 3
+    skipBackgroundJobs: true
+  worker:
+    enabled: true
+
+web:
+  replicaCount: 3
+
+pdb:
+  museum:
+    enabled: true
+  web:
+    enabled: true
+```
+
+The worker has no public Service and uses `Recreate` to prevent overlapping
+schedulers during rollout.
+
+Every Museum process attempts database migrations during startup. In HA, the
+chart adds a hardened PostgreSQL client sidecar to every Museum pod. The sidecar
+uses `pg_try_advisory_lock` without holding an active transaction, starts one
+Museum process, waits for port 8080, and only then releases the next pod. This
+avoids concurrent `CREATE INDEX CONCURRENTLY` migrations and a dirty migration
+state. Disabling `museum.migrationGate` in an HA or HPA topology is rejected.
+
+## Autoscaling
+
+```yaml
+museum:
+  api:
+    skipBackgroundJobs: true
+  worker:
+    enabled: true
+
+autoscaling:
+  museum:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 70
+  web:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+```
+
+Resource requests must remain set for utilization-based HPA metrics.
+
+## External Secrets Operator
+
+The chart accepts complete ExternalSecret specifications in `items[]`. This
+keeps provider-specific authentication and advanced ESO features available.
+
+```yaml
+museum:
+  existingSecret: ente-museum
+storage:
+  s3:
+    existingSecret: ente-s3
+
+externalSecrets:
+  enabled: true
+  items:
+    - name: museum
+      spec:
+        secretStoreRef:
+          name: production
+          kind: ClusterSecretStore
+        target:
+          name: ente-museum
+        dataFrom:
+          - extract:
+              key: ente/museum
+    - name: s3
+      spec:
+        secretStoreRef:
+          name: production
+          kind: ClusterSecretStore
+        target:
+          name: ente-s3
+        dataFrom:
+          - extract:
+              key: ente/s3
+```
+
+## Object storage
+
+Museum readiness only checks PostgreSQL. Validate S3 independently with an
+upload and download through an Ente client.
+
+Required CORS methods:
+
+- GET
+- HEAD
+- POST
+- PUT
+- DELETE
+
+Required request headers include `Content-Type`, `Content-MD5`, and
+`UPLOAD-URL`. Expose response headers needed by your provider and Ente client.
+
+Do not enable `storage.s3.localBuckets` in production. That setting activates
+upstream workarounds for local MinIO evaluation environments.
+
+## Backup and restore
+
+Enable the PostgreSQL dump CronJob:
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://backup.example.com
+    bucket: platform-backups
+    prefix: ente/postgresql
+    existingSecret: ente-backup-s3
+```
+
+The CronJob backs up PostgreSQL only. Back up the object bucket and Museum
+Secrets with provider-native tools. Restore all three as one consistency set.
+
+Test a manual backup:
+
+```bash
+kubectl create job ente-backup-test \
+  --from=cronjob/ente-postgresql-backup
+kubectl wait --for=condition=complete job/ente-backup-test --timeout=10m
+kubectl logs job/ente-backup-test --all-containers
+```
+
+## Observability
+
+Museum exposes Prometheus metrics on port 2112.
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack
+  prometheusRule:
+    enabled: true
+```
+
+ServiceMonitor and PrometheusRule remain disabled by default because they
+require Prometheus Operator CRDs.
+
+## Network policy
+
+```yaml
+networkPolicy:
+  enabled: true
+  egress:
+    allowDNS: true
+    allowSameNamespacePostgresql: true
+    allowObjectStorage: true
+```
+
+For external PostgreSQL, private S3, or restricted SMTP, add shared rules to
+`networkPolicy.extraEgress` or Museum-only rules to
+`networkPolicy.egress.museumExtraRules`. NetworkPolicy cannot authorize a DNS
+hostname directly; use stable provider CIDRs or a controlled egress gateway.
+
+## Gateway API
+
+```yaml
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  routes:
+    - name: museum
+      service: museum
+      hostnames: [api.ente.example.com]
+    - name: photos
+      service: photos
+      hostnames: [photos.ente.example.com]
+```
+
+TLS is configured on the referenced Gateway listener.
+
+## Web applications
+
+The single web image contains multiple static applications. Enabled apps receive
+individual Services and may receive individual routes.
+
+| Application | Default | Container port |
+| --- | --- | ---: |
+| Photos | enabled | 3000 |
+| Accounts | enabled | 3001 |
+| Albums | enabled | 3002 |
+| Auth | disabled | 3003 |
+| Cast | disabled | 3004 |
+| Share | disabled | 3005 |
+| Embed | disabled | 3006 |
+| Memories | disabled | 3010 |
+
+Ente Paste and Locker are separate products and are outside this chart's scope.
+
+## Upgrade procedure
+
+1. Back up Museum Secrets, PostgreSQL, and S3.
+2. Read chart and upstream release notes.
+3. Render the upgrade with production values.
+4. Confirm immutable image changes intentionally.
+5. Run `helm upgrade` without `--reuse-values` so new chart defaults are merged.
+6. Wait for the API, worker, and web rollouts.
+7. Run `helm test`.
+8. Verify account login, upload, download, and public albums.
+
+```bash
+helm upgrade ente oci://ghcr.io/helmforgedev/helm/ente \
+  -f values-production.yaml \
+  --wait \
+  --timeout 10m
+helm test ente --logs
+```
+
+## Troubleshooting
+
+### Museum is not Ready
+
+`/ping` checks PostgreSQL. Inspect database DNS, credentials, TLS mode, and
+Museum logs.
+
+### Museum is Ready but uploads fail
+
+Check S3 client reachability, credentials, bucket CORS, endpoint TLS, and
+path-style settings. `/ping` does not check S3.
+
+### Login code does not arrive
+
+Check SMTP host, port, encryption, sender policy, and credentials. Without SMTP,
+the code appears in Museum logs.
+
+### Passkeys fail
+
+The Accounts hostname must match `museum.config.webauthn.rpid` and the exact
+HTTPS origin must appear in `rporigins`.
+
+### Upgrade rotates keys
+
+Restore the previous Museum Secret immediately. Configure `existingSecret` or
+ensure the Helm-managed Secret was not deleted before the upgrade.
+
+### Multiple jobs execute
+
+Ensure every API uses `skipBackgroundJobs=true` and exactly one worker exists.
+
+### Web pod cannot write files
+
+Do not remove the web-content, nginx-cache, nginx-run, or tmp emptyDir mounts.
+They are required by the hardened read-only runtime.
+
+### NetworkPolicy blocks PostgreSQL
+
+Add the external database namespace, pod selector, or CIDR to
+`networkPolicy.extraEgress` for shared access or `museumExtraRules` for Museum
+only.
+
+### Museum reports a dirty database version
+
+Stop concurrent Museum starts and restore or repair PostgreSQL according to the
+upstream migration procedure. Keep `museum.migrationGate.enabled=true` for HA
+and inspect both `museum` and `migration-gate` container logs before retrying.
+
+### Metrics resources are rejected
+
+Install Prometheus Operator CRDs or disable ServiceMonitor and PrometheusRule.
+
+### Backup upload fails
+
+Inspect both `dump` init-container and `upload` container logs. Confirm the
+backup bucket and Secret independently from the Ente object bucket.
+
+## Validation
+
+```bash
+helm lint . --strict
+helm unittest .
+helm template ente . -f examples/production-ha.yaml
+helm test ente -n ente --logs
+```
+
+## Additional documentation
+
+- [Architecture](docs/architecture.md)
+- [Object storage](docs/object-storage.md)
+- [High availability](docs/high-availability.md)
+- [Backup and restore](docs/backup-restore.md)
+- [Security](docs/security.md)
+- [Upstream self-hosting documentation](https://help.ente.io/self-hosting)
+
+## Non-goals
+
+This chart does not deploy S3, SMTP, Paste, Locker, or an automatic PostgreSQL
+failover system. It does not treat Ente's multi-bucket replication as backup.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/charts/ente/RESEARCH.md
+++ b/charts/ente/RESEARCH.md
@@ -1,0 +1,188 @@
+# Ente - Research Findings
+
+**Chart request:** [#980](https://github.com/helmforgedev/charts/issues/980)
+**Requester:** `@Alxtp`
+**Upstream:** <https://github.com/ente/ente>
+**Research date:** 2026-08-15
+
+## Recommendation
+
+Ship Ente as a stable HelmForge chart. The upstream server release process builds
+an official image from the exact commit currently running in Ente production,
+which provides a defensible stable channel even though Museum does not use
+semantic image tags. The chart must pin that commit and must not use `latest`.
+
+The chart should deploy Ente Photos, not every Ente product. Its supported
+runtime consists of Museum, the web bundle, PostgreSQL, and externally managed
+S3-compatible object storage. S3 is intentionally not bundled because Ente's
+official documentation recommends an external provider for long-lived installs.
+
+## Core Architecture
+
+Ente Photos has four runtime responsibilities:
+
+1. Museum provides the API on port 8080 and Prometheus metrics on port 2112.
+2. The official web image serves Photos and supporting apps on separate ports.
+3. PostgreSQL stores account metadata and the encryption keys needed to recover
+   objects.
+4. S3-compatible storage holds encrypted objects and is accessed directly by
+   clients through presigned URLs.
+
+Museum applies database migrations on startup. `GET /ping` checks PostgreSQL but
+does not check S3. A successful readiness probe therefore does not prove that
+uploads work.
+
+The web image contains these applications:
+
+| Application | Port | Included scope |
+| --- | ---: | --- |
+| Photos | 3000 | Enabled by default |
+| Accounts | 3001 | Enabled by default |
+| Albums | 3002 | Enabled by default |
+| Auth | 3003 | Optional |
+| Cast | 3004 | Optional |
+| Share | 3005 | Optional |
+| Embed | 3006 | Optional |
+| Paste | 3008 | Out of Ente Photos scope |
+| Locker | 3009 | Out of Ente Photos scope |
+| Memories | 3010 | Optional |
+
+## Release And Image Policy
+
+Ente does not publish semantic releases for Museum or the web bundle.
+
+- Museum: `ghcr.io/ente/server:0472c929b6070e61fecaf2013d47efce2dcda462`
+- Web: `ghcr.io/ente/web:5ab0c5b4c7a89c4e470ef6f793600da33cebf35d`
+
+Both official images were verified as multi-architecture manifests for
+`linux/amd64` and `linux/arm64`. Museum's tag is the commit returned by Ente's
+production `/ping` endpoint and is published by the monthly official workflow.
+The web tag is the current commit published by the official weekly workflow.
+
+## Required Configuration
+
+Museum requires:
+
+- PostgreSQL host, port, database, user, password, and SSL mode.
+- Primary S3 credentials under the historically fixed `b2-eu-cen` key.
+- A 32-byte base64 encryption key.
+- A 64-byte base64 hash key.
+- A 32-byte base64 URL-safe JWT secret.
+
+SMTP is strongly recommended because Ente uses one-time codes for login. Without
+SMTP, the code is written to Museum logs, which is unsuitable for production.
+
+The S3 endpoint must be reachable by browsers and mobile clients. Its CORS policy
+must allow Ente's origins, methods, `Content-MD5`, and `UPLOAD-URL`. Object lock
+and versioning must not be enabled for Ente file-data buckets because upstream
+does not handle them.
+
+## High Availability
+
+Cron and background cleanup run inside every Museum process. Not every job has a
+database lock, so multiple cron-enabled replicas are unsafe.
+
+The supported HA topology is:
+
+- Two or more API replicas with `jobs.cron.skip=true`.
+- One singleton worker using the same Museum image with cron enabled.
+- No Service or external route for the worker.
+- A `Recreate` strategy for the worker to avoid overlapping schedulers.
+
+All instances still run migrations at startup. Rolling API updates should avoid
+unnecessary startup concurrency. Ente replication remains disabled by default
+because its workers start in every Museum process and require three buckets.
+
+## Security Requirements
+
+- Preserve generated cryptographic material across upgrades with `lookup`.
+- Prefer an existing Secret or External Secrets Operator in production.
+- Run Museum as a non-root user with a read-only root filesystem.
+- Prepare the web files and writable nginx paths before running nginx non-root.
+- Disable service account token mounts.
+- Apply restrictive pod and container security contexts.
+- Provide NetworkPolicy with explicit DNS, PostgreSQL, S3, SMTP, and custom
+  egress extension points.
+- Keep metrics and ServiceMonitor opt-in.
+- Require TLS at the external Ingress or Gateway for production examples.
+
+## Backup And Restore
+
+A recoverable Ente backup is an inseparable set:
+
+1. Museum configuration and cryptographic secrets.
+2. PostgreSQL data.
+3. S3 objects.
+
+Objects cannot be recovered from S3 alone because their encryption metadata is
+stored in PostgreSQL. Ente's multi-bucket replication is availability, not a
+backup. Documentation must include a complete restore drill.
+
+## Existing Charts Analysis
+
+### Official chart
+
+Ente does not maintain an official Helm chart. Its documentation references the
+community `l4gdev/helm-charts` implementation.
+
+### l4gdev/ente-photos
+
+Strengths:
+
+- Covers Museum and the web applications.
+- Includes Ingress, NetworkPolicy, PDB, ServiceMonitor, and schema files.
+- Supports external PostgreSQL.
+
+Limitations:
+
+- Uses floating `latest` tags from the retired `ente-io` image namespace.
+- Regenerates critical cryptographic keys during renders.
+- Leaves security contexts and resources effectively unset.
+- Does not provide Gateway API, ESO, backup, HPA, or production restore guidance.
+- Allows overly broad network ingress and cannot express private S3 egress well.
+- Models some upstream configuration keys incorrectly.
+- Creates a separate Deployment for every web application even though one image
+  can serve all ports.
+
+### jatinkatyal13/ente-helm
+
+This chart is a homelab-oriented minimal deployment. It uses floating images,
+hard-coded secrets and storage assumptions, and does not cover the PostgreSQL,
+S3, security, observability, schema, or validation contracts required here.
+
+## HelmForge Differentiation
+
+| Capability | Community charts | HelmForge |
+| --- | --- | --- |
+| Official images | Floating or retired namespace | Current official SHA pins |
+| Secret upgrades | Keys may rotate | `lookup`, existing Secret, and ESO |
+| PostgreSQL | External only or ad hoc | HelmForge dependency and external mode |
+| S3 contract | Basic credentials | Client reachability, CORS, TLS, validation |
+| HA cron safety | Not modeled | API replicas plus singleton worker |
+| Kubernetes exposure | Ingress | Ingress and Gateway API |
+| Security | Mostly unset | Non-root, read-only, tokenless, NetworkPolicy |
+| Observability | Partial | Metrics Service, ServiceMonitor, alerts |
+| Backup | Not integrated | PostgreSQL-to-S3 job and full restore guide |
+| Validation | Template-level | Unit, schema, kubeconform, and k3d behavior |
+
+## Risks And Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| No semantic upstream server version | Upgrade tracking ambiguity | Pin the production commit and document provenance |
+| S3 is not checked by `/ping` | Ready pods can still fail uploads | Validate S3 configuration and exercise S3 in k3d |
+| Multiple Museum jobs | Duplicate scheduled work | Singleton worker architecture |
+| Web image expects writable nginx paths | Hardened pod may fail | Init copy plus writable `emptyDir` mounts |
+| Secret loss | Permanent data loss | Stable generated Secret and production secret guidance |
+| Replication starts workers per process | Unexpected duplicate workers | Disable by default and document topology limits |
+
+## Primary Sources
+
+- <https://github.com/ente/ente/blob/main/server/RUNNING.md>
+- <https://github.com/ente/ente/blob/main/server/configurations/local.yaml>
+- <https://github.com/ente/ente/blob/main/web/docs/docker.md>
+- <https://help.ente.io/self-hosting/installation/config>
+- <https://help.ente.io/self-hosting/administration/object-storage>
+- <https://help.ente.io/self-hosting/administration/backup>
+- <https://github.com/ente/ente/blob/main/.github/workflows/server-publish-ghcr.yml>
+- <https://github.com/ente/ente/blob/main/.github/workflows/web-publish-ghcr.yml>

--- a/charts/ente/ci/backup-values.yaml
+++ b/charts/ente/ci/backup-values.yaml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+backup:
+  enabled: true
+  schedule: "15 2 * * *"
+  s3:
+    endpoint: https://backup.ente.test
+    bucket: ente-backups
+    existingSecret: ente-backup-s3

--- a/charts/ente/ci/default-values.yaml
+++ b/charts/ente/ci/default-values.yaml
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Default single-instance Museum, PostgreSQL, and web applications.

--- a/charts/ente/ci/dual-stack-values.yaml
+++ b/charts/ente/ci/dual-stack-values.yaml
@@ -2,12 +2,6 @@
 museum:
   service:
     ipFamilyPolicy: PreferDualStack
-    ipFamilies:
-      - IPv6
-      - IPv4
 web:
   service:
     ipFamilyPolicy: PreferDualStack
-    ipFamilies:
-      - IPv6
-      - IPv4

--- a/charts/ente/ci/dual-stack-values.yaml
+++ b/charts/ente/ci/dual-stack-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+museum:
+  service:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv6
+      - IPv4
+web:
+  service:
+    ipFamilyPolicy: PreferDualStack
+    ipFamilies:
+      - IPv6
+      - IPv4

--- a/charts/ente/ci/external-postgresql-values.yaml
+++ b/charts/ente/ci/external-postgresql-values.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+database:
+  mode: external
+  external:
+    host: ente-external-postgresql
+    name: ente
+    username: ente
+    existingSecret: ente-external-postgresql
+    sslMode: disable
+postgresql:
+  enabled: false

--- a/charts/ente/ci/external-secrets-values.yaml
+++ b/charts/ente/ci/external-secrets-values.yaml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+museum:
+  existingSecret: ente-museum
+storage:
+  s3:
+    existingSecret: ente-s3
+externalSecrets:
+  enabled: true
+  items:
+    - name: museum
+      spec:
+        secretStoreRef:
+          name: ente-runtime-fake-store
+          kind: SecretStore
+        target:
+          name: ente-museum
+        data:
+          - secretKey: encryption-key
+            remoteRef:
+              key: ente/encryption-key
+          - secretKey: hash-key
+            remoteRef:
+              key: ente/hash-key
+          - secretKey: jwt-secret
+            remoteRef:
+              key: ente/jwt-secret
+    - name: s3
+      spec:
+        secretStoreRef:
+          name: ente-runtime-fake-store
+          kind: SecretStore
+        target:
+          name: ente-s3
+        data:
+          - secretKey: access-key
+            remoteRef:
+              key: ente/s3-access-key
+          - secretKey: secret-key
+            remoteRef:
+              key: ente/s3-secret-key

--- a/charts/ente/ci/fixtures/external-postgresql-values.yaml
+++ b/charts/ente/ci/fixtures/external-postgresql-values.yaml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ente-external-postgresql
+type: Opaque
+stringData:
+  database-password: change-me
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ente-external-postgresql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ente-external-postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ente-external-postgresql
+        helmforge.dev/runtime-fixture: "true"
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/library/postgres:18.4-trixie
+          env:
+            - name: POSTGRES_DB
+              value: ente
+            - name: POSTGRES_USER
+              value: ente
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ente-external-postgresql
+                  key: database-password
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - --username=ente
+                - --dbname=ente
+            periodSeconds: 2
+            timeoutSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ente-external-postgresql
+spec:
+  selector:
+    app.kubernetes.io/name: ente-external-postgresql
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql

--- a/charts/ente/ci/fixtures/external-postgresql-values.yaml
+++ b/charts/ente/ci/fixtures/external-postgresql-values.yaml
@@ -22,10 +22,29 @@ spec:
         app.kubernetes.io/name: ente-external-postgresql
         helmforge.dev/runtime-fixture: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: postgresql
           image: docker.io/library/postgres:18.4-trixie
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 999
+            runAsGroup: 999
           env:
+            - name: PGDATA
+              value: /var/lib/postgresql/18/docker
             - name: POSTGRES_DB
               value: ente
             - name: POSTGRES_USER
@@ -46,6 +65,20 @@ spec:
                 - --dbname=ente
             periodSeconds: 2
             timeoutSeconds: 2
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql
+            - name: run
+              mountPath: /var/run/postgresql
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/ente/ci/fixtures/external-secrets-values.yaml
+++ b/charts/ente/ci/fixtures/external-secrets-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: ente-runtime-fake-store
+spec:
+  provider:
+    fake:
+      data:
+        - key: ente/encryption-key
+          value: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
+        - key: ente/hash-key
+          value: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMw==
+        - key: ente/jwt-secret
+          value: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
+        - key: ente/s3-access-key
+          value: helmforge-runtime-access
+        - key: ente/s3-secret-key
+          value: helmforge-runtime-secret

--- a/charts/ente/ci/fixtures/production-ha-values.yaml
+++ b/charts/ente/ci/fixtures/production-ha-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ente-production-museum
+type: Opaque
+stringData:
+  encryption-key: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
+  hash-key: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMw==
+  jwt-secret: MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ente-production-s3
+type: Opaque
+stringData:
+  access-key: helmforge-runtime-access
+  secret-key: helmforge-runtime-secret

--- a/charts/ente/ci/gateway-api-values.yaml
+++ b/charts/ente/ci/gateway-api-values.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+  routes:
+    - name: museum
+      service: museum
+      hostnames:
+        - api.ente.test
+    - name: photos
+      service: photos
+      hostnames:
+        - photos.ente.test

--- a/charts/ente/ci/ingress-values.yaml
+++ b/charts/ente/ci/ingress-values.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: api.ente.test
+      service: museum
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: photos.ente.test
+      service: photos
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: ente-tls
+      hosts:
+        - api.ente.test
+        - photos.ente.test

--- a/charts/ente/ci/network-policy-values.yaml
+++ b/charts/ente/ci/network-policy-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  extraEgress:
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+      ports:
+        - protocol: TCP
+          port: 587

--- a/charts/ente/ci/observability-values.yaml
+++ b/charts/ente/ci/observability-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: monitoring
+  prometheusRule:
+    enabled: true

--- a/charts/ente/ci/production-ha-values.yaml
+++ b/charts/ente/ci/production-ha-values.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+productionMode: true
+museum:
+  externalUrl: https://api.ente.test
+  existingSecret: ente-production-museum
+  api:
+    replicaCount: 3
+    skipBackgroundJobs: true
+  worker:
+    enabled: true
+web:
+  replicaCount: 3
+  apps:
+    photos:
+      externalUrl: https://photos.ente.test
+    accounts:
+      externalUrl: https://accounts.ente.test
+    albums:
+      externalUrl: https://albums.ente.test
+storage:
+  s3:
+    endpoint: https://objects.ente.test
+    existingSecret: ente-production-s3
+pdb:
+  museum:
+    enabled: true
+  web:
+    enabled: true
+autoscaling:
+  museum:
+    enabled: true
+  web:
+    enabled: true

--- a/charts/ente/docs/architecture.md
+++ b/charts/ente/docs/architecture.md
@@ -1,0 +1,51 @@
+# Ente Architecture
+
+## Runtime components
+
+Museum is Ente's API and control plane. It owns database migrations, account
+flows, metadata, presigned S3 URLs, Prometheus metrics, and background jobs.
+
+The web image contains static builds for multiple Ente applications. This chart
+runs one web Deployment and exposes a Service for every enabled application.
+
+PostgreSQL stores durable metadata and encryption material. S3 stores encrypted
+objects. Neither is independently sufficient for recovery.
+
+## Request flow
+
+1. A client connects to Photos, Accounts, or Albums over HTTPS.
+2. Static JavaScript calls the public Museum API origin.
+3. Museum reads and writes metadata in PostgreSQL.
+4. Museum creates a presigned S3 request.
+5. The client transfers encrypted data directly to S3.
+
+This direct path is why an internal-only object endpoint is not sufficient.
+
+## Configuration flow
+
+The chart mounts an explicit `/museum.yaml` instead of setting upstream's
+`ENVIRONMENT=production`. The upstream production file enables internal TLS and
+file logging, which are inappropriate defaults for Kubernetes. The chart uses
+HTTP inside the cluster, TLS at Ingress or Gateway, and stdout logging.
+
+Secrets override the non-sensitive ConfigMap through `ENTE_*` environment
+variables. Dots and hyphens in Museum keys become underscores.
+
+## Health model
+
+Startup and readiness call `/ping`, which runs `SELECT 1` against PostgreSQL.
+Liveness uses TCP port 8080 so a database outage does not trigger restart loops.
+S3 needs a separate functional check because `/ping` does not contact it.
+
+## Durable state
+
+Museum and web pods have no persistent volumes. Museum's temporary replication
+directory and nginx writable paths use emptyDir volumes. Durable state belongs
+to PostgreSQL, S3, and Kubernetes Secrets.
+
+## Related guides
+
+- [Object storage](object-storage.md)
+- [High availability](high-availability.md)
+- [Backup and restore](backup-restore.md)
+- [Security](security.md)

--- a/charts/ente/docs/backup-restore.md
+++ b/charts/ente/docs/backup-restore.md
@@ -1,0 +1,54 @@
+# Backup And Restore
+
+## Recovery set
+
+A recoverable Ente installation requires Museum configuration and cryptographic
+Secrets, PostgreSQL data, and S3 objects. Back up and restore them together.
+
+PostgreSQL contains the metadata and encryption keys required to interpret S3
+objects. An object-only backup is not recoverable.
+
+## PostgreSQL CronJob
+
+The chart's CronJob creates a custom-format `pg_dump` and uploads it through the
+MinIO client. Use a backup bucket and credentials independent from the live Ente
+object bucket when possible.
+
+```yaml
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://backup.example.com
+    bucket: backups
+    prefix: ente/postgresql
+    existingSecret: ente-backup-s3
+```
+
+## Object backup
+
+Use provider-native replication or backup tooling for the live Ente bucket.
+Preserve object names and contents exactly. Ente's application replication is
+availability, not point-in-time backup.
+
+## Secret backup
+
+Export Museum key names and encrypted Secret data to a protected secret manager.
+Do not store plaintext keys in source control. Verify the backup contains the
+encryption key, hash key, and JWT secret.
+
+## Restore order
+
+1. Create an isolated namespace and deny outbound notifications.
+2. Restore Museum Secrets.
+3. Restore the S3 objects to a test bucket.
+4. Restore PostgreSQL with `pg_restore`.
+5. Install Ente against the restored dependencies.
+6. Validate login, thumbnails, originals, and public albums.
+7. Confirm object counts and application logs.
+8. Only then perform the production cutover.
+
+## Restore drills
+
+Run a complete restore drill at least quarterly. A successful scheduled Job is
+not proof that the three-part recovery set is usable.

--- a/charts/ente/docs/backup-restore.md
+++ b/charts/ente/docs/backup-restore.md
@@ -48,6 +48,50 @@ encryption key, hash key, and JWT secret.
 7. Confirm object counts and application logs.
 8. Only then perform the production cutover.
 
+Bind the restored credentials and endpoints explicitly. This prevents the
+restore release from creating a new PostgreSQL instance or generating new
+Museum keys.
+
+```yaml
+museum:
+  existingSecret: ente-restored-museum
+
+storage:
+  s3:
+    endpoint: https://s3-restore.company.tld
+    region: us-east-1
+    bucket: ente-restore-test
+    existingSecret: ente-restored-s3
+
+database:
+  mode: external
+  external:
+    host: ente-restore-rw.database.svc.cluster.local
+    port: 5432
+    name: ente
+    username: ente
+    existingSecret: ente-restored-postgresql
+    existingSecretPasswordKey: database-password
+    sslMode: require
+
+postgresql:
+  enabled: false
+```
+
+Render the release before starting Museum and inspect the exact Secret
+references, database host, S3 endpoint, and bucket:
+
+```bash
+helm template ente-restore oci://ghcr.io/helmforgedev/helm/ente \
+  -f restore-values.yaml > ente-restore-rendered.yaml
+yq 'select(.kind == "Deployment" and .metadata.name == "ente-restore-ente-museum-api") |
+  .spec.template.spec.containers[0].env[] |
+  select(.valueFrom.secretKeyRef) |
+  .valueFrom.secretKeyRef.name' ente-restore-rendered.yaml
+yq 'select(.kind == "ConfigMap" and .metadata.name == "ente-restore-ente-config") |
+  .data."museum-api.yaml"' ente-restore-rendered.yaml
+```
+
 ## Restore drills
 
 Run a complete restore drill at least quarterly. A successful scheduled Job is

--- a/charts/ente/docs/high-availability.md
+++ b/charts/ente/docs/high-availability.md
@@ -1,0 +1,61 @@
+# High Availability
+
+## Museum jobs
+
+Every Museum process starts scheduled jobs and background cleanup unless
+`jobs.cron.skip=true`. Some jobs use database locks, but not all of them do.
+Scaling a default Museum Deployment therefore risks duplicate work.
+
+## Supported topology
+
+Set API replicas to two or more, enable `skipBackgroundJobs`, and enable the
+singleton worker. The worker runs the same Museum image without a public
+Service. Its Deployment uses `Recreate` so rolling updates do not overlap job
+schedulers.
+
+```yaml
+museum:
+  api:
+    replicaCount: 3
+    skipBackgroundJobs: true
+  worker:
+    enabled: true
+  migrationGate:
+    enabled: true
+```
+
+The chart validates the relationship and rejects unsafe combinations.
+
+## Database availability
+
+The bundled PostgreSQL standalone mode does not provide automatic failover.
+Use a managed service or PostgreSQL operator with a stable read-write endpoint
+for end-to-end HA.
+
+## Web availability
+
+Web pods are stateless after startup. Scale them independently and enable their
+PDB. HPA requires resource requests and a working metrics API.
+
+## Migration serialization
+
+All Museum instances run database migrations during startup. Concurrent first
+starts can conflict on migrations such as `CREATE INDEX CONCURRENTLY` and leave
+the database version dirty.
+
+For HA and Museum HPA topologies, the chart runs a PostgreSQL client sidecar in
+each Museum pod. It polls `pg_try_advisory_lock` without retaining an active
+transaction, writes a pod-local start marker, and waits for the local Museum
+port before releasing the lock. API and worker processes therefore start one at
+a time. The sidecar remains idle after release so the pod does not restart it.
+
+The chart rejects concurrent Museum processes when
+`museum.migrationGate.enabled=false`. Inspect `-c migration-gate` and
+`-c museum` logs together when a rollout waits at startup. Keep the worker on
+`Recreate` to avoid overlapping job schedulers.
+
+## Ente replication
+
+Ente object replication starts workers in every Museum process even when cron
+jobs are skipped. It also requires multiple hot and derived buckets. It is not
+enabled by this chart's default contract and is not a substitute for backup.

--- a/charts/ente/docs/object-storage.md
+++ b/charts/ente/docs/object-storage.md
@@ -1,0 +1,49 @@
+# Object Storage
+
+## Production contract
+
+Ente requires an S3-compatible endpoint, region, bucket, access key, and secret
+key. The logical upstream bucket key remains `b2-eu-cen` regardless of provider.
+
+Use an endpoint with valid TLS that is reachable by Museum and every client.
+Avoid cluster-local DNS names in production because presigned URLs are returned
+to browsers and mobile devices.
+
+## CORS
+
+Allow the exact Photos, Accounts, Albums, and optional application origins.
+Allow GET, HEAD, POST, PUT, and DELETE. Include `Content-Type`, `Content-MD5`,
+and `UPLOAD-URL` in allowed headers. Expose provider response headers required
+by clients.
+
+## Provider addressing
+
+Use virtual-host addressing by default. Enable `usePathStyle` only when required
+by a compatible provider. `localBuckets` also disables upstream production S3
+behavior and must remain false in production.
+
+## Bucket features
+
+Do not enable object lock or versioning on Ente file-data buckets. Upstream does
+not handle those semantics. Use separate provider-native backup destinations or
+replication mechanisms instead.
+
+## Validation
+
+Test credentials with the provider CLI, then create an Ente account and perform
+an upload and download. A successful Museum `/ping` is not an S3 test.
+
+## Private endpoints
+
+When NetworkPolicy is enabled, add provider CIDRs to
+`networkPolicy.extraEgress` for shared access or
+`networkPolicy.egress.museumExtraRules` for Museum only. DNS names cannot be
+selected directly by Kubernetes NetworkPolicy.
+
+## Troubleshooting
+
+- Signature mismatch: verify endpoint, region, clock, and path-style mode.
+- Browser CORS error: verify exact origins, methods, and headers.
+- Museum access works but client access fails: publish the same endpoint outside
+  the cluster.
+- Delete failures: remove object lock and versioning from file-data buckets.

--- a/charts/ente/docs/security.md
+++ b/charts/ente/docs/security.md
@@ -1,0 +1,46 @@
+# Security
+
+## Workload hardening
+
+Museum and web run as non-root users, drop Linux capabilities, disable privilege
+escalation, use RuntimeDefault seccomp, and mount read-only root filesystems.
+Service account tokens are disabled.
+
+The upstream web image normally modifies `/out` and nginx runtime directories.
+An init container copies static content into an emptyDir, then the non-root main
+container performs endpoint substitution and starts nginx with writable
+emptyDirs only where required.
+
+## Secret management
+
+Use existing Secrets or External Secrets Operator in production. Treat Museum's
+encryption key, hash key, JWT secret, PostgreSQL password, and S3 credentials as
+high-impact secrets. Restrict read access and audit every rotation.
+
+Generated Museum keys use `lookup` and remain stable across ordinary upgrades.
+Deleting the Secret before upgrade generates a new recovery identity and can
+make existing data unusable.
+
+## Transport security
+
+Terminate TLS at Ingress or Gateway. Use TLS to external PostgreSQL and S3.
+Configure WebAuthn with the exact Accounts hostname and HTTPS origin.
+
+## Network policy
+
+NetworkPolicy restricts workloads to published ports and known egress classes.
+Private S3, SMTP, and external PostgreSQL often need explicit CIDR or selector
+rules. Review the rendered rules against the cluster CNI before enabling them.
+
+## Registration
+
+Create the first administrator through a controlled bootstrap. Then set
+`museum.config.disableRegistration=true` if the instance is private.
+
+## Operational review
+
+- Verify pod security against the cluster's Restricted admission policy.
+- Scan pinned image digests on every update.
+- Review Museum and ingress logs for unexpected origins.
+- Test backup restoration after credential changes.
+- Avoid exposing Museum metrics publicly.

--- a/charts/ente/examples/backup.yaml
+++ b/charts/ente/examples/backup.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# PostgreSQL backup to an independent S3 bucket.
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  s3:
+    endpoint: https://backup.ente.test
+    bucket: platform-backups
+    prefix: ente/postgresql
+    existingSecret: ente-backup-s3

--- a/charts/ente/examples/external-secrets.yaml
+++ b/charts/ente/examples/external-secrets.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Secret material sourced from an existing ClusterSecretStore.
+museum:
+  existingSecret: ente-museum
+storage:
+  s3:
+    existingSecret: ente-s3
+externalSecrets:
+  enabled: true
+  items:
+    - name: museum
+      spec:
+        secretStoreRef:
+          name: production
+          kind: ClusterSecretStore
+        target:
+          name: ente-museum
+        dataFrom:
+          - extract:
+              key: ente/museum
+    - name: s3
+      spec:
+        secretStoreRef:
+          name: production
+          kind: ClusterSecretStore
+        target:
+          name: ente-s3
+        dataFrom:
+          - extract:
+              key: ente/s3

--- a/charts/ente/examples/external-services.yaml
+++ b/charts/ente/examples/external-services.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Managed PostgreSQL, S3, and SMTP.
+database:
+  mode: external
+  external:
+    host: ente-rw.database.svc.cluster.local
+    name: ente
+    username: ente
+    existingSecret: ente-postgresql
+    sslMode: verify-full
+postgresql:
+  enabled: false
+storage:
+  s3:
+    endpoint: https://objects.ente.test
+    region: eu-central-1
+    bucket: ente-photos
+    existingSecret: ente-s3
+smtp:
+  enabled: true
+  host: smtp.ente.test
+  email: ente@ente.test
+  existingSecret: ente-smtp

--- a/charts/ente/examples/gateway-api.yaml
+++ b/charts/ente/examples/gateway-api.yaml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# Gateway API routes. Configure HTTPS on the referenced listener.
+gateway:
+  enabled: true
+  parentRefs:
+    - name: public
+      namespace: gateway-system
+      sectionName: https
+  routes:
+    - name: museum
+      service: museum
+      hostnames:
+        - api.ente.test
+    - name: photos
+      service: photos
+      hostnames:
+        - photos.ente.test
+    - name: accounts
+      service: accounts
+      hostnames:
+        - accounts.ente.test

--- a/charts/ente/examples/production-ha.yaml
+++ b/charts/ente/examples/production-ha.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# HA application topology. Use external HA PostgreSQL for full-stack HA.
+productionMode: true
+museum:
+  externalUrl: https://api.ente.test
+  existingSecret: ente-museum
+  api:
+    replicaCount: 3
+    skipBackgroundJobs: true
+  worker:
+    enabled: true
+storage:
+  s3:
+    endpoint: https://objects.ente.test
+    bucket: ente-photos
+    existingSecret: ente-s3
+web:
+  replicaCount: 3
+pdb:
+  museum:
+    enabled: true
+  web:
+    enabled: true
+networkPolicy:
+  enabled: true

--- a/charts/ente/examples/production.yaml
+++ b/charts/ente/examples/production.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Single-instance production deployment with existing Secrets.
+productionMode: true
+museum:
+  externalUrl: https://api.ente.test
+  existingSecret: ente-museum
+  config:
+    webauthn:
+      rpid: accounts.ente.test
+      rporigins:
+        - https://accounts.ente.test
+storage:
+  s3:
+    endpoint: https://objects.ente.test
+    region: us-east-1
+    bucket: ente-photos
+    existingSecret: ente-s3
+smtp:
+  enabled: true
+  host: smtp.ente.test
+  port: 587
+  email: ente@ente.test
+  existingSecret: ente-smtp
+web:
+  apps:
+    photos:
+      externalUrl: https://photos.ente.test
+    accounts:
+      externalUrl: https://accounts.ente.test
+    albums:
+      externalUrl: https://albums.ente.test
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: api.ente.test
+      service: museum
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: photos.ente.test
+      service: photos
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/ente/examples/simple.yaml
+++ b/charts/ente/examples/simple.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+# Evaluation install. Replace the endpoint and credentials before use.
+storage:
+  s3:
+    endpoint: https://s3.example.com
+    region: us-east-1
+    bucket: ente
+    accessKey: evaluation-access
+    secretKey: evaluation-secret

--- a/charts/ente/templates/NOTES.txt
+++ b/charts/ente/templates/NOTES.txt
@@ -1,0 +1,196 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+1. Ente Photos installation summary
+===================================
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart version: {{ .Chart.Version }}
+Museum image: {{ include "ente.museumImage" . }}
+Web image: {{ include "ente.webImage" . }}
+
+Museum API replicas: {{ .Values.museum.api.replicaCount }}
+Museum background worker: {{ ternary "enabled" "disabled" .Values.museum.worker.enabled }}
+Web replicas: {{ .Values.web.replicaCount }}
+Production validation: {{ ternary "enabled" "disabled" .Values.productionMode }}
+
+2. Access Ente
+==============
+
+Museum API origin: {{ .Values.museum.externalUrl }}
+
+{{- if .Values.ingress.enabled }}
+Ingress routes:
+{{- range .Values.ingress.hosts }}
+- https://{{ .host }} -> {{ .service }}
+{{- end }}
+{{- else if .Values.gateway.enabled }}
+Gateway API routes:
+{{- range $route := .Values.gateway.routes }}
+{{- range .hostnames }}
+- https://{{ . }} -> {{ $route.service }}
+{{- end }}
+{{- end }}
+{{- else }}
+No external route was created. Use port-forwarding for local access:
+
+Museum:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "ente.fullname" . }}-museum 8080:{{ .Values.museum.service.port }}
+  curl http://127.0.0.1:8080/ping
+
+{{- range $name, $app := .Values.web.apps }}
+{{- if $app.enabled }}
+{{ title $name }}:
+  kubectl port-forward -n {{ $.Release.Namespace }} svc/{{ include "ente.fullname" $ }}-{{ $name }} 3000:{{ $.Values.web.service.port }}
+  Open http://127.0.0.1:3000
+{{- end }}
+{{- end }}
+{{- end }}
+
+3. Durable data and secrets
+===========================
+
+PostgreSQL mode: {{ include "ente.databaseMode" . }}
+PostgreSQL host: {{ include "ente.databaseHost" . }}:{{ include "ente.databasePort" . }}
+PostgreSQL database: {{ include "ente.databaseName" . }}
+S3 endpoint: {{ .Values.storage.s3.endpoint }}
+S3 bucket: {{ .Values.storage.s3.bucket }}
+S3 path-style URLs: {{ .Values.storage.s3.usePathStyle }}
+
+Museum cryptographic Secret: {{ include "ente.museumSecretName" . }}
+S3 credential Secret: {{ include "ente.s3SecretName" . }}
+Database credential Secret: {{ include "ente.databaseSecretName" . }}
+
+These assets form one recovery set:
+1. Museum cryptographic Secret and configuration.
+2. PostgreSQL data.
+3. Every object in the Ente S3 bucket.
+
+Back up all three. S3 objects cannot be decrypted without PostgreSQL and the
+Museum keys. Do not delete or rotate encryption-key, hash-key, or jwt-secret
+during an ordinary upgrade.
+
+4. Object storage validation
+============================
+
+Museum's /ping endpoint checks PostgreSQL but does not check S3. A Ready Museum
+pod does not prove that uploads work.
+
+Verify all of the following before inviting users:
+1. The S3 endpoint is reachable by Museum pods.
+2. The same endpoint is reachable by browsers and mobile clients.
+3. The configured credentials can read, write, and delete objects.
+4. Bucket CORS allows every Ente web origin.
+5. CORS allows GET, HEAD, POST, PUT, and DELETE.
+6. CORS allows Content-Type, Content-MD5, and UPLOAD-URL headers.
+7. File-data buckets do not use object lock or versioning.
+
+Inspect Museum's generated S3 configuration:
+  kubectl get configmap -n {{ .Release.Namespace }} {{ include "ente.fullname" . }}-config \
+    -o jsonpath='{.data.museum-api\.yaml}'
+
+5. High availability and jobs
+=============================
+
+{{- if .Values.museum.worker.enabled }}
+HA job topology is enabled:
+- Museum API pods skip cron and cleanup jobs.
+- One Museum worker runs cron and cleanup jobs.
+- The worker uses a Recreate strategy to avoid overlap.
+- The PostgreSQL advisory-lock sidecar serializes Museum migrations.
+
+Verify the topology:
+  kubectl get deploy -n {{ .Release.Namespace }} \
+    {{ include "ente.fullname" . }}-museum-api \
+    {{ include "ente.fullname" . }}-museum-worker
+{{- else }}
+Single-process job topology is enabled. The Museum API pod also runs scheduled
+jobs. Do not increase museum.api.replicaCount without enabling the singleton
+worker and museum.api.skipBackgroundJobs.
+{{- end }}
+
+The bundled PostgreSQL architecture is durable but is not automatic database
+failover. Use an external PostgreSQL service or operator for database HA.
+
+6. Authentication and email
+============================
+
+SMTP: {{ ternary "enabled" "disabled" .Values.smtp.enabled }}
+Registration disabled: {{ .Values.museum.config.disableRegistration }}
+WebAuthn relying-party ID: {{ .Values.museum.config.webauthn.rpid }}
+
+Ente uses one-time codes for login. Without SMTP, Museum writes those codes to
+its logs. Configure SMTP before production use:
+
+  kubectl logs -n {{ .Release.Namespace }} \
+    deploy/{{ include "ente.fullname" . }}-museum-api -c museum
+
+After creating the first administrator, consider setting:
+
+  museum:
+    config:
+      disableRegistration: true
+
+Keep the Accounts external URL and WebAuthn origins aligned with the TLS host.
+
+7. Validation and troubleshooting
+==================================
+
+Run the chart smoke test:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }} --logs
+
+List Ente resources:
+  kubectl get deploy,pod,svc,pdb,networkpolicy -n {{ .Release.Namespace }} \
+    -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Check Museum readiness:
+  kubectl run ente-ping --rm -i --restart=Never \
+    -n {{ .Release.Namespace }} \
+    --image=docker.io/curlimages/curl:8.21.0 -- \
+    curl -fsS http://{{ include "ente.fullname" . }}-museum:{{ .Values.museum.service.port }}/ping
+
+Inspect API logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    deploy/{{ include "ente.fullname" . }}-museum-api -c museum --tail=200
+
+Inspect worker logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    deploy/{{ include "ente.fullname" . }}-museum-worker -c museum --tail=200
+
+{{- if .Values.museum.worker.enabled }}
+Inspect migration-gate logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    deploy/{{ include "ente.fullname" . }}-museum-api -c migration-gate --tail=200
+{{- end }}
+
+Inspect web logs:
+  kubectl logs -n {{ .Release.Namespace }} \
+    deploy/{{ include "ente.fullname" . }}-web -c web --tail=200
+
+Inspect recent events:
+  kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+8. Production checklist and documentation
+==========================================
+
+Before production:
+1. Set productionMode=true and resolve every validation error.
+2. Use existing Secrets or External Secrets Operator.
+3. Configure a real HTTPS Museum origin and web hosts.
+4. Configure external S3 with tested CORS.
+5. Configure SMTP and verify one-time-code delivery.
+6. Enable backup and test a complete restore.
+7. Use an external HA PostgreSQL service when database failover is required.
+8. Enable NetworkPolicy and add private S3/SMTP egress rules when needed.
+9. Enable metrics and alerts only when Prometheus Operator is installed.
+10. Run an account, upload, download, public-album, and upgrade test.
+
+Chart documentation:
+  https://helmforge.dev/docs/charts/ente
+
+Upstream self-hosting documentation:
+  https://help.ente.io/self-hosting
+
+Chart source:
+  https://github.com/helmforgedev/charts/tree/main/charts/ente
+
+Happy Helmforging :)

--- a/charts/ente/templates/_helpers.tpl
+++ b/charts/ente/templates/_helpers.tpl
@@ -61,6 +61,7 @@ app.kubernetes.io/component: {{ .component }}
   {{- end -}}
 {{- else if eq $mode "external" -}}
   {{- if not .Values.database.external.host -}}{{- fail "database.mode=external requires database.external.host" -}}{{- end -}}
+  {{- if .Values.postgresql.enabled -}}{{- fail "database.mode=external requires postgresql.enabled=false to avoid deploying an unused PostgreSQL dependency" -}}{{- end -}}
 external
 {{- else if eq $mode "postgresql" -}}
   {{- if not .Values.postgresql.enabled -}}{{- fail "database.mode=postgresql requires postgresql.enabled=true" -}}{{- end -}}
@@ -189,6 +190,9 @@ postgresql
   {{- if hasSuffix ".example.com" .Values.storage.s3.endpoint -}}{{- fail "productionMode=true requires a real storage.s3.endpoint" -}}{{- end -}}
   {{- if and (not .Values.storage.s3.existingSecret) (or (eq .Values.storage.s3.accessKey "change-me") (eq .Values.storage.s3.secretKey "change-me")) -}}{{- fail "productionMode=true requires storage.s3.existingSecret or non-placeholder S3 credentials" -}}{{- end -}}
   {{- if .Values.storage.s3.localBuckets -}}{{- fail "productionMode=true forbids storage.s3.localBuckets" -}}{{- end -}}
+  {{- range $name, $app := .Values.web.apps -}}
+    {{- if and $app.enabled (hasSuffix ".example.com" $app.externalUrl) -}}{{- fail (printf "productionMode=true requires a real web.apps.%s.externalUrl" $name) -}}{{- end -}}
+  {{- end -}}
 {{- end -}}
 {{- if and .Values.smtp.enabled (not .Values.smtp.host) -}}{{- fail "smtp.enabled=true requires smtp.host" -}}{{- end -}}
 {{- if and .Values.smtp.enabled (not .Values.smtp.email) -}}{{- fail "smtp.enabled=true requires smtp.email" -}}{{- end -}}

--- a/charts/ente/templates/_helpers.tpl
+++ b/charts/ente/templates/_helpers.tpl
@@ -1,0 +1,445 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "ente.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ente.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "ente.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ente.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ente.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "ente.labels" -}}
+helm.sh/chart: {{ include "ente.chart" . }}
+{{ include "ente.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: ente
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "ente.componentLabels" -}}
+{{ include "ente.selectorLabels" .root }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{- define "ente.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "ente.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseMode" -}}
+{{- $mode := .Values.database.mode | default "auto" -}}
+{{- $hasExternal := or .Values.database.external.host .Values.database.external.existingSecret -}}
+{{- if eq $mode "auto" -}}
+  {{- if and $hasExternal .Values.postgresql.enabled -}}
+    {{- fail "ente database selection is ambiguous: configure external PostgreSQL or enable the postgresql subchart, not both" -}}
+  {{- else if $hasExternal -}}external
+  {{- else if .Values.postgresql.enabled -}}postgresql
+  {{- else -}}{{- fail "ente requires PostgreSQL: enable postgresql.enabled or configure database.external.host" -}}
+  {{- end -}}
+{{- else if eq $mode "external" -}}
+  {{- if not .Values.database.external.host -}}{{- fail "database.mode=external requires database.external.host" -}}{{- end -}}
+external
+{{- else if eq $mode "postgresql" -}}
+  {{- if not .Values.postgresql.enabled -}}{{- fail "database.mode=postgresql requires postgresql.enabled=true" -}}{{- end -}}
+postgresql
+{{- else -}}
+{{- fail (printf "database.mode must be one of: auto, postgresql, external (got %s)" $mode) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseHost" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}
+{{- .Values.database.external.host -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.databasePort" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}{{ .Values.database.external.port }}{{- else -}}5432{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseName" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}{{ .Values.database.external.name }}{{- else -}}{{ .Values.postgresql.auth.database }}{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseUsername" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}{{ .Values.database.external.username }}{{- else -}}{{ .Values.postgresql.auth.username }}{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseSslMode" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}{{ .Values.database.external.sslMode }}{{- else -}}disable{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseSecretName" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}
+{{- default (printf "%s-database" (include "ente.fullname" .)) .Values.database.external.existingSecret -}}
+{{- else -}}
+{{- default (printf "%s-postgresql-auth" .Release.Name) .Values.postgresql.auth.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.databaseSecretKey" -}}
+{{- if eq (include "ente.databaseMode" .) "external" -}}
+{{- .Values.database.external.existingSecretPasswordKey -}}
+{{- else -}}
+{{- default "user-password" .Values.postgresql.auth.existingSecretUserPasswordKey -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.museumSecretName" -}}
+{{- default (printf "%s-museum" (include "ente.fullname" .)) .Values.museum.existingSecret -}}
+{{- end -}}
+
+{{- define "ente.s3SecretName" -}}
+{{- default (printf "%s-s3" (include "ente.fullname" .)) .Values.storage.s3.existingSecret -}}
+{{- end -}}
+
+{{- define "ente.smtpSecretName" -}}
+{{- default (printf "%s-smtp" (include "ente.fullname" .)) .Values.smtp.existingSecret -}}
+{{- end -}}
+
+{{- define "ente.backupSecretName" -}}
+{{- default (printf "%s-backup" (include "ente.fullname" .)) .Values.backup.s3.existingSecret -}}
+{{- end -}}
+
+{{- define "ente.routeServiceName" -}}
+{{- $root := .root -}}
+{{- $service := .service -}}
+{{- if eq $service "museum" -}}
+{{- printf "%s-museum" (include "ente.fullname" $root) -}}
+{{- else if hasKey $root.Values.web.apps $service -}}
+  {{- $app := get $root.Values.web.apps $service -}}
+  {{- if not $app.enabled -}}{{- fail (printf "route service %q references a disabled web application" $service) -}}{{- end -}}
+{{- printf "%s-%s" (include "ente.fullname" $root) $service -}}
+{{- else -}}
+{{- fail (printf "route service must be museum or an enabled web application (got %s)" $service) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ente.routeServicePort" -}}
+{{- if eq .service "museum" -}}{{ .root.Values.museum.service.port }}{{- else -}}{{ .root.Values.web.service.port }}{{- end -}}
+{{- end -}}
+
+{{- define "ente.externalSecretName" -}}
+{{- $root := .root -}}
+{{- $item := .item -}}
+{{- $index := .index -}}
+{{- default (printf "%s-external-%d" (include "ente.fullname" $root) $index) $item.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ente.museumImage" -}}
+{{- printf "%s:%s" .Values.museum.image.repository .Values.museum.image.tag -}}
+{{- end -}}
+
+{{- define "ente.webImage" -}}
+{{- printf "%s:%s" .Values.web.image.repository .Values.web.image.tag -}}
+{{- end -}}
+
+{{- define "ente.firstWebApp" -}}
+{{- $result := dict "name" "" "port" 0 -}}
+{{- range $name, $app := .Values.web.apps -}}
+{{- if and $app.enabled (not $result.name) -}}
+{{- $_ := set $result "name" $name -}}
+{{- $_ := set $result "port" $app.port -}}
+{{- end -}}
+{{- end -}}
+{{- toJson $result -}}
+{{- end -}}
+
+{{- define "ente.validate" -}}
+{{- $databaseMode := include "ente.databaseMode" . -}}
+{{- if not .Values.storage.s3.endpoint -}}{{- fail "storage.s3.endpoint is required" -}}{{- end -}}
+{{- if not .Values.storage.s3.region -}}{{- fail "storage.s3.region is required" -}}{{- end -}}
+{{- if not .Values.storage.s3.bucket -}}{{- fail "storage.s3.bucket is required" -}}{{- end -}}
+{{- if and (not .Values.storage.s3.existingSecret) (not .Values.storage.s3.accessKey) -}}{{- fail "storage.s3.accessKey or storage.s3.existingSecret is required" -}}{{- end -}}
+{{- if and (not .Values.storage.s3.existingSecret) (not .Values.storage.s3.secretKey) -}}{{- fail "storage.s3.secretKey or storage.s3.existingSecret is required" -}}{{- end -}}
+{{- if and .Values.museum.worker.enabled (not .Values.museum.api.skipBackgroundJobs) -}}{{- fail "museum.worker.enabled=true requires museum.api.skipBackgroundJobs=true to prevent duplicate cron jobs" -}}{{- end -}}
+{{- if and (gt (int .Values.museum.api.replicaCount) 1) (not .Values.museum.api.skipBackgroundJobs) -}}{{- fail "museum.api.replicaCount greater than 1 requires museum.api.skipBackgroundJobs=true" -}}{{- end -}}
+{{- if and .Values.museum.api.skipBackgroundJobs (not .Values.museum.worker.enabled) -}}{{- fail "museum.api.skipBackgroundJobs=true requires museum.worker.enabled=true so scheduled maintenance still runs" -}}{{- end -}}
+{{- $concurrentMuseum := or (gt (int .Values.museum.api.replicaCount) 1) .Values.museum.worker.enabled .Values.autoscaling.museum.enabled -}}
+{{- if and $concurrentMuseum (not .Values.museum.migrationGate.enabled) -}}{{- fail "concurrent Museum processes require museum.migrationGate.enabled=true to serialize database migrations" -}}{{- end -}}
+{{- $firstApp := include "ente.firstWebApp" . | fromJson -}}
+{{- if not $firstApp.name -}}{{- fail "at least one web.apps entry must be enabled" -}}{{- end -}}
+{{- if .Values.productionMode -}}
+  {{- if hasSuffix ".example.com" .Values.museum.externalUrl -}}{{- fail "productionMode=true requires a real museum.externalUrl" -}}{{- end -}}
+  {{- if hasSuffix ".example.com" .Values.storage.s3.endpoint -}}{{- fail "productionMode=true requires a real storage.s3.endpoint" -}}{{- end -}}
+  {{- if and (not .Values.storage.s3.existingSecret) (or (eq .Values.storage.s3.accessKey "change-me") (eq .Values.storage.s3.secretKey "change-me")) -}}{{- fail "productionMode=true requires storage.s3.existingSecret or non-placeholder S3 credentials" -}}{{- end -}}
+  {{- if .Values.storage.s3.localBuckets -}}{{- fail "productionMode=true forbids storage.s3.localBuckets" -}}{{- end -}}
+{{- end -}}
+{{- if and .Values.smtp.enabled (not .Values.smtp.host) -}}{{- fail "smtp.enabled=true requires smtp.host" -}}{{- end -}}
+{{- if and .Values.smtp.enabled (not .Values.smtp.email) -}}{{- fail "smtp.enabled=true requires smtp.email" -}}{{- end -}}
+{{- if and .Values.pdb.museum.enabled (lt (int .Values.museum.api.replicaCount) 2) (not .Values.autoscaling.museum.enabled) -}}{{- fail "pdb.museum.enabled=true requires at least two Museum API replicas or Museum autoscaling" -}}{{- end -}}
+{{- if and .Values.pdb.web.enabled (lt (int .Values.web.replicaCount) 2) (not .Values.autoscaling.web.enabled) -}}{{- fail "pdb.web.enabled=true requires at least two web replicas or web autoscaling" -}}{{- end -}}
+{{- if and .Values.metrics.serviceMonitor.enabled (not .Values.metrics.enabled) -}}{{- fail "metrics.serviceMonitor.enabled=true requires metrics.enabled=true" -}}{{- end -}}
+{{- if and .Values.metrics.prometheusRule.enabled (not .Values.metrics.enabled) -}}{{- fail "metrics.prometheusRule.enabled=true requires metrics.enabled=true" -}}{{- end -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}{{- fail "ingress.enabled=true requires ingress.hosts" -}}{{- end -}}
+{{- range $index, $host := .Values.ingress.hosts }}
+  {{- if not $host.host -}}{{- fail (printf "ingress.hosts[%d].host is required" $index) -}}{{- end -}}
+  {{- if not $host.service -}}{{- fail (printf "ingress.hosts[%d].service is required" $index) -}}{{- end -}}
+  {{- $_ := include "ente.routeServiceName" (dict "root" $ "service" $host.service) -}}
+{{- end -}}
+{{- if and .Values.gateway.enabled (empty .Values.gateway.routes) -}}{{- fail "gateway.enabled=true requires gateway.routes" -}}{{- end -}}
+{{- range $index, $route := .Values.gateway.routes }}
+  {{- if not $route.name -}}{{- fail (printf "gateway.routes[%d].name is required" $index) -}}{{- end -}}
+  {{- if not $route.service -}}{{- fail (printf "gateway.routes[%d].service is required" $index) -}}{{- end -}}
+  {{- if and (empty ($route.parentRefs | default list)) (empty $.Values.gateway.parentRefs) -}}{{- fail (printf "gateway.routes[%d] requires parentRefs or gateway.parentRefs" $index) -}}{{- end -}}
+  {{- $_ := include "ente.routeServiceName" (dict "root" $ "service" $route.service) -}}
+{{- end -}}
+{{- if .Values.backup.enabled }}
+  {{- if not .Values.backup.s3.endpoint -}}{{- fail "backup.enabled=true requires backup.s3.endpoint" -}}{{- end -}}
+  {{- if not .Values.backup.s3.bucket -}}{{- fail "backup.enabled=true requires backup.s3.bucket" -}}{{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.accessKey) -}}{{- fail "backup.enabled=true requires backup.s3.accessKey or backup.s3.existingSecret" -}}{{- end -}}
+  {{- if and (not .Values.backup.s3.existingSecret) (not .Values.backup.s3.secretKey) -}}{{- fail "backup.enabled=true requires backup.s3.secretKey or backup.s3.existingSecret" -}}{{- end -}}
+{{- end }}
+{{- end -}}
+
+{{- define "ente.museumEnv" -}}
+- name: GIN_MODE
+  value: release
+- name: ENTE_DB_USER
+  value: {{ include "ente.databaseUsername" . | quote }}
+- name: ENTE_DB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.databaseSecretName" . }}
+      key: {{ include "ente.databaseSecretKey" . }}
+- name: ENTE_KEY_ENCRYPTION
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.museumSecretName" . }}
+      key: {{ .Values.museum.secretKeys.encryptionKey }}
+- name: ENTE_KEY_HASH
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.museumSecretName" . }}
+      key: {{ .Values.museum.secretKeys.hashKey }}
+- name: ENTE_JWT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.museumSecretName" . }}
+      key: {{ .Values.museum.secretKeys.jwtSecret }}
+- name: ENTE_S3_B2_EU_CEN_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.s3SecretName" . }}
+      key: {{ .Values.storage.s3.existingSecretAccessKeyKey }}
+- name: ENTE_S3_B2_EU_CEN_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.s3SecretName" . }}
+      key: {{ .Values.storage.s3.existingSecretSecretKeyKey }}
+{{- if .Values.smtp.enabled }}
+- name: ENTE_SMTP_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.smtpSecretName" . }}
+      key: {{ .Values.smtp.existingSecretUsernameKey }}
+- name: ENTE_SMTP_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ente.smtpSecretName" . }}
+      key: {{ .Values.smtp.existingSecretPasswordKey }}
+{{- end }}
+{{- with .Values.museum.extraEnv }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "ente.museumPodSpec" -}}
+{{- $root := .root -}}
+{{- $component := .component -}}
+{{- $configKey := .configKey -}}
+{{- $resources := .resources -}}
+{{- $migrationGate := and $root.Values.museum.migrationGate.enabled (or (gt (int $root.Values.museum.api.replicaCount) 1) $root.Values.museum.worker.enabled $root.Values.autoscaling.museum.enabled) -}}
+{{- with $root.Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+serviceAccountName: {{ include "ente.serviceAccountName" $root }}
+automountServiceAccountToken: {{ $root.Values.serviceAccount.automountServiceAccountToken }}
+securityContext:
+  {{- toYaml $root.Values.museum.podSecurityContext | nindent 2 }}
+terminationGracePeriodSeconds: {{ $root.Values.terminationGracePeriodSeconds }}
+initContainers:
+  - name: wait-for-postgresql
+    image: {{ $root.Values.waitForDatabase.image }}
+    imagePullPolicy: {{ $root.Values.waitForDatabase.pullPolicy }}
+    securityContext:
+      {{- toYaml $root.Values.waitForDatabase.securityContext | nindent 6 }}
+    {{- with $root.Values.waitForDatabase.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    command: ["sh", "-ec"]
+    args:
+      - until nc -z -w2 {{ include "ente.databaseHost" $root }} {{ include "ente.databasePort" $root }}; do sleep 2; done
+containers:
+  - name: museum
+    image: {{ include "ente.museumImage" $root | quote }}
+    imagePullPolicy: {{ $root.Values.museum.image.pullPolicy }}
+    securityContext:
+      {{- toYaml $root.Values.museum.securityContext | nindent 6 }}
+    {{- if $migrationGate }}
+    command: ["/bin/sh", "-ec"]
+    args:
+      - until [ -f /migration-gate/start ]; do sleep 1; done; exec /museum
+    {{- end }}
+    ports:
+      - name: http
+        containerPort: 8080
+        protocol: TCP
+      - name: metrics
+        containerPort: 2112
+        protocol: TCP
+    env:
+      {{- include "ente.museumEnv" $root | nindent 6 }}
+    {{- if $root.Values.museum.probes.startup.enabled }}
+    startupProbe:
+      httpGet:
+        path: /ping
+        port: http
+      initialDelaySeconds: {{ $root.Values.museum.probes.startup.initialDelaySeconds }}
+      periodSeconds: {{ $root.Values.museum.probes.startup.periodSeconds }}
+      timeoutSeconds: {{ $root.Values.museum.probes.startup.timeoutSeconds }}
+      failureThreshold: {{ $root.Values.museum.probes.startup.failureThreshold }}
+    {{- end }}
+    {{- if $root.Values.museum.probes.readiness.enabled }}
+    readinessProbe:
+      httpGet:
+        path: /ping
+        port: http
+      periodSeconds: {{ $root.Values.museum.probes.readiness.periodSeconds }}
+      timeoutSeconds: {{ $root.Values.museum.probes.readiness.timeoutSeconds }}
+      failureThreshold: {{ $root.Values.museum.probes.readiness.failureThreshold }}
+    {{- end }}
+    {{- if $root.Values.museum.probes.liveness.enabled }}
+    livenessProbe:
+      tcpSocket:
+        port: http
+      initialDelaySeconds: {{ $root.Values.museum.probes.liveness.initialDelaySeconds }}
+      periodSeconds: {{ $root.Values.museum.probes.liveness.periodSeconds }}
+      timeoutSeconds: {{ $root.Values.museum.probes.liveness.timeoutSeconds }}
+      failureThreshold: {{ $root.Values.museum.probes.liveness.failureThreshold }}
+    {{- end }}
+    resources:
+      {{- toYaml $resources | nindent 6 }}
+    volumeMounts:
+      - name: config
+        mountPath: /museum.yaml
+        subPath: {{ $configKey }}
+        readOnly: true
+      - name: tmp
+        mountPath: /tmp
+      {{- if $migrationGate }}
+      - name: migration-gate
+        mountPath: /migration-gate
+      {{- end }}
+      {{- with $root.Values.museum.extraVolumeMounts }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+  {{- if $migrationGate }}
+  - name: migration-gate
+    image: {{ printf "%s:%s" $root.Values.museum.migrationGate.image.repository $root.Values.museum.migrationGate.image.tag | quote }}
+    imagePullPolicy: {{ $root.Values.museum.migrationGate.image.pullPolicy }}
+    securityContext:
+      {{- toYaml $root.Values.museum.migrationGate.securityContext | nindent 6 }}
+    env:
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ include "ente.databaseSecretName" $root }}
+            key: {{ include "ente.databaseSecretKey" $root }}
+      - name: PGSSLMODE
+        value: {{ include "ente.databaseSslMode" $root | quote }}
+      - name: PSQL_HISTORY
+        value: /tmp/.psql_history
+    command: ["bash", "-ec"]
+    args:
+      - |
+        rm -f /migration-gate/start
+        cat > /tmp/acquire-migration-lock.sql <<'ACQUIRE_SQL'
+        SELECT pg_try_advisory_lock({{ printf "%d" (int64 $root.Values.museum.migrationGate.advisoryLockId) }}) AS acquired \gset
+        \if :acquired
+        \else
+        \! sleep 1
+        \i /tmp/acquire-migration-lock.sql
+        \endif
+        ACQUIRE_SQL
+        psql \
+          --host={{ include "ente.databaseHost" $root }} \
+          --port={{ include "ente.databasePort" $root }} \
+          --username={{ include "ente.databaseUsername" $root }} \
+          --dbname={{ include "ente.databaseName" $root }} \
+          --no-psqlrc \
+          --set=ON_ERROR_STOP=1 <<'SQL'
+        \i /tmp/acquire-migration-lock.sql
+        \! touch /migration-gate/start
+        \! until bash -c 'echo > /dev/tcp/127.0.0.1/8080' >/dev/null 2>&1; do sleep 1; done
+        SELECT pg_advisory_unlock({{ printf "%d" (int64 $root.Values.museum.migrationGate.advisoryLockId) }});
+        SQL
+        exec sleep infinity
+    resources:
+      {{- toYaml $root.Values.museum.migrationGate.resources | nindent 6 }}
+    volumeMounts:
+      - name: tmp
+        mountPath: /tmp
+      - name: migration-gate
+        mountPath: /migration-gate
+  {{- end }}
+volumes:
+  - name: config
+    configMap:
+      name: {{ include "ente.fullname" $root }}-config
+  - name: tmp
+    emptyDir: {}
+  {{- if $migrationGate }}
+  - name: migration-gate
+    emptyDir: {}
+  {{- end }}
+  {{- with $root.Values.museum.extraVolumes }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- with $root.Values.priorityClassName }}
+priorityClassName: {{ . }}
+{{- end }}
+{{- with $root.Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $root.Values.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/charts/ente/templates/backup-cronjob.yaml
+++ b/charts/ente/templates/backup-cronjob.yaml
@@ -1,0 +1,121 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "ente.fullname" . }}-postgresql-backup
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  suspend: {{ .Values.backup.suspend }}
+  concurrencyPolicy: {{ .Values.backup.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "ente.componentLabels" (dict "root" . "component" "backup") | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "ente.serviceAccountName" . }}
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          initContainers:
+            - name: dump
+              image: {{ .Values.backup.postgresqlImage | quote }}
+              command: ["sh", "-ec"]
+              args:
+                - pg_dump {{ .Values.backup.pgDumpArgs }} --file=/backup/ente.dump
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+              env:
+                - name: PGHOST
+                  value: {{ include "ente.databaseHost" . | quote }}
+                - name: PGPORT
+                  value: {{ include "ente.databasePort" . | quote }}
+                - name: PGDATABASE
+                  value: {{ include "ente.databaseName" . | quote }}
+                - name: PGUSER
+                  value: {{ include "ente.databaseUsername" . | quote }}
+                - name: PGSSLMODE
+                  value: {{ include "ente.databaseSslMode" . | quote }}
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "ente.databaseSecretName" . }}
+                      key: {{ include "ente.databaseSecretKey" . }}
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+                - name: tmp
+                  mountPath: /tmp
+          containers:
+            - name: upload
+              image: {{ .Values.backup.uploaderImage | quote }}
+              command: ["sh", "-ec"]
+              args:
+                - |
+                  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+                  mc alias set backup "${S3_ENDPOINT}" "${S3_ACCESS_KEY}" "${S3_SECRET_KEY}"
+                  mc cp /backup/ente.dump "backup/${S3_BUCKET}/${S3_PREFIX}/ente-${stamp}.dump"
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 65532
+              env:
+                - name: MC_CONFIG_DIR
+                  value: /tmp/.mc
+                - name: S3_ENDPOINT
+                  value: {{ .Values.backup.s3.endpoint | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PREFIX
+                  value: {{ .Values.backup.s3.prefix | trimAll "/" | quote }}
+                - name: S3_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "ente.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretAccessKeyKey }}
+                - name: S3_SECRET_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "ente.backupSecretName" . }}
+                      key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: backup
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/charts/ente/templates/configmap.yaml
+++ b/charts/ente/templates/configmap.yaml
@@ -1,0 +1,111 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ente.fullname" . }}-config
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+data:
+  museum-api.yaml: |
+    log-file: ""
+    log-level: {{ .Values.museum.config.logLevel | quote }}
+    http:
+      port: 8080
+      use-tls: false
+    apps:
+      public-albums: {{ .Values.web.apps.albums.externalUrl | quote }}
+      embed-albums: {{ .Values.web.apps.embed.externalUrl | quote }}
+      public-locker: {{ .Values.web.apps.share.externalUrl | quote }}
+      cast: {{ .Values.web.apps.cast.externalUrl | quote }}
+      accounts: {{ .Values.web.apps.accounts.externalUrl | quote }}
+      public-memories: {{ .Values.web.apps.memories.externalUrl | quote }}
+    db:
+      host: {{ include "ente.databaseHost" . | quote }}
+      port: {{ include "ente.databasePort" . }}
+      name: {{ include "ente.databaseName" . | quote }}
+      sslmode: {{ include "ente.databaseSslMode" . | quote }}
+    s3:
+      are_local_buckets: {{ .Values.storage.s3.localBuckets }}
+      use_path_style_urls: {{ .Values.storage.s3.usePathStyle }}
+      b2-eu-cen:
+        endpoint: {{ .Values.storage.s3.endpoint | quote }}
+        region: {{ .Values.storage.s3.region | quote }}
+        bucket: {{ .Values.storage.s3.bucket | quote }}
+    smtp:
+      host: {{ ternary .Values.smtp.host "" .Values.smtp.enabled | quote }}
+      port: {{ .Values.smtp.port }}
+      email: {{ ternary .Values.smtp.email "" .Values.smtp.enabled | quote }}
+      sender-name: {{ .Values.smtp.senderName | quote }}
+      encryption: {{ ternary .Values.smtp.encryption "" .Values.smtp.enabled | quote }}
+    webauthn:
+      rpid: {{ .Values.museum.config.webauthn.rpid | quote }}
+      rporigins:
+        {{- toYaml .Values.museum.config.webauthn.rporigins | nindent 8 }}
+    internal:
+      trusted-client-ip-header: {{ .Values.museum.config.trustedClientIpHeader | quote }}
+      admins:
+        {{- toYaml .Values.museum.config.admins | nindent 8 }}
+      disable-registration: {{ .Values.museum.config.disableRegistration }}
+    jobs:
+      cron:
+        skip: {{ .Values.museum.api.skipBackgroundJobs }}
+    {{- with .Values.museum.config.extraYaml }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  museum-worker.yaml: |
+    log-file: ""
+    log-level: {{ .Values.museum.config.logLevel | quote }}
+    http:
+      port: 8080
+      use-tls: false
+    db:
+      host: {{ include "ente.databaseHost" . | quote }}
+      port: {{ include "ente.databasePort" . }}
+      name: {{ include "ente.databaseName" . | quote }}
+      sslmode: {{ include "ente.databaseSslMode" . | quote }}
+    s3:
+      are_local_buckets: {{ .Values.storage.s3.localBuckets }}
+      use_path_style_urls: {{ .Values.storage.s3.usePathStyle }}
+      b2-eu-cen:
+        endpoint: {{ .Values.storage.s3.endpoint | quote }}
+        region: {{ .Values.storage.s3.region | quote }}
+        bucket: {{ .Values.storage.s3.bucket | quote }}
+    smtp:
+      host: {{ ternary .Values.smtp.host "" .Values.smtp.enabled | quote }}
+      port: {{ .Values.smtp.port }}
+      email: {{ ternary .Values.smtp.email "" .Values.smtp.enabled | quote }}
+      sender-name: {{ .Values.smtp.senderName | quote }}
+      encryption: {{ ternary .Values.smtp.encryption "" .Values.smtp.enabled | quote }}
+    internal:
+      trusted-client-ip-header: {{ .Values.museum.config.trustedClientIpHeader | quote }}
+      admins:
+        {{- toYaml .Values.museum.config.admins | nindent 8 }}
+      disable-registration: {{ .Values.museum.config.disableRegistration }}
+    jobs:
+      cron:
+        skip: false
+    {{- with .Values.museum.config.extraYaml }}
+    {{ . | nindent 4 }}
+    {{- end }}
+  nginx.conf: |
+    pid /var/run/nginx.pid;
+    worker_processes auto;
+    error_log /dev/stderr notice;
+    events { worker_connections 1024; }
+    http {
+      include /etc/nginx/mime.types;
+      default_type application/octet-stream;
+      access_log /dev/stdout;
+      sendfile on;
+      {{- range $name, $app := .Values.web.apps }}
+      {{- if $app.enabled }}
+      server {
+        listen {{ $app.port }};
+        listen [::]:{{ $app.port }};
+        server_name _;
+        root /out/{{ $name }};
+        location / { try_files $uri $uri.html /index.html; }
+      }
+      {{- end }}
+      {{- end }}
+    }

--- a/charts/ente/templates/externalsecret.yaml
+++ b/charts/ente/templates/externalsecret.yaml
@@ -1,0 +1,54 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- $names := dict }}
+{{- range $index, $item := .Values.externalSecrets.items | default list }}
+{{- $name := include "ente.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- if hasKey $names $name }}
+{{- fail (printf "externalSecrets.items render duplicate ExternalSecret name %q" $name) }}
+{{- end }}
+{{- $_ := set $names $name true }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $name }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStore := dig "secretStoreRef" "name" "" $spec }}
+{{- if not $hasStore }}
+  {{- range $dataIndex, $dataItem := ($spec.data | default list) }}
+    {{- $sourceRef := get $dataItem "sourceRef" | default dict }}
+    {{- if not (or (dig "storeRef" "name" "" $sourceRef) (dig "generatorRef" "name" "" $sourceRef)) }}
+      {{- fail (printf "externalSecrets.items[%d].spec.data[%d] requires a store or generator reference when spec.secretStoreRef.name is absent" $index $dataIndex) }}
+    {{- end }}
+  {{- end }}
+  {{- range $dataFromIndex, $dataFromItem := ($spec.dataFrom | default list) }}
+    {{- $sourceRef := get $dataFromItem "sourceRef" | default dict }}
+    {{- if not (or (dig "storeRef" "name" "" $sourceRef) (dig "generatorRef" "name" "" $sourceRef)) }}
+      {{- fail (printf "externalSecrets.items[%d].spec.dataFrom[%d] requires a store or generator reference when spec.secretStoreRef.name is absent" $index $dataFromIndex) }}
+    {{- end }}
+  {{- end }}
+  {{- if and (empty ($spec.data | default list)) (empty ($spec.dataFrom | default list)) }}
+    {{- fail "externalSecrets.items[].spec.secretStoreRef.name or item source references are required" }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: {{ $.Values.externalSecrets.apiVersion }}
+kind: ExternalSecret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "ente.labels" $ | nindent 4 }}
+    {{- with $item.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/ente/templates/extra-manifests.yaml
+++ b/charts/ente/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/ente/templates/gateway-httproute.yaml
+++ b/charts/ente/templates/gateway-httproute.yaml
@@ -1,11 +1,17 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.gateway.enabled }}
+{{- $routeNames := dict }}
 {{- range $route := .Values.gateway.routes }}
+{{- $routeName := printf "%s-%s" (include "ente.fullname" $) $route.name | trunc 63 | trimSuffix "-" }}
+{{- if hasKey $routeNames $routeName }}
+{{- fail (printf "gateway.routes render duplicate HTTPRoute name %q" $routeName) }}
+{{- end }}
+{{- $_ := set $routeNames $routeName true }}
 ---
 apiVersion: {{ $.Values.gateway.apiVersion }}
 kind: HTTPRoute
 metadata:
-  name: {{ printf "%s-%s" (include "ente.fullname" $) $route.name | trunc 63 | trimSuffix "-" }}
+  name: {{ $routeName }}
   labels:
     {{- include "ente.labels" $ | nindent 4 }}
   {{- with $route.annotations }}

--- a/charts/ente/templates/gateway-httproute.yaml
+++ b/charts/ente/templates/gateway-httproute.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gateway.enabled }}
+{{- range $route := .Values.gateway.routes }}
+---
+apiVersion: {{ $.Values.gateway.apiVersion }}
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-%s" (include "ente.fullname" $) $route.name | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "ente.labels" $ | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml (default $.Values.gateway.parentRefs $route.parentRefs) | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "ente.routeServiceName" (dict "root" $ "service" $route.service) }}
+          port: {{ include "ente.routeServicePort" (dict "root" $ "service" $route.service) }}
+          weight: 1
+{{- end }}
+{{- end }}

--- a/charts/ente/templates/hpa.yaml
+++ b/charts/ente/templates/hpa.yaml
@@ -2,6 +2,9 @@
 {{- range $component := list "museum" "web" }}
 {{- $config := get $.Values.autoscaling $component }}
 {{- if $config.enabled }}
+{{- if and (not $config.targetCPUUtilizationPercentage) (not $config.targetMemoryUtilizationPercentage) }}
+{{- fail (printf "autoscaling.%s requires targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage when enabled" $component) }}
+{{- end }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/charts/ente/templates/hpa.yaml
+++ b/charts/ente/templates/hpa.yaml
@@ -1,0 +1,41 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range $component := list "museum" "web" }}
+{{- $config := get $.Values.autoscaling $component }}
+{{- if $config.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ente.fullname" $ }}-{{ ternary "museum-api" "web" (eq $component "museum") }}
+  labels:
+    {{- include "ente.labels" $ | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ente.fullname" $ }}-{{ ternary "museum-api" "web" (eq $component "museum") }}
+  minReplicas: {{ $config.minReplicas }}
+  maxReplicas: {{ $config.maxReplicas }}
+  metrics:
+    {{- with $config.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with $config.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  {{- with $config.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ente/templates/ingress.yaml
+++ b/charts/ente/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ente.fullname" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host.host | quote }}
+      http:
+        paths:
+          {{- range $path := $host.paths }}
+          - path: {{ default "/" $path.path | quote }}
+            pathType: {{ default "Prefix" $path.pathType }}
+            backend:
+              service:
+                name: {{ include "ente.routeServiceName" (dict "root" $ "service" $host.service) }}
+                port:
+                  number: {{ include "ente.routeServicePort" (dict "root" $ "service" $host.service) }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ente/templates/metrics.yaml
+++ b/charts/ente/templates/metrics.yaml
@@ -1,0 +1,23 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ente.fullname" . }}-metrics
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: museum-api
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.museum.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "ente.componentLabels" (dict "root" . "component" "museum-api") | nindent 4 }}
+{{- end }}

--- a/charts/ente/templates/museum-api-deployment.yaml
+++ b/charts/ente/templates/museum-api-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ toJson (dict "museum" .Values.museum.config "database" .Values.database "storage" .Values.storage "smtp" .Values.smtp) | sha256sum }}
+        checksum/config: {{ toJson (dict "museum" .Values.museum "database" .Values.database "storage" .Values.storage "smtp" .Values.smtp "webApps" .Values.web.apps) | sha256sum }}
         checksum/credentials: {{ toJson (dict "museum" .Values.museum.existingSecret "storage" .Values.storage.s3.existingSecret "database" .Values.database.external.existingSecret) | sha256sum }}
         {{- with .Values.museum.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/ente/templates/museum-api-deployment.yaml
+++ b/charts/ente/templates/museum-api-deployment.yaml
@@ -1,0 +1,30 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ente.fullname" . }}-museum-api
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: museum-api
+spec:
+  {{- if not .Values.autoscaling.museum.enabled }}
+  replicas: {{ .Values.museum.api.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ente.componentLabels" (dict "root" . "component" "museum-api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ente.componentLabels" (dict "root" . "component" "museum-api") | nindent 8 }}
+        {{- with .Values.museum.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toJson (dict "museum" .Values.museum.config "database" .Values.database "storage" .Values.storage "smtp" .Values.smtp) | sha256sum }}
+        checksum/credentials: {{ toJson (dict "museum" .Values.museum.existingSecret "storage" .Values.storage.s3.existingSecret "database" .Values.database.external.existingSecret) | sha256sum }}
+        {{- with .Values.museum.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "ente.museumPodSpec" (dict "root" . "component" "museum-api" "configKey" "museum-api.yaml" "resources" .Values.museum.api.resources) | nindent 6 }}

--- a/charts/ente/templates/museum-worker-deployment.yaml
+++ b/charts/ente/templates/museum-worker-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        checksum/config: {{ toJson (dict "museum" .Values.museum.config "database" .Values.database "storage" .Values.storage "smtp" .Values.smtp) | sha256sum }}
+        checksum/config: {{ toJson (dict "museum" .Values.museum "database" .Values.database "storage" .Values.storage "smtp" .Values.smtp "webApps" .Values.web.apps) | sha256sum }}
         checksum/credentials: {{ toJson (dict "museum" .Values.museum.existingSecret "storage" .Values.storage.s3.existingSecret "database" .Values.database.external.existingSecret) | sha256sum }}
         {{- with .Values.museum.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/ente/templates/museum-worker-deployment.yaml
+++ b/charts/ente/templates/museum-worker-deployment.yaml
@@ -1,0 +1,32 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.museum.worker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ente.fullname" . }}-museum-worker
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: museum-worker
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "ente.componentLabels" (dict "root" . "component" "museum-worker") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ente.componentLabels" (dict "root" . "component" "museum-worker") | nindent 8 }}
+        {{- with .Values.museum.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toJson (dict "museum" .Values.museum.config "database" .Values.database "storage" .Values.storage "smtp" .Values.smtp) | sha256sum }}
+        checksum/credentials: {{ toJson (dict "museum" .Values.museum.existingSecret "storage" .Values.storage.s3.existingSecret "database" .Values.database.external.existingSecret) | sha256sum }}
+        {{- with .Values.museum.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "ente.museumPodSpec" (dict "root" . "component" "museum-worker" "configKey" "museum-worker.yaml" "resources" .Values.museum.worker.resources) | nindent 6 }}
+{{- end }}

--- a/charts/ente/templates/networkpolicy.yaml
+++ b/charts/ente/templates/networkpolicy.yaml
@@ -1,0 +1,111 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ente.fullname" . }}-museum
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ente.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - museum-api
+          - museum-worker
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress.allowExternal }}
+    - ports:
+        - protocol: TCP
+          port: 8080
+        {{- if .Values.metrics.enabled }}
+        - protocol: TCP
+          port: 2112
+        {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.ingress.museumExtraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowSameNamespacePostgresql }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      ports:
+        - protocol: TCP
+          port: {{ include "ente.databasePort" . }}
+    {{- end }}
+    {{- if .Values.networkPolicy.egress.allowObjectStorage }}
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 9000
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.museumExtraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "ente.fullname" . }}-web
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ente.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: web
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- if .Values.networkPolicy.ingress.allowExternal }}
+    - ports:
+        {{- range $name, $app := .Values.web.apps }}
+        {{- if $app.enabled }}
+        - protocol: TCP
+          port: {{ $app.port }}
+        {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.ingress.webExtraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.webExtraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/ente/templates/networkpolicy.yaml
+++ b/charts/ente/templates/networkpolicy.yaml
@@ -51,13 +51,13 @@ spec:
           port: {{ include "ente.databasePort" . }}
     {{- end }}
     {{- if .Values.networkPolicy.egress.allowObjectStorage }}
-    - ports:
+    - to:
+        {{- toYaml .Values.networkPolicy.egress.objectStorageDestinations | nindent 8 }}
+      ports:
+        {{- range .Values.networkPolicy.egress.objectStoragePorts }}
         - protocol: TCP
-          port: 443
-        - protocol: TCP
-          port: 80
-        - protocol: TCP
-          port: 9000
+          port: {{ . }}
+        {{- end }}
     {{- end }}
     {{- with .Values.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}

--- a/charts/ente/templates/pdb.yaml
+++ b/charts/ente/templates/pdb.yaml
@@ -1,0 +1,28 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.pdb.museum.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ente.fullname" . }}-museum-api
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.pdb.museum.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "ente.componentLabels" (dict "root" . "component" "museum-api") | nindent 6 }}
+{{- end }}
+{{- if .Values.pdb.web.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ente.fullname" . }}-web
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.pdb.web.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "ente.componentLabels" (dict "root" . "component" "web") | nindent 6 }}
+{{- end }}

--- a/charts/ente/templates/prometheusrule.yaml
+++ b/charts/ente/templates/prometheusrule.yaml
@@ -1,0 +1,31 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "ente.fullname" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.prometheusRule.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: {{ include "ente.fullname" . }}.rules
+      rules:
+        - alert: EnteMuseumUnavailable
+          expr: up{namespace={{ .Release.Namespace | quote }},service={{ printf "%s-metrics" (include "ente.fullname" .) | quote }}} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Ente Museum metrics target is unavailable
+            description: Museum has not been scrapeable for five minutes.
+        {{- with .Values.metrics.prometheusRule.rules }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/ente/templates/prometheusrule.yaml
+++ b/charts/ente/templates/prometheusrule.yaml
@@ -24,7 +24,15 @@ spec:
             severity: critical
           annotations:
             summary: Ente Museum metrics target is unavailable
-            description: Museum has not been scrapeable for five minutes.
+            description: Prometheus cannot scrape the Museum metrics target. The condition has lasted five minutes.
+        - alert: EnteMuseumMetricsTargetMissing
+          expr: absent(up{namespace={{ .Release.Namespace | quote }},service={{ printf "%s-metrics" (include "ente.fullname" .) | quote }}})
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: Ente Museum metrics target is missing
+            description: Prometheus has no scrape target for the Museum metrics Service.
         {{- with .Values.metrics.prometheusRule.rules }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/ente/templates/secret.yaml
+++ b/charts/ente/templates/secret.yaml
@@ -1,0 +1,67 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if not .Values.museum.existingSecret }}
+{{- $name := include "ente.museumSecretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.museum.secretKeys.encryptionKey }}: {{ if and $existing $existing.data (hasKey $existing.data .Values.museum.secretKeys.encryptionKey) }}{{ index $existing.data .Values.museum.secretKeys.encryptionKey }}{{ else }}{{ randBytes 32 | b64enc | quote }}{{ end }}
+  {{ .Values.museum.secretKeys.hashKey }}: {{ if and $existing $existing.data (hasKey $existing.data .Values.museum.secretKeys.hashKey) }}{{ index $existing.data .Values.museum.secretKeys.hashKey }}{{ else }}{{ randBytes 64 | b64enc | quote }}{{ end }}
+  {{ .Values.museum.secretKeys.jwtSecret }}: {{ if and $existing $existing.data (hasKey $existing.data .Values.museum.secretKeys.jwtSecret) }}{{ index $existing.data .Values.museum.secretKeys.jwtSecret }}{{ else }}{{ randBytes 32 | replace "+" "-" | replace "/" "_" | b64enc | quote }}{{ end }}
+{{- end }}
+{{- if not .Values.storage.s3.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ente.s3SecretName" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.storage.s3.existingSecretAccessKeyKey }}: {{ .Values.storage.s3.accessKey | quote }}
+  {{ .Values.storage.s3.existingSecretSecretKeyKey }}: {{ .Values.storage.s3.secretKey | quote }}
+{{- end }}
+{{- if and (eq (include "ente.databaseMode" .) "external") (not .Values.database.external.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ente.databaseSecretName" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.database.external.existingSecretPasswordKey }}: {{ .Values.database.external.password | quote }}
+{{- end }}
+{{- if and .Values.smtp.enabled (not .Values.smtp.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ente.smtpSecretName" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.smtp.existingSecretUsernameKey }}: {{ .Values.smtp.username | quote }}
+  {{ .Values.smtp.existingSecretPasswordKey }}: {{ .Values.smtp.password | quote }}
+{{- end }}
+{{- if and .Values.backup.enabled (not .Values.backup.s3.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ente.backupSecretName" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.backup.s3.existingSecretAccessKeyKey }}: {{ .Values.backup.s3.accessKey | quote }}
+  {{ .Values.backup.s3.existingSecretSecretKeyKey }}: {{ .Values.backup.s3.secretKey | quote }}
+{{- end }}

--- a/charts/ente/templates/serviceaccount.yaml
+++ b/charts/ente/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ente.serviceAccountName" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/ente/templates/servicemonitor.yaml
+++ b/charts/ente/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ente.fullname" . }}
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ente.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: museum-api
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ente/templates/services.yaml
+++ b/charts/ente/templates/services.yaml
@@ -1,0 +1,61 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ente.fullname" . }}-museum
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: museum-api
+  {{- with .Values.museum.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.museum.service.type }}
+  {{- with .Values.museum.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.museum.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.museum.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "ente.componentLabels" (dict "root" . "component" "museum-api") | nindent 4 }}
+{{- range $name, $app := .Values.web.apps }}
+{{- if $app.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ente.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "ente.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: web
+    app.kubernetes.io/service: {{ $name }}
+  {{- with $.Values.web.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $.Values.web.service.type }}
+  {{- with $.Values.web.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with $.Values.web.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ $.Values.web.service.port }}
+      targetPort: {{ $name }}
+      protocol: TCP
+  selector:
+    {{- include "ente.componentLabels" (dict "root" $ "component" "web") | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/ente/templates/tests/test-connection.yaml
+++ b/charts/ente/templates/tests/test-connection.yaml
@@ -1,0 +1,43 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "ente.fullname" . }}-test-connection
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: smoke
+      image: {{ .Values.test.image | quote }}
+      command: ["sh", "-ec"]
+      args:
+        - |
+          curl --fail --silent --show-error http://{{ include "ente.fullname" . }}-museum:{{ .Values.museum.service.port }}/ping
+          {{- range $name, $app := .Values.web.apps }}
+          {{- if $app.enabled }}
+          curl --fail --silent --show-error http://{{ include "ente.fullname" $ }}-{{ $name }}:{{ $.Values.web.service.port }}/ >/dev/null
+          {{- end }}
+          {{- end }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10001
+      {{- with .Values.test.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ente/templates/validate.yaml
+++ b/charts/ente/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "ente.validate" . -}}

--- a/charts/ente/templates/web-deployment.yaml
+++ b/charts/ente/templates/web-deployment.yaml
@@ -1,0 +1,148 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- $firstApp := include "ente.firstWebApp" . | fromJson }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ente.fullname" . }}-web
+  labels:
+    {{- include "ente.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  {{- if not .Values.autoscaling.web.enabled }}
+  replicas: {{ .Values.web.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ente.componentLabels" (dict "root" . "component" "web") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ente.componentLabels" (dict "root" . "component" "web") | nindent 8 }}
+        {{- with .Values.web.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toJson (dict "museumOrigin" .Values.museum.externalUrl "apps" .Values.web.apps) | sha256sum }}
+        {{- with .Values.web.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ente.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.web.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      initContainers:
+        - name: prepare-web-content
+          image: {{ include "ente.webImage" . | quote }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - cp -R /out/. /work/
+          securityContext:
+            {{- toYaml .Values.web.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: web-content
+              mountPath: /work
+      containers:
+        - name: web
+          image: {{ include "ente.webImage" . | quote }}
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          command: ["sh", "-ec"]
+          args:
+            - find /out -name '*.js' -exec sed -i "s#ENTE_API_ORIGIN_PLACEHOLDER#${ENTE_API_ORIGIN}#g" {} +; exec nginx -c /etc/ente/nginx.conf -g 'daemon off;'
+          securityContext:
+            {{- toYaml .Values.web.securityContext | nindent 12 }}
+          env:
+            - name: ENTE_API_ORIGIN
+              value: {{ .Values.museum.externalUrl | quote }}
+            {{- with .Values.web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            {{- range $name, $app := .Values.web.apps }}
+            {{- if $app.enabled }}
+            - name: {{ $name }}
+              containerPort: {{ $app.port }}
+              protocol: TCP
+            {{- end }}
+            {{- end }}
+          {{- if .Values.web.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ $firstApp.name }}
+            initialDelaySeconds: {{ .Values.web.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- if .Values.web.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ $firstApp.name }}
+            periodSeconds: {{ .Values.web.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.web.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ $firstApp.name }}
+            initialDelaySeconds: {{ .Values.web.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.web.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.web.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.web.probes.liveness.failureThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+          volumeMounts:
+            - name: web-content
+              mountPath: /out
+            - name: nginx-config
+              mountPath: /etc/ente/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: web-content
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: {{ include "ente.fullname" . }}-config
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ente/tests/externalsecret_test.yaml
+++ b/charts/ente/tests/externalsecret_test.yaml
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente External Secrets
+templates:
+  - templates/externalsecret.yaml
+tests:
+  - it: omits ExternalSecrets by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders a complete ExternalSecret
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: museum
+            spec:
+              secretStoreRef:
+                name: fake
+                kind: ClusterSecretStore
+              dataFrom:
+                - extract:
+                    key: ente/museum
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+  - it: defaults the target Secret name
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: museum
+            spec:
+              secretStoreRef:
+                name: fake
+              dataFrom:
+                - extract:
+                    key: ente/museum
+    asserts:
+      - equal:
+          path: spec.target.name
+          value: museum
+  - it: rejects duplicate rendered names
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - name: duplicate
+            spec:
+              secretStoreRef:
+                name: fake
+              dataFrom:
+                - extract:
+                    key: one
+          - name: duplicate
+            spec:
+              secretStoreRef:
+                name: fake
+              dataFrom:
+                - extract:
+                    key: two
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.items render duplicate ExternalSecret name "duplicate"
+  - it: requires a store reference
+    set:
+      externalSecrets:
+        enabled: true
+        items:
+          - spec:
+              data:
+                - secretKey: encryption-key
+                  remoteRef:
+                    key: ente
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.items[0].spec.data[0] requires a store or generator reference when spec.secretStoreRef.name is absent

--- a/charts/ente/tests/museum_test.yaml
+++ b/charts/ente/tests/museum_test.yaml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Museum API deployment
+templates:
+  - templates/museum-api-deployment.yaml
+tests:
+  - it: renders a Museum Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ente-museum-api
+  - it: uses the official pinned server image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/ente/server:0472c929b6070e61fecaf2013d47efce2dcda462
+  - it: runs Museum as non-root with a read-only root filesystem
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+  - it: uses HTTP readiness against ping
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ping
+  - it: uses TCP liveness independent of PostgreSQL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+  - it: disables service account token mounting
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+  - it: omits replicas when Museum HPA is enabled
+    set:
+      autoscaling.museum.enabled: true
+      museum.api.skipBackgroundJobs: true
+      museum.worker.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas
+  - it: includes user-provided Museum environment variables
+    set:
+      museum:
+        extraEnv:
+          - name: FEATURE_FLAG
+            value: enabled
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FEATURE_FLAG
+            value: enabled
+  - it: omits the migration gate for a single Museum process
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+      - notExists:
+          path: spec.template.spec.containers[0].command
+  - it: serializes Museum startup in HA
+    set:
+      museum.api.replicaCount: 2
+      museum.api.skipBackgroundJobs: true
+      museum.worker.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: /bin/sh
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: migration-gate
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: docker.io/library/postgres:18.4-trixie
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: migration-gate
+            emptyDir: {}

--- a/charts/ente/tests/production_test.yaml
+++ b/charts/ente/tests/production_test.yaml
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente production resources
+templates:
+  - templates/museum-worker-deployment.yaml
+  - templates/pdb.yaml
+  - templates/hpa.yaml
+  - templates/metrics.yaml
+  - templates/servicemonitor.yaml
+  - templates/prometheusrule.yaml
+  - templates/networkpolicy.yaml
+tests:
+  - it: omits the singleton worker by default
+    template: templates/museum-worker-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: renders one Recreate worker for HA
+    set:
+      museum.api.skipBackgroundJobs: true
+      museum.worker.enabled: true
+    template: templates/museum-worker-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+  - it: renders both PDBs for replicated workloads
+    set:
+      museum.api.replicaCount: 2
+      museum.api.skipBackgroundJobs: true
+      museum.worker.enabled: true
+      web.replicaCount: 2
+      pdb.museum.enabled: true
+      pdb.web.enabled: true
+    template: templates/pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: renders two HPAs
+    set:
+      museum.api.skipBackgroundJobs: true
+      museum.worker.enabled: true
+      autoscaling.museum.enabled: true
+      autoscaling.web.enabled: true
+    template: templates/hpa.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: renders the metrics Service when enabled
+    set:
+      metrics.enabled: true
+    template: templates/metrics.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].targetPort
+          value: metrics
+  - it: renders ServiceMonitor only when enabled
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    template: templates/servicemonitor.yaml
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+  - it: renders PrometheusRule only when enabled
+    set:
+      metrics.enabled: true
+      metrics.prometheusRule.enabled: true
+    template: templates/prometheusrule.yaml
+    asserts:
+      - isKind:
+          of: PrometheusRule
+  - it: renders Museum and web NetworkPolicies
+    set:
+      networkPolicy.enabled: true
+    template: templates/networkpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: applies shared extra egress rules to Museum and web
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.allowDNS: false
+      networkPolicy.egress.allowSameNamespacePostgresql: false
+      networkPolicy.egress.allowObjectStorage: false
+      networkPolicy.extraEgress:
+        - to:
+            - ipBlock:
+                cidr: 10.42.0.0/16
+          ports:
+            - protocol: TCP
+              port: 443
+    template: templates/networkpolicy.yaml
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].ipBlock.cidr
+          value: 10.42.0.0/16
+        documentIndex: 0
+      - equal:
+          path: spec.egress[0].to[0].ipBlock.cidr
+          value: 10.42.0.0/16
+        documentIndex: 1

--- a/charts/ente/tests/production_test.yaml
+++ b/charts/ente/tests/production_test.yaml
@@ -48,6 +48,15 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
+  - it: rejects an HPA without a metric target
+    set:
+      autoscaling.web.enabled: true
+      autoscaling.web.targetCPUUtilizationPercentage: ""
+      autoscaling.web.targetMemoryUtilizationPercentage: ""
+    template: templates/hpa.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: autoscaling.web requires targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage when enabled
   - it: renders the metrics Service when enabled
     set:
       metrics.enabled: true
@@ -74,6 +83,9 @@ tests:
     asserts:
       - isKind:
           of: PrometheusRule
+      - lengthEqual:
+          path: spec.groups[0].rules
+          count: 2
   - it: renders Museum and web NetworkPolicies
     set:
       networkPolicy.enabled: true
@@ -81,6 +93,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 443
+        documentIndex: 0
+      - contains:
+          path: spec.egress[2].to[0].ipBlock.except
+          content: 169.254.0.0/16
+        documentIndex: 0
   - it: applies shared extra egress rules to Museum and web
     set:
       networkPolicy.enabled: true

--- a/charts/ente/tests/routing_test.yaml
+++ b/charts/ente/tests/routing_test.yaml
@@ -68,3 +68,18 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: route service "memories" references a disabled web application
+  - it: rejects HTTPRoute names that collide after truncation
+    set:
+      gateway:
+        enabled: true
+        parentRefs:
+          - name: public
+        routes:
+          - name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-one
+            service: museum
+          - name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-two
+            service: museum
+    template: templates/gateway-httproute.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: gateway.routes render duplicate HTTPRoute name "RELEASE-NAME-ente-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/charts/ente/tests/routing_test.yaml
+++ b/charts/ente/tests/routing_test.yaml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente routing
+templates:
+  - templates/ingress.yaml
+  - templates/gateway-httproute.yaml
+tests:
+  - it: omits routing resources by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: routes an Ingress host to Museum
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: api.ente.test
+            service: museum
+            paths:
+              - path: /
+    template: templates/ingress.yaml
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-ente-museum
+  - it: routes an Ingress host to Photos
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: photos.ente.test
+            service: photos
+            paths:
+              - path: /
+    template: templates/ingress.yaml
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-ente-photos
+  - it: renders an HTTPRoute with a shared parent
+    set:
+      gateway:
+        enabled: true
+        parentRefs:
+          - name: public
+        routes:
+          - name: museum
+            service: museum
+            hostnames:
+              - api.ente.test
+    template: templates/gateway-httproute.yaml
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: public
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+  - it: rejects a route to a disabled web application
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: memories.ente.test
+            service: memories
+            paths:
+              - path: /
+    template: templates/ingress.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: route service "memories" references a disabled web application

--- a/charts/ente/tests/secret_test.yaml
+++ b/charts/ente/tests/secret_test.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente secrets
+templates:
+  - templates/secret.yaml
+tests:
+  - it: creates Museum and S3 Secrets by default
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: does not create a Museum Secret when existingSecret is configured
+    set:
+      museum.existingSecret: production-museum
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ente-s3
+  - it: does not create an S3 Secret when existingSecret is configured
+    set:
+      storage.s3.existingSecret: production-s3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ente-museum
+  - it: creates an external database Secret for inline password
+    set:
+      postgresql.enabled: false
+      database.mode: external
+      database.external.host: database.test
+      database.external.password: secret
+    asserts:
+      - hasDocuments:
+          count: 3
+  - it: creates SMTP credentials only when enabled
+    set:
+      smtp.enabled: true
+      smtp.host: smtp.test
+      smtp.email: ente@test.invalid
+    asserts:
+      - hasDocuments:
+          count: 3
+  - it: creates backup credentials only when backup is enabled
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://backup.test
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/charts/ente/tests/services_test.yaml
+++ b/charts/ente/tests/services_test.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente services
+templates:
+  - templates/services.yaml
+tests:
+  - it: renders Museum and three default web Services
+    asserts:
+      - hasDocuments:
+          count: 4
+  - it: maps Museum to its HTTP container port
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+  - it: applies dual-stack fields to Museum
+    set:
+      museum:
+        service:
+          ipFamilyPolicy: PreferDualStack
+          ipFamilies:
+            - IPv6
+            - IPv4
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - lengthEqual:
+          path: spec.ipFamilies
+          count: 2
+  - it: omits a disabled web application Service
+    set:
+      web.apps.albums.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 3
+  - it: adds an enabled optional application Service
+    set:
+      web.apps.memories.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 5

--- a/charts/ente/tests/validation_test.yaml
+++ b/charts/ente/tests/validation_test.yaml
@@ -36,6 +36,13 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: storage.s3.accessKey or storage.s3.existingSecret is required
+  - it: rejects the bundled dependency in external database mode
+    set:
+      database.mode: external
+      database.external.host: ente-rw.database.svc.cluster.local
+    asserts:
+      - failedTemplate:
+          errorMessage: database.mode=external requires postgresql.enabled=false to avoid deploying an unused PostgreSQL dependency
   - it: rejects placeholder S3 in production mode
     set:
       productionMode: true
@@ -44,6 +51,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: productionMode=true requires storage.s3.existingSecret or non-placeholder S3 credentials
+  - it: rejects enabled web application placeholders in production mode
+    set:
+      productionMode: true
+      museum.externalUrl: https://api.ente.test
+      storage.s3.endpoint: https://objects.ente.test
+      storage.s3.existingSecret: ente-s3
+      web.apps.accounts.externalUrl: https://accounts.ente.test
+      web.apps.photos.externalUrl: https://photos.ente.test
+    asserts:
+      - failedTemplate:
+          errorMessage: productionMode=true requires a real web.apps.albums.externalUrl
   - it: requires metrics before ServiceMonitor
     set:
       metrics.serviceMonitor.enabled: true

--- a/charts/ente/tests/validation_test.yaml
+++ b/charts/ente/tests/validation_test.yaml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente fail-fast validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: rejects multiple cron-enabled Museum API replicas
+    set:
+      museum.api.replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: museum.api.replicaCount greater than 1 requires museum.api.skipBackgroundJobs=true
+  - it: requires a singleton worker when API jobs are skipped
+    set:
+      museum.api.skipBackgroundJobs: true
+    asserts:
+      - failedTemplate:
+          errorMessage: museum.api.skipBackgroundJobs=true requires museum.worker.enabled=true so scheduled maintenance still runs
+  - it: requires API jobs to be skipped when worker is enabled
+    set:
+      museum.worker.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: museum.worker.enabled=true requires museum.api.skipBackgroundJobs=true to prevent duplicate cron jobs
+  - it: rejects an unsafe HA topology without the migration gate
+    set:
+      museum.api.replicaCount: 2
+      museum.api.skipBackgroundJobs: true
+      museum.worker.enabled: true
+      museum.migrationGate.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: concurrent Museum processes require museum.migrationGate.enabled=true to serialize database migrations
+  - it: requires S3 access credentials
+    set:
+      storage.s3.accessKey: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: storage.s3.accessKey or storage.s3.existingSecret is required
+  - it: rejects placeholder S3 in production mode
+    set:
+      productionMode: true
+      museum.externalUrl: https://api.ente.test
+      storage.s3.endpoint: https://objects.ente.test
+    asserts:
+      - failedTemplate:
+          errorMessage: productionMode=true requires storage.s3.existingSecret or non-placeholder S3 credentials
+  - it: requires metrics before ServiceMonitor
+    set:
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: metrics.serviceMonitor.enabled=true requires metrics.enabled=true
+  - it: requires backup endpoint
+    set:
+      backup.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: backup.enabled=true requires backup.s3.endpoint
+  - it: requires routes when Gateway API is enabled
+    set:
+      gateway.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: gateway.enabled=true requires gateway.routes

--- a/charts/ente/tests/web_test.yaml
+++ b/charts/ente/tests/web_test.yaml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Ente web deployment
+templates:
+  - templates/web-deployment.yaml
+tests:
+  - it: renders the web Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+  - it: uses the official pinned web image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/ente/web:5ab0c5b4c7a89c4e470ef6f793600da33cebf35d
+  - it: prepares web content before startup
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: prepare-web-content
+  - it: runs nginx with a read-only root filesystem
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+  - it: exposes the three default applications
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].ports
+          count: 3
+  - it: exposes an optional application when enabled
+    set:
+      web.apps.memories.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: memories
+            containerPort: 3010
+            protocol: TCP
+  - it: passes the public Museum origin to web
+    set:
+      museum.externalUrl: https://api.photos.test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENTE_API_ORIGIN
+            value: https://api.photos.test
+  - it: omits replicas when web HPA is enabled
+    set:
+      autoscaling.web.enabled: true
+    asserts:
+      - notExists:
+          path: spec.replicas

--- a/charts/ente/values.schema.json
+++ b/charts/ente/values.schema.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Ente Helm chart values",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["productionMode", "museum", "database", "postgresql", "storage", "smtp", "externalSecrets", "web", "ingress", "gateway", "networkPolicy", "pdb", "autoscaling", "metrics", "backup", "test", "serviceAccount"],
+  "definitions": {
+    "stringMap": {"type": "object", "additionalProperties": {"type": "string"}},
+    "image": {
+      "type": "object", "additionalProperties": false, "required": ["repository", "tag", "pullPolicy"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "minLength": 1, "not": {"enum": ["latest"]}},
+        "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"]}
+      }
+    },
+    "probe": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "periodSeconds", "timeoutSeconds", "failureThreshold"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "initialDelaySeconds": {"type": "integer", "minimum": 0},
+        "periodSeconds": {"type": "integer", "minimum": 1}, "timeoutSeconds": {"type": "integer", "minimum": 1},
+        "failureThreshold": {"type": "integer", "minimum": 1}
+      }
+    },
+    "resources": {
+      "type": "object", "additionalProperties": false,
+      "properties": {
+        "requests": {"type": "object", "additionalProperties": {"type": ["string", "number"]}},
+        "limits": {"type": "object", "additionalProperties": {"type": ["string", "number"]}}
+      }
+    },
+    "service": {
+      "type": "object", "additionalProperties": false,
+      "properties": {
+        "type": {"type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"]},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "metricsPort": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "annotations": {"$ref": "#/definitions/stringMap"},
+        "ipFamilyPolicy": {"type": "string", "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]},
+        "ipFamilies": {"type": "array", "maxItems": 2, "uniqueItems": true, "items": {"type": "string", "enum": ["IPv4", "IPv6"]}}
+      }
+    },
+    "webApp": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "port", "externalUrl"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "port": {"type": "integer", "minimum": 1024, "maximum": 65535},
+        "externalUrl": {"type": "string", "pattern": "^https?://"}
+      }
+    },
+    "autoscalingComponent": {
+      "type": "object", "additionalProperties": false,
+      "required": ["enabled", "minReplicas", "maxReplicas", "targetCPUUtilizationPercentage", "targetMemoryUtilizationPercentage", "behavior"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "minReplicas": {"type": "integer", "minimum": 1},
+        "maxReplicas": {"type": "integer", "minimum": 1},
+        "targetCPUUtilizationPercentage": {"type": ["integer", "string"]},
+        "targetMemoryUtilizationPercentage": {"type": ["integer", "string"]}, "behavior": {"type": "object"}
+      }
+    },
+    "pdbComponent": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "maxUnavailable"],
+      "properties": {"enabled": {"type": "boolean"}, "maxUnavailable": {"type": ["integer", "string"]}}
+    }
+  },
+  "properties": {
+    "nameOverride": {"type": "string"}, "fullnameOverride": {"type": "string"},
+    "commonLabels": {"$ref": "#/definitions/stringMap"}, "productionMode": {"type": "boolean"},
+    "imagePullSecrets": {"type": "array", "items": {"type": "object"}},
+    "museum": {
+      "type": "object", "additionalProperties": false,
+      "required": ["image", "externalUrl", "existingSecret", "secretKeys", "api", "worker", "migrationGate", "config", "service", "probes", "podAnnotations", "podLabels", "podSecurityContext", "securityContext", "extraEnv", "extraVolumes", "extraVolumeMounts"],
+      "properties": {
+        "image": {"$ref": "#/definitions/image"}, "externalUrl": {"type": "string", "pattern": "^https?://"},
+        "existingSecret": {"type": "string"},
+        "secretKeys": {
+          "type": "object", "additionalProperties": false, "required": ["encryptionKey", "hashKey", "jwtSecret"],
+          "properties": {"encryptionKey": {"type": "string", "minLength": 1}, "hashKey": {"type": "string", "minLength": 1}, "jwtSecret": {"type": "string", "minLength": 1}}
+        },
+        "api": {
+          "type": "object", "additionalProperties": false, "required": ["replicaCount", "skipBackgroundJobs", "resources"],
+          "properties": {"replicaCount": {"type": "integer", "minimum": 1}, "skipBackgroundJobs": {"type": "boolean"}, "resources": {"$ref": "#/definitions/resources"}}
+        },
+        "worker": {
+          "type": "object", "additionalProperties": false, "required": ["enabled", "resources"],
+          "properties": {"enabled": {"type": "boolean"}, "resources": {"$ref": "#/definitions/resources"}}
+        },
+        "migrationGate": {
+          "type": "object", "additionalProperties": false,
+          "required": ["enabled", "image", "advisoryLockId", "resources", "securityContext"],
+          "properties": {
+            "enabled": {"type": "boolean"}, "image": {"$ref": "#/definitions/image"},
+            "advisoryLockId": {"type": "integer", "minimum": 1},
+            "resources": {"$ref": "#/definitions/resources"}, "securityContext": {"type": "object"}
+          }
+        },
+        "config": {
+          "type": "object", "additionalProperties": false,
+          "required": ["logLevel", "disableRegistration", "admins", "trustedClientIpHeader", "webauthn", "extraYaml"],
+          "properties": {
+            "logLevel": {"type": "string", "enum": ["panic", "fatal", "error", "warn", "info", "debug", "trace"]},
+            "disableRegistration": {"type": "boolean"}, "admins": {"type": "array", "items": {"type": ["integer", "string"]}},
+            "trustedClientIpHeader": {"type": "string"},
+            "webauthn": {
+              "type": "object", "additionalProperties": false, "required": ["rpid", "rporigins"],
+              "properties": {"rpid": {"type": "string"}, "rporigins": {"type": "array", "items": {"type": "string", "pattern": "^https?://"}}}
+            },
+            "extraYaml": {"type": "string"}
+          }
+        },
+        "service": {"$ref": "#/definitions/service"},
+        "probes": {
+          "type": "object", "additionalProperties": false, "required": ["startup", "readiness", "liveness"],
+          "properties": {"startup": {"$ref": "#/definitions/probe"}, "readiness": {"$ref": "#/definitions/probe"}, "liveness": {"$ref": "#/definitions/probe"}}
+        },
+        "podAnnotations": {"$ref": "#/definitions/stringMap"}, "podLabels": {"$ref": "#/definitions/stringMap"},
+        "podSecurityContext": {"type": "object"}, "securityContext": {"type": "object"},
+        "extraEnv": {"type": "array", "items": {"type": "object"}}, "extraVolumes": {"type": "array", "items": {"type": "object"}},
+        "extraVolumeMounts": {"type": "array", "items": {"type": "object"}}
+      }
+    },
+    "database": {
+      "type": "object", "additionalProperties": false, "required": ["mode", "external"],
+      "properties": {
+        "mode": {"type": "string", "enum": ["auto", "postgresql", "external"]},
+        "external": {
+          "type": "object", "additionalProperties": false,
+          "required": ["host", "port", "name", "username", "password", "existingSecret", "existingSecretPasswordKey", "sslMode"],
+          "properties": {
+            "host": {"type": "string"}, "port": {"type": "integer", "minimum": 1, "maximum": 65535}, "name": {"type": "string", "minLength": 1},
+            "username": {"type": "string", "minLength": 1}, "password": {"type": "string"}, "existingSecret": {"type": "string"},
+            "existingSecretPasswordKey": {"type": "string", "minLength": 1},
+            "sslMode": {"type": "string", "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]}
+          }
+        }
+      }
+    },
+    "postgresql": {"type": "object"},
+    "storage": {
+      "type": "object", "additionalProperties": false, "required": ["s3"],
+      "properties": {
+        "s3": {
+          "type": "object", "additionalProperties": false,
+          "required": ["endpoint", "region", "bucket", "usePathStyle", "localBuckets", "accessKey", "secretKey", "existingSecret", "existingSecretAccessKeyKey", "existingSecretSecretKeyKey"],
+          "properties": {
+            "endpoint": {"type": "string", "pattern": "^https?://"}, "region": {"type": "string", "minLength": 1}, "bucket": {"type": "string", "minLength": 1},
+            "usePathStyle": {"type": "boolean"}, "localBuckets": {"type": "boolean"}, "accessKey": {"type": "string"}, "secretKey": {"type": "string"},
+            "existingSecret": {"type": "string"}, "existingSecretAccessKeyKey": {"type": "string", "minLength": 1},
+            "existingSecretSecretKeyKey": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "smtp": {
+      "type": "object", "additionalProperties": false,
+      "required": ["enabled", "host", "port", "email", "senderName", "encryption", "username", "password", "existingSecret", "existingSecretUsernameKey", "existingSecretPasswordKey"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "host": {"type": "string"}, "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "email": {"type": "string"}, "senderName": {"type": "string"}, "encryption": {"type": "string", "enum": ["", "tls", "ssl"]},
+        "username": {"type": "string"}, "password": {"type": "string"}, "existingSecret": {"type": "string"},
+        "existingSecretUsernameKey": {"type": "string", "minLength": 1}, "existingSecretPasswordKey": {"type": "string", "minLength": 1}
+      }
+    },
+    "externalSecrets": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "apiVersion", "refreshInterval", "items"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "apiVersion": {"type": "string", "minLength": 1}, "refreshInterval": {"type": "string", "minLength": 1},
+        "items": {
+          "type": "array", "items": {
+            "type": "object", "additionalProperties": false, "required": ["spec"],
+            "properties": {"name": {"type": "string"}, "labels": {"$ref": "#/definitions/stringMap"}, "annotations": {"$ref": "#/definitions/stringMap"}, "spec": {"type": "object"}}
+          }
+        }
+      }
+    },
+    "web": {
+      "type": "object", "additionalProperties": false,
+      "required": ["image", "replicaCount", "apps", "service", "probes", "podAnnotations", "podLabels", "podSecurityContext", "securityContext", "resources", "extraEnv"],
+      "properties": {
+        "image": {"$ref": "#/definitions/image"}, "replicaCount": {"type": "integer", "minimum": 1},
+        "apps": {
+          "type": "object", "additionalProperties": false, "required": ["photos", "accounts", "albums", "auth", "cast", "share", "embed", "memories"],
+          "properties": {
+            "photos": {"$ref": "#/definitions/webApp"}, "accounts": {"$ref": "#/definitions/webApp"}, "albums": {"$ref": "#/definitions/webApp"},
+            "auth": {"$ref": "#/definitions/webApp"}, "cast": {"$ref": "#/definitions/webApp"}, "share": {"$ref": "#/definitions/webApp"},
+            "embed": {"$ref": "#/definitions/webApp"}, "memories": {"$ref": "#/definitions/webApp"}
+          }
+        },
+        "service": {"$ref": "#/definitions/service"},
+        "probes": {
+          "type": "object", "additionalProperties": false, "required": ["startup", "readiness", "liveness"],
+          "properties": {"startup": {"$ref": "#/definitions/probe"}, "readiness": {"$ref": "#/definitions/probe"}, "liveness": {"$ref": "#/definitions/probe"}}
+        },
+        "podAnnotations": {"$ref": "#/definitions/stringMap"}, "podLabels": {"$ref": "#/definitions/stringMap"},
+        "podSecurityContext": {"type": "object"}, "securityContext": {"type": "object"}, "resources": {"$ref": "#/definitions/resources"},
+        "extraEnv": {"type": "array", "items": {"type": "object"}}
+      }
+    },
+    "ingress": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "ingressClassName", "annotations", "hosts", "tls"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "ingressClassName": {"type": "string"}, "annotations": {"$ref": "#/definitions/stringMap"},
+        "hosts": {"type": "array", "items": {
+          "type": "object", "additionalProperties": false, "required": ["host", "service", "paths"],
+          "properties": {
+            "host": {"type": "string", "minLength": 1},
+            "service": {"type": "string", "enum": ["museum", "photos", "accounts", "albums", "auth", "cast", "share", "embed", "memories"]},
+            "paths": {"type": "array", "minItems": 1, "items": {
+              "type": "object", "additionalProperties": false,
+              "properties": {"path": {"type": "string"}, "pathType": {"type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"]}}
+            }}
+          }
+        }},
+        "tls": {"type": "array", "items": {"type": "object"}}
+      }
+    },
+    "gateway": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "apiVersion", "parentRefs", "routes"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "apiVersion": {"type": "string", "minLength": 1}, "parentRefs": {"type": "array", "items": {"type": "object"}},
+        "routes": {"type": "array", "items": {
+          "type": "object", "additionalProperties": false, "required": ["name", "service"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "service": {"type": "string", "enum": ["museum", "photos", "accounts", "albums", "auth", "cast", "share", "embed", "memories"]},
+            "hostnames": {"type": "array", "items": {"type": "string"}}, "parentRefs": {"type": "array", "items": {"type": "object"}},
+            "annotations": {"$ref": "#/definitions/stringMap"}
+          }
+        }}
+      }
+    },
+    "networkPolicy": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "extraEgress", "ingress", "egress"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "extraEgress": {"type": "array", "items": {"type": "object"}},
+        "ingress": {
+          "type": "object", "additionalProperties": false, "required": ["allowExternal", "museumExtraRules", "webExtraRules"],
+          "properties": {"allowExternal": {"type": "boolean"}, "museumExtraRules": {"type": "array", "items": {"type": "object"}}, "webExtraRules": {"type": "array", "items": {"type": "object"}}}
+        },
+        "egress": {
+          "type": "object", "additionalProperties": false,
+          "required": ["allowDNS", "allowSameNamespacePostgresql", "allowObjectStorage", "museumExtraRules", "webExtraRules"],
+          "properties": {
+            "allowDNS": {"type": "boolean"}, "allowSameNamespacePostgresql": {"type": "boolean"}, "allowObjectStorage": {"type": "boolean"},
+            "museumExtraRules": {"type": "array", "items": {"type": "object"}}, "webExtraRules": {"type": "array", "items": {"type": "object"}}
+          }
+        }
+      }
+    },
+    "pdb": {
+      "type": "object", "additionalProperties": false, "required": ["museum", "web"],
+      "properties": {"museum": {"$ref": "#/definitions/pdbComponent"}, "web": {"$ref": "#/definitions/pdbComponent"}}
+    },
+    "autoscaling": {
+      "type": "object", "additionalProperties": false, "required": ["museum", "web"],
+      "properties": {"museum": {"$ref": "#/definitions/autoscalingComponent"}, "web": {"$ref": "#/definitions/autoscalingComponent"}}
+    },
+    "metrics": {
+      "type": "object", "additionalProperties": false, "required": ["enabled", "service", "serviceMonitor", "prometheusRule"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "service": {"type": "object", "additionalProperties": false, "required": ["annotations"], "properties": {"annotations": {"$ref": "#/definitions/stringMap"}}},
+        "serviceMonitor": {
+          "type": "object", "additionalProperties": false,
+          "required": ["enabled", "interval", "scrapeTimeout", "labels", "annotations", "relabelings", "metricRelabelings"],
+          "properties": {
+            "enabled": {"type": "boolean"}, "interval": {"type": "string", "minLength": 1}, "scrapeTimeout": {"type": "string", "minLength": 1},
+            "labels": {"$ref": "#/definitions/stringMap"}, "annotations": {"$ref": "#/definitions/stringMap"},
+            "relabelings": {"type": "array", "items": {"type": "object"}}, "metricRelabelings": {"type": "array", "items": {"type": "object"}}
+          }
+        },
+        "prometheusRule": {
+          "type": "object", "additionalProperties": false, "required": ["enabled", "labels", "annotations", "rules"],
+          "properties": {"enabled": {"type": "boolean"}, "labels": {"$ref": "#/definitions/stringMap"}, "annotations": {"$ref": "#/definitions/stringMap"}, "rules": {"type": "array", "items": {"type": "object"}}}
+        }
+      }
+    },
+    "backup": {
+      "type": "object", "additionalProperties": false,
+      "required": ["enabled", "schedule", "suspend", "concurrencyPolicy", "successfulJobsHistoryLimit", "failedJobsHistoryLimit", "backoffLimit", "postgresqlImage", "uploaderImage", "pgDumpArgs", "resources", "s3"],
+      "properties": {
+        "enabled": {"type": "boolean"}, "schedule": {"type": "string", "minLength": 1}, "suspend": {"type": "boolean"},
+        "concurrencyPolicy": {"type": "string", "enum": ["Allow", "Forbid", "Replace"]},
+        "successfulJobsHistoryLimit": {"type": "integer", "minimum": 0}, "failedJobsHistoryLimit": {"type": "integer", "minimum": 0},
+        "backoffLimit": {"type": "integer", "minimum": 0}, "postgresqlImage": {"type": "string", "minLength": 1},
+        "uploaderImage": {"type": "string", "minLength": 1}, "pgDumpArgs": {"type": "string"}, "resources": {"$ref": "#/definitions/resources"},
+        "s3": {
+          "type": "object", "additionalProperties": false,
+          "required": ["endpoint", "bucket", "prefix", "existingSecret", "existingSecretAccessKeyKey", "existingSecretSecretKeyKey", "accessKey", "secretKey"],
+          "properties": {
+            "endpoint": {"type": "string"}, "bucket": {"type": "string"}, "prefix": {"type": "string"}, "existingSecret": {"type": "string"},
+            "existingSecretAccessKeyKey": {"type": "string", "minLength": 1}, "existingSecretSecretKeyKey": {"type": "string", "minLength": 1},
+            "accessKey": {"type": "string"}, "secretKey": {"type": "string"}
+          }
+        }
+      }
+    },
+    "test": {
+      "type": "object", "additionalProperties": false, "required": ["image", "resources"],
+      "properties": {"image": {"type": "string", "minLength": 1}, "resources": {"$ref": "#/definitions/resources"}}
+    },
+    "extraManifests": {"type": "array", "items": {"type": "object"}},
+    "waitForDatabase": {
+      "type": "object", "additionalProperties": false, "required": ["image", "pullPolicy", "resources", "securityContext"],
+      "properties": {
+        "image": {"type": "string", "minLength": 1}, "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"]},
+        "resources": {"$ref": "#/definitions/resources"}, "securityContext": {"type": "object"}
+      }
+    },
+    "serviceAccount": {
+      "type": "object", "additionalProperties": false, "required": ["create", "name", "annotations", "automountServiceAccountToken"],
+      "properties": {"create": {"type": "boolean"}, "name": {"type": "string"}, "annotations": {"$ref": "#/definitions/stringMap"}, "automountServiceAccountToken": {"type": "boolean"}}
+    },
+    "priorityClassName": {"type": "string"}, "nodeSelector": {"type": "object"},
+    "tolerations": {"type": "array", "items": {"type": "object"}}, "affinity": {"type": "object"},
+    "topologySpreadConstraints": {"type": "array", "items": {"type": "object"}},
+    "terminationGracePeriodSeconds": {"type": "integer", "minimum": 0}
+  }
+}

--- a/charts/ente/values.schema.json
+++ b/charts/ente/values.schema.json
@@ -239,9 +239,11 @@
         },
         "egress": {
           "type": "object", "additionalProperties": false,
-          "required": ["allowDNS", "allowSameNamespacePostgresql", "allowObjectStorage", "museumExtraRules", "webExtraRules"],
+          "required": ["allowDNS", "allowSameNamespacePostgresql", "allowObjectStorage", "objectStorageDestinations", "objectStoragePorts", "museumExtraRules", "webExtraRules"],
           "properties": {
             "allowDNS": {"type": "boolean"}, "allowSameNamespacePostgresql": {"type": "boolean"}, "allowObjectStorage": {"type": "boolean"},
+            "objectStorageDestinations": {"type": "array", "minItems": 1, "items": {"type": "object"}},
+            "objectStoragePorts": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "integer", "minimum": 1, "maximum": 65535}},
             "museumExtraRules": {"type": "array", "items": {"type": "object"}}, "webExtraRules": {"type": "array", "items": {"type": "object"}}
           }
         }

--- a/charts/ente/values.yaml
+++ b/charts/ente/values.yaml
@@ -419,8 +419,26 @@ networkPolicy:
     allowDNS: true
     # -- Allow Museum to reach same-namespace PostgreSQL pods.
     allowSameNamespacePostgresql: true
-    # -- Allow HTTP/HTTPS egress for S3-compatible storage.
+    # -- Allow egress to the configured S3 destination peers and ports.
     allowObjectStorage: true
+    # -- NetworkPolicy peers allowed for object storage. Defaults to public IPv4/IPv6 and excludes private and link-local ranges.
+    objectStorageDestinations:
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+            - 10.0.0.0/8
+            - 169.254.0.0/16
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+      - ipBlock:
+          cidr: ::/0
+          except:
+            - ::1/128
+            - fc00::/7
+            - fe80::/10
+    # -- TCP ports allowed for object storage. Add 80 or 9000 only for explicitly accepted plaintext endpoints.
+    objectStoragePorts:
+      - 443
     # -- Additional complete Museum egress rules, required for private S3 or SMTP CIDRs.
     museumExtraRules: []
     # -- Additional complete web egress rules.

--- a/charts/ente/values.yaml
+++ b/charts/ente/values.yaml
@@ -1,0 +1,571 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Ente Photos Helm Chart
+# =============================================================================
+# Museum stores metadata and encryption material in PostgreSQL while encrypted
+# objects live in an external S3-compatible bucket. The S3 endpoint must be
+# reachable by both Museum and end-user clients through presigned URLs.
+# =============================================================================
+
+# -- Override the chart name used in Kubernetes object names.
+nameOverride: ""
+
+# -- Override the full release name used in Kubernetes object names.
+fullnameOverride: ""
+
+# -- Labels added to all resources created by this chart.
+commonLabels: {}
+
+# -- Reject evaluation placeholders and require a production credential contract.
+productionMode: false
+
+# -- Image pull secrets for private mirrors.
+imagePullSecrets: []
+
+museum:
+  image:
+    # -- Official Ente Museum image repository.
+    repository: ghcr.io/ente/server
+    # -- Immutable commit running in upstream Ente production.
+    tag: "0472c929b6070e61fecaf2013d47efce2dcda462"
+    # -- Museum image pull policy.
+    pullPolicy: IfNotPresent
+  # -- Public Museum API origin used by the web applications.
+  externalUrl: https://api.ente.example.com
+  # -- Existing Secret containing Museum cryptographic keys.
+  existingSecret: ""
+  secretKeys:
+    # -- Key containing the base64-standard 32-byte email encryption key.
+    encryptionKey: encryption-key
+    # -- Key containing the base64-standard 64-byte email hash key.
+    hashKey: hash-key
+    # -- Key containing the base64url 32-byte JWT secret.
+    jwtSecret: jwt-secret
+  api:
+    # -- Number of externally served Museum API replicas.
+    replicaCount: 1
+    # -- Skip cron and cleanup jobs in API replicas. Automatically required when worker.enabled=true.
+    skipBackgroundJobs: false
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+  worker:
+    # -- Run a singleton Museum process for cron and background cleanup.
+    enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+  migrationGate:
+    # -- Serialize Museum startup through a PostgreSQL advisory lock in HA topologies.
+    enabled: true
+    image:
+      # -- Official PostgreSQL client image repository used by the migration gate.
+      repository: docker.io/library/postgres
+      # -- Pinned PostgreSQL client image tag.
+      tag: 18.4-trixie
+      # -- Migration gate image pull policy.
+      pullPolicy: IfNotPresent
+    # -- PostgreSQL advisory lock identifier shared by all Museum pods.
+    advisoryLockId: 724336836
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 999
+      runAsGroup: 999
+  config:
+    # -- Museum log level: panic, fatal, error, warn, info, debug, or trace.
+    logLevel: info
+    # -- Disable new user registration after initial bootstrap.
+    disableRegistration: false
+    # -- User IDs allowed to use Museum admin APIs. The first user is admin when empty.
+    admins: []
+    # -- Header trusted for the original client IP when Museum is behind a proxy.
+    trustedClientIpHeader: X-Forwarded-For
+    webauthn:
+      # -- WebAuthn relying-party ID. Set to the Accounts hostname for passkeys.
+      rpid: accounts.ente.example.com
+      # -- Allowed WebAuthn origins.
+      rporigins:
+        - https://accounts.ente.example.com
+    # -- Raw YAML merged at the end of museum.yaml for advanced upstream settings.
+    extraYaml: ""
+  service:
+    # -- Museum API Service type.
+    type: ClusterIP
+    # -- Museum API Service port.
+    port: 8080
+    # -- Museum metrics Service port.
+    metricsPort: 2112
+    # -- Service annotations.
+    annotations: {}
+    # -- Service IP family policy. Empty uses the cluster default.
+    ipFamilyPolicy: ""
+    # -- Ordered Service IP families.
+    ipFamilies: []
+  probes:
+    startup:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 5
+      failureThreshold: 60
+    readiness:
+      enabled: true
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+    liveness:
+      enabled: true
+      initialDelaySeconds: 20
+      periodSeconds: 20
+      timeoutSeconds: 3
+      failureThreshold: 3
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10001
+  extraEnv: []
+  extraVolumes: []
+  extraVolumeMounts: []
+
+database:
+  # -- Database mode: auto | postgresql | external. Auto selects external config first, then the subchart.
+  mode: auto
+  external:
+    # -- External PostgreSQL hostname.
+    host: ""
+    # -- External PostgreSQL port.
+    port: 5432
+    # -- External PostgreSQL database name.
+    name: ente
+    # -- External PostgreSQL username.
+    username: ente
+    # -- External PostgreSQL password. Prefer existingSecret in production.
+    password: ""
+    # -- Existing Secret containing the external PostgreSQL password.
+    existingSecret: ""
+    # -- Password key in database.external.existingSecret.
+    existingSecretPasswordKey: database-password
+    # -- PostgreSQL sslmode. Use verify-full with managed production databases when possible.
+    sslMode: require
+
+# -- Deploy HelmForge PostgreSQL as the default durable metadata store.
+postgresql:
+  enabled: true
+  architecture: standalone
+  auth:
+    database: ente
+    username: ente
+    password: ""
+    postgresPassword: ""
+  standalone:
+    persistence:
+      enabled: true
+      size: 20Gi
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+
+storage:
+  s3:
+    # -- S3-compatible endpoint reachable by Museum and end-user clients.
+    endpoint: https://s3.example.com
+    # -- S3 region.
+    region: us-east-1
+    # -- Bucket used as Ente's primary hot storage.
+    bucket: ente
+    # -- Use path-style S3 URLs. Enable only when required by the provider.
+    usePathStyle: false
+    # -- Enable upstream local-bucket workarounds. Never enable for production.
+    localBuckets: false
+    # -- S3 access key. Prefer existingSecret in production.
+    accessKey: change-me
+    # -- S3 secret key. Prefer existingSecret in production.
+    secretKey: change-me
+    # -- Existing Secret containing S3 credentials.
+    existingSecret: ""
+    # -- Access-key field in storage.s3.existingSecret.
+    existingSecretAccessKeyKey: access-key
+    # -- Secret-key field in storage.s3.existingSecret.
+    existingSecretSecretKeyKey: secret-key
+
+smtp:
+  # -- Enable SMTP delivery for Ente one-time login codes.
+  enabled: false
+  # -- SMTP hostname.
+  host: ""
+  # -- SMTP port.
+  port: 587
+  # -- Sender email address.
+  email: ""
+  # -- Optional sender display name.
+  senderName: Ente
+  # -- SMTP encryption mode: tls | ssl | empty.
+  encryption: tls
+  # -- SMTP username. Prefer existingSecret in production.
+  username: ""
+  # -- SMTP password. Prefer existingSecret in production.
+  password: ""
+  # -- Existing Secret containing SMTP credentials.
+  existingSecret: ""
+  # -- Username key in smtp.existingSecret.
+  existingSecretUsernameKey: username
+  # -- Password key in smtp.existingSecret.
+  existingSecretPasswordKey: password
+
+externalSecrets:
+  # -- Render ExternalSecret resources for clusters running External Secrets Operator.
+  enabled: false
+  # -- ExternalSecret API version.
+  apiVersion: external-secrets.io/v1
+  # -- Default refresh interval applied when an item omits spec.refreshInterval.
+  refreshInterval: 1h
+  # -- Complete ExternalSecret definitions. Target names default to generated resource names.
+  items: []
+    # - name: ente-credentials
+    #   spec:
+    #     secretStoreRef:
+    #       name: production-secrets
+    #       kind: ClusterSecretStore
+    #     target:
+    #       name: ente-museum
+    #     dataFrom:
+    #       - extract:
+    #           key: ente/museum
+
+web:
+  image:
+    # -- Official Ente web bundle image repository.
+    repository: ghcr.io/ente/web
+    # -- Immutable upstream web build commit.
+    tag: "5ab0c5b4c7a89c4e470ef6f793600da33cebf35d"
+    # -- Web image pull policy.
+    pullPolicy: IfNotPresent
+  # -- Number of web pods serving all enabled applications.
+  replicaCount: 1
+  apps:
+    photos:
+      enabled: true
+      port: 3000
+      externalUrl: https://photos.ente.example.com
+    accounts:
+      enabled: true
+      port: 3001
+      externalUrl: https://accounts.ente.example.com
+    albums:
+      enabled: true
+      port: 3002
+      externalUrl: https://albums.ente.example.com
+    auth:
+      enabled: false
+      port: 3003
+      externalUrl: https://auth.ente.example.com
+    cast:
+      enabled: false
+      port: 3004
+      externalUrl: https://cast.ente.example.com
+    share:
+      enabled: false
+      port: 3005
+      externalUrl: https://share.ente.example.com
+    embed:
+      enabled: false
+      port: 3006
+      externalUrl: https://embed.ente.example.com
+    memories:
+      enabled: false
+      port: 3010
+      externalUrl: https://memories.ente.example.com
+  service:
+    # -- Web application Service type.
+    type: ClusterIP
+    # -- Service port exposed for each enabled application.
+    port: 80
+    # -- Service annotations applied to each web Service.
+    annotations: {}
+    # -- Service IP family policy. Empty uses the cluster default.
+    ipFamilyPolicy: ""
+    # -- Ordered Service IP families.
+    ipFamilies: []
+  probes:
+    startup:
+      enabled: true
+      initialDelaySeconds: 2
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 30
+    readiness:
+      enabled: true
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+    liveness:
+      enabled: true
+      initialDelaySeconds: 20
+      periodSeconds: 20
+      timeoutSeconds: 3
+      failureThreshold: 3
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 101
+    runAsGroup: 101
+    fsGroup: 101
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 101
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  extraEnv: []
+
+ingress:
+  # -- Create one Kubernetes Ingress containing the configured routes.
+  enabled: false
+  # -- Ingress class name.
+  ingressClassName: ""
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Routes to Museum or enabled web applications.
+  hosts: []
+    # - host: api.ente.example.com
+    #   service: museum
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS entries.
+  tls: []
+
+gateway:
+  # -- Create Gateway API HTTPRoutes for Museum and enabled web applications.
+  enabled: false
+  # -- API version for HTTPRoute.
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- Parent Gateway references shared by routes that omit parentRefs.
+  parentRefs: []
+  # -- HTTPRoute definitions.
+  routes: []
+    # - name: museum
+    #   service: museum
+    #   hostnames:
+    #     - api.ente.example.com
+    #   parentRefs: []
+    #   annotations: {}
+
+networkPolicy:
+  # -- Create NetworkPolicies for Museum and web pods.
+  enabled: false
+  # -- Additional complete egress rules applied to both Museum and web pods.
+  extraEgress: []
+  ingress:
+    # -- Allow traffic to published application ports from all sources.
+    allowExternal: true
+    # -- Additional complete ingress rules for Museum.
+    museumExtraRules: []
+    # -- Additional complete ingress rules for web.
+    webExtraRules: []
+  egress:
+    # -- Allow DNS through TCP and UDP port 53.
+    allowDNS: true
+    # -- Allow Museum to reach same-namespace PostgreSQL pods.
+    allowSameNamespacePostgresql: true
+    # -- Allow HTTP/HTTPS egress for S3-compatible storage.
+    allowObjectStorage: true
+    # -- Additional complete Museum egress rules, required for private S3 or SMTP CIDRs.
+    museumExtraRules: []
+    # -- Additional complete web egress rules.
+    webExtraRules: []
+
+pdb:
+  museum:
+    # -- Create a PDB for Museum API replicas. Requires at least two replicas.
+    enabled: false
+    # -- Maximum unavailable Museum API pods.
+    maxUnavailable: 1
+  web:
+    # -- Create a PDB for web replicas. Requires at least two replicas.
+    enabled: false
+    # -- Maximum unavailable web pods.
+    maxUnavailable: 1
+
+autoscaling:
+  museum:
+    # -- Create an HPA for Museum API replicas.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: ""
+    behavior: {}
+  web:
+    # -- Create an HPA for web replicas.
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: ""
+    behavior: {}
+
+metrics:
+  # -- Expose Museum's native Prometheus endpoint on a dedicated Service.
+  enabled: false
+  service:
+    annotations: {}
+  serviceMonitor:
+    # -- Create a ServiceMonitor. Requires Prometheus Operator CRDs.
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+    annotations: {}
+    relabelings: []
+    metricRelabelings: []
+  prometheusRule:
+    # -- Create baseline Museum alerting rules. Requires Prometheus Operator CRDs.
+    enabled: false
+    labels: {}
+    annotations: {}
+    rules: []
+
+backup:
+  # -- Back up PostgreSQL to an S3-compatible bucket with a CronJob.
+  enabled: false
+  # -- Cron schedule for PostgreSQL backups.
+  schedule: "0 3 * * *"
+  # -- Suspend the backup schedule.
+  suspend: false
+  # -- CronJob concurrency policy.
+  concurrencyPolicy: Forbid
+  # -- Successful Job history retained.
+  successfulJobsHistoryLimit: 3
+  # -- Failed Job history retained.
+  failedJobsHistoryLimit: 3
+  # -- Job retry limit.
+  backoffLimit: 1
+  # -- PostgreSQL client image used for pg_dump.
+  postgresqlImage: docker.io/library/postgres:18.4-trixie
+  # -- MinIO client image used for S3 upload.
+  uploaderImage: docker.io/helmforge/mc:1.0.0
+  # -- Additional pg_dump arguments.
+  pgDumpArgs: "--format=custom --compress=9"
+  resources: {}
+  s3:
+    # -- Backup S3 endpoint. It may differ from Ente object storage.
+    endpoint: ""
+    # -- Backup bucket.
+    bucket: ""
+    # -- Object prefix inside the backup bucket.
+    prefix: ente/postgresql
+    # -- Existing Secret containing backup S3 credentials.
+    existingSecret: ""
+    # -- Access key field in backup.s3.existingSecret.
+    existingSecretAccessKeyKey: access-key
+    # -- Secret key field in backup.s3.existingSecret.
+    existingSecretSecretKeyKey: secret-key
+    # -- Inline backup access key. Prefer an existing Secret.
+    accessKey: ""
+    # -- Inline backup secret key. Prefer an existing Secret.
+    secretKey: ""
+
+test:
+  # -- Image used by the Helm test hook.
+  image: docker.io/curlimages/curl:8.21.0
+  # -- Resources for the Helm test pod.
+  resources: {}
+
+# -- Additional Kubernetes manifests rendered with tpl support.
+extraManifests: []
+
+waitForDatabase:
+  # -- Image used by the database reachability init container.
+  image: docker.io/library/busybox:1.37
+  pullPolicy: IfNotPresent
+  resources: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- ServiceAccount name. Generated when empty.
+  name: ""
+  # -- ServiceAccount annotations.
+  annotations: {}
+  # -- Mount the Kubernetes API token into pods.
+  automountServiceAccountToken: false
+
+# -- Pod scheduling priority class.
+priorityClassName: ""
+
+# -- Node selector shared by Ente workloads.
+nodeSelector: {}
+
+# -- Tolerations shared by Ente workloads.
+tolerations: []
+
+# -- Affinity shared by Ente workloads.
+affinity: {}
+
+# -- Topology spread constraints shared by Ente workloads.
+topologySpreadConstraints: []
+
+# -- Grace period used by Ente workload pods.
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary

- add a stable, production-ready Ente chart using official immutable Museum and web images
- provide PostgreSQL, mandatory external S3, persistent secrets, ESO, Ingress, Gateway API, observability, backup, and hardened runtime controls
- support safe application HA with API replicas, a singleton jobs worker, and serialized database migrations
- add a complete values schema, documentation, examples, 57 unit tests, 10 CI scenarios, and runtime fixtures

## Type Of Change

- [x] New chart
- [ ] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## Production Design

- external S3 is mandatory; the chart does not bundle a test object store
- cryptographic keys persist across upgrades or come from existing or ESO-managed Secrets
- HA startup uses a PostgreSQL advisory-lock migration gate to prevent dirty concurrent migrations
- Museum `/ping` checks PostgreSQL; object storage requires a separate behavioral check
- official Museum and web images are pinned to immutable upstream commit tags

## PR Governance

- [x] This PR resolves #980
- [x] Labels `enhancement` and `type:feature` are applied
- [x] The branch was created from updated `main`
- [x] The PR targets `main`
- [x] Commit and PR title follow Conventional Commits
- [x] The root README, values schema, chart docs, and site documentation are updated

## Validation

- `make validate-chart CHART=ente`: all 20 layers passed, including default and all 10 k3d scenarios
- `make preflight`
- `make standards-check CHART=ente`
- `make deps-check CHART=ente`
- Kubescape MITRE, NSA, and SOC2 score: 89.11616%, with no critical failures
- Museum and S3 ExternalSecrets reached `SecretSynced=True`
- backup smoke test uploaded a real `pg_dump` to the external S3 fixture
- site formatting, lint, build, and targeted Ente Playwright scenarios passed

## Related PRs

- Site documentation and playground: helmforgedev/site#508
- Organization profile totals: helmforgedev/.github#18

Resolves #980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a production-ready Helm chart for deploying Ente Photos.
  - Supports Museum, web applications, bundled or external PostgreSQL, S3-compatible storage, SMTP, and existing secrets.
  - Added high-availability options, autoscaling, backups, ingress, Gateway API routing, network policies, and metrics monitoring.
  - Added configurable security settings, health checks, service accounts, and dual-stack networking.

- **Documentation**
  - Added installation, architecture, security, storage, backup/restore, troubleshooting, and high-availability guidance.

- **Tests**
  - Added comprehensive validation and rendering coverage for deployments, routing, secrets, services, monitoring, and production configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->