### PR TITLE
feat(mongodb): add configuration of securityContext in every Container.

### DIFF
--- a/charts/mongodb/DESIGN.md
+++ b/charts/mongodb/DESIGN.md
@@ -61,7 +61,16 @@ those are required.
 
 The chart defaults to authentication on, namespaced Secrets, explicit probes,
 and a MongoDB filesystem group (`fsGroup: 999`). It exposes no public ingress.
-Network isolation, TLS termination, storage encryption, and external credential
+To preserve compatibility with images and workloads that expect the upstream
+default root user, the chart ships with empty container-level `securityContext`
+and configurable `podSecurityContext`/`initContainerSecurityContext`. Operators
+with strict no-root policies can enable them via values: set `securityContext`
+and `podSecurityContext` to run the application containers as a non-root user
+(UID/GID `999`, the official image's `mongodb` user) with
+`allowPrivilegeEscalation: false`, and set `initContainerSecurityContext`
+(plus `auth.replicaSetKeySecretPermissions: 0440`) so the keyfile bootstrap
+container also runs non-root. The chart exposes no public ingress. Network
+isolation, TLS termination, storage encryption, and external credential
 rotation are cluster/operator responsibilities. External Secrets support is
 available for clusters that manage credentials through ESO.
 

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -55,7 +55,7 @@ Read before choosing an architecture:
 - **Built-in S3 backups** — scheduled `mongodump` archive upload for standalone, replica set, and sharded topologies
 - **Init scripts** — `.sh` and `.js` files via ConfigMap (`/docker-entrypoint-initdb.d/`)
 - **Custom mongod.conf** — mount via ConfigMap
-- **Security defaults** — `fsGroup: 999`, startup/liveness/readiness probes
+- **Security defaults** — `fsGroup: 999`, startup/liveness/readiness probes; optional strict non-root `securityContext`, `podSecurityContext`, and `initContainerSecurityContext` for clusters that require it
 - **Extra manifests** — inject arbitrary K8s resources with Helm templating
 
 ## Configuration
@@ -160,6 +160,7 @@ deciding constraint, and review the
 | `auth.existingSecret` | Existing secret with credentials | `""` |
 | `auth.replicaSetKey` | KeyFile content (auto-generated if empty) | `""` |
 | `auth.existingKeySecret` | Existing secret with keyFile | `""` |
+| `auth.replicaSetKeySecretPermissions` | KeyFile secret volume permission bits (`0440` for non-root init) | `0400` |
 
 ### Replica Set
 
@@ -249,7 +250,9 @@ deciding constraint, and review the
 | `extraVolumes` | Extra volumes | `[]` |
 | `extraVolumeMounts` | Extra volume mounts | `[]` |
 | `extraManifests` | Arbitrary K8s manifests | `[]` |
-| `podSecurityContext.fsGroup` | Pod filesystem group | `999` |
+| `podSecurityContext` | Pod-level security context (`fsGroup: 999` by default) | `{"fsGroup":999}` |
+| `securityContext` | Container-level security context (empty for compatibility) | `{}` |
+| `initContainerSecurityContext` | Security context for init containers (empty for compatibility) | `{}` |
 | `nodeSelector` | Node selector | `{}` |
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity rules | `{}` |

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -55,7 +55,9 @@ Read before choosing an architecture:
 - **Built-in S3 backups** — scheduled `mongodump` archive upload for standalone, replica set, and sharded topologies
 - **Init scripts** — `.sh` and `.js` files via ConfigMap (`/docker-entrypoint-initdb.d/`)
 - **Custom mongod.conf** — mount via ConfigMap
-- **Security defaults** — `fsGroup: 999`, startup/liveness/readiness probes; optional strict non-root `securityContext`, `podSecurityContext`, and `initContainerSecurityContext` for clusters that require it
+- **Security defaults** — `fsGroup: 999`, startup/liveness/readiness probes; optional strict
+  non-root `securityContext`, `podSecurityContext`, and keyfile init-container
+  `initContainerSecurityContext` for clusters that require it
 - **Extra manifests** — inject arbitrary K8s resources with Helm templating
 
 ## Configuration
@@ -252,7 +254,7 @@ deciding constraint, and review the
 | `extraManifests` | Arbitrary K8s manifests | `[]` |
 | `podSecurityContext` | Pod-level security context (`fsGroup: 999` by default) | `{"fsGroup":999}` |
 | `securityContext` | Container-level security context (empty for compatibility) | `{}` |
-| `initContainerSecurityContext` | Security context for init containers (root with all capabilities except CHOWN dropped, privilege escalation disabled) | `{"runAsNonRoot":false,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"],"add":["CHOWN"]}}` |
+| `initContainerSecurityContext` | Init container security context (root, CHOWN only) | `{"runAsNonRoot":false,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"],"add":["CHOWN"]}}` |
 | `nodeSelector` | Node selector | `{}` |
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity rules | `{}` |

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -252,7 +252,7 @@ deciding constraint, and review the
 | `extraManifests` | Arbitrary K8s manifests | `[]` |
 | `podSecurityContext` | Pod-level security context (`fsGroup: 999` by default) | `{"fsGroup":999}` |
 | `securityContext` | Container-level security context (empty for compatibility) | `{}` |
-| `initContainerSecurityContext` | Security context for init containers (empty for compatibility) | `{}` |
+| `initContainerSecurityContext` | Security context for init containers (root with all capabilities except CHOWN dropped, privilege escalation disabled) | `{"runAsNonRoot":false,"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"],"add":["CHOWN"]}}` |
 | `nodeSelector` | Node selector | `{}` |
 | `tolerations` | Tolerations | `[]` |
 | `affinity` | Affinity rules | `{}` |

--- a/charts/mongodb/templates/_helpers.tpl
+++ b/charts/mongodb/templates/_helpers.tpl
@@ -321,11 +321,16 @@ spec:
         - bash
         - -c
         - |
+          set -e
           cp /etc/mongodb/keyfile-readonly/replica-set-key /etc/mongodb/keyfile/replica-set-key
           chmod 400 /etc/mongodb/keyfile/replica-set-key
-          chown 999:999 /etc/mongodb/keyfile/replica-set-key
+          if [ "$(id -u)" = "0" ]; then
+            chown 999:999 /etc/mongodb/keyfile/replica-set-key
+          fi
+      {{- with .root.Values.initContainerSecurityContext }}
       securityContext:
-        runAsUser: 0
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumeMounts:
         - name: keyfile-readonly
           mountPath: /etc/mongodb/keyfile-readonly
@@ -444,6 +449,10 @@ spec:
       resources:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .root.Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
   volumes:
     {{- if .root.Values.config }}
@@ -460,7 +469,7 @@ spec:
     - name: keyfile-readonly
       secret:
         secretName: {{ include "mongodb.keySecretName" .root }}
-        defaultMode: 0400
+        defaultMode: {{ .root.Values.auth.replicaSetKeySecretPermissions }}
     - name: keyfile
       emptyDir: {}
     {{- end }}

--- a/charts/mongodb/templates/arbiter-statefulset.yaml
+++ b/charts/mongodb/templates/arbiter-statefulset.yaml
@@ -72,18 +72,16 @@ spec:
             - bash
             - -c
             - |
+              set -e
               cp /etc/mongodb/keyfile-readonly/replica-set-key /etc/mongodb/keyfile/replica-set-key
               chmod 400 /etc/mongodb/keyfile/replica-set-key
-              chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              if [ "$(id -u)" = "0" ]; then
+                chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              fi
+          {{- with .Values.initContainerSecurityContext }}
           securityContext:
-            runAsUser: 0
-            runAsNonRoot: false
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-              add:
-                - CHOWN
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keyfile-readonly
               mountPath: /etc/mongodb/keyfile-readonly
@@ -136,7 +134,7 @@ spec:
         - name: keyfile-readonly
           secret:
             secretName: {{ include "mongodb.keySecretName" . }}
-            defaultMode: 0400
+            defaultMode: {{ .Values.auth.replicaSetKeySecretPermissions }}
         - name: keyfile
           emptyDir: {}
         {{- end }}

--- a/charts/mongodb/templates/backup-cronjob.yaml
+++ b/charts/mongodb/templates/backup-cronjob.yaml
@@ -69,7 +69,7 @@ spec:
                       name: {{ include "mongodb.secretName" . }}
                       key: mongodb-root-password
                 {{- end }}
-              {{- with .Values.securityContext }}
+              {{- with .Values.initContainerSecurityContext }}
               securityContext:
                 {{- toYaml . | nindent 16 }}
               {{- end }}

--- a/charts/mongodb/templates/backup-cronjob.yaml
+++ b/charts/mongodb/templates/backup-cronjob.yaml
@@ -27,6 +27,10 @@ spec:
           imagePullSecrets:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
@@ -65,6 +69,10 @@ spec:
                       name: {{ include "mongodb.secretName" . }}
                       key: mongodb-root-password
                 {{- end }}
+              {{- with .Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
               volumeMounts:
@@ -96,6 +104,10 @@ spec:
                     secretKeyRef:
                       name: {{ include "mongodb.backupSecretName" . }}
                       key: {{ .Values.backup.s3.existingSecretSecretKeyKey }}
+              {{- with .Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               resources:
                 {{- toYaml .Values.backup.resources | nindent 16 }}
               volumeMounts:

--- a/charts/mongodb/templates/job-rs-init.yaml
+++ b/charts/mongodb/templates/job-rs-init.yaml
@@ -25,10 +25,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: rs-init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- if .Values.auth.enabled }}
             - name: MONGO_USER

--- a/charts/mongodb/templates/job-sharded-init.yaml
+++ b/charts/mongodb/templates/job-sharded-init.yaml
@@ -30,6 +30,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if include "mongodb.needsKeyFile" . }}
       initContainers:
         - name: init-keyfile
@@ -38,11 +42,16 @@ spec:
             - bash
             - -c
             - |
+              set -e
               cp /etc/mongodb/keyfile-readonly/replica-set-key /etc/mongodb/keyfile/replica-set-key
               chmod 400 /etc/mongodb/keyfile/replica-set-key
-              chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              if [ "$(id -u)" = "0" ]; then
+                chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              fi
+          {{- with .Values.initContainerSecurityContext }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keyfile-readonly
               mountPath: /etc/mongodb/keyfile-readonly
@@ -67,6 +76,10 @@ spec:
                   name: {{ include "mongodb.secretName" . }}
                   key: mongodb-root-password
             {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if include "mongodb.needsKeyFile" . }}
           volumeMounts:
             - name: keyfile
@@ -168,7 +181,7 @@ spec:
         - name: keyfile-readonly
           secret:
             secretName: {{ include "mongodb.keySecretName" . }}
-            defaultMode: 0400
+            defaultMode: {{ .Values.auth.replicaSetKeySecretPermissions }}
         - name: keyfile
           emptyDir: {}
         {{- end }}

--- a/charts/mongodb/templates/sharded-configsvr.yaml
+++ b/charts/mongodb/templates/sharded-configsvr.yaml
@@ -39,11 +39,16 @@ spec:
             - bash
             - -c
             - |
+              set -e
               cp /etc/mongodb/keyfile-readonly/replica-set-key /etc/mongodb/keyfile/replica-set-key
               chmod 400 /etc/mongodb/keyfile/replica-set-key
-              chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              if [ "$(id -u)" = "0" ]; then
+                chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              fi
+          {{- with .Values.initContainerSecurityContext }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keyfile-readonly
               mountPath: /etc/mongodb/keyfile-readonly
@@ -86,6 +91,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data/configdb
@@ -99,7 +108,7 @@ spec:
         - name: keyfile-readonly
           secret:
             secretName: {{ include "mongodb.keySecretName" . }}
-            defaultMode: 0400
+            defaultMode: {{ .Values.auth.replicaSetKeySecretPermissions }}
         - name: keyfile
           emptyDir: {}
         {{- end }}

--- a/charts/mongodb/templates/sharded-mongos.yaml
+++ b/charts/mongodb/templates/sharded-mongos.yaml
@@ -36,11 +36,16 @@ spec:
             - bash
             - -c
             - |
+              set -e
               cp /etc/mongodb/keyfile-readonly/replica-set-key /etc/mongodb/keyfile/replica-set-key
               chmod 400 /etc/mongodb/keyfile/replica-set-key
-              chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              if [ "$(id -u)" = "0" ]; then
+                chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              fi
+          {{- with .Values.initContainerSecurityContext }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keyfile-readonly
               mountPath: /etc/mongodb/keyfile-readonly
@@ -103,6 +108,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if include "mongodb.needsKeyFile" . }}
             - name: keyfile
@@ -114,7 +123,7 @@ spec:
         - name: keyfile-readonly
           secret:
             secretName: {{ include "mongodb.keySecretName" . }}
-            defaultMode: 0400
+            defaultMode: {{ .Values.auth.replicaSetKeySecretPermissions }}
         - name: keyfile
           emptyDir: {}
         {{- end }}

--- a/charts/mongodb/templates/sharded-shard.yaml
+++ b/charts/mongodb/templates/sharded-shard.yaml
@@ -44,11 +44,16 @@ spec:
             - bash
             - -c
             - |
+              set -e
               cp /etc/mongodb/keyfile-readonly/replica-set-key /etc/mongodb/keyfile/replica-set-key
               chmod 400 /etc/mongodb/keyfile/replica-set-key
-              chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              if [ "$(id -u)" = "0" ]; then
+                chown 999:999 /etc/mongodb/keyfile/replica-set-key
+              fi
+          {{- with $root.Values.initContainerSecurityContext }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: keyfile-readonly
               mountPath: /etc/mongodb/keyfile-readonly
@@ -91,6 +96,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $root.Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data/db
@@ -104,7 +113,7 @@ spec:
         - name: keyfile-readonly
           secret:
             secretName: {{ include "mongodb.keySecretName" $root }}
-            defaultMode: 0400
+            defaultMode: {{ $root.Values.auth.replicaSetKeySecretPermissions }}
         - name: keyfile
           emptyDir: {}
         {{- end }}

--- a/charts/mongodb/tests/backup_test.yaml
+++ b/charts/mongodb/tests/backup_test.yaml
@@ -64,3 +64,27 @@ tests:
           content:
             name: DB_HOST
             value: test-mongodb-mongos
+
+  - it: should apply initContainerSecurityContext to the backup init container
+    set:
+      backup.enabled: true
+      backup.s3.endpoint: https://minio.example.com
+      backup.s3.bucket: backups
+      backup.s3.accessKey: access
+      backup.s3.secretKey: secret
+      initContainerSecurityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+    template: templates/backup-cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 999
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -113,13 +113,20 @@ tests:
           path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
           value: true
 
-  - it: should leave the keyfile init container root by default for compatibility
+  - it: should harden the keyfile init container by default (root with CHOWN only)
     template: statefulset.yaml
     set:
       architecture: replicaset
     asserts:
-      - isNull:
-          path: spec.template.spec.initContainers[0].securityContext
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.add[0]
+          value: CHOWN
 
   - it: should use the configured keyfile secret permissions by default
     template: statefulset.yaml

--- a/charts/mongodb/tests/statefulset_test.yaml
+++ b/charts/mongodb/tests/statefulset_test.yaml
@@ -60,6 +60,76 @@ tests:
           path: spec.template.spec.securityContext.fsGroup
           value: 999
 
+  - it: should not set a container security context by default for compatibility
+    template: statefulset.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should allow configuring a non-root pod and container security context
+    template: statefulset.yaml
+    set:
+      podSecurityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        fsGroup: 999
+      securityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 999
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 999
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should apply a configurable security context to the keyfile init container
+    template: statefulset.yaml
+    set:
+      architecture: replicaset
+      initContainerSecurityContext:
+        runAsUser: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 999
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should leave the keyfile init container root by default for compatibility
+    template: statefulset.yaml
+    set:
+      architecture: replicaset
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers[0].securityContext
+
+  - it: should use the configured keyfile secret permissions by default
+    template: statefulset.yaml
+    set:
+      architecture: replicaset
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.defaultMode
+          value: 0400
+
   - it: should have probes
     template: statefulset.yaml
     asserts:

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -351,7 +351,7 @@
     },
     "initContainerSecurityContext": {
       "type": "object",
-      "description": "Security context applied to init containers (e.g. the replica-set keyfile bootstrap). Empty by default for compatibility; set a non-root context to satisfy strict policies."
+      "description": "Security context applied to init containers (e.g. the replica-set keyfile bootstrap). Defaults to root with all capabilities except CHOWN dropped and privilege escalation disabled; override with a non-root context to satisfy stricter policies."
     },
     "service": {
       "type": "object",

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -92,6 +92,11 @@
           "description": "Existing secret containing the keyFile (key: mongodb-replica-set-key)",
           "default": ""
         },
+        "replicaSetKeySecretPermissions": {
+          "type": "integer",
+          "description": "Filesystem permission bits for the replica-set keyFile secret volume. Raise to a group-readable mode (e.g. 0440) when the keyfile init container runs as a non-root user.",
+          "default": 400
+        },
         "users": {
           "type": "array",
           "description": "Additional users to create on first startup. Each entry creates a user with readWrite access to its database.",
@@ -338,11 +343,15 @@
     },
     "podSecurityContext": {
       "type": "object",
-      "description": "Pod-level security context"
+      "description": "Pod-level security context. Defaults to fsGroup 999. Set runAsUser/runAsNonRoot etc. to run workloads as a non-root user."
     },
     "securityContext": {
       "type": "object",
-      "description": "Container-level security context"
+      "description": "Container-level security context. Empty by default for compatibility; set runAsUser/runAsNonRoot etc. to run workloads as a non-root user."
+    },
+    "initContainerSecurityContext": {
+      "type": "object",
+      "description": "Security context applied to init containers (e.g. the replica-set keyfile bootstrap). Empty by default for compatibility; set a non-root context to satisfy strict policies."
     },
     "service": {
       "type": "object",

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -196,8 +196,11 @@ podSecurityContext:
 securityContext: {}
 
 # -- Security context applied to init containers (such as the replica-set
-# keyfile bootstrap container). Defaults to the image default user (root).
-# For strict non-root deployments set runAsNonRoot and a non-root uid/gid, e.g.:
+# keyfile bootstrap container). The default runs as the image default user
+# (root) but drops all capabilities except CHOWN and disables privilege
+# escalation, which is the minimum needed for the keyfile bootstrap step.
+# For strict non-root deployments override with runAsNonRoot and a non-root
+# uid/gid, e.g.:
 #   initContainerSecurityContext:
 #     runAsUser: 999
 #     runAsGroup: 999
@@ -206,7 +209,15 @@ securityContext: {}
 # NOTE: when running the keyfile init container as a non-root user, set
 # auth.replicaSetKeySecretPermissions to a group-readable mode (e.g. 0440) so
 # the non-root user (a member of fsGroup) can read the keyfile secret.
-initContainerSecurityContext: {}
+initContainerSecurityContext:
+  runAsNonRoot: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - CHOWN
+
 
 # =============================================================================
 # Service

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -45,6 +45,10 @@ auth:
   replicaSetKey: ""
   # -- Existing secret containing the keyFile (key: mongodb-replica-set-key)
   existingKeySecret: ""
+  # -- Filesystem permission bits for the replica-set keyFile secret volume.
+  # Raise to a group-readable mode (e.g. 0440) when the keyfile init container
+  # runs as a non-root user (see initContainerSecurityContext).
+  replicaSetKeySecretPermissions: 0400
   # -- Additional users to create on first startup.
   # Each entry creates a user with readWrite access to its database.
   # The database is also created automatically.
@@ -190,10 +194,19 @@ podSecurityContext:
   fsGroup: 999
 
 securityContext: {}
-  # runAsUser: 999
-  # runAsNonRoot: true
-  # allowPrivilegeEscalation: false
-  # readOnlyRootFilesystem: false
+
+# -- Security context applied to init containers (such as the replica-set
+# keyfile bootstrap container). Defaults to the image default user (root).
+# For strict non-root deployments set runAsNonRoot and a non-root uid/gid, e.g.:
+#   initContainerSecurityContext:
+#     runAsUser: 999
+#     runAsGroup: 999
+#     runAsNonRoot: true
+#     allowPrivilegeEscalation: false
+# NOTE: when running the keyfile init container as a non-root user, set
+# auth.replicaSetKeySecretPermissions to a group-readable mode (e.g. 0440) so
+# the non-root user (a member of fsGroup) can read the keyfile secret.
+initContainerSecurityContext: {}
 
 # =============================================================================
 # Service


### PR DESCRIPTION
## Summary

Resolves #1105 

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [ ] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [ ] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [ ] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [ ] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [ ] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [ ] `helm lint charts/<chart-name> --strict` passed
- [ ] `helm unittest charts/<chart-name>` passed
- [ ] All relevant `ci/*.yaml` scenarios rendered successfully
- [ ] I validated this change on a local `k3d` cluster when required
- [ ] I validated the default install
- [ ] I validated at least one main non-default scenario for this change
- [ ] If backup behavior changed, I validated the flow against local MinIO

## Notes

-

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pod, container, and init-container security contexts across MongoDB chart workloads.
  * Added support for non-root MongoDB and init-container execution.
  * Added configurable replica-set keyfile secret permissions, with a default of `0400`.

* **Documentation**
  * Documented security-context options, compatibility considerations, and recommended non-root settings.

* **Tests**
  * Added coverage for default and configurable security contexts and keyfile permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->