### PR TITLE
chore(uptime-kuma): bump Uptime Kuma to 2.5.3

### DIFF
--- a/charts/uptime-kuma/Chart.yaml
+++ b/charts/uptime-kuma/Chart.yaml
@@ -4,7 +4,7 @@ name: uptime-kuma
 description: Uptime Kuma self-hosted monitoring with HTTP/TCP/DNS/Ping checks, notifications, status pages, and optional MariaDB
 type: application
 version: 1.5.11
-appVersion: "2.5.0"
+appVersion: "2.5.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/uptime-kuma.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "bump Uptime Kuma to 2.5.3 (#1039)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/uptime-kuma/README.md
+++ b/charts/uptime-kuma/README.md
@@ -126,7 +126,7 @@ externalSecrets:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `docker.io/louislam/uptime-kuma` | Uptime Kuma container image |
-| `image.tag` | `2.5.0` | Uptime Kuma image tag |
+| `image.tag` | `2.5.3` | Uptime Kuma image tag |
 | `uptimeKuma.port` | `3001` | Application port |
 | `database.type` | `sqlite` | Database type (sqlite, mariadb) |
 | `mysql.enabled` | `false` | Deploy MySQL subchart (`helmforge/mysql` `2.0.3`) |
@@ -141,9 +141,9 @@ externalSecrets:
 
 ## Upgrade Notes
 
-Uptime Kuma `2.5.0` adds NTP monitoring and notification providers, widens
+Uptime Kuma `2.5.3` includes the 2.5.0 NTP monitoring and notification providers, widens
 daily statistics counters, and includes dependency security updates. The
-default `database.type=sqlite` path remains aligned with upstream behavior.
+2.5.3 hotfix corrects the reported application version. The default `database.type=sqlite` path remains aligned with upstream behavior.
 Keep persistence enabled and back up `/app/data` before upgrading live
 instances.
 

--- a/charts/uptime-kuma/tests/deployment_test.yaml
+++ b/charts/uptime-kuma/tests/deployment_test.yaml
@@ -30,7 +30,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/louislam/uptime-kuma:2.5.0"
+          value: "docker.io/louislam/uptime-kuma:2.5.3"
 
   - it: should set custom image tag
     set:

--- a/charts/uptime-kuma/values.schema.json
+++ b/charts/uptime-kuma/values.schema.json
@@ -32,7 +32,7 @@
         "tag": {
           "type": "string",
           "description": "Image tag",
-          "default": "2.5.0"
+          "default": "2.5.3"
         },
         "pullPolicy": {
           "type": "string",

--- a/charts/uptime-kuma/values.yaml
+++ b/charts/uptime-kuma/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- Uptime Kuma container image
   repository: docker.io/louislam/uptime-kuma
   # -- Image tag
-  tag: "2.5.0"
+  tag: "2.5.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update the official Uptime Kuma image from 2.5.0 to 2.5.3
- align schema defaults, tests, and upgrade guidance
- retain the established 2.x release track

## Upstream evidence

- Release: https://github.com/louislam/uptime-kuma/releases/tag/2.5.3
- Image: docker.io/louislam/uptime-kuma:2.5.3
- Digest: sha256:3e24e96c89efff0e3a4b0698cbdd36c15ad3022371db57166e5588853002ee5c

## Validation

- make validate-chart CHART=uptime-kuma K3D_SCENARIOS=default
- make standards-check CHART=uptime-kuma
- template standards, release, attribution, and site-sync checks
- real upstream image imported into k3d; workload reached Ready with zero restarts

## Site synchronization

- helmforgedev/site#534

Resolves #1039