### PR TITLE
chore(elasticsearch): bump elasticsearch to 9.5.2

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -4,7 +4,7 @@ name: elasticsearch
 description: Production-ready Elasticsearch cluster with intelligent presets, automated backups, ILM policies, and multi-role architecture
 type: application
 version: 1.1.6
-appVersion: "9.5.1"
+appVersion: "9.5.2"
 kubeVersion: ">=1.26.0-0"
 icon: https://helmforge.dev/icons/charts/elasticsearch.png
 home: https://helmforge.dev

--- a/charts/elasticsearch/README.md
+++ b/charts/elasticsearch/README.md
@@ -161,7 +161,7 @@ dataTiers:
 | `namespaceOverride` | Namespace for chart-managed namespaced resources | `""` |
 | `clusterName` | Elasticsearch cluster name | `helmforge-cluster` |
 | `image.repository` | Elasticsearch image | `docker.io/library/elasticsearch` |
-| `image.tag` | Image tag | `9.5.1` |
+| `image.tag` | Image tag | `9.5.2` |
 | `nameOverride` | Override chart name | `""` |
 | `fullnameOverride` | Override full release name | `""` |
 
@@ -262,7 +262,7 @@ dataTiers:
 | Parameter | Description | Default |
 |---|---|---|
 | `kibana.enabled` | Deploy Kibana alongside Elasticsearch | `false` |
-| `kibana.image.tag` | Kibana version (must match ES version) | `9.5.1` |
+| `kibana.image.tag` | Kibana version (must match ES version) | `9.5.2` |
 | `kibana.replicaCount` | Kibana replica count | `1` |
 | `kibana.ingress.enabled` | Expose Kibana via Ingress | `false` |
 | `kibana.ingress.hosts` | Ingress hostnames | `[kibana.example.com]` |
@@ -311,11 +311,10 @@ Security posture acceptable.
 
 ## Upgrade Notes
 
-`docker.io/library/elasticsearch:9.5.1` is an upstream image update from
-`9.4.3`. It improves aggregation memory accounting, search timeout enforcement,
-data stream authorization, snapshot handling on CIFS shares, ML model validation,
-and ES|QL reliability. Review the
-[upstream Elasticsearch 9.5.1 release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.1-release-notes)
+`docker.io/library/elasticsearch:9.5.2` is an upstream patch update from
+`9.5.1`. It improves settings and restore handling, index lifecycle reporting,
+ES|QL behavior during index deletion, and ingest concurrency. Review the
+[upstream Elasticsearch 9.5.2 release notes](https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.2-release-notes)
 before upgrading production clusters, take a snapshot backup, and verify Kibana
 compatibility, plugins, ILM policies, and index templates in a staging
 environment before reusing existing PVCs.

--- a/charts/elasticsearch/ci/kibana-values.yaml
+++ b/charts/elasticsearch/ci/kibana-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+persistence:
+  enabled: false
+
+kibana:
+  enabled: true

--- a/charts/elasticsearch/tests/kibana_test.yaml
+++ b/charts/elasticsearch/tests/kibana_test.yaml
@@ -58,7 +58,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/kibana:9.5.1
+          value: docker.io/library/kibana:9.5.2
         documentIndex: 0
 
   - it: kibana with security uses https url

--- a/charts/elasticsearch/tests/profile_test.yaml
+++ b/charts/elasticsearch/tests/profile_test.yaml
@@ -54,7 +54,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/elasticsearch:9.5.1
+          value: docker.io/library/elasticsearch:9.5.2
 
   - it: sysctl init should explicitly opt out of pod-level non-root policy
     set:

--- a/charts/elasticsearch/values.schema.json
+++ b/charts/elasticsearch/values.schema.json
@@ -37,7 +37,7 @@
         "tag": {
           "type": "string",
           "description": "Elasticsearch image tag (must not be latest)",
-          "default": "9.5.1"
+          "default": "9.5.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -247,7 +247,7 @@
             "tag": {
               "type": "string",
               "description": "Kibana image tag. Keep aligned with Elasticsearch.",
-              "default": "9.5.1"
+              "default": "9.5.2"
             },
             "pullPolicy": {
               "type": "string",

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ image:
   # -- Elasticsearch image repository (fully qualified, official)
   repository: docker.io/library/elasticsearch
   # -- Elasticsearch image tag. Defaults to appVersion.
-  tag: "9.5.1"
+  tag: "9.5.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -324,7 +324,7 @@ kibana:
   enabled: false
   image:
     repository: docker.io/library/kibana
-    tag: "9.5.1"
+    tag: "9.5.2"
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}


### PR DESCRIPTION
## Summary

- bump Elasticsearch and the matching optional Kibana image from `9.5.1` to `9.5.2`
- synchronize schema defaults, documentation, and image assertions
- add a focused CI profile that exercises Kibana with ephemeral Elasticsearch storage

## Upstream evidence

- Elasticsearch manifest: `docker.io/library/elasticsearch:9.5.2` (`linux/amd64`, `linux/arm64`)
- Kibana manifest: `docker.io/library/kibana:9.5.2`
- Official release: https://github.com/elastic/elasticsearch/releases/tag/v9.5.2
- Official release notes: https://www.elastic.co/docs/release-notes/elasticsearch#elasticsearch-9.5.2-release-notes
- Release track: stable patch to stable patch

## Impact matrix

| Upstream change | Chart impact | Validation |
|---|---|---|
| Settings, restore, ILM, ES|QL, and ingest fixes | Runtime images only; no chart setting, port, path, or persistence contract changes | `default` k3d scenario |
| Elasticsearch and Kibana must remain version-aligned | Both image defaults and schema defaults move together | `ci/kibana-values.yaml` k3d scenario |
| No storage migration or breaking change in 9.5.2 | Existing PVC layout and upgrade guidance remain valid | StatefulSet rollout, endpoints, logs, events, and ephemeral Kibana integration |

## Validation

- `make image-verify IMAGE=docker.io/library/elasticsearch:9.5.2`
- `make deps-check CHART=elasticsearch`
- `make validate-chart CHART=elasticsearch K3D_SCENARIOS="default ci/kibana-values.yaml"` — 12 layers passed
- `make standards-check CHART=elasticsearch`
- `node scripts/charts/template-standards-check.js --chart elasticsearch`
- `make preflight`

`default` validates the stateful Elasticsearch runtime. The new Kibana profile is included because this PR also changes the version-locked Kibana image; unrelated optional profiles were not affected. All static layers still validate every CI profile.

Resolves #1019

## Site synchronization

- helmforgedev/site#539