### PR TITLE
chore(vaultwarden): bump Vaultwarden to 1.37.2

### DIFF
--- a/charts/vaultwarden/Chart.yaml
+++ b/charts/vaultwarden/Chart.yaml
@@ -4,7 +4,7 @@ name: vaultwarden
 description: Vaultwarden for Kubernetes with persistent SQLite storage and explicit ingress/domain configuration
 type: application
 version: 1.13.0
-appVersion: "1.37.1"
+appVersion: "1.37.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,8 +21,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/vaultwarden.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Adding the possibility to control the deployment strategy through values.yaml (#1010)"
+    - kind: changed
+      description: "bump Vaultwarden to 1.37.2 (#1040)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/vaultwarden/README.md
+++ b/charts/vaultwarden/README.md
@@ -60,7 +60,7 @@ helm install vaultwarden oci://ghcr.io/helmforgedev/helm/vaultwarden -f values.y
 - Vaultwarden repository: <https://github.com/dani-garcia/vaultwarden>
 - Vaultwarden configuration template: <https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/.env.template>
 - Vaultwarden 1.37.0 security release: <https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0>
-- Vaultwarden 1.37.1 hotfix release: <https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.1>
+- Vaultwarden 1.37.2 release: <https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2>
 
 ## Best practices
 
@@ -182,7 +182,7 @@ The admin page should not use a plain-text `ADMIN_TOKEN` in real environments. P
 Simple generation options:
 
 ```bash
-docker run --rm -it vaultwarden/server:1.37.1 /vaultwarden hash
+docker run --rm -it vaultwarden/server:1.37.2 /vaultwarden hash
 ```
 
 ```bash
@@ -218,7 +218,7 @@ Official reference:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Vaultwarden image repository | `docker.io/vaultwarden/server` |
-| `image.tag` | Vaultwarden image tag | `1.37.1` |
+| `image.tag` | Vaultwarden image tag | `1.37.2` |
 | `domain` | Public Vaultwarden domain | `""` |
 | `database.mode` | `auto`, `sqlite`, `external`, `postgresql`, or `mysql` | `auto` |
 | `database.external.vendor` | External database vendor | `postgres` |

--- a/charts/vaultwarden/docs/admin-access-and-hardening.md
+++ b/charts/vaultwarden/docs/admin-access-and-hardening.md
@@ -21,7 +21,7 @@ In this chart:
 Using the Vaultwarden image:
 
 ```bash
-docker run --rm -it vaultwarden/server:1.37.1 /vaultwarden hash
+docker run --rm -it vaultwarden/server:1.37.2 /vaultwarden hash
 ```
 
 Using the `argon2` CLI:

--- a/charts/vaultwarden/tests/deployment_test.yaml
+++ b/charts/vaultwarden/tests/deployment_test.yaml
@@ -25,7 +25,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/vaultwarden/server:1.37.1"
+          value: "docker.io/vaultwarden/server:1.37.2"
 
   - it: should have 1 replica
     template: deployment.yaml

--- a/charts/vaultwarden/values.yaml
+++ b/charts/vaultwarden/values.yaml
@@ -17,7 +17,7 @@ image:
   # -- Vaultwarden image repository
   repository: docker.io/vaultwarden/server
   # -- Vaultwarden image tag
-  tag: "1.37.1"
+  tag: "1.37.2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -88,7 +88,7 @@ vaultwarden:
 admin:
   # -- Admin token value. Prefer an Argon2 PHC string for production.
   # -- Example with the container image:
-  # --   docker run --rm -it vaultwarden/server:1.37.1 /vaultwarden hash
+  # --   docker run --rm -it vaultwarden/server:1.37.2 /vaultwarden hash
   # -- Example with the argon2 CLI:
   # --   echo -n 'change-me' | argon2 "$(openssl rand -base64 32)" -e -id -k 65540 -t 3 -p 4
   # -- Official reference:


### PR DESCRIPTION
## Summary

- update the official Vaultwarden image from 1.37.1 to 1.37.2
- refresh tests, examples, and release guidance
- preserve the stable 1.37 release track

## Upstream evidence

- Release: https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.2
- Image: docker.io/vaultwarden/server:1.37.2
- Digest: sha256:094b5689ed81549bd293418395c7cf495ae9d960fc2d4928cef2083ef913d912
- Upstream marks it required for clients 2026.8.0 and newer

## Validation

- make validate-chart CHART=vaultwarden K3D_SCENARIOS=default
- make standards-check CHART=vaultwarden
- template standards, release, attribution, and site-sync checks
- real upstream image imported into k3d; workload reached Ready with zero restarts

## Site synchronization

- helmforgedev/site#535

Resolves #1040