### PR TITLE
chore(clickhouse): bump clickhouse to 26.7.5

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -4,7 +4,7 @@ name: clickhouse
 description: Fast column-oriented OLAP database with production-safe standalone defaults
 type: application
 version: 1.0.4
-appVersion: "26.7.3"
+appVersion: "26.7.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/clickhouse/README.md
+++ b/charts/clickhouse/README.md
@@ -15,7 +15,7 @@ helm install clickhouse oci://ghcr.io/helmforgedev/helm/clickhouse
 
 ## Features
 
-- Official ClickHouse image pinned to `26.7.3`.
+- Official ClickHouse image pinned to `26.7.5`.
 - StatefulSet with persistent data volume.
 - Client Service exposing HTTP `8123` and native TCP `9000`.
 - Headless Service for stable pod DNS.
@@ -55,7 +55,7 @@ networkPolicy:
 | --- | --- | --- |
 | `replicaCount` | ClickHouse pod count. Must remain `1` | `1` |
 | `image.repository` | Official image repository | `docker.io/clickhouse/clickhouse-server` |
-| `image.tag` | Official full-version tag | `26.7.3` |
+| `image.tag` | Official full-version tag | `26.7.5` |
 | `clickhouse.database` | Initial database | `default` |
 | `clickhouse.user` | Initial user | `default` |
 | `clickhouse.password` | Initial password | `""` |
@@ -104,7 +104,7 @@ clusters.
 ## Upgrade Notes
 
 This release moves ClickHouse from 26.6 to 26.7 stable. Review the upstream
-[ClickHouse 26.7 release notes](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.3.19-stable)
+[ClickHouse 26.7 release notes](https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.5.10-stable)
 and backward-incompatible changes before upgrading production workloads.
 Important changes include explicit credentials for user SQL that accesses S3,
 rejection of ZIP/ZIPX backups on object storage, stricter

--- a/charts/clickhouse/tests/statefulset_test.yaml
+++ b/charts/clickhouse/tests/statefulset_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/clickhouse/clickhouse-server:26.7.3
+          value: docker.io/clickhouse/clickhouse-server:26.7.5
   - it: exposes HTTP and native TCP ports
     template: statefulset.yaml
     asserts:

--- a/charts/clickhouse/tests/test_connection_test.yaml
+++ b/charts/clickhouse/tests/test_connection_test.yaml
@@ -17,7 +17,7 @@ tests:
           path: spec.containers[0].env
           content:
             name: CLICKHOUSE_EXPECTED_VERSION
-            value: "26.7.3"
+            value: "26.7.5"
       - contains:
           path: spec.containers[0].env
           content:

--- a/charts/clickhouse/values.yaml
+++ b/charts/clickhouse/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official ClickHouse image repository
   repository: docker.io/clickhouse/clickhouse-server
   # -- Official full-version tag
-  tag: "26.7.3"
+  tag: "26.7.5"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump ClickHouse from `26.7.3` to `26.7.5`
- update image assertions and the official stable-release reference

## Upstream evidence

- Image manifest: `docker.io/clickhouse/clickhouse-server:26.7.5`
- Platforms: `linux/amd64`, `linux/arm64`
- Official stable releases:
  - https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.4.58-stable
  - https://github.com/ClickHouse/ClickHouse/releases/tag/v26.7.5.10-stable
- Official changelogs:
  - https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelogs/v26.7.4.58-stable.md
  - https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelogs/v26.7.5.10-stable.md
- Release track: stable to stable; neither release is a prerelease

## Impact matrix

| Upstream change | Chart impact | Validation |
|---|---|---|
| Backported security, crash, race, and wrong-result fixes | Runtime image only; no chart configuration contract change | `default` k3d scenario |
| Query analyzer and format correctness fixes | No values, ports, paths, probes, or persistence changes | Static rendering of every CI profile |
| RESTORE durability and startup reliability fixes | Positive runtime behavior; storage layout is unchanged | StatefulSet rollout, endpoints, logs, events, and PVC lifecycle in `default` |

## Validation

- `make image-verify IMAGE=docker.io/clickhouse/clickhouse-server:26.7.5`
- `make deps-check CHART=clickhouse`
- `make validate-chart CHART=clickhouse K3D_SCENARIOS="default"` — 11 layers passed
- `make standards-check CHART=clickhouse`
- `node scripts/charts/template-standards-check.js --chart clickhouse`
- `make preflight`

Only `default` was selected for k3d because both skipped releases are stable patch backports without a chart contract or storage migration. All static layers still validated every CI profile.

Resolves #1018

## Site synchronization

- helmforgedev/site#538