### PR TITLE
chore(poznote): bump poznote to 6.65.3

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.1.3
-appVersion: "6.59.2"
+appVersion: "6.65.3"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "upgrade Poznote image to 6.65.3 (#996)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.59.2
+ghcr.io/timothepoznanski/poznote:6.65.3
 ```
 
-The tag maps to the upstream `6.59.2` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.65.3` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.59.2-rootless` variant. It is not the chart
+Upstream also publishes a `6.65.3-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.59.2` |
+| `image.tag` | Image tag | `6.65.3` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -141,10 +141,11 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.59.2` adds user webhooks, tenant-isolation controls, task management,
-optional S3 attachment and backup storage, an administrator activity log, and
-safer account deletion. The default local SQLite and filesystem deployment
-remains compatible; S3 integration is configured inside Poznote when needed.
+Poznote `6.65.3` includes shared-note access controls, Git Sync improvements,
+and UI maintenance accumulated since 6.59.2. Review the
+[upstream 6.65.3 release](https://github.com/timothepoznanski/poznote/releases/tag/6.65.3)
+before upgrading. The default local SQLite and filesystem deployment remains
+compatible; S3 integration is configured inside Poznote when needed.
 
 No upstream storage migration is required. Back up the `data` PVC before
 upgrading because it stores the SQLite database, notes, attachments, and

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.59.2"
+          value: "ghcr.io/timothepoznanski/poznote:6.65.3"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.59.2"
+  tag: "6.65.3"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- upgrade Poznote and its rootless image from 6.59.2 to 6.65.3
- update chart defaults, metadata, tests, and documentation for the pinned official image
- verify the published image manifest for amd64 and arm64

## Upstream Verification

- Official release: https://github.com/timothepoznanski/poznote/releases/tag/6.65.3

## Validation

- make validate-chart CHART=poznote
- default and sharing k3d scenarios passed
- make standards-check CHART=poznote
- make preflight
- make attribution-check REPO=charts

Site companion: helmforgedev/site#512

Resolves #996