### PR TITLE
chore(ghost): bump Ghost to 6.59.0

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -4,7 +4,7 @@ name: ghost
 description: Ghost modern publishing platform and headless CMS with MySQL backend
 type: application
 version: 1.2.3
-appVersion: "6.57.1"
+appVersion: "6.59.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "bump Ghost to 6.59.0 (#1022)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -106,7 +106,7 @@ through Ghost's environment-based configuration:
 ```yaml
 image:
   repository: registry.example.com/ghost-with-adapters
-  tag: "6.57.1"
+  tag: "6.59.0"
 
 ghost:
   extraEnv:
@@ -123,7 +123,7 @@ adapters when the container starts.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `ghost.url` | `""` | Public URL of the Ghost instance |
-| `image.tag` | `6.57.1` | Ghost image tag |
+| `image.tag` | `6.59.0` | Ghost image tag |
 | `mysql.enabled` | `true` | Deploy MySQL subchart |
 | `mysql.image.tag` | `8.4.11` | MySQL image tag pinned to the Ghost-supported MySQL 8 major |
 | `persistence.enabled` | `true` | Enable content persistence |
@@ -137,8 +137,9 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.57.1` fixes member webhook payloads, subdirectory redirect loops,
-theme-setting resets, and related presentation issues. The release does not
+Ghost `6.59.0` adds Docker Secrets configuration support and fixes MySQL
+migrations on versions older than 8.0.28, outbound-request crashes, member
+imports, newsletter filters, and donation checkout. The release does not
 change the official image's port, content path, database contract, probes, or
 required environment variables.
 Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -137,11 +137,11 @@ adapters when the container starts.
 
 ## Upgrade Notes
 
-Ghost `6.59.0` adds Docker Secrets configuration support and fixes MySQL
-migrations on versions older than 8.0.28, outbound-request crashes, member
-imports, newsletter filters, and donation checkout. The release does not
-change the official image's port, content path, database contract, probes, or
-required environment variables.
+Ghost `6.58.0` added Docker Secrets configuration support and fixed
+outbound-request crashes and member imports. Ghost `6.59.0` fixes MySQL
+migrations on versions older than 8.0.28, newsletter filters, and donation
+checkout. These releases do not change the official image's port, content
+path, database contract, probes, or required environment variables.
 Files edited in Ghost Admin remain under `/var/lib/ghost/content/data`, so the
 chart's content PVC and S3 content backup already cover them. Review the
 upstream Ghost release notes before upgrading

--- a/charts/ghost/tests/deployment_test.yaml
+++ b/charts/ghost/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/ghost:6.57.1"
+          value: "docker.io/library/ghost:6.59.0"
 
   - it: should expose port 2368
     asserts:

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -25,7 +25,7 @@
                                                                        },
                                                         "tag":  {
                                                                     "type":  "string",
-                                                                    "default":  "6.57.1"
+                                                                    "default":  "6.59.0"
                                                                 },
                                                         "pullPolicy":  {
                                                                            "type":  "string",

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Ghost container image
   repository: docker.io/library/ghost
   # -- Image tag
-  tag: "6.57.1"
+  tag: "6.59.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Ghost from 6.57.1 to 6.59.0
- synchronize image defaults, schema, tests, and upgrade guidance
- retain the existing image contract and MySQL 8 compatibility

## Upstream evidence

- Ghost 6.58.0: https://github.com/TryGhost/Ghost/releases/tag/v6.58.0
- Ghost 6.59.0: https://github.com/TryGhost/Ghost/releases/tag/v6.59.0
- Image digest: sha256:e1461a54865f98edc26f4decdfe967a8e317bbe388f3b7a4923ae98c6620f259

## Validation

- make validate-chart CHART=ghost K3D_SCENARIOS=default
- make standards-check CHART=ghost
- node scripts/charts/template-standards-check.js --chart ghost
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#519

Resolves #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default Ghost version to 6.59.0.
  * Added support for Docker Secrets.
* **Bug Fixes**
  * Includes upstream fixes for MySQL migrations, outbound requests, member imports, newsletter filters, and donation checkout.
* **Documentation**
  * Updated installation examples, version references, and upgrade notes for Ghost 6.59.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->