### PR TITLE
feat(mariadb): add affinity/tolerations spec to source and readReplicas

### DIFF
--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -97,9 +97,13 @@ replication:
 | `standalone.persistence.size` | `8Gi` | Standalone PVC size |
 | `replication.source.resourcesPreset` | `small` | Default source resource requests and limits |
 | `replication.source.persistence.size` | `20Gi` | Source PVC size |
+| `replication.source.affinity` | `{}` | Affinity for the source pod |
+| `replication.source.tolerations` | `[]` | Tolerations for the source pod |
 | `replication.readReplicas.replicaCount` | `2` | Number of read replicas |
 | `replication.readReplicas.resourcesPreset` | `small` | Default replica resource requests and limits |
 | `replication.readReplicas.persistence.size` | `20Gi` | Replica PVC size |
+| `replication.readReplicas.affinity` | `{}` | Affinity for the replica pods |
+| `replication.readReplicas.tolerations` | `[]` | Tolerations for the replica pods |
 | `replication.binlog.format` | `ROW` | Binlog format |
 | `service.type` | `ClusterIP` | Service type |
 | `service.port` | `3306` | MariaDB port |

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -464,24 +464,6 @@ terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 nodeSelector:
   {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- if .Values.affinity }}
-affinity:
-  {{- toYaml .Values.affinity | nindent 2 }}
-{{- else if and (eq .Values.architecture "replication") .Values.replication.scheduling.enableDefaultPodAntiAffinity }}
-affinity:
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchLabels:
-              {{- include "mariadb.selectorLabels" . | nindent 14 }}
-{{- end }}
-{{- with .Values.tolerations }}
-tolerations:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 {{- if .Values.topologySpreadConstraints }}
 topologySpreadConstraints:
   {{- toYaml .Values.topologySpreadConstraints | nindent 2 }}
@@ -495,6 +477,40 @@ topologySpreadConstraints:
         {{- include "mariadb.selectorLabels" . | nindent 8 }}
 {{- end }}
 {{- end -}}
+
+{{- define "mariadb.affinity" -}}
+{{- $root := .root }}
+{{- $instance := .instance }}
+{{- if and (eq $root.Values.architecture "replication") $instance.affinity }}
+affinity:
+  {{- toYaml $instance.affinity | nindent 2 }}
+{{- else if $root.Values.affinity }}
+affinity:
+  {{- toYaml $root.Values.affinity | nindent 2 }}
+{{- else if and (eq $root.Values.architecture "replication") $root.Values.replication.scheduling.enableDefaultPodAntiAffinity }}
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              {{- include "mariadb.selectorLabels" $root | nindent 14 }}
+{{- end }}
+{{- end -}}
+
+{{- define "mariadb.tolerations" -}}
+{{- $root := .root }}
+{{- $instance := .instance }}
+{{- if and (eq $root.Values.architecture "replication") $instance.tolerations }}
+tolerations:
+  {{- toYaml $instance.tolerations | nindent 2 }}
+{{- else if $root.Values.tolerations }}
+tolerations:
+  {{- toYaml $root.Values.tolerations | nindent 2 }}
+{{- end }}
+{{- end }}
 
 {{- define "mariadb.pdbEnabled" -}}
 {{- if eq .Values.architecture "replication" -}}

--- a/charts/mariadb/templates/statefulset-replicas.yaml
+++ b/charts/mariadb/templates/statefulset-replicas.yaml
@@ -27,6 +27,8 @@ spec:
         {{- end }}
     spec:
       {{- include "mariadb.podSpecCommon" . | nindent 6 }}
+      {{- include "mariadb.affinity" (dict "root" . "instance" .Values.replication.readReplicas) | nindent 6 }}
+      {{- include "mariadb.tolerations" (dict "root" . "instance" .Values.replication.readReplicas) | nindent 6 }}
       initContainers:
         {{- include "mariadb.prepareDataSubPathInitContainer" . | nindent 8 }}
         - name: clone-source

--- a/charts/mariadb/templates/statefulset-source.yaml
+++ b/charts/mariadb/templates/statefulset-source.yaml
@@ -25,6 +25,8 @@ spec:
         {{- end }}
     spec:
       {{- include "mariadb.podSpecCommon" . | nindent 6 }}
+      {{- include "mariadb.affinity" (dict "root" . "instance" .Values.replication.source) | nindent 6 }}
+      {{- include "mariadb.tolerations" (dict "root" . "instance" .Values.replication.source) | nindent 6 }}
       {{- if or (and .Values.persistence.subPath .Values.persistence.prepareDataDir.enabled) .Values.metrics.enabled }}
       initContainers:
         {{- include "mariadb.prepareDataSubPathInitContainer" . | nindent 8 }}

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -144,6 +144,10 @@ replication:
     probes:
       # -- In replication mode, require the source readiness check to confirm the pod is writable
       requireWritable: true
+    # -- Affinity for the replication source pod.
+    affinity: {}
+    # -- Tolerations for the replication source pod.
+    tolerations: []
   readReplicas:
     # -- Base server ID used to derive replica server IDs from pod ordinal
     serverIdBase: 100
@@ -168,6 +172,10 @@ replication:
       requireReadOnly: true
       # -- Optionally require the replica readiness check to confirm IO and SQL replication threads are running
       requireRunningReplication: false
+    # -- Affinity for the replica pods.
+    affinity: {}
+    # -- Tolerations for the replica pods.
+    tolerations: []
   binlog:
     # -- Binlog format used by the source
     format: ROW
@@ -187,6 +195,7 @@ replication:
     maxUnavailable: ""
   scheduling:
     # -- Enable opinionated default placement rules in replication mode when global affinity/topologySpreadConstraints are empty
+    # -- Also overwritten if affinity is set for source or readReplicas
     enableDefaultPodAntiAffinity: true
     enableDefaultTopologySpread: true
     topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Summary

This PR aims to implement #1064. I extracted the `affinity` and `tolerations` definitions from the `mariadb.podSpecCommon` template into their own templates.
For `standalone`, the global `affinity` and `tolerations` are used, otherwise the `source` / `readReplicas` local `affinity` and `tolerations` take the highest precedence over the global `affinity` and `replication.scheduling.enableDefaultPodAntiAffinity`.
If `affinity` is set for one of `source` or `readReplicas` only and `replication.scheduling.enableDefaultPodAntiAffinity` is set, then there might be a disconnect between both affinity definitions. I could add a note or fail templating in that case if this is wished.

-

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [ ] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [ ] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [ ] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation

- [ ] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm template` passed for default values and relevant `ci/*.yaml` scenarios
- [x] `helm unittest --with-subchart=false charts/<chart-name>` passed when tests exist
- [x] `kubeconform -strict` passed without `--ignore-missing-schema`
- [x] `ah lint -p charts/<chart-name>` passed
- [ ] `kubescape scan framework "MITRE,NSA,SOC2"` passed the minimum score gate
- [ ] local k3d runtime validation passed when required, including pod status, events, and logs (not run; add --runtime when runtime validation is required)
- [ ] I updated chart docs and the site repo when public behavior changed
- [ ] I linked or created the required GitHub issue for this PR

## Notes

-

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable node affinity and tolerations for MariaDB replication source and read-replica workloads.
  * Per-workload scheduling settings can override chart-wide defaults.
  * Documented the new configuration options in the values reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->