### PR TITLE
chore(ntfy): bump app to 2.28.0

### DIFF
--- a/charts/ntfy/Chart.yaml
+++ b/charts/ntfy/Chart.yaml
@@ -4,7 +4,7 @@ name: ntfy
 description: ntfy self-hosted push notification service with HTTP-based pub-sub
 type: application
 version: 1.2.1
-appVersion: "v2.27.0"
+appVersion: "v2.28.0"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 2.27.0 (#966)"
+      description: "bump ntfy to 2.28.0 (#1099)"
     - kind: fixed
       description: "support PostgreSQL database secrets (#933)"
   artifacthub.io/maintainers: |

--- a/charts/ntfy/README.md
+++ b/charts/ntfy/README.md
@@ -222,6 +222,15 @@ service:
     - IPv6
 ```
 
+## Upgrade Notes
+
+ntfy 2.28.0 hardens message and cache limits. Titles are limited to 1 KiB,
+combined tags to 512 bytes, and cache replay to 10 MiB. Cache replay now counts
+toward daily visitor bandwidth and can return HTTP 429; large deployments may
+need to review `visitor-attachment-daily-bandwidth-limit`. Clients should also
+handle `X-Messages-Truncated` on capped replay responses. Back up persistent
+state and validate publishing and replay workflows before rollout.
+
 ## Limitations
 
 - **Single replica** — the Deployment currently uses one replica regardless of database backend

--- a/charts/ntfy/tests/deployment_test.yaml
+++ b/charts/ntfy/tests/deployment_test.yaml
@@ -29,7 +29,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/binwiederhier/ntfy:v2.27.0"
+          value: "docker.io/binwiederhier/ntfy:v2.28.0"
 
   - it: should pass serve argument
     template: templates/deployment.yaml

--- a/charts/ntfy/values.yaml
+++ b/charts/ntfy/values.yaml
@@ -16,7 +16,7 @@ image:
   # -- ntfy container image
   repository: docker.io/binwiederhier/ntfy
   # -- Image tag
-  tag: "v2.27.0"
+  tag: "v2.28.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- update the official upstream image from 2.27.0 to 2.28.0
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Keep the existing deployment, persistence, and exposure contracts unchanged.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=ntfy passed all 18 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1099