### PR TITLE
chore(valkey): bump valkey to 9.1.2

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -4,7 +4,7 @@ name: valkey
 description: Valkey Helm chart for standalone, replication, sentinel, and cluster topologies
 type: application
 version: 2.0.3
-appVersion: "9.1.1"
+appVersion: "9.1.2"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -28,7 +28,7 @@ icon: https://helmforge.dev/icons/charts/valkey.png
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "upgrade to 9.1.1 security release (#883)"
+      description: "upgrade to 9.1.2 security release (#1150)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -218,7 +218,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `architecture` | Valkey topology: `standalone`, `replication`, `sentinel`, or `cluster` | `standalone` |
 | `clusterDomain` | Kubernetes cluster DNS domain used for internal service FQDNs | `cluster.local` |
 | `image.repository` | Valkey image repository | `docker.io/valkey/valkey` |
-| `image.tag` | Valkey image tag | `9.1.1` |
+| `image.tag` | Valkey image tag | `9.1.2` |
 | `auth.enabled` | Enable password authentication | `true` |
 | `auth.password` | Inline Valkey password | `""` |
 | `auth.existingSecret` | Existing Secret containing the Valkey password | `""` |
@@ -245,7 +245,7 @@ Use the generic extension values when platform-specific integration is needed:
 | `metrics.serviceMonitor.enabled` | Create ServiceMonitor | `false` |
 | `tests.enabled` | Render Helm test connection pod | `true` |
 | `tests.image.repository` | Helm test image repository | `docker.io/valkey/valkey` |
-| `tests.image.tag` | Helm test image tag | `9.1.1` |
+| `tests.image.tag` | Helm test image tag | `9.1.2` |
 | `automountServiceAccountToken` | Mount Kubernetes API service account token into pods | `false` |
 | `podSecurityContext.seccompProfile.type` | Pod seccomp profile | `RuntimeDefault` |
 | `securityContext.capabilities.drop` | Linux capabilities dropped by default | `["ALL"]` |
@@ -313,4 +313,4 @@ See `examples/`:
 - Valkey Sentinel: <https://valkey.io/docs/latest/operate/oss_and_stack/management/sentinel/>
 - Valkey Cluster: <https://valkey.io/docs/latest/operate/oss_and_stack/management/scaling/>
 - Valkey security: <https://valkey.io/docs/latest/operate/oss_and_stack/management/security/>
-- Valkey 9.1.1 security release: <https://github.com/valkey-io/valkey/releases/tag/9.1.1>
+- Valkey 9.1.2 security release: <https://github.com/valkey-io/valkey/releases/tag/9.1.2>

--- a/charts/valkey/scripts/runtime-smoke.mjs
+++ b/charts/valkey/scripts/runtime-smoke.mjs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+import { execFileSync } from 'node:child_process';
+
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const output = execFileSync('helm', [
+  'test', release, '--kube-context', context, '--namespace', namespace,
+  '--timeout', '120s', '--logs',
+], { encoding: 'utf8', timeout: 150000, stdio: ['ignore', 'pipe', 'pipe'] });
+process.stdout.write(output);

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -1,4 +1,10 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- define "valkey.validate" -}}
+{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) -}}
+{{- fail "tls.enabled requires tls.existingSecret" -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -1,7 +1,5 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if and .Values.tls.enabled (not .Values.tls.existingSecret) }}
-{{- fail "tls.enabled requires tls.existingSecret" }}
-{{- end }}
+{{- include "valkey.validate" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/valkey/templates/tests/test-connection.yaml
+++ b/charts/valkey/templates/tests/test-connection.yaml
@@ -42,6 +42,8 @@ spec:
           {{- else if include "valkey.isCluster" . }}
           for i in $(seq 1 30); do
             if valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS cluster info | grep -q 'cluster_state:ok'; then
+              valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS set helmforge:health ok | grep -q OK
+              test "$(valkey-cli $VALKEY_TLS_ARGS -c -h "$VALKEY_HOST" -p "$VALKEY_PORT" $VALKEY_AUTH_ARGS get helmforge:health)" = "ok"
               exit 0
             fi
             echo "waiting for Valkey Cluster to report cluster_state:ok ($i/30)"

--- a/charts/valkey/tests/standalone_statefulset_test.yaml
+++ b/charts/valkey/tests/standalone_statefulset_test.yaml
@@ -43,7 +43,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "docker.io/valkey/valkey:9.1.1"
+          value: "docker.io/valkey/valkey:9.1.2"
 
   - it: should have 1 replica
     template: standalone-statefulset.yaml

--- a/charts/valkey/tests/test_connection_test.yaml
+++ b/charts/valkey/tests/test_connection_test.yaml
@@ -12,7 +12,7 @@ tests:
           of: Pod
       - equal:
           path: spec.containers[0].image
-          value: "docker.io/valkey/valkey:9.1.1"
+          value: "docker.io/valkey/valkey:9.1.2"
       - equal:
           path: metadata.name
           value: test-valkey-test-connection

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -30,7 +30,7 @@ image:
   # -- Container image repository
   repository: docker.io/valkey/valkey
   # -- Container image tag
-  tag: "9.1.1"
+  tag: "9.1.2"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 
@@ -370,7 +370,7 @@ tests:
     # -- Helm test image repository
     repository: docker.io/valkey/valkey
     # -- Helm test image tag
-    tag: "9.1.1"
+    tag: "9.1.2"
     # -- Helm test image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updates the official Valkey server and Helm-test images from 9.1.1 to 9.1.2, preserving the stable 9.1 release line. This security release fixes Lua-debugger and optional RDMA use-after-free vulnerabilities, ACL enforcement, RDB validation and AOF replay defects.

The k3d gate now executes the existing Helm application tests; the cluster test also writes and reads a key after checking cluster health. The existing TLS Secret validation moved into a named helper without changing its behavior.

Resolves #1150.
Site PR: helmforgedev/site#555.

Upstream evidence: [release notes](https://github.com/valkey-io/valkey/releases/tag/9.1.2), [complete comparison](https://github.com/valkey-io/valkey/compare/9.1.1...9.1.2). Official manifest verified for linux/amd64, linux/arm64, linux/arm and linux/ppc64le. No chart dependencies.

| Upstream change | Chart impact | k3d coverage |
|---|---|---|
| Lua debugger and ACL fixes | Server and test image; existing authentication | default |
| RDB/AOF replay and replica accounting fixes | Persistence settings and replication | default, ci/replication.yaml |
| Sentinel initialization | Discovery of writable primary | ci/sentinel.yaml |
| TLS IO and cluster migration fixes | Secure replication and cluster operations | ci/tls-cluster.yaml, ci/tls-replication.yaml |

Validation: `make validate-chart CHART=valkey` passed all static layers and the five listed runtime scenarios. After adding the Helm-test runner during the first pass, default and replication were repeated through the complete gate; Sentinel and both TLS profiles already ran the final application tests. All five scenarios passed authenticated application checks with zero container restarts. TLS fixture profiles use their documented test certificates and insecure hostname option; this is not production certificate validation or an exhaustive fault-injection test.

`make preflight`, standards, dependency and template standards checks passed. Kubescape 4.0.13 scored 83.83839%, consistent with the README's rounded 83.84%. Site lint, formatting, build and all 156 local Valkey links/anchors passed. Other CI profiles remain statically covered; routing, metrics configuration and Secret wiring are unchanged by this release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to prevent enabling TLS without specifying an existing TLS secret.
  - Improved cluster-mode connection checks with a write/read health verification.

- **Bug Fixes**
  - Updated the Valkey chart and test images to version 9.1.2, including the associated security release reference.

- **Tests**
  - Added a runtime smoke test for Helm deployments and updated image-version expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->