### PR TITLE
chore(certimate): bump app to 0.4.32

### DIFF
--- a/charts/certimate/Chart.yaml
+++ b/charts/certimate/Chart.yaml
@@ -4,7 +4,7 @@ name: certimate
 description: Self-hosted SSL certificate automation platform for issuing, deploying, renewing, and monitoring certificates
 type: application
 version: 1.0.6
-appVersion: "0.4.31"
+appVersion: "0.4.32"
 home: https://helmforge.dev/docs/charts/certimate
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/certimate
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/certimate.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump certimate to 0.4.31 (#998)"
+      description: "bump certimate to 0.4.32 (#1081)"
   artifacthub.io/category: security
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/certimate/README.md
+++ b/charts/certimate/README.md
@@ -2,7 +2,7 @@
 
 Deploy [Certimate](https://github.com/certimate-go/certimate), a self-hosted certificate automation platform for ACME issuance, deployment, renewal, and monitoring.
 
-This chart packages the official `certimate/certimate:v0.4.31` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
+This chart packages the official `certimate/certimate:v0.4.32` image and follows the upstream container contract: HTTP on port `8090` and durable PocketBase data under `/app/pb_data`.
 
 ## Production Defaults
 
@@ -73,10 +73,10 @@ Back up the PersistentVolumeClaim before upgrades. Certimate stores its
 PocketBase database, uploaded certificate material, ACME account state, workflow
 definitions, and provider credentials under `/app/pb_data`.
 
-Certimate 0.4.31 adds the Huawei iBMC deployment provider and fixes Kubernetes
-Secret certificate deployment against API resources that were previously not
-discovered correctly. It does not change the container port, storage path, or
-chart configuration contract.
+Certimate 0.4.32 trims whitespace from form input except secret fields and fixes
+Nginx Proxy Manager host matching and timezone-aware certificate validity
+checks. It does not change the container port, storage path, or chart
+configuration contract.
 
 Certimate's upstream deployment uses PocketBase-local state. This chart does not
 ship PostgreSQL, MySQL, or Redis subcharts because the product does not expose an
@@ -92,7 +92,7 @@ ACME endpoints required by your workflows.
 Local security scan:
 
 ```text
-Image: certimate/certimate:v0.4.31
+Image: certimate/certimate:v0.4.32
 Scanner: Kubescape v4.0.9, frameworks MITRE, NSA, SOC2
 Result: 93.93939 compliance score
 ```

--- a/charts/certimate/tests/templates_test.yaml
+++ b/charts/certimate/tests/templates_test.yaml
@@ -13,7 +13,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: certimate/certimate:v0.4.31
+          value: certimate/certimate:v0.4.32
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/certimate/values.schema.json
+++ b/charts/certimate/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "certimate/certimate" },
-        "tag": { "type": "string", "default": "v0.4.31", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "v0.4.32", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/certimate/values.yaml
+++ b/charts/certimate/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Certimate container image repository.
   repository: certimate/certimate
   # -- Pinned Certimate image tag. Floating tags such as latest are not used by default.
-  tag: "v0.4.31"
+  tag: "v0.4.32"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official upstream image from 0.4.31 to 0.4.32
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Keep the chart contract unchanged while refreshing release and security documentation.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=certimate passed all 18 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Certimate Helm chart to release version 0.4.32.
  * Included the latest container image and release information.
* **Bug Fixes**
  * Form inputs now trim whitespace, excluding secret fields.
  * Improved Nginx Proxy Manager host matching.
  * Added timezone-aware certificate validity checks.
* **Tests**
  * Updated deployment image validation to expect version 0.4.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->