### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/alfio/Chart.yaml
+++ b/charts/alfio/Chart.yaml
@@ -47,6 +47,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/answer/Chart.yaml
+++ b/charts/answer/Chart.yaml
@@ -49,7 +49,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -54,7 +54,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -47,7 +47,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/chiefonboarding/Chart.yaml
+++ b/charts/chiefonboarding/Chart.yaml
@@ -49,6 +49,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -49,7 +49,7 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/Countly/countly-server
 dependencies:
   - name: mongodb
-    version: 1.7.16
+    version: 1.7.17
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -54,7 +54,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/ente/Chart.yaml
+++ b/charts/ente/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -54,7 +54,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -50,7 +50,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -52,7 +52,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -50,7 +50,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
 
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
 

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -54,7 +54,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -47,7 +47,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -54,6 +54,6 @@ annotations:
 dependencies:
   - name: elasticsearch
     alias: bundled-elasticsearch
-    version: 1.1.5
+    version: 1.1.6
     repository: oci://ghcr.io/helmforgedev/helm
     condition: bundledElasticsearch.enabled

--- a/charts/listmonk/Chart.yaml
+++ b/charts/listmonk/Chart.yaml
@@ -51,6 +51,6 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/medikeep/Chart.yaml
+++ b/charts/medikeep/Chart.yaml
@@ -40,6 +40,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -51,6 +51,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/postgresql
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/middlewarehq/middleware
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -51,7 +51,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -35,6 +35,6 @@ annotations:
   helmforge.dev/maturity: stable
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -49,7 +49,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -54,7 +54,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -55,7 +55,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/sonarqube/Chart.yaml
+++ b/charts/sonarqube/Chart.yaml
@@ -62,6 +62,6 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/jenkins
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -49,7 +49,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -53,7 +53,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis

--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -52,6 +52,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled

--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -47,7 +47,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: mysql

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -51,7 +51,7 @@ annotations:
     - url: https://artifacthub.io/packages/helm/helmforge/redis
 dependencies:
   - name: postgresql
-    version: 2.0.4
+    version: 2.0.5
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- alfio: postgresql 2.0.4 -> 2.0.5
- answer: postgresql 2.0.4 -> 2.0.5
- authelia: postgresql 2.0.4 -> 2.0.5
- automatisch: postgresql 2.0.4 -> 2.0.5
- chiefonboarding: postgresql 2.0.4 -> 2.0.5
- ckan: postgresql 2.0.4 -> 2.0.5
- countly: mongodb 1.7.16 -> 1.7.17
- docmost: postgresql 2.0.4 -> 2.0.5
- druid: postgresql 2.0.4 -> 2.0.5
- ente: postgresql 2.0.4 -> 2.0.5
- flowise: postgresql 2.0.4 -> 2.0.5
- gitea: postgresql 2.0.4 -> 2.0.5
- guacamole: postgresql 2.0.4 -> 2.0.5
- homarr: postgresql 2.0.4 -> 2.0.5
- hoppscotch: postgresql 2.0.4 -> 2.0.5
- immich: postgresql 2.0.4 -> 2.0.5
- keycloak: postgresql 2.0.4 -> 2.0.5
- kibana: elasticsearch 1.1.5 -> 1.1.6
- listmonk: postgresql 2.0.4 -> 2.0.5
- medikeep: postgresql 2.0.4 -> 2.0.5
- metabase: postgresql 2.0.4 -> 2.0.5
- middleware: postgresql 2.0.4 -> 2.0.5
- n8n: postgresql 2.0.4 -> 2.0.5
- netbird: postgresql 2.0.4 -> 2.0.5
- netbox: postgresql 2.0.4 -> 2.0.5
- open-webui: postgresql 2.0.4 -> 2.0.5
- opencut: postgresql 2.0.4 -> 2.0.5
- sonarqube: postgresql 2.0.4 -> 2.0.5
- strapi: postgresql 2.0.4 -> 2.0.5
- superset: postgresql 2.0.4 -> 2.0.5
- umami: postgresql 2.0.4 -> 2.0.5
- vaultwarden: postgresql 2.0.4 -> 2.0.5
- wallabag: postgresql 2.0.4 -> 2.0.5

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._