### PR TITLE
chore(cloudflared): bump cloudflared to 2026.8.2

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -4,7 +4,7 @@ name: cloudflared
 description: Cloudflare Tunnel client for secure, outbound-only connections between Kubernetes services and Cloudflare's network
 type: application
 version: 1.5.13
-appVersion: "2026.7.3"
+appVersion: "2026.8.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/cloudflared.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "upgrade image to 2026.7.3 (#864)"
+      description: "upgrade image to 2026.8.2 (#985)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -178,14 +178,13 @@ topologySpreadConstraints:
 
 ## Upgrade Notes
 
-Cloudflared 2026.7.3 is a security and connectivity maintenance release. It
-updates `golang.org/x/text` and related dependencies for a CVE fix, aligns
-connectivity prechecks with the curves used for edge connections, and protects
-Windows service tokens with `--token-file`. The Kubernetes tunnel command and
-chart values contract are unchanged.
+Cloudflared 2026.8.2 fixes the HTTP-origin path regressions introduced in
+2026.8.0 and 2026.8.1. Those releases could strip trailing slashes or normalize
+encoded paths, causing redirect loops or changing application URLs. The
+Kubernetes tunnel command and chart values contract are unchanged.
 
 Review the
-[official 2026.7.3 release](https://github.com/cloudflare/cloudflared/releases/tag/2026.7.3)
+[official 2026.8.2 release](https://github.com/cloudflare/cloudflared/releases/tag/2026.8.2)
 before production rollout.
 
 ## Security Scan

--- a/charts/cloudflared/tests/deployment_test.yaml
+++ b/charts/cloudflared/tests/deployment_test.yaml
@@ -37,7 +37,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/cloudflare/cloudflared:2026.7.3"
+          value: "docker.io/cloudflare/cloudflared:2026.8.2"
 
   - it: should use custom image tag
     template: templates/deployment.yaml

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- cloudflared container image
   repository: docker.io/cloudflare/cloudflared
   # -- Image tag
-  tag: "2026.7.3"
+  tag: "2026.8.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- upgrade cloudflared from 2026.7.3 to 2026.8.2
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/cloudflare/cloudflared/releases/tag/2026.8.2

## Validation

- make validate-chart CHART=cloudflared
- default k3d scenario passed
- make standards-check CHART=cloudflared
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Cloudflared to version `2026.8.2`.
  * Improved handling of HTTP-origin paths, including trailing slashes and encoded paths.
  * Refreshed upgrade documentation and deployment validation for the new version.
  * Existing Kubernetes tunnel commands and configuration options remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->