### PR TITLE
chore(poznote): bump app to 6.68.7

### DIFF
--- a/charts/poznote/Chart.yaml
+++ b/charts/poznote/Chart.yaml
@@ -4,7 +4,7 @@ name: poznote
 description: Self-hosted note-taking and documentation platform with SQLite persistence
 type: application
 version: 2.0.0
-appVersion: "6.68.3"
+appVersion: "6.68.7"
 kubeVersion: ">=1.26.0-0"
 home: https://helmforge.dev/docs/charts/poznote
 sources:
@@ -25,7 +25,7 @@ icon: https://helmforge.dev/icons/charts/poznote.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: promote chart to stable (#1073)"
+      description: "bump Poznote to 6.68.7 (#1100)"
   artifacthub.io/category: skip-prediction
   artifacthub.io/license: Apache-2.0
   artifacthub.io/prerelease: "false"

--- a/charts/poznote/DESIGN.md
+++ b/charts/poznote/DESIGN.md
@@ -14,12 +14,12 @@ Scaling above one pod is blocked because Poznote uses SQLite for persistence and
 The chart uses the official upstream image:
 
 ```text
-ghcr.io/timothepoznanski/poznote:6.68.3
+ghcr.io/timothepoznanski/poznote:6.68.7
 ```
 
-The tag maps to the upstream `6.68.3` release and publishes Linux `amd64` and `arm64` manifests.
+The tag maps to the upstream `6.68.7` release and publishes Linux `amd64` and `arm64` manifests.
 
-Upstream also publishes a `6.68.3-rootless` variant. It is not the chart
+Upstream also publishes a `6.68.7-rootless` variant. It is not the chart
 default because its startup script requires the mounted data directory itself
 to be owned by UID/GID 1000. New Kubernetes PVCs and volumes upgraded from the
 default image do not guarantee that ownership without a privileged recursive

--- a/charts/poznote/README.md
+++ b/charts/poznote/README.md
@@ -71,7 +71,7 @@ ingress:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `image.repository` | Image repository | `ghcr.io/timothepoznanski/poznote` |
-| `image.tag` | Image tag | `6.68.3` |
+| `image.tag` | Image tag | `6.68.7` |
 | `image.pullPolicy` | Pull policy | `IfNotPresent` |
 
 #### Application Parameters
@@ -143,9 +143,10 @@ This chart intentionally does NOT:
 
 ## Upgrade Notes
 
-Poznote `6.68.3` improves search and replace in rendered Markdown previews and
-fixes indented code blocks that contain inline Markdown. Review the
-[upstream 6.68.3 release](https://github.com/timothepoznanski/poznote/releases/tag/6.68.3)
+Poznote `6.68.4` through `6.68.7` include proxy share-link and attachment
+sanitization fixes, a critical backup-restore SQL execution fix, and stored XSS
+fixes. Review the
+[upstream 6.68.7 release](https://github.com/timothepoznanski/poznote/releases/tag/6.68.7)
 before upgrading. The default local SQLite and filesystem deployment remains
 compatible; S3 integration is configured inside Poznote when needed.
 

--- a/charts/poznote/tests/deployment_test.yaml
+++ b/charts/poznote/tests/deployment_test.yaml
@@ -35,7 +35,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/timothepoznanski/poznote:6.68.3"
+          value: "ghcr.io/timothepoznanski/poznote:6.68.7"
 
   - it: should expose HTTP port 80
     template: templates/deployment.yaml

--- a/charts/poznote/values.yaml
+++ b/charts/poznote/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official Poznote container image repository.
   repository: ghcr.io/timothepoznanski/poznote
   # -- Pinned Poznote image tag. Floating tags such as latest are not used by default.
-  tag: "6.68.3"
+  tag: "6.68.7"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official upstream image from 6.68.3 to 6.68.7
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Synchronize the pinned image and operational documentation.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=poznote passed all 19 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1100