### PR TITLE
chore(langflow): bump app to 1.11.5

### DIFF
--- a/charts/langflow/Chart.yaml
+++ b/charts/langflow/Chart.yaml
@@ -4,7 +4,7 @@ name: langflow
 description: Langflow visual AI workflow builder
 type: application
 version: 1.1.3
-appVersion: "1.11.4"
+appVersion: "1.11.5"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/langflow.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump Langflow to 1.11.4 (#1049)"
+      description: "bump Langflow to 1.11.5 (#1093)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/langflow/README.md
+++ b/charts/langflow/README.md
@@ -1,12 +1,12 @@
 # Langflow Helm Chart
 
 Langflow is a visual builder for AI workflows, RAG applications, agents, and integrations with model providers and vector databases.
-This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.4` image with persistent local state by default and explicit
+This HelmForge chart deploys the official `docker.io/langflowai/langflow:1.11.5` image with persistent local state by default and explicit
 production paths for secret management, PostgreSQL-compatible databases, ingress, Gateway API, and horizontal scaling.
 
 Langflow 1.11 adds native v2 workflow execution, trusted JWT authentication with just-in-time user mapping, RBAC-aware interfaces, A2A and
-human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.4 includes security dependency remediation and
-fixes for MCP transactions, global variables, background runs, chained inputs, and container toolchain pinning. Advanced runtime settings can be supplied through `app.env` or
+human-in-the-loop workflows, and additional provider and vector-store bundles. Version 1.11.5 adds security hardening and an opt-in
+multi-worker in-memory queue while keeping the default runtime contract unchanged. Advanced runtime settings can be supplied through `app.env` or
 `app.envFrom`.
 
 The chart generates a strong Langflow secret key and initial superuser password on first install when `auth.existingSecret` and inline

--- a/charts/langflow/tests/templates_test.yaml
+++ b/charts/langflow/tests/templates_test.yaml
@@ -14,7 +14,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/langflowai/langflow:1.11.4
+          value: docker.io/langflowai/langflow:1.11.5
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: langflow

--- a/charts/langflow/values.schema.json
+++ b/charts/langflow/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/langflowai/langflow" },
-        "tag": { "type": "string", "default": "1.11.4" },
+        "tag": { "type": "string", "default": "1.11.5" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/langflow/values.yaml
+++ b/charts/langflow/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Official Langflow image repository.
   repository: docker.io/langflowai/langflow
   # -- Official Langflow image tag. Do not use a floating tag.
-  tag: "1.11.4"
+  tag: "1.11.5"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official upstream image from 1.11.4 to 1.11.5
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Keep the existing application and persistence contracts unchanged.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=langflow passed all 18 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1093