### PR TITLE
feat(clickhouse)!: promote chart to stable

### DIFF
--- a/charts/clickhouse/Chart.yaml
+++ b/charts/clickhouse/Chart.yaml
@@ -30,7 +30,8 @@ annotations:
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: beta
+  artifacthub.io/prerelease: "false"
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D


### PR DESCRIPTION
## Summary

- Promote ClickHouse from beta to stable after validating the existing production profile and operator boundary.
- Upstream image verified: docker.io/clickhouse/clickhouse-server:26.7.5.
- Companion site synchronization: https://github.com/helmforgedev/site/pull/540
- Companion organization profile synchronization: https://github.com/helmforgedev/.github/pull/20

## Type Of Change

- [x] Existing chart change

## Governance

Maintainer-directed production promotion; no existing issue is open for this chart graduation.

## Upstream Verification

- [x] appVersion matches the stable upstream release where applicable
- [x] official image tag exists and supports amd64 and arm64
- [x] no floating or Bitnami image tags

## Local Validation

- [x] make validate-chart passed all 19 layers
- [x] default install passed on local k3d
- [x] every ci values scenario passed on local k3d
- [x] workloads became ready with endpoints
- [x] zero crash restarts and no fatal log patterns
- [x] helm unittest, kubeconform, Artifact Hub lint, standards, and dependency checks passed
- [x] Kubescape score remained above the repository floor

## Release

This is a maturity graduation and intentionally uses a breaking Conventional Commit so CI publishes the production-ready major chart release. Chart version remains CI-managed.
