### PR TITLE
feat(netbox)!: promote chart to stable

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -4,7 +4,7 @@ name: netbox
 description: NetBox infrastructure resource modeling with web, worker, and housekeeping workloads
 type: application
 version: 1.0.3
-appVersion: "4.6.7"
+appVersion: "4.6.9"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -30,7 +30,8 @@ annotations:
       email: berlofa@helmforge.dev
     - name: Maicon Berlofa
       email: maicon.berloffa@gmail.com
-  helmforge.dev/maturity: beta
+  artifacthub.io/prerelease: "false"
+  helmforge.dev/maturity: stable
   helmforge.dev/signed: gpg+cosign
   artifacthub.io/signKey: |
     fingerprint: 6748042FBAD8C2E11C65E564170D55148EB88A9D
@@ -53,6 +54,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/netbox/DESIGN.md
+++ b/charts/netbox/DESIGN.md
@@ -13,10 +13,9 @@ pods can never accidentally receive HTTP traffic.
 
 ## Image choice
 
-The default `v4.6.8-5.0.2` tag combines an exact NetBox application release
+The default `v4.6.9-5.0.2` tag combines an exact NetBox application release
 with an exact netbox-docker support release. It is published for amd64 and
-arm64. NetBox 4.6.7 existed when the chart was authored, but no matching exact
-5.0.2 image was published, so the chart does not invent or use a moving tag.
+arm64. The chart pins both version components and never uses a moving tag.
 
 ## State
 

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -114,7 +114,7 @@ also verifies database-backed Django startup.
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **85.43%** |
+| MITRE + NSA + SOC2 | **85.42568%** |
 
 Security posture acceptable.
 
@@ -122,7 +122,7 @@ Local details:
 
 - Tool: Kubescape v4.0.9
 - Command: `kubescape scan framework mitre,nsa,soc2 .tmp/netbox-render.yaml`
-- Result: 0 critical failed resources, resource summary score 85.43%.
+- Result: 0 critical failed resources, resource summary score 85.42568%.
 
 ## Examples
 

--- a/charts/netbox/ci/production-values.yaml
+++ b/charts/netbox/ci/production-values.yaml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# Production-like single-cluster scenario with explicit credentials and
+# operational workloads enabled.
+netbox:
+  allowedHosts:
+    - netbox.example.com
+  isolatedDeployment: true
+  metricsEnabled: true
+
+auth:
+  secretKey: ci-production-django-secret-key-with-stable-entropy
+  apiTokenPepper: ci-production-api-token-pepper-with-more-than-fifty-characters-2026
+  superuser:
+    enabled: false
+
+postgresql:
+  auth:
+    postgresPassword: ci-postgres-password
+    password: ci-netbox-password
+  primary:
+    persistence:
+      size: 20Gi
+
+redis:
+  auth:
+    password: ci-redis-password
+  master:
+    persistence:
+      size: 5Gi
+
+persistence:
+  size: 20Gi
+
+metrics:
+  serviceMonitor:
+    enabled: true
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true

--- a/charts/netbox/tests/deployment_test.yaml
+++ b/charts/netbox/tests/deployment_test.yaml
@@ -16,7 +16,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/netboxcommunity/netbox:v4.6.8-5.0.2
+          value: docker.io/netboxcommunity/netbox:v4.6.9-5.0.2
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080

--- a/charts/netbox/tests/production_test.yaml
+++ b/charts/netbox/tests/production_test.yaml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: netbox production contract
+templates:
+  - configmap.yaml
+  - secret.yaml
+  - externalsecret.yaml
+  - deployment-web.yaml
+  - deployment-worker.yaml
+  - cronjob-housekeeping.yaml
+  - servicemonitor.yaml
+tests:
+  - it: renders the current stable NetBox image for the web workload
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/netboxcommunity/netbox:v4.6.9-5.0.2
+  - it: disables outbound release checks in isolated deployments
+    template: deployment-web.yaml
+    set:
+      netbox.isolatedDeployment: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ISOLATED_DEPLOYMENT
+            value: "true"
+  - it: retains the worker and housekeeping operational workloads
+    template: deployment-worker.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+    documentSelector:
+      path: metadata.name
+      value: RELEASE-NAME-netbox-worker
+  - it: renders housekeeping with concurrency protection
+    template: cronjob-housekeeping.yaml
+    asserts:
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+  - it: exposes metrics only when both application and monitor are enabled
+    template: servicemonitor.yaml
+    set:
+      netbox.metricsEnabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official NetBox Docker image repository.
   repository: docker.io/netboxcommunity/netbox
   # -- Immutable NetBox and netbox-docker release combination.
-  tag: "v4.6.8-5.0.2"
+  tag: "v4.6.9-5.0.2"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 # -- Image pull secrets.


### PR DESCRIPTION
## Summary

- Promote NetBox from beta to stable, update NetBox to 4.6.9, refresh Redis, and add a production validation profile.
- Upstream image verified: docker.io/netboxcommunity/netbox:v4.6.9-5.0.2.
- Companion site synchronization: https://github.com/helmforgedev/site/pull/540
- Companion organization profile synchronization: https://github.com/helmforgedev/.github/pull/20

## Type Of Change

- [x] Existing chart change

## Governance

Maintainer-directed production promotion; no existing issue is open for this chart graduation.

## Upstream Verification

- [x] appVersion matches the stable upstream release where applicable
- [x] official image tag exists and supports amd64 and arm64
- [x] no floating or Bitnami image tags

## Local Validation

- [x] make validate-chart passed all 15 layers
- [x] default install passed on local k3d
- [x] every ci values scenario passed on local k3d
- [x] workloads became ready with endpoints
- [x] zero crash restarts and no fatal log patterns
- [x] helm unittest, kubeconform, Artifact Hub lint, standards, and dependency checks passed
- [x] Kubescape score remained above the repository floor

## Release

This is a maturity graduation and intentionally uses a breaking Conventional Commit so CI publishes the production-ready major chart release. Chart version remains CI-managed.
