### PR TITLE
chore(oauth2-proxy): bump OAuth2 Proxy to v7.15.4

### DIFF
--- a/charts/oauth2-proxy/Chart.yaml
+++ b/charts/oauth2-proxy/Chart.yaml
@@ -4,7 +4,7 @@ name: oauth2-proxy
 description: OAuth2 Proxy reverse proxy for OAuth2 and OIDC authentication in Kubernetes
 type: application
 version: 1.0.5
-appVersion: "7.15.3"
+appVersion: "7.15.4"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,8 +24,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/oauth2-proxy.png
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "align template standards (#682)"
+    - kind: changed
+      description: "bump OAuth2 Proxy to v7.15.4 (#1033)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/oauth2-proxy/README.md
+++ b/charts/oauth2-proxy/README.md
@@ -8,7 +8,7 @@ and runtime validation.
 ## Highlights
 
 - Official `quay.io/oauth2-proxy/oauth2-proxy` image.
-- `v7.15.3` default, including the upstream Go `1.26.4` rebuild and the latest
+- `v7.15.4` default, including the upstream Go `1.26.7` rebuild and the latest
   dependency vulnerability fixes published by the oauth2-proxy project.
 - Reverse proxy header trust disabled by default, with required explicit
   `trusted_proxy_ips` CIDRs when enabled behind ingress controllers, gateways,
@@ -60,9 +60,9 @@ implementation, or edge proxy.
 
 ## Upgrade Notes
 
-OAuth2 Proxy `v7.15.3` keeps the same chart-facing configuration surface as
-`v7.15.2`, but refreshes the runtime to Go `1.26.4` and rolls in the upstream
-dependency CVE fixes called out in the official release notes. No values change
+OAuth2 Proxy `v7.15.4` keeps the same chart-facing configuration surface as
+`v7.15.3`, but refreshes the runtime to Go `1.26.7` and rolls in the upstream
+dependency vulnerability fixes called out in the official release notes. No values change
 is required for this chart bump.
 
 The chart keeps `config.reverseProxy.enabled=false` by default. If you enable

--- a/charts/oauth2-proxy/tests/deployment_test.yaml
+++ b/charts/oauth2-proxy/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
+          value: quay.io/oauth2-proxy/oauth2-proxy:v7.15.4
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem

--- a/charts/oauth2-proxy/values.schema.json
+++ b/charts/oauth2-proxy/values.schema.json
@@ -13,7 +13,7 @@
       "additionalProperties": false,
       "properties": {
         "repository": { "type": "string", "default": "quay.io/oauth2-proxy/oauth2-proxy" },
-        "tag": { "type": "string", "default": "v7.15.3" },
+        "tag": { "type": "string", "default": "v7.15.4" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -20,7 +20,7 @@ image:
   # -- Official upstream OAuth2 Proxy image
   repository: quay.io/oauth2-proxy/oauth2-proxy
   # -- Image tag
-  tag: "v7.15.3"
+  tag: "v7.15.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump OAuth2 Proxy from v7.15.3 to v7.15.4
- synchronize image defaults, schema, tests, release metadata, and upgrade guidance
- preserve the existing authentication and reverse-proxy configuration contract

## Upstream evidence

- Release: https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.4
- Image digest: sha256:b1b2021fe8f4004573e8d690dec6c7bb29cc44364572cf8510a05bf3a0ae2ded

## Validation

- make validate-chart CHART=oauth2-proxy K3D_SCENARIOS=default
- make standards-check CHART=oauth2-proxy
- node scripts/charts/template-standards-check.js --chart oauth2-proxy
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#528

Resolves #1033