### PR TITLE
chore(adguard-home): bump adguard home to 0.107.79

### DIFF
--- a/charts/adguard-home/Chart.yaml
+++ b/charts/adguard-home/Chart.yaml
@@ -4,7 +4,7 @@ name: adguard-home
 description: AdGuard Home network-wide ad and tracker blocking DNS server with sync and S3 backup
 type: application
 version: 1.5.0
-appVersion: "0.107.78"
+appVersion: "0.107.79"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/adguard-home/README.md
+++ b/charts/adguard-home/README.md
@@ -35,9 +35,9 @@ To skip the wizard and deploy a pre-configured instance, provide `config.adGuard
 
 ## Upstream Version Notes
 
-AdGuard Home `0.107.78` is an upstream security and bugfix release. It improves
-resistance to JIGGLE attacks, validates responses from DNS-over-HTTPS upstreams
-more strictly, and protects QUIC connections from unbounded reads.
+AdGuard Home `0.107.79` is an upstream security and stability release. It
+updates Go to address upstream vulnerabilities and improves resistance to
+resource exhaustion attacks when DNS-over-QUIC is enabled.
 
 The `0.107.76` release notes also state that YAML duration values now support
 `d` day units. If you roll back to a version below `v0.107.76`, convert any `d`
@@ -187,7 +187,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/adguard/adguardhome` | Container image |
-| `image.tag` | `v0.107.78` | Image tag |
+| `image.tag` | `v0.107.79` | Image tag |
 | `image.pullPolicy` | `IfNotPresent` | Pull policy |
 
 ### General Configuration

--- a/charts/adguard-home/tests/deployment_test.yaml
+++ b/charts/adguard-home/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/adguard/adguardhome:v0.107.78"
+          value: "docker.io/adguard/adguardhome:v0.107.79"
 
   - it: should expose setup wizard port 3000 by default (no config)
     template: templates/deployment.yaml

--- a/charts/adguard-home/values.yaml
+++ b/charts/adguard-home/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- AdGuard Home container image
   repository: docker.io/adguard/adguardhome
   # -- Image tag
-  tag: "v0.107.78"
+  tag: "v0.107.79"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump AdGuard Home from `v0.107.78` to `v0.107.79`
- preserve the upstream `v` image-tag prefix omitted by the automated issue
- update the image assertion and upstream security notes

## Upstream evidence

- Image manifest: `docker.io/adguard/adguardhome:v0.107.79`
- Platforms: `linux/386`, `linux/amd64`, `linux/arm`, `linux/arm64`, `linux/ppc64le`
- Official release: https://github.com/AdguardTeam/AdGuardHome/releases/tag/v0.107.79
- Release track: stable to stable; the release is neither draft nor prerelease

## Impact matrix

| Upstream change | Chart impact | Validation |
|---|---|---|
| Go security updates and DNS-over-QUIC resource-exhaustion hardening | Runtime image only; no values, ports, paths, persistence, or probe contract changes | `default` k3d scenario |
| Bootstrap comment support and install API language field | No chart-generated AdGuard configuration fields are removed or renamed | Static rendering of every CI profile |
| `strict_sni_check` deprecation | Existing configuration remains accepted; no default chart change required | Unit tests and full template validation |

## Validation

- `make image-verify IMAGE=docker.io/adguard/adguardhome:v0.107.79`
- `make deps-check CHART=adguard-home`
- `make validate-chart CHART=adguard-home K3D_SCENARIOS="default"` — 11 layers passed
- `make standards-check CHART=adguard-home`
- `node scripts/charts/template-standards-check.js --chart adguard-home`
- `make preflight`

Only `default` was selected for k3d because this stable patch changes the runtime image without changing the chart contract. All static layers still rendered and validated every CI profile.

Resolves #1017

## Site synchronization

- helmforgedev/site#537