### PR TITLE
feat(matterbridge)!: add chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Common categories include:
 - **Identity and access**: Keycloak, Authelia, OAuth2 Proxy, and application charts with ingress/auth patterns.
 - **Operations and automation**: n8n, Cronicle, FastMCP Server, Cloudflared, Velero, DDNS Updater, Envoy Gateway, and Envoy Gateway CRDs.
 - **Content and collaboration**: WordPress, Ghost, Drupal, Gitea, Wallabag, Castopod, Komga, and Open WebUI.
+- **Home automation**: Matterbridge and openHAB for Matter and broad smart-home platform integration.
 - **Reusable platform workloads**: the [`generic`](charts/generic) chart for internal services, workers, jobs, and sidecars.
 
 ## Validation

--- a/charts/matterbridge/.helmignore
+++ b/charts/matterbridge/.helmignore
@@ -1,0 +1,12 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+.project
+.tmp/
+.vscode/
+*.swp
+*.tmp
+*.tgz
+RESEARCH.md
+PLAN.md

--- a/charts/matterbridge/Chart.yaml
+++ b/charts/matterbridge/Chart.yaml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v2
+name: matterbridge
+description: Production-ready Matter plugin manager for bridging smart-home platforms to Matter ecosystems
+type: application
+version: 1.0.0
+appVersion: "3.10.7"
+kubeVersion: ">=1.26.0-0"
+home: https://helmforge.dev/docs/charts/matterbridge
+sources:
+  - https://github.com/helmforgedev/charts/tree/main/charts/matterbridge
+  - https://github.com/Luligu/matterbridge
+  - https://matterbridge.io
+keywords:
+  - matterbridge
+  - matter
+  - smart-home
+  - iot
+  - home-automation
+  - mqtt
+  - kubernetes
+maintainers:
+  - name: HelmForge Team
+    url: https://helmforge.dev
+icon: https://helmforge.dev/icons/charts/matterbridge.png
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "initial stable Matterbridge chart (#1077)"
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/links: |
+    - name: Official Website
+      url: https://matterbridge.io
+    - name: Documentation
+      url: https://helmforge.dev/docs/charts/matterbridge
+    - name: Source
+      url: https://github.com/helmforgedev/charts/tree/main/charts/matterbridge
+    - name: support
+      url: https://github.com/helmforgedev/charts/issues
+  helmforge.dev/maturity: stable

--- a/charts/matterbridge/DESIGN.md
+++ b/charts/matterbridge/DESIGN.md
@@ -1,0 +1,70 @@
+# Matterbridge chart design
+
+## Goals
+
+This chart packages the official Matterbridge image as a stable, single-node
+Kubernetes workload. It prioritizes a safe install, durable Matter identity,
+clear LAN networking choices and direct compatibility with upstream behavior.
+
+## Workload model
+
+Matterbridge stores fabric identity, certificates, plugin packages and runtime
+configuration on disk. It also owns fixed Matter ports and advertises a single
+mDNS identity. The chart therefore uses a StatefulSet with exactly one replica,
+`OrderedReady` pod management and one persistent volume. Horizontal scaling and
+active-active failover are intentionally rejected.
+
+The official image normally starts through a root-oriented entrypoint. The chart
+calls the `matterbridge` executable directly and places its home under `/data`.
+This permits UID/GID 1000, a read-only image filesystem and a private writable
+npm prefix without modifying or replacing the official image.
+
+## Storage model
+
+One PVC is mounted at `/data`. The upstream `--homedir /data` option consolidates
+plugins, Matter state and certificates into `/data/Matterbridge`,
+`/data/.matterbridge` and `/data/.mattercert`. A single mount avoids partial
+backups and the shared-PVC deadlocks caused by multiple claims waiting for the
+same `WaitForFirstConsumer` pod.
+
+The PVC has Helm's `keep` annotation by default. Backups are storage-platform
+snapshots or filesystem copies taken while the StatefulSet is stopped. The chart
+does not invent an unsafe live-copy sidecar or application API.
+
+## Network model
+
+The portable default uses pod networking so it passes Pod Security baseline and
+works in ordinary clusters for frontend evaluation. Matter commissioning on a
+physical LAN generally requires multicast DNS, IPv6 link reachability and direct
+TCP/UDP Matter ports, which commonly requires `network.hostNetwork=true`.
+
+Host networking is opt-in because Kubernetes Pod Security baseline forbids it.
+Operators must schedule the singleton to a trusted LAN-connected node. Advanced
+CNIs may instead transport multicast and use the optional Matter Service port
+range. A Service never substitutes for mDNS.
+
+Ingress and Gateway API HTTPRoutes target only the management frontend. They do
+not proxy Matter or multicast traffic.
+
+## Security model
+
+The default pod is non-root, drops every Linux capability, prevents privilege
+escalation, uses RuntimeDefault seccomp, has a read-only root filesystem and does
+not mount a Kubernetes API token. Writable paths are limited to `/data` and
+`/tmp`.
+
+The frontend is private by default. Authentication is delegated to a trusted
+reverse proxy because Matterbridge does not expose a stable chart-manageable
+authentication contract. TLS can be terminated at Ingress/Gateway or supplied
+to Matterbridge through an existing Secret.
+
+## Deliberate omissions
+
+- No HPA or replica scaling: upstream is a singleton.
+- No PodDisruptionBudget: it cannot create availability from one replica and can
+  block voluntary maintenance.
+- No ServiceMonitor: upstream has no native Prometheus endpoint.
+- No automated plugin mutation: plugins are managed through the upstream UI/CLI
+  and persisted on the PVC.
+- No live backup CronJob: consistent backup requires a stopped application or a
+  storage-native snapshot.

--- a/charts/matterbridge/PLAN.md
+++ b/charts/matterbridge/PLAN.md
@@ -1,0 +1,172 @@
+# Matterbridge Chart Implementation Plan
+
+**Chart:** `matterbridge`
+**Issue:** helmforgedev/charts#1077
+**Initial chart version:** `1.0.0`
+**Application version:** `3.10.7`
+**Maturity:** stable
+**Complexity:** medium
+
+## Executive Summary
+
+Build a production-ready singleton Matterbridge deployment that works for its
+primary home-LAN use case without requiring users to understand Kubernetes
+multicast internals. The baseline-compatible default uses pod networking,
+persistent coupled state, ordered singleton upgrades and official health
+checks. A production/LAN example enables host networking with one value;
+advanced pod-network users can add a UDP Service and CNI/reflector integration.
+
+## Priority 1: Functional Core
+
+### P1-1: Stable Official Runtime
+
+- Pin `docker.io/luligu/matterbridge:3.10.7`.
+- Configure frontend port 8283 and Matter base port 5540.
+- Preserve the upstream `matterbridge --docker` command contract.
+- Support an optional profile and additional CLI arguments.
+
+### P1-2: Matter-Correct Networking
+
+- Keep pod networking as the Pod Security baseline-compatible default.
+- Provide a one-value host-network production/LAN mode matching upstream.
+- Use `ClusterFirstWithHostNet` automatically with host networking.
+- Expose the frontend through a ClusterIP Service.
+- Provide an optional Matter UDP Service for portable networking mode.
+- Document mDNS, multicast, IPv6, VLAN and firewall constraints.
+
+### P1-3: Durable Coupled State
+
+- Create one retained RWO PVC by default.
+- Use the official `--homedir /data` option so Matterbridge creates and owns
+  all three state trees on the same volume.
+- Support an existing claim and ephemeral mode.
+
+### P1-4: Safe Singleton Lifecycle
+
+- Render one replica only.
+- Use a one-replica StatefulSet with ordered replacement semantics.
+- Configure a 60-second termination grace period.
+- Add startup, readiness and liveness probes against `/health`.
+
+### P1 Validation
+
+- Render defaults and portable networking values.
+- Deploy defaults on the canonical k3d cluster.
+- Verify the Deployment becomes Available, `/health` returns success and logs
+  contain no crash/fatal patterns.
+- Verify cleanup before production features proceed.
+
+## Priority 2: Production Features
+
+### P2-1: Secure Kubernetes Defaults
+
+- Dedicated ServiceAccount with token automount disabled.
+- RuntimeDefault seccomp profile.
+- Drop all capabilities and disable privilege escalation.
+- Document why upstream currently requires root and a writable root filesystem.
+
+### P2-2: Controlled UI Exposure
+
+- Canonical Ingress with guarded `ingressClassName`.
+- Canonical multi-route Gateway API HTTPRoute.
+- State clearly that these resources expose only the HTTP UI.
+- Recommend private access or an authenticated reverse proxy.
+
+### P2-3: Network Controls
+
+- Optional NetworkPolicy for UI ingress.
+- Optional egress enforcement with DNS and complete `extraEgress` rules.
+- Explain that host-network policy enforcement depends on the CNI.
+
+### P2-4: Secret and Extension Integration
+
+- Canonical ExternalSecret `items[]` renderer.
+- `extraEnv`, `extraEnvFrom`, extra volumes, mounts, containers and manifests.
+- Avoid fictitious Matterbridge credential environment variables.
+
+### P2-5: Operational Safety
+
+- Retain PVC on uninstall by default.
+- Expose PVC annotations for Velero and storage tooling.
+- Add backup/restore guidance covering all three state domains.
+- Document port conflicts and single-instance scheduling.
+
+## Priority 3: User Experience and Polish
+
+### P3-1: Complete Validation Surface
+
+- Strict JSON schema for every value.
+- Fail-fast checks for ingress hosts, Gateway routes, selector-label
+  collisions, invalid port ranges, unsafe replica overrides and incomplete
+  ExternalSecret items.
+- At least 40 helm-unittest cases across every feature.
+- CI values for default, portable networking, dual-stack, ingress, Gateway
+  API, NetworkPolicy, existing claims and External Secrets.
+
+### P3-2: Product-Specific Documentation
+
+- README with quick start, networking decision guide and complete values.
+- Dedicated networking, persistence/backup and security/operations guides.
+- Five tested examples covering simple, production, portable networking,
+  Ingress and Gateway API deployments.
+- Eight-section operational NOTES dashboard.
+
+### P3-3: Site Integration
+
+- Stable catalog entry and official upstream mark.
+- Full site page covering all values and at least ten troubleshooting cases.
+- Playground configuration using safe defaults.
+- Cross-link chart and site PRs without closing the chart issue from the site.
+
+## Technical Architecture
+
+```text
+StatefulSet (replicas=1, ordered replacement)
+  |
+  +-- Matterbridge container
+  |     +-- TCP 8283: frontend and /health
+  |     +-- UDP 5540-5559: Matter nodes
+  |     +-- hostNetwork for production LAN deployments
+  |
+  +-- data volume
+        +-- plugins      -> /data/Matterbridge
+        +-- storage      -> /data/.matterbridge
+        +-- certificates -> /data/.mattercert
+
+Service (frontend TCP)
+  +-- optional Ingress
+  +-- optional HTTPRoute
+
+Optional Matter Service (UDP range for portable mode)
+```
+
+## Non-Goals
+
+- Horizontal scaling or active-active Matterbridge.
+- Bundled mDNS reflector.
+- Automatic plugin installation in a chart hook.
+- Prometheus ServiceMonitor without an upstream metrics endpoint.
+- Invented database, cache or credential abstractions.
+- Scheduled backups in an upstream-incompatible format.
+
+## Validation Strategy
+
+1. `make image-verify IMAGE=docker.io/luligu/matterbridge:3.10.7`.
+2. `make deps-check CHART=matterbridge` (expected: no dependencies).
+3. `make validate-chart CHART=matterbridge` for the full static and k3d gate.
+4. `make standards-check CHART=matterbridge` and template standards check.
+5. ESO end-to-end validation with the fake ClusterSecretStore.
+6. Kubescape scan and README evidence update.
+7. Site lint, format, build, link check and site-sync check.
+8. Repository preflight, release and attribution checks.
+
+## Success Criteria
+
+- Default install reaches Available and `/health` succeeds on k3d.
+- No floating image tags or non-official runtime images.
+- All three durable directories share one correctly initialized PVC.
+- Portable mode renders all configured UDP ports and dual-stack fields.
+- Ingress and Gateway API never claim to expose Matter traffic.
+- Every optional feature has CI values, unit tests and documentation.
+- Chart and site PRs are normal PRs to `main`, CI green, zero unresolved
+  review threads, and only the chart PR resolves issue #1077.

--- a/charts/matterbridge/README.md
+++ b/charts/matterbridge/README.md
@@ -1,0 +1,356 @@
+# Matterbridge
+
+A production-ready Helm chart for [Matterbridge](https://matterbridge.io), the
+official Matter plugin manager that bridges existing home-automation platforms
+and devices into Matter ecosystems.
+
+This chart uses the official `luligu/matterbridge` image, preserves the complete
+Matter identity on one PVC and runs the application as a hardened non-root
+singleton. It supports a portable pod-network default and an explicit LAN mode
+for reliable mDNS, IPv6 and Matter commissioning.
+
+## Installation
+
+### OCI registry
+
+```bash
+helm install matterbridge oci://ghcr.io/helmforgedev/helm/matterbridge
+```
+
+### HTTPS repository
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+helm repo update
+helm install matterbridge helmforge/matterbridge
+```
+
+The default installation is deliberately private and uses pod networking. Open
+the frontend for evaluation:
+
+```bash
+kubectl port-forward svc/matterbridge 8283:8283
+```
+
+Then visit `http://localhost:8283`.
+
+## Production quick start
+
+Normal Matter commissioning on a home or building LAN needs mDNS multicast,
+IPv6 reachability and direct Matter ports. Most Kubernetes CNIs do not transport
+those protocols between the pod network and the physical LAN. For that common
+case, label one trusted LAN-connected node and enable host networking:
+
+```bash
+kubectl label node my-lan-node matterbridge.helmforge.dev/lan-node=true
+helm upgrade --install matterbridge \
+  oci://ghcr.io/helmforgedev/helm/matterbridge \
+  --set network.hostNetwork=true \
+  --set nodeSelector.matterbridge\.helmforge\.dev/lan-node=true
+```
+
+Host networking is opt-in because Kubernetes Pod Security baseline rejects it.
+Only use it on a trusted node and protect the administrative frontend.
+
+## Features
+
+- Official, pinned multi-architecture Matterbridge image
+- Stable chart version `1.0.0` with upstream Matterbridge `3.10.7`
+- StatefulSet singleton with explicit validation against unsafe scaling
+- One retained PVC for plugins, fabrics, certificates and configuration
+- Non-root UID/GID 1000, read-only root filesystem and all capabilities dropped
+- RuntimeDefault seccomp and no mounted Kubernetes API token
+- Official `/health` startup, readiness and liveness probes
+- Portable pod-network default compatible with Pod Security baseline
+- Opt-in host networking for practical LAN mDNS, IPv6 and Matter support
+- Optional TCP/UDP Matter port-range Service for multicast-aware CNIs
+- Dual-stack Service configuration
+- Ingress and Gateway API frontend exposure
+- Generic External Secrets Operator resources for TLS and plugin credentials
+- Optional NetworkPolicy for pod-network deployments
+- Existing PVC, extra volumes, sidecars, init containers and manifests
+- Graceful 60-second shutdown for storage and Matter session cleanup
+
+### 🟢 Security Scan: `matterbridge`
+
+| Framework | Score |
+|---|---|
+| MITRE + NSA + SOC2 | **93.93939%** |
+
+> ✅ Security posture acceptable.
+
+The two medium findings are the intentionally optional NetworkPolicy controls.
+The default workload passes non-root, immutable filesystem, capability,
+privilege-escalation, seccomp, service-account and resource-limit controls. The
+production host-network option remains a documented networking exception
+required by common Matter LAN deployments.
+
+## Architecture
+
+Matterbridge is stateful and has no active-active clustering or leader election.
+Multiple replicas would contend for the same fabric identity, plugin files,
+mDNS identity and Matter ports. The chart always renders one StatefulSet replica
+and rejects any `replicaCount` other than `1`.
+
+The chart bypasses the root-oriented image entrypoint and starts the official
+`matterbridge` binary directly with `--homedir /data`. This keeps all mutable
+state below the PVC while the image filesystem remains read-only.
+
+## Network modes
+
+### Portable pod network
+
+This is the default:
+
+```yaml
+network:
+  hostNetwork: false
+```
+
+It is the safest and most portable Kubernetes configuration. The frontend,
+health checks and plugin management work. Matter commissioning works only when
+the CNI and LAN design provide multicast DNS and IPv6 reachability.
+
+### Typical LAN production mode
+
+```yaml
+network:
+  hostNetwork: true
+
+nodeSelector:
+  matterbridge.helmforge.dev/lan-node: "true"
+```
+
+Matterbridge uses the node interfaces directly. The chart selects
+`ClusterFirstWithHostNet` DNS unless `network.dnsPolicy` is explicitly set.
+
+### Advanced Service mode
+
+For a CNI that already transports mDNS and IPv6 correctly:
+
+```yaml
+matterService:
+  enabled: true
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+```
+
+This publishes TCP and UDP for every port from `matterbridge.matterPort` through
+the configured `matterPortRangeSize`. It does not relay UDP 5353 multicast and
+cannot make a multicast-incapable CNI work.
+
+See [docs/networking.md](docs/networking.md) for topology and troubleshooting.
+
+## Persistence
+
+The PVC is mounted at `/data`. Upstream then stores:
+
+- plugins under `/data/Matterbridge`;
+- configuration, logs and Matter storage under `/data/.matterbridge`;
+- Matter certificates under `/data/.mattercert`;
+- the private npm prefix and cache below `/data`.
+
+The chart creates a 2 GiB ReadWriteOnce PVC and annotates it with
+`helm.sh/resource-policy: keep` by default. To reuse an existing claim:
+
+```yaml
+persistence:
+  enabled: true
+  existingClaim: matterbridge-data
+```
+
+Back up the whole volume consistently while the StatefulSet is stopped. Partial
+restores can invalidate the Matter fabric identity. See
+[docs/persistence-backup.md](docs/persistence-backup.md).
+
+## Plugins and credentials
+
+Install and manage Matterbridge plugins through the upstream frontend. Installed
+packages survive restarts on the PVC. Plugins can require LAN, MQTT or cloud
+connections; size resources and NetworkPolicy egress for the selected plugins.
+
+Pass credentials from Kubernetes Secrets without writing them into values:
+
+```yaml
+extraEnvFrom:
+  - secretRef:
+      name: matterbridge-plugin
+```
+
+The chart can create generic `external-secrets.io/v1` ExternalSecrets:
+
+```yaml
+externalSecrets:
+  enabled: true
+  items:
+    - name: plugin
+      spec:
+        secretStoreRef:
+          name: production-secrets
+          kind: ClusterSecretStore
+        target:
+          name: matterbridge-plugin
+        data:
+          - secretKey: token
+            remoteRef:
+              key: matterbridge/plugin
+              property: token
+```
+
+No credential environment variable is invented by the chart; map Secrets using
+the contract documented by each plugin.
+
+## Frontend exposure
+
+The default ClusterIP is private. Matterbridge does not expose a stable
+chart-managed authentication contract, so an exposed frontend should use TLS,
+authentication and client restrictions at a trusted proxy.
+
+Ingress example:
+
+```yaml
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: matterbridge.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+Gateway API example:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: frontend
+      parentRefs:
+        - name: shared-gateway
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - matterbridge.example.com
+```
+
+These HTTP resources expose only the frontend. Matter and mDNS traffic never
+traverse an Ingress or HTTPRoute.
+
+## Native frontend TLS
+
+Matterbridge can serve HTTPS from an existing Secret:
+
+```yaml
+frontend:
+  tls:
+    enabled: true
+    existingSecret: matterbridge-frontend-tls
+```
+
+The Secret must contain `cert.pem` and `key.pem`; `ca.pem` is optional. It is
+mounted read-only into `/data/.matterbridge/certs`. Prefer proxy TLS when your
+Ingress or Gateway already manages certificates.
+
+## NetworkPolicy
+
+NetworkPolicy is optional and only valid with `network.hostNetwork=false`.
+Host-network policy behavior varies by CNI, so the chart rejects that ambiguous
+combination.
+
+By default the policy permits frontend ingress from all namespaces. Egress is
+not restricted unless enabled because plugin destinations are deployment
+specific. A restrictive example:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-system
+  egress:
+    enabled: true
+    allowDNS: true
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 192.0.2.10/32
+        ports:
+          - protocol: TCP
+            port: 1883
+```
+
+## Health and operations
+
+The official `/health` endpoint drives all three HTTP probes. Startup allows up
+to five minutes for first boot, storage restoration and plugin initialization.
+Liveness follows the conservative upstream health-check cadence.
+
+```bash
+kubectl get pod matterbridge-0
+kubectl logs matterbridge-0 --follow
+kubectl get events --sort-by=.lastTimestamp
+```
+
+Do not publish commissioning codes from logs. They grant access to an
+uncommissioned Matter bridge.
+
+## Upgrades
+
+Before upgrading:
+
+1. Read upstream Matterbridge release notes.
+2. Take and verify a consistent PVC backup.
+3. Confirm installed plugin compatibility.
+4. Keep the singleton on the same LAN topology.
+
+After upgrading, wait for readiness, inspect startup logs and test a bridged
+device. Application migrations may make a chart-only rollback insufficient, so
+restore chart and volume state together when necessary.
+
+## Uninstall
+
+```bash
+helm uninstall matterbridge
+```
+
+The chart-created PVC remains by default. Delete it only after verifying a
+backup and accepting that Matter commissioning and plugin state will be lost.
+
+## Examples
+
+- [Simple portable installation](examples/simple.yaml)
+- [Typical production LAN installation](examples/production.yaml)
+- [Advanced portable networking](examples/portable-networking.yaml)
+- [Ingress](examples/ingress.yaml)
+- [Gateway API](examples/gateway-api.yaml)
+- [External Secret](examples/external-secret.yaml)
+
+## Values
+
+See [values.yaml](values.yaml) for the complete documented contract and
+[values.schema.json](values.schema.json) for validation. Important groups are:
+
+| Group | Purpose |
+|---|---|
+| `matterbridge` | Runtime mode, ports, interface selection and logging |
+| `frontend` | HTTP port, bind address and native TLS |
+| `network` | Pod or host network behavior |
+| `service` | Frontend Service and dual-stack policy |
+| `matterService` | Optional TCP/UDP Matter range publishing |
+| `persistence` | PVC creation, retention and existing claims |
+| `ingress` | Frontend Ingress |
+| `gatewayAPI` | Frontend HTTPRoutes |
+| `externalSecrets` | Generic ExternalSecret resources |
+| `networkPolicy` | Pod-network ingress and optional egress controls |
+
+## Support
+
+Chart issues belong in the
+[HelmForge charts repository](https://github.com/helmforgedev/charts/issues).
+Application and plugin behavior belongs in the
+[Matterbridge repository](https://github.com/Luligu/matterbridge/issues).
+
+Matterbridge is a trademark and project of its upstream maintainers. HelmForge
+is not affiliated with or endorsed by Matterbridge.

--- a/charts/matterbridge/RESEARCH.md
+++ b/charts/matterbridge/RESEARCH.md
@@ -1,0 +1,200 @@
+# Matterbridge Chart Research
+
+**Chart request:** helmforgedev/charts#1077
+**Requester:** drieks
+**Upstream:** [Matterbridge on GitHub](https://github.com/Luligu/matterbridge)
+**Research date:** 2026-08-29
+
+## Product and Runtime
+
+Matterbridge is an Apache-2.0 Matter plugin manager. It exposes devices from
+platforms such as Zigbee2MQTT, MQTT, Home Assistant, Homebridge and Shelly to
+Matter controllers including Apple Home, Google Home and Amazon Alexa.
+
+The stable upstream release selected for this chart is `3.10.7`, published on
+2026-08-28. The official pinned image is
+`docker.io/luligu/matterbridge:3.10.7`. HelmForge manifest verification
+confirmed `linux/amd64` and `linux/arm64` support. The manifest digest observed
+during implementation was
+`sha256:568d9fae6342aadbd62aa72560b6e6c070c33b1c0c5224fe2925a28c1cb4ebc6`.
+
+The image is based on `node:24-trixie-slim`, runs as root, starts
+`matterbridge --docker`, and includes the `mb_health` binary. Its Docker
+healthcheck calls the HTTP health endpoint at `http://localhost:8283/health`.
+
+## Network Model
+
+Matterbridge uses three different network surfaces:
+
+1. The management frontend listens on TCP port `8283` by default.
+2. Matter nodes use UDP starting at port `5540`; child bridges can consume a
+   range such as `5540-5559`.
+3. Discovery relies on multicast DNS and routable LAN IPv6.
+
+The official Docker instructions require host networking on Linux because
+ordinary bridge/NAT networking does not reliably transport multicast or
+advertise addresses reachable by Matter controllers. Kubernetes Pod Security
+baseline forbids host namespaces, so the chart keeps pod networking as its
+installable default and exposes `network.hostNetwork: true` as the documented
+production/LAN setting. A pod-network deployment requires a suitable multicast
+CNI, reflector or L2 integration. Ingress and Gateway API expose only the web
+UI; they cannot carry Matter UDP or mDNS traffic.
+
+## Persistent State
+
+Upstream persists three coupled state domains:
+
+- `/root/Matterbridge`: installed plugins and plugin assets;
+- `/root/.matterbridge`: application configuration and operational state;
+- `/root/.mattercert`: Matter fabrics, certificates and commissioning data.
+
+Loss of the certificate or fabric state can require devices to be paired
+again. The chart therefore enables persistence by default and uses the
+official `--homedir /data` option to place all three directories on one PVC.
+This produces one atomic storage boundary, avoids three-claim coordination,
+and makes snapshot/restore procedures less error-prone. The PVC is retained on
+uninstall by default.
+
+## Existing Deployment Options
+
+### Official Docker and Compose
+
+Strengths:
+
+- canonical image and lifecycle;
+- host networking and 60-second stop grace period;
+- explicit mounts for all durable state;
+- built-in health command.
+
+Limitations:
+
+- floating `latest` tag in examples;
+- no Kubernetes scheduling, probes, Service, TLS ingress or schema validation;
+- operators must coordinate the three mounts and backups themselves.
+
+### Official Home Assistant Application
+
+Strengths:
+
+- convenient installation for Home Assistant OS users;
+- supervised lifecycle and persistent add-on storage.
+
+Limitations:
+
+- coupled to the Home Assistant Supervisor;
+- not a general-purpose Kubernetes deployment;
+- uses a specialized s6-rc image rather than the standard runtime.
+
+### Community Kubernetes and Helm Options
+
+No maintained Matterbridge-specific Helm chart or upstream Kubernetes
+manifest was identified. Generic application charts can run the image but do
+not model Matter networking, the coupled storage domains, singleton upgrades,
+or commissioning data safety.
+
+## Production Requirements
+
+### Singleton Lifecycle
+
+Matterbridge is stateful and binds node-local frontend/Matter ports when host
+networking is enabled. Multiple replicas would compete for ports, storage
+locks and Matter identity. The chart must render exactly one StatefulSet
+replica. Ordered singleton replacement prevents an upgrade from overlapping
+old and new pods.
+
+### Shutdown and Probes
+
+Upstream uses a 60-second Docker stop timeout. Kubernetes must provide at least
+the same termination grace period. Startup can be slow while plugins are
+restored or installed, so the startup probe must be substantially more
+tolerant than readiness and liveness probes. All probes should use the
+official `/health` endpoint.
+
+### Security
+
+The image entrypoint runs as root and stores data below `/root` by default.
+Matterbridge also officially supports `--homedir`, and the image contains the
+`node` user at UID/GID 1000. A direct runtime test proved that overriding the
+entrypoint with `matterbridge`, setting `--homedir /data`, and using UID/GID
+1000 works with a read-only root filesystem, all capabilities dropped and
+`/tmp` on an `emptyDir`. The chart uses that hardened path and stores the
+private npm prefix/cache on the persistent volume for non-root plugin installs.
+
+The frontend should normally remain on a private network or behind an
+authenticated proxy. Ingress/Gateway TLS protects transport but does not turn
+the Matterbridge frontend into a hardened internet-facing control plane.
+
+### Observability
+
+Matterbridge exposes health and structured application logs but no native
+Prometheus metrics endpoint. A ServiceMonitor would be misleading, so the
+chart intentionally provides probes and pod annotations without inventing
+metrics. Users can integrate log collectors through standard pod annotations
+or extra containers.
+
+### Backup and Restore
+
+Upstream provides logical backup through its UI. Kubernetes operators can also
+snapshot the single PVC. Crash-consistent storage snapshots are possible, but
+the safest backup and restore occurs while Matterbridge is stopped. The chart
+does not invent an unsupported scheduled backup format.
+
+## HelmForge Differentiation
+
+| Capability | Docker/Compose | Generic chart | HelmForge chart |
+|---|---:|---:|---:|
+| Stable pinned official image | No | Optional | Yes |
+| Explicit mDNS-ready LAN mode | Yes | No | Yes, opt-in host networking |
+| Portable pod-network mode | Manual | Generic | Documented and tested |
+| Atomic three-directory persistence | Manual | No | Yes |
+| PVC retained on uninstall | N/A | Optional | Default |
+| Singleton-safe upgrade | Restart | Usually rolling | Ordered singleton |
+| Official health probes | Docker only | Generic | Startup/readiness/liveness |
+| Ingress and Gateway API for UI | No | Generic | Yes, with scope clarified |
+| Dual-stack Service controls | No | Optional | Yes |
+| ExternalSecret adapter | No | Optional | Canonical items contract |
+| Schema and fail-fast validation | No | Limited | Complete |
+| Operational docs and examples | Basic | Varies | Product-specific |
+
+## High-Impact Differentiators
+
+1. **Matter-correct networking:** one explicit switch enables the upstream
+   host-network topology, while the baseline-compatible default explains the
+   multicast and IPv6 responsibilities.
+2. **Atomic durable state:** one retained PVC protects plugins, configuration,
+   fabrics and certificates together.
+3. **Safe lifecycle:** singleton validation, ordered upgrades, official health
+   probes and the upstream 60-second shutdown window prevent common failures.
+4. **Honest exposure model:** Service, Ingress and HTTPRoute simplify UI access
+   without implying they transport Matter or mDNS.
+5. **Escape hatches without clutter:** extra environment sources, volumes,
+   mounts, containers and manifests support plugin-specific integrations while
+   keeping the default contract small.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| CNI does not carry mDNS | Pairing/discovery fails | Opt-in host-network mode and dedicated networking guide |
+| Host ports collide | Pod cannot start | Singleton validation and scheduling docs |
+| PVC lost | Re-pairing may be required | Retain policy, atomic PVC and backup guide |
+| Plugin first boot is slow | False liveness failures | Generous startup probe |
+| Root runtime | Reduced hardening | Drop capabilities, no privilege escalation, no API token |
+| UI exposed publicly | Control-plane risk | Private-access guidance and proxy/TLS documentation |
+
+## Recommendation
+
+Implement the chart as a stable `1.0.0` release. Matterbridge is already a
+stable production application, the official image is multi-architecture, and
+the Kubernetes limitations are understood and can be made explicit. Do not
+represent horizontal scaling, Prometheus metrics or automatic multicast
+reflection as supported features.
+
+## Primary Sources
+
+- [Matterbridge repository](https://github.com/Luligu/matterbridge)
+- [Matterbridge 3.10.7 release](https://github.com/Luligu/matterbridge/releases/tag/3.10.7)
+- [Official Docker documentation](https://github.com/Luligu/matterbridge/blob/main/README-DOCKER.md)
+- [Official Docker Compose file](https://github.com/Luligu/matterbridge/blob/main/docker/docker-compose.yml)
+- [Official health check source](https://github.com/Luligu/matterbridge/blob/main/packages/core/src/mb_health.ts)
+- [Matterbridge website](https://matterbridge.io)

--- a/charts/matterbridge/ci/default-values.yaml
+++ b/charts/matterbridge/ci/default-values.yaml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: secure portable defaults.
+{}

--- a/charts/matterbridge/ci/dual-stack.yaml
+++ b/charts/matterbridge/ci/dual-stack.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv6
+    - IPv4

--- a/charts/matterbridge/ci/external-secrets-values.yaml
+++ b/charts/matterbridge/ci/external-secrets-values.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: plugin
+      spec:
+        secretStoreRef:
+          name: helmforge-fake-store
+          kind: ClusterSecretStore
+        target:
+          name: matterbridge-plugin
+        data:
+          - secretKey: MATTERBRIDGE_TEST_TOKEN
+            remoteRef:
+              key: test/token
+
+extraEnvFrom:
+  - secretRef:
+      name: matterbridge-plugin

--- a/charts/matterbridge/ci/gateway-api-values.yaml
+++ b/charts/matterbridge/ci/gateway-api-values.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: frontend
+      parentRefs:
+        - name: test-gateway
+          namespace: gateway-system
+      hostnames:
+        - matterbridge.example.test

--- a/charts/matterbridge/ci/host-network-values.yaml
+++ b/charts/matterbridge/ci/host-network-values.yaml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: production LAN networking.
+network:
+  hostNetwork: true
+matterbridge:
+  mdnsInterface: eth0

--- a/charts/matterbridge/ci/ingress-values.yaml
+++ b/charts/matterbridge/ci/ingress-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: matterbridge.example.test
+      paths:
+        - path: /
+          pathType: Prefix

--- a/charts/matterbridge/ci/network-policy-values.yaml
+++ b/charts/matterbridge/ci/network-policy-values.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    allowDNS: true
+    extraEgress:
+      - to:
+          - ipBlock:
+              cidr: 192.0.2.0/24
+        ports:
+          - protocol: TCP
+            port: 1883

--- a/charts/matterbridge/ci/portable-network-values.yaml
+++ b/charts/matterbridge/ci/portable-network-values.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: advanced CNI and Matter Service.
+matterService:
+  enabled: true
+  type: ClusterIP
+matterbridge:
+  matterPortRangeSize: 3

--- a/charts/matterbridge/docs/networking.md
+++ b/charts/matterbridge/docs/networking.md
@@ -1,0 +1,45 @@
+# Matterbridge networking
+
+## Choose a mode
+
+The default pod-network mode is useful for evaluation and clusters whose CNI can
+carry IPv4/IPv6 multicast between pods and the physical LAN. Most conventional
+CNIs do not, so a production Matter installation normally enables host network:
+
+```yaml
+network:
+  hostNetwork: true
+nodeSelector:
+  matterbridge.helmforge.dev/lan-node: "true"
+```
+
+Label exactly one trusted node before installing. Matterbridge then sees that
+node's LAN interfaces and uses `ClusterFirstWithHostNet` DNS automatically.
+
+## Ports and discovery
+
+The frontend listens on TCP 8283. Matterbridge starts at TCP/UDP 5540 and may use
+the configured consecutive range for child bridges and plugins. Commissioning
+also needs mDNS on UDP 5353 and functional IPv6 reachability.
+
+The optional `matterService` publishes the configured Matter range for advanced
+pod-network designs. It does not publish or relay mDNS. Confirm CNI multicast,
+source address preservation, firewall rules and controller routing before using
+that mode.
+
+## Frontend exposure
+
+Ingress and Gateway API expose only HTTP/HTTPS for administration. Keep them
+private or require authentication at the proxy. Never treat either as a way to
+carry Matter traffic.
+
+## Troubleshooting
+
+If the UI works but controllers cannot discover or commission the bridge:
+
+1. Confirm the controller and selected Kubernetes node share routable LAN/IPv6
+   connectivity.
+2. Enable host network and pin the pod to that node.
+3. Check node firewall rules for UDP 5353 and the reserved Matter TCP/UDP range.
+4. Set `matterbridge.mdnsInterface` when the node has several LAN interfaces.
+5. Inspect logs for mDNS advertisements and commissioning status.

--- a/charts/matterbridge/docs/persistence-backup.md
+++ b/charts/matterbridge/docs/persistence-backup.md
@@ -1,0 +1,45 @@
+# Persistence and backup
+
+Matterbridge state is inseparable from its commissioned Matter identity. Keep
+`persistence.enabled=true` for every real installation.
+
+The chart mounts one volume at `/data`, containing plugins, plugin configuration,
+Matter fabrics, certificates and application storage. The default PVC is 2 GiB,
+ReadWriteOnce and retained after uninstall.
+
+## Consistent backup
+
+Stop the StatefulSet before copying files or taking a non-atomic backup:
+
+```bash
+MATTERBRIDGE_NAMESPACE=matterbridge
+MATTERBRIDGE_STATEFULSET=$(kubectl get statefulset \
+  -n "$MATTERBRIDGE_NAMESPACE" \
+  -l app.kubernetes.io/name=matterbridge \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl scale -n "$MATTERBRIDGE_NAMESPACE" \
+  statefulset/"$MATTERBRIDGE_STATEFULSET" --replicas=0
+kubectl wait -n "$MATTERBRIDGE_NAMESPACE" \
+  --for=delete pod -l app.kubernetes.io/name=matterbridge --timeout=120s
+# Create and verify the PVC snapshot or backup.
+kubectl scale -n "$MATTERBRIDGE_NAMESPACE" \
+  statefulset/"$MATTERBRIDGE_STATEFULSET" --replicas=1
+kubectl rollout status -n "$MATTERBRIDGE_NAMESPACE" \
+  statefulset/"$MATTERBRIDGE_STATEFULSET" --timeout=300s
+```
+
+CSI snapshots that are atomic at the filesystem layer may reduce downtime, but
+operators should still follow their storage provider's application-consistency
+guidance. Test restore into an isolated namespace before relying on the backup.
+
+## Existing claims
+
+Set `persistence.existingClaim` to reuse a pre-created PVC. The claim must be in
+the release namespace and writable by UID/GID 1000. The chart never deletes an
+existing claim.
+
+## Restore
+
+Restore all `/data` content together, then start exactly one Matterbridge pod.
+Do not copy only plugin configuration or only Matter storage; partial restores
+can break fabric identity and force recommissioning.

--- a/charts/matterbridge/docs/security-operations.md
+++ b/charts/matterbridge/docs/security-operations.md
@@ -1,0 +1,45 @@
+# Security and operations
+
+## Default controls
+
+Matterbridge runs as UID/GID 1000, without Linux capabilities, privilege
+escalation or a Kubernetes API token. RuntimeDefault seccomp and a read-only root
+filesystem are enabled. Persistent state and temporary files are isolated to
+`/data` and `/tmp`.
+
+## Frontend boundary
+
+Treat the frontend as an administrative interface. The chart leaves it on a
+ClusterIP by default and does not claim that upstream provides a chart-managed
+login contract. If exposed through Ingress or Gateway API, enforce TLS and
+authentication in the proxy and restrict client networks.
+
+Commissioning QR codes, manual pairing codes, fabric data and private keys are
+credentials. Redact them from tickets, screenshots and centralized logs.
+
+## Plugins
+
+Plugins execute inside the Matterbridge process and may connect to LAN devices,
+MQTT brokers or cloud APIs. Install only trusted plugins, pin versions where the
+upstream workflow permits, and back up before changing them. Use `extraEnvFrom`
+with a Secret rather than putting credentials in values.
+
+## NetworkPolicy
+
+NetworkPolicy is available only in pod-network mode. Enabling it with host
+network is rejected because enforcement differs by CNI. Egress is unrestricted
+unless explicitly enabled; plugin destinations are product-specific and cannot
+be safely guessed by the chart.
+
+## Upgrade procedure
+
+1. Read upstream release notes and HelmForge chart changes.
+2. Verify a restorable PVC backup.
+3. Upgrade without changing the singleton identity or network node.
+4. Wait for readiness and inspect startup logs.
+5. Verify installed plugins and a representative bridged device.
+
+For an incompatible migration, keep the StatefulSet stopped, roll back the Helm
+release, restore the complete `/data` contents on the application PVC from the
+verified pre-upgrade snapshot or backup, and only then start the rolled-back
+release. Chart and PVC state must return to the same point in time.

--- a/charts/matterbridge/examples/external-secret.yaml
+++ b/charts/matterbridge/examples/external-secret.yaml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+externalSecrets:
+  enabled: true
+  items:
+    - name: plugin
+      spec:
+        secretStoreRef:
+          name: production-secrets
+          kind: ClusterSecretStore
+        target:
+          name: matterbridge-plugin
+        data:
+          - secretKey: token
+            remoteRef:
+              key: matterbridge/plugin
+              property: token
+
+extraEnvFrom:
+  - secretRef:
+      name: matterbridge-plugin

--- a/charts/matterbridge/examples/gateway-api.yaml
+++ b/charts/matterbridge/examples/gateway-api.yaml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+gatewayAPI:
+  enabled: true
+  httpRoutes:
+    - name: frontend
+      parentRefs:
+        - name: shared-gateway
+          namespace: gateway-system
+          sectionName: https
+      hostnames:
+        - matterbridge.example.com

--- a/charts/matterbridge/examples/ingress.yaml
+++ b/charts/matterbridge/examples/ingress.yaml
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hosts:
+    - host: matterbridge.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: matterbridge-ingress-tls
+      hosts:
+        - matterbridge.example.com

--- a/charts/matterbridge/examples/portable-networking.yaml
+++ b/charts/matterbridge/examples/portable-networking.yaml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Advanced mode: the CNI must transport LAN multicast and IPv6 independently.
+network:
+  hostNetwork: false
+
+matterService:
+  enabled: true
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv6
+    - IPv4
+
+service:
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv6
+    - IPv4

--- a/charts/matterbridge/examples/production.yaml
+++ b/charts/matterbridge/examples/production.yaml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Typical LAN deployment. Label one trusted node before applying this file.
+network:
+  hostNetwork: true
+
+nodeSelector:
+  matterbridge.helmforge.dev/lan-node: "true"
+
+persistence:
+  size: 5Gi
+  storageClass: fast-retained
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+matterbridge:
+  logger: info
+  matterLogger: notice

--- a/charts/matterbridge/examples/simple.yaml
+++ b/charts/matterbridge/examples/simple.yaml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Portable evaluation: access the frontend with kubectl port-forward.
+persistence:
+  size: 2Gi

--- a/charts/matterbridge/templates/NOTES.txt
+++ b/charts/matterbridge/templates/NOTES.txt
@@ -1,0 +1,114 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+=============================================================================
+Matterbridge {{ .Chart.AppVersion }} deployed successfully
+=============================================================================
+
+1. STATUS:
+  Workload: StatefulSet/{{ include "matterbridge.fullname" . }}
+  Namespace: {{ .Release.Namespace }}
+  Runtime mode: {{ .Values.matterbridge.mode }}
+  Network mode: {{ ternary "host network" "pod network" .Values.network.hostNetwork }}
+  Persistent data: {{ ternary (include "matterbridge.pvcName" .) "ephemeral emptyDir" .Values.persistence.enabled }}
+
+2. FRONTEND:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+{{- $paths := default (list (dict "path" "/")) .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}{{ (first $paths).path | default "/" }}
+{{- end }}
+{{- else if .Values.gatewayAPI.enabled }}
+{{- range .Values.gatewayAPI.httpRoutes }}
+{{- range .hostnames }}
+  https://{{ . }}/
+{{- end }}
+{{- end }}
+{{- else }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "matterbridge.fullname" . }} 8283:{{ .Values.service.port }}
+  Open http{{ ternary "s" "" .Values.frontend.tls.enabled }}://localhost:8283
+{{- end }}
+
+3. MATTER NETWORKING:
+{{- if .Values.network.hostNetwork }}
+  Host networking is enabled. Matterbridge can use node LAN interfaces for
+  mDNS, IPv6 and Matter commissioning. Keep this pod on a trusted LAN node.
+{{- else }}
+  Pod networking is enabled. The frontend and health checks work, but normal
+  Matter commissioning requires multicast and IPv6 reachability that most
+  Kubernetes CNIs do not provide across the LAN boundary.
+
+  For a typical home or building LAN, set:
+    network.hostNetwork=true
+
+  Alternatively, configure a multicast-aware CNI or reflector and enable
+  matterService for the Matter TCP/UDP port range. A Service alone does not
+  transport mDNS multicast.
+{{- end }}
+
+4. COMMISSIONING:
+  1. Wait until the pod is Ready.
+  2. Open the frontend and install/configure the required plugins.
+  3. Use the QR code or manual pairing code shown by Matterbridge.
+  4. Pair the bridge from an Apple Home, Google Home, Alexa, SmartThings or
+     another Matter controller on the reachable LAN.
+
+  Retrieve recent commissioning logs carefully:
+    kubectl logs -n {{ .Release.Namespace }} {{ include "matterbridge.fullname" . }}-0 --tail=100
+
+  Pairing codes are credentials. Do not paste them into tickets or public logs.
+
+5. PERSISTENCE AND BACKUP:
+{{- if .Values.persistence.enabled }}
+  Matter fabrics, plugin configuration, certificates and installed plugins are
+  stored together at /data on PVC {{ include "matterbridge.pvcName" . }}.
+
+  Stop Matterbridge before taking a filesystem-level snapshot:
+    kubectl scale -n {{ .Release.Namespace }} statefulset/{{ include "matterbridge.fullname" . }} --replicas=0
+    # Snapshot or back up the PVC with your storage platform.
+    kubectl scale -n {{ .Release.Namespace }} statefulset/{{ include "matterbridge.fullname" . }} --replicas=1
+
+  The chart retains its created PVC on uninstall by default. Verify the backup
+  before upgrades, storage migrations and destructive plugin changes.
+{{- else }}
+  Persistence is disabled. /data uses an ephemeral emptyDir and all plugins,
+  Matter fabrics, certificates and configuration are lost when the pod is
+  replaced or removed. Enable persistence before commissioning real devices.
+{{- end }}
+
+6. SECURITY:
+  The container runs as UID/GID 1000 with all capabilities dropped, a read-only
+  root filesystem, RuntimeDefault seccomp and no service-account token.
+
+  The Matterbridge frontend does not provide chart-managed authentication.
+  Keep the ClusterIP private or put authentication and TLS at a trusted reverse
+  proxy. Ingress and Gateway API expose only the frontend, never Matter or mDNS.
+
+7. OPERATIONS:
+  Health:
+    kubectl exec -n {{ .Release.Namespace }} {{ include "matterbridge.fullname" . }}-0 -- \
+      node -e "fetch('http://127.0.0.1:{{ .Values.frontend.port }}/health').then(r=>{if(!r.ok)process.exit(1)})"
+
+  Events:
+    kubectl get events -n {{ .Release.Namespace }} --sort-by=.lastTimestamp
+
+  Logs:
+    kubectl logs -n {{ .Release.Namespace }} {{ include "matterbridge.fullname" . }}-0 --follow
+
+  Restart:
+    kubectl rollout restart -n {{ .Release.Namespace }} statefulset/{{ include "matterbridge.fullname" . }}
+
+8. LIMITS:
+  Matterbridge is a singleton application. replicaCount values other than 1 are
+  rejected because active-active pods would conflict over fabric state,
+  persisted files, mDNS identity and Matter ports.
+
+  Matterbridge has no native Prometheus endpoint. Use Kubernetes health,
+  restart and resource metrics instead of scraping the frontend.
+
+9. DOCUMENTATION:
+  Chart: https://helmforge.dev/docs/charts/matterbridge
+  Networking: https://helmforge.dev/docs/charts/matterbridge#networking
+  Upstream: https://github.com/Luligu/matterbridge
+  Plugins: https://github.com/Luligu/matterbridge/blob/main/README.md
+
+=============================================================================
+Happy Helmforging :)

--- a/charts/matterbridge/templates/_helpers.tpl
+++ b/charts/matterbridge/templates/_helpers.tpl
@@ -1,0 +1,148 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{- define "matterbridge.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "matterbridge.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matterbridge.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "matterbridge.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "matterbridge.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "matterbridge.labels" -}}
+helm.sh/chart: {{ include "matterbridge.chart" . }}
+{{ include "matterbridge.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: helmforge
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "matterbridge.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "matterbridge.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matterbridge.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "matterbridge.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matterbridge.nameWithSuffix" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $baseMax := int (max 1 (sub 63 (len $suffix))) -}}
+{{- printf "%s%s" ($base | trunc $baseMax | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "matterbridge.httpRouteName" -}}
+{{- $root := .root -}}
+{{- $route := .route -}}
+{{- $index := int (.index | default 0) -}}
+{{- if $route.name -}}
+{{- include "matterbridge.nameWithSuffix" (dict "base" (include "matterbridge.fullname" $root) "suffix" (printf "-%s" $route.name)) -}}
+{{- else if gt $index 0 -}}
+{{- include "matterbridge.nameWithSuffix" (dict "base" (include "matterbridge.fullname" $root) "suffix" (printf "-%d" $index)) -}}
+{{- else -}}
+{{- include "matterbridge.fullname" $root -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matterbridge.externalSecretName" -}}
+{{- $root := .root -}}
+{{- $item := .item -}}
+{{- $index := int (.index | default 0) -}}
+{{- if $item.fullnameOverride -}}
+{{- $item.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if $item.name -}}
+{{- include "matterbridge.nameWithSuffix" (dict "base" (include "matterbridge.fullname" $root) "suffix" (printf "-%s" $item.name)) -}}
+{{- else if gt $index 0 -}}
+{{- include "matterbridge.nameWithSuffix" (dict "base" (include "matterbridge.fullname" $root) "suffix" (printf "-%d" $index)) -}}
+{{- else -}}
+{{- include "matterbridge.nameWithSuffix" (dict "base" (include "matterbridge.fullname" $root) "suffix" "-external") -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "matterbridge.validate" -}}
+{{- if hasKey .Values.commonLabels "app.kubernetes.io/name" -}}
+{{- fail "commonLabels must not override the selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey .Values.commonLabels "app.kubernetes.io/instance" -}}
+{{- fail "commonLabels must not override the selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "replicaCount must be 1 because Matterbridge does not support shared-state replicas or active-active operation" -}}
+{{- end -}}
+{{- if has .Values.image.tag (list "latest" "stable" "main" "master" "edge" "dev") -}}
+{{- fail "image.tag must be a pinned stable release tag" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled (empty .Values.ingress.hosts) -}}
+{{- fail "ingress.hosts must contain at least one host when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.gatewayAPI.enabled (empty .Values.gatewayAPI.httpRoutes) -}}
+{{- fail "gatewayAPI.httpRoutes must contain at least one route when gatewayAPI.enabled=true" -}}
+{{- end -}}
+{{- range .Values.gatewayAPI.httpRoutes | default list -}}
+{{- if empty .parentRefs -}}
+{{- fail "gatewayAPI.httpRoutes[].parentRefs must contain at least one parent reference" -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.externalSecrets.enabled (empty .Values.externalSecrets.items) -}}
+{{- fail "externalSecrets.items must contain at least one item when externalSecrets.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.networkPolicy.enabled .Values.network.hostNetwork -}}
+{{- fail "networkPolicy.enabled requires network.hostNetwork=false because host-network policy enforcement is CNI-dependent" -}}
+{{- end -}}
+{{- if and .Values.frontend.tls.enabled (empty .Values.frontend.tls.existingSecret) -}}
+{{- fail "frontend.tls.existingSecret is required when frontend.tls.enabled=true" -}}
+{{- end -}}
+{{- if and (not .Values.persistence.enabled) .Values.persistence.existingClaim -}}
+{{- fail "persistence.enabled must be true when persistence.existingClaim is set" -}}
+{{- end -}}
+{{- if lt (int .Values.matterbridge.matterPortRangeSize) 1 -}}
+{{- fail "matterbridge.matterPortRangeSize must be at least 1" -}}
+{{- end -}}
+{{- if gt (int .Values.matterbridge.matterPortRangeSize) 100 -}}
+{{- fail "matterbridge.matterPortRangeSize must not exceed 100" -}}
+{{- end -}}
+{{- $lastMatterPort := add (int .Values.matterbridge.matterPort) (sub (int .Values.matterbridge.matterPortRangeSize) 1) -}}
+{{- if gt (int $lastMatterPort) 65535 -}}
+{{- fail "matterbridge.matterPort plus matterPortRangeSize exceeds port 65535" -}}
+{{- end -}}
+{{- if and (ge (int .Values.frontend.port) (int .Values.matterbridge.matterPort)) (le (int .Values.frontend.port) (int $lastMatterPort)) -}}
+{{- fail "frontend.port must not overlap the reserved Matter port range" -}}
+{{- end -}}
+{{- if .Values.podLabels -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/name" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/name" -}}
+{{- end -}}
+{{- if hasKey .Values.podLabels "app.kubernetes.io/instance" -}}
+{{- fail "podLabels must not override the selector label app.kubernetes.io/instance" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/matterbridge/templates/externalsecret.yaml
+++ b/charts/matterbridge/templates/externalsecret.yaml
@@ -1,0 +1,55 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.externalSecrets.enabled }}
+{{- $externalSecretNames := dict }}
+{{- range $index, $item := .Values.externalSecrets.items }}
+{{- $externalSecretName := include "matterbridge.externalSecretName" (dict "root" $ "item" $item "index" $index) }}
+{{- if hasKey $externalSecretNames $externalSecretName }}
+{{- fail (printf "externalSecrets.items render duplicate ExternalSecret name %q; set name or fullnameOverride to a unique value" $externalSecretName) }}
+{{- end }}
+{{- $_ := set $externalSecretNames $externalSecretName true }}
+{{- $spec := deepCopy ($item.spec | default dict) }}
+{{- if and $.Values.externalSecrets.refreshInterval (not (hasKey $spec "refreshInterval")) }}
+{{- $_ := set $spec "refreshInterval" $.Values.externalSecrets.refreshInterval }}
+{{- end }}
+{{- $target := deepCopy (get $spec "target" | default dict) }}
+{{- if not (get $target "name") }}
+{{- $_ := set $target "name" $externalSecretName }}
+{{- $_ := set $spec "target" $target }}
+{{- end }}
+{{- $hasStoreRef := false }}
+{{- if dig "secretStoreRef" "name" "" $spec }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- range ($spec.data | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- range ($spec.dataFrom | default list) }}
+{{- if or (dig "sourceRef" "storeRef" "name" "" .) (dig "sourceRef" "generatorRef" "name" "" .) }}
+{{- $hasStoreRef = true }}
+{{- end }}
+{{- end }}
+{{- if not $hasStoreRef }}
+{{- fail "externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true" }}
+{{- end }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $externalSecretName }}
+  labels:
+    {{- include "matterbridge.labels" $ | nindent 4 }}
+    {{- with $item.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $item.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/matterbridge/templates/extra-manifests.yaml
+++ b/charts/matterbridge/templates/extra-manifests.yaml
@@ -1,0 +1,5 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/charts/matterbridge/templates/gateway-httproute.yaml
+++ b/charts/matterbridge/templates/gateway-httproute.yaml
@@ -1,0 +1,59 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.gatewayAPI.enabled }}
+{{- $httpRouteNames := dict }}
+{{- range $index, $route := .Values.gatewayAPI.httpRoutes }}
+{{- $name := include "matterbridge.httpRouteName" (dict "root" $ "route" $route "index" $index) }}
+{{- if hasKey $httpRouteNames $name }}
+{{- fail (printf "gatewayAPI.httpRoutes render duplicate HTTPRoute name %q; set name to a unique value" $name) }}
+{{- end }}
+{{- $_ := set $httpRouteNames $name true }}
+{{- if gt $index 0 }}
+---
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "matterbridge.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.rules }}
+    {{- range $route.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .backendRefs }}
+      backendRefs:
+        {{- toYaml .backendRefs | nindent 8 }}
+      {{- else if not .omitDefaultBackend }}
+      backendRefs:
+        - name: {{ include "matterbridge.fullname" $ }}
+          port: {{ $.Values.service.port }}
+      {{- end }}
+    {{- end }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ include "matterbridge.fullname" $ }}
+          port: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/matterbridge/templates/ingress.yaml
+++ b/charts/matterbridge/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "matterbridge.fullname" . }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.ingress.hosts }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- $paths := default (list (dict "path" "/" "pathType" "Prefix")) .paths }}
+          {{- range $paths }}
+          - path: {{ default "/" .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ include "matterbridge.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/matterbridge/templates/networkpolicy.yaml
+++ b/charts/matterbridge/templates/networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "matterbridge.fullname" . }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "matterbridge.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.egress.enabled }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.ingressFrom }}
+        {{- toYaml .Values.networkPolicy.ingressFrom | nindent 8 }}
+        {{- else }}
+        - namespaceSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: http
+        {{- if .Values.matterService.enabled }}
+        {{- $basePort := int .Values.matterbridge.matterPort }}
+        {{- range $offset := until (int .Values.matterbridge.matterPortRangeSize) }}
+        {{- $port := add $basePort $offset }}
+        {{- range $protocol := $.Values.matterService.protocols }}
+        - protocol: {{ $protocol }}
+          port: {{ $port }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+  {{- if .Values.networkPolicy.egress.enabled }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowDNS }}
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraTo }}
+    - to:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/matterbridge/templates/pvc.yaml
+++ b/charts/matterbridge/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "matterbridge.pvcName" . }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+  {{- if or .Values.persistence.retain .Values.persistence.annotations }}
+  annotations:
+    {{- if .Values.persistence.retain }}
+    helm.sh/resource-policy: keep
+    {{- end }}
+    {{- with .Values.persistence.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/matterbridge/templates/service.yaml
+++ b/charts/matterbridge/templates/service.yaml
@@ -1,0 +1,65 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "matterbridge.fullname" . }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.service.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "matterbridge.selectorLabels" . | nindent 4 }}
+{{- if .Values.matterService.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "matterbridge.nameWithSuffix" (dict "base" (include "matterbridge.fullname" .) "suffix" "-matter") }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+  {{- with .Values.matterService.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.matterService.type }}
+  {{- if and (or (eq .Values.matterService.type "LoadBalancer") (eq .Values.matterService.type "NodePort")) .Values.matterService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.matterService.externalTrafficPolicy }}
+  {{- end }}
+  {{- with .Values.matterService.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.matterService.ipFamilies }}
+  ipFamilies:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    {{- $basePort := int .Values.matterbridge.matterPort }}
+    {{- range $offset := until (int .Values.matterbridge.matterPortRangeSize) }}
+    {{- $port := add $basePort $offset }}
+    {{- range $protocol := $.Values.matterService.protocols }}
+    - name: {{ printf "m-%s-%d" (lower $protocol | trunc 1) $offset }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: {{ $protocol }}
+    {{- end }}
+    {{- end }}
+  selector:
+    {{- include "matterbridge.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/matterbridge/templates/serviceaccount.yaml
+++ b/charts/matterbridge/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "matterbridge.serviceAccountName" . }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/matterbridge/templates/statefulset.yaml
+++ b/charts/matterbridge/templates/statefulset.yaml
@@ -1,0 +1,230 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "matterbridge.fullname" . }}
+  labels:
+    {{- include "matterbridge.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "matterbridge.fullname" . }}
+  podManagementPolicy: OrderedReady
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "matterbridge.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "matterbridge.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "matterbridge.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      hostNetwork: {{ .Values.network.hostNetwork }}
+      {{- if .Values.network.dnsPolicy }}
+      dnsPolicy: {{ .Values.network.dnsPolicy }}
+      {{- else if .Values.network.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- else }}
+      dnsPolicy: ClusterFirst
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: matterbridge
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - matterbridge
+          args:
+            - --docker
+            - --homedir
+            - /data
+            - {{ printf "--%s" .Values.matterbridge.mode | quote }}
+            - --frontend
+            - {{ .Values.frontend.port | quote }}
+            - --port
+            - {{ .Values.matterbridge.matterPort | quote }}
+            - --logger
+            - {{ .Values.matterbridge.logger | quote }}
+            - --matterlogger
+            - {{ .Values.matterbridge.matterLogger | quote }}
+            {{- with .Values.matterbridge.profile }}
+            - --profile
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.matterbridge.mdnsInterface }}
+            - --mdnsinterface
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.matterbridge.ipv4Address }}
+            - --ipv4address
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.matterbridge.ipv6Address }}
+            - --ipv6address
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.frontend.bindAddress }}
+            - --bind
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.frontend.tls.enabled }}
+            - --ssl
+            {{- end }}
+            {{- if .Values.matterbridge.noAnsi }}
+            - --no-ansi
+            {{- end }}
+            {{- if .Values.matterbridge.fileLogger }}
+            - --filelogger
+            {{- end }}
+            {{- if .Values.matterbridge.matterFileLogger }}
+            - --matterfilelogger
+            {{- end }}
+            {{- if .Values.matterbridge.disableVirtualDevices }}
+            - --novirtual
+            {{- end }}
+            {{- if .Values.matterbridge.resetSessions }}
+            - --reset-sessions
+            {{- end }}
+            {{- range .Values.matterbridge.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          env:
+            - name: HOME
+              value: /data
+            - name: NPM_CONFIG_PREFIX
+              value: /data/.npm-global
+            - name: NPM_CONFIG_CACHE
+              value: /data/.npm-cache
+            - name: PATH
+              value: /data/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.port }}
+              protocol: TCP
+            - name: matter-udp
+              containerPort: {{ .Values.matterbridge.matterPort }}
+              protocol: UDP
+            - name: matter-tcp
+              containerPort: {{ .Values.matterbridge.matterPort }}
+              protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.frontend.tls.enabled }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.frontend.tls.enabled }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+              scheme: {{ ternary "HTTPS" "HTTP" .Values.frontend.tls.enabled }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.frontend.tls.enabled }}
+            - name: frontend-tls
+              mountPath: /data/.matterbridge/certs
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "matterbridge.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 256Mi
+        {{- if .Values.frontend.tls.enabled }}
+        - name: frontend-tls
+          secret:
+            secretName: {{ .Values.frontend.tls.existingSecret }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/matterbridge/templates/validate.yaml
+++ b/charts/matterbridge/templates/validate.yaml
@@ -1,0 +1,2 @@
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "matterbridge.validate" . -}}

--- a/charts/matterbridge/tests/exposure_test.yaml
+++ b/charts/matterbridge/tests/exposure_test.yaml
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Frontend exposure
+templates:
+  - templates/ingress.yaml
+  - templates/gateway-httproute.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: omits Ingress by default
+    template: templates/ingress.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a configured Ingress
+    template: templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.ingressClassName: nginx
+      ingress.hosts:
+        - host: matterbridge.example.test
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: matterbridge.example.test
+
+  - it: routes Ingress to frontend Service
+    template: templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: matterbridge.example.test
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: test-matterbridge
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8283
+
+  - it: renders Ingress TLS
+    template: templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: matterbridge.example.test
+      ingress.tls:
+        - secretName: ingress-tls
+          hosts:
+            - matterbridge.example.test
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: ingress-tls
+
+  - it: omits HTTPRoute by default
+    template: templates/gateway-httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a Gateway API HTTPRoute
+    template: templates/gateway-httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: frontend
+          parentRefs:
+            - name: gateway
+          hostnames:
+            - matterbridge.example.test
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test-matterbridge-frontend
+
+  - it: gives HTTPRoute the default frontend backend
+    template: templates/gateway-httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - parentRefs:
+            - name: gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: test-matterbridge
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8283
+
+  - it: supports multiple named HTTPRoutes
+    template: templates/gateway-httproute.yaml
+    set:
+      gatewayAPI.enabled: true
+      gatewayAPI.httpRoutes:
+        - name: internal
+          parentRefs:
+            - name: internal-gateway
+        - name: admin
+          parentRefs:
+            - name: admin-gateway
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/matterbridge/tests/integrations_test.yaml
+++ b/charts/matterbridge/tests/integrations_test.yaml
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Integrations
+templates:
+  - templates/externalsecret.yaml
+  - templates/networkpolicy.yaml
+  - templates/serviceaccount.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: creates a dedicated ServiceAccount by default
+    template: templates/serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: omits ServiceAccount when disabled
+    template: templates/serviceaccount.yaml
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits ExternalSecret by default
+    template: templates/externalsecret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders external-secrets.io v1
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: plugin
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            data:
+              - secretKey: token
+                remoteRef:
+                  key: plugin
+    asserts:
+      - isKind:
+          of: ExternalSecret
+      - equal:
+          path: apiVersion
+          value: external-secrets.io/v1
+      - equal:
+          path: metadata.name
+          value: test-matterbridge-plugin
+
+  - it: applies default refresh interval and target name
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: plugin
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: plugin
+    asserts:
+      - equal:
+          path: spec.refreshInterval
+          value: 1h
+      - equal:
+          path: spec.target.name
+          value: test-matterbridge-plugin
+
+  - it: preserves an item fullname override literally
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - fullnameOverride: shared-plugin-secret
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: plugin
+    asserts:
+      - equal:
+          path: metadata.name
+          value: shared-plugin-secret
+
+  - it: renders multiple ExternalSecret items
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: first
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: first
+        - name: second
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: second
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: rejects duplicate ExternalSecret names
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: plugin
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: first
+        - name: plugin
+          spec:
+            secretStoreRef:
+              name: fake
+              kind: ClusterSecretStore
+            dataFrom:
+              - extract:
+                  key: second
+    asserts:
+      - failedTemplate:
+          errorMessage: 'externalSecrets.items render duplicate ExternalSecret name "test-matterbridge-plugin"; set name or fullnameOverride to a unique value'
+
+  - it: rejects External Secret item without a store reference
+    template: templates/externalsecret.yaml
+    set:
+      externalSecrets.enabled: true
+      externalSecrets.items:
+        - name: plugin
+          spec:
+            data:
+              - secretKey: token
+                remoteRef:
+                  key: plugin
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.items[].spec.secretStoreRef.name or item sourceRef.storeRef.name/sourceRef.generatorRef.name is required when externalSecrets.enabled=true
+
+  - it: omits NetworkPolicy by default
+    template: templates/networkpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders ingress-only NetworkPolicy
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - notContains:
+          path: spec.policyTypes
+          content: Egress
+
+  - it: permits DNS when restrictive egress is enabled
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress.enabled: true
+    asserts:
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.egress[0].ports[0].port
+          value: 53
+      - equal:
+          path: spec.egress[0].ports[0].protocol
+          value: UDP
+
+  - it: adds Matter ports when Matter Service is enabled
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      matterService.enabled: true
+      matterbridge.matterPortRangeSize: 1
+    asserts:
+      - lengthEqual:
+          path: spec.ingress[0].ports
+          count: 3
+
+  - it: supports explicit frontend ingress peers
+    template: templates/networkpolicy.yaml
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.ingressFrom:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-system
+    asserts:
+      - isNotEmpty:
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels

--- a/charts/matterbridge/tests/notes_test.yaml
+++ b/charts/matterbridge/tests/notes_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Notes
+templates:
+  - templates/NOTES.txt
+release:
+  name: test
+  namespace: matterbridge-system
+tests:
+  - it: defaults an omitted Ingress path to root
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: matterbridge.example.test
+    asserts:
+      - matchRegexRaw:
+          pattern: "http://matterbridge\\.example\\.test/"
+
+  - it: prints persistent backup guidance by default
+    asserts:
+      - matchRegexRaw:
+          pattern: "stored together at /data on PVC test-matterbridge-data"
+      - matchRegexRaw:
+          pattern: "statefulset/test-matterbridge --replicas=0"
+
+  - it: warns about data loss for ephemeral storage
+    set:
+      persistence.enabled: false
+    asserts:
+      - matchRegexRaw:
+          pattern: "Persistence is disabled"
+      - notMatchRegexRaw:
+          pattern: "stored together at /data on PVC"

--- a/charts/matterbridge/tests/service_pvc_test.yaml
+++ b/charts/matterbridge/tests/service_pvc_test.yaml
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Services and persistence
+templates:
+  - templates/service.yaml
+  - templates/pvc.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: renders frontend Service by default
+    template: templates/service.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: renders a ClusterIP frontend service
+    template: templates/service.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 8283
+
+  - it: configures frontend dual stack
+    template: templates/service.yaml
+    documentIndex: 0
+    set:
+      service.ipFamilyPolicy: PreferDualStack
+      service.ipFamilies:
+        - IPv6
+        - IPv4
+    asserts:
+      - equal:
+          path: spec.ipFamilyPolicy
+          value: PreferDualStack
+      - equal:
+          path: spec.ipFamilies[0]
+          value: IPv6
+
+  - it: creates one retained PVC
+    template: templates/pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - isNotEmpty:
+          path: metadata.annotations
+      - equal:
+          path: spec.resources.requests.storage
+          value: 2Gi
+
+  - it: configures PVC storage class and access mode
+    template: templates/pvc.yaml
+    set:
+      persistence.storageClass: fast
+      persistence.accessModes:
+        - ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteMany
+
+  - it: omits PVC when persistence is disabled
+    template: templates/pvc.yaml
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits PVC for an existing claim
+    template: templates/pvc.yaml
+    set:
+      persistence.existingClaim: existing-data
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the optional Matter service
+    template: templates/service.yaml
+    documentIndex: 1
+    set:
+      matterService.enabled: true
+      matterService.type: ClusterIP
+      matterbridge.matterPortRangeSize: 2
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: test-matterbridge-matter
+      - lengthEqual:
+          path: spec.ports
+          count: 4
+
+  - it: includes TCP and UDP for the Matter base port
+    template: templates/service.yaml
+    documentIndex: 1
+    set:
+      matterService.enabled: true
+      matterService.type: ClusterIP
+      matterbridge.matterPortRangeSize: 1
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 5540
+      - equal:
+          path: spec.ports[0].protocol
+          value: UDP
+      - equal:
+          path: spec.ports[1].protocol
+          value: TCP
+
+  - it: sets local traffic policy for LoadBalancer
+    template: templates/service.yaml
+    documentIndex: 1
+    set:
+      matterService.enabled: true
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local

--- a/charts/matterbridge/tests/statefulset_test.yaml
+++ b/charts/matterbridge/tests/statefulset_test.yaml
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: StatefulSet
+templates:
+  - templates/statefulset.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: renders a singleton StatefulSet
+    asserts:
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.podManagementPolicy
+          value: OrderedReady
+
+  - it: uses the pinned official image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/luligu/matterbridge:3.10.7
+
+  - it: bypasses the root entrypoint and uses the persistent home
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: matterbridge
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --homedir
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: /data
+
+  - it: defaults to bridge mode
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --bridge
+
+  - it: supports childbridge mode and custom profile
+    set:
+      matterbridge.mode: childbridge
+      matterbridge.profile: upstairs
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --childbridge
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: upstairs
+
+  - it: uses pod networking and ClusterFirst by default
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirst
+
+  - it: selects host-network DNS automatically
+    set:
+      network.hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: accepts an explicit DNS policy
+    set:
+      network.dnsPolicy: Default
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: Default
+
+  - it: applies hardened pod security defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: applies hardened container security defaults
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: does not mount a service account token
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: mounts persistent data and temporary storage
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+
+  - it: uses official health endpoint for every probe
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health
+
+  - it: disables probes independently
+    set:
+      startupProbe.enabled: false
+      readinessProbe.enabled: false
+      livenessProbe.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: renders runtime interface flags and extra arguments
+    set:
+      matterbridge.mdnsInterface: eth1
+      matterbridge.ipv4Address: 192.0.2.10
+      matterbridge.ipv6Address: 2001:db8::10
+      matterbridge.extraArgs:
+        - --debug
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: eth1
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: 192.0.2.10
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: 2001:db8::10
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --debug
+
+  - it: supports extra environment sources
+    set:
+      extraEnvFrom:
+        - secretRef:
+            name: plugin-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: plugin-secret
+
+  - it: switches probes to HTTPS and mounts certificate secret
+    set:
+      frontend.tls.enabled: true
+      frontend.tls.existingSecret: frontend-tls
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --ssl
+      - equal:
+          path: spec.template.spec.volumes[2].secret.secretName
+          value: frontend-tls
+
+  - it: uses ephemeral data when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].emptyDir
+          value: {}

--- a/charts/matterbridge/tests/validation_test.yaml
+++ b/charts/matterbridge/tests/validation_test.yaml
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+suite: Validation
+templates:
+  - templates/validate.yaml
+tests:
+  - it: rejects reserved selector name in common labels
+    set:
+      commonLabels:
+        app.kubernetes.io/name: duplicate
+    asserts:
+      - failedTemplate:
+          errorMessage: commonLabels must not override the selector label app.kubernetes.io/name
+
+  - it: rejects reserved selector instance in common labels
+    set:
+      commonLabels:
+        app.kubernetes.io/instance: duplicate
+    asserts:
+      - failedTemplate:
+          errorMessage: commonLabels must not override the selector label app.kubernetes.io/instance
+
+  - it: rejects floating image tags
+    set:
+      image.tag: latest
+    asserts:
+      - failedTemplate:
+          errorMessage: image.tag must be a pinned stable release tag
+
+  - it: rejects Ingress without hosts
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress.hosts must contain at least one host when ingress.enabled=true
+
+  - it: rejects Gateway API without routes
+    set:
+      gatewayAPI.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: gatewayAPI.httpRoutes must contain at least one route when gatewayAPI.enabled=true
+
+  - it: rejects External Secrets without items
+    set:
+      externalSecrets.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: externalSecrets.items must contain at least one item when externalSecrets.enabled=true
+
+  - it: rejects NetworkPolicy with host network
+    set:
+      network.hostNetwork: true
+      networkPolicy.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: networkPolicy.enabled requires network.hostNetwork=false because host-network policy enforcement is CNI-dependent
+
+  - it: rejects frontend TLS without a Secret
+    set:
+      frontend.tls.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: frontend.tls.existingSecret is required when frontend.tls.enabled=true
+
+  - it: rejects an existing claim when persistence is disabled
+    set:
+      persistence.enabled: false
+      persistence.existingClaim: data
+    asserts:
+      - failedTemplate:
+          errorMessage: persistence.enabled must be true when persistence.existingClaim is set
+
+  - it: rejects an overflowing Matter port range
+    set:
+      matterbridge.matterPort: 65530
+      matterbridge.matterPortRangeSize: 10
+    asserts:
+      - failedTemplate:
+          errorMessage: matterbridge.matterPort plus matterPortRangeSize exceeds port 65535
+
+  - it: rejects frontend overlap with Matter ports
+    set:
+      frontend.port: 5541
+    asserts:
+      - failedTemplate:
+          errorMessage: frontend.port must not overlap the reserved Matter port range
+
+  - it: rejects selector name override in pod labels
+    set:
+      podLabels:
+        app.kubernetes.io/name: bad
+    asserts:
+      - failedTemplate:
+          errorMessage: podLabels must not override the selector label app.kubernetes.io/name
+
+  - it: accepts default values
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/matterbridge/values.schema.json
+++ b/charts/matterbridge/values.schema.json
@@ -1,0 +1,669 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Matterbridge Helm chart values",
+  "description": "Configuration contract for the HelmForge Matterbridge chart.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart name used in resource names."
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the fully qualified release name."
+    },
+    "commonLabels": {
+      "$ref": "#/$defs/stringMap"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "description": "Matterbridge replica count. Only one replica is supported.",
+      "const": 1
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "tag", "pullPolicy"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "matterbridge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "profile",
+        "matterPort",
+        "matterPortRangeSize",
+        "mdnsInterface",
+        "ipv4Address",
+        "ipv6Address",
+        "logger",
+        "matterLogger",
+        "noAnsi",
+        "fileLogger",
+        "matterFileLogger",
+        "disableVirtualDevices",
+        "resetSessions",
+        "extraArgs"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["bridge", "childbridge"]
+        },
+        "profile": {
+          "type": "string",
+          "maxLength": 63
+        },
+        "matterPort": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 65535
+        },
+        "matterPortRangeSize": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "mdnsInterface": {
+          "type": "string"
+        },
+        "ipv4Address": {
+          "type": "string"
+        },
+        "ipv6Address": {
+          "type": "string"
+        },
+        "logger": {
+          "$ref": "#/$defs/logLevel"
+        },
+        "matterLogger": {
+          "$ref": "#/$defs/logLevel"
+        },
+        "noAnsi": {
+          "type": "boolean"
+        },
+        "fileLogger": {
+          "type": "boolean"
+        },
+        "matterFileLogger": {
+          "type": "boolean"
+        },
+        "disableVirtualDevices": {
+          "type": "boolean"
+        },
+        "resetSessions": {
+          "type": "boolean"
+        },
+        "extraArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "frontend": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port", "bindAddress", "tls"],
+      "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1024,
+          "maximum": 65535
+        },
+        "bindAddress": {
+          "type": "string"
+        },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "existingSecret"],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "existingSecret": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hostNetwork", "dnsPolicy"],
+      "properties": {
+        "hostNetwork": {
+          "type": "boolean"
+        },
+        "dnsPolicy": {
+          "type": "string",
+          "enum": ["", "ClusterFirst", "ClusterFirstWithHostNet", "Default"]
+        }
+      }
+    },
+    "service": {
+      "$ref": "#/$defs/service"
+    },
+    "matterService": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "type",
+        "protocols",
+        "externalTrafficPolicy",
+        "annotations",
+        "ipFamilyPolicy",
+        "ipFamilies"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "protocols": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["UDP", "TCP"]
+          }
+        },
+        "externalTrafficPolicy": {
+          "type": "string",
+          "enum": ["Cluster", "Local"]
+        },
+        "annotations": {
+          "$ref": "#/$defs/stringMap"
+        },
+        "ipFamilyPolicy": {
+          "$ref": "#/$defs/ipFamilyPolicy"
+        },
+        "ipFamilies": {
+          "$ref": "#/$defs/ipFamilies"
+        }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "existingClaim",
+        "storageClass",
+        "accessModes",
+        "size",
+        "retain",
+        "annotations"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "existingClaim": {
+          "type": "string"
+        },
+        "storageClass": {
+          "type": "string"
+        },
+        "accessModes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
+          }
+        },
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)$"
+        },
+        "retain": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "$ref": "#/$defs/stringMap"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["create", "name", "annotations", "automountServiceAccountToken"],
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "annotations": {
+          "$ref": "#/$defs/stringMap"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Pod security context for the Matterbridge pod.",
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Container security context for Matterbridge.",
+      "additionalProperties": true
+    },
+    "startupProbe": {
+      "$ref": "#/$defs/probe"
+    },
+    "readinessProbe": {
+      "$ref": "#/$defs/probe"
+    },
+    "livenessProbe": {
+      "$ref": "#/$defs/probe"
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "ingressClassName", "annotations", "hosts", "tls"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressClassName": {
+          "type": "string"
+        },
+        "annotations": {
+          "$ref": "#/$defs/stringMap"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["host"],
+            "additionalProperties": false,
+            "properties": {
+              "host": {
+                "type": "string",
+                "minLength": 1
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "gatewayAPI": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "httpRoutes"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "httpRoutes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "labels": {
+                "$ref": "#/$defs/stringMap"
+              },
+              "annotations": {
+                "$ref": "#/$defs/stringMap"
+              },
+              "parentRefs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "hostnames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "externalSecrets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "refreshInterval", "items"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "refreshInterval": {
+          "type": "string",
+          "minLength": 1
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["spec"],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "fullnameOverride": {
+                "type": "string"
+              },
+              "labels": {
+                "$ref": "#/$defs/stringMap"
+              },
+              "annotations": {
+                "$ref": "#/$defs/stringMap"
+              },
+              "spec": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "ingressFrom", "egress"],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "allowDNS", "extraTo", "extraEgress"],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "allowDNS": {
+              "type": "boolean"
+            },
+            "extraTo": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "extraEgress": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "minimum": 60
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 20
+    },
+    "podAnnotations": {
+      "$ref": "#/$defs/stringMap"
+    },
+    "podLabels": {
+      "$ref": "#/$defs/stringMap"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "$ref": "#/$defs/stringMap"
+    },
+    "affinity": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraEnvFrom": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraInitContainers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraContainers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "extraManifests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+  "$defs": {
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "logLevel": {
+      "type": "string",
+      "enum": ["debug", "info", "notice", "warn", "error", "fatal"]
+    },
+    "ipFamilyPolicy": {
+      "type": "string",
+      "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+    },
+    "ipFamilies": {
+      "type": "array",
+      "maxItems": 2,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": ["IPv4", "IPv6"]
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "port", "annotations", "ipFamilyPolicy", "ipFamilies"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "$ref": "#/$defs/stringMap"
+        },
+        "ipFamilyPolicy": {
+          "$ref": "#/$defs/ipFamilyPolicy"
+        },
+        "ipFamilies": {
+          "$ref": "#/$defs/ipFamilies"
+        }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "initialDelaySeconds",
+        "periodSeconds",
+        "timeoutSeconds",
+        "failureThreshold",
+        "successThreshold"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/charts/matterbridge/values.yaml
+++ b/charts/matterbridge/values.yaml
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+# =============================================================================
+# Matterbridge Helm chart values
+# =============================================================================
+
+# -- Override the chart name used in resource names.
+nameOverride: ""
+
+# -- Override the fully qualified release name.
+fullnameOverride: ""
+
+# -- Labels added to every resource created by the chart.
+commonLabels: {}
+
+# -- Number of Matterbridge replicas. Matterbridge is stateful and only one replica is supported.
+replicaCount: 1
+
+image:
+  # -- Official Matterbridge container repository.
+  repository: docker.io/luligu/matterbridge
+  # -- Pinned stable Matterbridge image tag.
+  tag: "3.10.7"
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registry mirrors.
+imagePullSecrets: []
+
+matterbridge:
+  # -- Runtime mode. Bridge exposes one Matter bridge; childbridge exposes enabled plugins separately.
+  mode: bridge
+  # -- Optional instance profile used to isolate multiple independent Matterbridge installations.
+  profile: ""
+  # -- Matter commissioning base port. Additional nodes increment from this port.
+  matterPort: 5540
+  # -- Number of consecutive Matter ports reserved from matterPort.
+  matterPortRangeSize: 20
+  # -- Optional host interface name used for mDNS on multi-homed nodes.
+  mdnsInterface: ""
+  # -- Optional IPv4 listener address. Empty lets Matterbridge select all suitable addresses.
+  ipv4Address: ""
+  # -- Optional IPv6 listener address. Empty lets Matterbridge select all suitable addresses.
+  ipv6Address: ""
+  # -- Matterbridge application log level.
+  logger: info
+  # -- Matter protocol log level.
+  matterLogger: info
+  # -- Disable ANSI escape sequences in Kubernetes logs.
+  noAnsi: true
+  # -- Write Matterbridge logs to the persistent data volume.
+  fileLogger: false
+  # -- Write Matter protocol logs to the persistent data volume.
+  matterFileLogger: false
+  # -- Disable the virtual restart, update and reboot devices.
+  disableVirtualDevices: false
+  # -- Reset Matter sessions during graceful shutdown. Enable only for controller reconnection issues.
+  resetSessions: false
+  # -- Additional Matterbridge CLI arguments appended after chart-managed arguments.
+  extraArgs: []
+
+frontend:
+  # -- Frontend HTTP or HTTPS port.
+  port: 8283
+  # -- Frontend bind address. Empty lets Matterbridge bind all IPv4 and IPv6 addresses.
+  bindAddress: ""
+  tls:
+    # -- Enable HTTPS using an existing Secret mounted into Matterbridge's certificate directory.
+    enabled: false
+    # -- Existing Secret containing cert.pem and key.pem; ca.pem is optional.
+    existingSecret: ""
+
+network:
+  # -- Use the node network namespace. Enable for normal Matter mDNS and LAN IPv6 discovery; disabled by default for Pod Security baseline compatibility.
+  hostNetwork: false
+  # -- Pod DNS policy. Empty selects ClusterFirstWithHostNet for host networking and ClusterFirst otherwise.
+  dnsPolicy: ""
+
+service:
+  # -- Kubernetes Service type for the management frontend.
+  type: ClusterIP
+  # -- Frontend Service port.
+  port: 8283
+  # -- Service annotations.
+  annotations: {}
+  # -- Service IP family policy. Empty uses the cluster default.
+  # @default -- omitted
+  ipFamilyPolicy: ""
+  # -- Ordered Service IP families. Empty uses the cluster default.
+  ipFamilies: []
+
+matterService:
+  # -- Publish the Matter TCP/UDP port range through a Service. Intended for advanced pod-network deployments.
+  enabled: false
+  # -- Matter Service type.
+  type: LoadBalancer
+  # -- Service protocols generated for every reserved Matter port.
+  protocols:
+    - UDP
+    - TCP
+  # -- Preserve source addresses for LoadBalancer or NodePort traffic.
+  externalTrafficPolicy: Local
+  # -- Matter Service annotations.
+  annotations: {}
+  # -- Matter Service IP family policy. Empty uses the cluster default.
+  # @default -- omitted
+  ipFamilyPolicy: ""
+  # -- Ordered Matter Service IP families. Empty uses the cluster default.
+  ipFamilies: []
+
+persistence:
+  # -- Persist plugins, configuration, Matter fabrics and certificates in one PVC mounted at /data.
+  enabled: true
+  # -- Existing PVC to mount instead of creating one.
+  existingClaim: ""
+  # -- Storage class. Empty uses the cluster default.
+  storageClass: ""
+  # -- PVC access modes.
+  accessModes:
+    - ReadWriteOnce
+  # -- PVC requested size.
+  size: 2Gi
+  # -- Retain the chart-created PVC when the Helm release is uninstalled.
+  retain: true
+  # -- Additional PVC annotations, for example Velero or storage-provider metadata.
+  annotations: {}
+
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- ServiceAccount name override.
+  name: ""
+  # -- ServiceAccount annotations.
+  annotations: {}
+  # -- Mount the Kubernetes API token into the Matterbridge pod.
+  automountServiceAccountToken: false
+
+podSecurityContext:
+  # -- Run Matterbridge as the non-root node user included in the official image.
+  runAsNonRoot: true
+  # -- Matterbridge runtime UID.
+  runAsUser: 1000
+  # -- Matterbridge runtime GID.
+  runAsGroup: 1000
+  # -- Group applied to persistent volume contents.
+  fsGroup: 1000
+  # -- Avoid recursively changing ownership when the volume root already matches fsGroup.
+  fsGroupChangePolicy: OnRootMismatch
+  # -- Default seccomp profile.
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  # -- Prevent privilege escalation.
+  allowPrivilegeEscalation: false
+  # -- Keep the container image filesystem read-only; writable state lives under /data and /tmp.
+  readOnlyRootFilesystem: true
+  # -- Drop all Linux capabilities.
+  capabilities:
+    drop:
+      - ALL
+
+startupProbe:
+  # -- Enable the startup probe against the official health endpoint.
+  enabled: true
+  # -- Initial delay before startup checks.
+  initialDelaySeconds: 5
+  # -- Probe interval.
+  periodSeconds: 5
+  # -- Probe timeout.
+  timeoutSeconds: 5
+  # -- Consecutive failures allowed during plugin restoration and first boot.
+  failureThreshold: 60
+  # -- Success threshold.
+  successThreshold: 1
+
+readinessProbe:
+  # -- Enable the readiness probe against the official health endpoint.
+  enabled: true
+  # -- Initial delay before readiness checks.
+  initialDelaySeconds: 0
+  # -- Probe interval.
+  periodSeconds: 10
+  # -- Probe timeout.
+  timeoutSeconds: 5
+  # -- Consecutive failures before the pod becomes unready.
+  failureThreshold: 3
+  # -- Success threshold.
+  successThreshold: 1
+
+livenessProbe:
+  # -- Enable the liveness probe against the official health endpoint.
+  enabled: true
+  # -- Initial delay after startup succeeds.
+  initialDelaySeconds: 0
+  # -- Probe interval aligned with the upstream Docker healthcheck.
+  periodSeconds: 60
+  # -- Probe timeout.
+  timeoutSeconds: 10
+  # -- Consecutive failures before restart.
+  failureThreshold: 5
+  # -- Success threshold.
+  successThreshold: 1
+
+ingress:
+  # -- Expose the Matterbridge frontend with Kubernetes Ingress. This does not expose Matter or mDNS.
+  enabled: false
+  # -- Ingress class name. Empty uses the cluster default.
+  ingressClassName: ""
+  # -- Ingress annotations.
+  annotations: {}
+  # -- Ingress host and path rules.
+  hosts: []
+    # - host: matterbridge.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  # -- Ingress TLS configuration.
+  tls: []
+
+gatewayAPI:
+  # -- Render Gateway API HTTPRoutes for the frontend. This does not expose Matter or mDNS.
+  enabled: false
+  # -- HTTPRoute definitions.
+  httpRoutes: []
+    # - name: ""
+    #   labels: {}
+    #   annotations: {}
+    #   parentRefs:
+    #     - name: shared-gateway
+    #       namespace: gateway-system
+    #       sectionName: https
+    #   hostnames:
+    #     - matterbridge.example.com
+    #   rules: []
+
+externalSecrets:
+  # -- Render ExternalSecret resources for TLS or plugin-specific Secrets.
+  enabled: false
+  # -- Default refresh interval for items that omit spec.refreshInterval.
+  refreshInterval: 1h
+  # -- Complete ExternalSecret definitions.
+  items: []
+
+networkPolicy:
+  # -- Render a NetworkPolicy. Must be used with network.hostNetwork=false.
+  enabled: false
+  # -- Allowed peers for frontend ingress. Empty permits all namespaces.
+  ingressFrom: []
+  egress:
+    # -- Enforce egress rules. Matterbridge plugins often require LAN, MQTT and cloud access.
+    enabled: false
+    # -- Permit DNS over UDP and TCP port 53.
+    allowDNS: true
+    # -- Additional destination peers applied as a to block.
+    extraTo: []
+    # -- Complete additional egress rules with to and ports support.
+    extraEgress: []
+
+# -- CPU and memory resources. Increase memory for large plugin/device fleets.
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+# -- Grace period for Matter storage, sessions and mDNS shutdown.
+terminationGracePeriodSeconds: 60
+
+# -- StatefulSet revision history limit.
+revisionHistoryLimit: 3
+
+# -- Pod annotations, including log collector or backup metadata.
+podAnnotations: {}
+
+# -- Additional pod labels. Selector labels cannot be overridden.
+podLabels: {}
+
+# -- Pod priority class name.
+priorityClassName: ""
+
+# -- Node selector. Production host-network deployments should target a node attached to the Matter LAN.
+nodeSelector: {}
+
+# -- Pod affinity and anti-affinity rules.
+affinity: {}
+
+# -- Pod tolerations.
+tolerations: []
+
+# -- Pod topology spread constraints.
+topologySpreadConstraints: []
+
+# -- Additional environment variables for Matterbridge.
+extraEnv: []
+
+# -- Additional environment sources, including Secrets created by externalSecrets.items.
+extraEnvFrom: []
+
+# -- Additional volumes for plugin-specific configuration or device access.
+extraVolumes: []
+
+# -- Additional volume mounts for the Matterbridge container.
+extraVolumeMounts: []
+
+# -- Additional init containers.
+extraInitContainers: []
+
+# -- Additional sidecar containers.
+extraContainers: []
+
+# -- Additional Kubernetes manifests rendered with the release.
+extraManifests: []


### PR DESCRIPTION
## Summary

- add the production-ready Matterbridge chart using the official pinned 3.10.7 image
- preserve plugins, Matter fabrics, certificates, and configuration on one retained PVC
- provide a Pod Security baseline-compatible default plus an explicit host-network LAN mode for mDNS, IPv6, and Matter commissioning
- add Ingress, Gateway API, dual-stack Services, External Secrets, NetworkPolicy, strict schema validation, examples, and 60 unit tests
- document singleton operation, secure frontend exposure, consistent backup, plugin credentials, and upgrade boundaries

## Type Of Change

- [x] New chart
- [ ] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] Resolves #1077
- [x] Labels `enhancement` and `type:feature` are applied

## Checklist

- [x] Branch created from updated `main`
- [x] PR targets `main`
- [x] Commit and PR title follow Conventional Commits
- [x] Initial chart metadata is stable `1.0.0`; `feat(matterbridge)!` preserves the intended first-release semantics
- [x] Root README chart catalog categories updated
- [x] `values.schema.json` covers the full values contract
- [x] Chart README, DESIGN, feature docs, examples, CI profiles, and NOTES are included

## Upstream Verification

- [x] `appVersion` matches stable Matterbridge 3.10.7 released 2026-08-28
- [x] `docker.io/luligu/matterbridge:3.10.7` exists for linux/amd64 and linux/arm64
- [x] Official release, Docker documentation, Compose file, health source, and product site were reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/542
- [x] Organization profile PR: https://github.com/helmforgedev/.github/pull/21
- [x] Catalog, navigation, complete configuration reference, official icon, and playground are synchronized

## Local Validation

- [x] `make validate-chart CHART=matterbridge` — FULLY VALIDATED (19 layers)
- [x] `helm unittest charts/matterbridge` — 60 tests passed
- [x] kubeconform strict with real CRD schemas — 0 invalid, 0 skipped
- [x] ESO fake-store runtime — SecretSynced/Ready=True and consumed by the pod
- [x] default and all eight CI runtime scenarios passed on k3d
- [x] host-network production profile passed with zero restarts and clean logs
- [x] Kubescape MITRE + NSA + SOC2 — 93.93939%
- [x] `make template-standards-check CHART=matterbridge` — zero warnings
- [x] `make preflight`
- [x] `make org-check` — 96 charts in full parity

Backup is an offline PVC snapshot/filesystem procedure because upstream has no stable live-backup API; an invented S3 CronJob would not guarantee Matter fabric consistency.

Resolves #1077

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Helm chart for deploying Matterbridge on Kubernetes.
  - Supports persistent storage, host or pod networking, Matter services, health checks, and hardened container security.
  - Added optional Ingress, Gateway API, External Secrets, NetworkPolicy, TLS, dual-stack networking, and extensibility settings.
  - Includes installation guidance, production examples, backup and restore instructions, networking documentation, and operational notes.
- **Tests**
  - Added comprehensive validation and rendering coverage for deployments, services, persistence, integrations, networking, and exposure options.
- **Documentation**
  - Added Matterbridge to the chart catalog under Home automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->