### PR TITLE
chore(minecraft): bump server image to 2026.8.2

### DIFF
--- a/charts/minecraft/Chart.yaml
+++ b/charts/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: minecraft
 type: application
 version: 1.5.1
-appVersion: "2026.8.0"
+appVersion: "2026.8.2"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Minecraft Java Edition servers on Kubernetes
 maintainers:
@@ -26,7 +26,7 @@ icon: https://helmforge.dev/icons/charts/minecraft.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump server image to 2026.8.0 (#963)"
+      description: "bump server image to 2026.8.2 (#1028)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/minecraft/DESIGN.md
+++ b/charts/minecraft/DESIGN.md
@@ -5,7 +5,7 @@
 This chart deploys Minecraft Java Edition servers using the official community-standard
 `docker.io/itzg/minecraft-server` image. It supports vanilla, Paper, Forge, Fabric, Quilt, Geyser/Floodgate cross-play,
 RCON operations, persistent worlds, metrics, External Secrets, and S3-compatible backups.
-The 2026.8.0 runtime also exposes IPv6 stack preference, a replaceable process
+The 2026.8.2 runtime also exposes IPv6 stack preference, a replaceable process
 runner, and layered generic packs distributed as OCI artifacts.
 
 ## Architecture

--- a/charts/minecraft/README.md
+++ b/charts/minecraft/README.md
@@ -257,10 +257,10 @@ Spigot servers, provide the platform-specific Floodgate plugin through
 
 ## Upgrade Notes
 
-`docker.io/itzg/minecraft-server:2026.8.0` adds GTNH daily-build support, Java 25 knockd fixes, and retains native `PREFER_IPv6` and
-custom `SERVER_RUNNER` support, moves Vanilla installation to
-`mc-image-helper`, adds OCI generic-pack references, and includes GTNH,
-CurseForge HTTP, Java 17 compatibility, and dependency fixes. Configure the
+`docker.io/itzg/minecraft-server:2026.8.2` fixes Modrinth packs that require
+server-side mods, corrects `STOP_SERVER_DELAY_COMMAND`, and updates the bundled
+Minecraft helper tools. It retains native `PREFER_IPv6` and custom
+`SERVER_RUNNER` support. Configure the
 first two features with `server.preferIPv6` and `server.runner`.
 Review the upstream release notes before upgrading production servers, take a
 world backup, and verify plugins, mods, datapacks, proxy settings, and pinned

--- a/charts/minecraft/tests/backup_test.yaml
+++ b/charts/minecraft/tests/backup_test.yaml
@@ -68,10 +68,10 @@ tests:
           value: archive
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[0].image
-          value: docker.io/itzg/minecraft-server:2026.8.0
+          value: docker.io/itzg/minecraft-server:2026.8.2
       - equal:
           path: spec.jobTemplate.spec.template.spec.initContainers[1].image
-          value: docker.io/itzg/minecraft-server:2026.8.0
+          value: docker.io/itzg/minecraft-server:2026.8.2
 
   - it: should have upload and post-backup containers
     template: templates/backup-cronjob.yaml
@@ -91,7 +91,7 @@ tests:
           value: post-backup
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[1].image
-          value: docker.io/itzg/minecraft-server:2026.8.0
+          value: docker.io/itzg/minecraft-server:2026.8.2
 
   - it: should use existing secret for S3 credentials
     template: templates/backup-cronjob.yaml

--- a/charts/minecraft/tests/deployment_test.yaml
+++ b/charts/minecraft/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/itzg/minecraft-server:2026.8.0
+          value: docker.io/itzg/minecraft-server:2026.8.2
 
   - it: should set EULA to true
     asserts:

--- a/charts/minecraft/values.schema.json
+++ b/charts/minecraft/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Container image tag",
-          "default": "2026.8.0"
+          "default": "2026.8.2"
         },
         "pullPolicy": {
           "type": "string",
@@ -645,7 +645,7 @@
             "worker": {
               "type": "string",
               "description": "Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)",
-              "default": "docker.io/itzg/minecraft-server:2026.8.0"
+              "default": "docker.io/itzg/minecraft-server:2026.8.2"
             },
             "uploader": {
               "type": "string",

--- a/charts/minecraft/values.yaml
+++ b/charts/minecraft/values.yaml
@@ -24,7 +24,7 @@ image:
   # -- Container image repository
   repository: docker.io/itzg/minecraft-server
   # -- Container image tag
-  tag: "2026.8.0"
+  tag: "2026.8.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -387,7 +387,7 @@ backup:
 
   images:
     # -- Image used for RCON commands and tar archiving (must have sh, tar, and rcon-cli)
-    worker: docker.io/itzg/minecraft-server:2026.8.0
+    worker: docker.io/itzg/minecraft-server:2026.8.2
     # -- Image used for S3 upload (MinIO client)
     uploader: docker.io/helmforge/mc:1.0.0
 


### PR DESCRIPTION
## Summary

- bump itzg/minecraft-server from 2026.8.0 to 2026.8.2
- synchronize runtime and backup-worker image defaults, schema, tests, and docs
- preserve the existing Minecraft server and persistence contracts

## Upstream evidence

- 2026.8.1: https://github.com/itzg/docker-minecraft-server/releases/tag/2026.8.1
- 2026.8.2: https://github.com/itzg/docker-minecraft-server/releases/tag/2026.8.2
- Image digest: sha256:efa878ddb49cf5251b2e5f2ad71b08fd2f7236c1f7907433f6697258b31d2ce4

## Validation

- make validate-chart CHART=minecraft K3D_SCENARIOS=default
- make image-verify IMAGE=docker.io/itzg/minecraft-server:2026.8.2-java21
- make image-verify IMAGE=docker.io/itzg/minecraft-server:2026.8.2-java17
- make standards-check CHART=minecraft
- node scripts/charts/template-standards-check.js --chart minecraft
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#525

Resolves #1028