### PR TITLE
feat(envoy-gateway)!: add CRD lifecycle migration

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -34,7 +34,7 @@ icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "add the bridge migration to the standalone CRD lifecycle release (#981)"
+      description: "BREAKING: require the standalone CRD lifecycle migration and Kubernetes 1.33-1.36 (#981)"
     - kind: fixed
       description: "enforce the upstream Envoy Gateway v1.9 Kubernetes 1.33-1.36 compatibility matrix (#981)"
   artifacthub.io/maintainers: |

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: Production-ready Envoy Gateway operator with Gateway API support, c
 type: application
 version: 1.10.1
 appVersion: "v1.9.0"
-kubeVersion: ">=1.26.0-0"
+kubeVersion: ">=1.33.0-0 <1.37.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
   - https://github.com/helmforgedev/charts
@@ -34,7 +34,9 @@ icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump envoy gateway to 1.9.0 (#1000)"
+      description: "add the bridge migration to the standalone CRD lifecycle release (#981)"
+    - kind: fixed
+      description: "enforce the upstream Envoy Gateway v1.9 Kubernetes 1.33-1.36 compatibility matrix (#981)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev
@@ -50,6 +52,7 @@ annotations:
   helmforge.dev/repository: https://repo.helmforge.dev
   artifacthub.io/recommendations: |
     - url: https://gateway.envoyproxy.io/
+    - url: https://artifacthub.io/packages/helm/helmforge/envoy-gateway-crds
   artifacthub.io/links: |
     - name: Documentation
       url: https://helmforge.dev/docs/charts/envoy-gateway

--- a/charts/envoy-gateway/DESIGN.md
+++ b/charts/envoy-gateway/DESIGN.md
@@ -24,13 +24,18 @@ provisions Envoy proxies for ingress/egress traffic.
 ## CRDs
 
 The chart deploys an `EnvoyProxy` CR and other `gateway.envoyproxy.io` resources,
-so the **operator CRDs** ship in the chart's `crds/` and Helm installs them when
-absent. The supported upstream **Gateway API** v1.6.1 CRDs
-(`gateway.networking.k8s.io`, including `ListenerSet` from the experimental
-channel) are bundled in the local CRD subchart by default. The unrelated
-`gateway.networking.x-k8s.io` experimental APIs are excluded because their CEL
-schema requires Kubernetes 1.32 while the chart supports Kubernetes 1.26 and
-newer. Platform-managed installations can disable the subchart. See the README.
+so all required APIs must be discoverable before application rendering. New
+installations use the separate `envoy-gateway-crds` release, which contains the
+8 Envoy Gateway v1.9.0 CRDs, 10 Gateway API v1.6.1 Experimental CRDs, and the
+safe-upgrade admission policy. Kubernetes support follows the upstream Envoy
+Gateway v1.9 matrix: versions 1.33 through 1.36.
+
+The local CRD subchart remains temporarily enabled by default as a bridge for
+chart 1.10.1 users. Its policy and binding carry
+`helm.sh/resource-policy: keep`, allowing the dependency to be disabled before
+those resources are adopted by the standalone release. With
+`crds.enabled=false`, the application validates all 18 GVKs and, when connected
+to a cluster, the exact bundle metadata. See the README and migration guide.
 
 ## Optional rate limiting
 

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,8 +1,9 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.9.0 on Kubernetes. Envoy Gateway is a **Kubernetes operator** — it manages
-Envoy proxy pods automatically in response to Gateway API resources.
+v1.9.0 on Kubernetes 1.33 through 1.36. Envoy Gateway is a **Kubernetes
+operator** — it manages Envoy proxy pods automatically in response to Gateway
+API resources.
 
 ## Installation
 
@@ -11,39 +12,56 @@ Envoy proxy pods automatically in response to Gateway API resources.
 ```bash
 helm repo add helmforge https://repo.helmforge.dev
 helm repo update
-helm install envoy-gateway helmforge/envoy-gateway
+helm upgrade --install envoy-gateway-crds helmforge/envoy-gateway-crds \
+  --namespace envoy-gateway \
+  --create-namespace
+kubectl wait --for=condition=Established --timeout=120s \
+  crd/gateways.gateway.networking.k8s.io \
+  crd/envoyproxies.gateway.envoyproxy.io
+helm upgrade --install envoy-gateway helmforge/envoy-gateway \
+  --namespace envoy-gateway \
+  --set crds.enabled=false
 ```
 
 ### OCI Registry
 
 ```bash
-helm install envoy-gateway oci://ghcr.io/helmforgedev/helm/envoy-gateway
+helm upgrade --install envoy-gateway-crds \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --namespace envoy-gateway \
+  --create-namespace
+kubectl wait --for=condition=Established --timeout=120s \
+  crd/gateways.gateway.networking.k8s.io \
+  crd/envoyproxies.gateway.envoyproxy.io
+helm upgrade --install envoy-gateway \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway \
+  --namespace envoy-gateway \
+  --set crds.enabled=false
 ```
 
 ## Quick Start
 
-Envoy Gateway v1.9.0 and its supported Gateway API v1.6.1 CRDs are bundled in
-the local `crds` subchart and installed automatically by default. This includes
-`ListenerSet`, `TCPRoute`, `TLSRoute`, and `UDPRoute`, which are also present in
-the v1.6.1 Standard bundle. The bundled definitions retain the upstream
-experimental-channel schema used by Envoy Gateway v1.9.0. The separate
-`gateway.networking.x-k8s.io` experimental APIs are excluded so the chart
-remains compatible with its Kubernetes 1.26 minimum; Gateway API v1.6.1
-generates those APIs with CEL functions that require Kubernetes 1.32. Set
-`crds.enabled=false` only when a platform operator, GitOps controller, or
-another release manages all required CRDs. Helm installs CRDs on first install
-but does not upgrade or delete them automatically; review upstream CRD changes
-before chart upgrades.
+Envoy Gateway v1.9.0 requires Gateway API v1.6.1 Experimental and supports
+Kubernetes 1.33 through 1.36. New installations use the standalone
+`envoy-gateway-crds` release first, wait for discovery, then install this chart
+with `crds.enabled=false`. This makes the first `helm diff` work with Kubernetes
+validation enabled and gives CRDs an explicit forward-only lifecycle.
 
-For platform-managed CRDs, prefer `crds.enabled=false`; this also disables the
-subchart's safe-upgrade admission policy. Helm's `--skip-crds` flag skips the
-raw CRD files but still renders templates. If the platform also manages the
-safe-upgrade policy, combine `--skip-crds` with
-`--set crds.gatewayAPI.safeUpgradePolicy.enabled=false`.
+The bundled `crds` subchart remains enabled by default only as a migration
+bridge for users upgrading from chart 1.10.1. Existing users must first upgrade
+to this release with `crds.enabled=true`; that revision records
+`helm.sh/resource-policy: keep` on the safe-upgrade policy and binding. They can
+then install the standalone release, disable the old dependency, and transfer
+policy ownership without deleting or recreating any CRD or custom resource.
+
+Do not disable the bundled dependency directly from 1.10.1. Follow the
+[mandatory migration procedure](docs/crd-migration.md).
 
 ```bash
-# Install CRDs and the controller with the development profile.
-helm install envoy-gateway oci://ghcr.io/helmforgedev/helm/envoy-gateway \
+# Install the controller after the standalone CRD release is Established.
+helm upgrade --install envoy-gateway oci://ghcr.io/helmforgedev/helm/envoy-gateway \
+  --namespace envoy-gateway \
+  --set crds.enabled=false \
   --set profile=dev \
   --set gateway.create=true \
   --set gatewayAPI.examples.enabled=true
@@ -59,12 +77,12 @@ curl -H "Host: example.local" http://$GATEWAY_IP/
 
 ## How It Works
 
-1. **Chart installs**: bundled CRDs, GatewayClass, certgen job, controller Deployment, RBAC
-2. **certgen job** runs as a pre-install hook and generates TLS certs for the controller
-3. **Controller** starts and watches for `Gateway` resources
-4. When `gateway.create: true`, a **Gateway** resource is created → EG automatically provisions Envoy proxy pods and a Service
-5. Users create **HTTPRoute**, **TCPRoute**, **GRPCRoute** resources that attach to the Gateway
-6. Policies (SecurityPolicy, BackendTrafficPolicy, ClientTrafficPolicy) attach to Gateway or HTTPRoute resources
+1. **CRD release installs**: 18 CRDs and the Gateway API safe-upgrade policy
+2. **Application chart validates**: required discovery and bundle metadata
+3. **certgen job** runs as a pre-install hook and generates TLS certs for the controller
+4. **Controller** starts and watches for `Gateway` resources
+5. When `gateway.create: true`, a **Gateway** resource is created and EG provisions Envoy proxy pods and a Service
+6. Users create Routes and policies that attach to Gateway API resources
 
 Proxy pods are named `envoy-<namespace>-<gateway-name>-<uid>` and are managed entirely by the EG operator — not by this chart.
 
@@ -163,7 +181,7 @@ highAvailability:
 |-----|---------|-------------|
 | `profile` | `custom` | Profile preset (dev, production-ha, custom) |
 | `namespaceOverride` | `""` | Namespace for chart-managed resources; target namespace must already exist |
-| `crds.enabled` | `true` | Install bundled Envoy Gateway and supported Gateway API v1.6.1 CRDs |
+| `crds.enabled` | `true` | Migration bridge: retain bundled CRDs until the standalone release has been installed and ownership transferred |
 | `nameOverride` | `""` | Override chart name |
 | `fullnameOverride` | `""` | Override full name |
 | `imagePullSecrets` | `[]` | Image pull secrets |
@@ -455,6 +473,39 @@ Major architectural redesign to align with the EG operator model.
 
 ## Upgrade Notes
 
+### Mandatory CRD Migration From 1.10.1
+
+This release is the required bridge between the application-owned policy and
+the standalone `envoy-gateway-crds` release. It also corrects the supported
+Kubernetes range from the former `>=1.26` declaration to the upstream v1.9
+matrix: Kubernetes 1.33 through 1.36. Upgrade the cluster first if it is outside
+that range.
+
+The safe sequence is:
+
+1. Upgrade this application release with `crds.enabled=true`.
+2. Verify `helm.sh/resource-policy=keep` on the safe-upgrade policy and binding.
+3. Capture all CRD and custom-resource names, UIDs, and counts.
+4. Apply the matching standalone CRD bundle server-side.
+5. Install the standalone release with policy management disabled.
+6. Upgrade this release with `crds.enabled=false`.
+7. Verify every CRD and custom-resource UID remains unchanged.
+8. Adopt the policy and binding into the standalone release.
+
+Do not skip step 1: patching only the live object is insufficient because Helm
+uses the prior release manifest when deciding what to delete. Exact commands,
+Helm 3 fallback, recovery, rollback, and verification are in
+[CRD migration from 1.10.1](docs/crd-migration.md).
+
+After ownership transfer, never roll back to an application revision from
+before the bridge: it reintroduces the old policy resources. Upgrade a
+compatible application version with `crds.enabled=false` instead.
+
+When `crds.enabled=false`, rendering fails early unless all 18 required GVKs
+are discoverable. A server-connected install, upgrade, or server-side diff also
+checks Gateway API bundle `v1.6.1`/`experimental` and Envoy Gateway bundle
+`v1.9.0` annotations.
+
 `docker.io/envoyproxy/gateway:v1.9.0` is the upstream minor update from
 `v1.8.3`. The automatically generated issue referenced `1.9.0`, but Docker Hub
 publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
@@ -478,9 +529,9 @@ targets. Lua extensions are disabled by default and tracing client sampling now
 defaults to zero. EndpointSlice indexing is enabled by default and can increase
 controller memory use on large clusters. Review the
 [upstream v1.9.0 release notes](https://gateway.envoyproxy.io/news/releases/notes/v1.9.0/)
-before upgrading. The bundled supported CRD set is from Gateway API v1.6.1.
-Apply the bundled CRDs server-side before the controller
-upgrade, correct resources rejected by the new validations, and test existing
+before upgrading. The supported CRD set is Gateway API v1.6.1 Experimental.
+Apply the standalone CRD bundle server-side before the controller upgrade,
+correct resources rejected by the new validations, and test existing
 Gateway, route, EnvoyProxy, `BackendTrafficPolicy`, `SecurityPolicy`,
 EnvoyExtensionPolicy, and EnvoyPatchPolicy resources in staging.
 

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -5,6 +5,27 @@ v1.9.0 on Kubernetes 1.33 through 1.36. Envoy Gateway is a **Kubernetes
 operator** — it manages Envoy proxy pods automatically in response to Gateway
 API resources.
 
+> [!WARNING]
+> **Upgrading from chart 1.x to 2.0.0 requires a staged CRD migration.**
+>
+> Do not upgrade directly with `crds.enabled=false`, uninstall the bundled CRDs,
+> or replace the safe-upgrade policy. Use this order:
+>
+> 1. Upgrade Kubernetes first when it is outside the supported 1.33-1.36 range.
+> 2. Upgrade Envoy Gateway to 2.0.0 with `crds.enabled=true` so Helm records the
+>    keep policy.
+> 3. Capture all CRD, custom-resource, policy, and binding UIDs.
+> 4. Install `envoy-gateway-crds` 1.0.0 with policy management disabled and
+>    server-side apply its locked bundle.
+> 5. Upgrade Envoy Gateway 2.0.0 with `crds.enabled=false`.
+> 6. Transfer the policy and binding to the standalone release, then verify all
+>    captured UIDs and Gateway traffic.
+>
+> CRD schema upgrades are forward-only. Do not use Helm rollback to downgrade
+> the bundle or return the application to a pre-2.0.0 revision. Follow the
+> [complete 1.x to 2.0.0 migration procedure](docs/crd-migration.md) before
+> changing production releases.
+
 ## Installation
 
 ### HTTPS Repository
@@ -473,9 +494,11 @@ Major architectural redesign to align with the EG operator model.
 
 ## Upgrade Notes
 
-### Mandatory CRD Migration From 1.10.1
+### Mandatory CRD Migration From 1.10.1 to 2.0.0
 
-This release is the required bridge between the application-owned policy and
+Chart 2.0.0 is a major release because it raises the Kubernetes minimum from
+1.26 to 1.33 and changes the CRD lifecycle and ownership contract. It is the
+required bridge between the application-owned policy and
 the standalone `envoy-gateway-crds` release. It also corrects the supported
 Kubernetes range from the former `>=1.26` declaration to the upstream v1.9
 matrix: Kubernetes 1.33 through 1.36. Upgrade the cluster first if it is outside

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -12,9 +12,9 @@ API resources.
 > or replace the safe-upgrade policy. Use this order:
 >
 > 1. Upgrade Kubernetes first when it is outside the supported 1.33-1.36 range.
-> 2. Upgrade Envoy Gateway to 2.0.0 with `crds.enabled=true` so Helm records the
+> 2. Capture all CRD, custom-resource, policy, and binding UIDs.
+> 3. Upgrade Envoy Gateway to 2.0.0 with `crds.enabled=true` so Helm records the
 >    keep policy.
-> 3. Capture all CRD, custom-resource, policy, and binding UIDs.
 > 4. Install `envoy-gateway-crds` 1.0.0 with policy management disabled and
 >    server-side apply its locked bundle.
 > 5. Upgrade Envoy Gateway 2.0.0 with `crds.enabled=false`.
@@ -34,11 +34,15 @@ API resources.
 helm repo add helmforge https://repo.helmforge.dev
 helm repo update
 helm upgrade --install envoy-gateway-crds helmforge/envoy-gateway-crds \
+  --version 1.0.0 \
   --namespace envoy-gateway \
   --create-namespace
+helm show crds helmforge/envoy-gateway-crds \
+  --version 1.0.0 > envoy-gateway-crds-installed.yaml
 kubectl wait --for=condition=Established --timeout=120s \
-  crd/gateways.gateway.networking.k8s.io \
-  crd/envoyproxies.gateway.envoyproxy.io
+  -f envoy-gateway-crds-installed.yaml
+kubectl api-resources --api-group=gateway.networking.k8s.io
+kubectl api-resources --api-group=gateway.envoyproxy.io
 helm upgrade --install envoy-gateway helmforge/envoy-gateway \
   --namespace envoy-gateway \
   --set crds.enabled=false
@@ -49,11 +53,15 @@ helm upgrade --install envoy-gateway helmforge/envoy-gateway \
 ```bash
 helm upgrade --install envoy-gateway-crds \
   oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --version 1.0.0 \
   --namespace envoy-gateway \
   --create-namespace
+helm show crds oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --version 1.0.0 > envoy-gateway-crds-installed.yaml
 kubectl wait --for=condition=Established --timeout=120s \
-  crd/gateways.gateway.networking.k8s.io \
-  crd/envoyproxies.gateway.envoyproxy.io
+  -f envoy-gateway-crds-installed.yaml
+kubectl api-resources --api-group=gateway.networking.k8s.io
+kubectl api-resources --api-group=gateway.envoyproxy.io
 helm upgrade --install envoy-gateway \
   oci://ghcr.io/helmforgedev/helm/envoy-gateway \
   --namespace envoy-gateway \
@@ -506,14 +514,14 @@ that range.
 
 The safe sequence is:
 
-1. Upgrade this application release with `crds.enabled=true`.
-2. Verify `helm.sh/resource-policy=keep` on the safe-upgrade policy and binding.
-3. Capture all CRD and custom-resource names, UIDs, and counts.
+1. Capture all CRD, custom-resource, policy, and binding names, UIDs, and counts.
+2. Upgrade this application release with `crds.enabled=true`.
+3. Verify `helm.sh/resource-policy=keep` on the safe-upgrade policy and binding.
 4. Apply the matching standalone CRD bundle server-side.
 5. Install the standalone release with policy management disabled.
 6. Upgrade this release with `crds.enabled=false`.
-7. Verify every CRD and custom-resource UID remains unchanged.
-8. Adopt the policy and binding into the standalone release.
+7. Adopt the policy and binding into the standalone release.
+8. Verify every captured UID and resource count remains unchanged.
 
 Do not skip step 1: patching only the live object is insufficient because Helm
 uses the prior release manifest when deciding what to delete. Exact commands,

--- a/charts/envoy-gateway/charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
+++ b/charts/envoy-gateway/charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
@@ -38,6 +38,7 @@ metadata:
   annotations:
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: "safe-upgrades.gateway.networking.k8s.io"
 spec:
   failurePolicy: Fail
@@ -72,6 +73,7 @@ metadata:
   annotations:
     gateway.networking.k8s.io/bundle-version: v1.6.1
     gateway.networking.k8s.io/channel: standard
+    helm.sh/resource-policy: keep
   name: safe-upgrades.gateway.networking.k8s.io
 spec:
   policyName: safe-upgrades.gateway.networking.k8s.io

--- a/charts/envoy-gateway/docs/architecture.md
+++ b/charts/envoy-gateway/docs/architecture.md
@@ -12,13 +12,20 @@ Envoy Gateway (EG) is a Kubernetes operator built on the Gateway API. This chart
 - Watches EG-specific CRDs (SecurityPolicy, BackendTrafficPolicy, etc.)
 - Provisions and configures Envoy proxy pods automatically
 
-### CRD subchart (managed by this chart by default)
+### Standalone CRD lifecycle release
 
-- Installs Envoy Gateway v1.9.0 and its supported Gateway API v1.6.1 CRDs
-- Excludes the unrelated `gateway.networking.x-k8s.io` experimental APIs, whose
-  CEL schema requires Kubernetes 1.32
-- Includes the Gateway API safe-upgrade admission policy
-- Can be disabled with `crds.enabled=false` for externally managed CRDs
+- Installs 8 Envoy Gateway v1.9.0 and 10 Gateway API v1.6.1 Experimental CRDs
+  before the application release
+- Owns the Gateway API safe-upgrade admission policy and binding
+- Applies CRD upgrades server-side before controller upgrades because Helm does
+  not upgrade objects from `crds/`
+- Establishes the discovery boundary required by a validated first `helm diff`
+
+The local CRD subchart remains enabled by default only as the migration bridge
+from application chart 1.10.1. Existing users first upgrade with
+`crds.enabled=true`, then follow [the ownership-preserving CRD migration](crd-migration.md)
+before setting it to `false`. New installations apply `envoy-gateway-crds`
+first and install this application release with `crds.enabled=false`.
 
 ### Certgen Job (managed by this chart)
 
@@ -31,7 +38,7 @@ Envoy Gateway (EG) is a Kubernetes operator built on the Gateway API. This chart
 - Registers the controller with the Gateway API
 - References the EnvoyProxy CRD for proxy shape configuration
 
-### EnvoyProxy CRD (managed by this chart)
+### EnvoyProxy resource (managed by this chart)
 
 - Configures how EG provisions proxy pods:
   - `proxy.kind: Deployment|DaemonSet`

--- a/charts/envoy-gateway/docs/crd-migration.md
+++ b/charts/envoy-gateway/docs/crd-migration.md
@@ -1,4 +1,4 @@
-# CRD Migration From Chart 1.10.1
+# CRD Migration From Chart 1.10.1 to 2.0.0
 
 This procedure moves the Envoy Gateway v1.9.0 and Gateway API v1.6.1
 Experimental CRD lifecycle out of the application release without deleting or
@@ -12,7 +12,8 @@ missing objects but never tracked, upgraded, rolled back, or deleted them. The
 same subchart rendered a safe-upgrade `ValidatingAdmissionPolicy` and binding as
 normal Helm resources owned by the application release.
 
-The bridge release changes three contracts:
+Chart 2.0.0 is intentionally a major release. The bridge changes three
+contracts:
 
 - Kubernetes support is corrected to the upstream Envoy Gateway v1.9 matrix:
   1.33 through 1.36.
@@ -40,8 +41,8 @@ Set the placeholders used below:
 export NAMESPACE=envoy-gateway
 export APP_RELEASE=envoy-gateway
 export CRD_RELEASE=envoy-gateway-crds
-export BRIDGE_VERSION=BRIDGE_CHART_VERSION
-export CRD_CHART_VERSION=CRD_CHART_VERSION
+export BRIDGE_VERSION=2.0.0
+export CRD_CHART_VERSION=1.0.0
 
 REQUIRED_CRDS='backendtlspolicies.gateway.networking.k8s.io
 gatewayclasses.gateway.networking.k8s.io

--- a/charts/envoy-gateway/docs/crd-migration.md
+++ b/charts/envoy-gateway/docs/crd-migration.md
@@ -1,0 +1,351 @@
+# CRD Migration From Chart 1.10.1
+
+This procedure moves the Envoy Gateway v1.9.0 and Gateway API v1.6.1
+Experimental CRD lifecycle out of the application release without deleting or
+recreating cluster APIs or stored custom resources.
+
+## User Impact
+
+Chart 1.10.1 allowed Kubernetes 1.26 and installed 18 CRDs through a local
+subchart. The CRDs were under Helm's special `crds/` directory, so Helm created
+missing objects but never tracked, upgraded, rolled back, or deleted them. The
+same subchart rendered a safe-upgrade `ValidatingAdmissionPolicy` and binding as
+normal Helm resources owned by the application release.
+
+The bridge release changes three contracts:
+
+- Kubernetes support is corrected to the upstream Envoy Gateway v1.9 matrix:
+  1.33 through 1.36.
+- New installations place CRDs and the safe-upgrade policy in the standalone
+  `envoy-gateway-crds` release.
+- `crds.enabled=false` now fails before application rendering when the complete
+  compatible CRD bundle is not discoverable.
+
+Clusters older than Kubernetes 1.33 must be upgraded before this chart. Users
+already on 1.10.1 must not disable `crds.enabled` until the bridge step below is
+complete.
+
+## Requirements
+
+- Kubernetes 1.33 through 1.36.
+- Cluster-admin access for CRDs and admission policies.
+- Helm 3.17 or later for `--take-ownership`, or the audited metadata fallback.
+- `kubectl` and `jq` for the inventory checks.
+- Published bridge and standalone chart versions selected from the same Envoy
+  Gateway v1.9.0 compatibility line.
+
+Set the placeholders used below:
+
+```shell
+export NAMESPACE=envoy-gateway
+export APP_RELEASE=envoy-gateway
+export CRD_RELEASE=envoy-gateway-crds
+export BRIDGE_VERSION=BRIDGE_CHART_VERSION
+export CRD_CHART_VERSION=CRD_CHART_VERSION
+
+REQUIRED_CRDS='backendtlspolicies.gateway.networking.k8s.io
+gatewayclasses.gateway.networking.k8s.io
+gateways.gateway.networking.k8s.io
+grpcroutes.gateway.networking.k8s.io
+httproutes.gateway.networking.k8s.io
+listenersets.gateway.networking.k8s.io
+referencegrants.gateway.networking.k8s.io
+tcproutes.gateway.networking.k8s.io
+tlsroutes.gateway.networking.k8s.io
+udproutes.gateway.networking.k8s.io
+backends.gateway.envoyproxy.io
+backendtrafficpolicies.gateway.envoyproxy.io
+clienttrafficpolicies.gateway.envoyproxy.io
+envoyextensionpolicies.gateway.envoyproxy.io
+envoypatchpolicies.gateway.envoyproxy.io
+envoyproxies.gateway.envoyproxy.io
+httproutefilters.gateway.envoyproxy.io
+securitypolicies.gateway.envoyproxy.io'
+```
+
+## 1. Capture The Current State
+
+Confirm the current application release and Kubernetes version:
+
+```shell
+helm status "$APP_RELEASE" --namespace "$NAMESPACE"
+kubectl version
+```
+
+Create a change-record directory and capture cluster-scoped objects:
+
+```shell
+mkdir -p envoy-gateway-crd-migration
+for crd in $REQUIRED_CRDS; do
+  kubectl get crd "$crd" -o json
+done | jq -s '{apiVersion: "v1", kind: "List", items: .}' \
+  > envoy-gateway-crd-migration/crds-before.json
+kubectl get validatingadmissionpolicy,validatingadmissionpolicybinding \
+  safe-upgrades.gateway.networking.k8s.io \
+  -o json > envoy-gateway-crd-migration/policy-before.json
+```
+
+Capture every stored Gateway API and Envoy Gateway custom resource. A missing
+resource type should stop the preflight instead of being silently ignored:
+
+```shell
+for resource in $(kubectl api-resources \
+  --api-group=gateway.networking.k8s.io \
+  --verbs=list \
+  -o name); do
+  kubectl get "$resource" -A -o json
+done > envoy-gateway-crd-migration/gateway-api-before.json
+
+for resource in $(kubectl api-resources \
+  --api-group=gateway.envoyproxy.io \
+  --verbs=list \
+  -o name); do
+  kubectl get "$resource" -A -o json
+done > envoy-gateway-crd-migration/envoy-api-before.json
+```
+
+Create stable name/UID inventories for later comparison:
+
+```shell
+jq -r '.items[] | [.metadata.name, .metadata.uid] | @tsv' \
+  envoy-gateway-crd-migration/crds-before.json \
+  | sort > envoy-gateway-crd-migration/crd-uids-before.tsv
+
+jq -rs '[.[].items[]] | .[] |
+  [.apiVersion, .kind, (.metadata.namespace // ""), .metadata.name, .metadata.uid] |
+  @tsv' envoy-gateway-crd-migration/gateway-api-before.json \
+  envoy-gateway-crd-migration/envoy-api-before.json \
+  | sort > envoy-gateway-crd-migration/resource-uids-before.tsv
+```
+
+## 2. Upgrade To The Bridge With Bundled CRDs Enabled
+
+The bridge must become the current application revision before ownership is
+moved. It records `helm.sh/resource-policy: keep` in both the live resources and
+the Helm release manifest used by the next upgrade.
+
+```shell
+helm upgrade "$APP_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway \
+  --version "$BRIDGE_VERSION" \
+  --namespace "$NAMESPACE" \
+  --reuse-values \
+  --set crds.enabled=true \
+  --wait \
+  --timeout 10m
+```
+
+Verify the protection on both objects:
+
+```shell
+kubectl get validatingadmissionpolicy \
+  safe-upgrades.gateway.networking.k8s.io \
+  -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}{"\n"}'
+kubectl get validatingadmissionpolicybinding \
+  safe-upgrades.gateway.networking.k8s.io \
+  -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}{"\n"}'
+```
+
+Both commands must print `keep`. Stop if either value is absent.
+
+## 3. Apply The Matching CRD Bundle Server-Side
+
+Render only the selected CRDs. Disabling policy management prevents the
+standalone release from competing for policy ownership during this phase:
+
+```shell
+helm template "$CRD_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --version "$CRD_CHART_VERSION" \
+  --include-crds \
+  --set safeUpgradePolicy.management=disabled \
+  > envoy-gateway-crd-migration/envoy-gateway-crds.yaml
+```
+
+Run a server-side dry-run, inspect conflicts, then apply:
+
+```shell
+kubectl apply \
+  --server-side \
+  --dry-run=server \
+  --field-manager=helmforge-envoy-gateway-crds \
+  -f envoy-gateway-crd-migration/envoy-gateway-crds.yaml
+
+kubectl apply \
+  --server-side \
+  --field-manager=helmforge-envoy-gateway-crds \
+  -f envoy-gateway-crd-migration/envoy-gateway-crds.yaml
+
+kubectl wait \
+  --for=condition=Established \
+  --timeout=120s \
+  -f envoy-gateway-crd-migration/envoy-gateway-crds.yaml
+```
+
+Do not add `--force-conflicts` by default. If the dry-run reports conflicts,
+inspect `metadata.managedFields` and confirm that each conflicting field is part
+of the known v1.9.0/v1.6.1 bundle before making an explicit ownership decision.
+
+## 4. Create The Standalone Release Without Policy Ownership
+
+The CRDs already exist and were updated server-side. Record the standalone Helm
+release without asking Helm to create them again:
+
+```shell
+helm upgrade --install "$CRD_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --version "$CRD_CHART_VERSION" \
+  --namespace "$NAMESPACE" \
+  --create-namespace \
+  --skip-crds \
+  --set safeUpgradePolicy.management=disabled
+```
+
+## 5. Disable The Old Dependency
+
+Now upgrade the same bridge application release with the bundled dependency
+disabled:
+
+```shell
+helm upgrade "$APP_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway \
+  --version "$BRIDGE_VERSION" \
+  --namespace "$NAMESPACE" \
+  --reuse-values \
+  --set crds.enabled=false \
+  --wait \
+  --timeout 10m
+```
+
+This operation performs discovery checks for all 18 required GVKs. When the
+Helm operation is server-connected it also checks the v1.6.1 Experimental and
+v1.9.0 bundle annotations. Do not use `--disable-validation` to bypass a failure.
+
+Verify that the application manifest no longer contains the policy while the
+live policy remains present:
+
+```shell
+if helm get manifest "$APP_RELEASE" --namespace "$NAMESPACE" \
+  | grep -q 'safe-upgrades.gateway.networking.k8s.io'; then
+  echo "application release still contains the safe-upgrade policy" >&2
+  exit 1
+fi
+
+kubectl get validatingadmissionpolicy,validatingadmissionpolicybinding \
+  safe-upgrades.gateway.networking.k8s.io
+```
+
+## 6. Transfer Policy Ownership
+
+First render the standalone policy and compare its `spec` with the live policy.
+Do not adopt an unexpected policy:
+
+```shell
+helm template "$CRD_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --version "$CRD_CHART_VERSION" \
+  --namespace "$NAMESPACE" \
+  --skip-crds \
+  --set safeUpgradePolicy.management=managed \
+  > envoy-gateway-crd-migration/policy-standalone.yaml
+```
+
+With Helm 3.17 or later, adopt both existing objects and enable managed mode:
+
+```shell
+helm upgrade "$CRD_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway-crds \
+  --version "$CRD_CHART_VERSION" \
+  --namespace "$NAMESPACE" \
+  --skip-crds \
+  --take-ownership \
+  --set safeUpgradePolicy.management=managed
+```
+
+For older Helm clients, patch only the standard Helm ownership metadata after
+the same specification audit, then run the command without `--take-ownership`:
+
+```shell
+for kind in validatingadmissionpolicy validatingadmissionpolicybinding; do
+  kubectl label "$kind" safe-upgrades.gateway.networking.k8s.io \
+    app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl annotate "$kind" safe-upgrades.gateway.networking.k8s.io \
+    meta.helm.sh/release-name="$CRD_RELEASE" \
+    meta.helm.sh/release-namespace="$NAMESPACE" \
+    --overwrite
+done
+```
+
+Never edit Helm release Secrets and never use a hook to transfer ownership.
+
+## 7. Prove That No Object Was Recreated
+
+Capture the post-migration state and compare it to the preflight inventory:
+
+```shell
+for crd in $REQUIRED_CRDS; do
+  kubectl get crd "$crd" -o json
+done | jq -s '{apiVersion: "v1", kind: "List", items: .}' \
+  > envoy-gateway-crd-migration/crds-after.json
+jq -r '.items[] | [.metadata.name, .metadata.uid] | @tsv' \
+  envoy-gateway-crd-migration/crds-after.json \
+  | sort > envoy-gateway-crd-migration/crd-uids-after.tsv
+diff -u envoy-gateway-crd-migration/crd-uids-before.tsv \
+  envoy-gateway-crd-migration/crd-uids-after.tsv
+```
+
+Repeat the custom-resource inventory from step 1 into
+`resource-uids-after.tsv`, then compare it with `resource-uids-before.tsv`.
+Both diffs must be empty. Also verify:
+
+```shell
+kubectl get crd gateways.gateway.networking.k8s.io \
+  -o jsonpath='{.metadata.annotations.gateway\.networking\.k8s\.io/bundle-version}{" "}{.metadata.annotations.gateway\.networking\.k8s\.io/channel}{"\n"}'
+kubectl get crd envoyproxies.gateway.envoyproxy.io \
+  -o jsonpath='{.metadata.annotations.helmforge\.dev/bundle-version}{"\n"}'
+kubectl rollout status deployment --namespace "$NAMESPACE" --timeout=5m
+kubectl get gatewayclass,gateway,httproute -A
+```
+
+Expected bundle output is `v1.6.1 experimental` and `v1.9.0`.
+
+## Helm Diff And GitOps
+
+Bootstrap remains two-phase because a client-side diff cannot discover APIs
+that have not been applied. Apply and wait for the CRD release first. Then the
+application diff can retain Kubernetes validation:
+
+```shell
+helm diff upgrade "$APP_RELEASE" \
+  oci://ghcr.io/helmforgedev/helm/envoy-gateway \
+  --version "$BRIDGE_VERSION" \
+  --namespace "$NAMESPACE" \
+  --allow-unreleased \
+  --set crds.enabled=false
+```
+
+Do not add `--disable-validation`. Use `--dry-run=server` when exact lookup-based
+metadata checks are required during diff.
+
+## Rollback And Recovery
+
+CRD schemas are forward-only. `helm rollback envoy-gateway-crds` does not
+downgrade objects from `crds/`, and no supported procedure applies older CRD
+schemas over stored resources. Roll back the application only to a controller
+version compatible with the live bundle.
+
+After policy ownership has moved, do not run `helm rollback` to an application
+revision from before the bridge. That revision contains the old CRD dependency
+and attempts to add the policy and binding back to the application release.
+Use `helm diff rollback` to detect this unsafe plan. Recover by upgrading the
+desired compatible application chart with `crds.enabled=false`, not by restoring
+the pre-bridge release manifest.
+
+If an inventory comparison changes a UID or loses a custom resource, stop
+before policy adoption or further controller changes. Preserve diagnostics and
+recover forward from the captured manifests and application backups.
+
+Uninstalling the application release after migration does not touch CRDs or the
+policy. Uninstalling the standalone release also retains CRDs, custom resources,
+policy, and binding by design. Manual CRD deletion is outside this lifecycle
+because Kubernetes deletes all custom resources stored under a deleted CRD.

--- a/charts/envoy-gateway/docs/crd-migration.md
+++ b/charts/envoy-gateway/docs/crd-migration.md
@@ -76,6 +76,8 @@ kubectl version
 Create a change-record directory and capture cluster-scoped objects:
 
 ```shell
+set -euo pipefail
+
 mkdir -p envoy-gateway-crd-migration
 for crd in $REQUIRED_CRDS; do
   kubectl get crd "$crd" -o json
@@ -90,6 +92,8 @@ Capture every stored Gateway API and Envoy Gateway custom resource. A missing
 resource type should stop the preflight instead of being silently ignored:
 
 ```shell
+set -euo pipefail
+
 for resource in $(kubectl api-resources \
   --api-group=gateway.networking.k8s.io \
   --verbs=list \
@@ -108,6 +112,8 @@ done > envoy-gateway-crd-migration/envoy-api-before.json
 Create stable name/UID inventories for later comparison:
 
 ```shell
+set -euo pipefail
+
 jq -r '.items[] | [.metadata.name, .metadata.uid] | @tsv' \
   envoy-gateway-crd-migration/crds-before.json \
   | sort > envoy-gateway-crd-migration/crd-uids-before.tsv
@@ -117,6 +123,10 @@ jq -rs '[.[].items[]] | .[] |
   @tsv' envoy-gateway-crd-migration/gateway-api-before.json \
   envoy-gateway-crd-migration/envoy-api-before.json \
   | sort > envoy-gateway-crd-migration/resource-uids-before.tsv
+
+jq -r '.items[] | [.kind, .metadata.name, .metadata.uid] | @tsv' \
+  envoy-gateway-crd-migration/policy-before.json \
+  | sort > envoy-gateway-crd-migration/policy-uids-before.tsv
 ```
 
 ## 2. Upgrade To The Bridge With Bundled CRDs Enabled
@@ -177,10 +187,9 @@ kubectl apply \
   --field-manager=helmforge-envoy-gateway-crds \
   -f envoy-gateway-crd-migration/envoy-gateway-crds.yaml
 
-kubectl wait \
-  --for=condition=Established \
-  --timeout=120s \
-  -f envoy-gateway-crd-migration/envoy-gateway-crds.yaml
+for crd in $REQUIRED_CRDS; do
+  kubectl wait --for=condition=Established --timeout=120s "crd/$crd"
+done
 ```
 
 Do not add `--force-conflicts` by default. If the dry-run reports conflicts,
@@ -284,6 +293,8 @@ Never edit Helm release Secrets and never use a hook to transfer ownership.
 Capture the post-migration state and compare it to the preflight inventory:
 
 ```shell
+set -euo pipefail
+
 for crd in $REQUIRED_CRDS; do
   kubectl get crd "$crd" -o json
 done | jq -s '{apiVersion: "v1", kind: "List", items: .}' \
@@ -293,11 +304,21 @@ jq -r '.items[] | [.metadata.name, .metadata.uid] | @tsv' \
   | sort > envoy-gateway-crd-migration/crd-uids-after.tsv
 diff -u envoy-gateway-crd-migration/crd-uids-before.tsv \
   envoy-gateway-crd-migration/crd-uids-after.tsv
+
+kubectl get validatingadmissionpolicy,validatingadmissionpolicybinding \
+  safe-upgrades.gateway.networking.k8s.io \
+  -o json > envoy-gateway-crd-migration/policy-after.json
+jq -r '.items[] | [.kind, .metadata.name, .metadata.uid] | @tsv' \
+  envoy-gateway-crd-migration/policy-after.json \
+  | sort > envoy-gateway-crd-migration/policy-uids-after.tsv
+diff -u envoy-gateway-crd-migration/policy-uids-before.tsv \
+  envoy-gateway-crd-migration/policy-uids-after.tsv
 ```
 
 Repeat the custom-resource inventory from step 1 into
 `resource-uids-after.tsv`, then compare it with `resource-uids-before.tsv`.
-Both diffs must be empty. Also verify:
+The CRD, custom-resource, and policy-resource UID diffs must all be empty. Also
+verify:
 
 ```shell
 kubectl get crd gateways.gateway.networking.k8s.io \

--- a/charts/envoy-gateway/templates/NOTES.txt
+++ b/charts/envoy-gateway/templates/NOTES.txt
@@ -18,7 +18,9 @@ CRDs:
 {{- else }}
   Standalone lifecycle: crds.enabled=false
   Required bundle: Envoy Gateway v1.9.0 + Gateway API v1.6.1 Experimental
-  Discovery and server-connected metadata validation passed during rendering.
+  Required API discovery passed during rendering.
+  Exact bundle metadata is also validated during server-connected rendering;
+  client-only rendering cannot perform lookup-based metadata validation.
 {{- end }}
 
 --------------------------------------------------------------------------------

--- a/charts/envoy-gateway/templates/NOTES.txt
+++ b/charts/envoy-gateway/templates/NOTES.txt
@@ -9,9 +9,16 @@ Profile:      {{ .Values.profile | default "custom" }}
 
 CRDs:
 {{- if .Values.crds.enabled }}
-  Managed by this release: Envoy Gateway and Gateway API experimental CRDs
+  Bridge mode: bundled Envoy Gateway and Gateway API Experimental CRDs enabled
+  Migration protection: safe-upgrade policy and binding use resource-policy=keep
+
+  Existing chart 1.10.1 users must keep this mode for the first bridge upgrade,
+  then follow the migration guide before setting crds.enabled=false:
+  https://helmforge.dev/docs/charts/envoy-gateway#crd-migration-from-chart-1101
 {{- else }}
-  Managed externally (crds.enabled=false)
+  Standalone lifecycle: crds.enabled=false
+  Required bundle: Envoy Gateway v1.9.0 + Gateway API v1.6.1 Experimental
+  Discovery and server-connected metadata validation passed during rendering.
 {{- end }}
 
 --------------------------------------------------------------------------------
@@ -272,5 +279,4 @@ Gateway API:   https://gateway-api.sigs.k8s.io/
 Envoy Gateway: https://gateway.envoyproxy.io/
 
 ================================================================================
-
 Happy Helmforging :)

--- a/charts/envoy-gateway/templates/_helpers.tpl
+++ b/charts/envoy-gateway/templates/_helpers.tpl
@@ -279,4 +279,83 @@ Central fail-fast validation entrypoint.
 {{- fail (printf "podLabels must not override selector label %s" $key) -}}
 {{- end -}}
 {{- end -}}
+{{- if not .Values.crds.enabled -}}
+{{- $requiredGVKs := list
+  "gateway.networking.k8s.io/v1/BackendTLSPolicy"
+  "gateway.networking.k8s.io/v1/GatewayClass"
+  "gateway.networking.k8s.io/v1/Gateway"
+  "gateway.networking.k8s.io/v1/GRPCRoute"
+  "gateway.networking.k8s.io/v1/HTTPRoute"
+  "gateway.networking.k8s.io/v1/ListenerSet"
+  "gateway.networking.k8s.io/v1/ReferenceGrant"
+  "gateway.networking.k8s.io/v1/TCPRoute"
+  "gateway.networking.k8s.io/v1/TLSRoute"
+  "gateway.networking.k8s.io/v1/UDPRoute"
+  "gateway.envoyproxy.io/v1alpha1/Backend"
+  "gateway.envoyproxy.io/v1alpha1/BackendTrafficPolicy"
+  "gateway.envoyproxy.io/v1alpha1/ClientTrafficPolicy"
+  "gateway.envoyproxy.io/v1alpha1/EnvoyExtensionPolicy"
+  "gateway.envoyproxy.io/v1alpha1/EnvoyPatchPolicy"
+  "gateway.envoyproxy.io/v1alpha1/EnvoyProxy"
+  "gateway.envoyproxy.io/v1alpha1/HTTPRouteFilter"
+  "gateway.envoyproxy.io/v1alpha1/SecurityPolicy"
+-}}
+{{- $missingGVKs := list -}}
+{{- range $gvk := $requiredGVKs -}}
+{{- if not ($.Capabilities.APIVersions.Has $gvk) -}}
+{{- $missingGVKs = append $missingGVKs $gvk -}}
+{{- end -}}
+{{- end -}}
+{{- if $missingGVKs -}}
+{{- fail (printf "crds.enabled=false requires the complete Envoy Gateway v1.9.0 / Gateway API v1.6.1 Experimental bundle; missing discoverable APIs: %s. Install envoy-gateway-crds first, wait for all CRDs to become Established, then retry without --disable-validation" (join ", " $missingGVKs)) -}}
+{{- end -}}
+
+{{- /* `lookup` is empty in client-only rendering. When connected to a cluster,
+validate the exact bundle metadata in addition to discovery. */ -}}
+{{- $incompatible := list -}}
+{{- $gatewayCRDs := list
+  "backendtlspolicies.gateway.networking.k8s.io"
+  "gatewayclasses.gateway.networking.k8s.io"
+  "gateways.gateway.networking.k8s.io"
+  "grpcroutes.gateway.networking.k8s.io"
+  "httproutes.gateway.networking.k8s.io"
+  "listenersets.gateway.networking.k8s.io"
+  "referencegrants.gateway.networking.k8s.io"
+  "tcproutes.gateway.networking.k8s.io"
+  "tlsroutes.gateway.networking.k8s.io"
+  "udproutes.gateway.networking.k8s.io"
+-}}
+{{- range $name := $gatewayCRDs -}}
+{{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $name -}}
+{{- if $crd -}}
+{{- $version := dig "metadata" "annotations" "gateway.networking.k8s.io/bundle-version" "" $crd -}}
+{{- $channel := dig "metadata" "annotations" "gateway.networking.k8s.io/channel" "" $crd -}}
+{{- if or (ne $version "v1.6.1") (ne $channel "experimental") -}}
+{{- $incompatible = append $incompatible (printf "%s (bundle-version=%q, channel=%q)" $name $version $channel) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $envoyCRDs := list
+  "backends.gateway.envoyproxy.io"
+  "backendtrafficpolicies.gateway.envoyproxy.io"
+  "clienttrafficpolicies.gateway.envoyproxy.io"
+  "envoyextensionpolicies.gateway.envoyproxy.io"
+  "envoypatchpolicies.gateway.envoyproxy.io"
+  "envoyproxies.gateway.envoyproxy.io"
+  "httproutefilters.gateway.envoyproxy.io"
+  "securitypolicies.gateway.envoyproxy.io"
+-}}
+{{- range $name := $envoyCRDs -}}
+{{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $name -}}
+{{- if $crd -}}
+{{- $version := dig "metadata" "annotations" "helmforge.dev/bundle-version" "" $crd -}}
+{{- if ne $version "v1.9.0" -}}
+{{- $incompatible = append $incompatible (printf "%s (helmforge.dev/bundle-version=%q)" $name $version) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $incompatible -}}
+{{- fail (printf "crds.enabled=false found an incompatible external CRD bundle: %s. Apply the matching envoy-gateway-crds bundle server-side before upgrading the controller" (join ", " $incompatible)) -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/envoy-gateway/tests/crd_bridge_policy_test.yaml
+++ b/charts/envoy-gateway/tests/crd_bridge_policy_test.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: CRD bridge safe-upgrade policy
+templates:
+  - charts/crds/templates/gatewayapi-safe-upgrade-policy.yaml
+tests:
+  - it: records keep on both policy resources before ownership transfer
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        documentIndex: 1

--- a/charts/envoy-gateway/tests/validation_test.yaml
+++ b/charts/envoy-gateway/tests/validation_test.yaml
@@ -2,12 +2,83 @@
 suite: Validation
 templates:
   - validate.yaml
+kubernetesProvider:
+  scheme:
+    "apiextensions.k8s.io/v1/CustomResourceDefinition":
+      gvr:
+        group: apiextensions.k8s.io
+        version: v1
+        resource: customresourcedefinitions
+      namespaced: false
 tests:
   - it: should accept externally managed CRDs
     set:
       crds.enabled: false
+    capabilities: &complete-crd-capabilities
+      apiVersions:
+        - gateway.networking.k8s.io/v1/BackendTLSPolicy
+        - gateway.networking.k8s.io/v1/GatewayClass
+        - gateway.networking.k8s.io/v1/Gateway
+        - gateway.networking.k8s.io/v1/GRPCRoute
+        - gateway.networking.k8s.io/v1/HTTPRoute
+        - gateway.networking.k8s.io/v1/ListenerSet
+        - gateway.networking.k8s.io/v1/ReferenceGrant
+        - gateway.networking.k8s.io/v1/TCPRoute
+        - gateway.networking.k8s.io/v1/TLSRoute
+        - gateway.networking.k8s.io/v1/UDPRoute
+        - gateway.envoyproxy.io/v1alpha1/Backend
+        - gateway.envoyproxy.io/v1alpha1/BackendTrafficPolicy
+        - gateway.envoyproxy.io/v1alpha1/ClientTrafficPolicy
+        - gateway.envoyproxy.io/v1alpha1/EnvoyExtensionPolicy
+        - gateway.envoyproxy.io/v1alpha1/EnvoyPatchPolicy
+        - gateway.envoyproxy.io/v1alpha1/EnvoyProxy
+        - gateway.envoyproxy.io/v1alpha1/HTTPRouteFilter
+        - gateway.envoyproxy.io/v1alpha1/SecurityPolicy
     asserts:
       - notFailedTemplate: {}
+
+  - it: should reject an incomplete externally managed CRD bundle
+    set:
+      crds.enabled: false
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1/BackendTLSPolicy
+        - gateway.networking.k8s.io/v1/GatewayClass
+        - gateway.networking.k8s.io/v1/Gateway
+        - gateway.networking.k8s.io/v1/GRPCRoute
+        - gateway.networking.k8s.io/v1/HTTPRoute
+        - gateway.networking.k8s.io/v1/ListenerSet
+        - gateway.networking.k8s.io/v1/ReferenceGrant
+        - gateway.networking.k8s.io/v1/TCPRoute
+        - gateway.networking.k8s.io/v1/TLSRoute
+        - gateway.networking.k8s.io/v1/UDPRoute
+        - gateway.envoyproxy.io/v1alpha1/Backend
+        - gateway.envoyproxy.io/v1alpha1/BackendTrafficPolicy
+        - gateway.envoyproxy.io/v1alpha1/ClientTrafficPolicy
+        - gateway.envoyproxy.io/v1alpha1/EnvoyExtensionPolicy
+        - gateway.envoyproxy.io/v1alpha1/EnvoyPatchPolicy
+        - gateway.envoyproxy.io/v1alpha1/HTTPRouteFilter
+        - gateway.envoyproxy.io/v1alpha1/SecurityPolicy
+    asserts:
+      - failedTemplate:
+          errorMessage: "crds.enabled=false requires the complete Envoy Gateway v1.9.0 / Gateway API v1.6.1 Experimental bundle; missing discoverable APIs: gateway.envoyproxy.io/v1alpha1/EnvoyProxy. Install envoy-gateway-crds first, wait for all CRDs to become Established, then retry without --disable-validation"
+
+  - it: should reject incompatible externally managed CRD metadata
+    set:
+      crds.enabled: false
+    capabilities: *complete-crd-capabilities
+    kubernetesProvider:
+      objects:
+        - apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: gateways.gateway.networking.k8s.io
+            annotations:
+              gateway.networking.k8s.io/bundle-version: v1.5.1
+              gateway.networking.k8s.io/channel: experimental
+    asserts:
+      - failedTemplate:
+          errorMessage: 'crds.enabled=false found an incompatible external CRD bundle: gateways.gateway.networking.k8s.io (bundle-version="v1.5.1", channel="experimental"). Apply the matching envoy-gateway-crds bundle server-side before upgrading the controller'
   - it: should reject rate limiting without redis backend
     set:
       rateLimiting:

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -18,13 +18,13 @@
     },
     "crds": {
       "type": "object",
-      "description": "Bundled Envoy Gateway and Gateway API CRD installation",
+      "description": "Bridge lifecycle for bundled or standalone Envoy Gateway and Gateway API CRDs",
       "additionalProperties": false,
       "required": ["enabled"],
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Install bundled CRDs; disable only when CRDs are managed externally",
+          "description": "Install bundled CRDs; existing releases must migrate through this bridge before disabling",
           "default": true
         },
         "gatewayAPI": {

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -11,7 +11,9 @@ profile: custom
 namespaceOverride: ""
 
 # -- Install the Envoy Gateway and Gateway API CRDs bundled with the chart.
-# Disable only when a platform operator manages all required CRDs separately.
+# Existing installations must first upgrade to this bridge release with this
+# value enabled. Disable only after installing envoy-gateway-crds and completing
+# the documented UID-preserving migration.
 crds:
   enabled: true
 


### PR DESCRIPTION
## Merge blocker

Do not merge this PR until #1012 is merged and the
`envoy-gateway-crds` 1.0.0 package is published successfully. Existing users
need the standalone release to be available before Envoy Gateway 2.0.0 becomes
the current application chart.

## Breaking changes

This PR intentionally releases Envoy Gateway chart 2.0.0 because it:

- raises the Kubernetes requirement from `>=1.26` to `>=1.33 <1.37`;
- introduces a mandatory CRD lifecycle and ownership migration;
- changes the supported installation contract to use a standalone CRD release;
- makes `crds.enabled=false` fail fast unless all required APIs and compatible
  bundle metadata are present.

## What

- keeps the bundled CRD dependency enabled by default as a one-release
  migration bridge;
- records `helm.sh/resource-policy: keep` on the existing safe-upgrade policy
  and binding before ownership transfer;
- validates all 18 required API versions through discovery in external mode;
- validates exact Gateway API bundle version/channel and Envoy Gateway
  source/version metadata when connected to a cluster;
- adds the complete UID-preserving migration runbook from chart 1.10.1 to
  2.0.0;
- adds unit coverage for the bridge, missing APIs, partial bundles, and
  incompatible metadata.

## Why

Removing the current dependency in one step is unsafe. The CRDs themselves are
not part of Helm's release manifest, but the safe-upgrade policy is. Existing
users must first install the 2.0.0 bridge so the application release records
the keep policy, then establish and server-side apply the standalone CRD
bundle, disable the bundled dependency, and finally transfer policy ownership.

Resolves #981

## Mandatory upgrade sequence

1. Upgrade the existing Envoy Gateway release to 2.0.0 with
   `crds.enabled=true`.
2. Capture the CRD, custom-resource, and policy UIDs.
3. Install `envoy-gateway-crds` 1.0.0 with policy management disabled.
4. Server-side apply the locked CRD bundle and verify all 18 CRDs are
   `Established`.
5. Upgrade the application release with `crds.enabled=false`.
6. Transfer the policy and binding to the standalone release.
7. Compare all captured UIDs and validate Gateway traffic.

CRD schema upgrades are forward-only. Do not use Helm rollback to downgrade a
CRD bundle, and do not roll the application back to a release incompatible
with the live APIs.

## Validation

- migration from published chart 1.10.1 on Kubernetes 1.33 passed;
- all 18/18 CRD UIDs were preserved;
- all 4/4 test custom-resource UIDs were preserved;
- the safe-upgrade policy UID was preserved and ownership transferred;
- Helm 3.21.1, Helm 4.1.4, and helm-diff 3.15.11 paths passed;
- fresh Kubernetes 1.36 installation and runtime HTTP traffic passed;
- provider-managed Gateway API mode passed;
- incompatible bundle metadata was rejected before application manifests;
- `make validate-chart CHART=envoy-gateway`: 11/11 gates passed;
- combined `make preflight` passed.

## Related PRs

- Phase 1 chart: #1012
- Companion documentation: https://github.com/helmforgedev/site/pull/514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standalone CRD lifecycle support for Envoy Gateway and Gateway API resources.
  - Added validation for externally managed CRDs, including required versions, APIs, and bundle metadata.
  - Added migration safeguards that preserve resources and ownership during upgrades.
  - Added retention policies for admission policies during the transition.

- **Documentation**
  - Documented the required migration from chart 1.10.1 to 2.0.0, upgrade sequencing, recovery, and rollback limitations.
  - Updated installation guidance and support information for Kubernetes 1.33–1.36.

- **Bug Fixes**
  - Improved status messages and validation errors for missing or incompatible CRDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->