### PR TITLE
feat(mosquitto): Dual-stack listeners

### DIFF
--- a/charts/mosquitto/README.md
+++ b/charts/mosquitto/README.md
@@ -168,7 +168,7 @@ broker:
 
   extraConfig: |
     # Create a dedicated plaintext listener for health checks
-    listener 9000 0.0.0.0
+    listener 9000
     protocol mqtt
 
     # Silence the TCP connection logs

--- a/charts/mosquitto/templates/configmap.yaml
+++ b/charts/mosquitto/templates/configmap.yaml
@@ -14,17 +14,17 @@ data:
     per_listener_settings false
 
     {{- if not .Values.broker.tls.enabled }}
-    listener {{ .Values.broker.listeners.mqtt }} 0.0.0.0
+    listener {{ .Values.broker.listeners.mqtt }}
     protocol mqtt
     {{- end }}
 
     {{- if .Values.broker.listeners.websocketEnabled }}
-    listener {{ .Values.broker.listeners.websocket }} 0.0.0.0
+    listener {{ .Values.broker.listeners.websocket }}
     protocol websockets
     {{- end }}
 
     {{- if .Values.broker.tls.enabled }}
-    listener {{ .Values.broker.tls.port }} 0.0.0.0
+    listener {{ .Values.broker.tls.port }}
     protocol mqtt
     certfile /mosquitto/config/tls/{{ .Values.broker.tls.certFile }}
     keyfile /mosquitto/config/tls/{{ .Values.broker.tls.keyFile }}

--- a/charts/mosquitto/tests/configmap_test.yaml
+++ b/charts/mosquitto/tests/configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
           pattern: "listener 1883"
       - matchRegex:
           path: data["mosquitto.conf.tmpl"]
-          pattern: "listener 8883"
+          pattern: "(?m)^listener 8883$"
       - matchRegex:
           path: data["mosquitto.conf.tmpl"]
           pattern: "certfile /mosquitto/config/tls/tls.crt"

--- a/charts/mosquitto/tests/configmap_test.yaml
+++ b/charts/mosquitto/tests/configmap_test.yaml
@@ -15,10 +15,10 @@ tests:
     asserts:
       - notMatchRegex:
           path: data["mosquitto.conf.tmpl"]
-          pattern: "listener 1883 0.0.0.0"
+          pattern: "listener 1883"
       - matchRegex:
           path: data["mosquitto.conf.tmpl"]
-          pattern: "listener 8883 0.0.0.0"
+          pattern: "listener 8883"
       - matchRegex:
           path: data["mosquitto.conf.tmpl"]
           pattern: "certfile /mosquitto/config/tls/tls.crt"


### PR DESCRIPTION
## Summary

Mosquitto natively supports dual-stack TCP, but the current chart setup explicitly only listens on IPv4. Dropping `0.0.0.0` from the `listener` config stanzas brings in the IPv6 side as well.

Resolves #1015.

## Type Of Change

- [ ] New chart
- [X] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [X] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [X] I created this branch from updated `main`
- [X] My PR targets `main`
- [X] My commit message and PR title follow Conventional Commits
- [X] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [ ] I updated `values.schema.json` for any values changes
- [ ] I updated chart docs for behavior or default changes

## Upstream Verification

- [ ] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [ ] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [X] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [X] `helm lint charts/<chart-name> --strict` passed
- [X] `helm unittest charts/<chart-name>` passed
- [X] All relevant `ci/*.yaml` scenarios rendered successfully
- [ ] I validated this change on a local `k3d` cluster when required
- [X] I validated the default install
- [X] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

-

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Mosquitto listener configuration to use port-only directives for MQTT, WebSocket, and TLS connections.
  * Improved compatibility with environments where explicit `0.0.0.0` binding is unnecessary or unsupported.
* **Tests**
  * Updated configuration checks to reflect the revised listener format.
* **Documentation**
  * Updated the TLS health-check example to match the new listener configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->