### PR TITLE
chore(strapi): bump app to 5.52.2

### DIFF
--- a/charts/strapi/Chart.yaml
+++ b/charts/strapi/Chart.yaml
@@ -4,7 +4,7 @@ name: strapi
 description: Strapi headless CMS with SQLite, MySQL, or PostgreSQL support, uploads persistence, and S3 backups
 type: application
 version: 2.3.13
-appVersion: "5.52.0"
+appVersion: "5.52.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -24,7 +24,7 @@ icon: https://helmforge.dev/icons/charts/strapi.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump HelmForge subchart dependencies to latest minor/patch (#1011)"
+      description: "bump Strapi to 5.52.2 (#1101)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/strapi/README.md
+++ b/charts/strapi/README.md
@@ -18,9 +18,9 @@ This chart is designed for a prebuilt Strapi project image. It does not build ap
 
 ## HelmForge Base Image
 
-This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.52.0`) which provides:
+This chart uses the official **HelmForge Strapi base image** (`docker.io/helmforge/strapi-base:5.52.2`) which provides:
 
-- **Strapi 5.52.0** with all official plugins pre-installed
+- **Strapi 5.52.2** with all official plugins pre-installed
 - **Multi-database support** — SQLite, PostgreSQL, MySQL ready to use
 - **Health check endpoint** — HTTP health checks on `/_health` for proper Kubernetes integration
 - **Security hardened** — Non-root user (UID 1000), minimal attack surface
@@ -107,7 +107,7 @@ database:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `image.repository` | `helmforge/strapi-base` | Container image for the Strapi project |
-| `image.tag` | `5.52.0` | HelmForge Strapi base image version |
+| `image.tag` | `5.52.2` | HelmForge Strapi base image version |
 | `strapi.url` | `""` | Public URL (auto-detected from ingress if empty) |
 | `strapi.port` | `1337` | Container port |
 | `strapi.telemetryDisabled` | `true` | Disable telemetry |
@@ -141,16 +141,16 @@ database:
 
 ## Notes
 
-- The default image is `helmforge/strapi-base:5.52.0`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
+- The default image is `helmforge/strapi-base:5.52.2`, HelmForge's production-ready Strapi image. Override it if your deployment uses a custom Strapi build.
 - SQLite is supported for simple deployments, but server-based databases are recommended for production workloads.
 - Horizontal scaling is intentionally out of scope for this v1 chart because default local uploads persistence is single-writer oriented.
 - For ingress, set `ingress.ingressClassName` to the class used in your cluster, such as `traefik`, `nginx`, or another supported controller.
 
 ## Upgrade Notes
 
-Strapi `5.52.0` fixes document relation validation, database morph relations,
-admin audit filtering, recent-document serialization, and duplicate public
-assets. It also includes security-oriented dependency updates. The HelmForge
+Strapi `5.52.2` includes maintenance and security fixes plus an opt-in beta
+media library. Existing deployments keep their current SVG upload behavior;
+new upstream projects block SVG uploads by default. The HelmForge
 base image preserves the existing runtime and database contract. Back up the
 database and uploads PVC before upgrading production workloads.
 

--- a/charts/strapi/tests/deployment_test.yaml
+++ b/charts/strapi/tests/deployment_test.yaml
@@ -22,7 +22,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/helmforge/strapi-base:5.52.0"
+          value: "docker.io/helmforge/strapi-base:5.52.2"
 
   - it: should set container port to 1337
     template: templates/deployment.yaml

--- a/charts/strapi/values.yaml
+++ b/charts/strapi/values.yaml
@@ -26,7 +26,7 @@ replicaCount: 1
 # Image
 # =============================================================================
 # HelmForge provides a production-ready Strapi base image (helmforge/strapi-base)
-# that includes Strapi 5.52.0 with all official plugins, multi-database support,
+# that includes Strapi 5.52.2 with all official plugins, multi-database support,
 # security hardening, and health check endpoints. This image is multi-arch
 # (amd64/arm64), regularly updated, and optimized for Kubernetes deployments.
 #
@@ -38,7 +38,7 @@ image:
   # -- Container image repository for your Strapi project
   repository: docker.io/helmforge/strapi-base
   # -- Container image tag
-  tag: "5.52.0"
+  tag: "5.52.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- update the official upstream image from 5.52.0 to 5.52.2
- synchronize Chart.yaml appVersion, image defaults, chart documentation, and tests
- Keep the existing application and database contracts unchanged.

## Type Of Change

- [x] Existing chart change

## PR Governance

- [x] Existing issue linked below
- [x] Branch created from updated main and PR targets main
- [x] Commit and PR title follow Conventional Commits
- [x] Chart package version remains CI-managed

## Upstream Verification

- [x] appVersion matches the upstream release
- [x] official pinned image tag was verified
- [x] upstream release information was reviewed

## Site Sync

- [x] Companion site PR: https://github.com/helmforgedev/site/pull/546

## Local Validation

- [x] make validate-chart CHART=strapi passed all 19 layers, including behavioral k3d validation
- [x] unit tests, strict lint, CI rendering, kubeconform with real schemas, and Artifact Hub lint passed
- [x] make preflight passed
- [x] release and attribution checks passed

Resolves #1101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Strapi deployment to version 5.52.2.
  * Refreshed the chart’s default image settings and documentation to reflect the new version.
  * Added upgrade notes covering Strapi 5.52.2 maintenance and security fixes, plus the opt-in beta media library and SVG upload behavior.
* **Tests**
  * Updated deployment validation to expect Strapi 5.52.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->