### PR TITLE
chore(rabbitmq): bump RabbitMQ to 4.3.5

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -4,7 +4,7 @@ name: rabbitmq
 description: RabbitMQ for Kubernetes with explicit single-node and cluster modes
 type: application
 version: 1.7.0
-appVersion: "4.3.4"
+appVersion: "4.3.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/rabbitmq.png
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "upgrade to 4.3.4 and harden management ui (#881)"
+      description: "bump RabbitMQ to 4.3.5 (#1035)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -187,8 +187,8 @@ externalSecrets:
 
 ### Runtime efficiency
 
-- the default image is `docker.io/library/rabbitmq:4.3.4-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
-- RabbitMQ 4.3.4 removes `unsafe-eval` and `unsafe-inline` from the Management UI Content Security Policy
+- the default image is `docker.io/library/rabbitmq:4.3.5-alpine`; it contains the management, Prometheus, and Kubernetes peer-discovery plugins, and the chart enables only the plugins requested by values
+- RabbitMQ 4.3.5 fixes quorum queue recovery, AMQP 1.0 validation, rolling-upgrade queries, direct reply-to duplicates, and protocol frame limits
 - `management.referrerPolicy=no-referrer` enables the upstream Referrer-Policy support with a privacy-preserving default; set it to `""` to defer to the browser default
 - `runtime.disableSchedulerBusyWait=true` is enabled by default to reduce idle CPU from Erlang scheduler spin-wait in containers
 - default Kubernetes probes use lightweight TCP checks against the active AMQP listener instead of recurring `rabbitmq-diagnostics` commands
@@ -200,7 +200,7 @@ externalSecrets:
 |-----------|-------------|---------|
 | `architecture` | `single-node` or `cluster` | `single-node` |
 | `image.repository` | RabbitMQ image repository | `docker.io/library/rabbitmq` |
-| `image.tag` | RabbitMQ image tag | `4.3.4-alpine` |
+| `image.tag` | RabbitMQ image tag | `4.3.5-alpine` |
 | `auth.username` | Application username | `user` |
 | `auth.password` | Application password | `""` |
 | `auth.erlangCookie` | Erlang cookie | `""` |

--- a/charts/rabbitmq/tests/statefulset_test.yaml
+++ b/charts/rabbitmq/tests/statefulset_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/rabbitmq:4.3.4-alpine"
+          value: "docker.io/library/rabbitmq:4.3.5-alpine"
 
   - it: should have 1 replica in single-node mode
     template: statefulset.yaml

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -25,7 +25,7 @@ image:
   # -- RabbitMQ image repository
   repository: docker.io/library/rabbitmq
   # -- RabbitMQ image tag
-  tag: "4.3.4-alpine"
+  tag: "4.3.5-alpine"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump RabbitMQ from 4.3.4-alpine to 4.3.5-alpine
- synchronize image defaults, tests, release metadata, and upgrade guidance
- preserve the existing 4.3 series and plugin contract

## Upstream evidence

- Release: https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.5
- Image digest: sha256:d07d6a0657affe0354ae61b3ca1a3e4d244c247ac5d7e25940c8759658ce7ad7

## Validation

- make validate-chart CHART=rabbitmq K3D_SCENARIOS=default
- make standards-check CHART=rabbitmq
- node scripts/charts/template-standards-check.js --chart rabbitmq
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#530

Resolves #1035