### PR TITLE
chore(matomo): bump Matomo to 5.13.0

### DIFF
--- a/charts/matomo/Chart.yaml
+++ b/charts/matomo/Chart.yaml
@@ -4,7 +4,7 @@ name: matomo
 description: Privacy-focused web analytics platform with MySQL and production archiving support
 type: application
 version: 1.0.2
-appVersion: "5.12.0"
+appVersion: "5.13.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/matomo.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "bump Matomo to 5.13.0 (#1026)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/matomo/README.md
+++ b/charts/matomo/README.md
@@ -16,7 +16,7 @@ helm install matomo oci://ghcr.io/helmforgedev/helm/matomo
 
 ## Features
 
-- Official Matomo Apache image pinned to `5.12.0-apache`.
+- Official Matomo Apache image pinned to `5.13.0-apache`.
 - Bundled HelmForge MySQL subchart for simple deployments.
 - External MySQL/MariaDB mode for production.
 - CronJob-based `core:archive` execution.
@@ -24,6 +24,10 @@ helm install matomo oci://ghcr.io/helmforgedev/helm/matomo
 - Ingress and Gateway API HTTPRoute support.
 - NetworkPolicy, ServiceMonitor, dual-stack Service fields.
 - External Secrets integration for database passwords.
+
+Matomo 5.13.0 improves reporting and user management and includes maintenance
+and security fixes. Upstream reports no major database upgrade for this release;
+back up the database and persistent application volume before production rollout.
 
 ## Quick Start
 
@@ -64,7 +68,7 @@ ingress:
 | --- | --- | --- |
 | `replicaCount` | Matomo web replicas | `1` |
 | `image.repository` | Official Matomo image repository | `docker.io/library/matomo` |
-| `image.tag` | Official Matomo image tag | `5.12.0-apache` |
+| `image.tag` | Official Matomo image tag | `5.13.0-apache` |
 | `database.mode` | `auto`, `external`, or `mysql` | `auto` |
 | `mysql.enabled` | Deploy HelmForge MySQL subchart | `true` |
 | `persistence.enabled` | Persist `/var/www/html` | `true` |

--- a/charts/matomo/tests/deployment_test.yaml
+++ b/charts/matomo/tests/deployment_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/matomo:5.12.0-apache
+          value: docker.io/library/matomo:5.13.0-apache
   - it: wires Matomo database environment variables
     template: deployment.yaml
     asserts:

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -29,7 +29,7 @@ image:
   # -- Official Matomo image repository
   repository: docker.io/library/matomo
   # -- Official Matomo image tag. The apache variant includes the web server.
-  tag: "5.12.0-apache"
+  tag: "5.13.0-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Matomo from 5.12.0-apache to 5.13.0-apache
- synchronize image defaults, tests, release metadata, and upgrade guidance
- preserve the existing Apache, storage, and MySQL contracts

## Upstream evidence

- Release: https://github.com/matomo-org/matomo/releases/tag/5.13.0
- Changelog: https://matomo.org/changelog/matomo-5-13-0/
- Image digest: sha256:b4d6020b383d67170c3711035de534aa8ae3921aea0149ba3f9d54aca7c707c5

## Validation

- make validate-chart CHART=matomo K3D_SCENARIOS=default
- make standards-check CHART=matomo
- node scripts/charts/template-standards-check.js --chart matomo
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#523

Resolves #1026