### PR TITLE
chore(dolibarr): bump app to 24.0.0

### DIFF
--- a/charts/dolibarr/Chart.yaml
+++ b/charts/dolibarr/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: dolibarr
 type: application
 version: 1.2.17
-appVersion: "23.0.3"
+appVersion: "24.0.0"
 kubeVersion: ">=1.26.0-0"
 description: A Helm chart for deploying Dolibarr ERP/CRM on Kubernetes with MySQL support
 icon: https://helmforge.dev/icons/charts/dolibarr.png
@@ -25,7 +25,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "refresh upstream images and dependencies (#978)"
+      description: "bump Dolibarr to 24.0.0 (#1085)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/dolibarr/README.md
+++ b/charts/dolibarr/README.md
@@ -116,6 +116,19 @@ database:
 
 ## Parameters
 
+## Upgrade Notes
+
+Dolibarr 24.0.0 is a major application upgrade with database schema changes
+and stricter security defaults. Back up both the database and the documents and
+custom PVCs, review removed or renamed modules, hooks, configuration variables,
+and links, then test the upgrade in staging before reusing production storage.
+The release enables stricter CSRF handling, disables the login API unless
+`API_ENABLE_LOGIN_API` is configured, and restricts unsecured SELECT clauses in
+extrafield filters by default. Review integrations that depend on those paths.
+
+[Review the official Dolibarr 24.0.0 release notes](https://github.com/Dolibarr/dolibarr/releases/tag/24.0.0)
+before production rollout.
+
 ### Application
 
 | Key | Default | Description |

--- a/charts/dolibarr/tests/deployment_test.yaml
+++ b/charts/dolibarr/tests/deployment_test.yaml
@@ -24,7 +24,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/dolibarr/dolibarr:23.0.3
+          value: docker.io/dolibarr/dolibarr:24.0.0
 
   - it: should set database env vars for the MySQL subchart
     asserts:

--- a/charts/dolibarr/values.yaml
+++ b/charts/dolibarr/values.yaml
@@ -13,7 +13,7 @@ commonLabels: {}
 
 image:
   repository: docker.io/dolibarr/dolibarr
-  tag: "23.0.3"
+  tag: "24.0.0"
   pullPolicy: IfNotPresent
   # Keep tag empty to default to Chart.appVersion.
 


### PR DESCRIPTION
## Summary

- update the official upstream image from 23.0.3 to 24.0.0
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Validate the major application update against every chart runtime scenario.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=dolibarr passed all 18 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1085