### PR TITLE
chore(n8n): bump n8n to 2.35.3

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -4,7 +4,7 @@ name: n8n
 description: n8n workflow automation platform with SQLite, PostgreSQL, or MySQL and optional Redis queue mode
 type: application
 version: 1.6.14
-appVersion: "2.34.5"
+appVersion: "2.35.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/n8n.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "upgrade n8n and task runner images to 2.35.3 (#992)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -144,7 +144,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/n8nio/n8n` | n8n container image repository |
-| `image.tag` | `2.34.5` | n8n container image tag |
+| `image.tag` | `2.35.3` | n8n container image tag |
 | `n8n.encryptionKey` | `""` | Encryption key for credentials (auto-generated) |
 | `n8n.webhookUrl` | `""` | Webhook URL (auto-detected from ingress) |
 | `n8n.logLevel` | `info` | Log level (info, warn, error, debug) |
@@ -186,14 +186,14 @@ externalSecrets:
 
 ## Upgrade Notes
 
-n8n `2.34.5` includes task-runner health-check fixes and the 2.34 maintenance
+n8n `2.35.3` includes core, scaling-mode, queue, and task-runner maintenance
 updates. Review the
-[upstream 2.34.5 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.34.5)
+[upstream 2.35.3 release notes](https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.3)
 before upgrading. Back up the database, keep the encryption key stable, and
 validate task runners and queue workers in a staging namespace. This update also
 moves the bundled Redis dependency to HelmForge Redis `2.0.0`.
 
-When upgrading with `--reuse-values`, explicitly set `image.tag=2.34.5`.
+When upgrading with `--reuse-values`, explicitly set `image.tag=2.35.3`.
 Helm preserves the previous image override in that mode; also update
 `taskRunners.image.tag` when it was pinned separately.
 

--- a/charts/n8n/tests/deployment_test.yaml
+++ b/charts/n8n/tests/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/n8nio/n8n:2.34.5"
+          value: "docker.io/n8nio/n8n:2.35.3"
 
   - it: should set container port to 5678
     template: templates/deployment.yaml
@@ -239,7 +239,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.34.5"
+          value: "docker.io/n8nio/runners:2.35.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/tests/worker_deployment_test.yaml
+++ b/charts/n8n/tests/worker_deployment_test.yaml
@@ -134,7 +134,7 @@ tests:
           value: task-runners
       - equal:
           path: spec.template.spec.containers[1].image
-          value: "docker.io/n8nio/runners:2.34.5"
+          value: "docker.io/n8nio/runners:2.35.3"
       - contains:
           path: spec.template.spec.containers[1].env
           content:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -28,7 +28,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2.34.5"
+          "default": "2.35.3"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/n8nio/n8n
   # -- Container image tag
-  tag: "2.34.5"
+  tag: "2.35.3"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrade n8n and task runners from 2.34.5 to 2.35.3
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/n8n-io/n8n/releases/tag/n8n%402.35.3

## Validation

- make validate-chart CHART=n8n
- default and queue-mode k3d scenarios passed, including workers, PostgreSQL, Redis, and runners
- make standards-check CHART=n8n
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #992