### PR TITLE
chore(hoppscotch): bump app to 2026.8.0

### DIFF
--- a/charts/hoppscotch/Chart.yaml
+++ b/charts/hoppscotch/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev/docs/charts/hoppscotch
 icon: https://helmforge.dev/icons/charts/hoppscotch.png
 type: application
 version: 1.1.10
-appVersion: "2026.7.0"
+appVersion: "2026.8.0"
 kubeVersion: ">=1.26.0-0"
 
 keywords:
@@ -30,7 +30,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Hoppscotch to 2026.8.0 (#1091)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -77,7 +77,7 @@ backend process inside the AIO image.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `mode` | Chart mode: `dev` or `production` | `dev` |
-| `image.tag` | Hoppscotch image tag | `2026.7.0` |
+| `image.tag` | Hoppscotch image tag | `2026.8.0` |
 | `namespaceOverride` | Namespace for chart-managed resources. Use with an external database; bundled PostgreSQL remains in the Helm release namespace. | `""` |
 | `replicaCount` | Number of replicas | `1` |
 | `ingress.enabled` | Enable Ingress | `false` |
@@ -105,8 +105,8 @@ backend process inside the AIO image.
 
 ## Upgrade Notes
 
-Hoppscotch `2026.7.0` fixes collection data loss in personal workspaces and request loss when importing large team
-collections, adds fallback to initial values for empty environment variables, and includes security fixes. Back up the
+Hoppscotch `2026.8.0` unifies REST and GraphQL workspaces, adds data collection
+runs, and includes security and maintenance fixes. Back up the
 PostgreSQL database and keep `DATA_ENCRYPTION_KEY` stable before upgrading.
 The bundled PostgreSQL path now derives `DATABASE_URL` from the PostgreSQL
 user password Secret, bootstraps `pg_trgm` on fresh data directories, and runs

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -309,6 +309,17 @@ databaseName
 {{- end -}}
 
 {{/*
+databaseUsername
+*/}}
+{{- define "hoppscotch.databaseUsername" -}}
+{{- if .Values.database.external.enabled -}}
+{{- .Values.database.external.username | default "hoppscotch" -}}
+{{- else -}}
+{{- .Values.postgresql.auth.username | default "hoppscotch" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 databaseSecretName — name of the secret holding database-url
 */}}
 {{- define "hoppscotch.databaseSecretName" -}}

--- a/charts/hoppscotch/templates/deployment.yaml
+++ b/charts/hoppscotch/templates/deployment.yaml
@@ -39,14 +39,24 @@ spec:
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-db
-          image: docker.io/library/busybox:1.37
+          image: docker.io/library/postgres:18.6-trixie
           imagePullPolicy: IfNotPresent
           command:
             - sh
             - -c
             - |
-              until nc -z -w2 {{ include "hoppscotch.databaseHost" . }} {{ include "hoppscotch.databasePort" . }} >/dev/null 2>&1; do
-                echo "waiting for database..."; sleep 2;
+              ready_checks=0
+              while [ "$ready_checks" -lt 5 ]; do
+                if pg_isready \
+                  --host={{ include "hoppscotch.databaseHost" . }} \
+                  --port={{ include "hoppscotch.databasePort" . }} \
+                  --username={{ include "hoppscotch.databaseUsername" . }} \
+                  --dbname={{ include "hoppscotch.databaseName" . }}; then
+                  ready_checks=$((ready_checks + 1))
+                else
+                  ready_checks=0
+                fi
+                sleep 2
               done
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           resources:

--- a/charts/hoppscotch/tests/deployment_test.yaml
+++ b/charts/hoppscotch/tests/deployment_test.yaml
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/hoppscotch/hoppscotch:2026.7.0
+          value: docker.io/hoppscotch/hoppscotch:2026.8.0
         template: deployment.yaml
 
   - it: should have wait-for-db init container
@@ -38,11 +38,11 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: docker.io/library/busybox:1.37
+          value: docker.io/library/postgres:18.6-trixie
         template: deployment.yaml
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: ">/dev/null 2>&1"
+          pattern: "pg_isready"
         template: deployment.yaml
 
   - it: should have migrate init container
@@ -53,7 +53,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[1].image
-          value: docker.io/hoppscotch/hoppscotch:2026.7.0
+          value: docker.io/hoppscotch/hoppscotch:2026.8.0
         template: deployment.yaml
 
   - it: should prepare writable runtime files for non-root startup
@@ -87,7 +87,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].image
-          value: docker.io/hoppscotch/hoppscotch:2026.7.0
+          value: docker.io/hoppscotch/hoppscotch:2026.8.0
         template: deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[2].command[0]
@@ -152,7 +152,11 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "nc -z -w2 postgresql\\.database\\.svc\\.cluster\\.local 15432"
+          pattern: "--host=postgresql\\.database\\.svc\\.cluster\\.local"
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--port=15432"
         template: deployment.yaml
 
   - it: should derive wait-for-db host and port from bracketed IPv6 external database URL
@@ -166,7 +170,11 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
-          pattern: "nc -z -w2 2001:db8::1 15432"
+          pattern: "--host=2001:db8::1"
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "--port=15432"
         template: deployment.yaml
 
   - it: should use writable XDG directories for Caddy storage

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -31,7 +31,7 @@ image:
   # -- Hoppscotch AIO image repository
   repository: docker.io/hoppscotch/hoppscotch
   # -- Hoppscotch image tag
-  tag: "2026.7.0"
+  tag: "2026.8.0"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official upstream image from 2026.7.0 to 2026.8.0
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Use PostgreSQL pg_isready for database startup and honor the configured external database username.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=hoppscotch passed all 19 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1091