### PR TITLE
chore(netbox): bump netbox to 4.6.10

### DIFF
--- a/charts/netbox/Chart.yaml
+++ b/charts/netbox/Chart.yaml
@@ -4,7 +4,7 @@ name: netbox
 description: NetBox infrastructure resource modeling with web, worker, and housekeeping workloads
 type: application
 version: 2.0.0
-appVersion: "4.6.9"
+appVersion: "4.6.10"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - name: helmforgedev

--- a/charts/netbox/DESIGN.md
+++ b/charts/netbox/DESIGN.md
@@ -13,7 +13,7 @@ pods can never accidentally receive HTTP traffic.
 
 ## Image choice
 
-The default `v4.6.9-5.0.2` tag combines an exact NetBox application release
+The default `v4.6.10-5.0.2` tag combines an exact NetBox application release
 with an exact netbox-docker support release. It is published for amd64 and
 arm64. The chart pins both version components and never uses a moving tag.
 

--- a/charts/netbox/README.md
+++ b/charts/netbox/README.md
@@ -114,15 +114,15 @@ also verifies database-backed Django startup.
 
 | Framework | Score |
 |---|---|
-| MITRE + NSA + SOC2 | **85.42568%** |
+| MITRE + NSA + SOC2 | **85.43%** |
 
 Security posture acceptable.
 
 Local details:
 
-- Tool: Kubescape v4.0.9
+- Tool: Kubescape v4.0.13
 - Command: `kubescape scan framework mitre,nsa,soc2 .tmp/netbox-render.yaml`
-- Result: 0 critical failed resources, resource summary score 85.42568%.
+- Result: 0 critical failed resources, resource summary score 85.43%.
 
 ## Examples
 

--- a/charts/netbox/ci/external-services-values.yaml
+++ b/charts/netbox/ci/external-services-values.yaml
@@ -4,6 +4,10 @@ postgresql:
   enabled: true
 redis:
   enabled: true
+netbox:
+  extraEnv:
+    - name: REDIS_CACHE_USERNAME
+      value: default
 database:
   mode: external
   external:

--- a/charts/netbox/scripts/runtime-smoke.mjs
+++ b/charts/netbox/scripts/runtime-smoke.mjs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+import {execFileSync} from 'node:child_process';
+const [context,namespace,release]=process.argv.slice(2);
+if (!context?.startsWith('k3d-helmforge-') || !namespace || !release) {
+  throw new Error('Explicit HelmForge lab context, namespace and release required');
+}
+const run=(bin,args)=>{
+  try {
+    return execFileSync(bin,args,{encoding:'utf8',timeout:150000,stdio:['ignore','pipe','pipe']});
+  } catch (error) {
+    console.error(String(error.stderr || error.message).slice(-1800));
+    process.exit(1);
+  }
+};
+const target=['--context',context,'-n',namespace];
+const pods=JSON.parse(run('kubectl',[...target,'get','pods','-l',`app.kubernetes.io/instance=${release}`,'-o','json'])).items;
+const pod=pods.find(p=>p.spec.containers.some(c=>c.name==='netbox')&&!p.metadata.deletionTimestamp);
+if (!pod) throw new Error('NetBox web pod required');
+const check=[
+  'import os',
+  'from django.conf import settings',
+  'from django.db import connection',
+  'from django.core.cache import cache',
+  'assert settings.VERSION == "4.6.10-Docker-5.0.2", settings.VERSION',
+  'cursor = connection.cursor()',
+  'cursor.execute("SELECT 1")',
+  'assert cursor.fetchone()[0] == 1',
+  'cursor.close()',
+  'expected = os.getenv("REDIS_CACHE_USERNAME")',
+  'assert not expected or settings.CACHES["default"]["OPTIONS"]["USERNAME"] == expected',
+  'cache.set("helmforge-upstream-smoke", "verified", 60)',
+  'assert cache.get("helmforge-upstream-smoke") == "verified"',
+  'cache.delete("helmforge-upstream-smoke")',
+  'print("NetBox 4.6.10: database and cache roundtrip passed; configured cache username honored")',
+].join('; ');
+process.stdout.write(run('kubectl',[...target,'exec',pod.metadata.name,'-c','netbox','--',
+  '/opt/netbox/venv/bin/python','/opt/netbox/netbox/manage.py','shell','--command',check]));
+process.stdout.write(run('helm',['test',release,'--kube-context',context,'-n',namespace,'--timeout','120s','--logs']));

--- a/charts/netbox/tests/deployment_test.yaml
+++ b/charts/netbox/tests/deployment_test.yaml
@@ -16,7 +16,7 @@ tests:
           of: Deployment
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/netboxcommunity/netbox:v4.6.9-5.0.2
+          value: docker.io/netboxcommunity/netbox:v4.6.10-5.0.2
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8080

--- a/charts/netbox/tests/production_test.yaml
+++ b/charts/netbox/tests/production_test.yaml
@@ -14,7 +14,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: docker.io/netboxcommunity/netbox:v4.6.9-5.0.2
+          value: docker.io/netboxcommunity/netbox:v4.6.10-5.0.2
   - it: disables outbound release checks in isolated deployments
     template: deployment-web.yaml
     set:

--- a/charts/netbox/values.yaml
+++ b/charts/netbox/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Official NetBox Docker image repository.
   repository: docker.io/netboxcommunity/netbox
   # -- Immutable NetBox and netbox-docker release combination.
-  tag: "v4.6.9-5.0.2"
+  tag: "v4.6.10-5.0.2"
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 # -- Image pull secrets.


### PR DESCRIPTION
NetBox now runs 4.6.10 on the existing netbox-docker 5.0.2 distribution. The cache-username regression is covered by a Django SQL/cache smoke check and an external-services scenario that explicitly supplies REDIS_CACHE_USERNAME.

Resolves #1146

Companion site update: https://github.com/helmforgedev/site/pull/555

### Upstream evidence and scope

- [NetBox 4.6.10 release](https://github.com/netbox-community/netbox/releases/tag/v4.6.10).
- [netbox-docker 5.0.2 configuration](https://github.com/netbox-community/netbox-docker/blob/5.0.2/configuration/configuration.py).
- Official image `docker.io/netboxcommunity/netbox:v4.6.10-5.0.2`: verified manifest for linux/amd64 and linux/arm64. Preserve stable NetBox 4.6 and Docker wrapper 5.0.2.
- HelmForge PostgreSQL 2.0.5 and Redis 2.0.1 dependencies are current; chart version remains managed by release CI.

| Upstream change | Chart impact | Validation |
|---|---|---|
| Cache Redis username now reaches Django's default cache | Existing extraEnv supports REDIS_CACHE_USERNAME; verify its effective value and real cache access | default and ci/external-services-values.yaml |
| API/query and application fixes | Keep startup, database, worker and HTTP contracts | readiness, SQL SELECT 1, Redis set/get/delete, Helm HTTP test |
| Signed S3 static URLs | No change to the chart's media/configuration mounts | all CI values render; no claim of live S3 validation |

### Validation

- `make validate-chart CHART=netbox K3D_SCENARIOS="default ci/external-services-values.yaml" TIMEOUT=900`: passed all 12 layers, including both k3d scenarios, effective version assertion, SQL/cache roundtrip and Helm HTTP test. No workload restarts.
- `make preflight`, standards-check, standards-guard, dependency freshness and template standards: passed.
- Kubescape 4.0.13 MITRE/NSA/SOC2: 85.43%, zero critical failed resources; README refreshed.
- Site production build and 156 local links/anchors: passed.

The initial added version assertion expected only 4.6.10; the official image reports 4.6.10-Docker-5.0.2. The check now verifies that exact distribution version. Existing routing, ESO, and monitoring contracts are unchanged and remain covered by the static CI matrix. This patch does not claim an exhaustive existing-installation migration or Redis ACL isolation test.
