### PR TITLE
chore(metabase): bump Metabase to v0.63.14

### DIFF
--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -4,7 +4,7 @@ name: metabase
 description: Metabase open-source BI platform with visual data exploration and PostgreSQL metadata store
 type: application
 version: 1.2.25
-appVersion: "v0.63.13"
+appVersion: "v0.63.14"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/metabase.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Metabase to v0.63.14 (#1027)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/metabase/README.md
+++ b/charts/metabase/README.md
@@ -83,7 +83,7 @@ Metabase image, so proxy-based environments can mirror both images:
 ```yaml
 image:
   repository: registry.example.com/proxy/metabase/metabase
-  tag: v0.63.13
+  tag: v0.63.14
 
 waitForDatabase:
   image:
@@ -150,7 +150,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/metabase/metabase` | Metabase container image repository |
-| `image.tag` | `v0.63.13` | Metabase container image tag |
+| `image.tag` | `v0.63.14` | Metabase container image tag |
 | `waitForDatabase.image.repository` | `docker.io/library/busybox` | Wait-for-db init container image repository |
 | `waitForDatabase.image.tag` | `1.37` | Wait-for-db init container image tag |
 | `waitForDatabase.image.pullPolicy` | `IfNotPresent` | Wait-for-db init container image pull policy |
@@ -184,10 +184,11 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Metabase `v0.63.13` is the latest maintenance update selected by the upstream
-image monitor. Back up the Metabase application database and review the
-[official Metabase changelog](https://www.metabase.com/changelog/) before
-upgrading. Keep the encryption key stable and validate the `/api/health`
+Metabase `v0.63.14` is the public maintenance release that incorporates the
+security-hardening changes from private releases 63.3 through 63.13, plus
+administration, database, and querying fixes. Back up the Metabase application
+database and review the [official Metabase 63 changelog](https://www.metabase.com/changelog/63#metabase-6314)
+before upgrading. Keep the encryption key stable and validate the `/api/health`
 endpoint after rollout.
 
 ## Examples

--- a/charts/metabase/tests/deployment_test.yaml
+++ b/charts/metabase/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/metabase/metabase:v0.63.13"
+          value: "docker.io/metabase/metabase:v0.63.14"
 
   - it: should set custom image tag
     set:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Metabase container image
   repository: docker.io/metabase/metabase
   # -- Image tag
-  tag: "v0.63.13"
+  tag: "v0.63.14"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Metabase from v0.63.13 to v0.63.14
- synchronize image defaults, tests, release metadata, and upgrade guidance
- keep the branch strictly scoped to the upstream image update

## Upstream evidence

- Release: https://github.com/metabase/metabase/releases/tag/v0.63.14
- Changelog: https://www.metabase.com/changelog/63#metabase-6314
- Image digest: sha256:7fa304e677216ebafe81c4b55ce365b4fdc485673000846f7ca5a7cb7381a495

## Validation

- make validate-chart CHART=metabase K3D_SCENARIOS=default
- make standards-check CHART=metabase
- node scripts/charts/template-standards-check.js --chart metabase
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#524

Resolves #1027