### PR TITLE
chore(qdrant): bump qdrant to 1.19.1

### DIFF
--- a/charts/qdrant/Chart.yaml
+++ b/charts/qdrant/Chart.yaml
@@ -4,7 +4,7 @@ name: qdrant
 description: Qdrant vector database
 type: application
 version: 1.0.4
-appVersion: "1.19.0"
+appVersion: "1.19.1"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev
@@ -21,7 +21,7 @@ icon: https://helmforge.dev/icons/charts/qdrant.png
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump image to 1.19.0 (#968)"
+      description: "bump image to 1.19.1 (#1149)"
   artifacthub.io/maintainers: |
     - name: HelmForge
       email: berlofa@helmforge.dev

--- a/charts/qdrant/README.md
+++ b/charts/qdrant/README.md
@@ -2,7 +2,7 @@
 
 Qdrant is a vector database and similarity search engine for embeddings, payload filters, semantic search, retrieval-augmented generation,
 recommendation, and matching workloads.
-This HelmForge chart deploys the official `docker.io/qdrant/qdrant:v1.19.0` image with persistent storage, HTTP and gRPC services,
+This HelmForge chart deploys the official `docker.io/qdrant/qdrant:v1.19.1` image with persistent storage, HTTP and gRPC services,
 optional API key authentication, snapshot storage, Prometheus scraping, and guarded distributed-mode settings.
 
 ## Install

--- a/charts/qdrant/scripts/runtime-smoke.mjs
+++ b/charts/qdrant/scripts/runtime-smoke.mjs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+import assert from 'node:assert/strict';
+import {execFileSync, spawn} from 'node:child_process';
+import {setTimeout as delay} from 'node:timers/promises';
+
+const [context, namespace, release] = process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const target = ['--context', context, '--namespace', namespace];
+const k = (...args) => JSON.parse(execFileSync('kubectl', [...target, ...args, '-o', 'json'],
+  {encoding:'utf8', timeout:30000, stdio:['ignore','pipe','pipe']}));
+const pods = k('get', 'pods', '-l', `app.kubernetes.io/instance=${release}`).items
+  .filter(p => p.status.phase === 'Running' && !p.metadata.deletionTimestamp);
+assert.ok(pods.length, 'Qdrant pods required');
+const container = pods[0].spec.containers.find(c => c.ports?.some(p => p.name === 'http'));
+const env = container.env ?? [];
+function credential(name) {
+  const entry = env.find(e => e.name === name);
+  if (!entry) return undefined;
+  if (entry.value !== undefined) return entry.value;
+  const ref = entry.valueFrom.secretKeyRef;
+  return Buffer.from(k('get', 'secret', ref.name).data[ref.key], 'base64').toString();
+}
+const writeKey = credential('QDRANT__SERVICE__API_KEY');
+const readKey = credential('QDRANT__SERVICE__READ_ONLY_API_KEY');
+const port = container.ports.find(p => p.name === 'http').containerPort;
+const forward = spawn('kubectl', [...target, 'port-forward', `pod/${pods[0].metadata.name}`, `:${port}`, '--address=127.0.0.1'],
+  {windowsHide:true, stdio:['ignore','pipe','pipe']});
+let output = '';
+forward.stdout.on('data', chunk => { output += chunk; });
+forward.stderr.on('data', () => {});
+const collection = `helmforge_smoke_${Date.now()}`;
+let base;
+let created = false;
+async function request(method, route, body, key = writeKey, expected = 200) {
+  const response = await fetch(base + route, {
+    method, headers:{'content-type':'application/json', ...(key ? {'api-key':key} : {})},
+    body: body === undefined ? undefined : JSON.stringify(body), signal:AbortSignal.timeout(20000),
+  });
+  assert.equal(response.status, expected, `${method} ${route}: unexpected status`);
+  if (!response.ok) { await response.text(); return null; }
+  return response.json();
+}
+try {
+  for (let i = 0; i < 150 && !/127\.0\.0\.1:(\d+) ->/.test(output); i++) {
+    if (forward.exitCode !== null) throw new Error('port-forward exited before readiness');
+    await delay(100);
+  }
+  const localPort = output.match(/127\.0\.0\.1:(\d+) ->/)?.[1];
+  assert.ok(localPort, 'port-forward must become ready');
+  base = `http://127.0.0.1:${localPort}`;
+  const info = await request('GET', '/');
+  assert.equal(info.version, '1.19.1', 'the updated server must actually run');
+  if (writeKey) await request('GET', '/collections', undefined, 'invalid-key', 401);
+  const distributed = env.some(e => e.name === 'QDRANT__CLUSTER__ENABLED' && e.value === 'true');
+  if (distributed) {
+    const cluster = await request('GET', '/cluster');
+    assert.equal(cluster.result.status, 'enabled');
+    assert.equal(Object.keys(cluster.result.peers).length, pods.length, 'all peers must join');
+  }
+  await request('PUT', `/collections/${collection}`, {
+    vectors:{size:3,distance:'Cosine'}, ...(distributed ? {shard_number:3,replication_factor:2} : {}),
+  });
+  created = true;
+  await request('PUT', `/collections/${collection}/points?wait=true`, {
+    points:[{id:1,vector:[1,0,0],payload:{label:'verified'}},{id:2,vector:[0,1,0]}],
+  });
+  const found = await request('POST', `/collections/${collection}/points/query`, {
+    query:[1,0,0],limit:1,with_payload:true,
+  });
+  assert.equal(found.result.points[0].id, 1);
+  assert.equal(found.result.points[0].payload.label, 'verified');
+  if (readKey) {
+    await request('GET', `/collections/${collection}`, undefined, readKey);
+    await request('PUT', `/collections/${collection}/points?wait=true`, {points:[]}, readKey, 403);
+  }
+  await request('DELETE', `/collections/${collection}`);
+  created = false;
+  console.log(`Qdrant 1.19.1: vector write/query/delete passed; ${pods.length} pod(s); authenticated=${Boolean(writeKey)}; distributed=${distributed}`);
+} finally {
+  if (created) await request('DELETE', `/collections/${collection}`).catch(() => {});
+  if (forward.exitCode === null) {
+    if (process.platform === 'win32') {
+      // Package-manager shims may start a child kubectl; close the entire owned tree.
+      execFileSync('taskkill', ['/PID', String(forward.pid), '/T', '/F'], {stdio:'ignore'});
+    } else {
+      forward.kill();
+    }
+  }
+}

--- a/charts/qdrant/tests/templates_test.yaml
+++ b/charts/qdrant/tests/templates_test.yaml
@@ -11,7 +11,7 @@ tests:
           of: StatefulSet
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/qdrant/qdrant:v1.19.0
+          value: docker.io/qdrant/qdrant:v1.19.1
   - it: renders service
     template: templates/service.yaml
     asserts:

--- a/charts/qdrant/values.schema.json
+++ b/charts/qdrant/values.schema.json
@@ -13,7 +13,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "docker.io/qdrant/qdrant" },
-        "tag": { "type": "string", "default": "v1.19.0" },
+        "tag": { "type": "string", "default": "v1.19.1" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/qdrant/values.yaml
+++ b/charts/qdrant/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official Qdrant image repository.
   repository: docker.io/qdrant/qdrant
   # -- Official Qdrant image tag. Do not use a floating tag.
-  tag: "v1.19.0"
+  tag: "v1.19.1"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updates the official Qdrant image from v1.19.0 to v1.19.1 on the stable 1.19 release line. Adds chart-owned runtime checks for vector writes, searches and deletion, API-key rejection, read-only authorization and three-node cluster membership.

Resolves #1149.
Site PR: helmforgedev/site#555.

Upstream evidence: [release notes](https://github.com/qdrant/qdrant/releases/tag/v1.19.1), [comparison](https://github.com/qdrant/qdrant/compare/v1.19.0...v1.19.1). Official v-prefixed manifest verified for linux/amd64 and linux/arm64. No chart dependencies.

| Upstream changes | Impact | Runtime coverage |
|---|---|---|
| Search/vector scoring, payload filtering and validation | Core HTTP API | default: create/upsert/query/delete, assert actual server version |
| Collection-name hardening and existing authentication boundary | Protected API | ci/secure-values.yaml: invalid key denied, read-only key cannot write |
| Replica/transfer/consensus crash-safety fixes | Distributed deployment | ci/cluster-values.yaml: three peers, replicated collection and vector operations |
| Gridstore recovery and CoW flush fixes | Persistent data compatibility | 1.19.0 -> 1.19.1 upgrade on the same PVC, then pod replacement |

Validation: complete `make validate-chart CHART=qdrant` gate passed all static layers plus default and secure scenarios after correcting test-process cleanup on Windows and the expected invalid-key status (401). The three-node cluster scenario passed in the earlier run with the same distributed application checks. `make preflight`, standards and template standards checks passed.

The supplemental upgrade installed the old image, wrote a vector/payload and created a snapshot, upgraded with `--reset-then-reuse-values` and explicit new tag, then verified version 1.19.1, retained data and snapshot listing. A subsequent pod replacement retained searchable data. This validates persistent upgrade and restart, not exhaustive crash injection or snapshot restore. Kubescape 4.0.13 scored 75.757576%, matching the README's rounded 75.76%. Site production build and all 156 local Qdrant links/anchors passed.

Routing and other deployment profiles remain statically covered; their contracts are unchanged by this patch release.
