### PR TITLE
chore(mysql): bump mysql to 26.7.0

### DIFF
--- a/charts/mysql/Chart.yaml
+++ b/charts/mysql/Chart.yaml
@@ -4,7 +4,7 @@ name: mysql
 description: MySQL for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.0.3
-appVersion: "9.7.2"
+appVersion: "26.7.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/mysql.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump mysql lts to 9.7.2 (#975)"
+      description: "upgrade MySQL image to 26.7.0 (#991)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mysql/README.md
+++ b/charts/mysql/README.md
@@ -209,7 +209,7 @@ Operational documents:
 |-----------|-------------|---------|
 | `architecture` | `standalone` or `replication` | `standalone` |
 | `image.repository` | MySQL image repository | `docker.io/library/mysql` |
-| `image.tag` | MySQL image tag | `9.7.2` |
+| `image.tag` | MySQL image tag | `26.7.0` |
 | `auth.database` | App database created at bootstrap | `app` |
 | `auth.username` | App user created at bootstrap | `app` |
 | `auth.existingSecret` | Existing secret for passwords | `""` |
@@ -261,6 +261,17 @@ Operational documents:
 | `metrics.enabled` | Enable `mysqld-exporter` sidecar | `false` |
 | `metrics.serviceMonitor.enabled` | Enable ServiceMonitor | `false` |
 | `extraManifests` | Extra Kubernetes manifests rendered after chart resources | `[]` |
+
+## Upgrade Notes
+
+MySQL `26.7.0` introduces Oracle's calendar-based version numbering after the
+9.7 series and includes server, InnoDB, replication, Group Replication, and
+client fixes. Back up all databases and run MySQL Shell's upgrade checker before
+upgrading a persistent production instance. Review the
+[official MySQL 26.7.0 release notes](https://dev.mysql.com/doc/relnotes/mysql/26.7/en/news-26-7-0.html)
+for removed or changed server options, then validate authentication plugins,
+replication state, and application queries in staging. The backup CronJob client
+image is upgraded to the same version as the server.
 
 ## CI scenarios
 

--- a/charts/mysql/tests/statefulset_source_test.yaml
+++ b/charts/mysql/tests/statefulset_source_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mysql:9.7.2"
+          value: "docker.io/library/mysql:26.7.0"
 
   - it: should always have 1 replica
     template: statefulset-source.yaml

--- a/charts/mysql/values.schema.json
+++ b/charts/mysql/values.schema.json
@@ -44,7 +44,7 @@
         "tag": {
           "type": "string",
           "description": "MySQL image tag",
-          "default": "9.7.2"
+          "default": "26.7.0"
         },
         "pullPolicy": {
           "type": "string",
@@ -719,7 +719,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "9.7.2"
+                  "default": "26.7.0"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/mysql/values.yaml
+++ b/charts/mysql/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- MySQL image repository
   repository: docker.io/library/mysql
   # -- MySQL image tag
-  tag: "9.7.2"
+  tag: "26.7.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -277,7 +277,7 @@ backup:
       pullPolicy: IfNotPresent
     mysql:
       repository: docker.io/library/mysql
-      tag: "9.7.2"
+      tag: "26.7.0"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary

- upgrade MySQL from 9.7.2 to 26.7.0
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://dev.mysql.com/doc/relnotes/mysql/26.7/en/news-26-7-0.html
- A persistent-volume upgrade from 9.7.2 to 26.7.0 preserved and returned the pre-upgrade test row.

## Validation

- make validate-chart CHART=mysql
- default and replication k3d scenarios passed
- make standards-check CHART=mysql
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #991