### PR TITLE
chore(keycloak): bump Keycloak to 26.7.2

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 3.0.10
-appVersion: "26.7.1"
+appVersion: "26.7.2"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - keycloak
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Keycloak to 26.7.2 (#1024)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -88,11 +88,11 @@ Recommended reading before installation:
 
 ## Keycloak 26.7.x alignment
 
-This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.1`.
+This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.2`.
 
 Relevant 26.7.x operational changes to account for during rollout:
 
-- 26.7.1 includes security and authentication fixes; review the upstream migration guide before production rollout
+- 26.7.2 includes security fixes for account takeover, fine-grained admin permissions, rotated client secrets, and dependencies; review the upstream migration guide before production rollout
 - zero-downtime patch releases are supported within the same minor stream, but still require readiness, proxy, and database validation
 - the HTTP stack supports graceful shutdown, so keep `terminationGracePeriodSeconds` aligned with connection draining at the proxy layer
 - Kubernetes and OpenShift truststore initialization improved upstream; keep custom `truststore` and database CA mounts explicit when the platform uses private CAs
@@ -245,7 +245,7 @@ postgresql:
 |-----------|-------------|---------|
 | `mode` | `dev` or `production` | `dev` |
 | `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `26.7.1` |
+| `image.tag` | Keycloak image tag | `26.7.2` |
 | `admin.existingSecret` | Existing secret for bootstrap admin credentials | `""` |
 | `http.port` | Application HTTP port | `8080` |
 | `http.managementPort` | Management port for health and metrics | `9000` |

--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -157,11 +157,11 @@ When an ExternalSecret owns a target Secret, the native generated Secret for tha
 
 ## Keycloak 26.7.x rollout notes
 
-The default image is `quay.io/keycloak/keycloak:26.7.1`.
+The default image is `quay.io/keycloak/keycloak:26.7.2`.
 
 Before rolling this version into production:
 
-- read the official [26.7.1 release notes](https://github.com/keycloak/keycloak/releases/tag/26.7.1)
+- read the official [26.7.2 release notes](https://www.keycloak.org/2026/08/keycloak-2672-released)
 - validate database startup and migration logs
 - validate readiness and liveness on the management service
 - validate login, token refresh, logout, and admin console access through the real reverse proxy path

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.7.1"
+          value: "quay.io/keycloak/keycloak:26.7.2"
 
   - it: should have 1 replica by default
     template: deployment.yaml

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # -- Keycloak image tag
-  tag: "26.7.1"
+  tag: "26.7.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Keycloak from 26.7.1 to 26.7.2
- synchronize image defaults, tests, production guidance, and release metadata
- preserve the existing 26.7 runtime and database contracts

## Upstream evidence

- Release announcement: https://www.keycloak.org/2026/08/keycloak-2672-released
- Upgrade guide: https://www.keycloak.org/docs/latest/upgrading/index.html
- Image digest: sha256:831330513f55695572286e521f94fcd3c7e285250ed5b848090265a33192f669

## Validation

- make validate-chart CHART=keycloak K3D_SCENARIOS=default
- make standards-check CHART=keycloak
- node scripts/charts/template-standards-check.js --chart keycloak
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#521

Resolves #1024