### PR TITLE
feat(matomo): add imagepullsecrets to cronjob

### DIFF
--- a/charts/matomo/templates/cronjob-archiver.yaml
+++ b/charts/matomo/templates/cronjob-archiver.yaml
@@ -27,7 +27,7 @@ spec:
           automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.podSecurityContext }}
           securityContext:

--- a/charts/matomo/templates/cronjob-archiver.yaml
+++ b/charts/matomo/templates/cronjob-archiver.yaml
@@ -25,6 +25,10 @@ spec:
           restartPolicy: OnFailure
           serviceAccountName: {{ include "matomo.serviceAccountName" . }}
           automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
           {{- with .Values.podSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
## Summary

- Resolves #1102 

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO

## Notes

- 

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The archiver CronJob now supports configuring image pull secrets when provided in deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->