### PR TITLE
chore(umami): bump Umami to 3.3.1

### DIFF
--- a/charts/umami/Chart.yaml
+++ b/charts/umami/Chart.yaml
@@ -4,7 +4,7 @@ name: umami
 description: Umami privacy-first web analytics with PostgreSQL, Gateway API, External Secrets, backups, and production controls
 type: application
 version: 2.3.2
-appVersion: "3.3.0"
+appVersion: "3.3.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -27,7 +27,7 @@ icon: https://helmforge.dev/icons/charts/umami.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Umami to 3.3.1 (#1038)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/umami/README.md
+++ b/charts/umami/README.md
@@ -252,7 +252,7 @@ For production, test restore procedures outside Helm. Backups without restore va
 | --- | --- | --- |
 | `replicaCount` | `1` | Number of Umami pods. |
 | `image.repository` | `ghcr.io/umami-software/umami` | Umami image repository. |
-| `image.tag` | `3.1.0` | Umami image tag. |
+| `image.tag` | `3.3.1` | Umami image tag. |
 | `service.type` | `ClusterIP` | Kubernetes service type. |
 | `service.ipFamilyPolicy` | `""` | Optional service IP family policy. |
 | `service.ipFamilies` | `[]` | Optional service IP families. |
@@ -283,6 +283,8 @@ For production, test restore procedures outside Helm. Backups without restore va
 
 Umami 3.x includes database migrations for newer analytics features such as Boards, Shares, Session Replay, and Web Vitals.
 Back up PostgreSQL before upgrading live deployments, especially when migrating from Umami 2.x.
+Umami 3.3.1 adds a username-normalization migration and fixes two-factor authentication configuration, tracking session
+drift, event filtering and pagination, funnel metrics, and zero/false value responses.
 
 ## More Information
 

--- a/charts/umami/tests/deployment_test.yaml
+++ b/charts/umami/tests/deployment_test.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/umami-software/umami:3.3.0"
+          value: "ghcr.io/umami-software/umami:3.3.1"
 
   - it: should set custom image tag
     set:

--- a/charts/umami/values.schema.json
+++ b/charts/umami/values.schema.json
@@ -38,7 +38,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag",
-          "default": "3.1.0"
+          "default": "3.3.1"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/umami/values.yaml
+++ b/charts/umami/values.yaml
@@ -19,7 +19,7 @@ image:
   # -- Umami container image
   repository: ghcr.io/umami-software/umami
   # -- Image tag
-  tag: "3.3.0"
+  tag: "3.3.1"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update the official Umami image from 3.3.0 to 3.3.1
- align the values schema default and deployment tests with the new image
- document the lowercase-username migration and upgrade precautions

## Upstream evidence

- Release: https://github.com/umami-software/umami/releases/tag/v3.3.1
- Image: `ghcr.io/umami-software/umami:3.3.1`
- Digest: `sha256:fa32d116cf20cad52cbc3fad9a63b46e7fa02299d8f967168eb453d49c476b4a`

## Validation

- `make validate-chart CHART=umami K3D_SCENARIOS="default"`
- `make standards-check CHART=umami`
- `node scripts/charts/template-standards-check.js --chart umami`
- `make release-check REPO=charts`
- `make attribution-check REPO=charts`
- real upstream image imported into k3d; Umami and PostgreSQL reached Ready with zero restarts

## Site synchronization

- helmforgedev/site#533

Resolves #1038