### PR TITLE
chore(poznote): bump Poznote to 6.68.1

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.1.4
-appVersion: "6.65.3"
+appVersion: "6.68.1"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump poznote to 6.65.3 (#1009)"
+      description: "bump Poznote to 6.68.1 (#1034)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.65.3
+ghcr.io/timothepoznanski/poznote:6.68.1
 ```
 
-The tag maps to the upstream `6.65.3` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.68.1` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.65.3-rootless` variant. It is not the chart
+Upstream also publishes a `6.68.1-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.65.3` |
+| `image.tag` | Image tag | `6.68.1` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -141,9 +141,10 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.65.3` includes shared-note access controls, Git Sync improvements,
-and UI maintenance accumulated since 6.59.2. Review the
-[upstream 6.65.3 release](https://github.com/timothepoznanski/poznote/releases/tag/6.65.3)
+Poznote `6.68.1` adds workspace-scoped AI and tags, per-user AI providers,
+checklists on the tasks page, and fixes sidebar links after workspace switches.
+Review the
+[upstream 6.68.1 release](https://github.com/timothepoznanski/poznote/releases/tag/6.68.1)
 before upgrading. The default local SQLite and filesystem deployment remains
 compatible; S3 integration is configured inside Poznote when needed.
 

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.65.3"
+          value: "ghcr.io/timothepoznanski/poznote:6.68.1"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.65.3"
+  tag: "6.68.1"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Poznote from 6.65.3 to 6.68.1
- synchronize image defaults, tests, design notes, release metadata, and upgrade guidance
- preserve the SQLite, PVC, and standard-image contracts

## Upstream evidence

- 6.66.0: https://github.com/timothepoznanski/poznote/releases/tag/6.66.0
- 6.67.0: https://github.com/timothepoznanski/poznote/releases/tag/6.67.0
- 6.68.0: https://github.com/timothepoznanski/poznote/releases/tag/6.68.0
- 6.68.1: https://github.com/timothepoznanski/poznote/releases/tag/6.68.1
- Image digest: sha256:9d29952562702510ebdd6e5687ce1fac70fa3053faa7c3b809da202c9bfaf008

## Validation

- make validate-chart CHART=poznote K3D_SCENARIOS=default
- make image-verify IMAGE=ghcr.io/timothepoznanski/poznote:6.68.1-rootless
- make standards-check CHART=poznote
- node scripts/charts/template-standards-check.js --chart poznote
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#529

Resolves #1034