### PR TITLE
chore(deps): bump HelmForge subchart dependencies to latest minor/patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,15 @@ jobs:
       - name: Detect changed charts
         id: changed
         run: |
-          # For 'synchronize' (new push), compare only new commits
-          # For 'opened/reopened', compare full PR against base
-          if [ -n "${{ github.event.before }}" ]; then
-            BASE_SHA="${{ github.event.before }}"
-          else
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          fi
+          set -euo pipefail
+          # Validate the full PR, including after a rebase or force-push.
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD -- charts/)
 
-          CHANGED_DIRS=$(git diff --name-only "$BASE_SHA" HEAD -- charts/ \
-            | grep -v -E '(README\.md|examples/|docs/)' \
+          CHANGED_DIRS=$(printf '%s\n' "$CHANGED_FILES" \
+            | awk 'NF && !/(README\.md|examples\/|docs\/)/' \
             | cut -d'/' -f2 | sort -u \
-            | while read -r dir; do [ -f "charts/$dir/Chart.yaml" ] && echo "$dir"; done \
+            | while read -r dir; do if [ -f "charts/$dir/Chart.yaml" ]; then echo "$dir"; fi; done \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
 
           echo "charts=$CHANGED_DIRS" >> "$GITHUB_OUTPUT"

--- a/charts/appwrite/Chart.yaml
+++ b/charts/appwrite/Chart.yaml
@@ -52,7 +52,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.1.0
+    version: 2.1.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis

--- a/charts/booklore/Chart.yaml
+++ b/charts/booklore/Chart.yaml
@@ -44,6 +44,6 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.1.0
+    version: 2.1.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled

--- a/charts/castopod/Chart.yaml
+++ b/charts/castopod/Chart.yaml
@@ -48,7 +48,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.1.0
+    version: 2.1.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis

--- a/charts/countly/Chart.yaml
+++ b/charts/countly/Chart.yaml
@@ -24,7 +24,7 @@ sources:
   - https://github.com/Countly/countly-server
 dependencies:
   - name: mongodb
-    version: 1.7.18
+    version: 1.8.0
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mongodb.enabled
 annotations:

--- a/charts/pimcore/Chart.yaml
+++ b/charts/pimcore/Chart.yaml
@@ -53,7 +53,7 @@ annotations:
       url: https://github.com/helmforgedev/charts/issues
 dependencies:
   - name: mariadb
-    version: 2.1.0
+    version: 2.1.1
     repository: oci://ghcr.io/helmforgedev/helm
     condition: mariadb.enabled
   - name: redis


### PR DESCRIPTION
This PR updates the bundled MariaDB chart from 2.1.0 to 2.1.1 for Appwrite, Booklore, Castopod and Pimcore, and the bundled MongoDB chart from 1.7.18 to 1.8.0 for Countly.

MariaDB advances from 12.3.2 to 12.3.3. Both MongoDB chart versions retain the same 8.3.8 runtime; the dependency update adds security-context and keyfile-permission configuration. It does not introduce a MongoDB runtime upgrade or downgrade.

The Tests workflow now detects changes against the PR base with strict error handling. After rebases or force-pushes, it validates the complete PR instead of silently accepting an empty chart matrix. Local checks cover the five-chart diff, an empty diff and an invalid base reference.

Validation:
- Rebased on current main; scoped dependency commits, preflight, dependency policy and organization consistency checks pass.
- GitHub CI ran and passed all five chart matrices after the detector fix.
- Full local chart validation passed for appwrite, booklore, castopod, countly and pimcore: dependency integrity, strict lint, every CI values profile, unit tests, real-CRD kubeconform, Artifact Hub lint and isolated default-scenario k3d behavioral checks. All final deployments had zero container restarts, healthy service endpoints and no fatal workload logs. The runtime scope covers bundled default databases; optional database modes/security overrides are unchanged and remain covered statically.
- The Countly review thread is resolved: both released dependency versions use MongoDB 8.3.8. Upstream support for that existing runtime is a separate concern; no implicit data-directory downgrade is introduced here.

Local execution notes: the first Countly run exceeded 300 seconds while pulling its 1 GB image; the repeat passed with the image cached. The first Appwrite run hit kubelet image-pull QPS limits and bootstrap restarts; the repeat using cached images passed with all 21 workloads stable. Pimcore passed with a 600-second install timeout after downloading its runtime and bootstrapping the project. These are fresh-install checks, not an existing-data upgrade/restore exercise.

