### PR TITLE
chore(tomcat): bump Tomcat to 11.0.25

### DIFF
--- a/charts/tomcat/Chart.yaml
+++ b/charts/tomcat/Chart.yaml
@@ -4,7 +4,7 @@ name: tomcat
 description: Apache Tomcat Helm chart with official image, Gateway API, JMX, and production controls
 type: application
 version: 1.0.5
-appVersion: "11.0.24"
+appVersion: "11.0.25"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,7 +27,7 @@ icon: https://helmforge.dev/icons/charts/tomcat.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 11.0.24 (#775)"
+      description: "bump Tomcat to 11.0.25 (#1037)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -75,10 +75,11 @@ For authenticated or TLS-secured JMX, mount the required files with `extraVolume
 When `jmx.rmiPort` differs from `jmx.port`, the chart exposes the RMI endpoint
 through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique.
 
-Tomcat 11.0.25 fixes HTTP/2 prioritization, OpenSSL FFM symbol lookup, EL parser
-reuse, and a low-severity denial of service in the bundled WebSocket chat
-example. Custom clustering that uses `EncryptInterceptor` must account for its
-new `AES/GCM/NoPadding` default before a rolling upgrade.
+Tomcat 11.0.25 requires an authority on every HTTP/2 request, resets EL parser
+state before reuse, and limits buffering in the bundled WebSocket chat example.
+HTTP/2 stream prioritization and the OpenSSL FFM symbol-lookup fix were delivered
+in Tomcat 11.0.0-M18. Custom clustering that uses `EncryptInterceptor` must
+account for its new `AES/GCM/NoPadding` default before a rolling upgrade.
 
 ## Production Notes
 

--- a/charts/tomcat/README.md
+++ b/charts/tomcat/README.md
@@ -4,7 +4,7 @@ Apache Tomcat chart for Kubernetes using the official `docker.io/library/tomcat`
 
 ## Highlights
 
-- Official Tomcat image, pinned by default to `11.0.24-jdk17-temurin-noble`.
+- Official Tomcat image, pinned by default to `11.0.25-jdk17-temurin-noble`.
 - Stable default install with an optional ROOT health webapp for deterministic probes and Helm tests.
 - Preserves WARs or exploded applications baked into immutable Tomcat images before mounting the writable webapps volume.
 - Non-root runtime with writable `webapps`, `logs`, `temp`, and `work` volumes.
@@ -75,6 +75,11 @@ For authenticated or TLS-secured JMX, mount the required files with `extraVolume
 When `jmx.rmiPort` differs from `jmx.port`, the chart exposes the RMI endpoint
 through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique.
 
+Tomcat 11.0.25 fixes HTTP/2 prioritization, OpenSSL FFM symbol lookup, EL parser
+reuse, and a low-severity denial of service in the bundled WebSocket chat
+example. Custom clustering that uses `EncryptInterceptor` must account for its
+new `AES/GCM/NoPadding` default before a rolling upgrade.
+
 ## Production Notes
 
 - Keep `serviceAccount.automountServiceAccountToken=false` unless your app needs Kubernetes API access.
@@ -90,7 +95,7 @@ through `service.ports.jmxRmi` so the registry and RMI Service ports stay unique
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of Tomcat pods when HPA is disabled. |
 | `image.repository` | `docker.io/library/tomcat` | Tomcat image repository. |
-| `image.tag` | `11.0.24-jdk17-temurin-noble` | Tomcat image tag. |
+| `image.tag` | `11.0.25-jdk17-temurin-noble` | Tomcat image tag. |
 | `service.type` | `ClusterIP` | Kubernetes Service type. |
 | `service.ipFamilyPolicy` | `null` | Optional Service dual-stack policy. |
 | `service.ipFamilies` | `[]` | Optional Service IP family ordering. |

--- a/charts/tomcat/tests/deployment_test.yaml
+++ b/charts/tomcat/tests/deployment_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/library/tomcat:11.0.24-jdk17-temurin-noble
+          value: docker.io/library/tomcat:11.0.25-jdk17-temurin-noble
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: false

--- a/charts/tomcat/values.yaml
+++ b/charts/tomcat/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Tomcat image repository. Uses the official Docker image.
   repository: docker.io/library/tomcat
   # -- Tomcat image tag.
-  tag: "11.0.24-jdk17-temurin-noble"
+  tag: "11.0.25-jdk17-temurin-noble"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- bump Tomcat from 11.0.24 to 11.0.25 on the existing JDK 17 Temurin Noble image track
- synchronize image defaults, tests, release metadata, and operational guidance
- preserve the existing runtime and webapp contracts

## Upstream evidence

- Announcement: https://tomcat.apache.org/
- Changelog: https://tomcat.apache.org/tomcat-11.0-doc/changelog.html
- Security: https://tomcat.apache.org/security-11.html
- Image digest: sha256:9e1d2afa6898b014f0e6675b8e247f0c3de197912dfe35975440f0386092f8d0

## Validation

- make validate-chart CHART=tomcat K3D_SCENARIOS=default
- make standards-check CHART=tomcat
- node scripts/charts/template-standards-check.js --chart tomcat
- make release-check REPO=charts
- make attribution-check REPO=charts

Site PR: helmforgedev/site#532

Resolves #1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default Apache Tomcat image to version 11.0.25.
  - Included the latest Tomcat 11.0.25 fixes and upgrade considerations.

- **Documentation**
  - Updated chart metadata, image tags, values documentation, and deployment expectations to reflect Tomcat 11.0.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->