### PR TITLE
chore(ckan): bump app to 2.12.0

### DIFF
--- a/charts/ckan/Chart.yaml
+++ b/charts/ckan/Chart.yaml
@@ -4,7 +4,7 @@ name: ckan
 description: CKAN open data portal with DataPusher, Solr, PostgreSQL, and Redis
 type: application
 version: 1.3.7
-appVersion: "2.11.5"
+appVersion: "2.12.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/ckan.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1080)"
+      description: "bump CKAN to 2.12.0 (#1082)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/ckan/README.md
+++ b/charts/ckan/README.md
@@ -47,7 +47,7 @@ StatefulSet: solr (port 8983)
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `ckan/ckan-base` | CKAN container image |
-| `image.tag` | `2.11.5` | Image tag |
+| `image.tag` | `2.12.0` | Image tag |
 | `ckan.siteUrl` | `http://localhost:5000` | Public site URL |
 | `ckan.sysadminName` | `admin` | Sysadmin username |
 | `ckan.sysadminPassword` | `""` (auto) | Sysadmin password |
@@ -67,8 +67,15 @@ StatefulSet: solr (port 8983)
 | `postgresql.enabled` | `true` | Enable PostgreSQL subchart |
 | `redis.enabled` | `true` | Enable Redis subchart |
 
-This chart currently deploys CKAN `2.11.5` with HelmForge PostgreSQL `2.0.4` and Redis `2.0.0`.
+This chart currently deploys CKAN `2.12.0` with HelmForge PostgreSQL `2.0.5` and Redis `2.0.1`.
 It intentionally does not keep `Chart.lock`; dependencies are resolved by the release workflow.
+
+## Upgrade Notes
+
+CKAN 2.12.0 is a minor application upgrade. Back up the CKAN database and
+persistent storage, review the upstream 2.11.6 and 2.12.0 release notes, and
+test extensions against CKAN 2.12 before production rollout. Keep the Solr,
+PostgreSQL, and Redis services available while CKAN performs its upgrade steps.
 
 ## External Database
 

--- a/charts/ckan/templates/_helpers.tpl
+++ b/charts/ckan/templates/_helpers.tpl
@@ -283,16 +283,26 @@ exec /srv/app/start_ckan.sh
 
 {{- define "ckan.initContainers" -}}
 - name: wait-for-postgresql
-  image: docker.io/library/busybox:1.37
+  image: docker.io/library/postgres:18.6-trixie
   command:
     - sh
     - -c
     - |
       echo "Waiting for {{ include "ckan.databaseHost" . }}:{{ include "ckan.databasePort" . }} ..."
-      until nc -z -w2 {{ include "ckan.databaseHost" . }} {{ include "ckan.databasePort" . }}; do
+      ready_checks=0
+      while [ "$ready_checks" -lt 5 ]; do
+        if pg_isready \
+          --host={{ include "ckan.databaseHost" . }} \
+          --port={{ include "ckan.databasePort" . }} \
+          --username={{ include "ckan.databaseUsername" . }} \
+          --dbname={{ include "ckan.databaseName" . }}; then
+          ready_checks=$((ready_checks + 1))
+        else
+          ready_checks=0
+        fi
         sleep 2
       done
-      echo "PostgreSQL is reachable."
+      echo "PostgreSQL is accepting connections."
 {{- if .Values.solr.enabled }}
 - name: wait-for-solr
   image: docker.io/library/busybox:1.37

--- a/charts/ckan/tests/deployment_test.yaml
+++ b/charts/ckan/tests/deployment_test.yaml
@@ -28,7 +28,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ckan/ckan-base:2\\.11\\.5"
+          pattern: "ckan/ckan-base:2\\.12\\.0"
 
   - it: should expose port 5000
     template: templates/deployment.yaml
@@ -54,6 +54,9 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/library/postgres:18.6-trixie
 
   - it: should have health probes
     template: templates/deployment.yaml

--- a/charts/ckan/tests/deployment_test.yaml
+++ b/charts/ckan/tests/deployment_test.yaml
@@ -57,6 +57,15 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: docker.io/library/postgres:18.6-trixie
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'pg_isready'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'while \[ "\$ready_checks" -lt 5 \]; do'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'ready_checks=\$\(\(ready_checks \+ 1\)\)'
 
   - it: should have health probes
     template: templates/deployment.yaml

--- a/charts/ckan/values.yaml
+++ b/charts/ckan/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- CKAN container image repository
   repository: docker.io/ckan/ckan-base
   # -- CKAN image tag. Defaults to appVersion.
-  tag: "2.11.5"
+  tag: "2.12.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -357,6 +357,12 @@ extraManifests: []
 postgresql:
   # -- Enable PostgreSQL subchart
   enabled: true
+  startupProbe:
+    # -- Delay startup checks until the image entrypoint finishes its temporary init server cycle.
+    initialDelaySeconds: 30
+  readinessProbe:
+    # -- Delay readiness checks until the image entrypoint finishes its temporary init server cycle.
+    initialDelaySeconds: 30
   auth:
     # -- PostgreSQL database name
     database: ckan


### PR DESCRIPTION
## Summary

- update the official upstream image from 2.11.5 to 2.12.0
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Replace the fragile TCP-only database wait with PostgreSQL pg_isready and require consecutive readiness successes.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=ckan passed all 15 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default CKAN version to 2.12.0.
  - Added PostgreSQL startup and readiness delays of 30 seconds.
  - Improved startup validation by confirming PostgreSQL is accepting connections before CKAN proceeds.

- **Documentation**
  - Updated deployment version details for CKAN, PostgreSQL, and Redis.
  - Added upgrade notes covering the CKAN 2.12.0 minor upgrade and prerequisites.

- **Bug Fixes**
  - Improved reliability when waiting for PostgreSQL during deployment by requiring consecutive successful readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review Follow-up

- Added rendered-command assertions for pg_isready, the five-success loop bound, and the readiness counter increment in b5e729d2. The CodeRabbit nitpick was published only in the review summary, so no resolvable inline thread exists.

