### PR TITLE
feat(matomo): add possibility to define resources for the init container

### DIFF
--- a/charts/matomo/templates/deployment.yaml
+++ b/charts/matomo/templates/deployment.yaml
@@ -51,6 +51,10 @@ spec:
                 echo "waiting for database ${DB_HOST}:${DB_PORT}"
                 sleep 2
               done
+          {{- if .Values.database.waitForConnection.resources }}
+          resources:
+            {{- toYaml .Values.database.waitForConnection.resources | nindent 12 }}
+          {{- end }}
           env:
             - name: DB_HOST
               value: {{ include "matomo.databaseHost" . | quote }}

--- a/charts/matomo/values.schema.json
+++ b/charts/matomo/values.schema.json
@@ -35,14 +35,14 @@
           "type": "object",
           "properties": {
             "enabled": { "type": "boolean" },
+            "resources": { "type": "object" },
             "image": {
               "type": "object",
               "properties": {
                 "repository": { "type": "string" },
                 "tag": { "type": "string", "not": { "enum": ["latest"] } }
               }
-            },
-            "resources": { "type": "object" }
+            }
           }
         },
         "external": {

--- a/charts/matomo/values.schema.json
+++ b/charts/matomo/values.schema.json
@@ -41,7 +41,8 @@
                 "repository": { "type": "string" },
                 "tag": { "type": "string", "not": { "enum": ["latest"] } }
               }
-            }
+            },
+            "resources": { "type": "object" }
           }
         },
         "external": {

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -57,6 +57,8 @@ database:
       repository: "docker.io/library/busybox"
       # -- Image tag for the wait-for-db initContainer
       tag: "1.37"
+    # -- Define resources for the wait-for-db initContainer
+    resources: {}
   external:
     # -- External MySQL/MariaDB host
     host: ""

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -52,13 +52,13 @@ database:
   waitForConnection:
     # -- Wait for the configured database socket before starting Matomo.
     enabled: true
+    # -- Define resources for the wait-for-db initContainer
+    resources: {}
     image:
       # -- Image repository for the wait-for-db initContainer
       repository: "docker.io/library/busybox"
       # -- Image tag for the wait-for-db initContainer
       tag: "1.37"
-    # -- Define resources for the wait-for-db initContainer
-    resources: {}
   external:
     # -- External MySQL/MariaDB host
     host: ""


### PR DESCRIPTION
## Summary

-

## Type Of Change

- [ ] New chart
- [x] Existing chart change
- [ ] Documentation only
- [ ] CI / repository workflow

## PR Governance

- [x] I linked an existing issue in this PR body (`Resolves #NNN` or `Related to #NNN`)
- [ ] If this is a new chart PR, labels `enhancement` and `type:feature` are applied

## Checklist

- [x] I created this branch from updated `main`
- [x] My PR targets `main`
- [x] My commit message and PR title follow Conventional Commits
- [x] I did not edit `version` in `Chart.yaml` manually
- [x] I updated the root `README.md` if a new chart was added or public chart metadata changed
- [x] I updated `values.schema.json` for any values changes
- [x] I updated chart docs for behavior or default changes

## Upstream Verification

- [x] I verified `appVersion` in `Chart.yaml` matches the real upstream release
- [x] I confirmed the image tag in `values.yaml` corresponds to a published, stable tag
- [x] I cross-referenced [upstream GitHub Releases](https://github.com) and [Docker Hub tags](https://hub.docker.com)

## Site Sync (GR-007)

> If this change affects chart defaults, install path, architecture, backup, or maturity:

- [ ] I updated the corresponding page in `site/` repository
- [x] N/A — this change does not affect public documentation

## Local Validation

- [x] I confirmed `kubectl config current-context` before local installs/upgrades/uninstalls
- [x] `helm lint charts/<chart-name> --strict` passed
- [x] `helm unittest charts/<chart-name>` passed
- [x] All relevant `ci/*.yaml` scenarios rendered successfully
- [x] I validated this change on a local `k3d` cluster when required
- [x] I validated the default install
- [x] I validated at least one main non-default scenario for this change
- [x] If backup behavior changed, I validated the flow against local MinIO

## Notes

- Resolves #1123 

---

> 📚 See [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for CPU and memory requests and limits for the database connection wait step in the Matomo Helm chart.
  * Configured resource settings are applied to the initialization container when provided.

* **Documentation**
  * Updated chart values and validation to document and support the optional resource configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->