### PR TITLE
chore(keycloak): bump app to 26.7.3

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -6,7 +6,7 @@ home: https://helmforge.dev
 icon: https://helmforge.dev/icons/charts/keycloak.png
 type: application
 version: 3.0.11
-appVersion: "26.7.2"
+appVersion: "26.7.3"
 kubeVersion: ">=1.26.0-0"
 keywords:
   - keycloak
@@ -19,7 +19,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump Keycloak to 26.7.2 (#1048)"
+      description: "bump Keycloak to 26.7.3 (#1092)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -88,11 +88,11 @@ Recommended reading before installation:
 
 ## Keycloak 26.7.x alignment
 
-This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.2`.
+This chart tracks the official Keycloak server image `quay.io/keycloak/keycloak:26.7.3`.
 
 Relevant 26.7.x operational changes to account for during rollout:
 
-- 26.7.2 includes security fixes for account takeover, fine-grained admin permissions, rotated client secrets, and dependencies; review the upstream migration guide before production rollout
+- 26.7.3 includes multiple CVE and dependency security fixes; review the upstream migration guide before production rollout
 - zero-downtime patch releases are supported within the same minor stream, but still require readiness, proxy, and database validation
 - the HTTP stack supports graceful shutdown, so keep `terminationGracePeriodSeconds` aligned with connection draining at the proxy layer
 - Kubernetes and OpenShift truststore initialization improved upstream; keep custom `truststore` and database CA mounts explicit when the platform uses private CAs
@@ -245,7 +245,7 @@ postgresql:
 |-----------|-------------|---------|
 | `mode` | `dev` or `production` | `dev` |
 | `image.repository` | Keycloak image repository | `quay.io/keycloak/keycloak` |
-| `image.tag` | Keycloak image tag | `26.7.2` |
+| `image.tag` | Keycloak image tag | `26.7.3` |
 | `admin.existingSecret` | Existing secret for bootstrap admin credentials | `""` |
 | `http.port` | Application HTTP port | `8080` |
 | `http.managementPort` | Management port for health and metrics | `9000` |

--- a/charts/keycloak/docs/production.md
+++ b/charts/keycloak/docs/production.md
@@ -157,11 +157,11 @@ When an ExternalSecret owns a target Secret, the native generated Secret for tha
 
 ## Keycloak 26.7.x rollout notes
 
-The default image is `quay.io/keycloak/keycloak:26.7.2`.
+The default image is `quay.io/keycloak/keycloak:26.7.3`.
 
 Before rolling this version into production:
 
-- read the official [26.7.2 release notes](https://www.keycloak.org/2026/08/keycloak-2672-released)
+- read the official [26.7.3 release notes](https://www.keycloak.org/2026/08/keycloak-2673-released)
 - validate database startup and migration logs
 - validate readiness and liveness on the management service
 - validate login, token refresh, logout, and admin console access through the real reverse proxy path

--- a/charts/keycloak/tests/deployment_test.yaml
+++ b/charts/keycloak/tests/deployment_test.yaml
@@ -26,7 +26,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "quay.io/keycloak/keycloak:26.7.2"
+          value: "quay.io/keycloak/keycloak:26.7.3"
 
   - it: should have 1 replica by default
     template: deployment.yaml

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- Keycloak image repository
   repository: quay.io/keycloak/keycloak
   # -- Keycloak image tag
-  tag: "26.7.2"
+  tag: "26.7.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update the official upstream image from 26.7.2 to 26.7.3
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Validate the update across the complete Keycloak scenario matrix.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=keycloak passed all 34 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1092