### PR TITLE
feat(pimcore)!: promote chart to stable

### DIFF
--- a/charts/pimcore/Chart.yaml
+++ b/charts/pimcore/Chart.yaml
@@ -4,7 +4,7 @@ name: pimcore
 description: Pimcore data and experience management platform with PHP-FPM, Messenger workers, and maintenance automation
 type: application
 version: 1.0.1
-appVersion: "2026.2.8"
+appVersion: "2026.2.10"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -33,7 +33,8 @@ annotations:
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: beta
+  artifacthub.io/prerelease: "false"
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
@@ -52,14 +53,14 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.0.3
+    version: 2.1.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
   - name: rabbitmq
-    version: 1.7.0
+    version: 1.7.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: rabbitmq.enabled

--- a/charts/pimcore/README.md
+++ b/charts/pimcore/README.md
@@ -3,7 +3,7 @@
 Production-oriented deployment of [Pimcore](https://pimcore.com), the
 PHP/Symfony platform for PIM, MDM, DAM, CDP, DXP/CMS, and digital commerce.
 
-This chart targets Pimcore `2026.2.8` and pins the official multi-architecture
+This chart targets Pimcore `2026.2.10` and pins the official multi-architecture
 PHP 8.5 runtime `pimcore/pimcore:php8.5.9-max-v5.2-hardened`. It models the
 upstream topology instead of treating the runtime image as a complete
 application:
@@ -120,7 +120,7 @@ Deploy it with bootstrap and project persistence disabled:
 ```yaml
 image:
   repository: registry.example.com/platform/pimcore-project
-  tag: "2026.2.8-1"
+  tag: "2026.2.10-1"
 
 project:
   bootstrap:

--- a/charts/pimcore/ci/production-values.yaml
+++ b/charts/pimcore/ci/production-values.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+auth:
+  applicationSecret: pimcore-ci-production-application-secret
+  adminPassword: PimcoreProduction2026
+  mercureJWT: pimcore-ci-production-mercure-jwt-secret
+
+mariadb:
+  auth:
+    password: PimcoreDatabase2026
+    rootPassword: PimcoreRootDatabase2026
+
+rabbitmq:
+  auth:
+    password: PimcoreQueue2026
+
+cache:
+  enabled: true
+redis:
+  enabled: true
+  auth:
+    password: PimcoreCache2026
+
+mercure:
+  anonymous: false
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true

--- a/charts/pimcore/examples/production.yaml
+++ b/charts/pimcore/examples/production.yaml
@@ -2,7 +2,7 @@
 ---
 image:
   repository: registry.example.com/platform/pimcore-project
-  tag: "2026.2.8-1"
+  tag: "2026.2.10-1"
 
 project:
   bootstrap:

--- a/charts/pimcore/tests/production_test.yaml
+++ b/charts/pimcore/tests/production_test.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: pimcore production profile
+templates:
+  - configmap.yaml
+  - deployment-web.yaml
+  - secret.yaml
+  - networkpolicy.yaml
+tests:
+  - it: renders a hardened production profile with explicit credentials
+    values:
+      - ../ci/production-values.yaml
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.readOnlyRootFilesystem
+          value: true
+  - it: stores production credentials in a Secret
+    values:
+      - ../ci/production-values.yaml
+    template: secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - exists:
+          path: stringData.application-secret
+      - exists:
+          path: stringData.admin-password
+      - exists:
+          path: stringData.mercure-jwt-key
+  - it: enables network isolation for the production profile
+    values:
+      - ../ci/production-values.yaml
+    template: networkpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
## Summary

- Promote Pimcore from beta to stable, target upstream 2026.2.10, update three dependencies, and add a hardened production profile.
- Runtime image verified: docker.io/pimcore/pimcore:php8.5.9-max-v5.2-hardened.
- Companion site synchronization: https://github.com/helmforgedev/site/pull/540
- Companion organization profile synchronization: https://github.com/helmforgedev/.github/pull/20

## Type Of Change

- [x] Existing chart change

## Governance

Maintainer-directed production promotion; no existing issue is open for this chart graduation.

## Upstream Verification

- [x] appVersion matches the stable upstream release where applicable
- [x] official image tag exists and supports amd64 and arm64
- [x] no floating or Bitnami image tags

## Local Validation

- [x] make validate-chart passed all 15 layers
- [x] default install passed on local k3d
- [x] every ci values scenario passed on local k3d
- [x] workloads became ready with endpoints
- [x] zero crash restarts and no fatal log patterns
- [x] helm unittest, kubeconform, Artifact Hub lint, standards, and dependency checks passed
- [x] Kubescape score remained above the repository floor

## Release

This is a maturity graduation and intentionally uses a breaking Conventional Commit so CI publishes the production-ready major chart release. Chart version remains CI-managed.
