### PR TITLE
chore(gitea): bump app to 1.27.3

### DIFF
--- a/charts/gitea/Chart.yaml
+++ b/charts/gitea/Chart.yaml
@@ -4,7 +4,7 @@ name: gitea
 description: Gitea self-hosted Git service with SQLite, PostgreSQL, or MySQL, rootless image, SSH access, and S3 backup.
 type: application
 version: 1.1.19
-appVersion: "1.27.2"
+appVersion: "1.27.3"
 home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/gitea.png
 keywords:
@@ -23,7 +23,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Gitea to 1.27.3 (#1089)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/gitea/DESIGN.md
+++ b/charts/gitea/DESIGN.md
@@ -9,7 +9,7 @@ ClusterIP HTTP and SSH services, and restricted-compatible pod defaults.
 
 ## Goals
 
-- Run the official `docker.io/gitea/gitea:1.27.2-rootless` image without Bitnami
+- Run the official `docker.io/gitea/gitea:1.27.3-rootless` image without Bitnami
   or third-party runtime substitutions.
 - Keep the default install zero-config through SQLite while making PostgreSQL,
   MySQL, and external database modes explicit.

--- a/charts/gitea/README.md
+++ b/charts/gitea/README.md
@@ -4,8 +4,8 @@
 
 Helm chart for deploying [Gitea](https://gitea.io/) self-hosted Git service on Kubernetes using the official [`gitea/gitea`](https://hub.docker.com/r/gitea/gitea) rootless Docker image.
 
-- **Current application version** `1.27.2`
-- **Default image** `docker.io/gitea/gitea:1.27.2-rootless`
+- **Current application version** `1.27.3`
+- **Default image** `docker.io/gitea/gitea:1.27.3-rootless`
 - **Chart lock policy** source chart does not commit `Chart.lock`; dependencies are resolved during packaging/validation
 - **Rootless storage** PVC paths are prepared for UID/GID 1000 by a small initContainer
 
@@ -137,7 +137,7 @@ gitea:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `gitea/gitea` | Container image repository |
-| `image.tag` | `"1.27.2-rootless"` | Image tag |
+| `image.tag` | `"1.27.3-rootless"` | Image tag |
 | `replicaCount` | `1` | Number of replicas |
 | `gitea.appName` | `"Gitea: Git with a cup of tea"` | Application display name |
 | `gitea.runMode` | `prod` | Run mode (dev, prod, test) |
@@ -191,11 +191,11 @@ Only one database source can be active. The chart fails with a clear error if mu
 
 ## Upgrade Notes
 
-This update moves the default rootless image to `1.27.2-rootless`. Gitea 1.27.2
+This update moves the default rootless image to `1.27.3-rootless`. Gitea 1.27.3
 contains security and maintenance fixes without a documented change to the
 rootless image contract. Back up the database and repositories first; Gitea runs
 required database migrations during the first startup. Review the
-[upstream v1.27.2 release](https://github.com/go-gitea/gitea/releases/tag/v1.27.2)
+[upstream v1.27.3 release](https://github.com/go-gitea/gitea/releases/tag/v1.27.3)
 before upgrading.
 
 ## SSH Access

--- a/charts/gitea/values.yaml
+++ b/charts/gitea/values.yaml
@@ -6,7 +6,7 @@
 # -- Gitea image
 image:
   repository: docker.io/gitea/gitea
-  tag: "1.27.2-rootless"
+  tag: "1.27.3-rootless"
   pullPolicy: IfNotPresent
 
 # -- Image pull secrets


### PR DESCRIPTION
## Summary

- update the official upstream image from 1.27.2-rootless to 1.27.3-rootless
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Keep the official rootless image track and existing security context.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=gitea passed all 18 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1089