### PR TITLE
chore(notediscovery): bump NoteDiscovery to 0.31.3

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.1.4
-appVersion: "0.31.1"
+appVersion: "0.31.3"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/notediscovery.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump notediscovery to 0.31.1 (#1007)"
+      description: "bump NoteDiscovery to 0.31.3 (#1032)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.31.1` image.
+official `ghcr.io/gamosoft/notediscovery:0.31.3` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.1` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.3` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -151,10 +151,11 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.31.1` includes search and plugin maintenance fixes while
-retaining the interactive task checkboxes and cache-safe asset behavior from
-0.31.0. Review the
-[upstream 0.31.1 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.1)
+NoteDiscovery `0.31.3` adds custom human-readable share links, full note paths
+on hover, checklist bulk updates, corrected task statistics, and public share
+URL configuration, while retaining the interactive task checkboxes and
+cache-safe asset behavior from 0.31.0. Review the
+[upstream 0.31.3 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.3)
 before upgrading.
 
 Generated configuration now stores plugin state under the writable data volume

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.1
+          value: ghcr.io/gamosoft/notediscovery:0.31.3
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -24,7 +24,7 @@ tests:
           value: plugin-bootstrap
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.1
+          value: ghcr.io/gamosoft/notediscovery:0.31.3
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "if \\[ -d /app/plugins \\]"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.31.1", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.31.3", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.31.1"
+  tag: "0.31.3"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump NoteDiscovery from 0.31.1 to 0.31.3
- synchronize image defaults, schema, tests, design notes, and upgrade guidance
- preserve the existing storage and plugin-state contracts

## Upstream evidence

- 0.31.2: https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.2
- 0.31.3: https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.3
- Image digest: sha256:938cc2987fe57618f4a31a1d34b99c85046d1497d4df9615d490908526a960c6

## Validation

- make validate-chart CHART=notediscovery K3D_SCENARIOS=default
- make standards-check CHART=notediscovery
- node scripts/charts/template-standards-check.js --chart notediscovery
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#527

Resolves #1032