### PR TITLE
chore(wordpress): bump WordPress to 7.1.0

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: wordpress
 type: application
 version: 3.0.4
-appVersion: "7.0.4"
+appVersion: "7.1.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying WordPress on Kubernetes with MySQL support and S3 backup
 maintainers:
@@ -23,7 +23,7 @@ icon: https://helmforge.dev/icons/charts/wordpress.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "bump WordPress to 7.1.0 (#1041)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/wordpress/tests/backup_test.yaml
+++ b/charts/wordpress/tests/backup_test.yaml
@@ -7,7 +7,7 @@ release:
   name: test
   namespace: default
 chart:
-  appVersion: "7.0.4"
+  appVersion: "7.1.0"
 tests:
   - it: should not render backup by default
     template: templates/backup-cronjob.yaml

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -27,7 +27,7 @@ image:
   # -- Container image repository
   repository: docker.io/library/wordpress
   # -- Container image tag
-  tag: "7.0.4-apache"
+  tag: "7.1.0-apache"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official WordPress Apache image from 7.0.4 to 7.1.0
- align the chart appVersion and backup rendering test
- preserve the official Apache image track

## Upstream evidence

- Stable-version API: https://api.wordpress.org/core/version-check/1.7/
- Field guide: https://make.wordpress.org/core/2026/08/05/wordpress-7-1-field-guide/
- Image: docker.io/library/wordpress:7.1.0-apache
- Digest: sha256:65919a9ca10940feb10d9400fead0d639bf86241f47c91e2b9ea4703aa8452cf

## Validation

- make validate-chart CHART=wordpress K3D_SCENARIOS=default
- make standards-check CHART=wordpress
- template standards, release, attribution, and site-sync checks
- real upstream image imported into k3d; WordPress and MySQL reached Ready with zero restarts

## Site synchronization

- helmforgedev/site#536

Resolves #1041