### PR TITLE
chore(notediscovery): bump notediscovery to 0.31.5

### DIFF
--- a/charts/notediscovery/Chart.yaml
+++ b/charts/notediscovery/Chart.yaml
@@ -4,7 +4,7 @@ name: notediscovery
 description: Self-hosted Markdown knowledge base with graph view, search, sharing, and MCP integration
 type: application
 version: 2.0.0
-appVersion: "0.31.4"
+appVersion: "0.31.5"
 home: https://helmforge.dev/docs/charts/notediscovery
 sources:
   - https://github.com/helmforgedev/charts/tree/main/charts/notediscovery

--- a/charts/notediscovery/DESIGN.md
+++ b/charts/notediscovery/DESIGN.md
@@ -1,7 +1,7 @@
 # NoteDiscovery Chart Design
 
 This chart deploys NoteDiscovery as a self-hosted knowledge base using the
-official `ghcr.io/gamosoft/notediscovery:0.31.4` image.
+official `ghcr.io/gamosoft/notediscovery:0.31.5` image.
 
 ## Product Model
 

--- a/charts/notediscovery/README.md
+++ b/charts/notediscovery/README.md
@@ -4,7 +4,7 @@ Deploy [NoteDiscovery](https://github.com/gamosoft/NoteDiscovery), a
 self-hosted Markdown knowledge base with graph view, search, sharing, and MCP
 integration.
 
-This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.4` image
+This chart packages the official `ghcr.io/gamosoft/notediscovery:0.31.5` image
 and exposes the runtime settings that matter for Kubernetes: persistent note
 storage, generated or externally managed `config.yaml`, optional authentication,
 ingress/Gateway API exposure, network policy, pod disruption budget, and
@@ -151,8 +151,8 @@ volume.
 
 ## Upgrade Notes
 
-NoteDiscovery `0.31.4` is the current stable upstream release. Review the
-[upstream 0.31.4 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.4)
+NoteDiscovery `0.31.5` is the current stable upstream release. Review the
+[upstream 0.31.5 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.5)
 and back up the data PVC before upgrading.
 
 Generated configuration now stores plugin state under the writable data volume
@@ -193,6 +193,6 @@ egress rules after built-in DNS and HTTPS allowances.
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **87.37373%** |
+| MITRE + NSA + SOC2 | **87.37%** |
 
 > Security posture acceptable.

--- a/charts/notediscovery/tests/production_test.yaml
+++ b/charts/notediscovery/tests/production_test.yaml
@@ -11,7 +11,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.4
+          value: ghcr.io/gamosoft/notediscovery:0.31.5
       - equal:
           path: spec.strategy.type
           value: Recreate

--- a/charts/notediscovery/tests/templates_test.yaml
+++ b/charts/notediscovery/tests/templates_test.yaml
@@ -15,7 +15,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.4
+          value: ghcr.io/gamosoft/notediscovery:0.31.5
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -24,7 +24,7 @@ tests:
           value: plugin-bootstrap
       - equal:
           path: spec.template.spec.initContainers[0].image
-          value: ghcr.io/gamosoft/notediscovery:0.31.4
+          value: ghcr.io/gamosoft/notediscovery:0.31.5
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "if \\[ -d /app/plugins \\]"

--- a/charts/notediscovery/values.schema.json
+++ b/charts/notediscovery/values.schema.json
@@ -12,7 +12,7 @@
       "type": "object",
       "properties": {
         "repository": { "type": "string", "default": "ghcr.io/gamosoft/notediscovery" },
-        "tag": { "type": "string", "default": "0.31.4", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
+        "tag": { "type": "string", "default": "0.31.5", "pattern": "^v?[0-9][0-9A-Za-z._-]*$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "default": "IfNotPresent" }
       }
     },

--- a/charts/notediscovery/values.yaml
+++ b/charts/notediscovery/values.yaml
@@ -13,7 +13,7 @@ image:
   # -- Official NoteDiscovery container image repository.
   repository: ghcr.io/gamosoft/notediscovery
   # -- Pinned NoteDiscovery image tag. Floating tags such as latest are not used by default.
-  tag: "0.31.4"
+  tag: "0.31.5"
   # -- Kubernetes image pull policy.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updates the official NoteDiscovery image and appVersion from 0.31.4 to 0.31.5, preserving the stable release line. Aligns schema defaults, image assertions and documentation.

Resolves #1147.
Site PR: helmforgedev/site#555.

Upstream evidence: [0.31.5 release](https://github.com/gamosoft/NoteDiscovery/releases/tag/v0.31.5), [comparison](https://github.com/gamosoft/NoteDiscovery/compare/v0.31.4...v0.31.5). Official ghcr.io/gamosoft/notediscovery:0.31.5 manifest verified for linux/amd64 and linux/arm64. No dependencies.

| Upstream change | Impact | Runtime scenario |
|---|---|---|
| Nested-list presentation improvement | Application UI, no Kubernetes contract change | default |
| SECURITY.md reporting instructions | Upstream documentation only | no additional runtime profile |

Validation: `make validate-chart CHART=notediscovery K3D_SCENARIOS=default` passed all static layers across every CI profile plus the default k3d deployment, readiness and endpoint checks, with no container restarts. Additional auth/storage/ESO/routing profiles are unchanged and remain statically covered. `make preflight`, standards and template standards checks passed. Kubescape 4.0.13 scored 87.37374% (README rounded to 87.37%). Site build and all 156 local documentation links/anchors passed.
