### PR TITLE
chore(homarr): bump homarr to 1.75.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.2.3
-appVersion: "1.74.0"
+appVersion: "1.75.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "upgrade Homarr image to v1.75.0 (#989)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.74.0`.
+Current application version: `v1.75.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.74.0"` | Homarr image tag |
+| `image.tag` | `"v1.75.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,10 +265,12 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image to `v1.74.0`. Review upstream release notes before upgrading production
-environments. Homarr `v1.74.0` adds persistent widget layouts, custom URI schemes, and integration reliability fixes.
-No breaking changes or new required environment variables were identified in the upstream
-release metadata.
+This update moves the default image to `v1.75.0`. Review the
+[upstream v1.75.0 release](https://github.com/homarr-labs/homarr/releases/tag/v1.75.0)
+before upgrading production environments. Homarr `v1.75.0` fixes startup when
+IPv6 is disabled in the container and includes integration and UI maintenance
+fixes. No breaking changes or new required environment variables were identified
+in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.74.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.75.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.74.0"
+  tag: "v1.75.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- upgrade Homarr from 1.74.0 to 1.75.0
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/homarr-labs/homarr/releases/tag/v1.75.0

## Validation

- make validate-chart CHART=homarr
- default and dual-stack k3d scenarios passed
- make standards-check CHART=homarr
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #989