### PR TITLE
chore(postgresql): bump postgresql to 18.6

### DIFF
--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -4,7 +4,7 @@ name: postgresql
 description: PostgreSQL for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.0.4
-appVersion: "18.4"
+appVersion: "18.6"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,8 +21,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/postgresql.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "complete chart standards (#543)"
+    - kind: changed
+      description: "upgrade PostgreSQL image to 18.6-trixie (#995)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/postgresql/README.md
+++ b/charts/postgresql/README.md
@@ -334,7 +334,7 @@ Operational documents:
 |-----------|-------------|---------|
 | `architecture` | `standalone` or `replication` | `standalone` |
 | `image.repository` | PostgreSQL image repository | `docker.io/library/postgres` |
-| `image.tag` | PostgreSQL image tag | `18.4-trixie` |
+| `image.tag` | PostgreSQL image tag | `18.6-trixie` |
 | `auth.database` | App database created at bootstrap | `app` |
 | `auth.username` | App user created at bootstrap | `app` |
 | `auth.existingSecret` | Existing secret for passwords | `""` |
@@ -391,6 +391,16 @@ Operational documents:
 | `serviceAccount.automountServiceAccountToken` | Mount Kubernetes API credentials into PostgreSQL and backup pods | `false` |
 | `service.ipFamilyPolicy` | Service IP family policy: `SingleStack`, `PreferDualStack`, or `RequireDualStack` | omitted |
 | `service.ipFamilies` | Ordered Service IP families: `IPv4`, `IPv6` | omitted |
+
+## Upgrade Notes
+
+PostgreSQL `18.6` is the August 2026 security and bug-fix release; upstream did
+not publish 18.5 because of a post-wrap regression. Back up the cluster and
+review the [official PostgreSQL 18.6 release notes](https://www.postgresql.org/docs/release/18.6/)
+before upgrading. A dump and restore is not required when upgrading from an
+earlier PostgreSQL 18 release, but test extensions, authentication, replication,
+and application queries in staging. The backup CronJob client image is upgraded
+to the same `18.6-trixie` tag as the server.
 
 ## CI scenarios
 

--- a/charts/postgresql/tests/statefulset_primary_test.yaml
+++ b/charts/postgresql/tests/statefulset_primary_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/postgres:18.4-trixie"
+          value: "docker.io/library/postgres:18.6-trixie"
 
   - it: should have selector labels matching template labels
     template: statefulset-primary.yaml

--- a/charts/postgresql/values.schema.json
+++ b/charts/postgresql/values.schema.json
@@ -44,7 +44,7 @@
         "tag": {
           "type": "string",
           "description": "PostgreSQL image tag",
-          "default": "18.4-trixie"
+          "default": "18.6-trixie"
         },
         "pullPolicy": {
           "type": "string",
@@ -961,7 +961,7 @@
                 },
                 "tag": {
                   "type": "string",
-                  "default": "18.4-trixie"
+                  "default": "18.6-trixie"
                 },
                 "pullPolicy": {
                   "type": "string",

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- PostgreSQL image repository
   repository: docker.io/library/postgres
   # -- PostgreSQL image tag
-  tag: "18.4-trixie"
+  tag: "18.6-trixie"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -380,7 +380,7 @@ backup:
       pullPolicy: IfNotPresent
     postgresql:
       repository: docker.io/library/postgres
-      tag: "18.4-trixie"
+      tag: "18.6-trixie"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary

- upgrade PostgreSQL from 18.4-trixie to 18.6-trixie
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://www.postgresql.org/docs/release/18.6/
- A persistent-volume upgrade from 18.4 to 18.6 preserved and returned the pre-upgrade test row.

## Validation

- make validate-chart CHART=postgresql
- default and replication k3d scenarios passed
- make standards-check CHART=postgresql
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #995