### PR TITLE
chore(envoy-gateway): bump envoy gateway to 1.9.0

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 1.10.0
-appVersion: "v1.8.3"
+appVersion: "v1.9.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
@@ -33,8 +33,8 @@ maintainers:
 icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "support allowed listeners (#972)"
+    - kind: changed
+      description: "upgrade Envoy Gateway to v1.9.0 and supported Gateway API CRDs to v1.6.1 (#986)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/envoy-gateway/DESIGN.md
+++ b/charts/envoy-gateway/DESIGN.md
@@ -25,10 +25,12 @@ provisions Envoy proxies for ingress/egress traffic.
 
 The chart deploys an `EnvoyProxy` CR and other `gateway.envoyproxy.io` resources,
 so the **operator CRDs** ship in the chart's `crds/` and Helm installs them when
-absent. The upstream **Gateway API** CRDs (`gateway.networking.k8s.io`, including
-`ListenerSet` from the experimental channel that EG v1.8 watches) are a shared,
-cluster-scoped prerequisite — installed once per cluster, not bundled (they are
-large and are typically platform-managed, e.g. via Argo CD). See the README.
+absent. The supported upstream **Gateway API** v1.6.1 CRDs
+(`gateway.networking.k8s.io`, including `ListenerSet` from the experimental
+channel) are bundled in the local CRD subchart by default. The unrelated
+`gateway.networking.x-k8s.io` experimental APIs are excluded because their CEL
+schema requires Kubernetes 1.32 while the chart supports Kubernetes 1.26 and
+newer. Platform-managed installations can disable the subchart. See the README.
 
 ## Optional rate limiting
 
@@ -43,7 +45,8 @@ the operator provisions/sizes the Envoy fleet accordingly.
 
 ## What this chart deliberately does NOT do
 
-- It does not bundle the shared Gateway API CRDs (cluster prerequisite).
+- It does not bundle unrelated Gateway API `gateway.networking.x-k8s.io`
+  experimental CRDs.
 - It does not manage the Envoy data-plane pods directly (the operator does).
 
 ## References

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,7 +1,7 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.8.3 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
+v1.9.0 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
 Envoy proxy pods automatically in response to Gateway API resources.
 
 ## Installation
@@ -22,9 +22,13 @@ helm install envoy-gateway oci://ghcr.io/helmforgedev/helm/envoy-gateway
 
 ## Quick Start
 
-Envoy Gateway and Gateway API experimental v1.5.1 CRDs are bundled in the local
-`crds` subchart and installed automatically by default. This includes
-`ListenerSet`, which Envoy Gateway v1.8.3 requires. Set `crds.enabled=false`
+Envoy Gateway v1.9.0 and its supported Gateway API v1.6.1 CRDs are bundled in
+the local `crds` subchart and installed automatically by default. This includes
+the experimental `ListenerSet`, `TCPRoute`, `TLSRoute`, and `UDPRoute` APIs.
+The unrelated `gateway.networking.x-k8s.io` experimental APIs are excluded so
+the chart remains compatible with its Kubernetes 1.26 minimum; Gateway API
+v1.6.1 generates those APIs with CEL functions that require Kubernetes 1.32.
+Set `crds.enabled=false`
 only when a platform operator, GitOps controller, or another release manages
 all required CRDs. Helm installs CRDs on first install but does not upgrade or
 delete them automatically; review upstream CRD changes before chart upgrades.
@@ -164,7 +168,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.8.3` | Controller image tag |
+| `controller.image.tag` | `v1.9.0` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -182,7 +186,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.8.3` | Certgen image tag |
+| `certgen.image.tag` | `v1.9.0` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -198,10 +202,10 @@ highAvailability:
 | `proxy.kind` | `Deployment` | Proxy workload kind: `Deployment` or `DaemonSet` |
 | `proxy.replicaCount` | `1` | Number of proxy replicas (Deployment mode only, overridden by profile) |
 | `proxy.image.repository` | `docker.io/envoyproxy/envoy` | Proxy image repository |
-| `proxy.image.tag` | `distroless-v1.38.0` | Proxy image tag |
+| `proxy.image.tag` | `distroless-v1.39.0` | Proxy image tag |
 | `proxy.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `proxy.shutdownManager.image.repository` | `docker.io/envoyproxy/gateway` | Shutdown manager sidecar image repository |
-| `proxy.shutdownManager.image.tag` | `v1.8.3` | Shutdown manager sidecar image tag |
+| `proxy.shutdownManager.image.tag` | `v1.9.0` | Shutdown manager sidecar image tag |
 | `proxy.shutdownManager.image.pullPolicy` | `IfNotPresent` | Shutdown manager image pull policy |
 | `proxy.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `proxy.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -281,7 +285,7 @@ highAvailability:
 |-----|---------|-------------|
 | `rateLimiting.enabled` | `false` | Enable rate limiting |
 | `rateLimiting.service.image.repository` | `docker.io/envoyproxy/ratelimit` | Rate limit service image repository |
-| `rateLimiting.service.image.tag` | `1e50889b` | Rate limit service image tag aligned with Envoy Gateway v1.8.3 |
+| `rateLimiting.service.image.tag` | `17b1956c` | Rate limit service image tag aligned with Envoy Gateway v1.9.0 |
 | `rateLimiting.externalRedis.host` | `""` | External Redis host |
 | `rateLimiting.externalRedis.port` | `6379` | External Redis port |
 | `rateLimiting.externalRedis.auth.enabled` | `false` | Enable Redis authentication |
@@ -443,13 +447,13 @@ Major architectural redesign to align with the EG operator model.
 
 ## Upgrade Notes
 
-`docker.io/envoyproxy/gateway:v1.8.3` is the upstream patch update from
-`v1.8.2`. The automatically generated issue referenced `1.8.3`, but Docker Hub
+`docker.io/envoyproxy/gateway:v1.9.0` is the upstream minor update from
+`v1.8.3`. The automatically generated issue referenced `1.9.0`, but Docker Hub
 publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
-keeps the managed Envoy proxy image pinned to
-`docker.io/envoyproxy/envoy:distroless-v1.38.0`, which remains aligned with the
-upstream v1.8 compatibility matrix. The rate limit deployment now uses the
-upstream v1.8.3 default `docker.io/envoyproxy/ratelimit:1e50889b` and honors the
+pins the managed Envoy proxy image to
+`docker.io/envoyproxy/envoy:distroless-v1.39.0`, aligned with the upstream v1.9
+compatibility matrix. The rate limit deployment uses the upstream v1.9.0
+default `docker.io/envoyproxy/ratelimit:17b1956c` and honors the
 `rateLimiting.service.image` override through the EnvoyGateway configuration.
 When rate limiting is enabled, the chart also uses the upstream-required
 `envoy-gateway` names for the controller Deployment and ServiceAccount. If the
@@ -460,17 +464,17 @@ uses its `-redis-client` endpoint, and Redis authentication is injected into the
 managed rate-limit Deployment through `REDIS_AUTH` from either the bundled or
 external Secret.
 
-Envoy Gateway v1.8.3 updates its distroless base and fixes backend TLS 1.3
-defaults, mismatched or malformed listener certificates, IPv6 literal OIDC
-endpoints, translator status races, and Wasm fetch retries. It also moves
-EnvoyExtensionPolicy Lua source from per-route overrides to listener-level
-filters. This changes generated xDS Lua filter names and layout; update any
-EnvoyPatchPolicy or extension server that matches the previous
-`envoy.filters.http.lua/` keys. Review the
-[upstream v1.8.3 release notes](https://gateway.envoyproxy.io/news/releases/notes/v1.8.3)
-before upgrading, verify Gateway API and Envoy Gateway CRDs in staging, and test
-existing Gateway, HTTPRoute, EnvoyProxy, `BackendTrafficPolicy`,
-`SecurityPolicy`, EnvoyExtensionPolicy, and EnvoyPatchPolicy resources.
+Envoy Gateway v1.9.0 requires Gateway API v1.6 CRDs and includes stricter CEL
+validation for client IP detection, API key extraction, and policy merge
+targets. Lua extensions are disabled by default and tracing client sampling now
+defaults to zero. EndpointSlice indexing is enabled by default and can increase
+controller memory use on large clusters. Review the
+[upstream v1.9.0 release notes](https://gateway.envoyproxy.io/news/releases/notes/v1.9.0/)
+before upgrading. The bundled supported CRD set is from Gateway API v1.6.1.
+Apply the bundled CRDs server-side before the controller
+upgrade, correct resources rejected by the new validations, and test existing
+Gateway, route, EnvoyProxy, `BackendTrafficPolicy`, `SecurityPolicy`,
+EnvoyExtensionPolicy, and EnvoyPatchPolicy resources in staging.
 
 ### Version 1.0.0
 

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -24,14 +24,22 @@ helm install envoy-gateway oci://ghcr.io/helmforgedev/helm/envoy-gateway
 
 Envoy Gateway v1.9.0 and its supported Gateway API v1.6.1 CRDs are bundled in
 the local `crds` subchart and installed automatically by default. This includes
-the experimental `ListenerSet`, `TCPRoute`, `TLSRoute`, and `UDPRoute` APIs.
-The unrelated `gateway.networking.x-k8s.io` experimental APIs are excluded so
-the chart remains compatible with its Kubernetes 1.26 minimum; Gateway API
-v1.6.1 generates those APIs with CEL functions that require Kubernetes 1.32.
-Set `crds.enabled=false`
-only when a platform operator, GitOps controller, or another release manages
-all required CRDs. Helm installs CRDs on first install but does not upgrade or
-delete them automatically; review upstream CRD changes before chart upgrades.
+`ListenerSet`, `TCPRoute`, `TLSRoute`, and `UDPRoute`, which are also present in
+the v1.6.1 Standard bundle. The bundled definitions retain the upstream
+experimental-channel schema used by Envoy Gateway v1.9.0. The separate
+`gateway.networking.x-k8s.io` experimental APIs are excluded so the chart
+remains compatible with its Kubernetes 1.26 minimum; Gateway API v1.6.1
+generates those APIs with CEL functions that require Kubernetes 1.32. Set
+`crds.enabled=false` only when a platform operator, GitOps controller, or
+another release manages all required CRDs. Helm installs CRDs on first install
+but does not upgrade or delete them automatically; review upstream CRD changes
+before chart upgrades.
+
+For platform-managed CRDs, prefer `crds.enabled=false`; this also disables the
+subchart's safe-upgrade admission policy. Helm's `--skip-crds` flag skips the
+raw CRD files but still renders templates. If the platform also manages the
+safe-upgrade policy, combine `--skip-crds` with
+`--set crds.gatewayAPI.safeUpgradePolicy.enabled=false`.
 
 ```bash
 # Install CRDs and the controller with the development profile.
@@ -155,7 +163,7 @@ highAvailability:
 |-----|---------|-------------|
 | `profile` | `custom` | Profile preset (dev, production-ha, custom) |
 | `namespaceOverride` | `""` | Namespace for chart-managed resources; target namespace must already exist |
-| `crds.enabled` | `true` | Install bundled Envoy Gateway and Gateway API experimental CRDs |
+| `crds.enabled` | `true` | Install bundled Envoy Gateway and supported Gateway API v1.6.1 CRDs |
 | `nameOverride` | `""` | Override chart name |
 | `fullnameOverride` | `""` | Override full name |
 | `imagePullSecrets` | `[]` | Image pull secrets |

--- a/charts/envoy-gateway/charts/crds/Chart.yaml
+++ b/charts/envoy-gateway/charts/crds/Chart.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
-appVersion: 0.0.0
-description: Envoy Gateway and Gateway API CRDs
 name: crds
+description: Envoy Gateway and Gateway API CRDs
 type: application
 version: 0.0.0
+appVersion: "0.0.0"

--- a/charts/envoy-gateway/charts/crds/crds/gatewayapi-crds.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/gatewayapi-crds.yaml
@@ -25,7 +25,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct
@@ -136,12 +136,12 @@ spec:
 
                   Support Levels:
 
-                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+                  * Extended: Kubernetes Service referenced by backendRefs used on a Route.
+                    - HTTPRoute, GRPCRoute, TLSRoute with termination
+                    - Filters that needs a backend of type Service, like Mirror and External Authorization
 
-                  * Implementation-Specific: Services not connected via HTTPRoute, and any
-                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                  * Implementation-Specific: Implementations MAY use BackendTLSPolicy for:
                     - Services not referenced by any Route (e.g., infrastructure services)
-                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
                     - Service mesh workload-to-service communication
                     - Other resource types beyond Service
 
@@ -830,12 +830,12 @@ spec:
 
                   Support Levels:
 
-                  * Extended: Kubernetes Service referenced by HTTPRoute backendRefs.
+                  * Extended: Kubernetes Service referenced by backendRefs used on a Route.
+                    - HTTPRoute, GRPCRoute, TLSRoute with termination
+                    - Filters that needs a backend of type Service, like Mirror and External Authorization
 
-                  * Implementation-Specific: Services not connected via HTTPRoute, and any
-                    other kind of backend. Implementations MAY use BackendTLSPolicy for:
+                  * Implementation-Specific: Implementations MAY use BackendTLSPolicy for:
                     - Services not referenced by any Route (e.g., infrastructure services)
-                    - Gateway feature backends (e.g., ExternalAuth, rate-limiting services)
                     - Service mesh workload-to-service communication
                     - Other resource types beyond Service
 
@@ -1432,12 +1432,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -1447,7 +1441,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
@@ -1498,6 +1492,9 @@ spec:
           Gateway is not deleted while in use.
 
           GatewayClass is a Cluster level resource.
+
+          A GatewayClass name SHOULD be compliant with RFC 1035, consisting of a maximum of 63 lower case alphanumeric
+          characters or hyphens ('-'), and MUST start and end with an alphanumeric character.
         properties:
           apiVersion:
             description: |-
@@ -1951,12 +1948,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -1966,7 +1957,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: gateways.gateway.networking.k8s.io
 spec:
@@ -2001,6 +1992,8 @@ spec:
         description: |-
           Gateway represents an instance of a service-traffic handling infrastructure
           by binding Listeners to a set of IP addresses.
+          A Gateway name SHOULD be compliant with RFC 1035, consisting of a maximum of 63 lower case alphanumeric
+          characters or hyphens ('-'), and MUST start and end with an alphanumeric character.
         properties:
           apiVersion:
             description: |-
@@ -2234,7 +2227,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional
@@ -2455,6 +2448,12 @@ spec:
                   For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
                   request to "foo.example.com" SHOULD only be routed using routes attached
                   to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+
+                  If traffic to a Gateway does not match any Listener's hostname (or if
+                  the Listener does not specify a hostname and the request does not match
+                  any attached Route), the request MUST be rejected. The specific mechanism
+                  for rejection depends on the protocol: HTTP returns a 404 status code,
+                  while gRPC returns an Unimplemented status code.
 
                   This concept is known as "Listener Isolation", and it is an Extended feature
                   of Gateway API. Implementations that do not support Listener Isolation MUST
@@ -3096,7 +3095,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                maxItems: 8
+                                maxItems: 16
                                 minItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -3261,7 +3260,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                      maxItems: 8
+                                      maxItems: 16
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -3885,7 +3884,7 @@ spec:
                       An implementation may chose to add additional implementation-specific annotations as they see fit.
 
                       Support: Extended
-                    maxProperties: 8
+                    maxProperties: 16
                     type: object
                     x-kubernetes-validations:
                     - message: Annotation keys must be in the form of an optional
@@ -4106,6 +4105,12 @@ spec:
                   For example, if Listeners are defined for "foo.example.com" and "*.example.com", a
                   request to "foo.example.com" SHOULD only be routed using routes attached
                   to the "foo.example.com" Listener (and not the "*.example.com" Listener).
+
+                  If traffic to a Gateway does not match any Listener's hostname (or if
+                  the Listener does not specify a hostname and the request does not match
+                  any attached Route), the request MUST be rejected. The specific mechanism
+                  for rejection depends on the protocol: HTTP returns a 404 status code,
+                  while gRPC returns an Unimplemented status code.
 
                   This concept is known as "Listener Isolation", and it is an Extended feature
                   of Gateway API. Implementations that do not support Listener Isolation MUST
@@ -4747,7 +4752,7 @@ spec:
                                   - kind
                                   - name
                                   type: object
-                                maxItems: 8
+                                maxItems: 16
                                 minItems: 1
                                 type: array
                                 x-kubernetes-list-type: atomic
@@ -4912,7 +4917,7 @@ spec:
                                         - kind
                                         - name
                                         type: object
-                                      maxItems: 8
+                                      maxItems: 16
                                       minItems: 1
                                       type: array
                                       x-kubernetes-list-type: atomic
@@ -5284,12 +5289,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -5299,7 +5298,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: grpcroutes.gateway.networking.k8s.io
 spec:
@@ -5976,6 +5975,10 @@ spec:
                                         Support: Extended for Kubernetes Service
 
                                         Support: Implementation-specific for any other resource
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
                                       properties:
                                         group:
                                           default: ""
@@ -6643,6 +6646,10 @@ spec:
                                   Support: Extended for Kubernetes Service
 
                                   Support: Implementation-specific for any other resource
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
                                 properties:
                                   group:
                                     default: ""
@@ -7199,15 +7206,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -7567,12 +7565,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -7582,7 +7574,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: httproutes.gateway.networking.k8s.io
 spec:
@@ -8067,9 +8059,9 @@ spec:
                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
                                         response header are separated by a comma (",").
 
-                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        When the `allowHeaders` field is configured with one or more headers, the
                                         gateway must return the `Access-Control-Allow-Headers` response header
-                                        which value is present in the `AllowHeaders` field.
+                                        which value is present in the `allowHeaders` field.
 
                                         If any header name in the `Access-Control-Request-Headers` request header
                                         is not included in the list of header names specified by the response
@@ -8081,21 +8073,20 @@ spec:
                                         client side.
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
-                                        If config contains the wildcard "*" in allowHeaders and the request is
-                                        not credentialed, the `Access-Control-Allow-Headers` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Headers from the request.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Headers` response header. When
-                                        also the `AllowCredentials` field is true and `AllowHeaders` field
-                                        is specified with the `*` wildcard, the gateway must specify one or more
-                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                        header. The value of the header `Access-Control-Allow-Headers` is same as
-                                        the `Access-Control-Request-Headers` header provided by the client. If
-                                        the header `Access-Control-Request-Headers` is not included in the
-                                        request, the gateway will omit the `Access-Control-Allow-Headers`
-                                        response header, instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Headers` request header.
+
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                        return one or more header names matching the value of the
+                                        `Access-Control-Request-Headers` request header.
+                                        If the `Access-Control-Request-Headers` header is not present in the
+                                        request, the gateway must omit the `Access-Control-Allow-Headers`
+                                        response header.
 
                                         Support: Extended
                                       items:
@@ -8140,32 +8131,29 @@ spec:
                                         A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                         CORS-safelisted methods are always allowed, regardless of whether they
-                                        are specified in the `AllowMethods` field.
+                                        are specified in the `allowMethods` field.
 
-                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        When the `allowMethods` field is configured with one or more methods, the
                                         gateway must return the `Access-Control-Allow-Methods` response header
-                                        which value is present in the `AllowMethods` field.
+                                        which value is present in the `allowMethods` field.
 
                                         If the HTTP method of the `Access-Control-Request-Method` request header
                                         is not included in the list of methods specified by the response header
                                         `Access-Control-Allow-Methods`, it will present an error on the client
                                         side.
 
-                                        If config contains the wildcard "*" in allowMethods and the request is
-                                        not credentialed, the `Access-Control-Allow-Methods` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Method from the request.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Method` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Methods` response header. When
-                                        also the `AllowCredentials` field is true and `AllowMethods` field
-                                        specified with the `*` wildcard, the gateway must specify one HTTP method
-                                        in the value of the Access-Control-Allow-Methods response header. The
-                                        value of the header `Access-Control-Allow-Methods` is same as the
-                                        `Access-Control-Request-Method` header provided by the client. If the
-                                        header `Access-Control-Request-Method` is not included in the request,
-                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                        instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                        return a single HTTP method matching the value of the
+                                        `Access-Control-Request-Method` request header.
+                                        If the `Access-Control-Request-Method` header is not present in the request,
+                                        the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                         Support: Extended
                                       items:
@@ -8215,7 +8203,7 @@ spec:
                                         An origin value that includes _only_ the `*` character indicates requests
                                         from all `Origin`s are allowed.
 
-                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        When the `allowOrigins` field is configured with multiple origins, it
                                         means the server supports clients from multiple origins. If the request
                                         `Origin` matches the configured allowed origins, the gateway must return
                                         the given `Origin` and sets value of the header
@@ -8237,19 +8225,15 @@ spec:
                                         `Access-Control-Allow-Origin` to the same value as the `Origin`
                                         header provided by the client.
 
-                                        When config has the wildcard ("*") in allowOrigins, and the request
-                                        is not credentialed (e.g., it is a preflight request), the
-                                        `Access-Control-Allow-Origin` response header either contains the
-                                        wildcard as well or the Origin from the request.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Origin` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Origin` response header. When
-                                        also the `AllowCredentials` field is true and `AllowOrigins` field
-                                        specified with the `*` wildcard, the gateway must return a single origin
-                                        in the value of the `Access-Control-Allow-Origin` response header,
-                                        instead of specifying the `*` wildcard. The value of the header
-                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                        the client.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                        return a single origin matching the value of the `Origin` request header.
 
                                         Support: Extended
                                       items:
@@ -8288,7 +8272,7 @@ spec:
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                         The CORS-safelisted response headers are exposed to client by default.
 
-                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        When an HTTP header name is specified using the `exposeHeaders` field,
                                         this additional header will be exposed as part of the response to the
                                         client.
 
@@ -8298,12 +8282,15 @@ spec:
                                         response header are separated by a comma (",").
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
-                                        to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the request is not credentialed.
+                                        to clients.
 
-                                        When the `exposeHeaders` config field contains the "*" wildcard and
-                                        the request is credentialed, the gateway cannot use the `*` wildcard in
-                                        the `Access-Control-Expose-Headers` response header.
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                        response header can contain the wildcard `*`.
+
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                        in the `Access-Control-Expose-Headers` response header.
 
                                         Support: Extended
                                       items:
@@ -8811,6 +8798,10 @@ spec:
                                         Support: Extended for Kubernetes Service
 
                                         Support: Implementation-specific for any other resource
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
                                       properties:
                                         group:
                                           default: ""
@@ -9597,9 +9588,9 @@ spec:
                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
                                   response header are separated by a comma (",").
 
-                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  When the `allowHeaders` field is configured with one or more headers, the
                                   gateway must return the `Access-Control-Allow-Headers` response header
-                                  which value is present in the `AllowHeaders` field.
+                                  which value is present in the `allowHeaders` field.
 
                                   If any header name in the `Access-Control-Request-Headers` request header
                                   is not included in the list of header names specified by the response
@@ -9611,21 +9602,20 @@ spec:
                                   client side.
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
-                                  If config contains the wildcard "*" in allowHeaders and the request is
-                                  not credentialed, the `Access-Control-Allow-Headers` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Headers from the request.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Headers` response header. When
-                                  also the `AllowCredentials` field is true and `AllowHeaders` field
-                                  is specified with the `*` wildcard, the gateway must specify one or more
-                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                  header. The value of the header `Access-Control-Allow-Headers` is same as
-                                  the `Access-Control-Request-Headers` header provided by the client. If
-                                  the header `Access-Control-Request-Headers` is not included in the
-                                  request, the gateway will omit the `Access-Control-Allow-Headers`
-                                  response header, instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Headers` request header.
+
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                  return one or more header names matching the value of the
+                                  `Access-Control-Request-Headers` request header.
+                                  If the `Access-Control-Request-Headers` header is not present in the
+                                  request, the gateway must omit the `Access-Control-Allow-Headers`
+                                  response header.
 
                                   Support: Extended
                                 items:
@@ -9670,32 +9660,29 @@ spec:
                                   A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                   CORS-safelisted methods are always allowed, regardless of whether they
-                                  are specified in the `AllowMethods` field.
+                                  are specified in the `allowMethods` field.
 
-                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  When the `allowMethods` field is configured with one or more methods, the
                                   gateway must return the `Access-Control-Allow-Methods` response header
-                                  which value is present in the `AllowMethods` field.
+                                  which value is present in the `allowMethods` field.
 
                                   If the HTTP method of the `Access-Control-Request-Method` request header
                                   is not included in the list of methods specified by the response header
                                   `Access-Control-Allow-Methods`, it will present an error on the client
                                   side.
 
-                                  If config contains the wildcard "*" in allowMethods and the request is
-                                  not credentialed, the `Access-Control-Allow-Methods` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Method from the request.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Method` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Methods` response header. When
-                                  also the `AllowCredentials` field is true and `AllowMethods` field
-                                  specified with the `*` wildcard, the gateway must specify one HTTP method
-                                  in the value of the Access-Control-Allow-Methods response header. The
-                                  value of the header `Access-Control-Allow-Methods` is same as the
-                                  `Access-Control-Request-Method` header provided by the client. If the
-                                  header `Access-Control-Request-Method` is not included in the request,
-                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                  instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                  return a single HTTP method matching the value of the
+                                  `Access-Control-Request-Method` request header.
+                                  If the `Access-Control-Request-Method` header is not present in the request,
+                                  the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                   Support: Extended
                                 items:
@@ -9745,7 +9732,7 @@ spec:
                                   An origin value that includes _only_ the `*` character indicates requests
                                   from all `Origin`s are allowed.
 
-                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  When the `allowOrigins` field is configured with multiple origins, it
                                   means the server supports clients from multiple origins. If the request
                                   `Origin` matches the configured allowed origins, the gateway must return
                                   the given `Origin` and sets value of the header
@@ -9767,19 +9754,15 @@ spec:
                                   `Access-Control-Allow-Origin` to the same value as the `Origin`
                                   header provided by the client.
 
-                                  When config has the wildcard ("*") in allowOrigins, and the request
-                                  is not credentialed (e.g., it is a preflight request), the
-                                  `Access-Control-Allow-Origin` response header either contains the
-                                  wildcard as well or the Origin from the request.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Origin` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Origin` response header. When
-                                  also the `AllowCredentials` field is true and `AllowOrigins` field
-                                  specified with the `*` wildcard, the gateway must return a single origin
-                                  in the value of the `Access-Control-Allow-Origin` response header,
-                                  instead of specifying the `*` wildcard. The value of the header
-                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                  the client.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                  return a single origin matching the value of the `Origin` request header.
 
                                   Support: Extended
                                 items:
@@ -9818,7 +9801,7 @@ spec:
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                   The CORS-safelisted response headers are exposed to client by default.
 
-                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  When an HTTP header name is specified using the `exposeHeaders` field,
                                   this additional header will be exposed as part of the response to the
                                   client.
 
@@ -9828,12 +9811,15 @@ spec:
                                   response header are separated by a comma (",").
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
-                                  to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the request is not credentialed.
+                                  to clients.
 
-                                  When the `exposeHeaders` config field contains the "*" wildcard and
-                                  the request is credentialed, the gateway cannot use the `*` wildcard in
-                                  the `Access-Control-Expose-Headers` response header.
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                  response header can contain the wildcard `*`.
+
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                  in the `Access-Control-Expose-Headers` response header.
 
                                   Support: Extended
                                 items:
@@ -10337,6 +10323,10 @@ spec:
                                   Support: Extended for Kubernetes Service
 
                                   Support: Implementation-specific for any other resource
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
                                 properties:
                                   group:
                                     default: ""
@@ -11276,6 +11266,7 @@ spec:
                             a backend request is implementation-specific.
 
                             Support: Extended
+                          minimum: 1
                           type: integer
                         backoff:
                           description: |-
@@ -11344,7 +11335,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-
@@ -11396,15 +11387,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -12332,9 +12314,9 @@ spec:
                                         Multiple header names in the value of the `Access-Control-Allow-Headers`
                                         response header are separated by a comma (",").
 
-                                        When the `AllowHeaders` field is configured with one or more headers, the
+                                        When the `allowHeaders` field is configured with one or more headers, the
                                         gateway must return the `Access-Control-Allow-Headers` response header
-                                        which value is present in the `AllowHeaders` field.
+                                        which value is present in the `allowHeaders` field.
 
                                         If any header name in the `Access-Control-Request-Headers` request header
                                         is not included in the list of header names specified by the response
@@ -12346,21 +12328,20 @@ spec:
                                         client side.
 
                                         A wildcard indicates that the requests with all HTTP headers are allowed.
-                                        If config contains the wildcard "*" in allowHeaders and the request is
-                                        not credentialed, the `Access-Control-Allow-Headers` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Headers from the request.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Headers` response header. When
-                                        also the `AllowCredentials` field is true and `AllowHeaders` field
-                                        is specified with the `*` wildcard, the gateway must specify one or more
-                                        HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                        header. The value of the header `Access-Control-Allow-Headers` is same as
-                                        the `Access-Control-Request-Headers` header provided by the client. If
-                                        the header `Access-Control-Request-Headers` is not included in the
-                                        request, the gateway will omit the `Access-Control-Allow-Headers`
-                                        response header, instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Headers` request header.
+
+                                        If the configuration contains the wildcard `*` in `allowHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                        return one or more header names matching the value of the
+                                        `Access-Control-Request-Headers` request header.
+                                        If the `Access-Control-Request-Headers` header is not present in the
+                                        request, the gateway must omit the `Access-Control-Allow-Headers`
+                                        response header.
 
                                         Support: Extended
                                       items:
@@ -12405,32 +12386,29 @@ spec:
                                         A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                         CORS-safelisted methods are always allowed, regardless of whether they
-                                        are specified in the `AllowMethods` field.
+                                        are specified in the `allowMethods` field.
 
-                                        When the `AllowMethods` field is configured with one or more methods, the
+                                        When the `allowMethods` field is configured with one or more methods, the
                                         gateway must return the `Access-Control-Allow-Methods` response header
-                                        which value is present in the `AllowMethods` field.
+                                        which value is present in the `allowMethods` field.
 
                                         If the HTTP method of the `Access-Control-Request-Method` request header
                                         is not included in the list of methods specified by the response header
                                         `Access-Control-Allow-Methods`, it will present an error on the client
                                         side.
 
-                                        If config contains the wildcard "*" in allowMethods and the request is
-                                        not credentialed, the `Access-Control-Allow-Methods` response header
-                                        can either use the `*` wildcard or the value of
-                                        Access-Control-Request-Method from the request.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Access-Control-Request-Method` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Methods` response header. When
-                                        also the `AllowCredentials` field is true and `AllowMethods` field
-                                        specified with the `*` wildcard, the gateway must specify one HTTP method
-                                        in the value of the Access-Control-Allow-Methods response header. The
-                                        value of the header `Access-Control-Allow-Methods` is same as the
-                                        `Access-Control-Request-Method` header provided by the client. If the
-                                        header `Access-Control-Request-Method` is not included in the request,
-                                        the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                        instead of specifying the `*` wildcard.
+                                        If the configuration contains the wildcard `*` in `allowMethods` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                        return a single HTTP method matching the value of the
+                                        `Access-Control-Request-Method` request header.
+                                        If the `Access-Control-Request-Method` header is not present in the request,
+                                        the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                         Support: Extended
                                       items:
@@ -12480,7 +12458,7 @@ spec:
                                         An origin value that includes _only_ the `*` character indicates requests
                                         from all `Origin`s are allowed.
 
-                                        When the `AllowOrigins` field is configured with multiple origins, it
+                                        When the `allowOrigins` field is configured with multiple origins, it
                                         means the server supports clients from multiple origins. If the request
                                         `Origin` matches the configured allowed origins, the gateway must return
                                         the given `Origin` and sets value of the header
@@ -12502,19 +12480,15 @@ spec:
                                         `Access-Control-Allow-Origin` to the same value as the `Origin`
                                         header provided by the client.
 
-                                        When config has the wildcard ("*") in allowOrigins, and the request
-                                        is not credentialed (e.g., it is a preflight request), the
-                                        `Access-Control-Allow-Origin` response header either contains the
-                                        wildcard as well or the Origin from the request.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                        response header may either contain the wildcard `*` or echo the value
+                                        of the `Origin` request header.
 
-                                        When the request is credentialed, the gateway must not specify the `*`
-                                        wildcard in the `Access-Control-Allow-Origin` response header. When
-                                        also the `AllowCredentials` field is true and `AllowOrigins` field
-                                        specified with the `*` wildcard, the gateway must return a single origin
-                                        in the value of the `Access-Control-Allow-Origin` response header,
-                                        instead of specifying the `*` wildcard. The value of the header
-                                        `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                        the client.
+                                        If the configuration contains the wildcard `*` in `allowOrigins` and
+                                        `allowCredentials` is set to `true`, the gateway must not return `*`
+                                        in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                        return a single origin matching the value of the `Origin` request header.
 
                                         Support: Extended
                                       items:
@@ -12553,7 +12527,7 @@ spec:
                                         (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                         The CORS-safelisted response headers are exposed to client by default.
 
-                                        When an HTTP header name is specified using the `ExposeHeaders` field,
+                                        When an HTTP header name is specified using the `exposeHeaders` field,
                                         this additional header will be exposed as part of the response to the
                                         client.
 
@@ -12563,12 +12537,15 @@ spec:
                                         response header are separated by a comma (",").
 
                                         A wildcard indicates that the responses with all HTTP headers are exposed
-                                        to clients. The `Access-Control-Expose-Headers` response header can only
-                                        use `*` wildcard as value when the request is not credentialed.
+                                        to clients.
 
-                                        When the `exposeHeaders` config field contains the "*" wildcard and
-                                        the request is credentialed, the gateway cannot use the `*` wildcard in
-                                        the `Access-Control-Expose-Headers` response header.
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                        response header can contain the wildcard `*`.
+
+                                        If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                        `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                        in the `Access-Control-Expose-Headers` response header.
 
                                         Support: Extended
                                       items:
@@ -13076,6 +13053,10 @@ spec:
                                         Support: Extended for Kubernetes Service
 
                                         Support: Implementation-specific for any other resource
+
+                                        If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                        implementation to supply the TLS details to be used to connect to that
+                                        backend.
                                       properties:
                                         group:
                                           default: ""
@@ -13862,9 +13843,9 @@ spec:
                                   Multiple header names in the value of the `Access-Control-Allow-Headers`
                                   response header are separated by a comma (",").
 
-                                  When the `AllowHeaders` field is configured with one or more headers, the
+                                  When the `allowHeaders` field is configured with one or more headers, the
                                   gateway must return the `Access-Control-Allow-Headers` response header
-                                  which value is present in the `AllowHeaders` field.
+                                  which value is present in the `allowHeaders` field.
 
                                   If any header name in the `Access-Control-Request-Headers` request header
                                   is not included in the list of header names specified by the response
@@ -13876,21 +13857,20 @@ spec:
                                   client side.
 
                                   A wildcard indicates that the requests with all HTTP headers are allowed.
-                                  If config contains the wildcard "*" in allowHeaders and the request is
-                                  not credentialed, the `Access-Control-Allow-Headers` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Headers from the request.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Headers` response header. When
-                                  also the `AllowCredentials` field is true and `AllowHeaders` field
-                                  is specified with the `*` wildcard, the gateway must specify one or more
-                                  HTTP headers in the value of the `Access-Control-Allow-Headers` response
-                                  header. The value of the header `Access-Control-Allow-Headers` is same as
-                                  the `Access-Control-Request-Headers` header provided by the client. If
-                                  the header `Access-Control-Request-Headers` is not included in the
-                                  request, the gateway will omit the `Access-Control-Allow-Headers`
-                                  response header, instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Headers` request header.
+
+                                  If the configuration contains the wildcard `*` in `allowHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Headers` response header. Instead, it must
+                                  return one or more header names matching the value of the
+                                  `Access-Control-Request-Headers` request header.
+                                  If the `Access-Control-Request-Headers` header is not present in the
+                                  request, the gateway must omit the `Access-Control-Allow-Headers`
+                                  response header.
 
                                   Support: Extended
                                 items:
@@ -13935,32 +13915,29 @@ spec:
                                   A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
                                   CORS-safelisted methods are always allowed, regardless of whether they
-                                  are specified in the `AllowMethods` field.
+                                  are specified in the `allowMethods` field.
 
-                                  When the `AllowMethods` field is configured with one or more methods, the
+                                  When the `allowMethods` field is configured with one or more methods, the
                                   gateway must return the `Access-Control-Allow-Methods` response header
-                                  which value is present in the `AllowMethods` field.
+                                  which value is present in the `allowMethods` field.
 
                                   If the HTTP method of the `Access-Control-Request-Method` request header
                                   is not included in the list of methods specified by the response header
                                   `Access-Control-Allow-Methods`, it will present an error on the client
                                   side.
 
-                                  If config contains the wildcard "*" in allowMethods and the request is
-                                  not credentialed, the `Access-Control-Allow-Methods` response header
-                                  can either use the `*` wildcard or the value of
-                                  Access-Control-Request-Method from the request.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Access-Control-Request-Method` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Methods` response header. When
-                                  also the `AllowCredentials` field is true and `AllowMethods` field
-                                  specified with the `*` wildcard, the gateway must specify one HTTP method
-                                  in the value of the Access-Control-Allow-Methods response header. The
-                                  value of the header `Access-Control-Allow-Methods` is same as the
-                                  `Access-Control-Request-Method` header provided by the client. If the
-                                  header `Access-Control-Request-Method` is not included in the request,
-                                  the gateway will omit the `Access-Control-Allow-Methods` response header,
-                                  instead of specifying the `*` wildcard.
+                                  If the configuration contains the wildcard `*` in `allowMethods` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Methods` response header. Instead, it must
+                                  return a single HTTP method matching the value of the
+                                  `Access-Control-Request-Method` request header.
+                                  If the `Access-Control-Request-Method` header is not present in the request,
+                                  the gateway must omit the `Access-Control-Allow-Methods` response header.
 
                                   Support: Extended
                                 items:
@@ -14010,7 +13987,7 @@ spec:
                                   An origin value that includes _only_ the `*` character indicates requests
                                   from all `Origin`s are allowed.
 
-                                  When the `AllowOrigins` field is configured with multiple origins, it
+                                  When the `allowOrigins` field is configured with multiple origins, it
                                   means the server supports clients from multiple origins. If the request
                                   `Origin` matches the configured allowed origins, the gateway must return
                                   the given `Origin` and sets value of the header
@@ -14032,19 +14009,15 @@ spec:
                                   `Access-Control-Allow-Origin` to the same value as the `Origin`
                                   header provided by the client.
 
-                                  When config has the wildcard ("*") in allowOrigins, and the request
-                                  is not credentialed (e.g., it is a preflight request), the
-                                  `Access-Control-Allow-Origin` response header either contains the
-                                  wildcard as well or the Origin from the request.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
+                                  response header may either contain the wildcard `*` or echo the value
+                                  of the `Origin` request header.
 
-                                  When the request is credentialed, the gateway must not specify the `*`
-                                  wildcard in the `Access-Control-Allow-Origin` response header. When
-                                  also the `AllowCredentials` field is true and `AllowOrigins` field
-                                  specified with the `*` wildcard, the gateway must return a single origin
-                                  in the value of the `Access-Control-Allow-Origin` response header,
-                                  instead of specifying the `*` wildcard. The value of the header
-                                  `Access-Control-Allow-Origin` is same as the `Origin` header provided by
-                                  the client.
+                                  If the configuration contains the wildcard `*` in `allowOrigins` and
+                                  `allowCredentials` is set to `true`, the gateway must not return `*`
+                                  in the `Access-Control-Allow-Origin` response header. Instead, it must
+                                  return a single origin matching the value of the `Origin` request header.
 
                                   Support: Extended
                                 items:
@@ -14083,7 +14056,7 @@ spec:
                                   (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
                                   The CORS-safelisted response headers are exposed to client by default.
 
-                                  When an HTTP header name is specified using the `ExposeHeaders` field,
+                                  When an HTTP header name is specified using the `exposeHeaders` field,
                                   this additional header will be exposed as part of the response to the
                                   client.
 
@@ -14093,12 +14066,15 @@ spec:
                                   response header are separated by a comma (",").
 
                                   A wildcard indicates that the responses with all HTTP headers are exposed
-                                  to clients. The `Access-Control-Expose-Headers` response header can only
-                                  use `*` wildcard as value when the request is not credentialed.
+                                  to clients.
 
-                                  When the `exposeHeaders` config field contains the "*" wildcard and
-                                  the request is credentialed, the gateway cannot use the `*` wildcard in
-                                  the `Access-Control-Expose-Headers` response header.
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
+                                  response header can contain the wildcard `*`.
+
+                                  If the configuration contains the wildcard `*` in `exposeHeaders` and
+                                  `allowCredentials` is set to `true`, the gateway cannot use the `*`
+                                  in the `Access-Control-Expose-Headers` response header.
 
                                   Support: Extended
                                 items:
@@ -14602,6 +14578,10 @@ spec:
                                   Support: Extended for Kubernetes Service
 
                                   Support: Implementation-specific for any other resource
+
+                                  If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                  implementation to supply the TLS details to be used to connect to that
+                                  backend.
                                 properties:
                                   group:
                                     default: ""
@@ -15541,6 +15521,7 @@ spec:
                             a backend request is implementation-specific.
 
                             Support: Extended
+                          minimum: 1
                           type: integer
                         backoff:
                           description: |-
@@ -15609,7 +15590,7 @@ spec:
                             minimum: 400
                             type: integer
                           type: array
-                          x-kubernetes-list-type: atomic
+                          x-kubernetes-list-type: set
                       type: object
                     sessionPersistence:
                       description: |-
@@ -15661,15 +15642,6 @@ spec:
                               - Session
                               type: string
                           type: object
-                        idleTimeout:
-                          description: |-
-                            IdleTimeout defines the idle timeout of the persistent session.
-                            Once the session has been idle for more than the specified
-                            IdleTimeout duration, the session becomes invalid.
-
-                            Support: Extended
-                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                          type: string
                         sessionName:
                           description: |-
                             SessionName defines the name of the persistent session token
@@ -16126,12 +16098,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_listenersets.yaml
@@ -16141,7 +16107,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: listenersets.gateway.networking.k8s.io
 spec:
@@ -16910,12 +16876,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -16925,7 +16885,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: referencegrants.gateway.networking.k8s.io
 spec:
@@ -17100,6 +17060,8 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: false
@@ -17263,16 +17225,12 @@ spec:
             - from
             - to
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -17282,7 +17240,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: tcproutes.gateway.networking.k8s.io
 spec:
@@ -17300,6 +17258,728 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TCPRoute provides a way to route TCP requests. When combined with a Gateway
+          listener, it can be used to forward connections on the port specified by the
+          listener to a set of backends specified by the TCPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TCPRoute.
+            properties:
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of TCP matchers and actions.
+                items:
+                  description: TCPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Connection rejections must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        connections, then 80% of connections must be rejected instead.
+
+                        Support: Core for Kubernetes Service
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of TCPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of TCPRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -17579,12 +18259,6 @@ spec:
                         connections, then 80% of connections must be rejected instead.
 
                         Support: Core for Kubernetes Service
-
-                        Support: Extended for Kubernetes ServiceImport
-
-                        Support: Implementation-specific for any other resource
-
-                        Support for weight: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -17707,10 +18381,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     name:
-                      description: |-
-                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
-
-                        Support: Extended
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -18024,15 +18696,9 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -18042,7 +18708,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: tlsroutes.gateway.networking.k8s.io
 spec:
@@ -18120,7 +18786,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
@@ -18387,6 +19053,9 @@ spec:
                         weight; if an invalid backend is requested to have 80% of requests, then
                         80% of requests must be rejected instead.
 
+                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
+                        can be used to enable re-encryption of the traffic to the backends.
+
                         Support: Core for Kubernetes Service
 
                         Support: Extended for Kubernetes ServiceImport
@@ -18394,6 +19063,8 @@ spec:
                         Support: Implementation-specific for any other resource
 
                         Support for weight: Extended
+
+                        Support for BackendTLSPolicy: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -18921,7 +19592,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 type: array
                 x-kubernetes-list-type: atomic
               parentRefs:
@@ -19176,6 +19847,9 @@ spec:
                         weight; if an invalid backend is requested to have 80% of requests, then
                         80% of requests must be rejected instead.
 
+                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
+                        can be used to enable re-encryption of the traffic to the backends.
+
                         Support: Core for Kubernetes Service
 
                         Support: Extended for Kubernetes ServiceImport
@@ -19183,6 +19857,8 @@ spec:
                         Support: Implementation-specific for any other resource
 
                         Support for weight: Extended
+
+                        Support for BackendTLSPolicy: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -19690,7 +20366,7 @@ spec:
                   minLength: 1
                   pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                   type: string
-                maxItems: 16
+                maxItems: 1024
                 minItems: 1
                 type: array
                 x-kubernetes-list-type: atomic
@@ -19957,6 +20633,9 @@ spec:
                         weight; if an invalid backend is requested to have 80% of requests, then
                         80% of requests must be rejected instead.
 
+                        When a TLSRoute is attached to a listener in Terminate mode, a BackendTLSPolicy
+                        can be used to enable re-encryption of the traffic to the backends.
+
                         Support: Core for Kubernetes Service
 
                         Support: Extended for Kubernetes ServiceImport
@@ -19964,6 +20643,8 @@ spec:
                         Support: Implementation-specific for any other resource
 
                         Support for weight: Extended
+
+                        Support for BackendTLSPolicy: Extended
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -20401,12 +21082,6 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
 ---
 #
 # config/crd/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -20416,7 +21091,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: experimental
   name: udproutes.gateway.networking.k8s.io
 spec:
@@ -20434,6 +21109,728 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+          listener, it can be used to forward traffic on the port specified by the
+          listener to a set of backends specified by the UDPRoute.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of UDPRoute.
+            properties:
+              parentRefs:
+                description: |-
+                  ParentRefs references the resources (usually Gateways) that a Route wants
+                  to be attached to. Note that the referenced parent resource needs to
+                  allow this for the attachment to be complete. For Gateways, that means
+                  the Gateway needs to allow attachment from Routes of this kind and
+                  namespace. For Services, that means the Service must either be in the same
+                  namespace for a "producer" route, or the mesh implementation must support
+                  and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                  not applicable for governing ParentRefs to Services - it is not possible to
+                  create a "producer" route for a Service in a different namespace from the
+                  Route.
+
+                  There are two kinds of parent resources with "Core" support:
+
+                  * Gateway (Gateway conformance profile)
+                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                  This API may be extended in the future to support additional kinds of parent
+                  resources.
+
+                  ParentRefs must be _distinct_. This means either that:
+
+                  * They select different objects.  If this is the case, then parentRef
+                    entries are distinct. In terms of fields, this means that the
+                    multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                    be unique across all parentRef entries in the Route.
+                  * They do not select different objects, but for each optional field used,
+                    each ParentRef that selects the same object must set the same set of
+                    optional fields to different values. If one ParentRef sets a
+                    combination of optional fields, all must set the same combination.
+
+                  Some examples:
+
+                  * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                    same object must also set `sectionName`.
+                  * If one ParentRef sets `port`, all ParentRefs referencing the same
+                    object must also set `port`.
+                  * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                    referencing the same object must also set `sectionName` and `port`.
+
+                  It is possible to separately reference multiple distinct objects that may
+                  be collapsed by an implementation. For example, some implementations may
+                  choose to merge compatible Gateway Listeners together. If that is the
+                  case, the list of routes attached to those resources should also be
+                  merged.
+
+                  Note that for ParentRefs that cross namespace boundaries, there are specific
+                  rules. Cross-namespace references are only valid if they are explicitly
+                  allowed by something in the namespace they are referring to. For example,
+                  Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                  generic way to enable other kinds of cross-namespace reference.
+
+
+                  ParentRefs from a Route to a Service in the same namespace are "producer"
+                  routes, which apply default routing rules to inbound connections from
+                  any namespace to the Service.
+
+                  ParentRefs from a Route to a Service in a different namespace are
+                  "consumer" routes, and these routing rules are only applied to outbound
+                  connections originating from the same namespace as the Route, for which
+                  the intended destination of the connections are a Service targeted as a
+                  ParentRef of the Route.
+                items:
+                  description: |-
+                    ParentReference identifies an API object (usually a Gateway) that can be considered
+                    a parent of this resource (usually a route). There are two kinds of parent resources
+                    with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    The API object must be valid in the cluster; the Group and Kind must
+                    be registered in the cluster for this reference to be valid.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: |-
+                        Group is the group of the referent.
+                        When unspecified, "gateway.networking.k8s.io" is inferred.
+                        To set the core API group (such as for a "Service" kind referent),
+                        Group must be explicitly set to "" (empty string).
+
+                        Support: Core
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: |-
+                        Kind is kind of the referent.
+
+                        There are two kinds of parent resources with "Core" support:
+
+                        * Gateway (Gateway conformance profile)
+                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                        Support for other resources is Implementation-Specific.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: |-
+                        Name is the name of the referent.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent. When unspecified, this refers
+                        to the local namespace of the Route.
+
+                        Note that there are specific rules for ParentRefs which cross namespace
+                        boundaries. Cross-namespace references are only valid if they are explicitly
+                        allowed by something in the namespace they are referring to. For example:
+                        Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                        generic way to enable any other kind of cross-namespace reference.
+
+
+                        ParentRefs from a Route to a Service in the same namespace are "producer"
+                        routes, which apply default routing rules to inbound connections from
+                        any namespace to the Service.
+
+                        ParentRefs from a Route to a Service in a different namespace are
+                        "consumer" routes, and these routing rules are only applied to outbound
+                        connections originating from the same namespace as the Route, for which
+                        the intended destination of the connections are a Service targeted as a
+                        ParentRef of the Route.
+
+
+                        Support: Core
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    port:
+                      description: |-
+                        Port is the network port this Route targets. It can be interpreted
+                        differently based on the type of parent resource.
+
+                        When the parent resource is a Gateway, this targets all listeners
+                        listening on the specified port that also support this kind of Route(and
+                        select this Route). It's not recommended to set `Port` unless the
+                        networking behaviors specified in a Route must apply to a specific port
+                        as opposed to a listener(s) whose port(s) may be changed. When both Port
+                        and SectionName are specified, the name and port of the selected listener
+                        must match both specified values.
+
+
+                        When the parent resource is a Service, this targets a specific port in the
+                        Service spec. When both Port (experimental) and SectionName are specified,
+                        the name and port of the selected port must match both specified values.
+
+
+                        Implementations MAY choose to support other parent resources.
+                        Implementations supporting other types of parent resources MUST clearly
+                        document how/if Port is interpreted.
+
+                        For the purpose of status, an attachment is considered successful as
+                        long as the parent resource accepts it partially. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                        from the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route,
+                        the Route MUST be considered detached from the Gateway.
+
+                        Support: Extended
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    sectionName:
+                      description: |-
+                        SectionName is the name of a section within the target resource. In the
+                        following resources, SectionName is interpreted as the following:
+
+                        * Gateway: Listener name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+                        * Service: Port name. When both Port (experimental) and SectionName
+                        are specified, the name and port of the selected listener must match
+                        both specified values.
+
+                        Implementations MAY choose to support attaching Routes to other resources.
+                        If that is the case, they MUST clearly document how SectionName is
+                        interpreted.
+
+                        When unspecified (empty string), this will reference the entire resource.
+                        For the purpose of status, an attachment is considered successful if at
+                        least one section in the parent resource accepts it. For example, Gateway
+                        listeners can restrict which Routes can attach to them by Route kind,
+                        namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                        the referencing Route, the Route MUST be considered successfully
+                        attached. If no Gateway listeners accept attachment from this Route, the
+                        Route MUST be considered detached from the Gateway.
+
+                        Support: Core
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: sectionName or port must be specified when parentRefs includes
+                    2 or more references to the same parent
+                  rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName)
+                    || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName
+                    == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port)
+                    || p2.port == 0)): true))'
+                - message: sectionName or port must be unique when parentRefs includes
+                    2 or more references to the same parent
+                  rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind
+                    == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__)
+                    || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__
+                    == '')) || (has(p1.__namespace__) && has(p2.__namespace__) &&
+                    p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName)
+                    || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName
+                    == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName
+                    == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port)
+                    || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port
+                    == p2.port))))
+              rules:
+                description: Rules are a list of UDP matchers and actions.
+                items:
+                  description: UDPRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: |-
+                        BackendRefs defines the backend(s) where matching requests should be
+                        sent. If unspecified or invalid (refers to a nonexistent resource or a
+                        Service with no endpoints), the underlying implementation MUST actively
+                        reject connection attempts to this backend. Packet drops must
+                        respect weight; if an invalid backend is requested to have 80% of
+                        the packets, then 80% of packets must be dropped instead.
+
+                        Support: Extended for Kubernetes Service
+                      items:
+                        description: |-
+                          BackendRef defines how a Route should forward a request to a Kubernetes
+                          resource.
+
+                          Note that when a namespace different than the local namespace is specified, a
+                          ReferenceGrant object is required in the referent namespace to allow that
+                          namespace's owner to accept the reference. See the ReferenceGrant
+                          documentation for details.
+
+
+                          When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                          honor the appProtocol field if it is set for the target Service Port.
+
+                          Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                          Standard Application Protocols defined in KEP-3726.
+
+                          If a Service appProtocol isn't specified, an implementation MAY infer the
+                          backend protocol through its own means. Implementations MAY infer the
+                          protocol from the Route type referring to the backend Service.
+
+                          If a Route is not able to send traffic to the backend using the specified
+                          protocol then the backend is considered invalid. Implementations MUST set the
+                          "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                          Note that when the BackendTLSPolicy object is enabled by the implementation,
+                          there are some extra rules about validity to consider here. See the fields
+                          where this struct is used for more information about the exact behavior.
+                        properties:
+                          group:
+                            default: ""
+                            description: |-
+                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                              When unspecified or empty string, core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: |-
+                              Kind is the Kubernetes resource kind of the referent. For example
+                              "Service".
+
+                              Defaults to "Service" when not specified.
+
+                              ExternalName services can refer to CNAME DNS records that may live
+                              outside of the cluster and as such are difficult to reason about in
+                              terms of conformance. They also may not be safe to forward to (see
+                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                              support ExternalName Services.
+
+                              Support: Core (Services with a type other than ExternalName)
+
+                              Support: Implementation-specific (Services with type ExternalName)
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the backend. When unspecified, the local
+                              namespace is inferred.
+
+                              Note that when a namespace different than the local namespace is specified,
+                              a ReferenceGrant object is required in the referent namespace to allow that
+                              namespace's owner to accept the reference. See the ReferenceGrant
+                              documentation for details.
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port specifies the destination port number to use for this resource.
+                              Port is required when the referent is a Kubernetes Service. In this
+                              case, the port number is the service port number, not the target port.
+                              For other resources, destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: |-
+                              Weight specifies the proportion of requests forwarded to the referenced
+                              backend. This is computed as weight/(sum of all weights in this
+                              BackendRefs list). For non-zero values, there may be some epsilon from
+                              the exact proportion defined here depending on the precision an
+                              implementation supports. Weight is not a percentage and the sum of
+                              weights does not need to equal 100.
+
+                              If only one backend is specified and it has a weight greater than 0, 100%
+                              of the traffic is forwarded to that backend. If weight is set to 0, no
+                              traffic should be forwarded for this entry. If unspecified, weight
+                              defaults to 1.
+
+                              Support for this field varies based on the context where used.
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Must have port for Service reference
+                          rule: '(size(self.group) == 0 && self.kind == ''Service'')
+                            ? has(self.port) : true'
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    name:
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                  - backendRefs
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              useDefaultGateways:
+                description: |-
+                  UseDefaultGateways indicates the default Gateway scope to use for this
+                  Route. If unset (the default) or set to None, the Route will not be
+                  attached to any default Gateway; if set, it will be attached to any
+                  default Gateway supporting the named scope, subject to the usual rules
+                  about which Routes a Gateway is allowed to claim.
+
+                  Think carefully before using this functionality! The set of default
+                  Gateways supporting the requested scope can change over time without
+                  any notice to the Route author, and in many situations it will not be
+                  appropriate to request a default Gateway for a given Route -- for
+                  example, a Route with specific security requirements should almost
+                  certainly not use a default Gateway.
+                enum:
+                - All
+                - None
+                type: string
+            required:
+            - rules
+            type: object
+          status:
+            description: Status defines the current state of UDPRoute.
+            properties:
+              parents:
+                description: |-
+                  Parents is a list of parent resources (usually Gateways) that are
+                  associated with the route, and the status of the route with respect to
+                  each parent. When this route attaches to a parent, the controller that
+                  manages the parent must add an entry to this list when the controller
+                  first sees the route and should update the entry as appropriate when the
+                  route or gateway is modified.
+
+                  Note that parent references that cannot be resolved by an implementation
+                  of this API will not be added to this list. Implementations of this API
+                  can only populate Route status for the Gateways/parent resources they are
+                  responsible for.
+
+                  A maximum of 32 Gateways will be represented in this list. An empty list
+                  means the route has not been attached to any Gateway.
+                items:
+                  description: |-
+                    RouteParentStatus describes the status of a route with respect to an
+                    associated Parent.
+                  properties:
+                    conditions:
+                      description: |-
+                        Conditions describes the status of the route with respect to the Gateway.
+                        Note that the route's availability is also subject to the Gateway's own
+                        status conditions and listener status.
+
+                        If the Route's ParentRef specifies an existing Gateway that supports
+                        Routes of this kind AND that Gateway's controller has sufficient access,
+                        then that Gateway's controller MUST set the "Accepted" condition on the
+                        Route, to indicate whether the route has been accepted or rejected by the
+                        Gateway, and why.
+
+                        A Route MUST be considered "Accepted" if at least one of the Route's
+                        rules is implemented by the Gateway.
+
+                        There are a number of cases where the "Accepted" condition may not be set
+                        due to lack of controller visibility, that includes when:
+
+                        * The Route refers to a nonexistent parent.
+                        * The Route is of a type that the controller does not support.
+                        * The Route is in a namespace to which the controller does not have access.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: |-
+                        ParentRef corresponds with a ParentRef in the spec that this
+                        RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - conditions
+                  - controllerName
+                  - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - parents
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: The v1alpha2 version of UDPRoute has been deprecated and will
+      be removed in a future release of the API. Please upgrade to v1.
     name: v1alpha2
     schema:
       openAPIV3Schema:
@@ -20712,13 +22109,7 @@ spec:
                         respect weight; if an invalid backend is requested to have 80% of
                         the packets, then 80% of packets must be dropped instead.
 
-                        Support: Core for Kubernetes Service
-
-                        Support: Extended for Kubernetes ServiceImport
-
-                        Support: Implementation-specific for any other resource
-
-                        Support for weight: Extended
+                        Support: Extended for Kubernetes Service
                       items:
                         description: |-
                           BackendRef defines how a Route should forward a request to a Kubernetes
@@ -20841,10 +22232,8 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     name:
-                      description: |-
-                        Name is the name of the route rule. This name MUST be unique within a Route if it is set.
-
-                        Support: Extended
+                      description: Name is the name of the route rule. This name MUST
+                        be unique within a Route if it is set.
                       maxLength: 253
                       minLength: 1
                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -21158,876 +22547,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
----
-#
-# config/crd/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
-#
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
-    gateway.networking.k8s.io/channel: experimental
-  labels:
-    gateway.networking.k8s.io/policy: Direct
-  name: xbackendtrafficpolicies.gateway.networking.x-k8s.io
-spec:
-  group: gateway.networking.x-k8s.io
-  names:
-    categories:
-    - gateway-api
-    kind: XBackendTrafficPolicy
-    listKind: XBackendTrafficPolicyList
-    plural: xbackendtrafficpolicies
-    shortNames:
-    - xbtrafficpolicy
-    singular: xbackendtrafficpolicy
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          XBackendTrafficPolicy defines the configuration for how traffic to a
-          target backend should be handled.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of BackendTrafficPolicy.
-            properties:
-              retryConstraint:
-                description: |-
-                  RetryConstraint defines the configuration for when to allow or prevent
-                  further retries to a target backend, by dynamically calculating a 'retry
-                  budget'. This budget is calculated based on the percentage of incoming
-                  traffic composed of retries over a given time interval. Once the budget
-                  is exceeded, additional retries will be rejected.
-
-                  For example, if the retry budget interval is 10 seconds, there have been
-                  1000 active requests in the past 10 seconds, and the allowed percentage
-                  of requests that can be retried is 20% (the default), then 200 of those
-                  requests may be composed of retries. Active requests will only be
-                  considered for the duration of the interval when calculating the retry
-                  budget. Retrying the same original request multiple times within the
-                  retry budget interval will lead to each retry being counted towards
-                  calculating the budget.
-
-                  Configuring a RetryConstraint in BackendTrafficPolicy is compatible with
-                  HTTPRoute Retry settings for each HTTPRouteRule that targets the same
-                  backend. While the HTTPRouteRule Retry stanza can specify whether a
-                  request will be retried, and the number of retry attempts each client
-                  may perform, RetryConstraint helps prevent cascading failures such as
-                  retry storms during periods of consistent failures.
-
-                  After the retry budget has been exceeded, additional retries to the
-                  backend MUST return a 503 response to the client.
-
-                  Additional configurations for defining a constraint on retries MAY be
-                  defined in the future.
-
-                  Support: Extended
-                properties:
-                  budget:
-                    default:
-                      interval: 10s
-                      percent: 20
-                    description: Budget holds the details of the retry budget configuration.
-                    properties:
-                      interval:
-                        default: 10s
-                        description: |-
-                          Interval defines the duration in which requests will be considered
-                          for calculating the budget for retries.
-
-                          Support: Extended
-                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                        type: string
-                        x-kubernetes-validations:
-                        - message: interval cannot be greater than one hour or less
-                            than one second
-                          rule: '!(duration(self) < duration(''1s'') || duration(self)
-                            > duration(''1h''))'
-                      percent:
-                        default: 20
-                        description: |-
-                          Percent defines the maximum percentage of active requests that may
-                          be made up of retries.
-
-                          Support: Extended
-                        maximum: 100
-                        minimum: 0
-                        type: integer
-                    type: object
-                  minRetryRate:
-                    default:
-                      count: 10
-                      interval: 1s
-                    description: |-
-                      MinRetryRate defines the minimum rate of retries that will be allowable
-                      over a specified duration of time.
-
-                      The effective overall minimum rate of retries targeting the backend
-                      service may be much higher, as there can be any number of clients which
-                      are applying this setting locally.
-
-                      This ensures that requests can still be retried during periods of low
-                      traffic, where the budget for retries may be calculated as a very low
-                      value.
-
-                      Support: Extended
-                    properties:
-                      count:
-                        description: |-
-                          Count specifies the number of requests per time interval.
-
-                          Support: Extended
-                        maximum: 1000000
-                        minimum: 1
-                        type: integer
-                      interval:
-                        description: |-
-                          Interval specifies the divisor of the rate of requests, the amount of
-                          time during which the given count of requests occur.
-
-                          Support: Extended
-                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                        type: string
-                        x-kubernetes-validations:
-                        - message: interval cannot be greater than one hour
-                          rule: '!(duration(self) == duration(''0s'') || duration(self)
-                            > duration(''1h''))'
-                    type: object
-                type: object
-              sessionPersistence:
-                description: |-
-                  SessionPersistence defines and configures session persistence
-                  for the backend.
-
-                  Support: Extended
-                properties:
-                  absoluteTimeout:
-                    description: |-
-                      AbsoluteTimeout defines the absolute timeout of the persistent
-                      session. Once the AbsoluteTimeout duration has elapsed, the
-                      session becomes invalid.
-
-                      Support: Extended
-                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                    type: string
-                  cookieConfig:
-                    description: |-
-                      CookieConfig provides configuration settings that are specific
-                      to cookie-based session persistence.
-
-                      Support: Core
-                    properties:
-                      lifetimeType:
-                        default: Session
-                        description: |-
-                          LifetimeType specifies whether the cookie has a permanent or
-                          session-based lifetime. A permanent cookie persists until its
-                          specified expiry time, defined by the Expires or Max-Age cookie
-                          attributes, while a session cookie is deleted when the current
-                          session ends.
-
-                          When set to "Permanent", AbsoluteTimeout indicates the
-                          cookie's lifetime via the Expires or Max-Age cookie attributes
-                          and is required.
-
-                          When set to "Session", AbsoluteTimeout indicates the
-                          absolute lifetime of the cookie tracked by the gateway and
-                          is optional.
-
-                          Defaults to "Session".
-
-                          Support: Core for "Session" type
-
-                          Support: Extended for "Permanent" type
-                        enum:
-                        - Permanent
-                        - Session
-                        type: string
-                    type: object
-                  idleTimeout:
-                    description: |-
-                      IdleTimeout defines the idle timeout of the persistent session.
-                      Once the session has been idle for more than the specified
-                      IdleTimeout duration, the session becomes invalid.
-
-                      Support: Extended
-                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
-                    type: string
-                  sessionName:
-                    description: |-
-                      SessionName defines the name of the persistent session token
-                      which may be reflected in the cookie or the header. Users
-                      should avoid reusing session names to prevent unintended
-                      consequences, such as rejection or unpredictable behavior.
-
-                      Support: Implementation-specific
-                    maxLength: 128
-                    type: string
-                  type:
-                    default: Cookie
-                    description: |-
-                      Type defines the type of session persistence such as through
-                      the use of a header or cookie. Defaults to cookie based session
-                      persistence.
-
-                      Support: Core for "Cookie" type
-
-                      Support: Extended for "Header" type
-                    enum:
-                    - Cookie
-                    - Header
-                    type: string
-                type: object
-                x-kubernetes-validations:
-                - message: AbsoluteTimeout must be specified when cookie lifetimeType
-                    is Permanent
-                  rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType)
-                    || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
-                - message: cookieConfig can only be set with type Cookie
-                  rule: '!has(self.cookieConfig) || self.type == ''Cookie'''
-              targetRefs:
-                description: |-
-                  TargetRefs identifies API object(s) to apply this policy to.
-                  Currently, Backends (A grouping of like endpoints such as Service,
-                  ServiceImport, or any implementation-specific backendRef) are the only
-                  valid API target references.
-
-                  Currently, a TargetRef cannot be scoped to a specific port on a
-                  Service.
-                items:
-                  description: |-
-                    LocalPolicyTargetReference identifies an API object to apply a direct or
-                    inherited policy to. This should be used as part of Policy resources
-                    that can target Gateway API resources. For more information on how this
-                    policy attachment model works, and a sample Policy resource, refer to
-                    the policy attachment documentation for Gateway API.
-                  properties:
-                    group:
-                      description: Group is the group of the target resource.
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      type: string
-                    kind:
-                      description: Kind is kind of the target resource.
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                      type: string
-                    name:
-                      description: Name is the name of the target resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  - name
-                  type: object
-                maxItems: 16
-                minItems: 1
-                type: array
-                x-kubernetes-list-map-keys:
-                - group
-                - kind
-                - name
-                x-kubernetes-list-type: map
-            required:
-            - targetRefs
-            type: object
-          status:
-            description: Status defines the current state of BackendTrafficPolicy.
-            properties:
-              ancestors:
-                description: |-
-                  Ancestors is a list of ancestor resources (usually Gateways) that are
-                  associated with the policy, and the status of the policy with respect to
-                  each ancestor. When this policy attaches to a parent, the controller that
-                  manages the parent and the ancestors MUST add an entry to this list when
-                  the controller first sees the policy and SHOULD update the entry as
-                  appropriate when the relevant ancestor is modified.
-
-                  Note that choosing the relevant ancestor is left to the Policy designers;
-                  an important part of Policy design is designing the right object level at
-                  which to namespace this status.
-
-                  Note also that implementations MUST ONLY populate ancestor status for
-                  the Ancestor resources they are responsible for. Implementations MUST
-                  use the ControllerName field to uniquely identify the entries in this list
-                  that they are responsible for.
-
-                  Note that to achieve this, the list of PolicyAncestorStatus structs
-                  MUST be treated as a map with a composite key, made up of the AncestorRef
-                  and ControllerName fields combined.
-
-                  A maximum of 16 ancestors will be represented in this list. An empty list
-                  means the Policy is not relevant for any ancestors.
-
-                  If this slice is full, implementations MUST NOT add further entries.
-                  Instead they MUST consider the policy unimplementable and signal that
-                  on any related resources such as the ancestor that would be referenced
-                  here. For example, if this list was full on BackendTLSPolicy, no
-                  additional Gateways would be able to reference the Service targeted by
-                  the BackendTLSPolicy.
-                items:
-                  description: |-
-                    PolicyAncestorStatus describes the status of a route with respect to an
-                    associated Ancestor.
-
-                    Ancestors refer to objects that are either the Target of a policy or above it
-                    in terms of object hierarchy. For example, if a policy targets a Service, the
-                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
-                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
-                    useful object to place Policy status on, so we recommend that implementations
-                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
-                    have a _very_ good reason otherwise.
-
-                    In the context of policy attachment, the Ancestor is used to distinguish which
-                    resource results in a distinct application of this policy. For example, if a policy
-                    targets a Service, it may have a distinct result per attached Gateway.
-
-                    Policies targeting the same resource may have different effects depending on the
-                    ancestors of those resources. For example, different Gateways targeting the same
-                    Service may have different capabilities, especially if they have different underlying
-                    implementations.
-
-                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
-                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
-                    In this case, the relevant object for status is the Gateway, and that is the
-                    ancestor object referred to in this status.
-
-                    Note that a parent is also an ancestor, so for objects where the parent is the
-                    relevant object for status, this struct SHOULD still be used.
-
-                    This struct is intended to be used in a slice that's effectively a map,
-                    with a composite key made up of the AncestorRef and the ControllerName.
-                  properties:
-                    ancestorRef:
-                      description: |-
-                        AncestorRef corresponds with a ParentRef in the spec that this
-                        PolicyAncestorStatus struct describes the status of.
-                      properties:
-                        group:
-                          default: gateway.networking.k8s.io
-                          description: |-
-                            Group is the group of the referent.
-                            When unspecified, "gateway.networking.k8s.io" is inferred.
-                            To set the core API group (such as for a "Service" kind referent),
-                            Group must be explicitly set to "" (empty string).
-
-                            Support: Core
-                          maxLength: 253
-                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                        kind:
-                          default: Gateway
-                          description: |-
-                            Kind is kind of the referent.
-
-                            There are two kinds of parent resources with "Core" support:
-
-                            * Gateway (Gateway conformance profile)
-                            * Service (Mesh conformance profile, ClusterIP Services only)
-
-                            Support for other resources is Implementation-Specific.
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                          type: string
-                        name:
-                          description: |-
-                            Name is the name of the referent.
-
-                            Support: Core
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace is the namespace of the referent. When unspecified, this refers
-                            to the local namespace of the Route.
-
-                            Note that there are specific rules for ParentRefs which cross namespace
-                            boundaries. Cross-namespace references are only valid if they are explicitly
-                            allowed by something in the namespace they are referring to. For example:
-                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                            generic way to enable any other kind of cross-namespace reference.
-
-
-                            ParentRefs from a Route to a Service in the same namespace are "producer"
-                            routes, which apply default routing rules to inbound connections from
-                            any namespace to the Service.
-
-                            ParentRefs from a Route to a Service in a different namespace are
-                            "consumer" routes, and these routing rules are only applied to outbound
-                            connections originating from the same namespace as the Route, for which
-                            the intended destination of the connections are a Service targeted as a
-                            ParentRef of the Route.
-
-
-                            Support: Core
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                          type: string
-                        port:
-                          description: |-
-                            Port is the network port this Route targets. It can be interpreted
-                            differently based on the type of parent resource.
-
-                            When the parent resource is a Gateway, this targets all listeners
-                            listening on the specified port that also support this kind of Route(and
-                            select this Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to a specific port
-                            as opposed to a listener(s) whose port(s) may be changed. When both Port
-                            and SectionName are specified, the name and port of the selected listener
-                            must match both specified values.
-
-
-                            When the parent resource is a Service, this targets a specific port in the
-                            Service spec. When both Port (experimental) and SectionName are specified,
-                            the name and port of the selected port must match both specified values.
-
-
-                            Implementations MAY choose to support other parent resources.
-                            Implementations supporting other types of parent resources MUST clearly
-                            document how/if Port is interpreted.
-
-                            For the purpose of status, an attachment is considered successful as
-                            long as the parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                            from the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-
-                            Support: Extended
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                        sectionName:
-                          description: |-
-                            SectionName is the name of a section within the target resource. In the
-                            following resources, SectionName is interpreted as the following:
-
-                            * Gateway: Listener name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-                            * Service: Port name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-
-                            Implementations MAY choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName is
-                            interpreted.
-
-                            When unspecified (empty string), this will reference the entire resource.
-                            For the purpose of status, an attachment is considered successful if at
-                            least one section in the parent resource accepts it. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
-                            the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route, the
-                            Route MUST be considered detached from the Gateway.
-
-                            Support: Core
-                          maxLength: 253
-                          minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
-                      items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      maxItems: 8
-                      minItems: 1
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    controllerName:
-                      description: |-
-                        ControllerName is a domain/path string that indicates the name of the
-                        controller that wrote this status. This corresponds with the
-                        controllerName field on GatewayClass.
-
-                        Example: "example.net/gateway-controller".
-
-                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
-                        valid Kubernetes names
-                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
-                        Controllers MUST populate this field when writing status. Controllers should ensure that
-                        entries to status populated with their ControllerName are cleaned up when they are no
-                        longer necessary.
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
-                      type: string
-                  required:
-                  - ancestorRef
-                  - conditions
-                  - controllerName
-                  type: object
-                maxItems: 16
-                type: array
-                x-kubernetes-list-type: atomic
-            required:
-            - ancestors
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null
----
-#
-# config/crd/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
-#
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
-    gateway.networking.k8s.io/bundle-version: v1.5.1
-    gateway.networking.k8s.io/channel: experimental
-  name: xmeshes.gateway.networking.x-k8s.io
-spec:
-  group: gateway.networking.x-k8s.io
-  names:
-    categories:
-    - gateway-api
-    kind: XMesh
-    listKind: XMeshList
-    plural: xmeshes
-    shortNames:
-    - mesh
-    singular: xmesh
-  scope: Cluster
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
-      name: Accepted
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: XMesh defines mesh-wide characteristics of a GAMMA-compliant
-          service mesh.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec defines the desired state of XMesh.
-            properties:
-              controllerName:
-                description: |-
-                  ControllerName is the name of a controller that is managing Gateway API
-                  resources for mesh traffic management. The value of this field MUST be a
-                  domain prefixed path.
-
-                  Example: "example.com/awesome-mesh".
-
-                  This field is not mutable and cannot be empty.
-
-                  Support: Core
-                maxLength: 253
-                minLength: 1
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
-                type: string
-                x-kubernetes-validations:
-                - message: Value is immutable
-                  rule: self == oldSelf
-              description:
-                description: Description optionally provides a human-readable description
-                  of a Mesh.
-                maxLength: 64
-                type: string
-              parametersRef:
-                description: |-
-                  ParametersRef is an optional reference to a resource that contains
-                  implementation-specific configuration for this Mesh. If no
-                  implementation-specific parameters are needed, this field MUST be
-                  omitted.
-
-                  ParametersRef can reference a standard Kubernetes resource, i.e.
-                  ConfigMap, or an implementation-specific custom resource. The resource
-                  can be cluster-scoped or namespace-scoped.
-
-                  If the referent cannot be found, refers to an unsupported kind, or when
-                  the data within that resource is malformed, the Mesh MUST be rejected
-                  with the "Accepted" status condition set to "False" and an
-                  "InvalidParameters" reason.
-
-                  Support: Implementation-specific
-                properties:
-                  group:
-                    description: Group is the group of the referent.
-                    maxLength: 253
-                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  kind:
-                    description: Kind is kind of the referent.
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                    type: string
-                  name:
-                    description: Name is the name of the referent.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace is the namespace of the referent.
-                      This field is required when referring to a Namespace-scoped resource and
-                      MUST be unset when referring to a Cluster-scoped resource.
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                    type: string
-                required:
-                - group
-                - kind
-                - name
-                type: object
-            required:
-            - controllerName
-            type: object
-          status:
-            default:
-              conditions:
-              - lastTransitionTime: "1970-01-01T00:00:00Z"
-                message: Waiting for controller
-                reason: Pending
-                status: Unknown
-                type: Accepted
-            description: Status defines the current state of XMesh.
-            properties:
-              conditions:
-                default:
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Accepted
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Programmed
-                description: |-
-                  Conditions is the current status from the controller for
-                  this Mesh.
-
-                  Controllers should prefer to publish conditions using values
-                  of MeshConditionType for the type of each Condition.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                maxItems: 8
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              supportedFeatures:
-                description: |-
-                  SupportedFeatures is the set of features the Mesh support.
-                  It MUST be sorted in ascending alphabetical order by the Name key.
-                items:
-                  properties:
-                    name:
-                      description: |-
-                        FeatureName is used to describe distinct features that are covered by
-                        conformance tests.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                maxItems: 64
-                type: array
-                x-kubernetes-list-map-keys:
-                - name
-                x-kubernetes-list-type: map
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_backends.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_backends.yaml
@@ -81,7 +81,7 @@ spec:
                             endpoint.
                           maxLength: 253
                           minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\.?$
                           type: string
                         port:
                           description: Port defines the port of the backend endpoint.
@@ -189,6 +189,16 @@ spec:
                         using ALPN
                       type: string
                     type: array
+                  autoSNIFromEndpointHostname:
+                    description: |-
+                      AutoSNIFromEndpointHostname indicates whether the upstream endpoint's hostname should be used as the SNI value
+                      when establishing a TLS connection to the backend.
+                      This uses the resolved hostname of the upstream endpoint (e.g., from the Backend Endpoints list),
+                      rather than a static value.
+
+                      Mutually exclusive with SNI. When a BackendTLSPolicy is attached, its Hostname value takes
+                      precedence and AutoSNIFromEndpointHostname is ignored.
+                    type: boolean
                   caCertificateRefs:
                     description: |-
                       CACertificateRefs contains one or more references to Kubernetes objects that
@@ -401,14 +411,17 @@ spec:
                     type: array
                   sni:
                     description: |-
-                      SNI is specifies the SNI value used when establishing an upstream TLS connection to the backend.
+                      SNI specifies the fixed SNI value used when establishing an upstream TLS connection to the backend.
 
                       Envoy Gateway will use the HTTP host header value for SNI, when all resources referenced in BackendRefs are:
                       1. Backend resources that do not set SNI, or
                       2. Service/ServiceImport resources that do not have a BackendTLSPolicy attached to them
 
-                      When a BackendTLSPolicy attaches to a Backend resource, the BackendTLSPolicy's Hostname value takes precedence
-                      over this value.
+                      If a BackendTLSPolicy is attached to the Backend resource, the BackendTLSPolicy's validation.hostname
+                      value takes precedence over this field.
+
+                      If no BackendTLSPolicy validation.hostname applies and both this field and AutoSNIFromEndpointHostname
+                      are unset, Envoy Gateway configures Envoy to set the upstream SNI from the downstream HTTP host/authority header.
                     maxLength: 253
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -437,6 +450,9 @@ spec:
                     && ((has(self.caCertificateRefs) && size(self.caCertificateRefs)
                     > 0) || (has(self.wellKnownCACertificates) && self.wellKnownCACertificates
                     != "")))'
+                - message: sni and autoSNIFromEndpointHostname are mutually exclusive
+                  rule: '!(has(self.sni) && has(self.autoSNIFromEndpointHostname)
+                    && self.autoSNIFromEndpointHostname)'
                 - message: setting ciphers has no effect if the minimum possible TLS
                     version is 1.3
                   rule: 'has(self.minVersion) && self.minVersion == ''1.3'' ? !has(self.ciphers)
@@ -457,6 +473,14 @@ spec:
             x-kubernetes-validations:
             - message: DynamicResolver type cannot have endpoints specified
               rule: self.type != 'DynamicResolver' || !has(self.endpoints)
+            - message: DynamicResolver type cannot use autoSNIFromEndpointHostname
+              rule: self.type != 'DynamicResolver' || !has(self.tls) || !(has(self.tls.autoSNIFromEndpointHostname)
+                && self.tls.autoSNIFromEndpointHostname)
+            - message: when autoSNIFromEndpointHostname is enabled, IP and Unix endpoints
+                must define a hostname
+              rule: '!has(self.tls) || !(has(self.tls.autoSNIFromEndpointHostname)
+                && self.tls.autoSNIFromEndpointHostname) || self.endpoints.all(e,
+                (!has(e.ip) && !has(e.unix)) || has(e.hostname))'
           status:
             description: Status defines the current status of Backend.
             properties:

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
@@ -615,6 +615,73 @@ spec:
                               server and not to a specific service.
                             type: string
                         type: object
+                      healthCheckLog:
+                        description: |-
+                          HealthCheckLog defines health check event logging configuration for this cluster.
+                          When set, HC probe outcomes are logged to the configured sinks.
+                          Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                        properties:
+                          matches:
+                            description: |-
+                              Matches defines which health check probe outcomes produce a log entry.
+                              When omitted or empty, all events are logged.
+
+                              Each value must be unique. Multiple values are ORed. If any failure type is
+                              specified then a success type must also be specified, and vice versa.
+                            items:
+                              description: ProxyHealthCheckLogEventType specifies
+                                which health check probe outcomes produce a log entry.
+                              enum:
+                              - Failure
+                              - FailureSeriesStart
+                              - Success
+                              - HealthyTransition
+                              type: string
+                            maxItems: 4
+                            type: array
+                            x-kubernetes-list-type: set
+                            x-kubernetes-validations:
+                            - message: a failure type and a success type must both
+                                be specified together
+                              rule: self.exists(e, e == 'Failure' || e == 'FailureSeriesStart')
+                                == self.exists(e, e == 'Success' || e == 'HealthyTransition')
+                          sinks:
+                            description: |-
+                              Sinks defines where health check events are written.
+                              When omitted, events are written to /dev/stdout.
+                            items:
+                              description: ProxyHealthCheckLogSink defines a destination
+                                for health check event logs.
+                              properties:
+                                file:
+                                  description: |-
+                                    File defines the file sink configuration.
+                                    Required when type is File.
+                                  properties:
+                                    path:
+                                      description: |-
+                                        Path specifies the file path for health check event output.
+                                        Use /dev/stdout to write to standard output.
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                type:
+                                  description: Type defines the type of sink.
+                                  enum:
+                                  - File
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: If ProxyHealthCheckLogSink type is File,
+                                  file field needs to be set.
+                                rule: 'self.type == ''File'' ? has(self.file) : !has(self.file)'
+                            maxItems: 1
+                            type: array
+                        type: object
                       healthyThreshold:
                         default: 1
                         description: HealthyThreshold defines the number of healthy
@@ -682,6 +749,7 @@ spec:
                             description: |-
                               Method defines the HTTP method used for health checking.
                               Defaults to GET
+                            maxLength: 16
                             type: string
                           path:
                             description: Path defines the HTTP path that will be requested
@@ -689,6 +757,38 @@ spec:
                             maxLength: 1024
                             minLength: 1
                             type: string
+                          requestBody:
+                            description: RequestBody defines the HTTP request body
+                              payload sent during health checking.
+                            properties:
+                              binary:
+                                description: Binary payload base64 encoded.
+                                format: byte
+                                type: string
+                              text:
+                                description: Text payload in plain text.
+                                type: string
+                              type:
+                                allOf:
+                                - enum:
+                                  - Text
+                                  - Binary
+                                - enum:
+                                  - Text
+                                  - Binary
+                                description: Type defines the type of the payload.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: If payload type is Text, text field needs to
+                                be set.
+                              rule: 'self.type == ''Text'' ? has(self.text) : !has(self.text)'
+                            - message: If payload type is Binary, binary field needs
+                                to be set.
+                              rule: 'self.type == ''Binary'' ? has(self.binary) :
+                                !has(self.binary)'
                           retriableStatuses:
                             description: |-
                               RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -704,6 +804,11 @@ spec:
                         required:
                         - path
                         type: object
+                        x-kubernetes-validations:
+                        - message: The requestBody field can only be set when method
+                            is POST or PUT.
+                          rule: '!has(self.requestBody) || (has(self.method) && self.method.upperAscii()
+                            in [''POST'',''PUT''])'
                       initialJitter:
                         description: |-
                           InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -1064,6 +1169,43 @@ spec:
                         items:
                           type: string
                         type: array
+                      outOfBand:
+                        description: |-
+                          OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                          server-streaming gRPC connection to each endpoint's
+                          xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                          reports periodically, instead of relying on in-band ORCA metrics
+                          carried in response headers/trailers.
+
+                          The backend must implement OpenRcaService for this to take effect.
+                        properties:
+                          authority:
+                            description: |-
+                              Authority overrides the :authority header on the OutOfBand gRPC stream.
+                              If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                              the cluster name.
+                            maxLength: 259
+                            minLength: 1
+                            pattern: ^[^\x00\n\r]*$
+                            type: string
+                          port:
+                            description: |-
+                              Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                              reach a separate reporting sidecar. Defaults to the endpoint's port.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          reportingPeriod:
+                            description: |-
+                              ReportingPeriod is how often Envoy requests load reports from the server.
+                              Must be greater than 0. Defaults to 10s.
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                            x-kubernetes-validations:
+                            - message: reportingPeriod must be greater than 0
+                              rule: duration(self) > duration('0s')
+                        type: object
                       weightExpirationPeriod:
                         description: If a given endpoint has not reported load metrics
                           in this long, stop using the reported weight. Defaults to
@@ -1397,8 +1539,9 @@ spec:
                 description: |-
                   MergeType determines how this configuration is merged with existing BackendTrafficPolicy
                   configurations targeting a parent resource. When set, this configuration will be merged
-                  into a parent BackendTrafficPolicy (i.e. the one targeting a Gateway or Listener).
-                  This field cannot be set when targeting a parent resource (Gateway).
+                  into the closest parent BackendTrafficPolicy in the route's attachment hierarchy (for
+                  example, one targeting a Gateway, Gateway listener, ListenerSet, or ListenerSet listener).
+                  Currently, this field can only be set when targeting xRoute resources.
                   If unset, no merging occurs, and only the most specific configuration takes effect.
                 type: string
                 x-kubernetes-validations:
@@ -1507,7 +1650,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 64
+                                    maxItems: 128
                                     type: array
                                   methods:
                                     description: |-
@@ -1758,23 +1901,51 @@ spec:
                                 429 HTTP status code is sent back to the client when
                                 the selected requests have reached the limit.
                               properties:
+                                fromMetadata:
+                                  description: |-
+                                    FromMetadata sources the limit value from per-request dynamic metadata.
+                                    When the referenced metadata value is present, it overrides Requests/Unit for that
+                                    request; otherwise Requests/Unit are used as the default.
+
+                                    The referenced metadata value must be a struct containing an integer "requests_per_unit"
+                                    property and a "unit" property with a value parseable to a RateLimitUnit. An upstream
+                                    filter (e.g. ext_proc) is responsible for writing this struct into dynamic metadata.
+
+                                    Only supported for Global Rate Limits.
+                                  properties:
+                                    key:
+                                      description: Key is the key to retrieve the
+                                        limit value from within the namespaced filter
+                                        metadata.
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of the
+                                        dynamic metadata.
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - namespace
+                                  type: object
                                 requests:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
                                   format: int64
                                   maximum: 4294967295
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 unit:
                                   description: |-
                                     RateLimitUnit specifies the intervals for setting rate limits.
-                                    Valid RateLimitUnit values are "Second", "Minute", "Hour", "Day", "Month" and "Year".
+                                    Valid RateLimitUnit values are "Second", "Minute", "Hour", "Day", "Week", "Month" and "Year".
                                   enum:
                                   - Second
                                   - Minute
                                   - Hour
                                   - Day
+                                  - Week
                                   - Month
                                   - Year
                                   type: string
@@ -1891,7 +2062,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    maxItems: 64
+                                    maxItems: 128
                                     type: array
                                   methods:
                                     description: |-
@@ -2142,23 +2313,51 @@ spec:
                                 429 HTTP status code is sent back to the client when
                                 the selected requests have reached the limit.
                               properties:
+                                fromMetadata:
+                                  description: |-
+                                    FromMetadata sources the limit value from per-request dynamic metadata.
+                                    When the referenced metadata value is present, it overrides Requests/Unit for that
+                                    request; otherwise Requests/Unit are used as the default.
+
+                                    The referenced metadata value must be a struct containing an integer "requests_per_unit"
+                                    property and a "unit" property with a value parseable to a RateLimitUnit. An upstream
+                                    filter (e.g. ext_proc) is responsible for writing this struct into dynamic metadata.
+
+                                    Only supported for Global Rate Limits.
+                                  properties:
+                                    key:
+                                      description: Key is the key to retrieve the
+                                        limit value from within the namespaced filter
+                                        metadata.
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of the
+                                        dynamic metadata.
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - namespace
+                                  type: object
                                 requests:
                                   description: |-
                                     Requests is the number of requests (or cost units, when used with
                                     cost-based rate limiting) allowed per Unit.
                                   format: int64
                                   maximum: 4294967295
-                                  minimum: 1
+                                  minimum: 0
                                   type: integer
                                 unit:
                                   description: |-
                                     RateLimitUnit specifies the intervals for setting rate limits.
-                                    Valid RateLimitUnit values are "Second", "Minute", "Hour", "Day", "Month" and "Year".
+                                    Valid RateLimitUnit values are "Second", "Minute", "Hour", "Day", "Week", "Month" and "Year".
                                   enum:
                                   - Second
                                   - Minute
                                   - Hour
                                   - Day
+                                  - Week
                                   - Month
                                   - Year
                                   type: string
@@ -2198,6 +2397,9 @@ spec:
                         x-kubernetes-validations:
                         - message: response cost is not supported for Local Rate Limits
                           rule: self.all(r, !has(r.cost) || !has(r.cost.response))
+                        - message: limit fromMetadata is not supported for Local Rate
+                            Limits
+                          rule: self.all(r, !has(r.limit.fromMetadata))
                     type: object
                   type:
                     description: |-
@@ -2249,6 +2451,52 @@ spec:
                     match:
                       description: Match configuration.
                       properties:
+                        responseHeaders:
+                          description: Response headers to match on. The match evaluates
+                            to true if all matches are successful.
+                          items:
+                            description: ResponseOverrideHeaderMatch defines the configuration
+                              for matching a response header.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the HTTP header.
+                                  The header name is case-insensitive.
+                                  For example, "Foo" and "foo" are considered the same header.
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                type: string
+                              value:
+                                description: Value within the HTTP header to match
+                                  against.
+                                properties:
+                                  type:
+                                    default: Exact
+                                    description: Type specifies how to match against
+                                      a string.
+                                    enum:
+                                    - Exact
+                                    - Prefix
+                                    - Suffix
+                                    - RegularExpression
+                                    type: string
+                                  value:
+                                    description: Value specifies the string value
+                                      that the match must have.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - value
+                                type: object
+                            required:
+                            - name
+                            - value
+                            type: object
+                          maxItems: 16
+                          minItems: 1
+                          type: array
                         statusCodes:
                           description: Status code to match on. The match evaluates
                             to true if any of the matches are successful.
@@ -2304,9 +2552,11 @@ spec:
                           maxItems: 50
                           minItems: 1
                           type: array
-                      required:
-                      - statusCodes
                       type: object
+                      x-kubernetes-validations:
+                      - message: at least one of statusCodes or responseHeaders must
+                          be specified
+                        rule: has(self.statusCodes) || has(self.responseHeaders)
                     redirect:
                       description: Redirect configuration
                       properties:
@@ -3057,6 +3307,28 @@ spec:
 
                       This takes precedence over EnvoyProxy tracing when set.
                     properties:
+                      clientSamplingFraction:
+                        description: |-
+                          ClientSamplingFraction represents the fraction of requests that should be
+                          selected for tracing when requested by the client.
+                          If unspecified, client-forced tracing is disabled by default and users must
+                          set this field to opt in.
+                        properties:
+                          denominator:
+                            default: 100
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          numerator:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        required:
+                        - numerator
+                        type: object
+                        x-kubernetes-validations:
+                        - message: numerator must be less than or equal to denominator
+                          rule: self.numerator <= self.denominator
                       customTags:
                         additionalProperties:
                           properties:
@@ -3121,6 +3393,26 @@ spec:
 
                           Deprecated: Use Tags instead.
                         type: object
+                      overallSamplingFraction:
+                        description: |-
+                          OverallSamplingFraction represents the fraction of requests that should be
+                          selected for tracing after all other sampling checks have been applied.
+                        properties:
+                          denominator:
+                            default: 100
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          numerator:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        required:
+                        - numerator
+                        type: object
+                        x-kubernetes-validations:
+                        - message: numerator must be less than or equal to denominator
+                          rule: self.numerator <= self.denominator
                       samplingFraction:
                         description: |-
                           SamplingFraction represents the fraction of requests that should be
@@ -3240,28 +3532,37 @@ spec:
             - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
               rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
                 : true '
-            - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
-              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
-                ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''] : true'
+            - message: this policy can only have a targetRef.kind of Gateway/ListenerSet/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''ListenerSet'',
+                ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute'']
+                : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true '
-            - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+            - message: this policy can only have a targetRefs[*].kind of Gateway/ListenerSet/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
-                ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
-                : true '
+                ''ListenerSet'', ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'',
+                ''TLSRoute'']) : true '
+            - message: mergeType can only be used with xRoute targets
+              rule: '!has(self.mergeType) || ((!has(self.targetRef) || self.targetRef.kind
+                in [''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
+                && (!has(self.targetRefs) || self.targetRefs.all(ref, ref.kind in
+                [''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute'']))
+                && (!has(self.targetSelectors) || self.targetSelectors.all(sel, sel.kind
+                in [''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])))'
             - message: either compression or compressor can be set, not both
               rule: '!has(self.compression) || !has(self.compressor)'
             - message: requestBuffer cannot be used together with httpUpgrade
               rule: '!has(self.requestBuffer) || !has(self.httpUpgrade) || self.httpUpgrade.size()
                 == 0'
             - message: admissionControl can only be used with HTTPRoute, GRPCRoute,
-                or Gateway targets
+                Gateway, or ListenerSet targets
               rule: '!has(self.admissionControl) || ((!has(self.targetRef) || self.targetRef.kind
-                in [''Gateway'', ''HTTPRoute'', ''GRPCRoute'']) && (!has(self.targetRefs)
-                || self.targetRefs.all(ref, ref.kind in [''Gateway'', ''HTTPRoute'',
-                ''GRPCRoute''])) && (!has(self.targetSelectors) || self.targetSelectors.all(sel,
-                sel.kind in [''Gateway'', ''HTTPRoute'', ''GRPCRoute''])))'
+                in [''Gateway'', ''ListenerSet'', ''HTTPRoute'', ''GRPCRoute'']) &&
+                (!has(self.targetRefs) || self.targetRefs.all(ref, ref.kind in [''Gateway'',
+                ''ListenerSet'', ''HTTPRoute'', ''GRPCRoute''])) && (!has(self.targetSelectors)
+                || self.targetSelectors.all(sel, sel.kind in [''Gateway'', ''ListenerSet'',
+                ''HTTPRoute'', ''GRPCRoute''])))'
             - message: predictivePercent in preconnect policy only works with RoundRobin
                 or Random load balancers
               rule: '!((has(self.connection) && has(self.connection.preconnect) &&

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
@@ -77,11 +77,31 @@ spec:
                     required:
                     - name
                     type: object
+                  directSourceIP:
+                    description: |-
+                      DirectSourceIP configures the geoip filter to use the downstream connection
+                      source address (the TCP peer of the connection terminated by Envoy) as the client IP.
+
+                      Use this in L4-transparent topologies where a load balancer preserves the original
+                      client source IP at TCP level and does not populate XFF or a custom header — for
+                      example, AWS NLB with target-type=instance + externalTrafficPolicy=Local, or
+                      Azure Standard Load Balancer.
+
+                      Mutually exclusive with XForwardedFor and CustomHeader.
+                    type: object
                   xForwardedFor:
                     description: XForwardedForSettings provides configuration for
                       using X-Forwarded-For headers for determining the client IP
                       address.
                     properties:
+                      disableXForwardedForAppend:
+                        description: |-
+                          DisableXForwardedForAppend configures Envoy Proxy to stop appending the downstream address
+                          to the X-Forwarded-For header.
+
+                          This only disables the automatic append behavior. It does not remove or sanitize
+                          an incoming X-Forwarded-For header.
+                        type: boolean
                       numTrustedHops:
                         description: |-
                           NumTrustedHops specifies how many trusted hops to count from the rightmost side of
@@ -123,8 +143,10 @@ spec:
                         || (!has(self.numTrustedHops) && has(self.trustedCIDRs))
                 type: object
                 x-kubernetes-validations:
-                - message: customHeader cannot be used in conjunction with xForwardedFor
-                  rule: '!(has(self.xForwardedFor) && has(self.customHeader))'
+                - message: exactly one of xForwardedFor, customHeader, or directSourceIP
+                    must be set
+                  rule: '[has(self.xForwardedFor), has(self.customHeader), has(self.directSourceIP)].filter(x,
+                    x).size() == 1'
               connection:
                 description: Connection includes client connection settings.
                 properties:
@@ -477,6 +499,21 @@ spec:
                       EnableEnvoyHeaders configures Envoy Proxy to add the "X-Envoy-" headers to requests
                       and responses.
                     type: boolean
+                  host:
+                    description: Host enables managing how the Host/Authority header
+                      set by clients can be normalized.
+                    properties:
+                      stripTrailingHostDot:
+                        description: |-
+                          StripTrailingHostDot determines if the trailing dot of the host should be removed
+                          from the Host/Authority header before any processing of the request.
+                          This affects the upstream host header as well. Without this option, incoming requests
+                          with host "example.com." will not match routes with domains set to "example.com".
+                          When the host includes a port (for example "example.com.:443"), only the trailing dot
+                          from the host section is stripped, leaving the port as-is ("example.com:443").
+                          Defaults to false.
+                        type: boolean
+                    type: object
                   lateResponseHeaders:
                     description: LateResponseHeaders defines settings for global response
                       header modification.
@@ -1299,6 +1336,14 @@ spec:
                           Default: 1 hour.
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
+                      requestHeadersReceivedTimeout:
+                        description: |-
+                          RequestHeadersReceivedTimeout is the duration envoy waits for the request headers to arrive.
+                          The timer is activated when the first byte of the headers is received,
+                          and is disarmed when the last byte of the headers has been received.
+                          If not specified or set to 0, this timeout is disabled.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
                       requestReceivedTimeout:
                         description: |-
                           RequestReceivedTimeout is the duration envoy waits for the complete request reception. This timer starts upon request
@@ -1315,11 +1360,26 @@ spec:
                   tcp:
                     description: Timeout settings for TCP.
                     properties:
+                      connectionInspectionTimeout:
+                        description: |-
+                          ConnectionInspectionTimeout is the maximum time to wait for initial inspection
+                          (TLS / SNI and protocol detection, or HTTP protocol parsing) of an incoming connection on the listener socket.
+                          If exceeded, the connection is dropped.
+                          Default: 15 seconds.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
                       idleTimeout:
                         description: |-
                           IdleTimeout for a TCP connection. Idle time is defined as a period in which there are no
                           bytes sent or received on either the upstream or downstream connection.
                           Default: 1 hour.
+                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                        type: string
+                      tlsHandshakeTimeout:
+                        description: |-
+                          TLSHandshakeTimeout for a TCP connection. The maximum time to complete transport level connection negotiation
+                          (e.g. the TLS handshake) after a connection is accepted.
+                          If this expires before the transport reports connection establishment, the connection is summarily closed.
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                     type: object
@@ -1404,6 +1464,13 @@ spec:
                       ClientValidation specifies the configuration to validate the client
                       initiating the TLS connection to the Gateway listener.
                     properties:
+                      allowExpiredCertificate:
+                        description: |-
+                          AllowExpiredCertificate permits client certificates that have expired
+                          but are otherwise valid (CA chain, signature). When true, Envoy skips
+                          the NotAfter check during client certificate validation.
+                          Defaults to false.
+                        type: boolean
                       caCertificateRefs:
                         description: |-
                           CACertificateRefs contains one or more references to
@@ -1726,6 +1793,11 @@ spec:
                             type: array
                         type: object
                     type: object
+                    x-kubernetes-validations:
+                    - message: allowExpiredCertificate can only be set when mode is
+                        VerifyIfGiven or RequireAndVerify
+                      rule: '!has(self.allowExpiredCertificate) || !self.allowExpiredCertificate
+                        || !has(self.mode) || self.mode in [''VerifyIfGiven'', ''RequireAndVerify'']'
                   ecdhCurves:
                     description: |-
                       ECDHCurves specifies the set of supported ECDH curves.
@@ -1827,14 +1899,16 @@ spec:
             - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
               rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
                 : true'
-            - message: this policy can only have a targetRef.kind of Gateway
-              rule: 'has(self.targetRef) ? self.targetRef.kind == ''Gateway'' : true'
+            - message: this policy can only have a targetRef.kind of Gateway or ListenerSet
+              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''ListenerSet'']
+                : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true'
-            - message: this policy can only have a targetRefs[*].kind of Gateway
-              rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind == ''Gateway'')
-                : true'
+            - message: this policy can only have a targetRefs[*].kind of Gateway or
+                ListenerSet
+              rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
+                ''ListenerSet'']) : true'
           status:
             description: Status defines the current status of ClientTrafficPolicy.
             properties:

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
@@ -507,6 +507,77 @@ spec:
                                         server and not to a specific service.
                                       type: string
                                   type: object
+                                healthCheckLog:
+                                  description: |-
+                                    HealthCheckLog defines health check event logging configuration for this cluster.
+                                    When set, HC probe outcomes are logged to the configured sinks.
+                                    Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                  properties:
+                                    matches:
+                                      description: |-
+                                        Matches defines which health check probe outcomes produce a log entry.
+                                        When omitted or empty, all events are logged.
+
+                                        Each value must be unique. Multiple values are ORed. If any failure type is
+                                        specified then a success type must also be specified, and vice versa.
+                                      items:
+                                        description: ProxyHealthCheckLogEventType
+                                          specifies which health check probe outcomes
+                                          produce a log entry.
+                                        enum:
+                                        - Failure
+                                        - FailureSeriesStart
+                                        - Success
+                                        - HealthyTransition
+                                        type: string
+                                      maxItems: 4
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                      x-kubernetes-validations:
+                                      - message: a failure type and a success type
+                                          must both be specified together
+                                        rule: self.exists(e, e == 'Failure' || e ==
+                                          'FailureSeriesStart') == self.exists(e,
+                                          e == 'Success' || e == 'HealthyTransition')
+                                    sinks:
+                                      description: |-
+                                        Sinks defines where health check events are written.
+                                        When omitted, events are written to /dev/stdout.
+                                      items:
+                                        description: ProxyHealthCheckLogSink defines
+                                          a destination for health check event logs.
+                                        properties:
+                                          file:
+                                            description: |-
+                                              File defines the file sink configuration.
+                                              Required when type is File.
+                                            properties:
+                                              path:
+                                                description: |-
+                                                  Path specifies the file path for health check event output.
+                                                  Use /dev/stdout to write to standard output.
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          type:
+                                            description: Type defines the type of
+                                              sink.
+                                            enum:
+                                            - File
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: If ProxyHealthCheckLogSink type
+                                            is File, file field needs to be set.
+                                          rule: 'self.type == ''File'' ? has(self.file)
+                                            : !has(self.file)'
+                                      maxItems: 1
+                                      type: array
+                                  type: object
                                 healthyThreshold:
                                   default: 1
                                   description: HealthyThreshold defines the number
@@ -578,6 +649,7 @@ spec:
                                       description: |-
                                         Method defines the HTTP method used for health checking.
                                         Defaults to GET
+                                      maxLength: 16
                                       type: string
                                     path:
                                       description: Path defines the HTTP path that
@@ -585,6 +657,40 @@ spec:
                                       maxLength: 1024
                                       minLength: 1
                                       type: string
+                                    requestBody:
+                                      description: RequestBody defines the HTTP request
+                                        body payload sent during health checking.
+                                      properties:
+                                        binary:
+                                          description: Binary payload base64 encoded.
+                                          format: byte
+                                          type: string
+                                        text:
+                                          description: Text payload in plain text.
+                                          type: string
+                                        type:
+                                          allOf:
+                                          - enum:
+                                            - Text
+                                            - Binary
+                                          - enum:
+                                            - Text
+                                            - Binary
+                                          description: Type defines the type of the
+                                            payload.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: If payload type is Text, text field
+                                          needs to be set.
+                                        rule: 'self.type == ''Text'' ? has(self.text)
+                                          : !has(self.text)'
+                                      - message: If payload type is Binary, binary
+                                          field needs to be set.
+                                        rule: 'self.type == ''Binary'' ? has(self.binary)
+                                          : !has(self.binary)'
                                     retriableStatuses:
                                       description: |-
                                         RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -601,6 +707,11 @@ spec:
                                   required:
                                   - path
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: The requestBody field can only be set
+                                      when method is POST or PUT.
+                                    rule: '!has(self.requestBody) || (has(self.method)
+                                      && self.method.upperAscii() in [''POST'',''PUT''])'
                                 initialJitter:
                                   description: |-
                                     InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -937,6 +1048,44 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                outOfBand:
+                                  description: |-
+                                    OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                    server-streaming gRPC connection to each endpoint's
+                                    xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                    reports periodically, instead of relying on in-band ORCA metrics
+                                    carried in response headers/trailers.
+
+                                    The backend must implement OpenRcaService for this to take effect.
+                                  properties:
+                                    authority:
+                                      description: |-
+                                        Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                        If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                        the cluster name.
+                                      maxLength: 259
+                                      minLength: 1
+                                      pattern: ^[^\x00\n\r]*$
+                                      type: string
+                                    port:
+                                      description: |-
+                                        Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                        reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                    reportingPeriod:
+                                      description: |-
+                                        ReportingPeriod is how often Envoy requests load reports from the server.
+                                        Must be greater than 0. Defaults to 10s.
+                                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: reportingPeriod must be greater than
+                                          0
+                                        rule: duration(self) > duration('0s')
+                                  type: object
                                 weightExpirationPeriod:
                                   description: If a given endpoint has not reported
                                     load metrics in this long, stop using the reported
@@ -1569,6 +1718,59 @@ spec:
                               type: string
                           type: object
                       type: object
+                    shadowMode:
+                      description: |-
+                        ShadowMode sets if envoy gateway should treat this external processor as "send and go".
+                        When enabled, Envoy forwards request/response data to the external processor but does
+                        not wait for or apply any response from it. This maps to Envoy's `observability_mode`
+                        on the ext_proc filter.
+                        Defaults to false.
+                      type: boolean
+                    statusOnError:
+                      description: |-
+                        Sets the HTTP status that is returned to the client when the external processor returns an error
+                        or cannot be reached. Defaults to 500 Internal Server Error.
+                        Only 4xx and 5xx status codes are supported.
+                      enum:
+                      - 400
+                      - 401
+                      - 402
+                      - 403
+                      - 404
+                      - 405
+                      - 406
+                      - 407
+                      - 408
+                      - 409
+                      - 410
+                      - 411
+                      - 412
+                      - 413
+                      - 414
+                      - 415
+                      - 416
+                      - 417
+                      - 421
+                      - 422
+                      - 423
+                      - 424
+                      - 426
+                      - 428
+                      - 429
+                      - 431
+                      - 500
+                      - 501
+                      - 502
+                      - 503
+                      - 504
+                      - 505
+                      - 506
+                      - 507
+                      - 508
+                      - 510
+                      - 511
+                      format: int32
+                      type: integer
                   type: object
                   x-kubernetes-validations:
                   - message: BackendRefs must be used, backendRef is not supported.
@@ -1590,6 +1792,13 @@ spec:
                       && self.processingMode.request.body == ''FullDuplexStreamed'')
                       || (has(self.processingMode.response) && has(self.processingMode.response.body)
                       && self.processingMode.response.body == ''FullDuplexStreamed'')))'
+                  - message: If shadowMode is enabled, body processing mode must be
+                      Streamed or unset.
+                    rule: '!(has(self.shadowMode) && self.shadowMode == true && has(self.processingMode)
+                      && ((has(self.processingMode.request) && has(self.processingMode.request.body)
+                      && self.processingMode.request.body != ''Streamed'') || (has(self.processingMode.response)
+                      && has(self.processingMode.response.body) && self.processingMode.response.body
+                      != ''Streamed'')))'
                 maxItems: 16
                 type: array
               lua:
@@ -1601,6 +1810,13 @@ spec:
                     Lua defines a Lua extension
                     Only one of Inline or ValueRef must be set
                   properties:
+                    filterContext:
+                      description: |-
+                        FilterContext is the filter context configuration for the Lua script.
+                        This must be a JSON object (key/value pairs). The values are made available
+                        to the Lua script via request_handle:filterContext(). This allows a shared
+                        script to be parameterized differently per EnvoyExtensionPolicy/route.
+                      x-kubernetes-preserve-unknown-fields: true
                     inline:
                       description: Inline contains the source code as an inline string.
                       type: string
@@ -1659,6 +1875,19 @@ spec:
                       || (self.type == 'ValueRef' && !has(self.inline) && has(self.valueRef))
                 maxItems: 16
                 type: array
+              mergeType:
+                description: |-
+                  MergeType determines how this configuration is merged with existing EnvoyExtensionPolicy
+                  configurations targeting a parent resource. When set, this configuration will be merged
+                  into the closest parent EnvoyExtensionPolicy in the route's attachment hierarchy (for
+                  example, one targeting a Gateway, Gateway listener, ListenerSet, or ListenerSet
+                  listener).
+                  Currently, this field can only be set when targeting xRoute resources.
+                  If unset, no merging occurs, and only the most specific configuration takes effect.
+                type: string
+                x-kubernetes-validations:
+                - message: Replace is not a valid MergeType for EnvoyExtensionPolicy
+                  rule: self != 'Replace'
               targetRef:
                 description: |-
                   TargetRef is the name of the resource this policy is being attached to.
@@ -2210,16 +2439,24 @@ spec:
             - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
               rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
                 : true'
-            - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
-              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
-                ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''] : true'
+            - message: this policy can only have a targetRef.kind of Gateway/ListenerSet/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''ListenerSet'',
+                ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute'']
+                : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true '
-            - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
+            - message: this policy can only have a targetRefs[*].kind of Gateway/ListenerSet/HTTPRoute/GRPCRoute/TCPRoute/UDPRoute/TLSRoute
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
-                ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
-                : true '
+                ''ListenerSet'', ''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'',
+                ''TLSRoute'']) : true '
+            - message: mergeType can only be used with xRoute targets
+              rule: '!has(self.mergeType) || ((!has(self.targetRef) || self.targetRef.kind
+                in [''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])
+                && (!has(self.targetRefs) || self.targetRefs.all(ref, ref.kind in
+                [''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute'']))
+                && (!has(self.targetSelectors) || self.targetSelectors.all(sel, sel.kind
+                in [''HTTPRoute'', ''GRPCRoute'', ''UDPRoute'', ''TCPRoute'', ''TLSRoute''])))'
           status:
             description: Status defines the current status of EnvoyExtensionPolicy.
             properties:

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
@@ -510,6 +510,7 @@ spec:
                       - envoy.filters.http.health_check
                       - envoy.filters.http.fault
                       - envoy.filters.http.cors
+                      - envoy.filters.http.csrf
                       - envoy.filters.http.header_mutation
                       - envoy.filters.http.ext_authz
                       - envoy.filters.http.api_key_auth
@@ -542,6 +543,7 @@ spec:
                       - envoy.filters.http.health_check
                       - envoy.filters.http.fault
                       - envoy.filters.http.cors
+                      - envoy.filters.http.csrf
                       - envoy.filters.http.header_mutation
                       - envoy.filters.http.ext_authz
                       - envoy.filters.http.api_key_auth
@@ -572,6 +574,7 @@ spec:
                       - envoy.filters.http.health_check
                       - envoy.filters.http.fault
                       - envoy.filters.http.cors
+                      - envoy.filters.http.csrf
                       - envoy.filters.http.header_mutation
                       - envoy.filters.http.ext_authz
                       - envoy.filters.http.api_key_auth
@@ -759,6 +762,8 @@ spec:
                       - info
                       - warn
                       - error
+                      - "off"
+                      - critical
                       type: string
                     default:
                       default: warn
@@ -776,12 +781,75 @@ spec:
                 - InsecureSyntax
                 - Disabled
                 type: string
+              mergeBackends:
+                description: |-
+                  MergeBackends configures cluster deduplication: routes that reference the same backend
+                  share a single Envoy cluster instead of Envoy Gateway generating one cluster per route
+                  rule. This reduces xDS size, active health-check traffic, and stats cardinality, and
+                  improves upstream connection pooling.
+
+                  Disabled when unset; specifying this field at all (even without further configuration)
+                  enables it. Mutually exclusive with MergeGateways.
+                properties:
+                  selector:
+                    description: |-
+                      Selector restricts cluster deduplication to backends whose target Service, ServiceImport,
+                      or Backend resource matches this label selector. When unset, every otherwise-eligible
+                      backend is merged. Use this to opt individual backends into deduplication gradually
+                      instead of enabling it for every backend at once.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
               mergeGateways:
                 description: |-
                   MergeGateways defines if Gateway resources should be merged onto the same Envoy Proxy Infrastructure.
                   Setting this field to true would merge all Gateway Listeners under the parent Gateway Class.
                   This means that the port, protocol and hostname tuple must be unique for every listener.
                   If a duplicate listener is detected, the newer listener (based on timestamp) will be rejected and its status will be updated with a "Accepted=False" condition.
+
+                  Mutually exclusive with MergeBackends.
                 type: boolean
               mergeType:
                 description: |-
@@ -797,7 +865,7 @@ spec:
               preserveRouteOrder:
                 description: |-
                   PreserveRouteOrder determines if the order of matching for HTTPRoutes is determined by Gateway-API
-                  specification (https://gateway-api.sigs.k8s.io/reference/1.4/spec/#httprouterule)
+                  specification (https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#httprouterule)
                   or preserves the order defined by users in the HTTPRoute's HTTPRouteRule list.
                   Default: False
                 type: boolean
@@ -10386,8 +10454,11 @@ spec:
                             type: object
                         type: object
                       envoyHpa:
-                        description: EnvoyHpa defines the Horizontal Pod Autoscaler
-                          settings for Envoy Proxy Deployment.
+                        description: |-
+                          EnvoyHpa defines the Horizontal Pod Autoscaler settings for Envoy Proxy Deployment.
+                          If the HPA is set, the Replicas field from EnvoyDeployment will be ignored, and the
+                          number of replicas is solely managed by the HPA. Use MinReplicas to control the
+                          lower bound of the replica count instead.
                         properties:
                           behavior:
                             description: |-
@@ -11266,7 +11337,7 @@ spec:
                     description: |-
                       Type is the type of resource provider to use. A resource provider provides
                       infrastructure resources for running the data plane, e.g. Envoy proxy, and
-                      optional auxiliary control planes. Supported types are "Kubernetes"and "Host".
+                      optional auxiliary control planes. Supported types are "Kubernetes" and "Host".
                     enum:
                     - Kubernetes
                     - Host
@@ -11287,6 +11358,12 @@ spec:
                     description: |-
                       DrainTimeout defines the graceful drain timeout. This should be less than the pod's terminationGracePeriodSeconds.
                       If unspecified, defaults to 60 seconds.
+                    pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                    type: string
+                  healthCheckFailureDelay:
+                    description: |-
+                      HealthCheckFailureDelay defines the delay before failing health checks during the graceful drain process.
+                      If unspecified, defaults to 0 seconds.
                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                     type: string
                   minDrainDuration:
@@ -11796,6 +11873,83 @@ spec:
                                                           server and not to a specific service.
                                                         type: string
                                                     type: object
+                                                  healthCheckLog:
+                                                    description: |-
+                                                      HealthCheckLog defines health check event logging configuration for this cluster.
+                                                      When set, HC probe outcomes are logged to the configured sinks.
+                                                      Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                                    properties:
+                                                      matches:
+                                                        description: |-
+                                                          Matches defines which health check probe outcomes produce a log entry.
+                                                          When omitted or empty, all events are logged.
+
+                                                          Each value must be unique. Multiple values are ORed. If any failure type is
+                                                          specified then a success type must also be specified, and vice versa.
+                                                        items:
+                                                          description: ProxyHealthCheckLogEventType
+                                                            specifies which health
+                                                            check probe outcomes produce
+                                                            a log entry.
+                                                          enum:
+                                                          - Failure
+                                                          - FailureSeriesStart
+                                                          - Success
+                                                          - HealthyTransition
+                                                          type: string
+                                                        maxItems: 4
+                                                        type: array
+                                                        x-kubernetes-list-type: set
+                                                        x-kubernetes-validations:
+                                                        - message: a failure type
+                                                            and a success type must
+                                                            both be specified together
+                                                          rule: self.exists(e, e ==
+                                                            'Failure' || e == 'FailureSeriesStart')
+                                                            == self.exists(e, e ==
+                                                            'Success' || e == 'HealthyTransition')
+                                                      sinks:
+                                                        description: |-
+                                                          Sinks defines where health check events are written.
+                                                          When omitted, events are written to /dev/stdout.
+                                                        items:
+                                                          description: ProxyHealthCheckLogSink
+                                                            defines a destination
+                                                            for health check event
+                                                            logs.
+                                                          properties:
+                                                            file:
+                                                              description: |-
+                                                                File defines the file sink configuration.
+                                                                Required when type is File.
+                                                              properties:
+                                                                path:
+                                                                  description: |-
+                                                                    Path specifies the file path for health check event output.
+                                                                    Use /dev/stdout to write to standard output.
+                                                                  minLength: 1
+                                                                  type: string
+                                                              required:
+                                                              - path
+                                                              type: object
+                                                            type:
+                                                              description: Type defines
+                                                                the type of sink.
+                                                              enum:
+                                                              - File
+                                                              type: string
+                                                          required:
+                                                          - type
+                                                          type: object
+                                                          x-kubernetes-validations:
+                                                          - message: If ProxyHealthCheckLogSink
+                                                              type is File, file field
+                                                              needs to be set.
+                                                            rule: 'self.type == ''File''
+                                                              ? has(self.file) : !has(self.file)'
+                                                        maxItems: 1
+                                                        type: array
+                                                    type: object
                                                   healthyThreshold:
                                                     default: 1
                                                     description: HealthyThreshold
@@ -11874,6 +12028,7 @@ spec:
                                                         description: |-
                                                           Method defines the HTTP method used for health checking.
                                                           Defaults to GET
+                                                        maxLength: 16
                                                         type: string
                                                       path:
                                                         description: Path defines
@@ -11883,6 +12038,45 @@ spec:
                                                         maxLength: 1024
                                                         minLength: 1
                                                         type: string
+                                                      requestBody:
+                                                        description: RequestBody defines
+                                                          the HTTP request body payload
+                                                          sent during health checking.
+                                                        properties:
+                                                          binary:
+                                                            description: Binary payload
+                                                              base64 encoded.
+                                                            format: byte
+                                                            type: string
+                                                          text:
+                                                            description: Text payload
+                                                              in plain text.
+                                                            type: string
+                                                          type:
+                                                            allOf:
+                                                            - enum:
+                                                              - Text
+                                                              - Binary
+                                                            - enum:
+                                                              - Text
+                                                              - Binary
+                                                            description: Type defines
+                                                              the type of the payload.
+                                                            type: string
+                                                        required:
+                                                        - type
+                                                        type: object
+                                                        x-kubernetes-validations:
+                                                        - message: If payload type
+                                                            is Text, text field needs
+                                                            to be set.
+                                                          rule: 'self.type == ''Text''
+                                                            ? has(self.text) : !has(self.text)'
+                                                        - message: If payload type
+                                                            is Binary, binary field
+                                                            needs to be set.
+                                                          rule: 'self.type == ''Binary''
+                                                            ? has(self.binary) : !has(self.binary)'
                                                       retriableStatuses:
                                                         description: |-
                                                           RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -11900,6 +12094,13 @@ spec:
                                                     required:
                                                     - path
                                                     type: object
+                                                    x-kubernetes-validations:
+                                                    - message: The requestBody field
+                                                        can only be set when method
+                                                        is POST or PUT.
+                                                      rule: '!has(self.requestBody)
+                                                        || (has(self.method) && self.method.upperAscii()
+                                                        in [''POST'',''PUT''])'
                                                   initialJitter:
                                                     description: |-
                                                       InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -12267,6 +12468,44 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                  outOfBand:
+                                                    description: |-
+                                                      OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                                      server-streaming gRPC connection to each endpoint's
+                                                      xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                                      reports periodically, instead of relying on in-band ORCA metrics
+                                                      carried in response headers/trailers.
+
+                                                      The backend must implement OpenRcaService for this to take effect.
+                                                    properties:
+                                                      authority:
+                                                        description: |-
+                                                          Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                                          If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                                          the cluster name.
+                                                        maxLength: 259
+                                                        minLength: 1
+                                                        pattern: ^[^\x00\n\r]*$
+                                                        type: string
+                                                      port:
+                                                        description: |-
+                                                          Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                                          reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                                        format: int32
+                                                        maximum: 65535
+                                                        minimum: 1
+                                                        type: integer
+                                                      reportingPeriod:
+                                                        description: |-
+                                                          ReportingPeriod is how often Envoy requests load reports from the server.
+                                                          Must be greater than 0. Defaults to 10s.
+                                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                                        type: string
+                                                        x-kubernetes-validations:
+                                                        - message: reportingPeriod
+                                                            must be greater than 0
+                                                          rule: duration(self) > duration('0s')
+                                                    type: object
                                                   weightExpirationPeriod:
                                                     description: If a given endpoint
                                                       has not reported load metrics
@@ -13328,6 +13567,83 @@ spec:
                                                           server and not to a specific service.
                                                         type: string
                                                     type: object
+                                                  healthCheckLog:
+                                                    description: |-
+                                                      HealthCheckLog defines health check event logging configuration for this cluster.
+                                                      When set, HC probe outcomes are logged to the configured sinks.
+                                                      Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                                    properties:
+                                                      matches:
+                                                        description: |-
+                                                          Matches defines which health check probe outcomes produce a log entry.
+                                                          When omitted or empty, all events are logged.
+
+                                                          Each value must be unique. Multiple values are ORed. If any failure type is
+                                                          specified then a success type must also be specified, and vice versa.
+                                                        items:
+                                                          description: ProxyHealthCheckLogEventType
+                                                            specifies which health
+                                                            check probe outcomes produce
+                                                            a log entry.
+                                                          enum:
+                                                          - Failure
+                                                          - FailureSeriesStart
+                                                          - Success
+                                                          - HealthyTransition
+                                                          type: string
+                                                        maxItems: 4
+                                                        type: array
+                                                        x-kubernetes-list-type: set
+                                                        x-kubernetes-validations:
+                                                        - message: a failure type
+                                                            and a success type must
+                                                            both be specified together
+                                                          rule: self.exists(e, e ==
+                                                            'Failure' || e == 'FailureSeriesStart')
+                                                            == self.exists(e, e ==
+                                                            'Success' || e == 'HealthyTransition')
+                                                      sinks:
+                                                        description: |-
+                                                          Sinks defines where health check events are written.
+                                                          When omitted, events are written to /dev/stdout.
+                                                        items:
+                                                          description: ProxyHealthCheckLogSink
+                                                            defines a destination
+                                                            for health check event
+                                                            logs.
+                                                          properties:
+                                                            file:
+                                                              description: |-
+                                                                File defines the file sink configuration.
+                                                                Required when type is File.
+                                                              properties:
+                                                                path:
+                                                                  description: |-
+                                                                    Path specifies the file path for health check event output.
+                                                                    Use /dev/stdout to write to standard output.
+                                                                  minLength: 1
+                                                                  type: string
+                                                              required:
+                                                              - path
+                                                              type: object
+                                                            type:
+                                                              description: Type defines
+                                                                the type of sink.
+                                                              enum:
+                                                              - File
+                                                              type: string
+                                                          required:
+                                                          - type
+                                                          type: object
+                                                          x-kubernetes-validations:
+                                                          - message: If ProxyHealthCheckLogSink
+                                                              type is File, file field
+                                                              needs to be set.
+                                                            rule: 'self.type == ''File''
+                                                              ? has(self.file) : !has(self.file)'
+                                                        maxItems: 1
+                                                        type: array
+                                                    type: object
                                                   healthyThreshold:
                                                     default: 1
                                                     description: HealthyThreshold
@@ -13406,6 +13722,7 @@ spec:
                                                         description: |-
                                                           Method defines the HTTP method used for health checking.
                                                           Defaults to GET
+                                                        maxLength: 16
                                                         type: string
                                                       path:
                                                         description: Path defines
@@ -13415,6 +13732,45 @@ spec:
                                                         maxLength: 1024
                                                         minLength: 1
                                                         type: string
+                                                      requestBody:
+                                                        description: RequestBody defines
+                                                          the HTTP request body payload
+                                                          sent during health checking.
+                                                        properties:
+                                                          binary:
+                                                            description: Binary payload
+                                                              base64 encoded.
+                                                            format: byte
+                                                            type: string
+                                                          text:
+                                                            description: Text payload
+                                                              in plain text.
+                                                            type: string
+                                                          type:
+                                                            allOf:
+                                                            - enum:
+                                                              - Text
+                                                              - Binary
+                                                            - enum:
+                                                              - Text
+                                                              - Binary
+                                                            description: Type defines
+                                                              the type of the payload.
+                                                            type: string
+                                                        required:
+                                                        - type
+                                                        type: object
+                                                        x-kubernetes-validations:
+                                                        - message: If payload type
+                                                            is Text, text field needs
+                                                            to be set.
+                                                          rule: 'self.type == ''Text''
+                                                            ? has(self.text) : !has(self.text)'
+                                                        - message: If payload type
+                                                            is Binary, binary field
+                                                            needs to be set.
+                                                          rule: 'self.type == ''Binary''
+                                                            ? has(self.binary) : !has(self.binary)'
                                                       retriableStatuses:
                                                         description: |-
                                                           RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -13432,6 +13788,13 @@ spec:
                                                     required:
                                                     - path
                                                     type: object
+                                                    x-kubernetes-validations:
+                                                    - message: The requestBody field
+                                                        can only be set when method
+                                                        is POST or PUT.
+                                                      rule: '!has(self.requestBody)
+                                                        || (has(self.method) && self.method.upperAscii()
+                                                        in [''POST'',''PUT''])'
                                                   initialJitter:
                                                     description: |-
                                                       InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -13799,6 +14162,44 @@ spec:
                                                     items:
                                                       type: string
                                                     type: array
+                                                  outOfBand:
+                                                    description: |-
+                                                      OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                                      server-streaming gRPC connection to each endpoint's
+                                                      xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                                      reports periodically, instead of relying on in-band ORCA metrics
+                                                      carried in response headers/trailers.
+
+                                                      The backend must implement OpenRcaService for this to take effect.
+                                                    properties:
+                                                      authority:
+                                                        description: |-
+                                                          Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                                          If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                                          the cluster name.
+                                                        maxLength: 259
+                                                        minLength: 1
+                                                        pattern: ^[^\x00\n\r]*$
+                                                        type: string
+                                                      port:
+                                                        description: |-
+                                                          Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                                          reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                                        format: int32
+                                                        maximum: 65535
+                                                        minimum: 1
+                                                        type: integer
+                                                      reportingPeriod:
+                                                        description: |-
+                                                          ReportingPeriod is how often Envoy requests load reports from the server.
+                                                          Must be greater than 0. Defaults to 10s.
+                                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                                        type: string
+                                                        x-kubernetes-validations:
+                                                        - message: reportingPeriod
+                                                            must be greater than 0
+                                                          rule: duration(self) > duration('0s')
+                                                    type: object
                                                   weightExpirationPeriod:
                                                     description: If a given endpoint
                                                       has not reported load metrics
@@ -14509,6 +14910,71 @@ spec:
                         minItems: 1
                         type: array
                     type: object
+                  healthCheckLog:
+                    description: HealthCheckLog defines health check event logging
+                      for xRoute-backed clusters.
+                    properties:
+                      matches:
+                        description: |-
+                          Matches defines which health check probe outcomes produce a log entry.
+                          When omitted or empty, all events are logged.
+
+                          Each value must be unique. Multiple values are ORed. If any failure type is
+                          specified then a success type must also be specified, and vice versa.
+                        items:
+                          description: ProxyHealthCheckLogEventType specifies which
+                            health check probe outcomes produce a log entry.
+                          enum:
+                          - Failure
+                          - FailureSeriesStart
+                          - Success
+                          - HealthyTransition
+                          type: string
+                        maxItems: 4
+                        type: array
+                        x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: a failure type and a success type must both be
+                            specified together
+                          rule: self.exists(e, e == 'Failure' || e == 'FailureSeriesStart')
+                            == self.exists(e, e == 'Success' || e == 'HealthyTransition')
+                      sinks:
+                        description: |-
+                          Sinks defines where health check events are written.
+                          When omitted, events are written to /dev/stdout.
+                        items:
+                          description: ProxyHealthCheckLogSink defines a destination
+                            for health check event logs.
+                          properties:
+                            file:
+                              description: |-
+                                File defines the file sink configuration.
+                                Required when type is File.
+                              properties:
+                                path:
+                                  description: |-
+                                    Path specifies the file path for health check event output.
+                                    Use /dev/stdout to write to standard output.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type:
+                              description: Type defines the type of sink.
+                              enum:
+                              - File
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: If ProxyHealthCheckLogSink type is File, file
+                              field needs to be set.
+                            rule: 'self.type == ''File'' ? has(self.file) : !has(self.file)'
+                        maxItems: 1
+                        type: array
+                    type: object
                   metrics:
                     description: Metrics defines metrics configuration for managed
                       proxies.
@@ -15050,6 +15516,82 @@ spec:
                                                     server and not to a specific service.
                                                   type: string
                                               type: object
+                                            healthCheckLog:
+                                              description: |-
+                                                HealthCheckLog defines health check event logging configuration for this cluster.
+                                                When set, HC probe outcomes are logged to the configured sinks.
+                                                Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                              properties:
+                                                matches:
+                                                  description: |-
+                                                    Matches defines which health check probe outcomes produce a log entry.
+                                                    When omitted or empty, all events are logged.
+
+                                                    Each value must be unique. Multiple values are ORed. If any failure type is
+                                                    specified then a success type must also be specified, and vice versa.
+                                                  items:
+                                                    description: ProxyHealthCheckLogEventType
+                                                      specifies which health check
+                                                      probe outcomes produce a log
+                                                      entry.
+                                                    enum:
+                                                    - Failure
+                                                    - FailureSeriesStart
+                                                    - Success
+                                                    - HealthyTransition
+                                                    type: string
+                                                  maxItems: 4
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                                  x-kubernetes-validations:
+                                                  - message: a failure type and a
+                                                      success type must both be specified
+                                                      together
+                                                    rule: self.exists(e, e == 'Failure'
+                                                      || e == 'FailureSeriesStart')
+                                                      == self.exists(e, e == 'Success'
+                                                      || e == 'HealthyTransition')
+                                                sinks:
+                                                  description: |-
+                                                    Sinks defines where health check events are written.
+                                                    When omitted, events are written to /dev/stdout.
+                                                  items:
+                                                    description: ProxyHealthCheckLogSink
+                                                      defines a destination for health
+                                                      check event logs.
+                                                    properties:
+                                                      file:
+                                                        description: |-
+                                                          File defines the file sink configuration.
+                                                          Required when type is File.
+                                                        properties:
+                                                          path:
+                                                            description: |-
+                                                              Path specifies the file path for health check event output.
+                                                              Use /dev/stdout to write to standard output.
+                                                            minLength: 1
+                                                            type: string
+                                                        required:
+                                                        - path
+                                                        type: object
+                                                      type:
+                                                        description: Type defines
+                                                          the type of sink.
+                                                        enum:
+                                                        - File
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                    x-kubernetes-validations:
+                                                    - message: If ProxyHealthCheckLogSink
+                                                        type is File, file field needs
+                                                        to be set.
+                                                      rule: 'self.type == ''File''
+                                                        ? has(self.file) : !has(self.file)'
+                                                  maxItems: 1
+                                                  type: array
+                                              type: object
                                             healthyThreshold:
                                               default: 1
                                               description: HealthyThreshold defines
@@ -15125,6 +15667,7 @@ spec:
                                                   description: |-
                                                     Method defines the HTTP method used for health checking.
                                                     Defaults to GET
+                                                  maxLength: 16
                                                   type: string
                                                 path:
                                                   description: Path defines the HTTP
@@ -15133,6 +15676,43 @@ spec:
                                                   maxLength: 1024
                                                   minLength: 1
                                                   type: string
+                                                requestBody:
+                                                  description: RequestBody defines
+                                                    the HTTP request body payload
+                                                    sent during health checking.
+                                                  properties:
+                                                    binary:
+                                                      description: Binary payload
+                                                        base64 encoded.
+                                                      format: byte
+                                                      type: string
+                                                    text:
+                                                      description: Text payload in
+                                                        plain text.
+                                                      type: string
+                                                    type:
+                                                      allOf:
+                                                      - enum:
+                                                        - Text
+                                                        - Binary
+                                                      - enum:
+                                                        - Text
+                                                        - Binary
+                                                      description: Type defines the
+                                                        type of the payload.
+                                                      type: string
+                                                  required:
+                                                  - type
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: If payload type is Text,
+                                                      text field needs to be set.
+                                                    rule: 'self.type == ''Text'' ?
+                                                      has(self.text) : !has(self.text)'
+                                                  - message: If payload type is Binary,
+                                                      binary field needs to be set.
+                                                    rule: 'self.type == ''Binary''
+                                                      ? has(self.binary) : !has(self.binary)'
                                                 retriableStatuses:
                                                   description: |-
                                                     RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -15149,6 +15729,12 @@ spec:
                                               required:
                                               - path
                                               type: object
+                                              x-kubernetes-validations:
+                                              - message: The requestBody field can
+                                                  only be set when method is POST
+                                                  or PUT.
+                                                rule: '!has(self.requestBody) || (has(self.method)
+                                                  && self.method.upperAscii() in [''POST'',''PUT''])'
                                             initialJitter:
                                               description: |-
                                                 InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -15500,6 +16086,44 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            outOfBand:
+                                              description: |-
+                                                OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                                server-streaming gRPC connection to each endpoint's
+                                                xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                                reports periodically, instead of relying on in-band ORCA metrics
+                                                carried in response headers/trailers.
+
+                                                The backend must implement OpenRcaService for this to take effect.
+                                              properties:
+                                                authority:
+                                                  description: |-
+                                                    Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                                    If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                                    the cluster name.
+                                                  maxLength: 259
+                                                  minLength: 1
+                                                  pattern: ^[^\x00\n\r]*$
+                                                  type: string
+                                                port:
+                                                  description: |-
+                                                    Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                                    reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                                  format: int32
+                                                  maximum: 65535
+                                                  minimum: 1
+                                                  type: integer
+                                                reportingPeriod:
+                                                  description: |-
+                                                    ReportingPeriod is how often Envoy requests load reports from the server.
+                                                    Must be greater than 0. Defaults to 10s.
+                                                  pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                                  type: string
+                                                  x-kubernetes-validations:
+                                                  - message: reportingPeriod must
+                                                      be greater than 0
+                                                    rule: duration(self) > duration('0s')
+                                              type: object
                                             weightExpirationPeriod:
                                               description: If a given endpoint has
                                                 not reported load metrics in this
@@ -16189,6 +16813,28 @@ spec:
                       Tracing defines tracing configuration for managed proxies.
                       If unspecified, will not send tracing data.
                     properties:
+                      clientSamplingFraction:
+                        description: |-
+                          ClientSamplingFraction represents the fraction of requests that should be
+                          selected for tracing when requested by the client.
+                          If unspecified, client-forced tracing is disabled by default and users must
+                          set this field to opt in.
+                        properties:
+                          denominator:
+                            default: 100
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          numerator:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        required:
+                        - numerator
+                        type: object
+                        x-kubernetes-validations:
+                        - message: numerator must be less than or equal to denominator
+                          rule: self.numerator <= self.denominator
                       customTags:
                         additionalProperties:
                           properties:
@@ -16253,6 +16899,26 @@ spec:
 
                           Deprecated: Use Tags instead.
                         type: object
+                      overallSamplingFraction:
+                        description: |-
+                          OverallSamplingFraction represents the fraction of requests that should be
+                          selected for tracing after all other sampling checks have been applied.
+                        properties:
+                          denominator:
+                            default: 100
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          numerator:
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        required:
+                        - numerator
+                        type: object
+                        x-kubernetes-validations:
+                        - message: numerator must be less than or equal to denominator
+                          rule: self.numerator <= self.denominator
                       provider:
                         description: Provider defines the tracing provider.
                         properties:
@@ -16660,6 +17326,79 @@ spec:
                                               server and not to a specific service.
                                             type: string
                                         type: object
+                                      healthCheckLog:
+                                        description: |-
+                                          HealthCheckLog defines health check event logging configuration for this cluster.
+                                          When set, HC probe outcomes are logged to the configured sinks.
+                                          Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                        properties:
+                                          matches:
+                                            description: |-
+                                              Matches defines which health check probe outcomes produce a log entry.
+                                              When omitted or empty, all events are logged.
+
+                                              Each value must be unique. Multiple values are ORed. If any failure type is
+                                              specified then a success type must also be specified, and vice versa.
+                                            items:
+                                              description: ProxyHealthCheckLogEventType
+                                                specifies which health check probe
+                                                outcomes produce a log entry.
+                                              enum:
+                                              - Failure
+                                              - FailureSeriesStart
+                                              - Success
+                                              - HealthyTransition
+                                              type: string
+                                            maxItems: 4
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                            x-kubernetes-validations:
+                                            - message: a failure type and a success
+                                                type must both be specified together
+                                              rule: self.exists(e, e == 'Failure'
+                                                || e == 'FailureSeriesStart') == self.exists(e,
+                                                e == 'Success' || e == 'HealthyTransition')
+                                          sinks:
+                                            description: |-
+                                              Sinks defines where health check events are written.
+                                              When omitted, events are written to /dev/stdout.
+                                            items:
+                                              description: ProxyHealthCheckLogSink
+                                                defines a destination for health check
+                                                event logs.
+                                              properties:
+                                                file:
+                                                  description: |-
+                                                    File defines the file sink configuration.
+                                                    Required when type is File.
+                                                  properties:
+                                                    path:
+                                                      description: |-
+                                                        Path specifies the file path for health check event output.
+                                                        Use /dev/stdout to write to standard output.
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type:
+                                                  description: Type defines the type
+                                                    of sink.
+                                                  enum:
+                                                  - File
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: If ProxyHealthCheckLogSink
+                                                  type is File, file field needs to
+                                                  be set.
+                                                rule: 'self.type == ''File'' ? has(self.file)
+                                                  : !has(self.file)'
+                                            maxItems: 1
+                                            type: array
+                                        type: object
                                       healthyThreshold:
                                         default: 1
                                         description: HealthyThreshold defines the
@@ -16734,6 +17473,7 @@ spec:
                                             description: |-
                                               Method defines the HTTP method used for health checking.
                                               Defaults to GET
+                                            maxLength: 16
                                             type: string
                                           path:
                                             description: Path defines the HTTP path
@@ -16742,6 +17482,43 @@ spec:
                                             maxLength: 1024
                                             minLength: 1
                                             type: string
+                                          requestBody:
+                                            description: RequestBody defines the HTTP
+                                              request body payload sent during health
+                                              checking.
+                                            properties:
+                                              binary:
+                                                description: Binary payload base64
+                                                  encoded.
+                                                format: byte
+                                                type: string
+                                              text:
+                                                description: Text payload in plain
+                                                  text.
+                                                type: string
+                                              type:
+                                                allOf:
+                                                - enum:
+                                                  - Text
+                                                  - Binary
+                                                - enum:
+                                                  - Text
+                                                  - Binary
+                                                description: Type defines the type
+                                                  of the payload.
+                                                type: string
+                                            required:
+                                            - type
+                                            type: object
+                                            x-kubernetes-validations:
+                                            - message: If payload type is Text, text
+                                                field needs to be set.
+                                              rule: 'self.type == ''Text'' ? has(self.text)
+                                                : !has(self.text)'
+                                            - message: If payload type is Binary,
+                                                binary field needs to be set.
+                                              rule: 'self.type == ''Binary'' ? has(self.binary)
+                                                : !has(self.binary)'
                                           retriableStatuses:
                                             description: |-
                                               RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -16758,6 +17535,11 @@ spec:
                                         required:
                                         - path
                                         type: object
+                                        x-kubernetes-validations:
+                                        - message: The requestBody field can only
+                                            be set when method is POST or PUT.
+                                          rule: '!has(self.requestBody) || (has(self.method)
+                                            && self.method.upperAscii() in [''POST'',''PUT''])'
                                       initialJitter:
                                         description: |-
                                           InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -17108,6 +17890,44 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      outOfBand:
+                                        description: |-
+                                          OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                          server-streaming gRPC connection to each endpoint's
+                                          xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                          reports periodically, instead of relying on in-band ORCA metrics
+                                          carried in response headers/trailers.
+
+                                          The backend must implement OpenRcaService for this to take effect.
+                                        properties:
+                                          authority:
+                                            description: |-
+                                              Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                              If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                              the cluster name.
+                                            maxLength: 259
+                                            minLength: 1
+                                            pattern: ^[^\x00\n\r]*$
+                                            type: string
+                                          port:
+                                            description: |-
+                                              Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                              reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
+                                          reportingPeriod:
+                                            description: |-
+                                              ReportingPeriod is how often Envoy requests load reports from the server.
+                                              Must be greater than 0. Defaults to 10s.
+                                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: reportingPeriod must be greater
+                                                than 0
+                                              rule: duration(self) > duration('0s')
+                                        type: object
                                       weightExpirationPeriod:
                                         description: If a given endpoint has not reported
                                           load metrics in this long, stop using the
@@ -17887,6 +18707,9 @@ spec:
                       rule: '!(has(self.samplingRate) && has(self.samplingFraction))'
                 type: object
             type: object
+            x-kubernetes-validations:
+            - message: mergeGateways and mergeBackends cannot both be enabled
+              rule: '!(has(self.mergeGateways) && self.mergeGateways && has(self.mergeBackends))'
           status:
             description: EnvoyProxyStatus defines the actual state of EnvoyProxy.
             properties:

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
@@ -124,8 +124,15 @@ spec:
                 - credential
                 type: object
               directResponse:
-                description: HTTPDirectResponseFilter defines the configuration to
-                  return a fixed response.
+                description: |-
+                  DirectResponse returns a fixed response for matching requests.
+
+                  When this filter is referenced from a GRPCRoute, only a non-2xx status code
+                  is supported. gRPC signals success with a grpc-status trailer and a response
+                  message, which a direct response cannot produce, so a 2xx status code (which
+                  maps to the gRPC OK status) yields an invalid response for gRPC clients. Use a
+                  non-2xx status code to deny or block gRPC requests (e.g. 403 maps to
+                  PERMISSION_DENIED, 404 to UNIMPLEMENTED, 429/503 to UNAVAILABLE).
                 properties:
                   body:
                     description: |-
@@ -346,6 +353,8 @@ spec:
                     description: |-
                       Status Code of the HTTP response
                       If unset, defaults to 200.
+                      Note: when this filter is referenced from a GRPCRoute, a 2xx status code
+                      (including the default 200) is rejected; a non-2xx status code must be set.
                     type: integer
                 type: object
               matches:
@@ -415,12 +424,48 @@ spec:
                         description: Header is the name of the header whose value
                           would be used to rewrite the Host header
                         type: string
+                      pathRegex:
+                        description: |-
+                          PathRegex defines a regex match and substitution applied to the request path to compute
+                          the rewritten Host header.
+                          For example, with:
+                          pathRegex:
+                            pattern: "^/tenant/([a-z0-9-]+)/.*"
+                            substitution: "\\1.example.internal"
+                          a request to "http://foo.bar.com/tenant/tenant1/api/v1" has its upstream Host header rewritten
+                          to "tenant1.example.internal" (the request path "/tenant/tenant1/api/v1" is preserved).
+                        properties:
+                          pattern:
+                            description: |-
+                              Pattern matches a regular expression against the value of the HTTP Path. The regex string must
+                              adhere to the syntax documented in https://github.com/google/re2/wiki/Syntax.
+                            minLength: 1
+                            type: string
+                          substitution:
+                            description: |-
+                              Substitution is an expression that replaces the matched portion. The expression may include numbered
+                              capture groups that adhere to syntax documented in https://github.com/google/re2/wiki/Syntax.
+
+                              The resulting value is used as the upstream Host header and should be constrained to a valid
+                              DNS hostname by using explicit regex capture groups in Pattern.
+
+                              The NUL, CR, and LF characters are not allowed: they are invalid in an HTTP header value and are
+                              rejected by the Envoy proto (well_known_regex HTTP_HEADER_VALUE), which would otherwise cause the
+                              generated configuration to be rejected by the data plane.
+                            minLength: 1
+                            pattern: ^[^\r\n\x00]*$
+                            type: string
+                        required:
+                        - pattern
+                        - substitution
+                        type: object
                       type:
                         description: HTTPPathModifierType defines the type of Hostname
                           rewrite.
                         enum:
                         - Header
                         - Backend
+                        - PathRegex
                         type: string
                     required:
                     - type
@@ -430,6 +475,10 @@ spec:
                       rule: '!(has(self.header) && self.type != ''Header'')'
                     - message: header must be specified for Header type
                       rule: '!(!has(self.header) && self.type == ''Header'')'
+                    - message: pathRegex must be nil if the type is not PathRegex
+                      rule: '!(has(self.pathRegex) && self.type != ''PathRegex'')'
+                    - message: pathRegex must be specified for PathRegex type
+                      rule: '!(!has(self.pathRegex) && self.type == ''PathRegex'')'
                   path:
                     description: Path defines a path rewrite.
                     properties:

--- a/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+++ b/charts/envoy-gateway/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
@@ -201,6 +201,35 @@ spec:
                           - Allow
                           - Deny
                           type: string
+                        cel:
+                          description: |-
+                            CEL specifies a Common Expression Language expression to evaluate for the
+                            request. If specified, the expression must evaluate to true for the rule to match.
+
+                            The expression can use Envoy attributes exposed to the CEL runtime.
+                            Request attributes, such as request.path, request.url_path, request.host,
+                            request.scheme, request.method, request.headers, and request.query, are
+                            generally available during authorization. Connection attributes, such as
+                            source.address, source.port, destination.address, destination.port,
+                            connection.mtls, and connection.requested_server_name, may also be used.
+                            Dynamic metadata and filter state produced by earlier filters may also be
+                            available through attributes such as metadata and filter_state.
+                            Response attributes are only available after the request completes and
+                            should not be used for authorization decisions.
+
+                            For more details, see:
+                            https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+
+                            The rule matches only when the expression evaluates to a boolean true.
+                            Non-boolean results, false, null, and CEL evaluation errors are treated as
+                            no match.
+
+                            Examples:
+                            `request.headers['x-tenant'] == 'team-a'`
+                            `request.method == 'POST' && request.path.startsWith('/admin')`
+                          maxLength: 4096
+                          minLength: 1
+                          type: string
                         name:
                           description: |-
                             Name is a user-friendly name for the rule.
@@ -245,9 +274,37 @@ spec:
                               maxItems: 16
                               minItems: 1
                               type: array
-                          required:
-                          - methods
+                            path:
+                              description: |-
+                                Path is the HTTP path of the request.
+                                Support Exact, PathPrefix and RegularExpression match types.
+                              properties:
+                                invert:
+                                  default: false
+                                  description: Invert specifies whether the value
+                                    match result will be inverted.
+                                  type: boolean
+                                type:
+                                  default: PathPrefix
+                                  description: Type specifies how to match against
+                                    the value of the path.
+                                  enum:
+                                  - Exact
+                                  - PathPrefix
+                                  - RegularExpression
+                                  type: string
+                                value:
+                                  default: /
+                                  description: Value specifies the HTTP path.
+                                  maxLength: 1024
+                                  type: string
+                              required:
+                              - value
+                              type: object
                           type: object
+                          x-kubernetes-validations:
+                          - message: at least one of methods or path must be specified
+                            rule: has(self.methods) || has(self.path)
                         principal:
                           description: |-
                             Principal specifies the client identity of a request.
@@ -292,7 +349,8 @@ spec:
 
                                 If multiple entries are specified,  one of the ClientIPGeoLocation entries must match for the rule to match.
 
-                                The client IP is inferred from the X-Forwarded-For header or a custom header.
+                                The client IP is inferred from the X-Forwarded-For header, a custom header, or the
+                                direct downstream connection source address (the TCP peer of the connection terminated by Envoy).
                                 You can use the `ClientIPDetection` field in the `ClientTrafficPolicy` to configure the client IP detection.
                               items:
                                 description: ClientIPGeoLocation specifies geolocation-based
@@ -494,8 +552,10 @@ spec:
                               || has(self.clientIPGeoLocations))
                       required:
                       - action
-                      - principal
                       type: object
+                      x-kubernetes-validations:
+                      - message: at least one of principal or cel must be specified
+                        rule: has(self.principal) || has(self.cel)
                     type: array
                 type: object
               basicAuth:
@@ -609,9 +669,11 @@ spec:
                         - http://foo.example.com:8080
                         - http://*.example.com:8080
                         - https://*
+                        - moz-extension://example.com
+                        - foo://*.example.com:8080
                       maxLength: 253
                       minLength: 1
-                      pattern: ^(\*|https?:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      pattern: ^(\*|[A-Za-z][A-Za-z0-9+.-]*:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
                       type: string
                     type: array
                   exposeHeaders:
@@ -629,6 +691,75 @@ spec:
                       It specifies the value in the Access-Control-Max-Age CORS response header..
                     pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                     type: string
+                type: object
+              csrf:
+                description: |-
+                  CSRF defines the configuration for Cross-Site Request Forgery (CSRF) protection.
+                  When enabled, the CSRF filter checks that the Origin header matches the destination
+                  or one of the additional allowed origins on mutating requests (POST, PUT, DELETE, PATCH).
+                properties:
+                  additionalOrigins:
+                    description: |-
+                      AdditionalOrigins specifies additional origins that are allowed to make mutating
+                      requests, beyond the destination origin. A request whose Origin header matches one
+                      of them is allowed. The value "*" allows any origin, which effectively disables
+                      origin validation.
+
+                      Note: Envoy's CSRF filter compares the host and port of the origin only, so the
+                      scheme is ignored: "https://www.example.com" and "http://www.example.com" are
+                      equivalent here, and both allow the request regardless of the scheme the client
+                      used.
+                    items:
+                      description: |-
+                        Origin is defined by the scheme (protocol), hostname (domain), and port of
+                        the URL used to access it. The hostname can be "precise" which is just the
+                        domain name or "wildcard" which is a domain name prefixed with a single
+                        wildcard label such as "*.example.com".
+                        In addition to that a single wildcard (with or without scheme) can be
+                        configured to match any origin.
+
+                        For example, the following are valid origins:
+                        - https://foo.example.com
+                        - https://*.example.com
+                        - http://foo.example.com:8080
+                        - http://*.example.com:8080
+                        - https://*
+                        - moz-extension://example.com
+                        - foo://*.example.com:8080
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^(\*|[A-Za-z][A-Za-z0-9+.-]*:\/\/(\*|(\*\.)?(([\w-]+\.?)+)?[\w-]+)(:\d{1,5})?)$
+                      type: string
+                    maxItems: 16
+                    type: array
+                  shadowFraction:
+                    description: |-
+                      ShadowFraction represents the fraction of requests for which the CSRF policy is
+                      evaluated in shadow (dry-run) mode. For these requests, the filter records whether
+                      the request would have been allowed or rejected in the `csrf.request_valid` and
+                      `csrf.request_invalid` stats, but always lets the request through. The remaining
+                      requests are enforced, i.e. a mutating request with a missing or non-matching
+                      Origin header is rejected with a 403.
+
+                      Defaults to 0% (all requests are enforced) if not specified. Set it to 100% to
+                      dry run the filter, watch the stats to find origins that would be rejected, then
+                      lower it to roll enforcement out gradually.
+                    properties:
+                      denominator:
+                        default: 100
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      numerator:
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    required:
+                    - numerator
+                    type: object
+                    x-kubernetes-validations:
+                    - message: numerator must be less than or equal to denominator
+                      rule: self.numerator <= self.denominator
                 type: object
               extAuth:
                 description: ExtAuth defines the configuration for External Authorization.
@@ -1146,6 +1277,77 @@ spec:
                                           server and not to a specific service.
                                         type: string
                                     type: object
+                                  healthCheckLog:
+                                    description: |-
+                                      HealthCheckLog defines health check event logging configuration for this cluster.
+                                      When set, HC probe outcomes are logged to the configured sinks.
+                                      Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                    properties:
+                                      matches:
+                                        description: |-
+                                          Matches defines which health check probe outcomes produce a log entry.
+                                          When omitted or empty, all events are logged.
+
+                                          Each value must be unique. Multiple values are ORed. If any failure type is
+                                          specified then a success type must also be specified, and vice versa.
+                                        items:
+                                          description: ProxyHealthCheckLogEventType
+                                            specifies which health check probe outcomes
+                                            produce a log entry.
+                                          enum:
+                                          - Failure
+                                          - FailureSeriesStart
+                                          - Success
+                                          - HealthyTransition
+                                          type: string
+                                        maxItems: 4
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                        - message: a failure type and a success type
+                                            must both be specified together
+                                          rule: self.exists(e, e == 'Failure' || e
+                                            == 'FailureSeriesStart') == self.exists(e,
+                                            e == 'Success' || e == 'HealthyTransition')
+                                      sinks:
+                                        description: |-
+                                          Sinks defines where health check events are written.
+                                          When omitted, events are written to /dev/stdout.
+                                        items:
+                                          description: ProxyHealthCheckLogSink defines
+                                            a destination for health check event logs.
+                                          properties:
+                                            file:
+                                              description: |-
+                                                File defines the file sink configuration.
+                                                Required when type is File.
+                                              properties:
+                                                path:
+                                                  description: |-
+                                                    Path specifies the file path for health check event output.
+                                                    Use /dev/stdout to write to standard output.
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of
+                                                sink.
+                                              enum:
+                                              - File
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: If ProxyHealthCheckLogSink type
+                                              is File, file field needs to be set.
+                                            rule: 'self.type == ''File'' ? has(self.file)
+                                              : !has(self.file)'
+                                        maxItems: 1
+                                        type: array
+                                    type: object
                                   healthyThreshold:
                                     default: 1
                                     description: HealthyThreshold defines the number
@@ -1217,6 +1419,7 @@ spec:
                                         description: |-
                                           Method defines the HTTP method used for health checking.
                                           Defaults to GET
+                                        maxLength: 16
                                         type: string
                                       path:
                                         description: Path defines the HTTP path that
@@ -1224,6 +1427,41 @@ spec:
                                         maxLength: 1024
                                         minLength: 1
                                         type: string
+                                      requestBody:
+                                        description: RequestBody defines the HTTP
+                                          request body payload sent during health
+                                          checking.
+                                        properties:
+                                          binary:
+                                            description: Binary payload base64 encoded.
+                                            format: byte
+                                            type: string
+                                          text:
+                                            description: Text payload in plain text.
+                                            type: string
+                                          type:
+                                            allOf:
+                                            - enum:
+                                              - Text
+                                              - Binary
+                                            - enum:
+                                              - Text
+                                              - Binary
+                                            description: Type defines the type of
+                                              the payload.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: If payload type is Text, text field
+                                            needs to be set.
+                                          rule: 'self.type == ''Text'' ? has(self.text)
+                                            : !has(self.text)'
+                                        - message: If payload type is Binary, binary
+                                            field needs to be set.
+                                          rule: 'self.type == ''Binary'' ? has(self.binary)
+                                            : !has(self.binary)'
                                       retriableStatuses:
                                         description: |-
                                           RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -1240,6 +1478,11 @@ spec:
                                     required:
                                     - path
                                     type: object
+                                    x-kubernetes-validations:
+                                    - message: The requestBody field can only be set
+                                        when method is POST or PUT.
+                                      rule: '!has(self.requestBody) || (has(self.method)
+                                        && self.method.upperAscii() in [''POST'',''PUT''])'
                                   initialJitter:
                                     description: |-
                                       InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -1580,6 +1823,44 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  outOfBand:
+                                    description: |-
+                                      OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                      server-streaming gRPC connection to each endpoint's
+                                      xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                      reports periodically, instead of relying on in-band ORCA metrics
+                                      carried in response headers/trailers.
+
+                                      The backend must implement OpenRcaService for this to take effect.
+                                    properties:
+                                      authority:
+                                        description: |-
+                                          Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                          If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                          the cluster name.
+                                        maxLength: 259
+                                        minLength: 1
+                                        pattern: ^[^\x00\n\r]*$
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                          reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                        format: int32
+                                        maximum: 65535
+                                        minimum: 1
+                                        type: integer
+                                      reportingPeriod:
+                                        description: |-
+                                          ReportingPeriod is how often Envoy requests load reports from the server.
+                                          Must be greater than 0. Defaults to 10s.
+                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: reportingPeriod must be greater
+                                            than 0
+                                          rule: duration(self) > duration('0s')
+                                    type: object
                                   weightExpirationPeriod:
                                     description: If a given endpoint has not reported
                                       load metrics in this long, stop using the reported
@@ -2550,6 +2831,77 @@ spec:
                                           server and not to a specific service.
                                         type: string
                                     type: object
+                                  healthCheckLog:
+                                    description: |-
+                                      HealthCheckLog defines health check event logging configuration for this cluster.
+                                      When set, HC probe outcomes are logged to the configured sinks.
+                                      Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                    properties:
+                                      matches:
+                                        description: |-
+                                          Matches defines which health check probe outcomes produce a log entry.
+                                          When omitted or empty, all events are logged.
+
+                                          Each value must be unique. Multiple values are ORed. If any failure type is
+                                          specified then a success type must also be specified, and vice versa.
+                                        items:
+                                          description: ProxyHealthCheckLogEventType
+                                            specifies which health check probe outcomes
+                                            produce a log entry.
+                                          enum:
+                                          - Failure
+                                          - FailureSeriesStart
+                                          - Success
+                                          - HealthyTransition
+                                          type: string
+                                        maxItems: 4
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                        - message: a failure type and a success type
+                                            must both be specified together
+                                          rule: self.exists(e, e == 'Failure' || e
+                                            == 'FailureSeriesStart') == self.exists(e,
+                                            e == 'Success' || e == 'HealthyTransition')
+                                      sinks:
+                                        description: |-
+                                          Sinks defines where health check events are written.
+                                          When omitted, events are written to /dev/stdout.
+                                        items:
+                                          description: ProxyHealthCheckLogSink defines
+                                            a destination for health check event logs.
+                                          properties:
+                                            file:
+                                              description: |-
+                                                File defines the file sink configuration.
+                                                Required when type is File.
+                                              properties:
+                                                path:
+                                                  description: |-
+                                                    Path specifies the file path for health check event output.
+                                                    Use /dev/stdout to write to standard output.
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of
+                                                sink.
+                                              enum:
+                                              - File
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: If ProxyHealthCheckLogSink type
+                                              is File, file field needs to be set.
+                                            rule: 'self.type == ''File'' ? has(self.file)
+                                              : !has(self.file)'
+                                        maxItems: 1
+                                        type: array
+                                    type: object
                                   healthyThreshold:
                                     default: 1
                                     description: HealthyThreshold defines the number
@@ -2621,6 +2973,7 @@ spec:
                                         description: |-
                                           Method defines the HTTP method used for health checking.
                                           Defaults to GET
+                                        maxLength: 16
                                         type: string
                                       path:
                                         description: Path defines the HTTP path that
@@ -2628,6 +2981,41 @@ spec:
                                         maxLength: 1024
                                         minLength: 1
                                         type: string
+                                      requestBody:
+                                        description: RequestBody defines the HTTP
+                                          request body payload sent during health
+                                          checking.
+                                        properties:
+                                          binary:
+                                            description: Binary payload base64 encoded.
+                                            format: byte
+                                            type: string
+                                          text:
+                                            description: Text payload in plain text.
+                                            type: string
+                                          type:
+                                            allOf:
+                                            - enum:
+                                              - Text
+                                              - Binary
+                                            - enum:
+                                              - Text
+                                              - Binary
+                                            description: Type defines the type of
+                                              the payload.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: If payload type is Text, text field
+                                            needs to be set.
+                                          rule: 'self.type == ''Text'' ? has(self.text)
+                                            : !has(self.text)'
+                                        - message: If payload type is Binary, binary
+                                            field needs to be set.
+                                          rule: 'self.type == ''Binary'' ? has(self.binary)
+                                            : !has(self.binary)'
                                       retriableStatuses:
                                         description: |-
                                           RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -2644,6 +3032,11 @@ spec:
                                     required:
                                     - path
                                     type: object
+                                    x-kubernetes-validations:
+                                    - message: The requestBody field can only be set
+                                        when method is POST or PUT.
+                                      rule: '!has(self.requestBody) || (has(self.method)
+                                        && self.method.upperAscii() in [''POST'',''PUT''])'
                                   initialJitter:
                                     description: |-
                                       InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -2984,6 +3377,44 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  outOfBand:
+                                    description: |-
+                                      OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                      server-streaming gRPC connection to each endpoint's
+                                      xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                      reports periodically, instead of relying on in-band ORCA metrics
+                                      carried in response headers/trailers.
+
+                                      The backend must implement OpenRcaService for this to take effect.
+                                    properties:
+                                      authority:
+                                        description: |-
+                                          Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                          If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                          the cluster name.
+                                        maxLength: 259
+                                        minLength: 1
+                                        pattern: ^[^\x00\n\r]*$
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                          reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                        format: int32
+                                        maximum: 65535
+                                        minimum: 1
+                                        type: integer
+                                      reportingPeriod:
+                                        description: |-
+                                          ReportingPeriod is how often Envoy requests load reports from the server.
+                                          Must be greater than 0. Defaults to 10s.
+                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: reportingPeriod must be greater
+                                            than 0
+                                          rule: duration(self) > duration('0s')
+                                    type: object
                                   weightExpirationPeriod:
                                     description: If a given endpoint has not reported
                                       load metrics in this long, stop using the reported
@@ -3654,10 +4085,26 @@ spec:
                 description: JWT defines the configuration for JSON Web Token (JWT)
                   authentication.
                 properties:
+                  failOpen:
+                    description: |-
+                      FailOpen lets a request pass JWT authentication even when its JWT is
+                      missing or invalid, rather than being rejected. This helps when a header
+                      that clients use to carry a JWT may also legitimately hold a non-JWT value
+                      that the backend relies on.
+
+                      A valid JWT is still verified and its claims forwarded as usual; only the
+                      rejection of requests with a missing or invalid JWT is relaxed. Because this
+                      does not enforce authentication on its own, pair it with an Authorization
+                      policy when access needs to be restricted.
+
+                      This is broader than Optional (which tolerates a missing JWT but still
+                      rejects an invalid one) and takes precedence over it.
+                    type: boolean
                   optional:
                     description: |-
                       Optional determines whether a missing JWT is acceptable, defaulting to false if not specified.
-                      Note: Even if optional is set to true, JWT authentication will still fail if an invalid JWT is presented.
+                      Note: Even if optional is set to true, JWT authentication will still fail if an invalid JWT
+                      is presented. See FailOpen if this is necessary for your use case.
                     type: boolean
                   providers:
                     description: |-
@@ -4230,6 +4677,80 @@ spec:
                                                 server and not to a specific service.
                                               type: string
                                           type: object
+                                        healthCheckLog:
+                                          description: |-
+                                            HealthCheckLog defines health check event logging configuration for this cluster.
+                                            When set, HC probe outcomes are logged to the configured sinks.
+                                            Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                          properties:
+                                            matches:
+                                              description: |-
+                                                Matches defines which health check probe outcomes produce a log entry.
+                                                When omitted or empty, all events are logged.
+
+                                                Each value must be unique. Multiple values are ORed. If any failure type is
+                                                specified then a success type must also be specified, and vice versa.
+                                              items:
+                                                description: ProxyHealthCheckLogEventType
+                                                  specifies which health check probe
+                                                  outcomes produce a log entry.
+                                                enum:
+                                                - Failure
+                                                - FailureSeriesStart
+                                                - Success
+                                                - HealthyTransition
+                                                type: string
+                                              maxItems: 4
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                              x-kubernetes-validations:
+                                              - message: a failure type and a success
+                                                  type must both be specified together
+                                                rule: self.exists(e, e == 'Failure'
+                                                  || e == 'FailureSeriesStart') ==
+                                                  self.exists(e, e == 'Success' ||
+                                                  e == 'HealthyTransition')
+                                            sinks:
+                                              description: |-
+                                                Sinks defines where health check events are written.
+                                                When omitted, events are written to /dev/stdout.
+                                              items:
+                                                description: ProxyHealthCheckLogSink
+                                                  defines a destination for health
+                                                  check event logs.
+                                                properties:
+                                                  file:
+                                                    description: |-
+                                                      File defines the file sink configuration.
+                                                      Required when type is File.
+                                                    properties:
+                                                      path:
+                                                        description: |-
+                                                          Path specifies the file path for health check event output.
+                                                          Use /dev/stdout to write to standard output.
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  type:
+                                                    description: Type defines the
+                                                      type of sink.
+                                                    enum:
+                                                    - File
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                                x-kubernetes-validations:
+                                                - message: If ProxyHealthCheckLogSink
+                                                    type is File, file field needs
+                                                    to be set.
+                                                  rule: 'self.type == ''File'' ? has(self.file)
+                                                    : !has(self.file)'
+                                              maxItems: 1
+                                              type: array
+                                          type: object
                                         healthyThreshold:
                                           default: 1
                                           description: HealthyThreshold defines the
@@ -4304,6 +4825,7 @@ spec:
                                               description: |-
                                                 Method defines the HTTP method used for health checking.
                                                 Defaults to GET
+                                              maxLength: 16
                                               type: string
                                             path:
                                               description: Path defines the HTTP path
@@ -4312,6 +4834,43 @@ spec:
                                               maxLength: 1024
                                               minLength: 1
                                               type: string
+                                            requestBody:
+                                              description: RequestBody defines the
+                                                HTTP request body payload sent during
+                                                health checking.
+                                              properties:
+                                                binary:
+                                                  description: Binary payload base64
+                                                    encoded.
+                                                  format: byte
+                                                  type: string
+                                                text:
+                                                  description: Text payload in plain
+                                                    text.
+                                                  type: string
+                                                type:
+                                                  allOf:
+                                                  - enum:
+                                                    - Text
+                                                    - Binary
+                                                  - enum:
+                                                    - Text
+                                                    - Binary
+                                                  description: Type defines the type
+                                                    of the payload.
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                              x-kubernetes-validations:
+                                              - message: If payload type is Text,
+                                                  text field needs to be set.
+                                                rule: 'self.type == ''Text'' ? has(self.text)
+                                                  : !has(self.text)'
+                                              - message: If payload type is Binary,
+                                                  binary field needs to be set.
+                                                rule: 'self.type == ''Binary'' ? has(self.binary)
+                                                  : !has(self.binary)'
                                             retriableStatuses:
                                               description: |-
                                                 RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -4328,6 +4887,11 @@ spec:
                                           required:
                                           - path
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: The requestBody field can only
+                                              be set when method is POST or PUT.
+                                            rule: '!has(self.requestBody) || (has(self.method)
+                                              && self.method.upperAscii() in [''POST'',''PUT''])'
                                         initialJitter:
                                           description: |-
                                             InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -4678,6 +5242,44 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                        outOfBand:
+                                          description: |-
+                                            OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                            server-streaming gRPC connection to each endpoint's
+                                            xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                            reports periodically, instead of relying on in-band ORCA metrics
+                                            carried in response headers/trailers.
+
+                                            The backend must implement OpenRcaService for this to take effect.
+                                          properties:
+                                            authority:
+                                              description: |-
+                                                Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                                If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                                the cluster name.
+                                              maxLength: 259
+                                              minLength: 1
+                                              pattern: ^[^\x00\n\r]*$
+                                              type: string
+                                            port:
+                                              description: |-
+                                                Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                                reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                              format: int32
+                                              maximum: 65535
+                                              minimum: 1
+                                              type: integer
+                                            reportingPeriod:
+                                              description: |-
+                                                ReportingPeriod is how often Envoy requests load reports from the server.
+                                                Must be greater than 0. Defaults to 10s.
+                                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                              type: string
+                                              x-kubernetes-validations:
+                                              - message: reportingPeriod must be greater
+                                                  than 0
+                                                rule: duration(self) > duration('0s')
+                                          type: object
                                         weightExpirationPeriod:
                                           description: If a given endpoint has not
                                             reported load metrics in this long, stop
@@ -5228,6 +5830,15 @@ spec:
                                 in GEP-2257, a strict subset of the syntax parsed by Golang time.ParseDuration.
                               pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                               type: string
+                            failedRefetchDuration:
+                              description: |-
+                                FailedRefetchDuration is the duration Envoy waits before re-fetching the JWKS
+                                after a failed fetch.
+                                This does not control retries within a single fetch attempt (see BackendSettings.Retry),
+                                only the interval between fetch attempts after a failure.
+                                If not specified, Envoy's default of 1 second is used.
+                              pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                              type: string
                             uri:
                               description: |-
                                 URI is the HTTPS URI to fetch the JWKS. Envoy's system trust bundle is used to validate the server certificate.
@@ -5265,12 +5876,18 @@ spec:
                 required:
                 - providers
                 type: object
+                x-kubernetes-validations:
+                - message: optional and failOpen cannot both be set; failOpen already
+                    tolerates a missing JWT
+                  rule: '!(has(self.optional) && has(self.failOpen))'
               mergeType:
                 description: |-
                   MergeType determines how this configuration is merged with existing SecurityPolicy
                   configurations targeting a parent resource. When set, this configuration will be merged
-                  into a parent SecurityPolicy (i.e. the one targeting a Gateway or Listener).
-                  This field cannot be set when targeting a parent resource (Gateway).
+                  into the closest parent SecurityPolicy in the route's attachment hierarchy (for
+                  example, one targeting a Gateway, Gateway listener, ListenerSet, or ListenerSet
+                  listener).
+                  Currently, this field can only be set when targeting xRoute resources.
                   If unset, no merging occurs, and only the most specific configuration takes effect.
                 type: string
                 x-kubernetes-validations:
@@ -5399,7 +6016,7 @@ spec:
                       If not set, the cookies will default to the host of the request, not including the subdomains.
                       If set, the cookies will be set on the specified domain and all subdomains.
                       This means that requests to any subdomain will not require reauthentication after users log in to the parent domain.
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9]))*$
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   cookieNames:
                     description: |-
@@ -5513,12 +6130,24 @@ spec:
                       If the configured header is "Authorization", EG forwards the ID token using
                       the "Bearer " prefix. For any other header, EG forwards the raw token value.
                       If not specified, the ID token will not be forwarded.
+
+                      Note: when passThroughAuthHeader is enabled, this header must not be the same
+                      as a header a JWT provider extracts from (the "Authorization" header by
+                      default). The forwarded ID token header is owned by Envoy, and Envoy rejects
+                      an OAuth2 configuration whose pass-through matcher keys on it.
                     properties:
                       header:
-                        description: Header is the upstream request header that will
-                          carry the ID token.
+                        description: |-
+                          Header is the upstream request header that will carry the ID token.
+                          It must be a valid HTTP header name. Pseudo-headers (names starting with ":")
+                          and the "Host" header are not allowed.
+                        maxLength: 256
                         minLength: 1
+                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                         type: string
+                        x-kubernetes-validations:
+                        - message: header cannot be the Host header
+                          rule: self.lowerAscii() != 'host'
                     required:
                     - header
                     type: object
@@ -5948,6 +6577,77 @@ spec:
                                           server and not to a specific service.
                                         type: string
                                     type: object
+                                  healthCheckLog:
+                                    description: |-
+                                      HealthCheckLog defines health check event logging configuration for this cluster.
+                                      When set, HC probe outcomes are logged to the configured sinks.
+                                      Takes precedence over the gateway-level EnvoyProxy.spec.telemetry.healthCheckLog.
+                                    properties:
+                                      matches:
+                                        description: |-
+                                          Matches defines which health check probe outcomes produce a log entry.
+                                          When omitted or empty, all events are logged.
+
+                                          Each value must be unique. Multiple values are ORed. If any failure type is
+                                          specified then a success type must also be specified, and vice versa.
+                                        items:
+                                          description: ProxyHealthCheckLogEventType
+                                            specifies which health check probe outcomes
+                                            produce a log entry.
+                                          enum:
+                                          - Failure
+                                          - FailureSeriesStart
+                                          - Success
+                                          - HealthyTransition
+                                          type: string
+                                        maxItems: 4
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                        - message: a failure type and a success type
+                                            must both be specified together
+                                          rule: self.exists(e, e == 'Failure' || e
+                                            == 'FailureSeriesStart') == self.exists(e,
+                                            e == 'Success' || e == 'HealthyTransition')
+                                      sinks:
+                                        description: |-
+                                          Sinks defines where health check events are written.
+                                          When omitted, events are written to /dev/stdout.
+                                        items:
+                                          description: ProxyHealthCheckLogSink defines
+                                            a destination for health check event logs.
+                                          properties:
+                                            file:
+                                              description: |-
+                                                File defines the file sink configuration.
+                                                Required when type is File.
+                                              properties:
+                                                path:
+                                                  description: |-
+                                                    Path specifies the file path for health check event output.
+                                                    Use /dev/stdout to write to standard output.
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            type:
+                                              description: Type defines the type of
+                                                sink.
+                                              enum:
+                                              - File
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: If ProxyHealthCheckLogSink type
+                                              is File, file field needs to be set.
+                                            rule: 'self.type == ''File'' ? has(self.file)
+                                              : !has(self.file)'
+                                        maxItems: 1
+                                        type: array
+                                    type: object
                                   healthyThreshold:
                                     default: 1
                                     description: HealthyThreshold defines the number
@@ -6019,6 +6719,7 @@ spec:
                                         description: |-
                                           Method defines the HTTP method used for health checking.
                                           Defaults to GET
+                                        maxLength: 16
                                         type: string
                                       path:
                                         description: Path defines the HTTP path that
@@ -6026,6 +6727,41 @@ spec:
                                         maxLength: 1024
                                         minLength: 1
                                         type: string
+                                      requestBody:
+                                        description: RequestBody defines the HTTP
+                                          request body payload sent during health
+                                          checking.
+                                        properties:
+                                          binary:
+                                            description: Binary payload base64 encoded.
+                                            format: byte
+                                            type: string
+                                          text:
+                                            description: Text payload in plain text.
+                                            type: string
+                                          type:
+                                            allOf:
+                                            - enum:
+                                              - Text
+                                              - Binary
+                                            - enum:
+                                              - Text
+                                              - Binary
+                                            description: Type defines the type of
+                                              the payload.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: If payload type is Text, text field
+                                            needs to be set.
+                                          rule: 'self.type == ''Text'' ? has(self.text)
+                                            : !has(self.text)'
+                                        - message: If payload type is Binary, binary
+                                            field needs to be set.
+                                          rule: 'self.type == ''Binary'' ? has(self.binary)
+                                            : !has(self.binary)'
                                       retriableStatuses:
                                         description: |-
                                           RetriableStatuses defines a list of HTTP response statuses considered retriable.
@@ -6042,6 +6778,11 @@ spec:
                                     required:
                                     - path
                                     type: object
+                                    x-kubernetes-validations:
+                                    - message: The requestBody field can only be set
+                                        when method is POST or PUT.
+                                      rule: '!has(self.requestBody) || (has(self.method)
+                                        && self.method.upperAscii() in [''POST'',''PUT''])'
                                   initialJitter:
                                     description: |-
                                       InitialJitter defines the maximum time Envoy will wait before the first health check.
@@ -6382,6 +7123,44 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  outOfBand:
+                                    description: |-
+                                      OutOfBand enables out-of-band ORCA load reporting. When set, Envoy opens a
+                                      server-streaming gRPC connection to each endpoint's
+                                      xds.service.orca.v3.OpenRcaService/StreamCoreMetrics and pulls load
+                                      reports periodically, instead of relying on in-band ORCA metrics
+                                      carried in response headers/trailers.
+
+                                      The backend must implement OpenRcaService for this to take effect.
+                                    properties:
+                                      authority:
+                                        description: |-
+                                          Authority overrides the :authority header on the OutOfBand gRPC stream.
+                                          If unset, Envoy uses the endpoint hostname, then the dialed address, then
+                                          the cluster name.
+                                        maxLength: 259
+                                        minLength: 1
+                                        pattern: ^[^\x00\n\r]*$
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Port overrides the port used for the OutOfBand reporting connection, e.g. to
+                                          reach a separate reporting sidecar. Defaults to the endpoint's port.
+                                        format: int32
+                                        maximum: 65535
+                                        minimum: 1
+                                        type: integer
+                                      reportingPeriod:
+                                        description: |-
+                                          ReportingPeriod is how often Envoy requests load reports from the server.
+                                          Must be greater than 0. Defaults to 10s.
+                                        pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: reportingPeriod must be greater
+                                            than 0
+                                          rule: duration(self) > duration('0s')
+                                    type: object
                                   weightExpirationPeriod:
                                     description: If a given endpoint has not reported
                                       load metrics in this long, stop using the reported
@@ -7245,19 +8024,25 @@ spec:
             - message: this policy can only have a targetRef.group of gateway.networking.k8s.io
               rule: 'has(self.targetRef) ? self.targetRef.group == ''gateway.networking.k8s.io''
                 : true'
-            - message: this policy can only have a targetRef.kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute
-              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''HTTPRoute'',
-                ''GRPCRoute'', ''TCPRoute''] : true'
+            - message: this policy can only have a targetRef.kind of Gateway/ListenerSet/HTTPRoute/GRPCRoute/TCPRoute
+              rule: 'has(self.targetRef) ? self.targetRef.kind in [''Gateway'', ''ListenerSet'',
+                ''HTTPRoute'', ''GRPCRoute'', ''TCPRoute''] : true'
             - message: this policy can only have a targetRefs[*].group of gateway.networking.k8s.io
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.group ==
                 ''gateway.networking.k8s.io'') : true '
-            - message: this policy can only have a targetRefs[*].kind of Gateway/HTTPRoute/GRPCRoute/TCPRoute
+            - message: this policy can only have a targetRefs[*].kind of Gateway/ListenerSet/HTTPRoute/GRPCRoute/TCPRoute
               rule: 'has(self.targetRefs) ? self.targetRefs.all(ref, ref.kind in [''Gateway'',
-                ''HTTPRoute'', ''GRPCRoute'', ''TCPRoute'']) : true '
+                ''ListenerSet'', ''HTTPRoute'', ''GRPCRoute'', ''TCPRoute'']) : true '
+            - message: mergeType can only be used with xRoute targets
+              rule: '!has(self.mergeType) || ((!has(self.targetRef) || self.targetRef.kind
+                in [''HTTPRoute'', ''GRPCRoute'', ''TCPRoute'']) && (!has(self.targetRefs)
+                || self.targetRefs.all(ref, ref.kind in [''HTTPRoute'', ''GRPCRoute'',
+                ''TCPRoute''])) && (!has(self.targetSelectors) || self.targetSelectors.all(sel,
+                sel.kind in [''HTTPRoute'', ''GRPCRoute'', ''TCPRoute''])))'
             - message: if authorization.rules.principal.jwt is used, jwt must be defined
               rule: '(has(self.authorization) && has(self.authorization.rules) &&
-                self.authorization.rules.exists(r, has(r.principal.jwt))) ? has(self.jwt)
-                : true'
+                self.authorization.rules.exists(r, has(r.principal) ? has(r.principal.jwt)
+                : false)) ? has(self.jwt) : true'
           status:
             description: Status defines the current status of SecurityPolicy.
             properties:

--- a/charts/envoy-gateway/charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
+++ b/charts/envoy-gateway/charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
@@ -5,7 +5,7 @@ Render Gateway API safe upgrade policy resources only when
 safe-upgrades ValidatingAdmissionPolicy and binding shipped with the
 Gateway API bundle.
 */ -}}
-{{- if and .Values.gatewayAPI.safeUpgradePolicy.enabled (semverCompare ">=1.30-0" .Capabilities.KubeVersion.Version) }}
+{{- if .Values.gatewayAPI.safeUpgradePolicy.enabled }}
 {{- $renderSafeUpgradePolicy := true -}}
 {{- /*
 Require existing Gateway API policy resources to be absent or already owned by this Helm release 
@@ -36,7 +36,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
   name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
@@ -55,11 +55,13 @@ spec:
         oldObject.metadata.annotations['gateway.networking.k8s.io/channel'] == 'experimental' )"
       message: "Installing experimental CRDs on top of standard channel CRDs is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install experimental CRDs on top of standard channel CRDs."
       reason: Invalid
-    - expression: "object.spec.group != 'gateway.networking.k8s.io' ||
+    - expression: |
+        object.spec.group != 'gateway.networking.k8s.io' ||
         (has(object.metadata.annotations) && object.metadata.annotations.exists(k, k == 'gateway.networking.k8s.io/bundle-version') &&
-        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v1.[0-4].\\\\d+') &&
-        !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], 'v0'))" #TODO Kubernetes 1.37: Migrate to kubernetes semver library
-      message: "Installing CRDs with version before v1.5.0 is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install older versions."
+        (object.metadata.annotations['gateway.networking.k8s.io/bundle-version'] == 'v0.0.0-dev' ||
+        (object.metadata.annotations['gateway.networking.k8s.io/bundle-version'].startsWith('v1.') &&
+         !matches(object.metadata.annotations['gateway.networking.k8s.io/bundle-version'], '^v1\\.[0-4](\\.|$)'))))
+      message: "Installing CRDs with version other than v0.0.0-dev or v1.5+ is prohibited by default. Uninstall ValidatingAdmissionPolicy safe-upgrades.gateway.networking.k8s.io to install other versions."
       reason: Invalid
 
 ---
@@ -68,7 +70,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   annotations:
-    gateway.networking.k8s.io/bundle-version: v1.5.0-dev
+    gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
   name: safe-upgrades.gateway.networking.k8s.io
 spec:

--- a/charts/envoy-gateway/docs/architecture.md
+++ b/charts/envoy-gateway/docs/architecture.md
@@ -14,7 +14,9 @@ Envoy Gateway (EG) is a Kubernetes operator built on the Gateway API. This chart
 
 ### CRD subchart (managed by this chart by default)
 
-- Installs Envoy Gateway and Gateway API experimental v1.5.1 CRDs
+- Installs Envoy Gateway v1.9.0 and its supported Gateway API v1.6.1 CRDs
+- Excludes the unrelated `gateway.networking.x-k8s.io` experimental APIs, whose
+  CEL schema requires Kubernetes 1.32
 - Includes the Gateway API safe-upgrade admission policy
 - Can be disabled with `crds.enabled=false` for externally managed CRDs
 

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -34,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.8.3
+    tag: v1.9.0
   resources:
     requests:
       cpu: 10m

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -79,7 +79,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.3
+          value: docker.io/envoyproxy/gateway:v1.9.0
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
+++ b/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
@@ -34,13 +34,13 @@ tests:
     asserts:
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: docker.io/envoyproxy/envoy:distroless-v1.38.0
+          value: docker.io/envoyproxy/envoy:distroless-v1.39.0
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].name
           value: shutdown-manager
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.3
+          value: docker.io/envoyproxy/gateway:v1.9.0
 
   - it: should configure DaemonSet mode when kind is DaemonSet
     set:
@@ -53,7 +53,7 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment
       - equal:
           path: spec.provider.kubernetes.envoyDaemonSet.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.8.3
+          value: docker.io/envoyproxy/gateway:v1.9.0
 
   - it: should set proxy service type
     set:

--- a/charts/envoy-gateway/tests/monitoring_test.yaml
+++ b/charts/envoy-gateway/tests/monitoring_test.yaml
@@ -116,7 +116,7 @@ tests:
         template: configmap.yaml
       - matchRegex:
           path: data["envoy-gateway.yaml"]
-          pattern: "image: docker.io/envoyproxy/ratelimit:1e50889b"
+          pattern: "image: docker.io/envoyproxy/ratelimit:17b1956c"
         template: configmap.yaml
 
   - it: should configure a custom rate limit service image

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -111,7 +111,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.8.3"
+              "default": "v1.9.0"
             },
             "pullPolicy": {
               "type": "string",
@@ -236,7 +236,7 @@
             "tag": {
               "type": "string",
               "description": "Proxy image tag",
-              "default": "distroless-v1.38.0"
+              "default": "distroless-v1.39.0"
             },
             "pullPolicy": {
               "type": "string",
@@ -262,7 +262,7 @@
                 "tag": {
                   "type": "string",
                   "description": "Shutdown manager sidecar image tag",
-                  "default": "v1.8.3"
+                  "default": "v1.9.0"
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -541,7 +541,7 @@
                 "tag": {
                   "type": "string",
                   "description": "Rate limit service image tag",
-                  "default": "1e50889b"
+                  "default": "17b1956c"
                 }
               }
             }

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -33,7 +33,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.8.3"
+    tag: "v1.9.0"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -75,7 +75,7 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.8.3"
+    tag: "v1.9.0"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:
@@ -91,15 +91,15 @@ proxy:
     repository: docker.io/envoyproxy/envoy
     # -- Proxy image pull policy
     pullPolicy: IfNotPresent
-    # -- Envoy image tag for EG v1.8 compatibility matrix (distroless)
-    tag: "distroless-v1.38.0"
+    # -- Envoy image tag for EG v1.9 compatibility matrix (distroless)
+    tag: "distroless-v1.39.0"
 
   shutdownManager:
     image:
       # -- Shutdown manager sidecar image repository
       repository: docker.io/envoyproxy/gateway
       # -- Shutdown manager sidecar image tag
-      tag: "v1.8.3"
+      tag: "v1.9.0"
       # -- Shutdown manager image pull policy
       pullPolicy: IfNotPresent
 
@@ -330,7 +330,7 @@ rateLimiting:
   service:
     image:
       repository: docker.io/envoyproxy/ratelimit
-      tag: "1e50889b"
+      tag: "17b1956c"
   # -- Use an external Redis instead of the bundled subchart
   # Set this if redis.enabled=false and you want to point to your own Redis.
   externalRedis:


### PR DESCRIPTION
## Summary

- upgrade Envoy Gateway from 1.8.3 to 1.9.0 and refresh its supported CRDs
- update chart defaults, metadata, tests, and documentation for the pinned official images
- clarify Gateway API channel and platform-managed CRD ownership guidance
- verify the published image manifests for amd64 and arm64

## Upstream Verification

- Official release: https://gateway.envoyproxy.io/news/releases/notes/v1.9.0/
- The Gateway API v1.6.1 supported CRDs are included. Separate x-k8s CRDs requiring Kubernetes 1.32 CEL format support remain outside the chart contract.

## Validation

- `make validate-chart CHART=envoy-gateway`: 20 layers passed
- all 11 detected k3d scenarios passed, including default, security, rate limiting, production HA, dual stack, monitoring, external secrets, and namespace override
- `make standards-check CHART=envoy-gateway`
- `make preflight`
- `make attribution-check REPO=charts`

Site companion: helmforgedev/site#512

Resolves #986