### PR TITLE
chore(mariadb): bump app to 12.3.3

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ name: mariadb
 description: MariaDB for Kubernetes with explicit standalone and replication modes
 type: application
 version: 2.1.0
-appVersion: "12.3.2"
+appVersion: "12.3.3"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -20,8 +20,8 @@ sources:
 icon: https://helmforge.dev/icons/charts/mariadb.png
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add affinity/tolerations spec to source and readReplicas (#1065)"
+    - kind: changed
+      description: "bump MariaDB to 12.3.3 (#1094)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -82,7 +82,7 @@ replication:
 |-----|---------|-------------|
 | `architecture` | `standalone` | Deployment mode: standalone or replication |
 | `image.repository` | `mariadb` | MariaDB image |
-| `image.tag` | `12.3.2` | MariaDB version |
+| `image.tag` | `12.3.3` | MariaDB version |
 | `auth.rootPassword` | `""` | Root password (auto-generated if empty) |
 | `auth.database` | `app` | Application database |
 | `auth.username` | `app` | Application user |
@@ -124,6 +124,11 @@ replication:
 | `externalSecrets.data` | `[]` | Remote key mappings |
 
 ## Dual-Stack Services
+
+MariaDB 12.3.3 is a maintenance and hardening release. It adds optional,
+backward-compatible SST TLS settings without changing the chart defaults. Back
+up databases and validate startup, replication, and restore behavior before
+production rollout.
 
 All 6 Service objects (client, metrics, source, source-metrics, replicas, replicas-metrics)
 carry the same `ipFamilyPolicy` and `ipFamilies` settings.

--- a/charts/mariadb/tests/statefulset_source_test.yaml
+++ b/charts/mariadb/tests/statefulset_source_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/library/mariadb:12.3.2"
+          value: "docker.io/library/mariadb:12.3.3"
 
   - it: should always have 1 replica
     template: templates/statefulset-source.yaml

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -28,7 +28,7 @@ image:
   # -- MariaDB image repository
   repository: docker.io/library/mariadb
   # -- MariaDB image tag
-  tag: "12.3.2"
+  tag: "12.3.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -298,7 +298,7 @@ backup:
       pullPolicy: IfNotPresent
     mariadb:
       repository: docker.io/library/mariadb
-      tag: "12.3.2"
+      tag: "12.3.3"
       pullPolicy: IfNotPresent
   s3:
     # -- S3-compatible endpoint URL, for example: https://s3.amazonaws.com or https://minio.example.com


### PR DESCRIPTION
## Summary

- update the official upstream image from 12.3.2 to 12.3.3
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Validate the database update across the complete MariaDB scenario matrix.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=mariadb passed all 25 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1094