### PR TITLE
chore(homarr): bump Homarr to 1.76.0

### DIFF
--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -4,7 +4,7 @@ name: homarr
 description: Homarr - modern application dashboard with SQLite, PostgreSQL, or MySQL, Kubernetes integration, and S3 backup.
 type: application
 version: 1.2.5
-appVersion: "1.75.0"
+appVersion: "1.76.0"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/homarr.png
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Homarr to 1.76.0 (#1023)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -5,7 +5,7 @@
 Helm chart for deploying [Homarr](https://homarr.dev/) modern application dashboard on Kubernetes using the official
 [`ghcr.io/homarr-labs/homarr`](https://github.com/homarr-labs/homarr/pkgs/container/homarr) container image.
 
-Current application version: `v1.75.0`.
+Current application version: `v1.76.0`.
 
 ## Features
 
@@ -173,7 +173,7 @@ backup:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ghcr.io/homarr-labs/homarr` | Container image repository |
-| `image.tag` | `"v1.75.0"` | Homarr image tag |
+| `image.tag` | `"v1.76.0"` | Homarr image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `homarr.logLevel` | `info` | Log level |
 | `homarr.authProviders` | `credentials` | Auth providers (credentials, ldap, oidc) |
@@ -265,12 +265,12 @@ writable and does not force a non-root UID or dropped capabilities by default. O
 
 ## Upgrade Notes
 
-This update moves the default image to `v1.75.0`. Review the
-[upstream v1.75.0 release](https://github.com/homarr-labs/homarr/releases/tag/v1.75.0)
-before upgrading production environments. Homarr `v1.75.0` fixes startup when
-IPv6 is disabled in the container and includes integration and UI maintenance
-fixes. No breaking changes or new required environment variables were identified
-in the upstream release metadata.
+This update moves the default image to `v1.76.0`. Review the
+[upstream v1.76.0 release](https://github.com/homarr-labs/homarr/releases/tag/v1.76.0)
+before upgrading production environments. Homarr `v1.76.0` fixes startup
+ownership handling for default IDs, TrueNAS capacity reporting, Home Assistant
+widget responsiveness, and several monitoring widgets. No breaking changes or
+new required environment variables were identified in the upstream release metadata.
 
 For PostgreSQL and MySQL, the chart sets `DB_DIALECT`, `DB_DRIVER`, and discrete database environment variables instead of
 rendering a full `DB_URL`; this avoids requiring URL-encoded passwords in Kubernetes Secrets.

--- a/charts/homarr/tests/deployment_test.yaml
+++ b/charts/homarr/tests/deployment_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/homarr-labs/homarr:v1.75.0"
+          value: "ghcr.io/homarr-labs/homarr:v1.76.0"
 
   - it: should use Recreate strategy for SQLite
     asserts:

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -6,7 +6,7 @@
 # -- Homarr image
 image:
   repository: ghcr.io/homarr-labs/homarr
-  tag: "v1.75.0"
+  tag: "v1.76.0"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- bump Homarr from v1.75.0 to v1.76.0 while preserving the upstream v-prefixed tag
- synchronize image defaults, tests, release notes, and upgrade guidance
- retain the existing runtime and database contracts

## Upstream evidence

- Release: https://github.com/homarr-labs/homarr/releases/tag/v1.76.0
- Image digest: sha256:1a47c2afd892d8939b49195a7098fcbe44f4ac15a74b9ba02ed2de237089542f

## Validation

- make validate-chart CHART=homarr K3D_SCENARIOS=default
- make standards-check CHART=homarr
- node scripts/charts/template-standards-check.js --chart homarr
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#520

Resolves #1023