### PR TITLE
chore(redis): bump Redis to 8.10.1

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -4,7 +4,7 @@ name: redis
 description: Redis Helm Chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 2.0.0
-appVersion: "8.10.0"
+appVersion: "8.10.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,7 +27,7 @@ icon: https://helmforge.dev/icons/charts/redis.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: use role-neutral nodes in sentinel mode (#954)"
+      description: "bump Redis to 8.10.1 (#1036)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -222,7 +222,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Redis topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Redis image repository | `docker.io/library/redis` |
-| `image.tag` | Redis image tag | `8.10.0` |
+| `image.tag` | Redis image tag | `8.10.1` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Redis password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Redis password | `""` |
@@ -291,12 +291,17 @@ See `examples/`:
 - If your cluster domain is not `cluster.local`, set `clusterDomain` before installing stateful topologies.
 - For production, verify storage, credentials, scheduling, network policy, monitoring, backup strategy, and client compatibility before exposing Redis to applications.
 
+Redis 8.10.1 is an upstream security release addressing memory-safety issues in
+RDB loading, Vector Sets, TLS, and blocked-client handling, including an RDB
+slot validation issue that could lead to remote code execution. Back up data
+and complete a controlled rollout promptly.
+
 ## Official product references
 
 - Redis Sentinel: <https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/>
 - Redis Cluster: <https://redis.io/docs/latest/operate/oss_and_stack/management/scaling/>
 - Redis security: <https://redis.io/docs/latest/operate/oss_and_stack/management/security/>
-- Redis 8.10.0 release: <https://github.com/redis/redis/releases/tag/8.10.0>
+- Redis 8.10.1 security release: <https://github.com/redis/redis/releases/tag/8.10.1>
 
 ### 🟢 Security Scan: `redis`
 

--- a/charts/redis/tests/standalone_statefulset_test.yaml
+++ b/charts/redis/tests/standalone_statefulset_test.yaml
@@ -33,7 +33,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/redis:8.10.0"
+          value: "docker.io/library/redis:8.10.1"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -28,7 +28,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/library/redis
-  tag: "8.10.0"
+  tag: "8.10.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- bump Redis from 8.10.0 to 8.10.1
- synchronize image defaults, tests, release metadata, and security guidance
- preserve the existing 8.10 topology and persistence contracts

Upstream marks this release SECURITY urgency.

## Upstream evidence

- Release: https://github.com/redis/redis/releases/tag/8.10.1
- Image digest: sha256:691577adaf11927f4bb8871d40a5dd69a5c300d4453b742e8f6383c3e6e8d2e1

## Validation

- make validate-chart CHART=redis K3D_SCENARIOS=default
- make standards-check CHART=redis
- node scripts/charts/template-standards-check.js --chart redis
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#531

Resolves #1036