### PR TITLE
chore(langflow): bump Langflow to 1.11.4

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.1.2
-appVersion: "1.11.3"
+appVersion: "1.11.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "bump Langflow to 1.11.4 (#1025)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,12 +1,12 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.3` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.4` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
 
 Langflow 1.11 adds native v2 workflow execution, trusted JWT authentication with just-in-time user mapping, RBAC-aware interfaces, A2A and
-human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.3 also includes upstream fixes for authentication,
-tracing, MCP, SSRF protections, and component loading. Advanced runtime settings for these capabilities can be supplied through `app.env` or
+human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.4 includes security dependency remediation and
+fixes for MCP transactions, global variables, background runs, chained inputs, and container toolchain pinning. Advanced runtime settings can be supplied through `app.env` or
 `app.envFrom`.
 
 The chart generates a strong Langflow secret key and initial superuser password on first install when `auth.existingSecret` and inline

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.11.3
+          value: docker.io/langflowai/langflow:1.11.4
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.11.3" },
+        "tag": { "type": "string", "default": "1.11.4" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.11.3"
+  tag: "1.11.4"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Langflow from 1.11.3 to 1.11.4
- synchronize image defaults, schema, tests, and release guidance
- preserve the existing runtime, persistence, and probe contracts

## Upstream evidence

- Release: https://github.com/langflow-ai/langflow/releases/tag/v1.11.4
- Image digest: sha256:3fe9a758b8a4fa9bbeec726d71d2f69391643bfc20c175288c1b4e166b7348fb

## Validation

- make validate-chart CHART=langflow K3D_SCENARIOS=default
- make standards-check CHART=langflow
- node scripts/charts/template-standards-check.js --chart langflow
- make md-lint REPO=charts
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#522

Resolves #1025