### PR TITLE
chore(certimate): bump certimate to 0.4.31

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -4,7 +4,7 @@ name: certimate
 description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
 type: application
 version: 1.0.5
-appVersion: "0.4.30"
+appVersion: "0.4.31"
 home: https://helmforge.dev/docs/charts/certimate
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/certimate

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -2,7 +2,7 @@
 
 Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
 
-This chart packages the official `certimate/certimate:v0.4.30` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+This chart packages the official `certimate/certimate:v0.4.31` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
 
 ## Production Defaults
 
@@ -73,9 +73,10 @@ Back up the PersistentVolumeClaim before upgrades. Certimate stores its
 PocketBase database, uploaded certificate material, ACME account state, workflow
 definitions, and provider credentials under `/app/pb_data`.
 
-Certimate 0.4.30 adds AxisNow and Proxmox Backup Server deployment providers and
-fixes Kubernetes Secret certificate deployment. It does not change the container
-port, storage path, or chart configuration contract.
+Certimate 0.4.31 adds the Huawei iBMC deployment provider and fixes Kubernetes
+Secret certificate deployment against API resources that were previously not
+discovered correctly. It does not change the container port, storage path, or
+chart configuration contract.
 
 Certimate's upstream deployment uses PocketBase-local state. This chart does not
 ship PostgreSQL, MySQL, or Redis subcharts because the product does not expose an
@@ -91,7 +92,7 @@ ACME endpoints required by your workflows.
 Local security scan:
 
 ```text
-Image: certimate/certimate:v0.4.30
+Image: certimate/certimate:v0.4.31
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 93.93939 compliance score
 ```

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: certimate/certimate:v0.4.30
+          value: certimate/certimate:v0.4.31
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "certimate/certimate" },
-        "tag": { "type": "string", "default": "v0.4.30", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "v0.4.31", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Certimate container image repository.
   repository: certimate/certimate
   # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
-  tag: "v0.4.30"
+  tag: "v0.4.31"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrade Certimate from 0.4.30 to 0.4.31
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/certimate-go/certimate/releases/tag/v0.4.31

## Validation

- make validate-chart CHART=certimate
- default k3d scenario passed
- make standards-check CHART=certimate
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Certimate Helm chart to release `v0.4.31`.
  * Added documentation for Huawei iBMC support.
  * Documented a fix for deploying certificates through Kubernetes Secrets.

* **Documentation**
  * Updated image references, security scan details, and deployment notes for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->