### PR TITLE
feat(matomo): Allow to set the image for the initcontainer

### DIFF
--- a/charts/matomo/templates/_helpers.tpl
+++ b/charts/matomo/templates/_helpers.tpl
@@ -45,7 +45,7 @@ app.kubernetes.io/part-of: helmforge
 {{- end -}}
 
 {{- define "initContainers.wait-for-db.image" -}}
-{{- printf "%s:%s" .Values.database.waitForConnection.image.repository (.Values.database.waitForConnection.image.tag -}}
+{{- printf "%s:%s" .Values.database.waitForConnection.image.repository (.Values.database.waitForConnection.image.tag) -}}
 {{- end -}}
 
 {{- define "matomo.serviceAccountName" -}}

--- a/charts/matomo/templates/_helpers.tpl
+++ b/charts/matomo/templates/_helpers.tpl
@@ -44,6 +44,10 @@ app.kubernetes.io/part-of: helmforge
 {{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default (printf "%s-apache" .Chart.AppVersion)) -}}
 {{- end -}}
 
+{{- define "initContainers.wait-for-db.image" -}}
+{{- printf "%s:%s" .Values.database.waitForConnection.image.repository (.Values.database.waitForConnection.image.tag -}}
+{{- end -}}
+
 {{- define "matomo.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "matomo.fullname" .) .Values.serviceAccount.name -}}

--- a/charts/matomo/templates/deployment.yaml
+++ b/charts/matomo/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       initContainers:
         {{- if .Values.database.waitForConnection.enabled }}
         - name: wait-for-db
-          image: docker.io/library/busybox:1.37
+          image: {{ include "initContainers.wait-for-db.image" . | quote }}
           command:
             - sh
             - -ec

--- a/charts/matomo/values.schema.json
+++ b/charts/matomo/values.schema.json
@@ -34,7 +34,9 @@
         "waitForConnection": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" }
+            "enabled": { "type": "boolean" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string", "not": { "enum": ["latest"] } }
           }
         },
         "external": {

--- a/charts/matomo/values.schema.json
+++ b/charts/matomo/values.schema.json
@@ -35,8 +35,13 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
-            "repository": { "type": "string" },
-            "tag": { "type": "string", "not": { "enum": ["latest"] } }
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string", "not": { "enum": ["latest"] } }
+              }
+            }
           }
         },
         "external": {

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -52,6 +52,11 @@ database:
   waitForConnection:
     # -- Wait for the configured database socket before starting Matomo.
     enabled: true
+    image:
+      # -- Image repository for the wait-for-db initContainer
+      repository: "docker.io/library/busybox"
+      # -- Image tag for the wait-for-db initContainer
+      tag: "1.37"
   external:
     # -- External MySQL/MariaDB host
     host: ""


### PR DESCRIPTION
## Summary

- Resolves #1104 

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [ ] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO

## Notes

-

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable repository and tag settings for the database connection wait container image.
  * The wait container image now uses the configured image rather than a fixed default.

* **Configuration**
  * Added schema validation for the image repository and tag settings.
  * The default image remains BusyBox 1.37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->