### PR TITLE
chore(envoy-gateway): bump app to 1.9.1

### DIFF
--- a/charts/envoy-gateway/Chart.yaml
+++ b/charts/envoy-gateway/Chart.yaml
@@ -4,7 +4,7 @@ name: envoy-gateway
 description: Production-ready Envoy Gateway operator with Gateway API support, cert generation, and advanced traffic policies
 type: application
 version: 2.0.1
-appVersion: "v1.9.0"
+appVersion: "v1.9.1"
 kubeVersion: ">=1.33.0-0 <1.37.0-0"
 home: https://helmforge.dev/docs/charts/envoy-gateway
 sources:
@@ -34,7 +34,7 @@ icon: https://helmforge.dev/icons/charts/envoy-gateway.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1080)"
+      description: "bump Envoy Gateway to v1.9.1 (#1086)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -1,7 +1,7 @@
 # Envoy Gateway
 
 A Helm chart for deploying [Envoy Gateway](https://gateway.envoyproxy.io/)
-v1.9.0 on Kubernetes 1.33 through 1.36. Envoy Gateway is a **Kubernetes
+v1.9.1 on Kubernetes 1.33 through 1.36. Envoy Gateway is a **Kubernetes
 operator** — it manages Envoy proxy pods automatically in response to Gateway
 API resources.
 
@@ -70,7 +70,7 @@ helm upgrade --install envoy-gateway \
 
 ## Quick Start
 
-Envoy Gateway v1.9.0 requires Gateway API v1.6.1 Experimental and supports
+Envoy Gateway v1.9.1 requires Gateway API v1.6.1 Experimental and supports
 Kubernetes 1.33 through 1.36. New installations use the standalone
 `envoy-gateway-crds` release first, wait for discovery, then install this chart
 with `crds.enabled=false`. This makes the first `helm diff` work with Kubernetes
@@ -223,7 +223,7 @@ highAvailability:
 |-----|---------|-------------|
 | `controller.replicaCount` | `1` | Number of controller replicas (overridden by profile) |
 | `controller.image.repository` | `docker.io/envoyproxy/gateway` | Controller image repository |
-| `controller.image.tag` | `v1.9.0` | Controller image tag |
+| `controller.image.tag` | `v1.9.1` | Controller image tag |
 | `controller.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `controller.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `controller.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -241,7 +241,7 @@ highAvailability:
 |-----|---------|-------------|
 | `certgen.enabled` | `true` | Run certgen pre-install/pre-upgrade job for controller TLS certs |
 | `certgen.image.repository` | `docker.io/envoyproxy/gateway` | Certgen image (same as controller) |
-| `certgen.image.tag` | `v1.9.0` | Certgen image tag |
+| `certgen.image.tag` | `v1.9.1` | Certgen image tag |
 | `certgen.resources.requests.cpu` | `10m` | CPU request |
 | `certgen.resources.requests.memory` | `64Mi` | Memory request |
 | `certgen.resources.limits.cpu` | `100m` | CPU limit |
@@ -260,7 +260,7 @@ highAvailability:
 | `proxy.image.tag` | `distroless-v1.39.0` | Proxy image tag |
 | `proxy.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `proxy.shutdownManager.image.repository` | `docker.io/envoyproxy/gateway` | Shutdown manager sidecar image repository |
-| `proxy.shutdownManager.image.tag` | `v1.9.0` | Shutdown manager sidecar image tag |
+| `proxy.shutdownManager.image.tag` | `v1.9.1` | Shutdown manager sidecar image tag |
 | `proxy.shutdownManager.image.pullPolicy` | `IfNotPresent` | Shutdown manager image pull policy |
 | `proxy.resources.requests.cpu` | `100m` | CPU request (overridden by profile) |
 | `proxy.resources.requests.memory` | `128Mi` | Memory request (overridden by profile) |
@@ -370,6 +370,7 @@ highAvailability:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `security.networkPolicies` | `false` | Enable rendering of NetworkPolicy resources |
+| `security.networkPolicy.apiServerCIDRs` | `["0.0.0.0/0","::/0"]` | Kubernetes API endpoint CIDRs; TCP 443/6443 only. Narrow when known. |
 | `security.networkPolicy.dns.namespace` | `kube-system` | Namespace containing cluster DNS pods allowed by NetworkPolicies |
 | `security.networkPolicy.dns.podLabels` | `{"k8s-app":"kube-dns"}` | Labels selecting cluster DNS pods allowed by NetworkPolicies |
 | `security.podSecurityStandards` | `true` | Enable PodSecurityStandards (restricted mode) |
@@ -537,10 +538,8 @@ are discoverable. A server-connected install, upgrade, or server-side diff also
 checks Gateway API bundle `v1.6.1`/`experimental` and Envoy Gateway bundle
 `v1.9.0` annotations.
 
-`docker.io/envoyproxy/gateway:v1.9.0` is the upstream minor update from
-`v1.8.3`. The automatically generated issue referenced `1.9.0`, but Docker Hub
-publishes the canonical Envoy Gateway image tag with the `v` prefix. This chart
-pins the managed Envoy proxy image to
+`docker.io/envoyproxy/gateway:v1.9.1` is the canonical upstream patch image for
+the v1.9 release line. This chart pins the managed Envoy proxy image to
 `docker.io/envoyproxy/envoy:distroless-v1.39.0`, aligned with the upstream v1.9
 compatibility matrix. The rate limit deployment uses the upstream v1.9.0
 default `docker.io/envoyproxy/ratelimit:17b1956c` and honors the
@@ -554,13 +553,13 @@ uses its `-redis-client` endpoint, and Redis authentication is injected into the
 managed rate-limit Deployment through `REDIS_AUTH` from either the bundled or
 external Secret.
 
-Envoy Gateway v1.9.0 requires Gateway API v1.6 CRDs and includes stricter CEL
-validation for client IP detection, API key extraction, and policy merge
-targets. Lua extensions are disabled by default and tracing client sampling now
-defaults to zero. EndpointSlice indexing is enabled by default and can increase
-controller memory use on large clusters. Review the
-[upstream v1.9.0 release notes](https://gateway.envoyproxy.io/news/releases/notes/v1.9.0/)
-before upgrading. The supported CRD set is Gateway API v1.6.1 Experimental.
+Envoy Gateway v1.9.1 fixes a tenant `SecurityContext` path that could replace
+the hardened default and escape Pod Security Admission expectations. It also
+contains control-plane availability, OIDC URL validation, and TCPRoute fixes.
+Review the
+[upstream v1.9.1 release notes](https://gateway.envoyproxy.io/news/releases/notes/v1.9.1/)
+before upgrading. The supported CRD set remains Gateway API v1.6.1 Experimental
+with the Envoy Gateway v1.9.0 CRD bundle annotations.
 Apply the standalone CRD bundle server-side before the controller upgrade,
 correct resources rejected by the new validations, and test existing
 Gateway, route, EnvoyProxy, `BackendTrafficPolicy`, `SecurityPolicy`,

--- a/charts/envoy-gateway/docs/certificates.md
+++ b/charts/envoy-gateway/docs/certificates.md
@@ -34,7 +34,7 @@ certgen:
   enabled: true          # Enable the certgen job (required for EG to function)
   image:
     repository: docker.io/envoyproxy/gateway
-    tag: v1.9.0
+    tag: v1.9.1
   resources:
     requests:
       cpu: 10m

--- a/charts/envoy-gateway/templates/networkpolicy.yaml
+++ b/charts/envoy-gateway/templates/networkpolicy.yaml
@@ -40,6 +40,10 @@ spec:
   egress:
   - to:
     - namespaceSelector: {}
+    {{- range .Values.security.networkPolicy.apiServerCIDRs }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{- end }}
     ports:
     - protocol: TCP
       port: 443

--- a/charts/envoy-gateway/tests/certgen_test.yaml
+++ b/charts/envoy-gateway/tests/certgen_test.yaml
@@ -79,7 +79,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.9.0
+          value: docker.io/envoyproxy/gateway:v1.9.1
         documentIndex: 3
 
   - it: should grant ClusterRole secrets permission

--- a/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
+++ b/charts/envoy-gateway/tests/envoyproxy_config_test.yaml
@@ -40,7 +40,7 @@ tests:
           value: shutdown-manager
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.9.0
+          value: docker.io/envoyproxy/gateway:v1.9.1
 
   - it: should configure DaemonSet mode when kind is DaemonSet
     set:
@@ -53,7 +53,7 @@ tests:
           path: spec.provider.kubernetes.envoyDeployment
       - equal:
           path: spec.provider.kubernetes.envoyDaemonSet.patch.value.spec.template.spec.containers[0].image
-          value: docker.io/envoyproxy/gateway:v1.9.0
+          value: docker.io/envoyproxy/gateway:v1.9.1
 
   - it: should set proxy service type
     set:

--- a/charts/envoy-gateway/tests/security_test.yaml
+++ b/charts/envoy-gateway/tests/security_test.yaml
@@ -40,6 +40,16 @@ tests:
         template: networkpolicy.yaml
         documentIndex: 0
       - equal:
+          path: spec.egress[0].to[1].ipBlock.cidr
+          value: 0.0.0.0/0
+        template: networkpolicy.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.egress[0].to[2].ipBlock.cidr
+          value: ::/0
+        template: networkpolicy.yaml
+        documentIndex: 0
+      - equal:
           path: spec.egress[1].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
           value: kube-system
         template: networkpolicy.yaml

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -111,7 +111,7 @@
             "tag": {
               "type": "string",
               "description": "Controller image tag",
-              "default": "v1.9.0"
+              "default": "v1.9.1"
             },
             "pullPolicy": {
               "type": "string",
@@ -262,7 +262,7 @@
                 "tag": {
                   "type": "string",
                   "description": "Shutdown manager sidecar image tag",
-                  "default": "v1.9.0"
+                  "default": "v1.9.1"
                 },
                 "pullPolicy": {
                   "type": "string",
@@ -687,6 +687,13 @@
           "type": "object",
           "description": "NetworkPolicy rule extensions used when security.networkPolicies is enabled",
           "properties": {
+            "apiServerCIDRs": {
+              "type": "array",
+              "description": "IPv4 and IPv6 CIDRs that may contain Kubernetes API endpoints; access is restricted to TCP ports 443 and 6443",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1,
+              "default": ["0.0.0.0/0", "::/0"]
+            },
             "dns": {
               "type": "object",
               "description": "Cluster DNS selector used by controller and rate-limit NetworkPolicies",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -35,7 +35,7 @@ controller:
     # -- Controller image pull policy
     pullPolicy: IfNotPresent
     # -- Controller image tag (defaults to chart appVersion)
-    tag: "v1.9.0"
+    tag: "v1.9.1"
 
   # -- Resources for controller (overridden by profile)
   resources:
@@ -77,7 +77,7 @@ certgen:
     # -- Certgen image pull policy
     pullPolicy: IfNotPresent
     # -- Certgen image tag (defaults to chart appVersion)
-    tag: "v1.9.0"
+    tag: "v1.9.1"
 
 ## Proxy configuration via EnvoyProxy CRD (EG manages the actual proxy pods)
 proxy:
@@ -101,7 +101,7 @@ proxy:
       # -- Shutdown manager sidecar image repository
       repository: docker.io/envoyproxy/gateway
       # -- Shutdown manager sidecar image tag
-      tag: "v1.9.0"
+      tag: "v1.9.1"
       # -- Shutdown manager image pull policy
       pullPolicy: IfNotPresent
 
@@ -400,6 +400,10 @@ security:
   # -- Enable rendering of NetworkPolicy resources
   networkPolicies: false
   networkPolicy:
+    # -- CIDRs that may contain Kubernetes API endpoints; traffic is limited to TCP ports 443 and 6443. Narrow these portable IPv4/IPv6 defaults when the API endpoint CIDRs are known.
+    apiServerCIDRs:
+      - 0.0.0.0/0
+      - ::/0
     dns:
       # -- Namespace containing the cluster DNS pods allowed by NetworkPolicies
       namespace: kube-system


### PR DESCRIPTION
## Summary

- update the official upstream image from 1.9.0 to 1.9.1
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Add explicit API-server egress to the default NetworkPolicy and validate Kubernetes 1.36 plus the External Secrets path.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=envoy-gateway passed all 21 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1086