### PR TITLE
chore(generic): bump nginx to 1.31.4

### DIFF
--- a/charts/generic/Chart.yaml
+++ b/charts/generic/Chart.yaml
@@ -7,14 +7,14 @@ maintainers:
   - name: helmforgedev
   - name: mberlofa
 version: 3.1.3
-appVersion: "1.31.3"
+appVersion: "1.31.4"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/generic-helmforge.png
 kubeVersion: ">=1.26.0-0"
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump nginx to 1.31.3 (#814)"
+      description: "bump nginx to 1.31.4 (#1021)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/generic/README.md
+++ b/charts/generic/README.md
@@ -3,9 +3,9 @@
 A single chart that handles **Deployments**, **StatefulSets**, **DaemonSets**, **Jobs**, and **CronJobs** with a unified values
 interface. Designed for teams that deploy many services and want one chart to rule them all.
 
-The default `nginx:1.31.3` image includes upstream fixes for CVE-2026-42533,
-CVE-2026-60005, and CVE-2026-56434. Existing Generic chart configuration
-remains compatible with this image update.
+The default `nginx:1.31.4` image adds stricter protocol validation, standards-correct
+HTTP/2 and gRPC upstream host handling, and worker stability and memory-safety fixes.
+Existing Generic chart configuration remains compatible with this image update.
 
 ## Install
 
@@ -370,7 +370,7 @@ See the [examples/](examples/) directory for complete, ready-to-use values files
 | **Image** | | |
 | `global.imageRegistry` | Optional registry prefix for unqualified repositories | `""` |
 | `image.repository` | Container image repository | `docker.io/library/nginx` |
-| `image.tag` | Image tag | `1.31.3` |
+| `image.tag` | Image tag | `1.31.4` |
 | `image.digest` | Image digest, takes precedence over tag | `""` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Registry pull secrets | `[]` |

--- a/charts/generic/ci/deployment-values.yaml
+++ b/charts/generic/ci/deployment-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.3"
+  tag: "1.31.4"
   pullPolicy: IfNotPresent
 
 containers:

--- a/charts/generic/ci/multi-container-values.yaml
+++ b/charts/generic/ci/multi-container-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.3"
+  tag: "1.31.4"
 
 containers:
   - name: api

--- a/charts/generic/ci/platform-values.yaml
+++ b/charts/generic/ci/platform-values.yaml
@@ -5,7 +5,7 @@ workload:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.3"
+  tag: "1.31.4"
   pullPolicy: IfNotPresent
 
 containers:

--- a/charts/generic/tests/daemonset_test.yaml
+++ b/charts/generic/tests/daemonset_test.yaml
@@ -15,4 +15,4 @@ tests:
           of: DaemonSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/nginx:1.31.3
+          value: docker.io/library/nginx:1.31.4

--- a/charts/generic/tests/deployment_test.yaml
+++ b/charts/generic/tests/deployment_test.yaml
@@ -56,7 +56,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/nginx:1.31.3"
+          value: "docker.io/library/nginx:1.31.4"
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: IfNotPresent
@@ -88,7 +88,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/nginx:1.31.3"
+          value: "registry.example.com/nginx:1.31.4"
 
   - it: should apply global registry to namespaced unqualified repositories
     set:
@@ -97,7 +97,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "registry.example.com/team/app:1.31.3"
+          value: "registry.example.com/team/app:1.31.4"
 
   - it: should not apply global registry to fully qualified repositories
     set:
@@ -106,7 +106,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/team/app:1.31.3"
+          value: "ghcr.io/team/app:1.31.4"
 
   - it: should allow per-container image digest override
     set:

--- a/charts/generic/values.schema.json
+++ b/charts/generic/values.schema.json
@@ -81,7 +81,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "1.31.3"
+          "default": "1.31.4"
         },
         "digest": {
           "type": "string",

--- a/charts/generic/values.yaml
+++ b/charts/generic/values.yaml
@@ -52,7 +52,7 @@ global:
 
 image:
   repository: docker.io/library/nginx
-  tag: "1.31.3"
+  tag: "1.31.4"
   digest: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump the Generic chart default nginx image from 1.31.3 to 1.31.4
- synchronize schema defaults, CI values, unit expectations, and release notes
- document upstream protocol validation, HTTP/2 and gRPC behavior, and stability fixes

## Upstream evidence

- Release announcement: https://blog.nginx.org/blog/nginx-1-31-4-proxy-protocol-v2-stricter-validation-and-more
- Official download: https://nginx.org/en/download.html
- Image digest: sha256:0d4374c710a9649200e84f8ef8dbdd4fa76c0c107839cd50f1e42a63916b0f2e

## Validation

- make validate-chart CHART=generic K3D_SCENARIOS=default
- make standards-check CHART=generic
- node scripts/charts/template-standards-check.js --chart generic
- make release-check REPO=charts
- make preflight

Site PR: helmforgedev/site#518

Resolves #1021