### PR TITLE
feat(booklore)!: promote chart to stable

### DIFF
--- a/charts/booklore/Chart.yaml
+++ b/charts/booklore/Chart.yaml
@@ -34,7 +34,7 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"
-  helmforge.dev/maturity: alpha
+  helmforge.dev/maturity: stable
   artifacthub.io/links: |
     - name: Official Source
       url: https://github.com/booklore-app/booklore
@@ -44,6 +44,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.0.3
+    version: 2.1.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled

--- a/charts/booklore/README.md
+++ b/charts/booklore/README.md
@@ -39,6 +39,14 @@ access. See [examples/](examples/) for ready-to-use configurations.
 | books | /books | 50Gi | Library book files |
 | bookdrop | /bookdrop | disabled | BookDrop import folder |
 
+## Production
+
+Production deployments should pin the public browser origin, source database
+credentials from a Secret, protect all three persistent data domains, and keep
+the application at one replica unless shared-storage concurrency has been
+validated independently. See [docs/production.md](docs/production.md) and
+[examples/production.yaml](examples/production.yaml).
+
 ## Security Scan: `booklore`
 
 | Framework | Score |

--- a/charts/booklore/ci/production-values.yaml
+++ b/charts/booklore/ci/production-values.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-like single-replica scenario with durable storage and isolation.
+app:
+  allowedOrigins: https://library.example.com
+
+persistence:
+  data:
+    size: 20Gi
+  books:
+    size: 100Gi
+  bookdrop:
+    enabled: true
+    size: 10Gi
+
+pdb:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+
+mariadb:
+  auth:
+    rootPassword: ci-root-password
+    password: ci-booklore-password
+  standalone:
+    persistence:
+      size: 20Gi

--- a/charts/booklore/docs/production.md
+++ b/charts/booklore/docs/production.md
@@ -1,0 +1,48 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Production Guide
+
+BookLore stores application state, book files, and imported files on separate
+volumes and relies on MariaDB for relational data. A production backup must
+cover the database plus every enabled BookLore volume.
+
+## Scaling Boundary
+
+Keep `replicaCount=1` with the default `ReadWriteOnce` volumes. Horizontal
+scaling requires shared writable storage for `/app/data`, `/books`, and
+`/bookdrop`, plus validation that concurrent workers do not process the same
+BookDrop item. The chart does not claim that topology as supported.
+
+## Credentials
+
+Use `mariadb.auth.existingSecret` for the bundled database or
+`database.external.existingSecret` for an external database. Do not store
+production passwords in a values file. External Secrets can create either
+Secret before BookLore starts.
+
+## Network And Browser Origins
+
+Set `app.allowedOrigins` to the public HTTPS origin instead of the permissive
+default. Enable TLS on Ingress or Gateway API and use NetworkPolicy egress
+rules that allow DNS, MariaDB, and any metadata providers BookLore must reach.
+
+## Availability And Storage
+
+The PodDisruptionBudget protects the single pod from voluntary eviction, but
+it does not provide high availability. Use a StorageClass with snapshots and
+expansion, test volume restoration, and schedule maintenance windows when the
+pod must be restarted.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: BookLore Production Guide
+description: Production operating boundaries for BookLore storage, credentials, and availability
+keywords: booklore, production, mariadb, storage, backup
+purpose: Document the supported production topology
+scope: Chart
+relations:
+  - charts/booklore/values.yaml
+path: charts/booklore/docs/production.md
+version: 1.0
+date: 2026-08-27
+-->

--- a/charts/booklore/examples/production.yaml
+++ b/charts/booklore/examples/production.yaml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented BookLore deployment with TLS, persistent imports, and
+# credentials supplied through an existing Secret.
+app:
+  allowedOrigins: https://library.example.com
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: library.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: booklore-tls
+      hosts:
+        - library.example.com
+
+persistence:
+  data:
+    size: 20Gi
+  books:
+    size: 100Gi
+  bookdrop:
+    enabled: true
+    size: 10Gi
+
+pdb:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+
+mariadb:
+  auth:
+    existingSecret: booklore-mariadb
+  standalone:
+    persistence:
+      size: 20Gi

--- a/charts/booklore/tests/production_test.yaml
+++ b/charts/booklore/tests/production_test.yaml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: booklore production contract
+templates:
+  - templates/deployment.yaml
+  - templates/networkpolicy.yaml
+  - templates/pdb.yaml
+tests:
+  - it: renders the supported production storage and browser origin contract
+    template: templates/deployment.yaml
+    set:
+      app.allowedOrigins: https://library.example.com
+      persistence.bookdrop.enabled: true
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ALLOWED_ORIGINS
+            value: https://library.example.com
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: bookdrop
+            mountPath: /bookdrop
+  - it: isolates ingress and database egress when network policy is enabled
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 3306
+  - it: protects the single supported replica from voluntary disruption
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1


### PR DESCRIPTION
## Summary

- Promote BookLore from alpha to stable, update the MariaDB dependency, and add a production profile with documentation and tests.
- Upstream image verified: ghcr.io/booklore-app/booklore:v2.3.1.
- Companion site synchronization: https://github.com/helmforgedev/site/pull/540
- Companion organization profile synchronization: https://github.com/helmforgedev/.github/pull/20

## Type Of Change

- [x] Existing chart change

## Governance

Maintainer-directed production promotion; no existing issue is open for this chart graduation.

## Upstream Verification

- [x] appVersion matches the stable upstream release where applicable
- [x] official image tag exists and supports amd64 and arm64
- [x] no floating or Bitnami image tags

## Local Validation

- [x] make validate-chart passed all 19 layers
- [x] default install passed on local k3d
- [x] every ci values scenario passed on local k3d
- [x] workloads became ready with endpoints
- [x] zero crash restarts and no fatal log patterns
- [x] helm unittest, kubeconform, Artifact Hub lint, standards, and dependency checks passed
- [x] Kubescape score remained above the repository floor

## Release

This is a maturity graduation and intentionally uses a breaking Conventional Commit so CI publishes the production-ready major chart release. Chart version remains CI-managed.
