### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/Countly/countly-server
 dependencies:
   - name: mongodb
-    version: 1.7.16
+    version: 1.7.17
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -54,6 +54,6 @@ annotations:
 dependencies:
   - name: elasticsearch
     alias: bundled-elasticsearch
-    version: 1.1.5
+    version: 1.1.6
     repository: oci://ghcr.io/helmforgedev/helm
     condition: bundledElasticsearch.enabled


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- countly: mongodb 1.7.16 -> 1.7.17
- kibana: elasticsearch 1.1.5 -> 1.1.6

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled MongoDB component to version 1.7.17 in the Countly deployment chart.
  * Updated the bundled Elasticsearch component to version 1.1.6 in the Kibana deployment chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->