### PR TITLE
feat(notediscovery)!: promote chart to stable

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 1.1.5
-appVersion: "0.31.3"
+appVersion: "0.31.4"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery
@@ -28,4 +28,4 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.31.3` image.
+official `ghcr.io/gamosoft/notediscovery:0.31.4` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.3` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.4` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -151,12 +151,9 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.31.3` adds custom human-readable share links, full note paths
-on hover, checklist bulk updates, corrected task statistics, and public share
-URL configuration, while retaining the interactive task checkboxes and
-cache-safe asset behavior from 0.31.0. Review the
-[upstream 0.31.3 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.3)
-before upgrading.
+NoteDiscovery `0.31.4` is the current stable upstream release. Review the
+[upstream 0.31.4 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.4)
+and back up the data PVC before upgrading.
 
 Generated configuration now stores plugin state under the writable data volume
 and bootstraps the official bundled plugins there. Existing Secrets should use
@@ -190,14 +187,12 @@ egress rules after built-in DNS and HTTPS allowances.
 - [Authentication](docs/authentication.md)
 - [Exposure](docs/exposure.md)
 - [MCP integration](docs/mcp.md)
+- [Production](docs/production.md)
 
 ## Security Scan: `notediscovery`
 
 | Framework | Score |
 |---|---|
-| Overall | **87.37%** |
-| MITRE | **100.00%** |
-| NSA | **82.50%** |
-| SOC2 | **86.67%** |
+| MITRE + NSA + SOC2 | **87.37373%** |
 
 > Security posture acceptable.

--- a/charts/notediscovery/ci/production-values.yaml
+++ b/charts/notediscovery/ci/production-values.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-like authenticated single-replica scenario.
+notediscovery:
+  allowedOrigins:
+    - https://notes.example.com
+  debug: false
+
+auth:
+  enabled: true
+  secretKey: ci-production-session-secret-with-stable-entropy
+  password: CiProductionPassword2026!
+  sessionMaxAge: 28800
+
+persistence:
+  size: 20Gi
+
+pdb:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi

--- a/charts/notediscovery/docs/production.md
+++ b/charts/notediscovery/docs/production.md
@@ -1,0 +1,49 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Production Guide
+
+NoteDiscovery stores notes, images, drawings, search data, and writable plugin
+state under `/app/data`. The supported production topology is one application
+pod backed by one durable volume.
+
+## Authentication And Browser Origins
+
+Enable authentication for every shared deployment. Prefer
+`auth.existingSecret` with a complete `config.yaml` so session secrets,
+passwords, and API keys do not enter Helm release values. Restrict
+`notediscovery.allowedOrigins` to the exact public HTTPS origins and keep debug
+mode disabled.
+
+## Storage And Backups
+
+Back up the entire data volume, including its `plugins` directory. Verify a
+restore into a clean namespace before upgrades. Use a StorageClass that
+supports snapshots and expansion, and keep `persistence.mountPath` stable.
+
+## Scaling Boundary
+
+The generated volume is `ReadWriteOnce` and the Deployment uses `Recreate`.
+Keep `replicaCount=1`. Supplying a shared existing claim removes the render-time
+guard, but the operator must independently validate concurrent file writes,
+search indexing, and plugin state before running multiple replicas.
+
+## Network And MCP Access
+
+Terminate TLS at Ingress or Gateway API and enable NetworkPolicy. The default
+policy permits inbound HTTP from namespaces and adds DNS/HTTPS egress only when
+custom egress rules are configured. Limit MCP and API access to trusted clients
+and rotate exposed API keys.
+
+<!-- @AI-METADATA
+type: chart-docs
+title: NoteDiscovery Production Guide
+description: Production controls for NoteDiscovery authentication, storage, scaling, and MCP access
+keywords: notediscovery, production, markdown, authentication, mcp
+purpose: Document the supported production topology
+scope: Chart
+relations:
+  - charts/notediscovery/values.yaml
+path: charts/notediscovery/docs/production.md
+version: 1.0
+date: 2026-08-27
+-->

--- a/charts/notediscovery/examples/production.yaml
+++ b/charts/notediscovery/examples/production.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-oriented NoteDiscovery deployment using a pre-created config
+# Secret. See docs/production.md for the required config.yaml structure.
+notediscovery:
+  allowedOrigins:
+    - https://notes.example.com
+  debug: false
+
+auth:
+  enabled: true
+  existingSecret: notediscovery-config
+  existingSecretKey: config.yaml
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: notes.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: notediscovery-tls
+      hosts:
+        - notes.example.com
+
+persistence:
+  size: 20Gi
+
+pdb:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi

--- a/charts/notediscovery/tests/production_test.yaml
+++ b/charts/notediscovery/tests/production_test.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: notediscovery production contract
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+  - templates/pdb.yaml
+  - templates/secret.yaml
+tests:
+  - it: pins the current stable image and uses the Recreate strategy
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/gamosoft/notediscovery:0.31.4
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+  - it: stores authenticated production configuration in a Secret
+    template: templates/secret.yaml
+    set:
+      auth.enabled: true
+      auth.secretKey: ci-production-session-secret-with-stable-entropy
+      auth.password: CiProductionPassword2026!
+      notediscovery.allowedOrigins[0]: https://notes.example.com
+      notediscovery.debug: false
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'allowed_origins:'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'debug: false'
+      - matchRegex:
+          path: stringData["config.yaml"]
+          pattern: 'enabled: true'
+  - it: protects the supported single replica from voluntary disruption
+    template: templates/pdb.yaml
+    set:
+      pdb.enabled: true
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.3
+          value: ghcr.io/gamosoft/notediscovery:0.31.4
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -24,7 +24,7 @@ tests:
           value: plugin-bootstrap
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.3
+          value: ghcr.io/gamosoft/notediscovery:0.31.4
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "if \\[ -d /app/plugins \\]"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.31.3", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.31.4", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.31.3"
+  tag: "0.31.4"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- Promote NoteDiscovery from beta to stable, update to 0.31.4, and add production documentation, example, CI values, and tests.
- Upstream image verified: ghcr.io/gamosoft/notediscovery:0.31.4.
- Companion site synchronization: https://github.com/helmforgedev/site/pull/540
- Companion organization profile synchronization: https://github.com/helmforgedev/.github/pull/20

## Type Of Change

- [x] Existing chart change

## Governance

Maintainer-directed production promotion; no existing issue is open for this chart graduation.

## Upstream Verification

- [x] appVersion matches the stable upstream release where applicable
- [x] official image tag exists and supports amd64 and arm64
- [x] no floating or Bitnami image tags

## Local Validation

- [x] make validate-chart passed all 22 layers
- [x] default install passed on local k3d
- [x] every ci values scenario passed on local k3d
- [x] workloads became ready with endpoints
- [x] zero crash restarts and no fatal log patterns
- [x] helm unittest, kubeconform, Artifact Hub lint, standards, and dependency checks passed
- [x] Kubescape score remained above the repository floor

## Release

This is a maturity graduation and intentionally uses a breaking Conventional Commit so CI publishes the production-ready major chart release. Chart version remains CI-managed.
