### PR TITLE
feat(envoy-gateway): support servicemonitor selection labels

### DIFF
--- a/charts/envoy-gateway/README.md
+++ b/charts/envoy-gateway/README.md
@@ -360,10 +360,24 @@ highAvailability:
 |-----|---------|-------------|
 | `monitoring.enabled` | `false` | Enable monitoring |
 | `monitoring.prometheus.serviceMonitor` | `true` | Create Prometheus ServiceMonitor (controller only) |
+| `monitoring.prometheus.serviceMonitorLabels` | `{}` | Extra ServiceMonitor metadata labels for Prometheus selection; built-in chart labels take precedence |
 | `monitoring.prometheus.prometheusRule` | `false` | Create PrometheusRule with 6 alert rules |
 | `monitoring.grafana.dashboards` | `false` | Create Grafana dashboard ConfigMap |
 | `monitoring.accessLogs.enabled` | `true` | Enable access logs |
 | `monitoring.accessLogs.format` | `json` | Access log format (json or text) |
+
+To match a Prometheus `serviceMonitorSelector` such as `release: monitoring`:
+
+```yaml
+monitoring:
+  enabled: true
+  prometheus:
+    serviceMonitor: true
+    serviceMonitorLabels:
+      release: monitoring
+```
+
+These labels apply only to ServiceMonitor metadata. Its service selector remains unchanged.
 
 ### Security
 

--- a/charts/envoy-gateway/ci/monitoring-values.yaml
+++ b/charts/envoy-gateway/ci/monitoring-values.yaml
@@ -5,6 +5,8 @@ monitoring:
   enabled: true
   prometheus:
     serviceMonitor: true
+    serviceMonitorLabels:
+      release: monitoring
     prometheusRule: true
   grafana:
     dashboards: true

--- a/charts/envoy-gateway/docs/observability.md
+++ b/charts/envoy-gateway/docs/observability.md
@@ -82,8 +82,16 @@ monitoring:
   enabled: true
   prometheus:
     serviceMonitor: true
-    namespace: monitoring  # Prometheus Operator namespace
+    serviceMonitorLabels:
+      release: monitoring
 ```
+
+Set `monitoring.prometheus.serviceMonitorLabels` to match your Prometheus
+`spec.serviceMonitorSelector.matchLabels`. The map defaults to `{}` and accepts
+string values. Built-in chart labels take precedence when keys overlap.
+These labels apply only to ServiceMonitor metadata; its service selector is unchanged.
+The ServiceMonitor uses the release namespace (or `namespaceOverride`), which must
+also be allowed by Prometheus `spec.serviceMonitorNamespaceSelector`.
 
 Verify ServiceMonitors:
 

--- a/charts/envoy-gateway/templates/servicemonitor.yaml
+++ b/charts/envoy-gateway/templates/servicemonitor.yaml
@@ -6,7 +6,8 @@ metadata:
   name: {{ include "envoy-gateway.fullname" . }}-controller
   namespace: {{ include "envoy-gateway.namespace" . }}
   labels:
-    {{- include "envoy-gateway.controller.labels" . | nindent 4 }}
+    {{- $labels := include "envoy-gateway.controller.labels" . | fromYaml }}
+    {{- merge $labels (.Values.monitoring.prometheus.serviceMonitorLabels | default dict) | toYaml | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/envoy-gateway/tests/monitoring_test.yaml
+++ b/charts/envoy-gateway/tests/monitoring_test.yaml
@@ -26,6 +26,45 @@ tests:
         template: servicemonitor.yaml
         documentIndex: 0
 
+  - it: should add monitor selection labels without changing the service selector
+    set:
+      monitoring.enabled: true
+      monitoring.prometheus.serviceMonitorLabels:
+        release: monitoring
+        team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: monitoring
+        template: servicemonitor.yaml
+      - equal:
+          path: metadata.labels.team
+          value: platform
+        template: servicemonitor.yaml
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: envoy-gateway
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/component: controller
+        template: servicemonitor.yaml
+
+  - it: should preserve built-in labels when custom labels overlap
+    set:
+      monitoring.enabled: true
+      monitoring.prometheus.serviceMonitorLabels:
+        app.kubernetes.io/component: custom
+        app.kubernetes.io/instance: custom
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: controller
+        template: servicemonitor.yaml
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+        template: servicemonitor.yaml
+
   - it: should not create ServiceMonitors when monitoring disabled
     set:
       monitoring:

--- a/charts/envoy-gateway/values.schema.json
+++ b/charts/envoy-gateway/values.schema.json
@@ -474,6 +474,14 @@
               "description": "Create PrometheusRule with alerts",
               "default": false
             },
+            "serviceMonitorLabels": {
+              "type": "object",
+              "description": "Extra ServiceMonitor metadata labels for Prometheus selection. Built-in chart labels take precedence.",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {}
+            },
             "namespace": {
               "type": "string",
               "description": "Namespace for ServiceMonitor and PrometheusRule (defaults to Release.Namespace)",

--- a/charts/envoy-gateway/values.yaml
+++ b/charts/envoy-gateway/values.yaml
@@ -385,6 +385,8 @@ monitoring:
   prometheus:
     # -- Create ServiceMonitor for Prometheus Operator
     serviceMonitor: true
+    # -- Extra ServiceMonitor metadata labels for Prometheus selection. Built-in chart labels take precedence.
+    serviceMonitorLabels: {}
     # -- Create PrometheusRule with alert rules
     prometheusRule: false
   grafana:


### PR DESCRIPTION
Adds `monitoring.prometheus.serviceMonitorLabels` so Prometheus can select the Envoy Gateway controller ServiceMonitor using labels such as `release: monitoring`. The existing `serviceMonitor` boolean is unchanged, the new map defaults to `{}`, and built-in chart labels take precedence. Labels apply only to monitor metadata; the controller Service selector is unchanged.

Includes a string-valued schema, selection/collision unit tests, a monitoring CI example, and README/observability documentation.

Validation:
- `make validate-chart CHART=envoy-gateway K3D_SCENARIOS="default ci/monitoring-values.yaml" CONTEXT=k3d-helmforge-crds-e2e-gate-136 TIMEOUT=600` passed all 12 layers, including isolated default and monitoring k3d scenarios.
- Confirmed the live ServiceMonitor is selectable with `release=monitoring` and retains its original controller Service selector.
- Schema rejects numeric label values. Preflight, standards/no-regression, dependency checks and org consistency pass.
- Kubernetes 1.36.3 was used because this chart supports 1.33–1.36. The default 1.31 lab has incompatible older Gateway API CRDs.

Closes #1152.

Site PR: helmforgedev/site#551.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `monitoring.prometheus.serviceMonitorLabels` to configure additional ServiceMonitor metadata labels.
  * Supports Prometheus selection labels while preserving built-in chart label precedence.
  * Clarified that custom labels affect ServiceMonitor metadata only; service selectors remain unchanged.

* **Documentation**
  * Added configuration examples and guidance for label and namespace selection behavior.

* **Tests**
  * Added coverage for custom labels and conflicts with built-in labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->