### PR TITLE
chore(metabase): bump metabase to 0.63.13

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.23
-appVersion: "v0.63.5"
+appVersion: "v0.63.13"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump metabase to v0.63.5 (#974)"
+      description: "upgrade Metabase image to v0.63.13 (#990)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.63.5
+  tag: v0.63.13
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.63.5` | Metabase container image tag |
+| `image.tag` | `v0.63.13` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,10 +184,11 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.63.5` includes upstream security fixes. Back up the Metabase
-application database and review the official security advisory before upgrading.
-Keep the encryption key stable and validate the `/api/health` endpoint after
-rollout.
+Metabase `v0.63.13` is the latest maintenance update selected by the upstream
+image monitor. Back up the Metabase application database and review the
+[official Metabase changelog](https://www.metabase.com/changelog/) before
+upgrading. Keep the encryption key stable and validate the `/api/health`
+endpoint after rollout.
 
 ## Examples
 

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.63.5"
+          value: "docker.io/metabase/metabase:v0.63.13"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.63.5"
+  tag: "v0.63.13"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- upgrade Metabase from 0.63.5 to 0.63.13
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://www.metabase.com/changelog/

## Validation

- make validate-chart CHART=metabase
- default and external database k3d scenarios passed
- make standards-check CHART=metabase
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #990