### PR TITLE
feat(poznote)!: promote chart to stable

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 1.1.5
-appVersion: "6.68.1"
+appVersion: "6.68.3"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -29,7 +29,7 @@ annotations:
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"
-  helmforge.dev/maturity: beta
+  helmforge.dev/maturity: stable
   artifacthub.io/links: |
     - name: Official Source
       url: https://github.com/timothepoznanski/poznote

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.68.1
+ghcr.io/timothepoznanski/poznote:6.68.3
 ```
 
-The tag maps to the upstream `6.68.1` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.68.3` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.68.1-rootless` variant. It is not the chart
+Upstream also publishes a `6.68.3-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.68.1` |
+| `image.tag` | Image tag | `6.68.3` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -116,12 +116,14 @@ ingress:
 - [Ingress Exposure](examples/ingress.yaml)
 - [Gateway API Exposure](examples/gateway-api.yaml)
 - [OIDC Secured](examples/secured.yaml)
+- [Production](examples/production.yaml)
 
 ## Architecture Guides
 
 - [Storage Guide](docs/storage.md)
 - [Exposure Guide](docs/exposure.md)
 - [Authentication Guide](docs/authentication.md)
+- [Production Guide](docs/production.md)
 
 ## Connecting to Poznote
 
@@ -141,10 +143,9 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.68.1` adds workspace-scoped AI and tags, per-user AI providers,
-checklists on the tasks page, and fixes sidebar links after workspace switches.
-Review the
-[upstream 6.68.1 release](https://github.com/timothepoznanski/poznote/releases/tag/6.68.1)
+Poznote `6.68.3` improves search and replace in rendered Markdown previews and
+fixes indented code blocks that contain inline Markdown. Review the
+[upstream 6.68.3 release](https://github.com/timothepoznanski/poznote/releases/tag/6.68.3)
 before upgrading. The default local SQLite and filesystem deployment remains
 compatible; S3 integration is configured inside Poznote when needed.
 

--- a/charts/poznote/ci/production-values.yaml
+++ b/charts/poznote/ci/production-values.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+persistence:
+  data:
+    enabled: true
+    size: 10Gi
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: notes.example.com
+  tls:
+    - secretName: notes-tls
+      hosts:
+        - notes.example.com
+
+pdb:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true

--- a/charts/poznote/docs/production.md
+++ b/charts/poznote/docs/production.md
@@ -1,0 +1,24 @@
+# Production operations
+
+Poznote stores its SQLite database, notes, attachments, and application
+configuration in the `data` volume. Use a retained storage class, monitor free
+space, and take application-consistent backups before upgrades.
+
+Poznote supports one replica because the embedded SQLite database and local
+filesystem are not safe for concurrent writers. The chart therefore uses the
+`Recreate` deployment strategy. A PodDisruptionBudget protects the single pod
+from voluntary eviction, but it does not provide high availability.
+
+Expose the Service through TLS-enabled Ingress or Gateway API. Enable the
+NetworkPolicy and restrict `networkPolicy.ingressFrom` to the namespace or
+pods that run the selected ingress controller. Permit only the egress required
+by DNS, OIDC, S3, and other integrations that are actually configured.
+
+For SSO, place OIDC credentials in an existing Secret or synchronize them with
+External Secrets. Test OIDC end to end before setting
+`poznote.oidc.disableNormalLogin=true`, so an identity-provider outage does not
+lock administrators out unexpectedly.
+
+Before an upgrade, back up the complete `data` volume and verify a restore in a
+separate namespace. After rollout, confirm `/api/health`, authentication, note
+rendering, search, attachments, and any external storage integration.

--- a/charts/poznote/examples/production.yaml
+++ b/charts/poznote/examples/production.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+persistence:
+  data:
+    enabled: true
+    storageClass: fast-retain
+    size: 20Gi
+
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: notes.example.com
+  tls:
+    - secretName: notes-tls
+      hosts:
+        - notes.example.com
+
+pdb:
+  enabled: true
+
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    enabled: true
+    allowDNS: true

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.68.1"
+          value: "ghcr.io/timothepoznanski/poznote:6.68.3"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/tests/production_test.yaml
+++ b/charts/poznote/tests/production_test.yaml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Production profile
+templates:
+  - templates/deployment.yaml
+  - templates/pvc.yaml
+  - templates/pdb.yaml
+  - templates/networkpolicy.yaml
+  - templates/ingress.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: keeps the single-replica SQLite deployment persistent
+    values:
+      - ../ci/production-values.yaml
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+  - it: creates retained application storage
+    values:
+      - ../ci/production-values.yaml
+    template: templates/pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+  - it: protects the single pod from voluntary disruption
+    values:
+      - ../ci/production-values.yaml
+    template: templates/pdb.yaml
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+  - it: enables ingress and egress isolation
+    values:
+      - ../ci/production-values.yaml
+    template: templates/networkpolicy.yaml
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+  - it: exposes the production hostname over TLS
+    values:
+      - ../ci/production-values.yaml
+    template: templates/ingress.yaml
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.tls[0].secretName
+          value: notes-tls

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.68.1"
+  tag: "6.68.3"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- Promote Poznote from beta to stable, update to 6.68.3, and add production operations guidance, example, CI values, and tests.
- Upstream image verified: ghcr.io/timothepoznanski/poznote:6.68.3.
- Companion site synchronization: https://github.com/helmforgedev/site/pull/540
- Companion organization profile synchronization: https://github.com/helmforgedev/.github/pull/20

## Type Of Change

- [x] Existing chart change

## Governance

Maintainer-directed production promotion; no existing issue is open for this chart graduation.

## Upstream Verification

- [x] appVersion matches the stable upstream release where applicable
- [x] official image tag exists and supports amd64 and arm64
- [x] no floating or Bitnami image tags

## Local Validation

- [x] make validate-chart passed all 19 layers
- [x] default install passed on local k3d
- [x] every ci values scenario passed on local k3d
- [x] workloads became ready with endpoints
- [x] zero crash restarts and no fatal log patterns
- [x] helm unittest, kubeconform, Artifact Hub lint, standards, and dependency checks passed
- [x] Kubescape score remained above the repository floor

## Release

This is a maturity graduation and intentionally uses a breaking Conventional Commit so CI publishes the production-ready major chart release. Chart version remains CI-managed.
