### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -52,10 +52,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.0.3
+    version: 2.1.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -62,6 +62,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/automatisch/Chart.yaml
+++ b/charts/automatisch/Chart.yaml
@@ -51,6 +51,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -48,10 +48,10 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.0.3
+    version: 2.1.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -53,6 +53,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/Countly/countly-server
 dependencies:
   - name: mongodb
-    version: 1.7.17
+    version: 1.7.18
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:

--- a/charts/docmost/Chart.yaml
+++ b/charts/docmost/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     repository: ""
     condition: crds.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     alias: redis
     condition: redis.enabled

--- a/charts/flowise/Chart.yaml
+++ b/charts/flowise/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/immich/Chart.yaml
+++ b/charts/immich/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     condition: postgresql.enabled
   - name: redis
     alias: valkey
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: valkey.internal.enabled

--- a/charts/kibana/Chart.yaml
+++ b/charts/kibana/Chart.yaml
@@ -54,6 +54,6 @@ annotations:
 dependencies:
   - name: elasticsearch
     alias: bundled-elasticsearch
-    version: 1.1.6
+    version: 1.1.7
     repository: oci://ghcr.io/helmforgedev/helm
     condition: bundledElasticsearch.enabled

--- a/charts/middleware/Chart.yaml
+++ b/charts/middleware/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled
 annotations:

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/opencut/Chart.yaml
+++ b/charts/opencut/Chart.yaml
@@ -59,6 +59,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/superset/Chart.yaml
+++ b/charts/superset/Chart.yaml
@@ -57,6 +57,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wallabag/Chart.yaml
+++ b/charts/wallabag/Chart.yaml
@@ -55,6 +55,6 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: postgresql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: redis.enabled

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mysql.enabled
   - name: redis
-    version: 2.0.0
+    version: 2.0.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: objectCache.redis.subchart.enabled
   - name: memcached


### PR DESCRIPTION
Automated fix from the helmforge-ops reporter.

### Applied changes
- appwrite: mariadb 2.0.3 -> 2.1.0
- appwrite: redis 2.0.0 -> 2.0.1
- authelia: redis 2.0.0 -> 2.0.1
- automatisch: redis 2.0.0 -> 2.0.1
- castopod: mariadb 2.0.3 -> 2.1.0
- castopod: redis 2.0.0 -> 2.0.1
- ckan: redis 2.0.0 -> 2.0.1
- countly: mongodb 1.7.17 -> 1.7.18
- docmost: redis 2.0.0 -> 2.0.1
- envoy-gateway: redis 2.0.0 -> 2.0.1
- flowise: redis 2.0.0 -> 2.0.1
- immich: redis 2.0.0 -> 2.0.1
- kibana: elasticsearch 1.1.6 -> 1.1.7
- middleware: redis 2.0.0 -> 2.0.1
- n8n: redis 2.0.0 -> 2.0.1
- open-webui: redis 2.0.0 -> 2.0.1
- opencut: redis 2.0.0 -> 2.0.1
- superset: redis 2.0.0 -> 2.0.1
- wallabag: redis 2.0.0 -> 2.0.1
- wordpress: redis 2.0.0 -> 2.0.1

---
_Review and merge manually. CI runs on this PR. Generated by helmforge-ops automation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated bundled service components across multiple deployment charts.
  - Redis dependencies were upgraded to version 2.0.1.
  - MariaDB dependencies were upgraded to version 2.1.0.
  - MongoDB was upgraded to version 1.7.18.
  - Elasticsearch was upgraded to version 1.1.7.
  - No functional or structural application changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->