### PR TITLE
chore(gitea): bump gitea to 1.27.2

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -4,7 +4,7 @@ name: gitea
 description: Gitea self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.17
-appVersion: "1.27.1"
+appVersion: "1.27.2"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "upgrade Gitea rootless image to 1.27.2 (#988)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/gitea/DESIGN.md
+++ b/charts/gitea/DESIGN.md
@@ -9,7 +9,7 @@ ClusterIP HTTP and SSH services, and restricted-compatible pod defaults.
 
 ## Goals
 
-- Run the official `docker.io/gitea/gitea:1.27.1-rootless` image without Bitnami
+- Run the official `docker.io/gitea/gitea:1.27.2-rootless` image without Bitnami
   or third-party runtime substitutions.
 - Keep the default install zero-config through SQLite while making PostgreSQL,
   MySQL, and external database modes explicit.

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -4,8 +4,8 @@
 
 Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
 
-- **Current application version** `1.27.1`
-- **Default image** `docker.io/gitea/gitea:1.27.1-rootless`
+- **Current application version** `1.27.2`
+- **Default image** `docker.io/gitea/gitea:1.27.2-rootless`
 - **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
 - **Rootless storage** PVC paths are prepared for UID/GID 1000 by a small initContainer
 
@@ -137,7 +137,7 @@ gitea:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `gitea/gitea` | Container image repository |
-| `image.tag` | `"1.27.1-rootless"` | Image tag |
+| `image.tag` | `"1.27.2-rootless"` | Image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
 | `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
@@ -191,11 +191,12 @@ Only one database source can be active. The chart fails with a clear error if mu
 
 ## Upgrade Notes
 
-This update moves the default rootless image to `1.27.1-rootless`. Gitea 1.27.1
-contains security, Actions, OAuth2, repository cleanup, API schema, and UI fixes
-without a documented change to the rootless image contract. Back up the database
-and repositories first; Gitea runs required database migrations during the first
-startup.
+This update moves the default rootless image to `1.27.2-rootless`. Gitea 1.27.2
+contains security and maintenance fixes without a documented change to the
+rootless image contract. Back up the database and repositories first; Gitea runs
+required database migrations during the first startup. Review the
+[upstream v1.27.2 release](https://github.com/go-gitea/gitea/releases/tag/v1.27.2)
+before upgrading.
 
 ## SSH Access
 

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -6,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.27.1-rootless"
+  tag: "1.27.2-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- upgrade Gitea rootless from 1.27.1 to 1.27.2
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/go-gitea/gitea/releases/tag/v1.27.2

## Validation

- make validate-chart CHART=gitea
- default k3d scenario passed
- make standards-check CHART=gitea
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #988