### PR TITLE
chore(netbird): bump netbird to 0.77.0

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -4,7 +4,7 @@ name: netbird
 description: Self-hosted NetBird control plane for WireGuard overlay networks, identity-aware access, and device management
 type: application
 version: 1.0.6
-appVersion: "0.76.3"
+appVersion: "0.77.0"
 home: https://helmforge.dev/docs/charts/netbird
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/netbird
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/netbird.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "upgrade NetBird server image to 0.77.0 (#993)"
   artifacthub.io/category: networking
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -4,7 +4,7 @@ Deploy [NetBird](https://github.com/netbirdio/netbird), a self-hosted WireGuard 
 
 This chart packages the current upstream combined architecture:
 
-- `netbirdio/netbird-server:0.76.3` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
+- `netbirdio/netbird-server:0.77.0` for the management API, gRPC endpoint, signal, relay, metrics, health, and UDP STUN service
 - `netbirdio/dashboard:v2.90.10` for the web UI
 - a generated or externally supplied `config.yaml`
 - HelmForge PostgreSQL subchart as the default production store
@@ -110,7 +110,7 @@ Use `externalSecrets.items[]` to synchronize sensitive values such as `config.ya
 Local security scan:
 
 ```text
-Image: netbirdio/netbird-server:0.76.3
+Image: netbirdio/netbird-server:0.77.0
 Image: netbirdio/dashboard:v2.90.10
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 86.86869 compliance score
@@ -121,12 +121,13 @@ repository security gate. Remaining findings are tracked as hardening trade-offs
 for optional NetworkPolicy enablement, upstream dashboard startup model, and
 operator-owned resource limit tuning across the database-backed topology.
 
-## Upgrade from 0.76.1
+## Upgrade to 0.77.0
 
-NetBird `0.76.3` includes management fixes for posture-check caching, user update
-propagation, reverse-proxy authorization, and agent-network group references.
-The chart's combined server image keeps management, signal, relay, and proxy
-components on the same version.
+NetBird `0.77.0` updates Agent Network behavior, client bootstrap flows, and
+management components. The chart's combined server image keeps management,
+signal, relay, and proxy components on the same version. Review the
+[upstream 0.77.0 release](https://github.com/netbirdio/netbird/releases/tag/v0.77.0)
+before upgrading.
 
 Back up the configured database and `/var/lib/netbird`, then apply the new chart
 defaults while preserving your explicit overrides:
@@ -139,7 +140,7 @@ helm upgrade netbird helmforge/netbird \
 ```
 
 Using `--reuse-values` alone retains the previous default image tag. Remove any
-explicit `server.image.tag` override if you want the chart default `0.76.3`.
+explicit `server.image.tag` override if you want the chart default `0.77.0`.
 
 ## Validation
 

--- a/charts/netbird/tests/templates_test.yaml
+++ b/charts/netbird/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: netbirdio/netbird-server:0.76.3
+          value: netbirdio/netbird-server:0.77.0
         template: templates/deployment.yaml
         documentIndex: 0
   - it: renders the official pinned dashboard image

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -14,7 +14,7 @@ server:
     # -- Official NetBird server container image repository.
     repository: netbirdio/netbird-server
     # -- Pinned NetBird server image tag. Floating tags such as latest are not used by default.
-    tag: "0.76.3"
+    tag: "0.77.0"
     # -- Kubernetes image pull policy.
     pullPolicy: IfNotPresent
   # -- Number of NetBird server pods. Keep 1 with the default sqlite store.


### PR DESCRIPTION
## Summary

- upgrade NetBird from 0.76.3 to 0.77.0
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/netbirdio/netbird/releases/tag/v0.77.0

## Validation

- make validate-chart CHART=netbird
- default k3d scenario passed
- make standards-check CHART=netbird
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #993